### PR TITLE
Add TemplatesService for project templates

### DIFF
--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -45,6 +45,7 @@ type Client struct {
 	webhooks       *WebhooksService
 	events         *EventsService
 	search          *SearchService
+	templates       *TemplatesService
 }
 
 // Response wraps an API response.
@@ -582,4 +583,12 @@ func (c *Client) Search() *SearchService {
 		c.search = NewSearchService(c)
 	}
 	return c.search
+}
+
+// Templates returns the TemplatesService for template operations.
+func (c *Client) Templates() *TemplatesService {
+	if c.templates == nil {
+		c.templates = NewTemplatesService(c)
+	}
+	return c.templates
 }

--- a/go/pkg/basecamp/templates.go
+++ b/go/pkg/basecamp/templates.go
@@ -1,0 +1,213 @@
+package basecamp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Template represents a Basecamp project template.
+type Template struct {
+	ID          int64     `json:"id"`
+	Status      string    `json:"status"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	Name        string    `json:"name"`
+	Description string    `json:"description"`
+}
+
+// ProjectConstruction represents the status of a project being created from a template.
+type ProjectConstruction struct {
+	ID      int64    `json:"id"`
+	Status  string   `json:"status"`
+	URL     string   `json:"url"`
+	Project *Project `json:"project,omitempty"`
+}
+
+// CreateTemplateRequest specifies the parameters for creating a template.
+type CreateTemplateRequest struct {
+	// Name is the template name (required).
+	Name string `json:"name"`
+	// Description is an optional template description.
+	Description string `json:"description,omitempty"`
+}
+
+// UpdateTemplateRequest specifies the parameters for updating a template.
+type UpdateTemplateRequest struct {
+	// Name is the template name (required for update).
+	Name string `json:"name"`
+	// Description is an optional template description.
+	Description string `json:"description,omitempty"`
+}
+
+// CreateProjectRequest specifies the parameters for creating a project from a template.
+type CreateProjectFromTemplateRequest struct {
+	// Name is the project name (required).
+	Name string `json:"name"`
+	// Description is an optional project description.
+	Description string `json:"description,omitempty"`
+}
+
+// TemplatesService handles template operations.
+type TemplatesService struct {
+	client *Client
+}
+
+// NewTemplatesService creates a new TemplatesService.
+func NewTemplatesService(client *Client) *TemplatesService {
+	return &TemplatesService{client: client}
+}
+
+// List returns all templates visible to the current user.
+func (s *TemplatesService) List(ctx context.Context) ([]Template, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	results, err := s.client.GetAll(ctx, "/templates.json")
+	if err != nil {
+		return nil, err
+	}
+
+	templates := make([]Template, 0, len(results))
+	for _, raw := range results {
+		var t Template
+		if err := json.Unmarshal(raw, &t); err != nil {
+			return nil, fmt.Errorf("failed to parse template: %w", err)
+		}
+		templates = append(templates, t)
+	}
+
+	return templates, nil
+}
+
+// Get returns a template by ID.
+func (s *TemplatesService) Get(ctx context.Context, templateID int64) (*Template, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/templates/%d.json", templateID)
+	resp, err := s.client.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var template Template
+	if err := resp.UnmarshalData(&template); err != nil {
+		return nil, fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	return &template, nil
+}
+
+// Create creates a new template.
+// Returns the created template.
+func (s *TemplatesService) Create(ctx context.Context, req *CreateTemplateRequest) (*Template, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	if req.Name == "" {
+		return nil, ErrUsage("template name is required")
+	}
+
+	resp, err := s.client.Post(ctx, "/templates.json", req)
+	if err != nil {
+		return nil, err
+	}
+
+	var template Template
+	if err := resp.UnmarshalData(&template); err != nil {
+		return nil, fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	return &template, nil
+}
+
+// Update updates an existing template.
+// Returns the updated template.
+func (s *TemplatesService) Update(ctx context.Context, templateID int64, req *UpdateTemplateRequest) (*Template, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	if req.Name == "" {
+		return nil, ErrUsage("template name is required")
+	}
+
+	path := fmt.Sprintf("/templates/%d.json", templateID)
+	resp, err := s.client.Put(ctx, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var template Template
+	if err := resp.UnmarshalData(&template); err != nil {
+		return nil, fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	return &template, nil
+}
+
+// Delete deletes a template.
+func (s *TemplatesService) Delete(ctx context.Context, templateID int64) error {
+	if err := s.client.RequireAccount(); err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/templates/%d.json", templateID)
+	_, err := s.client.Delete(ctx, path)
+	return err
+}
+
+// CreateProject creates a new project from a template.
+// This operation is asynchronous; use GetConstruction to check the status.
+func (s *TemplatesService) CreateProject(ctx context.Context, templateID int64, name, description string) (*ProjectConstruction, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	if name == "" {
+		return nil, ErrUsage("project name is required")
+	}
+
+	path := fmt.Sprintf("/templates/%d/project_constructions.json", templateID)
+	req := &CreateProjectFromTemplateRequest{
+		Name:        name,
+		Description: description,
+	}
+
+	resp, err := s.client.Post(ctx, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var construction ProjectConstruction
+	if err := resp.UnmarshalData(&construction); err != nil {
+		return nil, fmt.Errorf("failed to parse project construction: %w", err)
+	}
+
+	return &construction, nil
+}
+
+// GetConstruction returns the status of a project construction.
+func (s *TemplatesService) GetConstruction(ctx context.Context, templateID, constructionID int64) (*ProjectConstruction, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/templates/%d/project_constructions/%d.json", templateID, constructionID)
+	resp, err := s.client.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var construction ProjectConstruction
+	if err := resp.UnmarshalData(&construction); err != nil {
+		return nil, fmt.Errorf("failed to parse project construction: %w", err)
+	}
+
+	return &construction, nil
+}

--- a/go/pkg/basecamp/templates_test.go
+++ b/go/pkg/basecamp/templates_test.go
@@ -1,0 +1,201 @@
+package basecamp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// templatesFixturesDir returns the path to the templates fixtures directory.
+func templatesFixturesDir() string {
+	return filepath.Join("..", "..", "..", "spec", "fixtures", "templates")
+}
+
+// loadTemplatesFixture reads a fixture file and returns its contents.
+func loadTemplatesFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	path := filepath.Join(templatesFixturesDir(), name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func TestTemplate_UnmarshalList(t *testing.T) {
+	data := loadTemplatesFixture(t, "list.json")
+
+	var templates []Template
+	if err := json.Unmarshal(data, &templates); err != nil {
+		t.Fatalf("failed to unmarshal list.json: %v", err)
+	}
+
+	if len(templates) != 2 {
+		t.Errorf("expected 2 templates, got %d", len(templates))
+	}
+
+	// Verify first template
+	t1 := templates[0]
+	if t1.ID != 2085958501 {
+		t.Errorf("expected ID 2085958501, got %d", t1.ID)
+	}
+	if t1.Name != "Project Template" {
+		t.Errorf("expected name 'Project Template', got %q", t1.Name)
+	}
+	if t1.Status != "active" {
+		t.Errorf("expected status 'active', got %q", t1.Status)
+	}
+	if t1.Description != "Standard project template for new initiatives." {
+		t.Errorf("expected description 'Standard project template for new initiatives.', got %q", t1.Description)
+	}
+
+	// Verify second template
+	t2 := templates[1]
+	if t2.ID != 2085958502 {
+		t.Errorf("expected ID 2085958502, got %d", t2.ID)
+	}
+	if t2.Name != "Client Onboarding" {
+		t.Errorf("expected name 'Client Onboarding', got %q", t2.Name)
+	}
+}
+
+func TestTemplate_UnmarshalGet(t *testing.T) {
+	data := loadTemplatesFixture(t, "get.json")
+
+	var template Template
+	if err := json.Unmarshal(data, &template); err != nil {
+		t.Fatalf("failed to unmarshal get.json: %v", err)
+	}
+
+	if template.ID != 2085958501 {
+		t.Errorf("expected ID 2085958501, got %d", template.ID)
+	}
+	if template.Name != "Project Template" {
+		t.Errorf("expected name 'Project Template', got %q", template.Name)
+	}
+	if template.Description != "Standard project template for new initiatives." {
+		t.Errorf("expected description 'Standard project template for new initiatives.', got %q", template.Description)
+	}
+	if template.CreatedAt.IsZero() {
+		t.Error("expected non-zero CreatedAt")
+	}
+	if template.UpdatedAt.IsZero() {
+		t.Error("expected non-zero UpdatedAt")
+	}
+}
+
+func TestCreateTemplateRequest_Marshal(t *testing.T) {
+	data := loadTemplatesFixture(t, "create-request.json")
+
+	var req CreateTemplateRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		t.Fatalf("failed to unmarshal create-request.json: %v", err)
+	}
+
+	if req.Name != "New Template" {
+		t.Errorf("expected name 'New Template', got %q", req.Name)
+	}
+	if req.Description != "A new project template." {
+		t.Errorf("expected description 'A new project template.', got %q", req.Description)
+	}
+
+	// Re-marshal and verify round-trip
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal CreateTemplateRequest: %v", err)
+	}
+
+	var roundtrip CreateTemplateRequest
+	if err := json.Unmarshal(out, &roundtrip); err != nil {
+		t.Fatalf("failed to unmarshal round-trip: %v", err)
+	}
+
+	if roundtrip.Name != req.Name || roundtrip.Description != req.Description {
+		t.Error("round-trip mismatch")
+	}
+}
+
+func TestUpdateTemplateRequest_Marshal(t *testing.T) {
+	data := loadTemplatesFixture(t, "update-request.json")
+
+	var req UpdateTemplateRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		t.Fatalf("failed to unmarshal update-request.json: %v", err)
+	}
+
+	if req.Name != "Updated Template" {
+		t.Errorf("expected name 'Updated Template', got %q", req.Name)
+	}
+	if req.Description != "Updated template description." {
+		t.Errorf("expected description 'Updated template description.', got %q", req.Description)
+	}
+}
+
+func TestProjectConstruction_Unmarshal(t *testing.T) {
+	data := loadTemplatesFixture(t, "project_construction.json")
+
+	var construction ProjectConstruction
+	if err := json.Unmarshal(data, &construction); err != nil {
+		t.Fatalf("failed to unmarshal project_construction.json: %v", err)
+	}
+
+	if construction.ID != 1234567890 {
+		t.Errorf("expected ID 1234567890, got %d", construction.ID)
+	}
+	if construction.Status != "pending" {
+		t.Errorf("expected status 'pending', got %q", construction.Status)
+	}
+	if construction.URL == "" {
+		t.Error("expected non-empty URL")
+	}
+	if construction.Project != nil {
+		t.Error("expected nil Project for pending construction")
+	}
+}
+
+func TestProjectConstruction_UnmarshalCompleted(t *testing.T) {
+	data := loadTemplatesFixture(t, "project_construction_completed.json")
+
+	var construction ProjectConstruction
+	if err := json.Unmarshal(data, &construction); err != nil {
+		t.Fatalf("failed to unmarshal project_construction_completed.json: %v", err)
+	}
+
+	if construction.ID != 1234567890 {
+		t.Errorf("expected ID 1234567890, got %d", construction.ID)
+	}
+	if construction.Status != "completed" {
+		t.Errorf("expected status 'completed', got %q", construction.Status)
+	}
+	if construction.Project == nil {
+		t.Fatal("expected non-nil Project for completed construction")
+	}
+	if construction.Project.ID != 2085958503 {
+		t.Errorf("expected Project.ID 2085958503, got %d", construction.Project.ID)
+	}
+	if construction.Project.Name != "New Project from Template" {
+		t.Errorf("expected Project.Name 'New Project from Template', got %q", construction.Project.Name)
+	}
+}
+
+func TestTemplate_TimestampParsing(t *testing.T) {
+	data := loadTemplatesFixture(t, "get.json")
+
+	var template Template
+	if err := json.Unmarshal(data, &template); err != nil {
+		t.Fatalf("failed to unmarshal get.json: %v", err)
+	}
+
+	// Verify ISO8601 timestamps parse correctly
+	// created_at: "2022-10-28T08:23:58.169Z"
+	if template.CreatedAt.Year() != 2022 {
+		t.Errorf("expected year 2022, got %d", template.CreatedAt.Year())
+	}
+	if template.CreatedAt.Month() != 10 {
+		t.Errorf("expected month 10, got %d", template.CreatedAt.Month())
+	}
+	if template.CreatedAt.Day() != 28 {
+		t.Errorf("expected day 28, got %d", template.CreatedAt.Day())
+	}
+}

--- a/spec/fixtures/templates/create-request.json
+++ b/spec/fixtures/templates/create-request.json
@@ -1,0 +1,4 @@
+{
+  "name": "New Template",
+  "description": "A new project template."
+}

--- a/spec/fixtures/templates/get.json
+++ b/spec/fixtures/templates/get.json
@@ -1,0 +1,8 @@
+{
+  "id": 2085958501,
+  "status": "active",
+  "created_at": "2022-10-28T08:23:58.169Z",
+  "updated_at": "2022-11-22T17:56:27.363Z",
+  "name": "Project Template",
+  "description": "Standard project template for new initiatives."
+}

--- a/spec/fixtures/templates/list.json
+++ b/spec/fixtures/templates/list.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": 2085958501,
+    "status": "active",
+    "created_at": "2022-10-28T08:23:58.169Z",
+    "updated_at": "2022-11-22T17:56:27.363Z",
+    "name": "Project Template",
+    "description": "Standard project template for new initiatives."
+  },
+  {
+    "id": 2085958502,
+    "status": "active",
+    "created_at": "2022-09-15T10:30:00.000Z",
+    "updated_at": "2022-11-20T14:22:15.000Z",
+    "name": "Client Onboarding",
+    "description": "Template for onboarding new clients."
+  }
+]

--- a/spec/fixtures/templates/project_construction.json
+++ b/spec/fixtures/templates/project_construction.json
@@ -1,0 +1,5 @@
+{
+  "id": 1234567890,
+  "status": "pending",
+  "url": "https://3.basecampapi.com/195539477/templates/2085958501/project_constructions/1234567890.json"
+}

--- a/spec/fixtures/templates/project_construction_completed.json
+++ b/spec/fixtures/templates/project_construction_completed.json
@@ -1,0 +1,15 @@
+{
+  "id": 1234567890,
+  "status": "completed",
+  "url": "https://3.basecampapi.com/195539477/templates/2085958501/project_constructions/1234567890.json",
+  "project": {
+    "id": 2085958503,
+    "status": "active",
+    "created_at": "2022-11-25T10:00:00.000Z",
+    "updated_at": "2022-11-25T10:00:00.000Z",
+    "name": "New Project from Template",
+    "description": "Created from Project Template.",
+    "url": "https://3.basecampapi.com/195539477/projects/2085958503.json",
+    "app_url": "https://3.basecamp.com/195539477/projects/2085958503"
+  }
+}

--- a/spec/fixtures/templates/update-request.json
+++ b/spec/fixtures/templates/update-request.json
@@ -1,0 +1,4 @@
+{
+  "name": "Updated Template",
+  "description": "Updated template description."
+}


### PR DESCRIPTION
## Summary
- Add `Template` and `ProjectConstruction` structs
- Implement `TemplatesService` with full CRUD operations (List, Get, Create, Update, Delete)
- Add `CreateProject` and `GetConstruction` methods for creating projects from templates
- Add `Templates()` accessor to Client
- Include test fixtures and comprehensive tests

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `go build ./...` passes