### PR TITLE
Add CampfiresService for chat operations

### DIFF
--- a/go/pkg/basecamp/campfires.go
+++ b/go/pkg/basecamp/campfires.go
@@ -1,0 +1,188 @@
+package basecamp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Campfire represents a Basecamp Campfire (real-time chat room).
+type Campfire struct {
+	ID               int64     `json:"id"`
+	Status           string    `json:"status"`
+	VisibleToClients bool      `json:"visible_to_clients"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+	Title            string    `json:"title"`
+	InheritsStatus   bool      `json:"inherits_status"`
+	Type             string    `json:"type"`
+	URL              string    `json:"url"`
+	AppURL           string    `json:"app_url"`
+	LinesURL         string    `json:"lines_url"`
+	Bucket           *Bucket   `json:"bucket,omitempty"`
+	Creator          *Person   `json:"creator,omitempty"`
+}
+
+// CampfireLine represents a message in a Campfire chat.
+type CampfireLine struct {
+	ID               int64      `json:"id"`
+	Status           string     `json:"status"`
+	VisibleToClients bool       `json:"visible_to_clients"`
+	CreatedAt        time.Time  `json:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+	Title            string     `json:"title"`
+	InheritsStatus   bool       `json:"inherits_status"`
+	Type             string     `json:"type"`
+	URL              string     `json:"url"`
+	AppURL           string     `json:"app_url"`
+	Content          string     `json:"content"`
+	Parent           *Parent    `json:"parent,omitempty"`
+	Bucket           *Bucket    `json:"bucket,omitempty"`
+	Creator          *Person    `json:"creator,omitempty"`
+}
+
+// CreateCampfireLineRequest specifies the parameters for creating a campfire line.
+type CreateCampfireLineRequest struct {
+	// Content is the plain text message body (required).
+	Content string `json:"content"`
+}
+
+// CampfiresService handles campfire operations.
+type CampfiresService struct {
+	client *Client
+}
+
+// NewCampfiresService creates a new CampfiresService.
+func NewCampfiresService(client *Client) *CampfiresService {
+	return &CampfiresService{client: client}
+}
+
+// List returns all campfires across the account.
+func (s *CampfiresService) List(ctx context.Context) ([]Campfire, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	results, err := s.client.GetAll(ctx, "/chats.json")
+	if err != nil {
+		return nil, err
+	}
+
+	campfires := make([]Campfire, 0, len(results))
+	for _, raw := range results {
+		var c Campfire
+		if err := json.Unmarshal(raw, &c); err != nil {
+			return nil, fmt.Errorf("failed to parse campfire: %w", err)
+		}
+		campfires = append(campfires, c)
+	}
+
+	return campfires, nil
+}
+
+// Get returns a campfire by ID.
+// bucketID is the project ID, campfireID is the campfire ID.
+func (s *CampfiresService) Get(ctx context.Context, bucketID, campfireID int64) (*Campfire, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/chats/%d.json", bucketID, campfireID)
+	resp, err := s.client.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var campfire Campfire
+	if err := resp.UnmarshalData(&campfire); err != nil {
+		return nil, fmt.Errorf("failed to parse campfire: %w", err)
+	}
+
+	return &campfire, nil
+}
+
+// ListLines returns all lines (messages) in a campfire.
+// bucketID is the project ID, campfireID is the campfire ID.
+func (s *CampfiresService) ListLines(ctx context.Context, bucketID, campfireID int64) ([]CampfireLine, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/chats/%d/lines.json", bucketID, campfireID)
+	results, err := s.client.GetAll(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	lines := make([]CampfireLine, 0, len(results))
+	for _, raw := range results {
+		var l CampfireLine
+		if err := json.Unmarshal(raw, &l); err != nil {
+			return nil, fmt.Errorf("failed to parse campfire line: %w", err)
+		}
+		lines = append(lines, l)
+	}
+
+	return lines, nil
+}
+
+// GetLine returns a single line (message) from a campfire.
+// bucketID is the project ID, campfireID is the campfire ID, lineID is the line ID.
+func (s *CampfiresService) GetLine(ctx context.Context, bucketID, campfireID, lineID int64) (*CampfireLine, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/chats/%d/lines/%d.json", bucketID, campfireID, lineID)
+	resp, err := s.client.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var line CampfireLine
+	if err := resp.UnmarshalData(&line); err != nil {
+		return nil, fmt.Errorf("failed to parse campfire line: %w", err)
+	}
+
+	return &line, nil
+}
+
+// CreateLine creates a new line (message) in a campfire.
+// bucketID is the project ID, campfireID is the campfire ID.
+// Returns the created line.
+func (s *CampfiresService) CreateLine(ctx context.Context, bucketID, campfireID int64, content string) (*CampfireLine, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	if content == "" {
+		return nil, ErrUsage("campfire line content is required")
+	}
+
+	req := &CreateCampfireLineRequest{Content: content}
+	path := fmt.Sprintf("/buckets/%d/chats/%d/lines.json", bucketID, campfireID)
+	resp, err := s.client.Post(ctx, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var line CampfireLine
+	if err := resp.UnmarshalData(&line); err != nil {
+		return nil, fmt.Errorf("failed to parse campfire line: %w", err)
+	}
+
+	return &line, nil
+}
+
+// DeleteLine deletes a line (message) from a campfire.
+// bucketID is the project ID, campfireID is the campfire ID, lineID is the line ID.
+func (s *CampfiresService) DeleteLine(ctx context.Context, bucketID, campfireID, lineID int64) error {
+	if err := s.client.RequireAccount(); err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/chats/%d/lines/%d.json", bucketID, campfireID, lineID)
+	_, err := s.client.Delete(ctx, path)
+	return err
+}

--- a/go/pkg/basecamp/campfires_test.go
+++ b/go/pkg/basecamp/campfires_test.go
@@ -1,0 +1,340 @@
+package basecamp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func campfiresFixturesDir() string {
+	return filepath.Join("..", "..", "..", "spec", "fixtures", "campfires")
+}
+
+func loadCampfiresFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	path := filepath.Join(campfiresFixturesDir(), name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func TestCampfire_UnmarshalList(t *testing.T) {
+	data := loadCampfiresFixture(t, "list.json")
+
+	var campfires []Campfire
+	if err := json.Unmarshal(data, &campfires); err != nil {
+		t.Fatalf("failed to unmarshal list.json: %v", err)
+	}
+
+	if len(campfires) != 2 {
+		t.Errorf("expected 2 campfires, got %d", len(campfires))
+	}
+
+	// Verify first campfire
+	c1 := campfires[0]
+	if c1.ID != 1069479345 {
+		t.Errorf("expected ID 1069479345, got %d", c1.ID)
+	}
+	if c1.Status != "active" {
+		t.Errorf("expected status 'active', got %q", c1.Status)
+	}
+	if c1.Type != "Chat::Transcript" {
+		t.Errorf("expected type 'Chat::Transcript', got %q", c1.Type)
+	}
+	if c1.Title != "Campfire" {
+		t.Errorf("expected title 'Campfire', got %q", c1.Title)
+	}
+	if c1.VisibleToClients != false {
+		t.Errorf("expected VisibleToClients false, got true")
+	}
+	if c1.URL != "https://3.basecampapi.com/195539477/buckets/2085958499/chats/1069479345.json" {
+		t.Errorf("unexpected URL: %q", c1.URL)
+	}
+	if c1.AppURL != "https://3.basecamp.com/195539477/buckets/2085958499/chats/1069479345" {
+		t.Errorf("unexpected AppURL: %q", c1.AppURL)
+	}
+	if c1.LinesURL != "https://3.basecampapi.com/195539477/buckets/2085958499/chats/1069479345/lines.json" {
+		t.Errorf("unexpected LinesURL: %q", c1.LinesURL)
+	}
+
+	// Verify bucket
+	if c1.Bucket == nil {
+		t.Fatal("expected Bucket to be non-nil")
+	}
+	if c1.Bucket.ID != 2085958499 {
+		t.Errorf("expected Bucket.ID 2085958499, got %d", c1.Bucket.ID)
+	}
+	if c1.Bucket.Name != "The Leto Laptop" {
+		t.Errorf("expected Bucket.Name 'The Leto Laptop', got %q", c1.Bucket.Name)
+	}
+	if c1.Bucket.Type != "Project" {
+		t.Errorf("expected Bucket.Type 'Project', got %q", c1.Bucket.Type)
+	}
+
+	// Verify creator
+	if c1.Creator == nil {
+		t.Fatal("expected Creator to be non-nil")
+	}
+	if c1.Creator.ID != 1049715914 {
+		t.Errorf("expected Creator.ID 1049715914, got %d", c1.Creator.ID)
+	}
+	if c1.Creator.Name != "Victor Cooper" {
+		t.Errorf("expected Creator.Name 'Victor Cooper', got %q", c1.Creator.Name)
+	}
+
+	// Verify second campfire
+	c2 := campfires[1]
+	if c2.ID != 1069479400 {
+		t.Errorf("expected ID 1069479400, got %d", c2.ID)
+	}
+	if c2.VisibleToClients != true {
+		t.Errorf("expected VisibleToClients true, got false")
+	}
+	if c2.Bucket == nil {
+		t.Fatal("expected Bucket to be non-nil for second campfire")
+	}
+	if c2.Bucket.Name != "Marketing Campaign" {
+		t.Errorf("expected Bucket.Name 'Marketing Campaign', got %q", c2.Bucket.Name)
+	}
+	if c2.Creator == nil {
+		t.Fatal("expected Creator to be non-nil for second campfire")
+	}
+	if c2.Creator.Name != "Annie Bryan" {
+		t.Errorf("expected Creator.Name 'Annie Bryan', got %q", c2.Creator.Name)
+	}
+}
+
+func TestCampfire_UnmarshalGet(t *testing.T) {
+	data := loadCampfiresFixture(t, "get.json")
+
+	var campfire Campfire
+	if err := json.Unmarshal(data, &campfire); err != nil {
+		t.Fatalf("failed to unmarshal get.json: %v", err)
+	}
+
+	if campfire.ID != 1069479345 {
+		t.Errorf("expected ID 1069479345, got %d", campfire.ID)
+	}
+	if campfire.Status != "active" {
+		t.Errorf("expected status 'active', got %q", campfire.Status)
+	}
+	if campfire.Type != "Chat::Transcript" {
+		t.Errorf("expected type 'Chat::Transcript', got %q", campfire.Type)
+	}
+	if campfire.Title != "Campfire" {
+		t.Errorf("expected title 'Campfire', got %q", campfire.Title)
+	}
+
+	// Verify timestamps are parsed
+	if campfire.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be non-zero")
+	}
+	if campfire.UpdatedAt.IsZero() {
+		t.Error("expected UpdatedAt to be non-zero")
+	}
+
+	// Verify creator with full details
+	if campfire.Creator == nil {
+		t.Fatal("expected Creator to be non-nil")
+	}
+	if campfire.Creator.ID != 1049715914 {
+		t.Errorf("expected Creator.ID 1049715914, got %d", campfire.Creator.ID)
+	}
+	if campfire.Creator.Name != "Victor Cooper" {
+		t.Errorf("expected Creator.Name 'Victor Cooper', got %q", campfire.Creator.Name)
+	}
+	if campfire.Creator.EmailAddress != "victor@honchodesign.com" {
+		t.Errorf("expected Creator.EmailAddress 'victor@honchodesign.com', got %q", campfire.Creator.EmailAddress)
+	}
+	if campfire.Creator.Title != "Chief Strategist" {
+		t.Errorf("expected Creator.Title 'Chief Strategist', got %q", campfire.Creator.Title)
+	}
+	if !campfire.Creator.Owner {
+		t.Error("expected Creator.Owner to be true")
+	}
+	if !campfire.Creator.Admin {
+		t.Error("expected Creator.Admin to be true")
+	}
+	// Verify creator with company
+	if campfire.Creator.Company == nil {
+		t.Fatal("expected Creator.Company to be non-nil")
+	}
+	if campfire.Creator.Company.Name != "Honcho Design" {
+		t.Errorf("expected Creator.Company.Name 'Honcho Design', got %q", campfire.Creator.Company.Name)
+	}
+}
+
+func TestCampfireLine_UnmarshalList(t *testing.T) {
+	data := loadCampfiresFixture(t, "lines_list.json")
+
+	var lines []CampfireLine
+	if err := json.Unmarshal(data, &lines); err != nil {
+		t.Fatalf("failed to unmarshal lines_list.json: %v", err)
+	}
+
+	if len(lines) != 2 {
+		t.Errorf("expected 2 lines, got %d", len(lines))
+	}
+
+	// Verify first line
+	l1 := lines[0]
+	if l1.ID != 1069479350 {
+		t.Errorf("expected ID 1069479350, got %d", l1.ID)
+	}
+	if l1.Status != "active" {
+		t.Errorf("expected status 'active', got %q", l1.Status)
+	}
+	if l1.Type != "Chat::Lines::Text" {
+		t.Errorf("expected type 'Chat::Lines::Text', got %q", l1.Type)
+	}
+	if l1.Content != "Hello everyone!" {
+		t.Errorf("expected content 'Hello everyone!', got %q", l1.Content)
+	}
+	if l1.Title != "Hello everyone!" {
+		t.Errorf("expected title 'Hello everyone!', got %q", l1.Title)
+	}
+	if l1.URL != "https://3.basecampapi.com/195539477/buckets/2085958499/chats/1069479345/lines/1069479350.json" {
+		t.Errorf("unexpected URL: %q", l1.URL)
+	}
+
+	// Verify parent (campfire)
+	if l1.Parent == nil {
+		t.Fatal("expected Parent to be non-nil")
+	}
+	if l1.Parent.ID != 1069479345 {
+		t.Errorf("expected Parent.ID 1069479345, got %d", l1.Parent.ID)
+	}
+	if l1.Parent.Title != "Campfire" {
+		t.Errorf("expected Parent.Title 'Campfire', got %q", l1.Parent.Title)
+	}
+	if l1.Parent.Type != "Chat::Transcript" {
+		t.Errorf("expected Parent.Type 'Chat::Transcript', got %q", l1.Parent.Type)
+	}
+
+	// Verify bucket
+	if l1.Bucket == nil {
+		t.Fatal("expected Bucket to be non-nil")
+	}
+	if l1.Bucket.ID != 2085958499 {
+		t.Errorf("expected Bucket.ID 2085958499, got %d", l1.Bucket.ID)
+	}
+	if l1.Bucket.Name != "The Leto Laptop" {
+		t.Errorf("expected Bucket.Name 'The Leto Laptop', got %q", l1.Bucket.Name)
+	}
+
+	// Verify creator
+	if l1.Creator == nil {
+		t.Fatal("expected Creator to be non-nil")
+	}
+	if l1.Creator.ID != 1049715914 {
+		t.Errorf("expected Creator.ID 1049715914, got %d", l1.Creator.ID)
+	}
+	if l1.Creator.Name != "Victor Cooper" {
+		t.Errorf("expected Creator.Name 'Victor Cooper', got %q", l1.Creator.Name)
+	}
+
+	// Verify second line
+	l2 := lines[1]
+	if l2.ID != 1069479355 {
+		t.Errorf("expected ID 1069479355, got %d", l2.ID)
+	}
+	if l2.Content != "Welcome to the project!" {
+		t.Errorf("expected content 'Welcome to the project!', got %q", l2.Content)
+	}
+	if l2.Creator == nil {
+		t.Fatal("expected Creator to be non-nil for second line")
+	}
+	if l2.Creator.Name != "Annie Bryan" {
+		t.Errorf("expected Creator.Name 'Annie Bryan', got %q", l2.Creator.Name)
+	}
+	// Verify creator with company
+	if l2.Creator.Company == nil {
+		t.Fatal("expected Creator.Company to be non-nil for second line")
+	}
+	if l2.Creator.Company.Name != "Honcho Design" {
+		t.Errorf("expected Creator.Company.Name 'Honcho Design', got %q", l2.Creator.Company.Name)
+	}
+}
+
+func TestCampfireLine_UnmarshalGet(t *testing.T) {
+	data := loadCampfiresFixture(t, "line_get.json")
+
+	var line CampfireLine
+	if err := json.Unmarshal(data, &line); err != nil {
+		t.Fatalf("failed to unmarshal line_get.json: %v", err)
+	}
+
+	if line.ID != 1069479350 {
+		t.Errorf("expected ID 1069479350, got %d", line.ID)
+	}
+	if line.Status != "active" {
+		t.Errorf("expected status 'active', got %q", line.Status)
+	}
+	if line.Type != "Chat::Lines::Text" {
+		t.Errorf("expected type 'Chat::Lines::Text', got %q", line.Type)
+	}
+	if line.Content != "Hello everyone!" {
+		t.Errorf("expected content 'Hello everyone!', got %q", line.Content)
+	}
+
+	// Verify timestamps are parsed
+	if line.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be non-zero")
+	}
+	if line.UpdatedAt.IsZero() {
+		t.Error("expected UpdatedAt to be non-zero")
+	}
+
+	// Verify creator with full details
+	if line.Creator == nil {
+		t.Fatal("expected Creator to be non-nil")
+	}
+	if line.Creator.ID != 1049715914 {
+		t.Errorf("expected Creator.ID 1049715914, got %d", line.Creator.ID)
+	}
+	if line.Creator.Name != "Victor Cooper" {
+		t.Errorf("expected Creator.Name 'Victor Cooper', got %q", line.Creator.Name)
+	}
+	if line.Creator.EmailAddress != "victor@honchodesign.com" {
+		t.Errorf("expected Creator.EmailAddress 'victor@honchodesign.com', got %q", line.Creator.EmailAddress)
+	}
+	if line.Creator.Bio != "Don't let your dreams be dreams" {
+		t.Errorf("expected Creator.Bio 'Don't let your dreams be dreams', got %q", line.Creator.Bio)
+	}
+	if line.Creator.Location != "Chicago, IL" {
+		t.Errorf("expected Creator.Location 'Chicago, IL', got %q", line.Creator.Location)
+	}
+}
+
+func TestCreateCampfireLineRequest_Marshal(t *testing.T) {
+	req := CreateCampfireLineRequest{
+		Content: "Hello team!",
+	}
+
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal CreateCampfireLineRequest: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(out, &data); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	if data["content"] != "Hello team!" {
+		t.Errorf("unexpected content: %v", data["content"])
+	}
+
+	// Round-trip test
+	var roundtrip CreateCampfireLineRequest
+	if err := json.Unmarshal(out, &roundtrip); err != nil {
+		t.Fatalf("failed to unmarshal round-trip: %v", err)
+	}
+
+	if roundtrip.Content != req.Content {
+		t.Errorf("expected content %q, got %q", req.Content, roundtrip.Content)
+	}
+}

--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -49,6 +49,7 @@ type Client struct {
 	tools           *ToolsService
 	lineup          *LineupService
 	subscriptions   *SubscriptionsService
+	campfires       *CampfiresService
 }
 
 // Response wraps an API response.
@@ -618,4 +619,12 @@ func (c *Client) Subscriptions() *SubscriptionsService {
 		c.subscriptions = NewSubscriptionsService(c)
 	}
 	return c.subscriptions
+}
+
+// Campfires returns the CampfiresService for campfire chat operations.
+func (c *Client) Campfires() *CampfiresService {
+	if c.campfires == nil {
+		c.campfires = NewCampfiresService(c)
+	}
+	return c.campfires
 }

--- a/spec/fixtures/campfires/get.json
+++ b/spec/fixtures/campfires/get.json
@@ -1,0 +1,42 @@
+{
+  "id": 1069479345,
+  "status": "active",
+  "visible_to_clients": false,
+  "created_at": "2022-10-28T15:21:46.169Z",
+  "updated_at": "2022-10-28T15:21:46.169Z",
+  "title": "Campfire",
+  "inherits_status": true,
+  "type": "Chat::Transcript",
+  "url": "https://3.basecampapi.com/195539477/buckets/2085958499/chats/1069479345.json",
+  "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/chats/1069479345",
+  "lines_url": "https://3.basecampapi.com/195539477/buckets/2085958499/chats/1069479345/lines.json",
+  "bucket": {
+    "id": 2085958499,
+    "name": "The Leto Laptop",
+    "type": "Project"
+  },
+  "creator": {
+    "id": 1049715914,
+    "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+    "name": "Victor Cooper",
+    "email_address": "victor@honchodesign.com",
+    "personable_type": "User",
+    "title": "Chief Strategist",
+    "bio": "Don't let your dreams be dreams",
+    "location": "Chicago, IL",
+    "created_at": "2022-11-22T08:23:21.732Z",
+    "updated_at": "2022-11-22T08:23:21.732Z",
+    "admin": true,
+    "owner": true,
+    "client": false,
+    "employee": true,
+    "time_zone": "America/Chicago",
+    "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+    "company": {
+      "id": 1033447817,
+      "name": "Honcho Design"
+    },
+    "can_manage_projects": true,
+    "can_manage_people": true
+  }
+}

--- a/spec/fixtures/campfires/line_get.json
+++ b/spec/fixtures/campfires/line_get.json
@@ -1,0 +1,49 @@
+{
+  "id": 1069479350,
+  "status": "active",
+  "visible_to_clients": false,
+  "created_at": "2022-10-28T15:25:00.000Z",
+  "updated_at": "2022-10-28T15:25:00.000Z",
+  "title": "Hello everyone!",
+  "inherits_status": true,
+  "type": "Chat::Lines::Text",
+  "url": "https://3.basecampapi.com/195539477/buckets/2085958499/chats/1069479345/lines/1069479350.json",
+  "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/chats/1069479345#__recording_1069479350",
+  "content": "Hello everyone!",
+  "parent": {
+    "id": 1069479345,
+    "title": "Campfire",
+    "type": "Chat::Transcript",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/chats/1069479345.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/chats/1069479345"
+  },
+  "bucket": {
+    "id": 2085958499,
+    "name": "The Leto Laptop",
+    "type": "Project"
+  },
+  "creator": {
+    "id": 1049715914,
+    "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+    "name": "Victor Cooper",
+    "email_address": "victor@honchodesign.com",
+    "personable_type": "User",
+    "title": "Chief Strategist",
+    "bio": "Don't let your dreams be dreams",
+    "location": "Chicago, IL",
+    "created_at": "2022-11-22T08:23:21.732Z",
+    "updated_at": "2022-11-22T08:23:21.732Z",
+    "admin": true,
+    "owner": true,
+    "client": false,
+    "employee": true,
+    "time_zone": "America/Chicago",
+    "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+    "company": {
+      "id": 1033447817,
+      "name": "Honcho Design"
+    },
+    "can_manage_projects": true,
+    "can_manage_people": true
+  }
+}

--- a/spec/fixtures/campfires/lines_list.json
+++ b/spec/fixtures/campfires/lines_list.json
@@ -1,0 +1,96 @@
+[
+  {
+    "id": 1069479350,
+    "status": "active",
+    "visible_to_clients": false,
+    "created_at": "2022-10-28T15:25:00.000Z",
+    "updated_at": "2022-10-28T15:25:00.000Z",
+    "title": "Hello everyone!",
+    "inherits_status": true,
+    "type": "Chat::Lines::Text",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/chats/1069479345/lines/1069479350.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/chats/1069479345#__recording_1069479350",
+    "content": "Hello everyone!",
+    "parent": {
+      "id": 1069479345,
+      "title": "Campfire",
+      "type": "Chat::Transcript",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/chats/1069479345.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/chats/1069479345"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715914,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+      "name": "Victor Cooper",
+      "email_address": "victor@honchodesign.com",
+      "personable_type": "User",
+      "title": "Chief Strategist",
+      "bio": null,
+      "location": null,
+      "created_at": "2022-11-22T08:23:21.732Z",
+      "updated_at": "2022-11-22T08:23:21.732Z",
+      "admin": true,
+      "owner": true,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+      "can_manage_projects": true,
+      "can_manage_people": true
+    }
+  },
+  {
+    "id": 1069479355,
+    "status": "active",
+    "visible_to_clients": false,
+    "created_at": "2022-10-28T15:26:00.000Z",
+    "updated_at": "2022-10-28T15:26:00.000Z",
+    "title": "Welcome to the project!",
+    "inherits_status": true,
+    "type": "Chat::Lines::Text",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/chats/1069479345/lines/1069479355.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/chats/1069479345#__recording_1069479355",
+    "content": "Welcome to the project!",
+    "parent": {
+      "id": 1069479345,
+      "title": "Campfire",
+      "type": "Chat::Transcript",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/chats/1069479345.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/chats/1069479345"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715915,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aeb392ebf54ffd820e45f27add22bae3a8c7da56",
+      "name": "Annie Bryan",
+      "email_address": "annie@honchodesign.com",
+      "personable_type": "User",
+      "title": "Central Markets Manager",
+      "bio": null,
+      "location": null,
+      "created_at": "2022-11-22T08:23:21.911Z",
+      "updated_at": "2022-11-22T08:23:21.911Z",
+      "admin": false,
+      "owner": false,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMtkkT4=--avatar",
+      "company": {
+        "id": 1033447817,
+        "name": "Honcho Design"
+      },
+      "can_manage_projects": true,
+      "can_manage_people": true
+    }
+  }
+]

--- a/spec/fixtures/campfires/list.json
+++ b/spec/fixtures/campfires/list.json
@@ -1,0 +1,78 @@
+[
+  {
+    "id": 1069479345,
+    "status": "active",
+    "visible_to_clients": false,
+    "created_at": "2022-10-28T15:21:46.169Z",
+    "updated_at": "2022-10-28T15:21:46.169Z",
+    "title": "Campfire",
+    "inherits_status": true,
+    "type": "Chat::Transcript",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/chats/1069479345.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/chats/1069479345",
+    "lines_url": "https://3.basecampapi.com/195539477/buckets/2085958499/chats/1069479345/lines.json",
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715914,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+      "name": "Victor Cooper",
+      "email_address": "victor@honchodesign.com",
+      "personable_type": "User",
+      "title": "Chief Strategist",
+      "bio": null,
+      "location": null,
+      "created_at": "2022-11-22T08:23:21.732Z",
+      "updated_at": "2022-11-22T08:23:21.732Z",
+      "admin": true,
+      "owner": true,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+      "can_manage_projects": true,
+      "can_manage_people": true
+    }
+  },
+  {
+    "id": 1069479400,
+    "status": "active",
+    "visible_to_clients": true,
+    "created_at": "2022-10-29T10:00:00.000Z",
+    "updated_at": "2022-10-29T10:00:00.000Z",
+    "title": "Campfire",
+    "inherits_status": true,
+    "type": "Chat::Transcript",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958500/chats/1069479400.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958500/chats/1069479400",
+    "lines_url": "https://3.basecampapi.com/195539477/buckets/2085958500/chats/1069479400/lines.json",
+    "bucket": {
+      "id": 2085958500,
+      "name": "Marketing Campaign",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715915,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aeb392ebf54ffd820e45f27add22bae3a8c7da56",
+      "name": "Annie Bryan",
+      "email_address": "annie@honchodesign.com",
+      "personable_type": "User",
+      "title": "Central Markets Manager",
+      "bio": null,
+      "location": null,
+      "created_at": "2022-11-22T08:23:21.911Z",
+      "updated_at": "2022-11-22T08:23:21.911Z",
+      "admin": false,
+      "owner": false,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMtkkT4=--avatar",
+      "can_manage_projects": true,
+      "can_manage_people": true
+    }
+  }
+]


### PR DESCRIPTION
## Summary

- Add `CampfiresService` with methods for managing Basecamp Campfires (real-time chat)
- Implement `Campfire` and `CampfireLine` structs with full JSON field mappings
- Add `Campfires()` accessor to client

### Methods
- `List(ctx)` - GET /chats.json (account-wide)
- `Get(ctx, bucketID, campfireID)` - GET /buckets/{id}/chats/{id}.json
- `ListLines(ctx, bucketID, campfireID)` - GET /buckets/{id}/chats/{id}/lines.json
- `GetLine(ctx, bucketID, campfireID, lineID)` - GET /buckets/{id}/chats/{id}/lines/{id}.json
- `CreateLine(ctx, bucketID, campfireID, content)` - POST /buckets/{id}/chats/{id}/lines.json
- `DeleteLine(ctx, bucketID, campfireID, lineID)` - DELETE /buckets/{id}/chats/{id}/lines/{id}.json

## Test plan

- [x] Unit tests for Campfire struct JSON unmarshaling (list and get)
- [x] Unit tests for CampfireLine struct JSON unmarshaling (list and get)
- [x] Unit tests for CreateCampfireLineRequest marshaling
- [x] All tests pass: `go test ./...`
- [x] No lint errors: `go vet ./...`
- [x] Build succeeds: `go build ./...`