### PR TITLE
Add ToolsService for project dock tools

### DIFF
--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -46,6 +46,7 @@ type Client struct {
 	events         *EventsService
 	search          *SearchService
 	templates       *TemplatesService
+	tools           *ToolsService
 }
 
 // Response wraps an API response.
@@ -591,4 +592,12 @@ func (c *Client) Templates() *TemplatesService {
 		c.templates = NewTemplatesService(c)
 	}
 	return c.templates
+}
+
+// Tools returns the ToolsService for dock tool operations.
+func (c *Client) Tools() *ToolsService {
+	if c.tools == nil {
+		c.tools = NewToolsService(c)
+	}
+	return c.tools
 }

--- a/go/pkg/basecamp/tools.go
+++ b/go/pkg/basecamp/tools.go
@@ -1,0 +1,165 @@
+package basecamp
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Tool represents a dock tool in a Basecamp project.
+type Tool struct {
+	ID        int64     `json:"id"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Title     string    `json:"title"`
+	Name      string    `json:"name"`
+	Enabled   bool      `json:"enabled"`
+	Position  *int      `json:"position"`
+	URL       string    `json:"url"`
+	AppURL    string    `json:"app_url"`
+	Bucket    *Bucket   `json:"bucket,omitempty"`
+}
+
+// UpdateToolRequest specifies the parameters for updating (renaming) a tool.
+type UpdateToolRequest struct {
+	// Name is the new name for the tool (required).
+	Name string `json:"name"`
+}
+
+// ToolsService handles dock tool operations.
+type ToolsService struct {
+	client *Client
+}
+
+// NewToolsService creates a new ToolsService.
+func NewToolsService(client *Client) *ToolsService {
+	return &ToolsService{client: client}
+}
+
+// Get returns a tool by ID.
+// bucketID is the project ID, toolID is the tool ID.
+func (s *ToolsService) Get(ctx context.Context, bucketID, toolID int64) (*Tool, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/dock/tools/%d.json", bucketID, toolID)
+	resp, err := s.client.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var tool Tool
+	if err := resp.UnmarshalData(&tool); err != nil {
+		return nil, fmt.Errorf("failed to parse tool: %w", err)
+	}
+
+	return &tool, nil
+}
+
+// Create clones an existing tool to create a new one.
+// bucketID is the project ID, sourceToolID is the ID of the tool to clone.
+// Returns the newly created tool.
+func (s *ToolsService) Create(ctx context.Context, bucketID, sourceToolID int64) (*Tool, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/dock/tools/%d/clone.json", bucketID, sourceToolID)
+	resp, err := s.client.Post(ctx, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var tool Tool
+	if err := resp.UnmarshalData(&tool); err != nil {
+		return nil, fmt.Errorf("failed to parse tool: %w", err)
+	}
+
+	return &tool, nil
+}
+
+// Update updates (renames) an existing tool.
+// bucketID is the project ID, toolID is the tool ID.
+// Returns the updated tool.
+func (s *ToolsService) Update(ctx context.Context, bucketID, toolID int64, name string) (*Tool, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	if name == "" {
+		return nil, ErrUsage("tool name is required")
+	}
+
+	path := fmt.Sprintf("/buckets/%d/dock/tools/%d.json", bucketID, toolID)
+	req := &UpdateToolRequest{Name: name}
+	resp, err := s.client.Put(ctx, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var tool Tool
+	if err := resp.UnmarshalData(&tool); err != nil {
+		return nil, fmt.Errorf("failed to parse tool: %w", err)
+	}
+
+	return &tool, nil
+}
+
+// Delete moves a tool to the trash.
+// bucketID is the project ID, toolID is the tool ID.
+// Trashed tools can be recovered from the trash.
+func (s *ToolsService) Delete(ctx context.Context, bucketID, toolID int64) error {
+	if err := s.client.RequireAccount(); err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/dock/tools/%d.json", bucketID, toolID)
+	_, err := s.client.Delete(ctx, path)
+	return err
+}
+
+// Enable enables (shows) a tool on the project dock.
+// bucketID is the project ID, toolID is the tool ID.
+// The tool will be placed at the end of the dock.
+func (s *ToolsService) Enable(ctx context.Context, bucketID, toolID int64) error {
+	if err := s.client.RequireAccount(); err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/dock/tools/%d/position.json", bucketID, toolID)
+	_, err := s.client.Post(ctx, path, nil)
+	return err
+}
+
+// Disable disables (hides) a tool from the project dock.
+// bucketID is the project ID, toolID is the tool ID.
+// The tool is not deleted, just hidden from the dock.
+func (s *ToolsService) Disable(ctx context.Context, bucketID, toolID int64) error {
+	if err := s.client.RequireAccount(); err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/dock/tools/%d/position.json", bucketID, toolID)
+	_, err := s.client.Delete(ctx, path)
+	return err
+}
+
+// Reposition changes the position of a tool on the project dock.
+// bucketID is the project ID, toolID is the tool ID.
+// position is 1-based (1 = first position on dock).
+func (s *ToolsService) Reposition(ctx context.Context, bucketID, toolID int64, position int) error {
+	if err := s.client.RequireAccount(); err != nil {
+		return err
+	}
+
+	if position < 1 {
+		return ErrUsage("position must be at least 1")
+	}
+
+	path := fmt.Sprintf("/buckets/%d/dock/tools/%d/position.json", bucketID, toolID)
+	body := map[string]int{"position": position}
+	_, err := s.client.Put(ctx, path, body)
+	return err
+}

--- a/go/pkg/basecamp/tools_test.go
+++ b/go/pkg/basecamp/tools_test.go
@@ -1,0 +1,177 @@
+package basecamp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func toolsFixturesDir() string {
+	return filepath.Join("..", "..", "..", "spec", "fixtures", "tools")
+}
+
+func loadToolsFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	path := filepath.Join(toolsFixturesDir(), name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func TestTool_UnmarshalGet(t *testing.T) {
+	data := loadToolsFixture(t, "get.json")
+
+	var tool Tool
+	if err := json.Unmarshal(data, &tool); err != nil {
+		t.Fatalf("failed to unmarshal get.json: %v", err)
+	}
+
+	if tool.ID != 1069479339 {
+		t.Errorf("expected ID 1069479339, got %d", tool.ID)
+	}
+	if tool.Status != "active" {
+		t.Errorf("expected status 'active', got %q", tool.Status)
+	}
+	if tool.Title != "To-dos" {
+		t.Errorf("expected title 'To-dos', got %q", tool.Title)
+	}
+	if tool.Name != "todoset" {
+		t.Errorf("expected name 'todoset', got %q", tool.Name)
+	}
+	if !tool.Enabled {
+		t.Error("expected Enabled to be true")
+	}
+	if tool.Position == nil || *tool.Position != 2 {
+		t.Errorf("expected position 2, got %v", tool.Position)
+	}
+	if tool.URL != "https://3.basecampapi.com/195539477/buckets/2085958499/todosets/1069479339.json" {
+		t.Errorf("unexpected URL: %q", tool.URL)
+	}
+	if tool.AppURL != "https://3.basecamp.com/195539477/buckets/2085958499/todosets/1069479339" {
+		t.Errorf("unexpected AppURL: %q", tool.AppURL)
+	}
+
+	// Verify timestamps are parsed
+	if tool.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be non-zero")
+	}
+	if tool.UpdatedAt.IsZero() {
+		t.Error("expected UpdatedAt to be non-zero")
+	}
+
+	// Verify bucket
+	if tool.Bucket == nil {
+		t.Fatal("expected Bucket to be non-nil")
+	}
+	if tool.Bucket.ID != 2085958499 {
+		t.Errorf("expected Bucket.ID 2085958499, got %d", tool.Bucket.ID)
+	}
+	if tool.Bucket.Name != "The Leto Laptop" {
+		t.Errorf("expected Bucket.Name 'The Leto Laptop', got %q", tool.Bucket.Name)
+	}
+	if tool.Bucket.Type != "Project" {
+		t.Errorf("expected Bucket.Type 'Project', got %q", tool.Bucket.Type)
+	}
+}
+
+func TestTool_UnmarshalCreate(t *testing.T) {
+	data := loadToolsFixture(t, "create.json")
+
+	var tool Tool
+	if err := json.Unmarshal(data, &tool); err != nil {
+		t.Fatalf("failed to unmarshal create.json: %v", err)
+	}
+
+	if tool.ID != 1069479400 {
+		t.Errorf("expected ID 1069479400, got %d", tool.ID)
+	}
+	if tool.Title != "To-dos (copy)" {
+		t.Errorf("expected title 'To-dos (copy)', got %q", tool.Title)
+	}
+	if tool.Name != "todoset" {
+		t.Errorf("expected name 'todoset', got %q", tool.Name)
+	}
+	if !tool.Enabled {
+		t.Error("expected Enabled to be true")
+	}
+	if tool.Position == nil || *tool.Position != 6 {
+		t.Errorf("expected position 6, got %v", tool.Position)
+	}
+}
+
+func TestTool_UnmarshalUpdate(t *testing.T) {
+	data := loadToolsFixture(t, "update.json")
+
+	var tool Tool
+	if err := json.Unmarshal(data, &tool); err != nil {
+		t.Fatalf("failed to unmarshal update.json: %v", err)
+	}
+
+	if tool.ID != 1069479339 {
+		t.Errorf("expected ID 1069479339, got %d", tool.ID)
+	}
+	if tool.Title != "Project Tasks" {
+		t.Errorf("expected title 'Project Tasks', got %q", tool.Title)
+	}
+	if tool.Name != "todoset" {
+		t.Errorf("expected name 'todoset', got %q", tool.Name)
+	}
+}
+
+func TestTool_UnmarshalDisabled(t *testing.T) {
+	data := loadToolsFixture(t, "disabled.json")
+
+	var tool Tool
+	if err := json.Unmarshal(data, &tool); err != nil {
+		t.Fatalf("failed to unmarshal disabled.json: %v", err)
+	}
+
+	if tool.ID != 1069479343 {
+		t.Errorf("expected ID 1069479343, got %d", tool.ID)
+	}
+	if tool.Title != "Automatic Check-ins" {
+		t.Errorf("expected title 'Automatic Check-ins', got %q", tool.Title)
+	}
+	if tool.Name != "questionnaire" {
+		t.Errorf("expected name 'questionnaire', got %q", tool.Name)
+	}
+	if tool.Enabled {
+		t.Error("expected Enabled to be false")
+	}
+	if tool.Position != nil {
+		t.Errorf("expected position to be nil, got %v", tool.Position)
+	}
+}
+
+func TestUpdateToolRequest_Marshal(t *testing.T) {
+	req := UpdateToolRequest{
+		Name: "Project Tasks",
+	}
+
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal UpdateToolRequest: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(out, &data); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	if data["name"] != "Project Tasks" {
+		t.Errorf("expected name 'Project Tasks', got %v", data["name"])
+	}
+
+	// Round-trip test
+	var roundtrip UpdateToolRequest
+	if err := json.Unmarshal(out, &roundtrip); err != nil {
+		t.Fatalf("failed to unmarshal round-trip: %v", err)
+	}
+
+	if roundtrip.Name != req.Name {
+		t.Errorf("expected name %q, got %q", req.Name, roundtrip.Name)
+	}
+}

--- a/spec/fixtures/tools/create.json
+++ b/spec/fixtures/tools/create.json
@@ -1,0 +1,17 @@
+{
+  "id": 1069479400,
+  "status": "active",
+  "created_at": "2022-11-25T10:00:00.000Z",
+  "updated_at": "2022-11-25T10:00:00.000Z",
+  "title": "To-dos (copy)",
+  "name": "todoset",
+  "enabled": true,
+  "position": 6,
+  "url": "https://3.basecampapi.com/195539477/buckets/2085958499/todosets/1069479400.json",
+  "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/todosets/1069479400",
+  "bucket": {
+    "id": 2085958499,
+    "name": "The Leto Laptop",
+    "type": "Project"
+  }
+}

--- a/spec/fixtures/tools/disabled.json
+++ b/spec/fixtures/tools/disabled.json
@@ -1,0 +1,17 @@
+{
+  "id": 1069479343,
+  "status": "active",
+  "created_at": "2022-10-28T08:23:58.169Z",
+  "updated_at": "2022-11-22T17:56:27.363Z",
+  "title": "Automatic Check-ins",
+  "name": "questionnaire",
+  "enabled": false,
+  "position": null,
+  "url": "https://3.basecampapi.com/195539477/buckets/2085958499/questionnaires/1069479343.json",
+  "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/questionnaires/1069479343",
+  "bucket": {
+    "id": 2085958499,
+    "name": "The Leto Laptop",
+    "type": "Project"
+  }
+}

--- a/spec/fixtures/tools/get.json
+++ b/spec/fixtures/tools/get.json
@@ -1,0 +1,17 @@
+{
+  "id": 1069479339,
+  "status": "active",
+  "created_at": "2022-10-28T08:23:58.169Z",
+  "updated_at": "2022-11-22T17:56:27.363Z",
+  "title": "To-dos",
+  "name": "todoset",
+  "enabled": true,
+  "position": 2,
+  "url": "https://3.basecampapi.com/195539477/buckets/2085958499/todosets/1069479339.json",
+  "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/todosets/1069479339",
+  "bucket": {
+    "id": 2085958499,
+    "name": "The Leto Laptop",
+    "type": "Project"
+  }
+}

--- a/spec/fixtures/tools/update.json
+++ b/spec/fixtures/tools/update.json
@@ -1,0 +1,17 @@
+{
+  "id": 1069479339,
+  "status": "active",
+  "created_at": "2022-10-28T08:23:58.169Z",
+  "updated_at": "2022-11-25T12:00:00.000Z",
+  "title": "Project Tasks",
+  "name": "todoset",
+  "enabled": true,
+  "position": 2,
+  "url": "https://3.basecampapi.com/195539477/buckets/2085958499/todosets/1069479339.json",
+  "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/todosets/1069479339",
+  "bucket": {
+    "id": 2085958499,
+    "name": "The Leto Laptop",
+    "type": "Project"
+  }
+}


### PR DESCRIPTION
## Summary
- Add ToolsService to manage project dock tools (get, clone, rename, trash, enable/disable, reposition)
- Add Tool struct representing a dock tool with full metadata
- Add UpdateToolRequest for renaming tools
- Add Tools() accessor to Client
- Add test fixtures and unit tests for Tool unmarshaling

## Test plan
- [x] Unit tests pass (`go test ./...`)
- [x] Code compiles (`go build ./...`)
- [x] Code passes vet (`go vet ./...`)