### PR TITLE
Add LineupService for lineup markers

### DIFF
--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -47,6 +47,7 @@ type Client struct {
 	search          *SearchService
 	templates       *TemplatesService
 	tools           *ToolsService
+	lineup          *LineupService
 }
 
 // Response wraps an API response.
@@ -600,4 +601,12 @@ func (c *Client) Tools() *ToolsService {
 		c.tools = NewToolsService(c)
 	}
 	return c.tools
+}
+
+// Lineup returns the LineupService for lineup marker operations.
+func (c *Client) Lineup() *LineupService {
+	if c.lineup == nil {
+		c.lineup = NewLineupService(c)
+	}
+	return c.lineup
 }

--- a/go/pkg/basecamp/lineup.go
+++ b/go/pkg/basecamp/lineup.go
@@ -1,0 +1,133 @@
+package basecamp
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// LineupMarker represents a marker on the Basecamp Lineup.
+type LineupMarker struct {
+	ID          int64     `json:"id"`
+	Status      string    `json:"status"`
+	Color       string    `json:"color"`
+	Title       string    `json:"title"`
+	StartsOn    string    `json:"starts_on"`
+	EndsOn      string    `json:"ends_on"`
+	Description string    `json:"description,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+	Type        string    `json:"type"`
+	URL         string    `json:"url"`
+	AppURL      string    `json:"app_url"`
+	Creator     *Person   `json:"creator,omitempty"`
+	Parent      *Parent   `json:"parent,omitempty"`
+	Bucket      *Bucket   `json:"bucket,omitempty"`
+}
+
+// CreateMarkerRequest specifies the parameters for creating a lineup marker.
+type CreateMarkerRequest struct {
+	// Title is the marker title (required).
+	Title string `json:"title"`
+	// StartsOn is the start date in YYYY-MM-DD format (required).
+	StartsOn string `json:"starts_on"`
+	// EndsOn is the end date in YYYY-MM-DD format (required).
+	EndsOn string `json:"ends_on"`
+	// Color is the marker color (optional).
+	Color string `json:"color,omitempty"`
+	// Description is the marker description in HTML (optional).
+	Description string `json:"description,omitempty"`
+}
+
+// UpdateMarkerRequest specifies the parameters for updating a lineup marker.
+type UpdateMarkerRequest struct {
+	// Title is the marker title (optional).
+	Title string `json:"title,omitempty"`
+	// StartsOn is the start date in YYYY-MM-DD format (optional).
+	StartsOn string `json:"starts_on,omitempty"`
+	// EndsOn is the end date in YYYY-MM-DD format (optional).
+	EndsOn string `json:"ends_on,omitempty"`
+	// Color is the marker color (optional).
+	Color string `json:"color,omitempty"`
+	// Description is the marker description in HTML (optional).
+	Description string `json:"description,omitempty"`
+}
+
+// LineupService handles lineup marker operations.
+type LineupService struct {
+	client *Client
+}
+
+// NewLineupService creates a new LineupService.
+func NewLineupService(client *Client) *LineupService {
+	return &LineupService{client: client}
+}
+
+// CreateMarker creates a new marker on the lineup.
+// Returns the created marker.
+func (s *LineupService) CreateMarker(ctx context.Context, req *CreateMarkerRequest) (*LineupMarker, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	if req == nil || req.Title == "" {
+		return nil, ErrUsage("marker title is required")
+	}
+	if req.StartsOn == "" {
+		return nil, ErrUsage("marker starts_on date is required")
+	}
+	if req.EndsOn == "" {
+		return nil, ErrUsage("marker ends_on date is required")
+	}
+
+	path := "/lineup/markers.json"
+	resp, err := s.client.Post(ctx, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var marker LineupMarker
+	if err := resp.UnmarshalData(&marker); err != nil {
+		return nil, fmt.Errorf("failed to parse marker: %w", err)
+	}
+
+	return &marker, nil
+}
+
+// UpdateMarker updates an existing marker.
+// markerID is the marker ID.
+// Returns the updated marker.
+func (s *LineupService) UpdateMarker(ctx context.Context, markerID int64, req *UpdateMarkerRequest) (*LineupMarker, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	if req == nil {
+		return nil, ErrUsage("update request is required")
+	}
+
+	path := fmt.Sprintf("/lineup/markers/%d.json", markerID)
+	resp, err := s.client.Put(ctx, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var marker LineupMarker
+	if err := resp.UnmarshalData(&marker); err != nil {
+		return nil, fmt.Errorf("failed to parse marker: %w", err)
+	}
+
+	return &marker, nil
+}
+
+// DeleteMarker deletes a marker.
+// markerID is the marker ID.
+func (s *LineupService) DeleteMarker(ctx context.Context, markerID int64) error {
+	if err := s.client.RequireAccount(); err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/lineup/markers/%d.json", markerID)
+	_, err := s.client.Delete(ctx, path)
+	return err
+}

--- a/go/pkg/basecamp/lineup_test.go
+++ b/go/pkg/basecamp/lineup_test.go
@@ -1,0 +1,280 @@
+package basecamp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func lineupFixturesDir() string {
+	return filepath.Join("..", "..", "..", "spec", "fixtures", "lineup")
+}
+
+func loadLineupFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	path := filepath.Join(lineupFixturesDir(), name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func TestLineupMarker_UnmarshalCreate(t *testing.T) {
+	data := loadLineupFixture(t, "create.json")
+
+	var marker LineupMarker
+	if err := json.Unmarshal(data, &marker); err != nil {
+		t.Fatalf("failed to unmarshal create.json: %v", err)
+	}
+
+	if marker.ID != 1069479400 {
+		t.Errorf("expected ID 1069479400, got %d", marker.ID)
+	}
+	if marker.Status != "active" {
+		t.Errorf("expected status 'active', got %q", marker.Status)
+	}
+	if marker.Type != "Lineup::Marker" {
+		t.Errorf("expected type 'Lineup::Marker', got %q", marker.Type)
+	}
+	if marker.Title != "Product Launch" {
+		t.Errorf("expected title 'Product Launch', got %q", marker.Title)
+	}
+	if marker.Color != "blue" {
+		t.Errorf("expected color 'blue', got %q", marker.Color)
+	}
+	if marker.StartsOn != "2024-03-01" {
+		t.Errorf("expected starts_on '2024-03-01', got %q", marker.StartsOn)
+	}
+	if marker.EndsOn != "2024-03-15" {
+		t.Errorf("expected ends_on '2024-03-15', got %q", marker.EndsOn)
+	}
+	if marker.Description != "<div>Launch phase for the new product</div>" {
+		t.Errorf("unexpected description: %q", marker.Description)
+	}
+	if marker.URL != "https://3.basecampapi.com/195539477/lineup/markers/1069479400.json" {
+		t.Errorf("unexpected URL: %q", marker.URL)
+	}
+	if marker.AppURL != "https://3.basecamp.com/195539477/lineup" {
+		t.Errorf("unexpected AppURL: %q", marker.AppURL)
+	}
+
+	// Verify timestamps are parsed
+	if marker.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be non-zero")
+	}
+	if marker.UpdatedAt.IsZero() {
+		t.Error("expected UpdatedAt to be non-zero")
+	}
+
+	// Verify creator
+	if marker.Creator == nil {
+		t.Fatal("expected Creator to be non-nil")
+	}
+	if marker.Creator.ID != 1049715914 {
+		t.Errorf("expected Creator.ID 1049715914, got %d", marker.Creator.ID)
+	}
+	if marker.Creator.Name != "Victor Cooper" {
+		t.Errorf("expected Creator.Name 'Victor Cooper', got %q", marker.Creator.Name)
+	}
+	if marker.Creator.EmailAddress != "victor@honchodesign.com" {
+		t.Errorf("expected Creator.EmailAddress 'victor@honchodesign.com', got %q", marker.Creator.EmailAddress)
+	}
+}
+
+func TestLineupMarker_UnmarshalUpdate(t *testing.T) {
+	data := loadLineupFixture(t, "update.json")
+
+	var marker LineupMarker
+	if err := json.Unmarshal(data, &marker); err != nil {
+		t.Fatalf("failed to unmarshal update.json: %v", err)
+	}
+
+	if marker.ID != 1069479400 {
+		t.Errorf("expected ID 1069479400, got %d", marker.ID)
+	}
+	if marker.Title != "Product Launch - Extended" {
+		t.Errorf("expected title 'Product Launch - Extended', got %q", marker.Title)
+	}
+	if marker.Color != "green" {
+		t.Errorf("expected color 'green', got %q", marker.Color)
+	}
+	if marker.EndsOn != "2024-03-31" {
+		t.Errorf("expected ends_on '2024-03-31', got %q", marker.EndsOn)
+	}
+	if marker.Description != "<div>Extended launch phase for the new product</div>" {
+		t.Errorf("unexpected description: %q", marker.Description)
+	}
+}
+
+func TestCreateMarkerRequest_Marshal(t *testing.T) {
+	req := CreateMarkerRequest{
+		Title:       "Sprint 1",
+		StartsOn:    "2024-04-01",
+		EndsOn:      "2024-04-14",
+		Color:       "purple",
+		Description: "<div>First sprint</div>",
+	}
+
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal CreateMarkerRequest: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(out, &data); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	if data["title"] != "Sprint 1" {
+		t.Errorf("unexpected title: %v", data["title"])
+	}
+	if data["starts_on"] != "2024-04-01" {
+		t.Errorf("unexpected starts_on: %v", data["starts_on"])
+	}
+	if data["ends_on"] != "2024-04-14" {
+		t.Errorf("unexpected ends_on: %v", data["ends_on"])
+	}
+	if data["color"] != "purple" {
+		t.Errorf("unexpected color: %v", data["color"])
+	}
+	if data["description"] != "<div>First sprint</div>" {
+		t.Errorf("unexpected description: %v", data["description"])
+	}
+
+	// Round-trip test
+	var roundtrip CreateMarkerRequest
+	if err := json.Unmarshal(out, &roundtrip); err != nil {
+		t.Fatalf("failed to unmarshal round-trip: %v", err)
+	}
+
+	if roundtrip.Title != req.Title {
+		t.Errorf("expected title %q, got %q", req.Title, roundtrip.Title)
+	}
+	if roundtrip.StartsOn != req.StartsOn {
+		t.Errorf("expected starts_on %q, got %q", req.StartsOn, roundtrip.StartsOn)
+	}
+	if roundtrip.EndsOn != req.EndsOn {
+		t.Errorf("expected ends_on %q, got %q", req.EndsOn, roundtrip.EndsOn)
+	}
+}
+
+func TestCreateMarkerRequest_MarshalMinimal(t *testing.T) {
+	// Test with only required fields
+	req := CreateMarkerRequest{
+		Title:    "Quick marker",
+		StartsOn: "2024-05-01",
+		EndsOn:   "2024-05-07",
+	}
+
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal CreateMarkerRequest: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(out, &data); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	if data["title"] != "Quick marker" {
+		t.Errorf("unexpected title: %v", data["title"])
+	}
+	if data["starts_on"] != "2024-05-01" {
+		t.Errorf("unexpected starts_on: %v", data["starts_on"])
+	}
+	if data["ends_on"] != "2024-05-07" {
+		t.Errorf("unexpected ends_on: %v", data["ends_on"])
+	}
+	// Optional fields with omitempty should not be present
+	if _, ok := data["color"]; ok {
+		t.Error("expected color to be omitted")
+	}
+	if _, ok := data["description"]; ok {
+		t.Error("expected description to be omitted")
+	}
+}
+
+func TestUpdateMarkerRequest_Marshal(t *testing.T) {
+	req := UpdateMarkerRequest{
+		Title:       "Updated Sprint",
+		StartsOn:    "2024-04-01",
+		EndsOn:      "2024-04-21",
+		Color:       "orange",
+		Description: "<div>Extended sprint</div>",
+	}
+
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal UpdateMarkerRequest: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(out, &data); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	if data["title"] != "Updated Sprint" {
+		t.Errorf("unexpected title: %v", data["title"])
+	}
+	if data["starts_on"] != "2024-04-01" {
+		t.Errorf("unexpected starts_on: %v", data["starts_on"])
+	}
+	if data["ends_on"] != "2024-04-21" {
+		t.Errorf("unexpected ends_on: %v", data["ends_on"])
+	}
+	if data["color"] != "orange" {
+		t.Errorf("unexpected color: %v", data["color"])
+	}
+	if data["description"] != "<div>Extended sprint</div>" {
+		t.Errorf("unexpected description: %v", data["description"])
+	}
+
+	// Round-trip test
+	var roundtrip UpdateMarkerRequest
+	if err := json.Unmarshal(out, &roundtrip); err != nil {
+		t.Fatalf("failed to unmarshal round-trip: %v", err)
+	}
+
+	if roundtrip.Title != req.Title {
+		t.Errorf("expected title %q, got %q", req.Title, roundtrip.Title)
+	}
+	if roundtrip.EndsOn != req.EndsOn {
+		t.Errorf("expected ends_on %q, got %q", req.EndsOn, roundtrip.EndsOn)
+	}
+}
+
+func TestUpdateMarkerRequest_MarshalPartial(t *testing.T) {
+	// Test with only some fields
+	req := UpdateMarkerRequest{
+		Title: "Just updating title",
+	}
+
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal UpdateMarkerRequest: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(out, &data); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	if data["title"] != "Just updating title" {
+		t.Errorf("unexpected title: %v", data["title"])
+	}
+	// Optional fields should be omitted
+	if _, ok := data["starts_on"]; ok {
+		t.Error("expected starts_on to be omitted")
+	}
+	if _, ok := data["ends_on"]; ok {
+		t.Error("expected ends_on to be omitted")
+	}
+	if _, ok := data["color"]; ok {
+		t.Error("expected color to be omitted")
+	}
+	if _, ok := data["description"]; ok {
+		t.Error("expected description to be omitted")
+	}
+}

--- a/spec/fixtures/lineup/create.json
+++ b/spec/fixtures/lineup/create.json
@@ -1,0 +1,29 @@
+{
+  "id": 1069479400,
+  "status": "active",
+  "color": "blue",
+  "title": "Product Launch",
+  "starts_on": "2024-03-01",
+  "ends_on": "2024-03-15",
+  "description": "<div>Launch phase for the new product</div>",
+  "created_at": "2024-02-15T10:30:00.000Z",
+  "updated_at": "2024-02-15T10:30:00.000Z",
+  "type": "Lineup::Marker",
+  "url": "https://3.basecampapi.com/195539477/lineup/markers/1069479400.json",
+  "app_url": "https://3.basecamp.com/195539477/lineup",
+  "creator": {
+    "id": 1049715914,
+    "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aeb392ebf54ffd1e041c3b8a49481eebbf69d8b3",
+    "name": "Victor Cooper",
+    "email_address": "victor@honchodesign.com",
+    "personable_type": "User",
+    "title": "Chief Strategist",
+    "bio": "Don't let your dreams be dreams",
+    "location": "Chicago, IL",
+    "admin": true,
+    "owner": true,
+    "client": false,
+    "time_zone": "America/Chicago",
+    "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--5520caeec1845b5090bbfc993bbe8f684dd4d01d/avatar?v=1"
+  }
+}

--- a/spec/fixtures/lineup/update.json
+++ b/spec/fixtures/lineup/update.json
@@ -1,0 +1,29 @@
+{
+  "id": 1069479400,
+  "status": "active",
+  "color": "green",
+  "title": "Product Launch - Extended",
+  "starts_on": "2024-03-01",
+  "ends_on": "2024-03-31",
+  "description": "<div>Extended launch phase for the new product</div>",
+  "created_at": "2024-02-15T10:30:00.000Z",
+  "updated_at": "2024-02-20T14:45:00.000Z",
+  "type": "Lineup::Marker",
+  "url": "https://3.basecampapi.com/195539477/lineup/markers/1069479400.json",
+  "app_url": "https://3.basecamp.com/195539477/lineup",
+  "creator": {
+    "id": 1049715914,
+    "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aeb392ebf54ffd1e041c3b8a49481eebbf69d8b3",
+    "name": "Victor Cooper",
+    "email_address": "victor@honchodesign.com",
+    "personable_type": "User",
+    "title": "Chief Strategist",
+    "bio": "Don't let your dreams be dreams",
+    "location": "Chicago, IL",
+    "admin": true,
+    "owner": true,
+    "client": false,
+    "time_zone": "America/Chicago",
+    "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--5520caeec1845b5090bbfc993bbe8f684dd4d01d/avatar?v=1"
+  }
+}


### PR DESCRIPTION
Adds LineupService with CreateMarker, UpdateMarker, and DeleteMarker
methods for managing lineup markers via the Basecamp API.
