### PR TITLE
Add SearchService for content search

### DIFF
--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -44,6 +44,7 @@ type Client struct {
 	messageTypes   *MessageTypesService
 	webhooks       *WebhooksService
 	events         *EventsService
+	search          *SearchService
 }
 
 // Response wraps an API response.
@@ -573,4 +574,12 @@ func (c *Client) Events() *EventsService {
 		c.events = NewEventsService(c)
 	}
 	return c.events
+}
+
+// Search returns the SearchService for search operations.
+func (c *Client) Search() *SearchService {
+	if c.search == nil {
+		c.search = NewSearchService(c)
+	}
+	return c.search
 }

--- a/go/pkg/basecamp/search.go
+++ b/go/pkg/basecamp/search.go
@@ -1,0 +1,114 @@
+package basecamp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// SearchResult represents a single search result from the Basecamp API.
+type SearchResult struct {
+	ID               int64     `json:"id"`
+	Status           string    `json:"status"`
+	VisibleToClients bool      `json:"visible_to_clients"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+	Title            string    `json:"title"`
+	InheritsStatus   bool      `json:"inherits_status"`
+	Type             string    `json:"type"`
+	URL              string    `json:"url"`
+	AppURL           string    `json:"app_url"`
+	BookmarkURL      string    `json:"bookmark_url"`
+	Parent           *Parent   `json:"parent,omitempty"`
+	Bucket           *Bucket   `json:"bucket,omitempty"`
+	Creator          *Person   `json:"creator,omitempty"`
+	Content          string    `json:"content,omitempty"`
+	Description      string    `json:"description,omitempty"`
+	Subject          string    `json:"subject,omitempty"`
+}
+
+// SearchMetadata represents metadata about available search scopes.
+type SearchMetadata struct {
+	Projects []SearchProject `json:"projects"`
+}
+
+// SearchProject represents a project available for search scope filtering.
+type SearchProject struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+}
+
+// SearchOptions specifies optional parameters for search.
+type SearchOptions struct {
+	// Sort specifies the sort order: "created_at" or "updated_at" (default: relevance).
+	Sort string
+}
+
+// SearchService handles search operations.
+type SearchService struct {
+	client *Client
+}
+
+// NewSearchService creates a new SearchService.
+func NewSearchService(client *Client) *SearchService {
+	return &SearchService{client: client}
+}
+
+// Search searches for content across the account.
+// The query parameter is the search string.
+// Returns a list of matching results.
+func (s *SearchService) Search(ctx context.Context, query string, opts *SearchOptions) ([]SearchResult, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	if query == "" {
+		return nil, ErrUsage("search query is required")
+	}
+
+	// Build the query string
+	params := url.Values{}
+	params.Set("query", query)
+	if opts != nil && opts.Sort != "" {
+		params.Set("sort", opts.Sort)
+	}
+
+	path := fmt.Sprintf("/search.json?%s", params.Encode())
+	results, err := s.client.GetAll(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	searchResults := make([]SearchResult, 0, len(results))
+	for _, raw := range results {
+		var sr SearchResult
+		if err := json.Unmarshal(raw, &sr); err != nil {
+			return nil, fmt.Errorf("failed to parse search result: %w", err)
+		}
+		searchResults = append(searchResults, sr)
+	}
+
+	return searchResults, nil
+}
+
+// Metadata returns metadata about available search scopes.
+// This includes the list of projects available for filtering.
+func (s *SearchService) Metadata(ctx context.Context) (*SearchMetadata, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.Get(ctx, "/searches/metadata.json")
+	if err != nil {
+		return nil, err
+	}
+
+	var metadata SearchMetadata
+	if err := resp.UnmarshalData(&metadata); err != nil {
+		return nil, fmt.Errorf("failed to parse search metadata: %w", err)
+	}
+
+	return &metadata, nil
+}

--- a/go/pkg/basecamp/search_test.go
+++ b/go/pkg/basecamp/search_test.go
@@ -1,0 +1,231 @@
+package basecamp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func searchFixturesDir() string {
+	return filepath.Join("..", "..", "..", "spec", "fixtures", "search")
+}
+
+func loadSearchFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	path := filepath.Join(searchFixturesDir(), name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func TestSearchResult_UnmarshalResults(t *testing.T) {
+	data := loadSearchFixture(t, "results.json")
+
+	var results []SearchResult
+	if err := json.Unmarshal(data, &results); err != nil {
+		t.Fatalf("failed to unmarshal results.json: %v", err)
+	}
+
+	if len(results) != 3 {
+		t.Errorf("expected 3 results, got %d", len(results))
+	}
+
+	// Verify first result (Message)
+	r1 := results[0]
+	if r1.ID != 1069479351 {
+		t.Errorf("expected ID 1069479351, got %d", r1.ID)
+	}
+	if r1.Status != "active" {
+		t.Errorf("expected status 'active', got %q", r1.Status)
+	}
+	if r1.Type != "Message" {
+		t.Errorf("expected type 'Message', got %q", r1.Type)
+	}
+	if r1.Title != "We won Leto!" {
+		t.Errorf("expected title 'We won Leto!', got %q", r1.Title)
+	}
+	if r1.Subject != "We won Leto!" {
+		t.Errorf("expected subject 'We won Leto!', got %q", r1.Subject)
+	}
+	if r1.Content != "<div>Hello everyone! We got the Leto Laptop project! Time to get started.</div>" {
+		t.Errorf("unexpected content: %q", r1.Content)
+	}
+	if r1.URL != "https://3.basecampapi.com/195539477/buckets/2085958499/messages/1069479351.json" {
+		t.Errorf("unexpected URL: %q", r1.URL)
+	}
+	if r1.AppURL != "https://3.basecamp.com/195539477/buckets/2085958499/messages/1069479351" {
+		t.Errorf("unexpected AppURL: %q", r1.AppURL)
+	}
+
+	// Verify parent (message board)
+	if r1.Parent == nil {
+		t.Fatal("expected Parent to be non-nil")
+	}
+	if r1.Parent.ID != 1069479338 {
+		t.Errorf("expected Parent.ID 1069479338, got %d", r1.Parent.ID)
+	}
+	if r1.Parent.Title != "Message Board" {
+		t.Errorf("expected Parent.Title 'Message Board', got %q", r1.Parent.Title)
+	}
+	if r1.Parent.Type != "Message::Board" {
+		t.Errorf("expected Parent.Type 'Message::Board', got %q", r1.Parent.Type)
+	}
+
+	// Verify bucket
+	if r1.Bucket == nil {
+		t.Fatal("expected Bucket to be non-nil")
+	}
+	if r1.Bucket.ID != 2085958499 {
+		t.Errorf("expected Bucket.ID 2085958499, got %d", r1.Bucket.ID)
+	}
+	if r1.Bucket.Name != "The Leto Laptop" {
+		t.Errorf("expected Bucket.Name 'The Leto Laptop', got %q", r1.Bucket.Name)
+	}
+	if r1.Bucket.Type != "Project" {
+		t.Errorf("expected Bucket.Type 'Project', got %q", r1.Bucket.Type)
+	}
+
+	// Verify creator
+	if r1.Creator == nil {
+		t.Fatal("expected Creator to be non-nil")
+	}
+	if r1.Creator.ID != 1049715914 {
+		t.Errorf("expected Creator.ID 1049715914, got %d", r1.Creator.ID)
+	}
+	if r1.Creator.Name != "Victor Cooper" {
+		t.Errorf("expected Creator.Name 'Victor Cooper', got %q", r1.Creator.Name)
+	}
+
+	// Verify second result (Todo)
+	r2 := results[1]
+	if r2.ID != 1069479400 {
+		t.Errorf("expected ID 1069479400, got %d", r2.ID)
+	}
+	if r2.Type != "Todo" {
+		t.Errorf("expected type 'Todo', got %q", r2.Type)
+	}
+	if r2.Title != "Design specs for Leto display" {
+		t.Errorf("expected title 'Design specs for Leto display', got %q", r2.Title)
+	}
+	if r2.Description != "Create detailed specifications for the Leto laptop display panel" {
+		t.Errorf("unexpected description: %q", r2.Description)
+	}
+	if r2.Parent == nil {
+		t.Fatal("expected Parent to be non-nil for second result")
+	}
+	if r2.Parent.Type != "Todolist" {
+		t.Errorf("expected Parent.Type 'Todolist', got %q", r2.Parent.Type)
+	}
+	if r2.Creator == nil {
+		t.Fatal("expected Creator to be non-nil for second result")
+	}
+	if r2.Creator.Name != "Annie Bryan" {
+		t.Errorf("expected Creator.Name 'Annie Bryan', got %q", r2.Creator.Name)
+	}
+
+	// Verify third result (Comment)
+	r3 := results[2]
+	if r3.ID != 1069479450 {
+		t.Errorf("expected ID 1069479450, got %d", r3.ID)
+	}
+	if r3.Type != "Comment" {
+		t.Errorf("expected type 'Comment', got %q", r3.Type)
+	}
+	if r3.Content != "<div>The Leto keyboard layout looks great. Let's finalize it.</div>" {
+		t.Errorf("unexpected content for comment: %q", r3.Content)
+	}
+
+	// Verify timestamps are parsed
+	if r1.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be non-zero")
+	}
+	if r1.UpdatedAt.IsZero() {
+		t.Error("expected UpdatedAt to be non-zero")
+	}
+}
+
+func TestSearchMetadata_Unmarshal(t *testing.T) {
+	data := loadSearchFixture(t, "metadata.json")
+
+	var metadata SearchMetadata
+	if err := json.Unmarshal(data, &metadata); err != nil {
+		t.Fatalf("failed to unmarshal metadata.json: %v", err)
+	}
+
+	if len(metadata.Projects) != 3 {
+		t.Errorf("expected 3 projects, got %d", len(metadata.Projects))
+	}
+
+	// Verify first project
+	p1 := metadata.Projects[0]
+	if p1.ID != 2085958499 {
+		t.Errorf("expected ID 2085958499, got %d", p1.ID)
+	}
+	if p1.Name != "The Leto Laptop" {
+		t.Errorf("expected name 'The Leto Laptop', got %q", p1.Name)
+	}
+
+	// Verify second project
+	p2 := metadata.Projects[1]
+	if p2.ID != 2085958500 {
+		t.Errorf("expected ID 2085958500, got %d", p2.ID)
+	}
+	if p2.Name != "Marketing Campaign Q4" {
+		t.Errorf("expected name 'Marketing Campaign Q4', got %q", p2.Name)
+	}
+
+	// Verify third project
+	p3 := metadata.Projects[2]
+	if p3.ID != 2085958501 {
+		t.Errorf("expected ID 2085958501, got %d", p3.ID)
+	}
+	if p3.Name != "Internal Operations" {
+		t.Errorf("expected name 'Internal Operations', got %q", p3.Name)
+	}
+}
+
+func TestSearchOptions_Marshal(t *testing.T) {
+	opts := SearchOptions{
+		Sort: "created_at",
+	}
+
+	out, err := json.Marshal(opts)
+	if err != nil {
+		t.Fatalf("failed to marshal SearchOptions: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(out, &data); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	if data["Sort"] != "created_at" {
+		t.Errorf("unexpected Sort: %v", data["Sort"])
+	}
+}
+
+func TestSearchResult_DifferentTypes(t *testing.T) {
+	data := loadSearchFixture(t, "results.json")
+
+	var results []SearchResult
+	if err := json.Unmarshal(data, &results); err != nil {
+		t.Fatalf("failed to unmarshal results.json: %v", err)
+	}
+
+	// Collect unique types
+	types := make(map[string]bool)
+	for _, r := range results {
+		types[r.Type] = true
+	}
+
+	// Verify we have multiple types
+	expectedTypes := []string{"Message", "Todo", "Comment"}
+	for _, et := range expectedTypes {
+		if !types[et] {
+			t.Errorf("expected type %q in results", et)
+		}
+	}
+}

--- a/spec/fixtures/search/metadata.json
+++ b/spec/fixtures/search/metadata.json
@@ -1,0 +1,16 @@
+{
+  "projects": [
+    {
+      "id": 2085958499,
+      "name": "The Leto Laptop"
+    },
+    {
+      "id": 2085958500,
+      "name": "Marketing Campaign Q4"
+    },
+    {
+      "id": 2085958501,
+      "name": "Internal Operations"
+    }
+  ]
+}

--- a/spec/fixtures/search/results.json
+++ b/spec/fixtures/search/results.json
@@ -1,0 +1,141 @@
+[
+  {
+    "id": 1069479351,
+    "status": "active",
+    "visible_to_clients": false,
+    "created_at": "2022-10-28T15:21:46.169Z",
+    "updated_at": "2022-10-28T15:21:46.169Z",
+    "title": "We won Leto!",
+    "inherits_status": true,
+    "type": "Message",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/messages/1069479351.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/messages/1069479351",
+    "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5MzUxP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--aabbccdd.json",
+    "subject": "We won Leto!",
+    "content": "<div>Hello everyone! We got the Leto Laptop project! Time to get started.</div>",
+    "parent": {
+      "id": 1069479338,
+      "title": "Message Board",
+      "type": "Message::Board",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/message_boards/1069479338.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/message_boards/1069479338"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715914,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+      "name": "Victor Cooper",
+      "email_address": "victor@honchodesign.com",
+      "personable_type": "User",
+      "title": "Chief Strategist",
+      "bio": null,
+      "location": null,
+      "created_at": "2022-11-22T08:23:21.732Z",
+      "updated_at": "2022-11-22T08:23:21.732Z",
+      "admin": true,
+      "owner": true,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+      "can_manage_projects": true,
+      "can_manage_people": true
+    }
+  },
+  {
+    "id": 1069479400,
+    "status": "active",
+    "visible_to_clients": false,
+    "created_at": "2022-10-29T10:30:00.000Z",
+    "updated_at": "2022-10-29T10:30:00.000Z",
+    "title": "Design specs for Leto display",
+    "inherits_status": true,
+    "type": "Todo",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/todos/1069479400.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/todos/1069479400",
+    "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5NDAwP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--eeffgghh.json",
+    "description": "Create detailed specifications for the Leto laptop display panel",
+    "parent": {
+      "id": 1069479390,
+      "title": "Hardware Design",
+      "type": "Todolist",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/todolists/1069479390.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/todolists/1069479390"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715915,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aeb392ebf54ffd820e45f27add22bae3a8c7da56",
+      "name": "Annie Bryan",
+      "email_address": "annie@honchodesign.com",
+      "personable_type": "User",
+      "title": "Central Markets Manager",
+      "bio": "To open a store is easy, to keep it open is an art",
+      "location": null,
+      "created_at": "2022-11-22T08:23:21.911Z",
+      "updated_at": "2022-11-22T08:23:21.911Z",
+      "admin": false,
+      "owner": false,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMtkkT4=--avatar",
+      "can_manage_projects": true,
+      "can_manage_people": true
+    }
+  },
+  {
+    "id": 1069479450,
+    "status": "active",
+    "visible_to_clients": false,
+    "created_at": "2022-10-30T14:00:00.000Z",
+    "updated_at": "2022-10-30T14:00:00.000Z",
+    "title": "Leto keyboard layout review",
+    "inherits_status": true,
+    "type": "Comment",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/comments/1069479450.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/comments/1069479450",
+    "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5NDUwP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--iijjkkll.json",
+    "content": "<div>The Leto keyboard layout looks great. Let's finalize it.</div>",
+    "parent": {
+      "id": 1069479400,
+      "title": "Design specs for Leto display",
+      "type": "Todo",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/todos/1069479400.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/todos/1069479400"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715914,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+      "name": "Victor Cooper",
+      "email_address": "victor@honchodesign.com",
+      "personable_type": "User",
+      "title": "Chief Strategist",
+      "bio": null,
+      "location": null,
+      "created_at": "2022-11-22T08:23:21.732Z",
+      "updated_at": "2022-11-22T08:23:21.732Z",
+      "admin": true,
+      "owner": true,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+      "can_manage_projects": true,
+      "can_manage_people": true
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- Add `SearchService` with `Search()` and `Metadata()` methods for searching content across a Basecamp account
- Add `SearchResult` struct supporting multiple recording types (Message, Todo, Comment, etc.)
- Add `SearchOptions` struct for controlling sort order
- Add client accessor `Search()` for the new service
- Add test fixtures and comprehensive unit tests

## Test plan
- [x] All existing tests pass
- [x] New search tests pass: `go test ./...`
- [x] Linting passes: `golangci-lint run`