### PR TITLE
Add TimesheetService for timesheet reports

### DIFF
--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -50,6 +50,7 @@ type Client struct {
 	lineup          *LineupService
 	subscriptions   *SubscriptionsService
 	campfires       *CampfiresService
+	timesheet       *TimesheetService
 }
 
 // Response wraps an API response.
@@ -627,4 +628,12 @@ func (c *Client) Campfires() *CampfiresService {
 		c.campfires = NewCampfiresService(c)
 	}
 	return c.campfires
+}
+
+// Timesheet returns the TimesheetService for timesheet report operations.
+func (c *Client) Timesheet() *TimesheetService {
+	if c.timesheet == nil {
+		c.timesheet = NewTimesheetService(c)
+	}
+	return c.timesheet
 }

--- a/go/pkg/basecamp/timesheet.go
+++ b/go/pkg/basecamp/timesheet.go
@@ -1,0 +1,141 @@
+package basecamp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// TimesheetEntry represents a single time entry in a Basecamp timesheet report.
+type TimesheetEntry struct {
+	ID             int64     `json:"id"`
+	Date           string    `json:"date"`
+	Hours          string    `json:"hours"`
+	Description    string    `json:"description,omitempty"`
+	Creator        *Person   `json:"creator,omitempty"`
+	Parent         *Parent   `json:"parent,omitempty"`
+	Bucket         *Bucket   `json:"bucket,omitempty"`
+	BillableStatus string    `json:"billable_status,omitempty"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+// TimesheetReportOptions specifies options for timesheet reports.
+type TimesheetReportOptions struct {
+	// From filters entries on or after this date (ISO 8601 format, e.g., "2024-01-01").
+	From string
+	// To filters entries on or before this date (ISO 8601 format, e.g., "2024-01-31").
+	To string
+	// PersonID filters entries by a specific person.
+	PersonID int64
+}
+
+// TimesheetService handles timesheet report operations.
+type TimesheetService struct {
+	client *Client
+}
+
+// NewTimesheetService creates a new TimesheetService.
+func NewTimesheetService(client *Client) *TimesheetService {
+	return &TimesheetService{client: client}
+}
+
+// buildQueryParams builds query parameters from options.
+func (s *TimesheetService) buildQueryParams(opts *TimesheetReportOptions) string {
+	if opts == nil {
+		return ""
+	}
+
+	params := url.Values{}
+	if opts.From != "" {
+		params.Set("from", opts.From)
+	}
+	if opts.To != "" {
+		params.Set("to", opts.To)
+	}
+	if opts.PersonID != 0 {
+		params.Set("person_id", fmt.Sprintf("%d", opts.PersonID))
+	}
+
+	if len(params) == 0 {
+		return ""
+	}
+	return "?" + params.Encode()
+}
+
+// Report returns the account-wide timesheet report.
+// This includes time entries across all projects in the account.
+func (s *TimesheetService) Report(ctx context.Context, opts *TimesheetReportOptions) ([]TimesheetEntry, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := "/reports/timesheet.json" + s.buildQueryParams(opts)
+	results, err := s.client.GetAll(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]TimesheetEntry, 0, len(results))
+	for _, raw := range results {
+		var e TimesheetEntry
+		if err := json.Unmarshal(raw, &e); err != nil {
+			return nil, fmt.Errorf("failed to parse timesheet entry: %w", err)
+		}
+		entries = append(entries, e)
+	}
+
+	return entries, nil
+}
+
+// ProjectReport returns the timesheet report for a specific project.
+// projectID is the project (bucket) ID.
+func (s *TimesheetService) ProjectReport(ctx context.Context, projectID int64, opts *TimesheetReportOptions) ([]TimesheetEntry, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/projects/%d/timesheet.json", projectID) + s.buildQueryParams(opts)
+	results, err := s.client.GetAll(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]TimesheetEntry, 0, len(results))
+	for _, raw := range results {
+		var e TimesheetEntry
+		if err := json.Unmarshal(raw, &e); err != nil {
+			return nil, fmt.Errorf("failed to parse timesheet entry: %w", err)
+		}
+		entries = append(entries, e)
+	}
+
+	return entries, nil
+}
+
+// RecordingReport returns the timesheet report for a specific recording within a project.
+// projectID is the project (bucket) ID, recordingID is the recording ID (e.g., a todo).
+func (s *TimesheetService) RecordingReport(ctx context.Context, projectID, recordingID int64, opts *TimesheetReportOptions) ([]TimesheetEntry, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/projects/%d/recordings/%d/timesheet.json", projectID, recordingID) + s.buildQueryParams(opts)
+	results, err := s.client.GetAll(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]TimesheetEntry, 0, len(results))
+	for _, raw := range results {
+		var e TimesheetEntry
+		if err := json.Unmarshal(raw, &e); err != nil {
+			return nil, fmt.Errorf("failed to parse timesheet entry: %w", err)
+		}
+		entries = append(entries, e)
+	}
+
+	return entries, nil
+}

--- a/go/pkg/basecamp/timesheet_test.go
+++ b/go/pkg/basecamp/timesheet_test.go
@@ -1,0 +1,248 @@
+package basecamp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func timesheetFixturesDir() string {
+	return filepath.Join("..", "..", "..", "spec", "fixtures", "timesheet")
+}
+
+func loadTimesheetFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	path := filepath.Join(timesheetFixturesDir(), name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func TestTimesheetEntry_UnmarshalReport(t *testing.T) {
+	data := loadTimesheetFixture(t, "report.json")
+
+	var entries []TimesheetEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		t.Fatalf("failed to unmarshal report.json: %v", err)
+	}
+
+	if len(entries) != 3 {
+		t.Errorf("expected 3 entries, got %d", len(entries))
+	}
+
+	// Verify first entry
+	e1 := entries[0]
+	if e1.ID != 9007199254741001 {
+		t.Errorf("expected ID 9007199254741001, got %d", e1.ID)
+	}
+	if e1.Date != "2024-01-15" {
+		t.Errorf("expected date '2024-01-15', got %q", e1.Date)
+	}
+	if e1.Hours != "2.5" {
+		t.Errorf("expected hours '2.5', got %q", e1.Hours)
+	}
+	if e1.Description != "Worked on project setup and initial planning" {
+		t.Errorf("unexpected description: %q", e1.Description)
+	}
+	if e1.BillableStatus != "billable" {
+		t.Errorf("expected billable_status 'billable', got %q", e1.BillableStatus)
+	}
+
+	// Verify creator
+	if e1.Creator == nil {
+		t.Fatal("expected Creator to be non-nil")
+	}
+	if e1.Creator.ID != 1049715914 {
+		t.Errorf("expected Creator.ID 1049715914, got %d", e1.Creator.ID)
+	}
+	if e1.Creator.Name != "Victor Cooper" {
+		t.Errorf("expected Creator.Name 'Victor Cooper', got %q", e1.Creator.Name)
+	}
+
+	// Verify parent (todo)
+	if e1.Parent == nil {
+		t.Fatal("expected Parent to be non-nil")
+	}
+	if e1.Parent.ID != 1069479345 {
+		t.Errorf("expected Parent.ID 1069479345, got %d", e1.Parent.ID)
+	}
+	if e1.Parent.Title != "Design homepage mockups" {
+		t.Errorf("expected Parent.Title 'Design homepage mockups', got %q", e1.Parent.Title)
+	}
+	if e1.Parent.Type != "Todo" {
+		t.Errorf("expected Parent.Type 'Todo', got %q", e1.Parent.Type)
+	}
+
+	// Verify bucket
+	if e1.Bucket == nil {
+		t.Fatal("expected Bucket to be non-nil")
+	}
+	if e1.Bucket.ID != 2085958499 {
+		t.Errorf("expected Bucket.ID 2085958499, got %d", e1.Bucket.ID)
+	}
+	if e1.Bucket.Name != "The Leto Laptop" {
+		t.Errorf("expected Bucket.Name 'The Leto Laptop', got %q", e1.Bucket.Name)
+	}
+
+	// Verify timestamps are parsed
+	if e1.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be non-zero")
+	}
+	if e1.UpdatedAt.IsZero() {
+		t.Error("expected UpdatedAt to be non-zero")
+	}
+
+	// Verify second entry with different creator
+	e2 := entries[1]
+	if e2.ID != 9007199254741002 {
+		t.Errorf("expected ID 9007199254741002, got %d", e2.ID)
+	}
+	if e2.Hours != "4.0" {
+		t.Errorf("expected hours '4.0', got %q", e2.Hours)
+	}
+	if e2.Creator == nil {
+		t.Fatal("expected Creator to be non-nil for second entry")
+	}
+	if e2.Creator.Name != "Annie Bryan" {
+		t.Errorf("expected Creator.Name 'Annie Bryan', got %q", e2.Creator.Name)
+	}
+	// Verify creator with company
+	if e2.Creator.Company == nil {
+		t.Fatal("expected Creator.Company to be non-nil for second entry")
+	}
+	if e2.Creator.Company.Name != "Honcho Design" {
+		t.Errorf("expected Creator.Company.Name 'Honcho Design', got %q", e2.Creator.Company.Name)
+	}
+
+	// Verify third entry has non_billable status
+	e3 := entries[2]
+	if e3.BillableStatus != "non_billable" {
+		t.Errorf("expected billable_status 'non_billable', got %q", e3.BillableStatus)
+	}
+	// Third entry is for a different project
+	if e3.Bucket == nil {
+		t.Fatal("expected Bucket to be non-nil for third entry")
+	}
+	if e3.Bucket.ID != 2085958500 {
+		t.Errorf("expected Bucket.ID 2085958500, got %d", e3.Bucket.ID)
+	}
+}
+
+func TestTimesheetEntry_UnmarshalProjectReport(t *testing.T) {
+	data := loadTimesheetFixture(t, "project_report.json")
+
+	var entries []TimesheetEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		t.Fatalf("failed to unmarshal project_report.json: %v", err)
+	}
+
+	if len(entries) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(entries))
+	}
+
+	// All entries should be for the same project
+	for i, e := range entries {
+		if e.Bucket == nil {
+			t.Fatalf("entry %d: expected Bucket to be non-nil", i)
+		}
+		if e.Bucket.ID != 2085958499 {
+			t.Errorf("entry %d: expected Bucket.ID 2085958499, got %d", i, e.Bucket.ID)
+		}
+	}
+}
+
+func TestTimesheetEntry_UnmarshalRecordingReport(t *testing.T) {
+	data := loadTimesheetFixture(t, "recording_report.json")
+
+	var entries []TimesheetEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		t.Fatalf("failed to unmarshal recording_report.json: %v", err)
+	}
+
+	if len(entries) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(entries))
+	}
+
+	// Verify the single entry
+	e := entries[0]
+	if e.ID != 9007199254741001 {
+		t.Errorf("expected ID 9007199254741001, got %d", e.ID)
+	}
+	if e.Parent == nil {
+		t.Fatal("expected Parent to be non-nil")
+	}
+	if e.Parent.ID != 1069479345 {
+		t.Errorf("expected Parent.ID 1069479345, got %d", e.Parent.ID)
+	}
+}
+
+func TestTimesheetReportOptions_BuildQueryParams(t *testing.T) {
+	service := &TimesheetService{}
+
+	tests := []struct {
+		name     string
+		opts     *TimesheetReportOptions
+		expected string
+	}{
+		{
+			name:     "nil options",
+			opts:     nil,
+			expected: "",
+		},
+		{
+			name:     "empty options",
+			opts:     &TimesheetReportOptions{},
+			expected: "",
+		},
+		{
+			name: "from only",
+			opts: &TimesheetReportOptions{
+				From: "2024-01-01",
+			},
+			expected: "?from=2024-01-01",
+		},
+		{
+			name: "to only",
+			opts: &TimesheetReportOptions{
+				To: "2024-01-31",
+			},
+			expected: "?to=2024-01-31",
+		},
+		{
+			name: "person_id only",
+			opts: &TimesheetReportOptions{
+				PersonID: 1049715914,
+			},
+			expected: "?person_id=1049715914",
+		},
+		{
+			name: "from and to",
+			opts: &TimesheetReportOptions{
+				From: "2024-01-01",
+				To:   "2024-01-31",
+			},
+			expected: "?from=2024-01-01&to=2024-01-31",
+		},
+		{
+			name: "all options",
+			opts: &TimesheetReportOptions{
+				From:     "2024-01-01",
+				To:       "2024-01-31",
+				PersonID: 1049715914,
+			},
+			expected: "?from=2024-01-01&person_id=1049715914&to=2024-01-31",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := service.buildQueryParams(tt.opts)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}

--- a/spec/fixtures/timesheet/project_report.json
+++ b/spec/fixtures/timesheet/project_report.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": 9007199254741001,
+    "date": "2024-01-15",
+    "hours": "2.5",
+    "description": "Worked on project setup and initial planning",
+    "billable_status": "billable",
+    "created_at": "2024-01-15T10:30:00.000Z",
+    "updated_at": "2024-01-15T10:30:00.000Z",
+    "creator": {
+      "id": 1049715914,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+      "name": "Victor Cooper",
+      "email_address": "victor@honchodesign.com",
+      "personable_type": "User",
+      "title": "Chief Strategist",
+      "admin": true,
+      "owner": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar"
+    },
+    "parent": {
+      "id": 1069479345,
+      "title": "Design homepage mockups",
+      "type": "Todo",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/todos/1069479345.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/todos/1069479345"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    }
+  },
+  {
+    "id": 9007199254741002,
+    "date": "2024-01-16",
+    "hours": "4.0",
+    "description": "Implemented core features",
+    "billable_status": "billable",
+    "created_at": "2024-01-16T14:00:00.000Z",
+    "updated_at": "2024-01-16T14:00:00.000Z",
+    "creator": {
+      "id": 1049715915,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--eeffgghhii",
+      "name": "Annie Bryan",
+      "email_address": "annie@honchodesign.com",
+      "personable_type": "User",
+      "title": "Central Markets Manager",
+      "admin": false,
+      "owner": false,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMtkkT4=--avatar",
+      "company": {
+        "id": 1033447817,
+        "name": "Honcho Design"
+      }
+    },
+    "parent": {
+      "id": 1069479346,
+      "title": "Write documentation",
+      "type": "Todo",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/todos/1069479346.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/todos/1069479346"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    }
+  }
+]

--- a/spec/fixtures/timesheet/recording_report.json
+++ b/spec/fixtures/timesheet/recording_report.json
@@ -1,0 +1,35 @@
+[
+  {
+    "id": 9007199254741001,
+    "date": "2024-01-15",
+    "hours": "2.5",
+    "description": "Worked on project setup and initial planning",
+    "billable_status": "billable",
+    "created_at": "2024-01-15T10:30:00.000Z",
+    "updated_at": "2024-01-15T10:30:00.000Z",
+    "creator": {
+      "id": 1049715914,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+      "name": "Victor Cooper",
+      "email_address": "victor@honchodesign.com",
+      "personable_type": "User",
+      "title": "Chief Strategist",
+      "admin": true,
+      "owner": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar"
+    },
+    "parent": {
+      "id": 1069479345,
+      "title": "Design homepage mockups",
+      "type": "Todo",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/todos/1069479345.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/todos/1069479345"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    }
+  }
+]

--- a/spec/fixtures/timesheet/report.json
+++ b/spec/fixtures/timesheet/report.json
@@ -1,0 +1,105 @@
+[
+  {
+    "id": 9007199254741001,
+    "date": "2024-01-15",
+    "hours": "2.5",
+    "description": "Worked on project setup and initial planning",
+    "billable_status": "billable",
+    "created_at": "2024-01-15T10:30:00.000Z",
+    "updated_at": "2024-01-15T10:30:00.000Z",
+    "creator": {
+      "id": 1049715914,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+      "name": "Victor Cooper",
+      "email_address": "victor@honchodesign.com",
+      "personable_type": "User",
+      "title": "Chief Strategist",
+      "admin": true,
+      "owner": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar"
+    },
+    "parent": {
+      "id": 1069479345,
+      "title": "Design homepage mockups",
+      "type": "Todo",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/todos/1069479345.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/todos/1069479345"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    }
+  },
+  {
+    "id": 9007199254741002,
+    "date": "2024-01-16",
+    "hours": "4.0",
+    "description": "Implemented core features",
+    "billable_status": "billable",
+    "created_at": "2024-01-16T14:00:00.000Z",
+    "updated_at": "2024-01-16T14:00:00.000Z",
+    "creator": {
+      "id": 1049715915,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--eeffgghhii",
+      "name": "Annie Bryan",
+      "email_address": "annie@honchodesign.com",
+      "personable_type": "User",
+      "title": "Central Markets Manager",
+      "admin": false,
+      "owner": false,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMtkkT4=--avatar",
+      "company": {
+        "id": 1033447817,
+        "name": "Honcho Design"
+      }
+    },
+    "parent": {
+      "id": 1069479346,
+      "title": "Write documentation",
+      "type": "Todo",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/todos/1069479346.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/todos/1069479346"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    }
+  },
+  {
+    "id": 9007199254741003,
+    "date": "2024-01-16",
+    "hours": "1.5",
+    "description": "Code review and feedback",
+    "billable_status": "non_billable",
+    "created_at": "2024-01-16T16:30:00.000Z",
+    "updated_at": "2024-01-16T16:30:00.000Z",
+    "creator": {
+      "id": 1049715914,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+      "name": "Victor Cooper",
+      "email_address": "victor@honchodesign.com",
+      "personable_type": "User",
+      "title": "Chief Strategist",
+      "admin": true,
+      "owner": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar"
+    },
+    "parent": {
+      "id": 1069479346,
+      "title": "Write documentation",
+      "type": "Todo",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/todos/1069479346.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/todos/1069479346"
+    },
+    "bucket": {
+      "id": 2085958500,
+      "name": "Marketing Campaign",
+      "type": "Project"
+    }
+  }
+]


### PR DESCRIPTION
Implements timesheet report functionality with three methods:
- Report: Account-wide timesheet report
- ProjectReport: Project-specific timesheet report
- RecordingReport: Recording-specific timesheet report

All methods support filtering by date range (from/to) and person ID.
