### PR TITLE
Add PeopleService for user and project membership operations

### DIFF
--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -37,6 +37,7 @@ type Client struct {
 	todosets       *TodosetsService
 	todolists      *TodolistsService
 	todolistGroups *TodolistGroupsService
+	people         *PeopleService
 }
 
 // Response wraps an API response.
@@ -510,4 +511,12 @@ func (c *Client) TodolistGroups() *TodolistGroupsService {
 		c.todolistGroups = NewTodolistGroupsService(c)
 	}
 	return c.todolistGroups
+}
+
+// People returns the PeopleService for people operations.
+func (c *Client) People() *PeopleService {
+	if c.people == nil {
+		c.people = NewPeopleService(c)
+	}
+	return c.people
 }

--- a/go/pkg/basecamp/people.go
+++ b/go/pkg/basecamp/people.go
@@ -1,0 +1,180 @@
+package basecamp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// UpdateProjectAccessRequest specifies the parameters for updating project access.
+type UpdateProjectAccessRequest struct {
+	// Grant is a list of person IDs to grant access to the project.
+	Grant []int64 `json:"grant,omitempty"`
+	// Revoke is a list of person IDs to revoke access from the project.
+	Revoke []int64 `json:"revoke,omitempty"`
+	// Create is a list of new people to create and grant access.
+	Create []CreatePersonRequest `json:"create,omitempty"`
+}
+
+// CreatePersonRequest specifies the parameters for creating a new person.
+type CreatePersonRequest struct {
+	// Name is the person's full name (required).
+	Name string `json:"name"`
+	// EmailAddress is the person's email address (required).
+	EmailAddress string `json:"email_address"`
+	// Title is the person's job title (optional).
+	Title string `json:"title,omitempty"`
+	// CompanyName is the person's company name (optional).
+	CompanyName string `json:"company_name,omitempty"`
+}
+
+// UpdateProjectAccessResponse is the response from updating project access.
+type UpdateProjectAccessResponse struct {
+	// Granted is the list of people who were granted access.
+	Granted []Person `json:"granted"`
+	// Revoked is the list of people whose access was revoked.
+	Revoked []Person `json:"revoked"`
+}
+
+// PeopleService handles people operations.
+type PeopleService struct {
+	client *Client
+}
+
+// NewPeopleService creates a new PeopleService.
+func NewPeopleService(client *Client) *PeopleService {
+	return &PeopleService{client: client}
+}
+
+// List returns all people visible to the current user in the account.
+func (s *PeopleService) List(ctx context.Context) ([]Person, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	results, err := s.client.GetAll(ctx, "/people.json")
+	if err != nil {
+		return nil, err
+	}
+
+	people := make([]Person, 0, len(results))
+	for _, raw := range results {
+		var p Person
+		if err := json.Unmarshal(raw, &p); err != nil {
+			return nil, fmt.Errorf("failed to parse person: %w", err)
+		}
+		people = append(people, p)
+	}
+
+	return people, nil
+}
+
+// Get returns a person by ID.
+func (s *PeopleService) Get(ctx context.Context, personID int64) (*Person, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/people/%d.json", personID)
+	resp, err := s.client.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var person Person
+	if err := resp.UnmarshalData(&person); err != nil {
+		return nil, fmt.Errorf("failed to parse person: %w", err)
+	}
+
+	return &person, nil
+}
+
+// Me returns the current authenticated user's profile.
+func (s *PeopleService) Me(ctx context.Context) (*Person, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Get(ctx, "/my/profile.json")
+	if err != nil {
+		return nil, err
+	}
+
+	var person Person
+	if err := resp.UnmarshalData(&person); err != nil {
+		return nil, fmt.Errorf("failed to parse person: %w", err)
+	}
+
+	return &person, nil
+}
+
+// ListProjectPeople returns all active people on a project.
+// bucketID is the project ID.
+func (s *PeopleService) ListProjectPeople(ctx context.Context, bucketID int64) ([]Person, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/projects/%d/people.json", bucketID)
+	results, err := s.client.GetAll(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	people := make([]Person, 0, len(results))
+	for _, raw := range results {
+		var p Person
+		if err := json.Unmarshal(raw, &p); err != nil {
+			return nil, fmt.Errorf("failed to parse person: %w", err)
+		}
+		people = append(people, p)
+	}
+
+	return people, nil
+}
+
+// Pingable returns all account users who can be pinged.
+// Note: This endpoint is not paginated in the Basecamp API.
+func (s *PeopleService) Pingable(ctx context.Context) ([]Person, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Get(ctx, "/circles/people.json")
+	if err != nil {
+		return nil, err
+	}
+
+	var people []Person
+	if err := resp.UnmarshalData(&people); err != nil {
+		return nil, fmt.Errorf("failed to parse people: %w", err)
+	}
+
+	return people, nil
+}
+
+// UpdateProjectAccess grants or revokes project access for people.
+// bucketID is the project ID.
+// Returns the list of people who were granted and revoked access.
+func (s *PeopleService) UpdateProjectAccess(ctx context.Context, bucketID int64, req *UpdateProjectAccessRequest) (*UpdateProjectAccessResponse, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	if req == nil || (len(req.Grant) == 0 && len(req.Revoke) == 0 && len(req.Create) == 0) {
+		return nil, ErrUsage("at least one of grant, revoke, or create must be specified")
+	}
+
+	path := fmt.Sprintf("/projects/%d/people/users.json", bucketID)
+	resp, err := s.client.Put(ctx, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var result UpdateProjectAccessResponse
+	if err := resp.UnmarshalData(&result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return &result, nil
+}

--- a/go/pkg/basecamp/people_test.go
+++ b/go/pkg/basecamp/people_test.go
@@ -1,0 +1,275 @@
+package basecamp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func peopleFixturesDir() string {
+	return filepath.Join("..", "..", "..", "spec", "fixtures", "people")
+}
+
+func loadPeopleFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	path := filepath.Join(peopleFixturesDir(), name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func TestPerson_UnmarshalList(t *testing.T) {
+	data := loadPeopleFixture(t, "list.json")
+
+	var people []Person
+	if err := json.Unmarshal(data, &people); err != nil {
+		t.Fatalf("failed to unmarshal list.json: %v", err)
+	}
+
+	if len(people) != 2 {
+		t.Errorf("expected 2 people, got %d", len(people))
+	}
+
+	// Verify first person
+	p1 := people[0]
+	if p1.ID != 1049715915 {
+		t.Errorf("expected ID 1049715915, got %d", p1.ID)
+	}
+	if p1.Name != "Victor Cooper" {
+		t.Errorf("expected name 'Victor Cooper', got %q", p1.Name)
+	}
+	if p1.EmailAddress != "victor@honchodesign.com" {
+		t.Errorf("expected email 'victor@honchodesign.com', got %q", p1.EmailAddress)
+	}
+	if p1.PersonableType != "User" {
+		t.Errorf("expected personable_type 'User', got %q", p1.PersonableType)
+	}
+	if p1.Title != "Chief Strategist" {
+		t.Errorf("expected title 'Chief Strategist', got %q", p1.Title)
+	}
+	if !p1.Admin {
+		t.Error("expected admin to be true")
+	}
+	if !p1.Owner {
+		t.Error("expected owner to be true")
+	}
+	if p1.Client {
+		t.Error("expected client to be false")
+	}
+	if !p1.Employee {
+		t.Error("expected employee to be true")
+	}
+
+	// Verify company
+	if p1.Company == nil {
+		t.Fatal("expected Company to be non-nil")
+	}
+	if p1.Company.ID != 1033447817 {
+		t.Errorf("expected Company.ID 1033447817, got %d", p1.Company.ID)
+	}
+	if p1.Company.Name != "Honcho Design" {
+		t.Errorf("expected Company.Name 'Honcho Design', got %q", p1.Company.Name)
+	}
+
+	// Verify second person
+	p2 := people[1]
+	if p2.ID != 1049715920 {
+		t.Errorf("expected ID 1049715920, got %d", p2.ID)
+	}
+	if p2.Name != "Steve Marsh" {
+		t.Errorf("expected name 'Steve Marsh', got %q", p2.Name)
+	}
+	if p2.Admin {
+		t.Error("expected admin to be false for second person")
+	}
+}
+
+func TestPerson_UnmarshalGet(t *testing.T) {
+	data := loadPeopleFixture(t, "get.json")
+
+	var person Person
+	if err := json.Unmarshal(data, &person); err != nil {
+		t.Fatalf("failed to unmarshal get.json: %v", err)
+	}
+
+	if person.ID != 1049715915 {
+		t.Errorf("expected ID 1049715915, got %d", person.ID)
+	}
+	if person.Name != "Victor Cooper" {
+		t.Errorf("expected name 'Victor Cooper', got %q", person.Name)
+	}
+	if person.Bio != "Don't let your dreams be dreams" {
+		t.Errorf("expected bio 'Don't let your dreams be dreams', got %q", person.Bio)
+	}
+	if person.Location != "Chicago, IL" {
+		t.Errorf("expected location 'Chicago, IL', got %q", person.Location)
+	}
+	if person.TimeZone != "America/Chicago" {
+		t.Errorf("expected time_zone 'America/Chicago', got %q", person.TimeZone)
+	}
+	if person.AvatarURL == "" {
+		t.Error("expected non-empty AvatarURL")
+	}
+	if !person.CanManageProjects {
+		t.Error("expected can_manage_projects to be true")
+	}
+	if !person.CanManagePeople {
+		t.Error("expected can_manage_people to be true")
+	}
+}
+
+func TestPerson_UnmarshalPingable(t *testing.T) {
+	data := loadPeopleFixture(t, "pingable.json")
+
+	var people []Person
+	if err := json.Unmarshal(data, &people); err != nil {
+		t.Fatalf("failed to unmarshal pingable.json: %v", err)
+	}
+
+	if len(people) != 1 {
+		t.Errorf("expected 1 person, got %d", len(people))
+	}
+
+	p := people[0]
+	if p.ID != 1049715915 {
+		t.Errorf("expected ID 1049715915, got %d", p.ID)
+	}
+	if !p.CanPing {
+		t.Error("expected can_ping to be true")
+	}
+}
+
+func TestUpdateProjectAccessRequest_Marshal(t *testing.T) {
+	data := loadPeopleFixture(t, "update-access-request.json")
+
+	var req UpdateProjectAccessRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		t.Fatalf("failed to unmarshal update-access-request.json: %v", err)
+	}
+
+	if len(req.Grant) != 1 || req.Grant[0] != 1049715920 {
+		t.Errorf("expected grant [1049715920], got %v", req.Grant)
+	}
+	if len(req.Revoke) != 1 || req.Revoke[0] != 1049715925 {
+		t.Errorf("expected revoke [1049715925], got %v", req.Revoke)
+	}
+	if len(req.Create) != 1 {
+		t.Fatalf("expected 1 create entry, got %d", len(req.Create))
+	}
+	if req.Create[0].Name != "New Person" {
+		t.Errorf("expected create name 'New Person', got %q", req.Create[0].Name)
+	}
+	if req.Create[0].EmailAddress != "new@example.com" {
+		t.Errorf("expected create email 'new@example.com', got %q", req.Create[0].EmailAddress)
+	}
+	if req.Create[0].Title != "Developer" {
+		t.Errorf("expected create title 'Developer', got %q", req.Create[0].Title)
+	}
+	if req.Create[0].CompanyName != "Acme Corp" {
+		t.Errorf("expected create company_name 'Acme Corp', got %q", req.Create[0].CompanyName)
+	}
+
+	// Round-trip test
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal UpdateProjectAccessRequest: %v", err)
+	}
+
+	var roundtrip UpdateProjectAccessRequest
+	if err := json.Unmarshal(out, &roundtrip); err != nil {
+		t.Fatalf("failed to unmarshal round-trip: %v", err)
+	}
+
+	if len(roundtrip.Grant) != len(req.Grant) || len(roundtrip.Revoke) != len(req.Revoke) {
+		t.Error("round-trip mismatch")
+	}
+}
+
+func TestUpdateProjectAccessResponse_Unmarshal(t *testing.T) {
+	data := loadPeopleFixture(t, "update-access-response.json")
+
+	var resp UpdateProjectAccessResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		t.Fatalf("failed to unmarshal update-access-response.json: %v", err)
+	}
+
+	if len(resp.Granted) != 1 {
+		t.Fatalf("expected 1 granted person, got %d", len(resp.Granted))
+	}
+	if resp.Granted[0].ID != 1049715920 {
+		t.Errorf("expected granted ID 1049715920, got %d", resp.Granted[0].ID)
+	}
+	if resp.Granted[0].Name != "Steve Marsh" {
+		t.Errorf("expected granted name 'Steve Marsh', got %q", resp.Granted[0].Name)
+	}
+
+	if len(resp.Revoked) != 1 {
+		t.Fatalf("expected 1 revoked person, got %d", len(resp.Revoked))
+	}
+	if resp.Revoked[0].ID != 1049715925 {
+		t.Errorf("expected revoked ID 1049715925, got %d", resp.Revoked[0].ID)
+	}
+	if resp.Revoked[0].Name != "Former Member" {
+		t.Errorf("expected revoked name 'Former Member', got %q", resp.Revoked[0].Name)
+	}
+}
+
+func TestCreatePersonRequest_Marshal(t *testing.T) {
+	req := CreatePersonRequest{
+		Name:         "Test User",
+		EmailAddress: "test@example.com",
+		Title:        "Engineer",
+		CompanyName:  "Test Corp",
+	}
+
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal CreatePersonRequest: %v", err)
+	}
+
+	var roundtrip CreatePersonRequest
+	if err := json.Unmarshal(out, &roundtrip); err != nil {
+		t.Fatalf("failed to unmarshal round-trip: %v", err)
+	}
+
+	if roundtrip.Name != req.Name {
+		t.Errorf("expected name %q, got %q", req.Name, roundtrip.Name)
+	}
+	if roundtrip.EmailAddress != req.EmailAddress {
+		t.Errorf("expected email %q, got %q", req.EmailAddress, roundtrip.EmailAddress)
+	}
+	if roundtrip.Title != req.Title {
+		t.Errorf("expected title %q, got %q", req.Title, roundtrip.Title)
+	}
+	if roundtrip.CompanyName != req.CompanyName {
+		t.Errorf("expected company_name %q, got %q", req.CompanyName, roundtrip.CompanyName)
+	}
+}
+
+func TestCreatePersonRequest_MarshalOmitsEmpty(t *testing.T) {
+	req := CreatePersonRequest{
+		Name:         "Test User",
+		EmailAddress: "test@example.com",
+	}
+
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal CreatePersonRequest: %v", err)
+	}
+
+	// Verify that empty optional fields are omitted
+	var data map[string]interface{}
+	if err := json.Unmarshal(out, &data); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	if _, ok := data["title"]; ok {
+		t.Error("expected title to be omitted when empty")
+	}
+	if _, ok := data["company_name"]; ok {
+		t.Error("expected company_name to be omitted when empty")
+	}
+}

--- a/spec/fixtures/people/get.json
+++ b/spec/fixtures/people/get.json
@@ -1,0 +1,24 @@
+{
+  "id": 1049715915,
+  "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--919d2c8b11ff403eefcab9db42dd26846d0c3102",
+  "name": "Victor Cooper",
+  "email_address": "victor@honchodesign.com",
+  "personable_type": "User",
+  "title": "Chief Strategist",
+  "bio": "Don't let your dreams be dreams",
+  "location": "Chicago, IL",
+  "created_at": "2022-11-22T08:23:21.732Z",
+  "updated_at": "2022-11-22T08:23:21.904Z",
+  "admin": true,
+  "owner": true,
+  "client": false,
+  "employee": true,
+  "time_zone": "America/Chicago",
+  "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMtkkT4=--e609ef146e39f9ca5e4bb7571f0f7da68e5f6302/avatar?v=1",
+  "company": {
+    "id": 1033447817,
+    "name": "Honcho Design"
+  },
+  "can_manage_projects": true,
+  "can_manage_people": true
+}

--- a/spec/fixtures/people/list.json
+++ b/spec/fixtures/people/list.json
@@ -1,0 +1,46 @@
+[
+  {
+    "id": 1049715915,
+    "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--919d2c8b11ff403eefcab9db42dd26846d0c3102",
+    "name": "Victor Cooper",
+    "email_address": "victor@honchodesign.com",
+    "personable_type": "User",
+    "title": "Chief Strategist",
+    "bio": "Don't let your dreams be dreams",
+    "location": "Chicago, IL",
+    "created_at": "2022-11-22T08:23:21.732Z",
+    "updated_at": "2022-11-22T08:23:21.904Z",
+    "admin": true,
+    "owner": true,
+    "client": false,
+    "employee": true,
+    "time_zone": "America/Chicago",
+    "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMtkkT4=--e609ef146e39f9ca5e4bb7571f0f7da68e5f6302/avatar?v=1",
+    "company": {
+      "id": 1033447817,
+      "name": "Honcho Design"
+    },
+    "can_manage_projects": true,
+    "can_manage_people": true
+  },
+  {
+    "id": 1049715920,
+    "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTIwP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--f0d48d2c54d09541d4fe79b0b4de328e89b4a0c0",
+    "name": "Steve Marsh",
+    "email_address": "steve@honchodesign.com",
+    "personable_type": "User",
+    "title": "Legacy Directives Strategist",
+    "bio": "You can do it!",
+    "location": "Chicago, IL",
+    "created_at": "2022-11-22T08:23:22.131Z",
+    "updated_at": "2022-11-22T08:23:22.131Z",
+    "admin": false,
+    "owner": false,
+    "client": false,
+    "employee": true,
+    "time_zone": "America/Chicago",
+    "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBNBkkT4=--79c86665c9c218598d3cce24d5eb0eba8b38519a/avatar?v=1",
+    "can_manage_projects": true,
+    "can_manage_people": true
+  }
+]

--- a/spec/fixtures/people/pingable.json
+++ b/spec/fixtures/people/pingable.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": 1049715915,
+    "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--919d2c8b11ff403eefcab9db42dd26846d0c3102",
+    "name": "Victor Cooper",
+    "email_address": "victor@honchodesign.com",
+    "personable_type": "User",
+    "title": "Chief Strategist",
+    "bio": "Don't let your dreams be dreams",
+    "location": "Chicago, IL",
+    "created_at": "2022-11-22T08:23:21.732Z",
+    "updated_at": "2022-11-22T08:23:21.904Z",
+    "admin": true,
+    "owner": true,
+    "client": false,
+    "employee": true,
+    "time_zone": "America/Chicago",
+    "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMtkkT4=--e609ef146e39f9ca5e4bb7571f0f7da68e5f6302/avatar?v=1",
+    "can_ping": true
+  }
+]

--- a/spec/fixtures/people/update-access-request.json
+++ b/spec/fixtures/people/update-access-request.json
@@ -1,0 +1,12 @@
+{
+  "grant": [1049715920],
+  "revoke": [1049715925],
+  "create": [
+    {
+      "name": "New Person",
+      "email_address": "new@example.com",
+      "title": "Developer",
+      "company_name": "Acme Corp"
+    }
+  ]
+}

--- a/spec/fixtures/people/update-access-response.json
+++ b/spec/fixtures/people/update-access-response.json
@@ -1,0 +1,20 @@
+{
+  "granted": [
+    {
+      "id": 1049715920,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTIwP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--f0d48d2c54d09541d4fe79b0b4de328e89b4a0c0",
+      "name": "Steve Marsh",
+      "email_address": "steve@honchodesign.com",
+      "personable_type": "User",
+      "title": "Legacy Directives Strategist"
+    }
+  ],
+  "revoked": [
+    {
+      "id": 1049715925,
+      "name": "Former Member",
+      "email_address": "former@example.com",
+      "personable_type": "User"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `PeopleService` to the SDK for user and project membership operations
- Implements all Basecamp 3 People API endpoints

## Methods
| Method | Description |
|--------|-------------|
| `List()` | Returns all people visible to current user |
| `Get(personID)` | Returns a specific person |
| `Me()` | Returns the current user's profile |
| `ListProjectPeople(bucketID)` | Returns people with project access |
| `Pingable()` | Returns @mentionable users |
| `UpdateProjectAccess()` | Grants/revokes project access |

## Test plan
- [x] Unit tests pass: `go test ./...`
- [x] Build passes: `go build ./...`
- [ ] Integration test with bcq migration (separate PR)