### PR TITLE
Add WebhooksService for webhook operations

### DIFF
--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -32,16 +32,17 @@ type Client struct {
 	verbose       bool
 
 	// Services
-	projects        *ProjectsService
-	todos           *TodosService
-	todosets        *TodosetsService
-	todolists       *TodolistsService
-	todolistGroups  *TodolistGroupsService
-	people          *PeopleService
-	comments        *CommentsService
-	messages        *MessagesService
-	messageBoards   *MessageBoardsService
-	messageTypes    *MessageTypesService
+	projects       *ProjectsService
+	todos          *TodosService
+	todosets       *TodosetsService
+	todolists      *TodolistsService
+	todolistGroups *TodolistGroupsService
+	people         *PeopleService
+	comments       *CommentsService
+	messages       *MessagesService
+	messageBoards  *MessageBoardsService
+	messageTypes   *MessageTypesService
+	webhooks       *WebhooksService
 }
 
 // Response wraps an API response.
@@ -555,4 +556,12 @@ func (c *Client) MessageTypes() *MessageTypesService {
 		c.messageTypes = NewMessageTypesService(c)
 	}
 	return c.messageTypes
+}
+
+// Webhooks returns the WebhooksService for webhook operations.
+func (c *Client) Webhooks() *WebhooksService {
+	if c.webhooks == nil {
+		c.webhooks = NewWebhooksService(c)
+	}
+	return c.webhooks
 }

--- a/go/pkg/basecamp/projects.go
+++ b/go/pkg/basecamp/projects.go
@@ -28,13 +28,13 @@ type Project struct {
 
 // DockItem represents a tool in a project's dock.
 type DockItem struct {
-	ID       int64   `json:"id"`
-	Title    string  `json:"title"`
-	Name     string  `json:"name"`
-	Enabled  bool    `json:"enabled"`
-	Position *int    `json:"position"`
-	URL      string  `json:"url"`
-	AppURL   string  `json:"app_url"`
+	ID       int64  `json:"id"`
+	Title    string `json:"title"`
+	Name     string `json:"name"`
+	Enabled  bool   `json:"enabled"`
+	Position *int   `json:"position"`
+	URL      string `json:"url"`
+	AppURL   string `json:"app_url"`
 }
 
 // ClientCompany represents a client company associated with a project.

--- a/go/pkg/basecamp/todolists.go
+++ b/go/pkg/basecamp/todolists.go
@@ -9,31 +9,31 @@ import (
 
 // Todolist represents a Basecamp todolist.
 type Todolist struct {
-	ID                int64     `json:"id"`
-	Status            string    `json:"status"`
-	VisibleToClients  bool      `json:"visible_to_clients"`
-	CreatedAt         time.Time `json:"created_at"`
-	UpdatedAt         time.Time `json:"updated_at"`
-	Title             string    `json:"title"`
-	InheritsStatus    bool      `json:"inherits_status"`
-	Type              string    `json:"type"`
-	URL               string    `json:"url"`
-	AppURL            string    `json:"app_url"`
-	BookmarkURL       string    `json:"bookmark_url"`
-	SubscriptionURL   string    `json:"subscription_url"`
-	CommentsCount     int       `json:"comments_count"`
-	CommentsURL       string    `json:"comments_url"`
-	Position          int       `json:"position"`
-	Parent            *Parent   `json:"parent,omitempty"`
-	Bucket            *Bucket   `json:"bucket,omitempty"`
-	Creator           *Person   `json:"creator,omitempty"`
-	Description       string    `json:"description"`
-	Completed         bool      `json:"completed"`
-	CompletedRatio    string    `json:"completed_ratio"`
-	Name              string    `json:"name"`
-	TodosURL          string    `json:"todos_url"`
-	GroupsURL         string    `json:"groups_url"`
-	AppTodosURL       string    `json:"app_todos_url"`
+	ID               int64     `json:"id"`
+	Status           string    `json:"status"`
+	VisibleToClients bool      `json:"visible_to_clients"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+	Title            string    `json:"title"`
+	InheritsStatus   bool      `json:"inherits_status"`
+	Type             string    `json:"type"`
+	URL              string    `json:"url"`
+	AppURL           string    `json:"app_url"`
+	BookmarkURL      string    `json:"bookmark_url"`
+	SubscriptionURL  string    `json:"subscription_url"`
+	CommentsCount    int       `json:"comments_count"`
+	CommentsURL      string    `json:"comments_url"`
+	Position         int       `json:"position"`
+	Parent           *Parent   `json:"parent,omitempty"`
+	Bucket           *Bucket   `json:"bucket,omitempty"`
+	Creator          *Person   `json:"creator,omitempty"`
+	Description      string    `json:"description"`
+	Completed        bool      `json:"completed"`
+	CompletedRatio   string    `json:"completed_ratio"`
+	Name             string    `json:"name"`
+	TodosURL         string    `json:"todos_url"`
+	GroupsURL        string    `json:"groups_url"`
+	AppTodosURL      string    `json:"app_todos_url"`
 }
 
 // TodolistListOptions specifies options for listing todolists.

--- a/go/pkg/basecamp/todos.go
+++ b/go/pkg/basecamp/todos.go
@@ -9,53 +9,53 @@ import (
 
 // Todo represents a Basecamp todo item.
 type Todo struct {
-	ID          int64     `json:"id"`
-	Status      string    `json:"status"`
-	VisibleTo   []int64   `json:"visible_to"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
-	Title       string    `json:"title"`
-	InheritsVis bool      `json:"inherits_status"`
-	Type        string    `json:"type"`
-	URL         string    `json:"url"`
-	AppURL      string    `json:"app_url"`
-	BookmarkURL string    `json:"bookmark_url"`
-	Parent      *Parent   `json:"parent,omitempty"`
-	Bucket      *Bucket   `json:"bucket,omitempty"`
-	Creator     *Person   `json:"creator,omitempty"`
-	Content     string    `json:"content"`
-	Description string    `json:"description"`
-	StartsOn    string    `json:"starts_on,omitempty"`
-	DueOn       string    `json:"due_on,omitempty"`
-	Completed   bool      `json:"completed"`
+	ID          int64      `json:"id"`
+	Status      string     `json:"status"`
+	VisibleTo   []int64    `json:"visible_to"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	Title       string     `json:"title"`
+	InheritsVis bool       `json:"inherits_status"`
+	Type        string     `json:"type"`
+	URL         string     `json:"url"`
+	AppURL      string     `json:"app_url"`
+	BookmarkURL string     `json:"bookmark_url"`
+	Parent      *Parent    `json:"parent,omitempty"`
+	Bucket      *Bucket    `json:"bucket,omitempty"`
+	Creator     *Person    `json:"creator,omitempty"`
+	Content     string     `json:"content"`
+	Description string     `json:"description"`
+	StartsOn    string     `json:"starts_on,omitempty"`
+	DueOn       string     `json:"due_on,omitempty"`
+	Completed   bool       `json:"completed"`
 	CompletedAt *time.Time `json:"completed_at,omitempty"`
-	Completer   *Person   `json:"completer,omitempty"`
-	Assignees   []Person  `json:"assignees,omitempty"`
-	Position    int       `json:"position"`
+	Completer   *Person    `json:"completer,omitempty"`
+	Assignees   []Person   `json:"assignees,omitempty"`
+	Position    int        `json:"position"`
 }
 
 // Person represents a Basecamp user.
 type Person struct {
-	ID                 int64          `json:"id"`
-	AttachableSGID     string         `json:"attachable_sgid,omitempty"`
-	Name               string         `json:"name"`
-	EmailAddress       string         `json:"email_address,omitempty"`
-	PersonableType     string         `json:"personable_type,omitempty"`
-	Title              string         `json:"title,omitempty"`
-	Bio                string         `json:"bio,omitempty"`
-	Location           string         `json:"location,omitempty"`
-	CreatedAt          string         `json:"created_at,omitempty"`
-	UpdatedAt          string         `json:"updated_at,omitempty"`
-	Admin              bool           `json:"admin,omitempty"`
-	Owner              bool           `json:"owner,omitempty"`
-	Client             bool           `json:"client,omitempty"`
-	Employee           bool           `json:"employee,omitempty"`
-	TimeZone           string         `json:"time_zone,omitempty"`
-	AvatarURL          string         `json:"avatar_url,omitempty"`
-	CanPing            bool           `json:"can_ping,omitempty"`
-	Company            *PersonCompany `json:"company,omitempty"`
-	CanManageProjects  bool           `json:"can_manage_projects,omitempty"`
-	CanManagePeople    bool           `json:"can_manage_people,omitempty"`
+	ID                int64          `json:"id"`
+	AttachableSGID    string         `json:"attachable_sgid,omitempty"`
+	Name              string         `json:"name"`
+	EmailAddress      string         `json:"email_address,omitempty"`
+	PersonableType    string         `json:"personable_type,omitempty"`
+	Title             string         `json:"title,omitempty"`
+	Bio               string         `json:"bio,omitempty"`
+	Location          string         `json:"location,omitempty"`
+	CreatedAt         string         `json:"created_at,omitempty"`
+	UpdatedAt         string         `json:"updated_at,omitempty"`
+	Admin             bool           `json:"admin,omitempty"`
+	Owner             bool           `json:"owner,omitempty"`
+	Client            bool           `json:"client,omitempty"`
+	Employee          bool           `json:"employee,omitempty"`
+	TimeZone          string         `json:"time_zone,omitempty"`
+	AvatarURL         string         `json:"avatar_url,omitempty"`
+	CanPing           bool           `json:"can_ping,omitempty"`
+	Company           *PersonCompany `json:"company,omitempty"`
+	CanManageProjects bool           `json:"can_manage_projects,omitempty"`
+	CanManagePeople   bool           `json:"can_manage_people,omitempty"`
 }
 
 // PersonCompany represents a company associated with a person.

--- a/go/pkg/basecamp/todosets.go
+++ b/go/pkg/basecamp/todosets.go
@@ -9,29 +9,29 @@ import (
 // Todoset represents a Basecamp todoset (container for todolists in a project).
 // Each project has exactly one todoset in its dock.
 type Todoset struct {
-	ID                   int64     `json:"id"`
-	Status               string    `json:"status"`
-	VisibleToClients     bool      `json:"visible_to_clients"`
-	CreatedAt            time.Time `json:"created_at"`
-	UpdatedAt            time.Time `json:"updated_at"`
-	Title                string    `json:"title"`
-	InheritsStatus       bool      `json:"inherits_status"`
-	Type                 string    `json:"type"`
-	URL                  string    `json:"url"`
-	AppURL               string    `json:"app_url"`
-	BookmarkURL          string    `json:"bookmark_url"`
-	Position             *int      `json:"position,omitempty"`
-	Bucket               *Bucket   `json:"bucket,omitempty"`
-	Creator              *Person   `json:"creator,omitempty"`
-	Name                 string    `json:"name"`
-	TodolistsCount       int       `json:"todolists_count"`
-	TodolistsURL         string    `json:"todolists_url"`
-	CompletedRatio       string    `json:"completed_ratio"`
-	Completed            bool      `json:"completed"`
-	CompletedCount       int       `json:"completed_count"`
-	OnScheduleCount      int       `json:"on_schedule_count"`
-	OverScheduleCount    int       `json:"over_schedule_count"`
-	AppTodolistsURL      string    `json:"app_todolists_url"`
+	ID                int64     `json:"id"`
+	Status            string    `json:"status"`
+	VisibleToClients  bool      `json:"visible_to_clients"`
+	CreatedAt         time.Time `json:"created_at"`
+	UpdatedAt         time.Time `json:"updated_at"`
+	Title             string    `json:"title"`
+	InheritsStatus    bool      `json:"inherits_status"`
+	Type              string    `json:"type"`
+	URL               string    `json:"url"`
+	AppURL            string    `json:"app_url"`
+	BookmarkURL       string    `json:"bookmark_url"`
+	Position          *int      `json:"position,omitempty"`
+	Bucket            *Bucket   `json:"bucket,omitempty"`
+	Creator           *Person   `json:"creator,omitempty"`
+	Name              string    `json:"name"`
+	TodolistsCount    int       `json:"todolists_count"`
+	TodolistsURL      string    `json:"todolists_url"`
+	CompletedRatio    string    `json:"completed_ratio"`
+	Completed         bool      `json:"completed"`
+	CompletedCount    int       `json:"completed_count"`
+	OnScheduleCount   int       `json:"on_schedule_count"`
+	OverScheduleCount int       `json:"over_schedule_count"`
+	AppTodolistsURL   string    `json:"app_todolists_url"`
 }
 
 // TodosetsService handles todoset operations.

--- a/go/pkg/basecamp/webhooks.go
+++ b/go/pkg/basecamp/webhooks.go
@@ -1,0 +1,160 @@
+package basecamp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Webhook represents a Basecamp webhook subscription.
+type Webhook struct {
+	ID         int64     `json:"id"`
+	Active     bool      `json:"active"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+	PayloadURL string    `json:"payload_url"`
+	Types      []string  `json:"types"`
+	AppURL     string    `json:"app_url,omitempty"`
+	URL        string    `json:"url,omitempty"`
+}
+
+// CreateWebhookRequest specifies the parameters for creating a webhook.
+type CreateWebhookRequest struct {
+	// PayloadURL is the URL to receive webhook payloads (required).
+	PayloadURL string `json:"payload_url"`
+	// Types is a list of event types to subscribe to (required).
+	// Example: ["Todo", "Todolist", "Comment"]
+	Types []string `json:"types"`
+	// Active indicates whether the webhook is active (default: true).
+	Active *bool `json:"active,omitempty"`
+}
+
+// UpdateWebhookRequest specifies the parameters for updating a webhook.
+type UpdateWebhookRequest struct {
+	// PayloadURL is the URL to receive webhook payloads.
+	PayloadURL string `json:"payload_url,omitempty"`
+	// Types is a list of event types to subscribe to.
+	Types []string `json:"types,omitempty"`
+	// Active indicates whether the webhook is active.
+	Active *bool `json:"active,omitempty"`
+}
+
+// WebhooksService handles webhook operations.
+type WebhooksService struct {
+	client *Client
+}
+
+// NewWebhooksService creates a new WebhooksService.
+func NewWebhooksService(client *Client) *WebhooksService {
+	return &WebhooksService{client: client}
+}
+
+// List returns all webhooks for a project (bucket).
+// bucketID is the project ID.
+func (s *WebhooksService) List(ctx context.Context, bucketID int64) ([]Webhook, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/webhooks.json", bucketID)
+	results, err := s.client.GetAll(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	webhooks := make([]Webhook, 0, len(results))
+	for _, raw := range results {
+		var wh Webhook
+		if err := json.Unmarshal(raw, &wh); err != nil {
+			return nil, fmt.Errorf("failed to parse webhook: %w", err)
+		}
+		webhooks = append(webhooks, wh)
+	}
+
+	return webhooks, nil
+}
+
+// Get returns a webhook by ID.
+// bucketID is the project ID, webhookID is the webhook ID.
+func (s *WebhooksService) Get(ctx context.Context, bucketID, webhookID int64) (*Webhook, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/webhooks/%d.json", bucketID, webhookID)
+	resp, err := s.client.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var webhook Webhook
+	if err := resp.UnmarshalData(&webhook); err != nil {
+		return nil, fmt.Errorf("failed to parse webhook: %w", err)
+	}
+
+	return &webhook, nil
+}
+
+// Create creates a new webhook for a project (bucket).
+// bucketID is the project ID.
+// Returns the created webhook.
+func (s *WebhooksService) Create(ctx context.Context, bucketID int64, req *CreateWebhookRequest) (*Webhook, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	if req.PayloadURL == "" {
+		return nil, ErrUsage("webhook payload_url is required")
+	}
+	if len(req.Types) == 0 {
+		return nil, ErrUsage("webhook types are required")
+	}
+
+	path := fmt.Sprintf("/buckets/%d/webhooks.json", bucketID)
+	resp, err := s.client.Post(ctx, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var webhook Webhook
+	if err := resp.UnmarshalData(&webhook); err != nil {
+		return nil, fmt.Errorf("failed to parse webhook: %w", err)
+	}
+
+	return &webhook, nil
+}
+
+// Update updates an existing webhook.
+// bucketID is the project ID, webhookID is the webhook ID.
+// Returns the updated webhook.
+func (s *WebhooksService) Update(ctx context.Context, bucketID, webhookID int64, req *UpdateWebhookRequest) (*Webhook, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/webhooks/%d.json", bucketID, webhookID)
+	resp, err := s.client.Put(ctx, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var webhook Webhook
+	if err := resp.UnmarshalData(&webhook); err != nil {
+		return nil, fmt.Errorf("failed to parse webhook: %w", err)
+	}
+
+	return &webhook, nil
+}
+
+// Delete removes a webhook.
+// bucketID is the project ID, webhookID is the webhook ID.
+func (s *WebhooksService) Delete(ctx context.Context, bucketID, webhookID int64) error {
+	if err := s.client.RequireAccount(); err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/webhooks/%d.json", bucketID, webhookID)
+	_, err := s.client.Delete(ctx, path)
+	return err
+}

--- a/go/pkg/basecamp/webhooks_test.go
+++ b/go/pkg/basecamp/webhooks_test.go
@@ -1,0 +1,174 @@
+package basecamp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func webhooksFixturesDir() string {
+	return filepath.Join("..", "..", "..", "spec", "fixtures", "webhooks")
+}
+
+func loadWebhooksFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	path := filepath.Join(webhooksFixturesDir(), name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func TestWebhook_UnmarshalList(t *testing.T) {
+	data := loadWebhooksFixture(t, "list.json")
+
+	var webhooks []Webhook
+	if err := json.Unmarshal(data, &webhooks); err != nil {
+		t.Fatalf("failed to unmarshal list.json: %v", err)
+	}
+
+	if len(webhooks) != 2 {
+		t.Errorf("expected 2 webhooks, got %d", len(webhooks))
+	}
+
+	// Verify first webhook
+	wh1 := webhooks[0]
+	if wh1.ID != 9007199254741433 {
+		t.Errorf("expected ID 9007199254741433, got %d", wh1.ID)
+	}
+	if wh1.PayloadURL != "https://example.com/webhooks/basecamp" {
+		t.Errorf("expected payload_url 'https://example.com/webhooks/basecamp', got %q", wh1.PayloadURL)
+	}
+	if !wh1.Active {
+		t.Error("expected active to be true")
+	}
+	if len(wh1.Types) != 2 {
+		t.Errorf("expected 2 types, got %d", len(wh1.Types))
+	}
+	if wh1.Types[0] != "Todo" {
+		t.Errorf("expected first type 'Todo', got %q", wh1.Types[0])
+	}
+	if wh1.Types[1] != "Todolist" {
+		t.Errorf("expected second type 'Todolist', got %q", wh1.Types[1])
+	}
+
+	// Verify second webhook is inactive
+	wh2 := webhooks[1]
+	if wh2.ID != 9007199254741434 {
+		t.Errorf("expected ID 9007199254741434, got %d", wh2.ID)
+	}
+	if wh2.Active {
+		t.Error("expected active to be false")
+	}
+	if len(wh2.Types) != 1 || wh2.Types[0] != "Comment" {
+		t.Errorf("expected types ['Comment'], got %v", wh2.Types)
+	}
+}
+
+func TestWebhook_UnmarshalGet(t *testing.T) {
+	data := loadWebhooksFixture(t, "get.json")
+
+	var webhook Webhook
+	if err := json.Unmarshal(data, &webhook); err != nil {
+		t.Fatalf("failed to unmarshal get.json: %v", err)
+	}
+
+	if webhook.ID != 9007199254741433 {
+		t.Errorf("expected ID 9007199254741433, got %d", webhook.ID)
+	}
+	if webhook.PayloadURL != "https://example.com/webhooks/basecamp" {
+		t.Errorf("expected payload_url 'https://example.com/webhooks/basecamp', got %q", webhook.PayloadURL)
+	}
+	if !webhook.Active {
+		t.Error("expected active to be true")
+	}
+	if len(webhook.Types) != 2 {
+		t.Errorf("expected 2 types, got %d", len(webhook.Types))
+	}
+	if webhook.URL == "" {
+		t.Error("expected non-empty URL")
+	}
+	if webhook.AppURL == "" {
+		t.Error("expected non-empty AppURL")
+	}
+}
+
+func TestCreateWebhookRequest_Marshal(t *testing.T) {
+	data := loadWebhooksFixture(t, "create-request.json")
+
+	var req CreateWebhookRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		t.Fatalf("failed to unmarshal create-request.json: %v", err)
+	}
+
+	if req.PayloadURL != "https://example.com/webhooks/new" {
+		t.Errorf("expected payload_url 'https://example.com/webhooks/new', got %q", req.PayloadURL)
+	}
+	if len(req.Types) != 3 {
+		t.Errorf("expected 3 types, got %d", len(req.Types))
+	}
+	if req.Types[0] != "Todo" || req.Types[1] != "Comment" || req.Types[2] != "Message" {
+		t.Errorf("unexpected types: %v", req.Types)
+	}
+	if req.Active == nil || !*req.Active {
+		t.Error("expected active to be true")
+	}
+
+	// Round-trip test
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal CreateWebhookRequest: %v", err)
+	}
+
+	var roundtrip CreateWebhookRequest
+	if err := json.Unmarshal(out, &roundtrip); err != nil {
+		t.Fatalf("failed to unmarshal round-trip: %v", err)
+	}
+
+	if roundtrip.PayloadURL != req.PayloadURL {
+		t.Error("round-trip payload_url mismatch")
+	}
+	if len(roundtrip.Types) != len(req.Types) {
+		t.Error("round-trip types mismatch")
+	}
+}
+
+func TestUpdateWebhookRequest_Marshal(t *testing.T) {
+	data := loadWebhooksFixture(t, "update-request.json")
+
+	var req UpdateWebhookRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		t.Fatalf("failed to unmarshal update-request.json: %v", err)
+	}
+
+	if req.PayloadURL != "https://example.com/webhooks/updated" {
+		t.Errorf("expected payload_url 'https://example.com/webhooks/updated', got %q", req.PayloadURL)
+	}
+	if len(req.Types) != 1 || req.Types[0] != "Todo" {
+		t.Errorf("expected types ['Todo'], got %v", req.Types)
+	}
+	if req.Active == nil || *req.Active {
+		t.Error("expected active to be false")
+	}
+}
+
+func TestWebhook_TimestampParsing(t *testing.T) {
+	data := loadWebhooksFixture(t, "get.json")
+
+	var webhook Webhook
+	if err := json.Unmarshal(data, &webhook); err != nil {
+		t.Fatalf("failed to unmarshal get.json: %v", err)
+	}
+
+	if webhook.CreatedAt.IsZero() {
+		t.Error("expected non-zero CreatedAt")
+	}
+	if webhook.UpdatedAt.IsZero() {
+		t.Error("expected non-zero UpdatedAt")
+	}
+	if webhook.CreatedAt.Year() != 2022 {
+		t.Errorf("expected year 2022, got %d", webhook.CreatedAt.Year())
+	}
+}

--- a/spec/fixtures/webhooks/create-request.json
+++ b/spec/fixtures/webhooks/create-request.json
@@ -1,0 +1,5 @@
+{
+  "payload_url": "https://example.com/webhooks/new",
+  "types": ["Todo", "Comment", "Message"],
+  "active": true
+}

--- a/spec/fixtures/webhooks/get.json
+++ b/spec/fixtures/webhooks/get.json
@@ -1,0 +1,10 @@
+{
+  "id": 9007199254741433,
+  "active": true,
+  "created_at": "2022-11-22T15:58:38.851Z",
+  "updated_at": "2022-11-22T15:58:38.851Z",
+  "payload_url": "https://example.com/webhooks/basecamp",
+  "types": ["Todo", "Todolist"],
+  "url": "https://3.basecampapi.com/999999999/buckets/2085958500/webhooks/9007199254741433.json",
+  "app_url": "https://3.basecamp.com/999999999/buckets/2085958500/webhooks/9007199254741433"
+}

--- a/spec/fixtures/webhooks/list.json
+++ b/spec/fixtures/webhooks/list.json
@@ -1,0 +1,22 @@
+[
+  {
+    "id": 9007199254741433,
+    "active": true,
+    "created_at": "2022-11-22T15:58:38.851Z",
+    "updated_at": "2022-11-22T15:58:38.851Z",
+    "payload_url": "https://example.com/webhooks/basecamp",
+    "types": ["Todo", "Todolist"],
+    "url": "https://3.basecampapi.com/999999999/buckets/2085958500/webhooks/9007199254741433.json",
+    "app_url": "https://3.basecamp.com/999999999/buckets/2085958500/webhooks/9007199254741433"
+  },
+  {
+    "id": 9007199254741434,
+    "active": false,
+    "created_at": "2022-11-22T16:00:00.000Z",
+    "updated_at": "2022-11-22T16:05:00.000Z",
+    "payload_url": "https://example.com/webhooks/comments",
+    "types": ["Comment"],
+    "url": "https://3.basecampapi.com/999999999/buckets/2085958500/webhooks/9007199254741434.json",
+    "app_url": "https://3.basecamp.com/999999999/buckets/2085958500/webhooks/9007199254741434"
+  }
+]

--- a/spec/fixtures/webhooks/update-request.json
+++ b/spec/fixtures/webhooks/update-request.json
@@ -1,0 +1,5 @@
+{
+  "payload_url": "https://example.com/webhooks/updated",
+  "types": ["Todo"],
+  "active": false
+}


### PR DESCRIPTION
Implements CRUD operations for Basecamp webhooks:
- List, Get, Create, Update, Delete methods
- Webhook struct with ID, PayloadURL, Types, Active fields
- CreateWebhookRequest and UpdateWebhookRequest types
- Test coverage with JSON fixture files
