### PR TITLE
Add SubscriptionsService for recording subscriptions

### DIFF
--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -48,6 +48,7 @@ type Client struct {
 	templates       *TemplatesService
 	tools           *ToolsService
 	lineup          *LineupService
+	subscriptions   *SubscriptionsService
 }
 
 // Response wraps an API response.
@@ -609,4 +610,12 @@ func (c *Client) Lineup() *LineupService {
 		c.lineup = NewLineupService(c)
 	}
 	return c.lineup
+}
+
+// Subscriptions returns the SubscriptionsService for subscription operations.
+func (c *Client) Subscriptions() *SubscriptionsService {
+	if c.subscriptions == nil {
+		c.subscriptions = NewSubscriptionsService(c)
+	}
+	return c.subscriptions
 }

--- a/go/pkg/basecamp/subscriptions.go
+++ b/go/pkg/basecamp/subscriptions.go
@@ -1,0 +1,114 @@
+package basecamp
+
+import (
+	"context"
+	"fmt"
+)
+
+// Subscription represents the subscription state for a recording.
+type Subscription struct {
+	Subscribed  bool     `json:"subscribed"`
+	Count       int      `json:"count"`
+	URL         string   `json:"url"`
+	Subscribers []Person `json:"subscribers"`
+}
+
+// UpdateSubscriptionRequest specifies the parameters for updating subscriptions.
+type UpdateSubscriptionRequest struct {
+	// Subscriptions is a list of person IDs to subscribe to the recording.
+	Subscriptions []int64 `json:"subscriptions,omitempty"`
+	// Unsubscriptions is a list of person IDs to unsubscribe from the recording.
+	Unsubscriptions []int64 `json:"unsubscriptions,omitempty"`
+}
+
+// SubscriptionsService handles subscription operations on recordings.
+type SubscriptionsService struct {
+	client *Client
+}
+
+// NewSubscriptionsService creates a new SubscriptionsService.
+func NewSubscriptionsService(client *Client) *SubscriptionsService {
+	return &SubscriptionsService{client: client}
+}
+
+// Get returns the subscription information for a recording.
+// bucketID is the project ID, recordingID is the ID of the recording.
+func (s *SubscriptionsService) Get(ctx context.Context, bucketID, recordingID int64) (*Subscription, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/recordings/%d/subscription.json", bucketID, recordingID)
+	resp, err := s.client.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var subscription Subscription
+	if err := resp.UnmarshalData(&subscription); err != nil {
+		return nil, fmt.Errorf("failed to parse subscription: %w", err)
+	}
+
+	return &subscription, nil
+}
+
+// Subscribe subscribes the current user to the recording.
+// bucketID is the project ID, recordingID is the ID of the recording.
+// Returns the updated subscription information.
+func (s *SubscriptionsService) Subscribe(ctx context.Context, bucketID, recordingID int64) (*Subscription, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/recordings/%d/subscription.json", bucketID, recordingID)
+	resp, err := s.client.Post(ctx, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var subscription Subscription
+	if err := resp.UnmarshalData(&subscription); err != nil {
+		return nil, fmt.Errorf("failed to parse subscription: %w", err)
+	}
+
+	return &subscription, nil
+}
+
+// Unsubscribe unsubscribes the current user from the recording.
+// bucketID is the project ID, recordingID is the ID of the recording.
+// Returns nil on success (204 No Content).
+func (s *SubscriptionsService) Unsubscribe(ctx context.Context, bucketID, recordingID int64) error {
+	if err := s.client.RequireAccount(); err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/recordings/%d/subscription.json", bucketID, recordingID)
+	_, err := s.client.Delete(ctx, path)
+	return err
+}
+
+// Update batch modifies subscriptions by adding or removing specific users.
+// bucketID is the project ID, recordingID is the ID of the recording.
+// Returns the updated subscription information.
+func (s *SubscriptionsService) Update(ctx context.Context, bucketID, recordingID int64, req *UpdateSubscriptionRequest) (*Subscription, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	if req == nil || (len(req.Subscriptions) == 0 && len(req.Unsubscriptions) == 0) {
+		return nil, ErrUsage("at least one of subscriptions or unsubscriptions must be specified")
+	}
+
+	path := fmt.Sprintf("/buckets/%d/recordings/%d/subscription.json", bucketID, recordingID)
+	resp, err := s.client.Put(ctx, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var subscription Subscription
+	if err := resp.UnmarshalData(&subscription); err != nil {
+		return nil, fmt.Errorf("failed to parse subscription: %w", err)
+	}
+
+	return &subscription, nil
+}

--- a/go/pkg/basecamp/subscriptions_test.go
+++ b/go/pkg/basecamp/subscriptions_test.go
@@ -1,0 +1,230 @@
+package basecamp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func subscriptionsFixturesDir() string {
+	return filepath.Join("..", "..", "..", "spec", "fixtures", "subscriptions")
+}
+
+func loadSubscriptionsFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	path := filepath.Join(subscriptionsFixturesDir(), name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func TestSubscription_UnmarshalGet(t *testing.T) {
+	data := loadSubscriptionsFixture(t, "get.json")
+
+	var subscription Subscription
+	if err := json.Unmarshal(data, &subscription); err != nil {
+		t.Fatalf("failed to unmarshal get.json: %v", err)
+	}
+
+	if !subscription.Subscribed {
+		t.Error("expected Subscribed to be true")
+	}
+	if subscription.Count != 3 {
+		t.Errorf("expected Count 3, got %d", subscription.Count)
+	}
+	if subscription.URL != "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479351/subscription.json" {
+		t.Errorf("unexpected URL: %q", subscription.URL)
+	}
+	if len(subscription.Subscribers) != 3 {
+		t.Errorf("expected 3 subscribers, got %d", len(subscription.Subscribers))
+	}
+
+	// Verify first subscriber
+	s1 := subscription.Subscribers[0]
+	if s1.ID != 1049715915 {
+		t.Errorf("expected ID 1049715915, got %d", s1.ID)
+	}
+	if s1.Name != "Victor Cooper" {
+		t.Errorf("expected Name 'Victor Cooper', got %q", s1.Name)
+	}
+	if s1.EmailAddress != "victor@honchodesign.com" {
+		t.Errorf("expected EmailAddress 'victor@honchodesign.com', got %q", s1.EmailAddress)
+	}
+	if s1.Title != "Chief Strategist" {
+		t.Errorf("expected Title 'Chief Strategist', got %q", s1.Title)
+	}
+	if !s1.Admin {
+		t.Error("expected Admin to be true")
+	}
+	if !s1.Owner {
+		t.Error("expected Owner to be true")
+	}
+	if !s1.Employee {
+		t.Error("expected Employee to be true")
+	}
+	if s1.TimeZone != "America/Chicago" {
+		t.Errorf("expected TimeZone 'America/Chicago', got %q", s1.TimeZone)
+	}
+
+	// Verify company
+	if s1.Company == nil {
+		t.Fatal("expected Company to be non-nil")
+	}
+	if s1.Company.ID != 1033447817 {
+		t.Errorf("expected Company.ID 1033447817, got %d", s1.Company.ID)
+	}
+	if s1.Company.Name != "Honcho Design" {
+		t.Errorf("expected Company.Name 'Honcho Design', got %q", s1.Company.Name)
+	}
+
+	// Verify second subscriber
+	s2 := subscription.Subscribers[1]
+	if s2.ID != 1049715923 {
+		t.Errorf("expected ID 1049715923, got %d", s2.ID)
+	}
+	if s2.Name != "Andrew Wong" {
+		t.Errorf("expected Name 'Andrew Wong', got %q", s2.Name)
+	}
+
+	// Verify third subscriber
+	s3 := subscription.Subscribers[2]
+	if s3.ID != 1049715916 {
+		t.Errorf("expected ID 1049715916, got %d", s3.ID)
+	}
+	if s3.Name != "Annie Bryan" {
+		t.Errorf("expected Name 'Annie Bryan', got %q", s3.Name)
+	}
+}
+
+func TestSubscription_UnmarshalSubscribe(t *testing.T) {
+	data := loadSubscriptionsFixture(t, "subscribe.json")
+
+	var subscription Subscription
+	if err := json.Unmarshal(data, &subscription); err != nil {
+		t.Fatalf("failed to unmarshal subscribe.json: %v", err)
+	}
+
+	if !subscription.Subscribed {
+		t.Error("expected Subscribed to be true")
+	}
+	if subscription.Count != 4 {
+		t.Errorf("expected Count 4, got %d", subscription.Count)
+	}
+	if len(subscription.Subscribers) != 4 {
+		t.Errorf("expected 4 subscribers, got %d", len(subscription.Subscribers))
+	}
+
+	// Verify the new subscriber (current user) was added
+	s4 := subscription.Subscribers[3]
+	if s4.ID != 1049715917 {
+		t.Errorf("expected ID 1049715917, got %d", s4.ID)
+	}
+	if s4.Name != "Current User" {
+		t.Errorf("expected Name 'Current User', got %q", s4.Name)
+	}
+}
+
+func TestSubscription_UnmarshalUpdate(t *testing.T) {
+	data := loadSubscriptionsFixture(t, "update.json")
+
+	var subscription Subscription
+	if err := json.Unmarshal(data, &subscription); err != nil {
+		t.Fatalf("failed to unmarshal update.json: %v", err)
+	}
+
+	if !subscription.Subscribed {
+		t.Error("expected Subscribed to be true")
+	}
+	if subscription.Count != 2 {
+		t.Errorf("expected Count 2, got %d", subscription.Count)
+	}
+	if len(subscription.Subscribers) != 2 {
+		t.Errorf("expected 2 subscribers, got %d", len(subscription.Subscribers))
+	}
+
+	// Verify Victor is still subscribed
+	if subscription.Subscribers[0].ID != 1049715915 {
+		t.Errorf("expected first subscriber ID 1049715915, got %d", subscription.Subscribers[0].ID)
+	}
+
+	// Verify Annie is still subscribed
+	if subscription.Subscribers[1].ID != 1049715916 {
+		t.Errorf("expected second subscriber ID 1049715916, got %d", subscription.Subscribers[1].ID)
+	}
+}
+
+func TestUpdateSubscriptionRequest_Marshal(t *testing.T) {
+	req := UpdateSubscriptionRequest{
+		Subscriptions:   []int64{1049715916},
+		Unsubscriptions: []int64{1049715923},
+	}
+
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal UpdateSubscriptionRequest: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(out, &data); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	subs, ok := data["subscriptions"].([]interface{})
+	if !ok {
+		t.Fatal("subscriptions should be an array")
+	}
+	if len(subs) != 1 {
+		t.Errorf("expected 1 subscription, got %d", len(subs))
+	}
+	if int64(subs[0].(float64)) != 1049715916 {
+		t.Errorf("expected subscription ID 1049715916, got %v", subs[0])
+	}
+
+	unsubs, ok := data["unsubscriptions"].([]interface{})
+	if !ok {
+		t.Fatal("unsubscriptions should be an array")
+	}
+	if len(unsubs) != 1 {
+		t.Errorf("expected 1 unsubscription, got %d", len(unsubs))
+	}
+	if int64(unsubs[0].(float64)) != 1049715923 {
+		t.Errorf("expected unsubscription ID 1049715923, got %v", unsubs[0])
+	}
+
+	// Round-trip test
+	var roundtrip UpdateSubscriptionRequest
+	if err := json.Unmarshal(out, &roundtrip); err != nil {
+		t.Fatalf("failed to unmarshal round-trip: %v", err)
+	}
+
+	if len(roundtrip.Subscriptions) != 1 || roundtrip.Subscriptions[0] != 1049715916 {
+		t.Errorf("expected Subscriptions [1049715916], got %v", roundtrip.Subscriptions)
+	}
+	if len(roundtrip.Unsubscriptions) != 1 || roundtrip.Unsubscriptions[0] != 1049715923 {
+		t.Errorf("expected Unsubscriptions [1049715923], got %v", roundtrip.Unsubscriptions)
+	}
+}
+
+func TestUpdateSubscriptionRequest_MarshalOmitsEmpty(t *testing.T) {
+	// Test that empty arrays are omitted
+	req := UpdateSubscriptionRequest{
+		Subscriptions: []int64{1049715916},
+	}
+
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal UpdateSubscriptionRequest: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(out, &data); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	if _, exists := data["unsubscriptions"]; exists {
+		t.Error("unsubscriptions should be omitted when empty")
+	}
+}

--- a/spec/fixtures/subscriptions/get.json
+++ b/spec/fixtures/subscriptions/get.json
@@ -1,0 +1,79 @@
+{
+  "subscribed": true,
+  "count": 3,
+  "url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479351/subscription.json",
+  "subscribers": [
+    {
+      "id": 1049715915,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--919d2c8b11ff403eefcab9db42dd26846d0c3102",
+      "name": "Victor Cooper",
+      "email_address": "victor@honchodesign.com",
+      "personable_type": "User",
+      "title": "Chief Strategist",
+      "bio": "Don't let your dreams be dreams",
+      "location": "Chicago, IL",
+      "created_at": "2022-11-22T08:23:21.732Z",
+      "updated_at": "2022-11-22T08:23:21.904Z",
+      "admin": true,
+      "owner": true,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMtkkT4=--e609ef146e39f9ca5e4bb7571f0f7da68e5f6302/avatar?v=1",
+      "company": {
+        "id": 1033447817,
+        "name": "Honcho Design"
+      },
+      "can_manage_projects": true,
+      "can_manage_people": true
+    },
+    {
+      "id": 1049715923,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTIzP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--5f2a8b7c2d1e3f4a5b6c7d8e9f0a1b2c3d4e5f6g",
+      "name": "Andrew Wong",
+      "email_address": "andrew@honchodesign.com",
+      "personable_type": "User",
+      "title": "Senior Developer",
+      "bio": null,
+      "location": "San Francisco, CA",
+      "created_at": "2022-11-22T08:23:21.732Z",
+      "updated_at": "2022-11-22T08:23:21.904Z",
+      "admin": false,
+      "owner": false,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Los_Angeles",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBNNkkT4=--e609ef146e39f9ca5e4bb7571f0f7da68e5f6303/avatar?v=1",
+      "company": {
+        "id": 1033447817,
+        "name": "Honcho Design"
+      },
+      "can_manage_projects": false,
+      "can_manage_people": false
+    },
+    {
+      "id": 1049715916,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE2P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--6g3a9c8d2e2f4g5b7c8d9e0f1a2b3c4d5e6f7g8h",
+      "name": "Annie Bryan",
+      "email_address": "annie@honchodesign.com",
+      "personable_type": "User",
+      "title": "Central Markets Manager",
+      "bio": null,
+      "location": "New York, NY",
+      "created_at": "2022-11-22T08:23:21.732Z",
+      "updated_at": "2022-11-22T08:23:21.904Z",
+      "admin": false,
+      "owner": false,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/New_York",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMxkkT4=--e609ef146e39f9ca5e4bb7571f0f7da68e5f6304/avatar?v=1",
+      "company": {
+        "id": 1033447817,
+        "name": "Honcho Design"
+      },
+      "can_manage_projects": false,
+      "can_manage_people": false
+    }
+  ]
+}

--- a/spec/fixtures/subscriptions/subscribe.json
+++ b/spec/fixtures/subscriptions/subscribe.json
@@ -1,0 +1,103 @@
+{
+  "subscribed": true,
+  "count": 4,
+  "url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479351/subscription.json",
+  "subscribers": [
+    {
+      "id": 1049715915,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--919d2c8b11ff403eefcab9db42dd26846d0c3102",
+      "name": "Victor Cooper",
+      "email_address": "victor@honchodesign.com",
+      "personable_type": "User",
+      "title": "Chief Strategist",
+      "bio": "Don't let your dreams be dreams",
+      "location": "Chicago, IL",
+      "created_at": "2022-11-22T08:23:21.732Z",
+      "updated_at": "2022-11-22T08:23:21.904Z",
+      "admin": true,
+      "owner": true,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMtkkT4=--e609ef146e39f9ca5e4bb7571f0f7da68e5f6302/avatar?v=1",
+      "company": {
+        "id": 1033447817,
+        "name": "Honcho Design"
+      },
+      "can_manage_projects": true,
+      "can_manage_people": true
+    },
+    {
+      "id": 1049715923,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTIzP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--5f2a8b7c2d1e3f4a5b6c7d8e9f0a1b2c3d4e5f6g",
+      "name": "Andrew Wong",
+      "email_address": "andrew@honchodesign.com",
+      "personable_type": "User",
+      "title": "Senior Developer",
+      "bio": null,
+      "location": "San Francisco, CA",
+      "created_at": "2022-11-22T08:23:21.732Z",
+      "updated_at": "2022-11-22T08:23:21.904Z",
+      "admin": false,
+      "owner": false,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Los_Angeles",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBNNkkT4=--e609ef146e39f9ca5e4bb7571f0f7da68e5f6303/avatar?v=1",
+      "company": {
+        "id": 1033447817,
+        "name": "Honcho Design"
+      },
+      "can_manage_projects": false,
+      "can_manage_people": false
+    },
+    {
+      "id": 1049715916,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE2P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--6g3a9c8d2e2f4g5b7c8d9e0f1a2b3c4d5e6f7g8h",
+      "name": "Annie Bryan",
+      "email_address": "annie@honchodesign.com",
+      "personable_type": "User",
+      "title": "Central Markets Manager",
+      "bio": null,
+      "location": "New York, NY",
+      "created_at": "2022-11-22T08:23:21.732Z",
+      "updated_at": "2022-11-22T08:23:21.904Z",
+      "admin": false,
+      "owner": false,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/New_York",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMxkkT4=--e609ef146e39f9ca5e4bb7571f0f7da68e5f6304/avatar?v=1",
+      "company": {
+        "id": 1033447817,
+        "name": "Honcho Design"
+      },
+      "can_manage_projects": false,
+      "can_manage_people": false
+    },
+    {
+      "id": 1049715917,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE3P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--7h4b0d9e3f3g5h6c8d0e1f2a3b4c5d6e7f8g9h0i",
+      "name": "Current User",
+      "email_address": "current@honchodesign.com",
+      "personable_type": "User",
+      "title": "Developer",
+      "bio": null,
+      "location": "Austin, TX",
+      "created_at": "2022-11-22T08:23:21.732Z",
+      "updated_at": "2022-11-22T08:23:21.904Z",
+      "admin": false,
+      "owner": false,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMdkkT4=--e609ef146e39f9ca5e4bb7571f0f7da68e5f6305/avatar?v=1",
+      "company": {
+        "id": 1033447817,
+        "name": "Honcho Design"
+      },
+      "can_manage_projects": false,
+      "can_manage_people": false
+    }
+  ]
+}

--- a/spec/fixtures/subscriptions/update-request.json
+++ b/spec/fixtures/subscriptions/update-request.json
@@ -1,0 +1,4 @@
+{
+  "subscriptions": [1049715916],
+  "unsubscriptions": [1049715923]
+}

--- a/spec/fixtures/subscriptions/update.json
+++ b/spec/fixtures/subscriptions/update.json
@@ -1,0 +1,55 @@
+{
+  "subscribed": true,
+  "count": 2,
+  "url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479351/subscription.json",
+  "subscribers": [
+    {
+      "id": 1049715915,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--919d2c8b11ff403eefcab9db42dd26846d0c3102",
+      "name": "Victor Cooper",
+      "email_address": "victor@honchodesign.com",
+      "personable_type": "User",
+      "title": "Chief Strategist",
+      "bio": "Don't let your dreams be dreams",
+      "location": "Chicago, IL",
+      "created_at": "2022-11-22T08:23:21.732Z",
+      "updated_at": "2022-11-22T08:23:21.904Z",
+      "admin": true,
+      "owner": true,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMtkkT4=--e609ef146e39f9ca5e4bb7571f0f7da68e5f6302/avatar?v=1",
+      "company": {
+        "id": 1033447817,
+        "name": "Honcho Design"
+      },
+      "can_manage_projects": true,
+      "can_manage_people": true
+    },
+    {
+      "id": 1049715916,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE2P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--6g3a9c8d2e2f4g5b7c8d9e0f1a2b3c4d5e6f7g8h",
+      "name": "Annie Bryan",
+      "email_address": "annie@honchodesign.com",
+      "personable_type": "User",
+      "title": "Central Markets Manager",
+      "bio": null,
+      "location": "New York, NY",
+      "created_at": "2022-11-22T08:23:21.732Z",
+      "updated_at": "2022-11-22T08:23:21.904Z",
+      "admin": false,
+      "owner": false,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/New_York",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMxkkT4=--e609ef146e39f9ca5e4bb7571f0f7da68e5f6304/avatar?v=1",
+      "company": {
+        "id": 1033447817,
+        "name": "Honcho Design"
+      },
+      "can_manage_projects": false,
+      "can_manage_people": false
+    }
+  ]
+}


### PR DESCRIPTION
Implements subscription management for Basecamp recordings with:
- Get: retrieve subscription info for a recording
- Subscribe: subscribe the current user
- Unsubscribe: unsubscribe the current user
- Update: batch add/remove subscribers by person ID
