### PR TITLE
Add ForwardsService for email forwards

### DIFF
--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -52,6 +52,7 @@ type Client struct {
 	campfires       *CampfiresService
 	timesheet       *TimesheetService
 	schedules       *SchedulesService
+	forwards        *ForwardsService
 }
 
 // Response wraps an API response.
@@ -645,4 +646,12 @@ func (c *Client) Schedules() *SchedulesService {
 		c.schedules = NewSchedulesService(c)
 	}
 	return c.schedules
+}
+
+// Forwards returns the ForwardsService for email forward operations.
+func (c *Client) Forwards() *ForwardsService {
+	if c.forwards == nil {
+		c.forwards = NewForwardsService(c)
+	}
+	return c.forwards
 }

--- a/go/pkg/basecamp/forwards.go
+++ b/go/pkg/basecamp/forwards.go
@@ -1,0 +1,177 @@
+package basecamp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Inbox represents a Basecamp email inbox (forwards tool).
+type Inbox struct {
+	ID        int64     `json:"id"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Title     string    `json:"title"`
+	Type      string    `json:"type"`
+	URL       string    `json:"url"`
+	AppURL    string    `json:"app_url"`
+	Bucket    *Bucket   `json:"bucket,omitempty"`
+	Creator   *Person   `json:"creator,omitempty"`
+}
+
+// Forward represents a forwarded email in Basecamp.
+type Forward struct {
+	ID        int64     `json:"id"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Subject   string    `json:"subject"`
+	Content   string    `json:"content"`
+	From      string    `json:"from"`
+	Type      string    `json:"type"`
+	URL       string    `json:"url"`
+	AppURL    string    `json:"app_url"`
+	Parent    *Parent   `json:"parent,omitempty"`
+	Bucket    *Bucket   `json:"bucket,omitempty"`
+	Creator   *Person   `json:"creator,omitempty"`
+}
+
+// ForwardReply represents a reply to a forwarded email.
+type ForwardReply struct {
+	ID        int64     `json:"id"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Content   string    `json:"content"`
+	Type      string    `json:"type"`
+	URL       string    `json:"url"`
+	AppURL    string    `json:"app_url"`
+	Parent    *Parent   `json:"parent,omitempty"`
+	Bucket    *Bucket   `json:"bucket,omitempty"`
+	Creator   *Person   `json:"creator,omitempty"`
+}
+
+// ForwardsService handles email forward operations.
+type ForwardsService struct {
+	client *Client
+}
+
+// NewForwardsService creates a new ForwardsService.
+func NewForwardsService(client *Client) *ForwardsService {
+	return &ForwardsService{client: client}
+}
+
+// GetInbox returns an inbox by ID.
+// bucketID is the project ID, inboxID is the inbox ID.
+func (s *ForwardsService) GetInbox(ctx context.Context, bucketID, inboxID int64) (*Inbox, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/inboxes/%d.json", bucketID, inboxID)
+	resp, err := s.client.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var inbox Inbox
+	if err := resp.UnmarshalData(&inbox); err != nil {
+		return nil, fmt.Errorf("failed to parse inbox: %w", err)
+	}
+
+	return &inbox, nil
+}
+
+// List returns all forwards in an inbox.
+// bucketID is the project ID, inboxID is the inbox ID.
+func (s *ForwardsService) List(ctx context.Context, bucketID, inboxID int64) ([]Forward, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/inboxes/%d/forwards.json", bucketID, inboxID)
+	results, err := s.client.GetAll(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	forwards := make([]Forward, 0, len(results))
+	for _, raw := range results {
+		var f Forward
+		if err := json.Unmarshal(raw, &f); err != nil {
+			return nil, fmt.Errorf("failed to parse forward: %w", err)
+		}
+		forwards = append(forwards, f)
+	}
+
+	return forwards, nil
+}
+
+// Get returns a forward by ID.
+// bucketID is the project ID, forwardID is the forward ID.
+func (s *ForwardsService) Get(ctx context.Context, bucketID, forwardID int64) (*Forward, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/inbox_forwards/%d.json", bucketID, forwardID)
+	resp, err := s.client.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var forward Forward
+	if err := resp.UnmarshalData(&forward); err != nil {
+		return nil, fmt.Errorf("failed to parse forward: %w", err)
+	}
+
+	return &forward, nil
+}
+
+// ListReplies returns all replies to a forward.
+// bucketID is the project ID, forwardID is the forward ID.
+func (s *ForwardsService) ListReplies(ctx context.Context, bucketID, forwardID int64) ([]ForwardReply, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/inbox_forwards/%d/replies.json", bucketID, forwardID)
+	results, err := s.client.GetAll(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	replies := make([]ForwardReply, 0, len(results))
+	for _, raw := range results {
+		var r ForwardReply
+		if err := json.Unmarshal(raw, &r); err != nil {
+			return nil, fmt.Errorf("failed to parse forward reply: %w", err)
+		}
+		replies = append(replies, r)
+	}
+
+	return replies, nil
+}
+
+// GetReply returns a forward reply by ID.
+// bucketID is the project ID, forwardID is the forward ID, replyID is the reply ID.
+func (s *ForwardsService) GetReply(ctx context.Context, bucketID, forwardID, replyID int64) (*ForwardReply, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/inbox_forwards/%d/replies/%d.json", bucketID, forwardID, replyID)
+	resp, err := s.client.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var reply ForwardReply
+	if err := resp.UnmarshalData(&reply); err != nil {
+		return nil, fmt.Errorf("failed to parse forward reply: %w", err)
+	}
+
+	return &reply, nil
+}

--- a/go/pkg/basecamp/forwards_test.go
+++ b/go/pkg/basecamp/forwards_test.go
@@ -1,0 +1,364 @@
+package basecamp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func forwardsFixturesDir() string {
+	return filepath.Join("..", "..", "..", "spec", "fixtures", "forwards")
+}
+
+func loadForwardsFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	path := filepath.Join(forwardsFixturesDir(), name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func TestInbox_Unmarshal(t *testing.T) {
+	data := loadForwardsFixture(t, "inbox.json")
+
+	var inbox Inbox
+	if err := json.Unmarshal(data, &inbox); err != nil {
+		t.Fatalf("failed to unmarshal inbox.json: %v", err)
+	}
+
+	if inbox.ID != 1069479342 {
+		t.Errorf("expected ID 1069479342, got %d", inbox.ID)
+	}
+	if inbox.Status != "active" {
+		t.Errorf("expected status 'active', got %q", inbox.Status)
+	}
+	if inbox.Type != "Inbox" {
+		t.Errorf("expected type 'Inbox', got %q", inbox.Type)
+	}
+	if inbox.Title != "Email Forwards" {
+		t.Errorf("expected title 'Email Forwards', got %q", inbox.Title)
+	}
+	if inbox.URL != "https://3.basecampapi.com/195539477/buckets/2085958499/inboxes/1069479342.json" {
+		t.Errorf("unexpected URL: %q", inbox.URL)
+	}
+	if inbox.AppURL != "https://3.basecamp.com/195539477/buckets/2085958499/inboxes/1069479342" {
+		t.Errorf("unexpected AppURL: %q", inbox.AppURL)
+	}
+
+	// Verify bucket
+	if inbox.Bucket == nil {
+		t.Fatal("expected Bucket to be non-nil")
+	}
+	if inbox.Bucket.ID != 2085958499 {
+		t.Errorf("expected Bucket.ID 2085958499, got %d", inbox.Bucket.ID)
+	}
+	if inbox.Bucket.Name != "The Leto Laptop" {
+		t.Errorf("expected Bucket.Name 'The Leto Laptop', got %q", inbox.Bucket.Name)
+	}
+
+	// Verify creator
+	if inbox.Creator == nil {
+		t.Fatal("expected Creator to be non-nil")
+	}
+	if inbox.Creator.ID != 1049715914 {
+		t.Errorf("expected Creator.ID 1049715914, got %d", inbox.Creator.ID)
+	}
+	if inbox.Creator.Name != "Victor Cooper" {
+		t.Errorf("expected Creator.Name 'Victor Cooper', got %q", inbox.Creator.Name)
+	}
+
+	// Verify timestamps are parsed
+	if inbox.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be non-zero")
+	}
+	if inbox.UpdatedAt.IsZero() {
+		t.Error("expected UpdatedAt to be non-zero")
+	}
+}
+
+func TestForward_UnmarshalList(t *testing.T) {
+	data := loadForwardsFixture(t, "list.json")
+
+	var forwards []Forward
+	if err := json.Unmarshal(data, &forwards); err != nil {
+		t.Fatalf("failed to unmarshal list.json: %v", err)
+	}
+
+	if len(forwards) != 2 {
+		t.Errorf("expected 2 forwards, got %d", len(forwards))
+	}
+
+	// Verify first forward
+	f1 := forwards[0]
+	if f1.ID != 1069479380 {
+		t.Errorf("expected ID 1069479380, got %d", f1.ID)
+	}
+	if f1.Status != "active" {
+		t.Errorf("expected status 'active', got %q", f1.Status)
+	}
+	if f1.Type != "Inbox::Forward" {
+		t.Errorf("expected type 'Inbox::Forward', got %q", f1.Type)
+	}
+	if f1.Subject != "Project proposal from client" {
+		t.Errorf("expected subject 'Project proposal from client', got %q", f1.Subject)
+	}
+	if f1.From != "client@example.com" {
+		t.Errorf("expected from 'client@example.com', got %q", f1.From)
+	}
+	if f1.Content != "<div>Hi team,<br><br>Please review the attached proposal for the new project.</div>" {
+		t.Errorf("unexpected content: %q", f1.Content)
+	}
+
+	// Verify parent (inbox)
+	if f1.Parent == nil {
+		t.Fatal("expected Parent to be non-nil")
+	}
+	if f1.Parent.ID != 1069479342 {
+		t.Errorf("expected Parent.ID 1069479342, got %d", f1.Parent.ID)
+	}
+	if f1.Parent.Title != "Email Forwards" {
+		t.Errorf("expected Parent.Title 'Email Forwards', got %q", f1.Parent.Title)
+	}
+	if f1.Parent.Type != "Inbox" {
+		t.Errorf("expected Parent.Type 'Inbox', got %q", f1.Parent.Type)
+	}
+
+	// Verify bucket
+	if f1.Bucket == nil {
+		t.Fatal("expected Bucket to be non-nil")
+	}
+	if f1.Bucket.ID != 2085958499 {
+		t.Errorf("expected Bucket.ID 2085958499, got %d", f1.Bucket.ID)
+	}
+
+	// Verify creator
+	if f1.Creator == nil {
+		t.Fatal("expected Creator to be non-nil")
+	}
+	if f1.Creator.ID != 1049715914 {
+		t.Errorf("expected Creator.ID 1049715914, got %d", f1.Creator.ID)
+	}
+	if f1.Creator.Name != "Victor Cooper" {
+		t.Errorf("expected Creator.Name 'Victor Cooper', got %q", f1.Creator.Name)
+	}
+
+	// Verify second forward
+	f2 := forwards[1]
+	if f2.ID != 1069479390 {
+		t.Errorf("expected ID 1069479390, got %d", f2.ID)
+	}
+	if f2.Subject != "Invoice #12345" {
+		t.Errorf("expected subject 'Invoice #12345', got %q", f2.Subject)
+	}
+	if f2.From != "billing@vendor.com" {
+		t.Errorf("expected from 'billing@vendor.com', got %q", f2.From)
+	}
+	if f2.Creator == nil {
+		t.Fatal("expected Creator to be non-nil for second forward")
+	}
+	if f2.Creator.Name != "Annie Bryan" {
+		t.Errorf("expected Creator.Name 'Annie Bryan', got %q", f2.Creator.Name)
+	}
+	// Verify creator with company
+	if f2.Creator.Company == nil {
+		t.Fatal("expected Creator.Company to be non-nil for second forward")
+	}
+	if f2.Creator.Company.Name != "Honcho Design" {
+		t.Errorf("expected Creator.Company.Name 'Honcho Design', got %q", f2.Creator.Company.Name)
+	}
+}
+
+func TestForward_UnmarshalGet(t *testing.T) {
+	data := loadForwardsFixture(t, "get.json")
+
+	var forward Forward
+	if err := json.Unmarshal(data, &forward); err != nil {
+		t.Fatalf("failed to unmarshal get.json: %v", err)
+	}
+
+	if forward.ID != 1069479380 {
+		t.Errorf("expected ID 1069479380, got %d", forward.ID)
+	}
+	if forward.Status != "active" {
+		t.Errorf("expected status 'active', got %q", forward.Status)
+	}
+	if forward.Type != "Inbox::Forward" {
+		t.Errorf("expected type 'Inbox::Forward', got %q", forward.Type)
+	}
+	if forward.Subject != "Project proposal from client" {
+		t.Errorf("expected subject 'Project proposal from client', got %q", forward.Subject)
+	}
+	if forward.From != "client@example.com" {
+		t.Errorf("expected from 'client@example.com', got %q", forward.From)
+	}
+
+	// Verify timestamps are parsed
+	if forward.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be non-zero")
+	}
+	if forward.UpdatedAt.IsZero() {
+		t.Error("expected UpdatedAt to be non-zero")
+	}
+
+	// Verify creator with full details
+	if forward.Creator == nil {
+		t.Fatal("expected Creator to be non-nil")
+	}
+	if forward.Creator.ID != 1049715914 {
+		t.Errorf("expected Creator.ID 1049715914, got %d", forward.Creator.ID)
+	}
+	if forward.Creator.Name != "Victor Cooper" {
+		t.Errorf("expected Creator.Name 'Victor Cooper', got %q", forward.Creator.Name)
+	}
+	if forward.Creator.EmailAddress != "victor@honchodesign.com" {
+		t.Errorf("expected Creator.EmailAddress 'victor@honchodesign.com', got %q", forward.Creator.EmailAddress)
+	}
+	if forward.Creator.Title != "Chief Strategist" {
+		t.Errorf("expected Creator.Title 'Chief Strategist', got %q", forward.Creator.Title)
+	}
+	if !forward.Creator.Owner {
+		t.Error("expected Creator.Owner to be true")
+	}
+	if !forward.Creator.Admin {
+		t.Error("expected Creator.Admin to be true")
+	}
+}
+
+func TestForwardReply_UnmarshalList(t *testing.T) {
+	data := loadForwardsFixture(t, "replies_list.json")
+
+	var replies []ForwardReply
+	if err := json.Unmarshal(data, &replies); err != nil {
+		t.Fatalf("failed to unmarshal replies_list.json: %v", err)
+	}
+
+	if len(replies) != 2 {
+		t.Errorf("expected 2 replies, got %d", len(replies))
+	}
+
+	// Verify first reply
+	r1 := replies[0]
+	if r1.ID != 1069479400 {
+		t.Errorf("expected ID 1069479400, got %d", r1.ID)
+	}
+	if r1.Status != "active" {
+		t.Errorf("expected status 'active', got %q", r1.Status)
+	}
+	if r1.Type != "Inbox::Forward::Reply" {
+		t.Errorf("expected type 'Inbox::Forward::Reply', got %q", r1.Type)
+	}
+	if r1.Content != "<div>Thanks for forwarding this. I'll review and get back to you by EOD.</div>" {
+		t.Errorf("unexpected content: %q", r1.Content)
+	}
+
+	// Verify parent (forward)
+	if r1.Parent == nil {
+		t.Fatal("expected Parent to be non-nil")
+	}
+	if r1.Parent.ID != 1069479380 {
+		t.Errorf("expected Parent.ID 1069479380, got %d", r1.Parent.ID)
+	}
+	if r1.Parent.Title != "Project proposal from client" {
+		t.Errorf("expected Parent.Title 'Project proposal from client', got %q", r1.Parent.Title)
+	}
+	if r1.Parent.Type != "Inbox::Forward" {
+		t.Errorf("expected Parent.Type 'Inbox::Forward', got %q", r1.Parent.Type)
+	}
+
+	// Verify bucket
+	if r1.Bucket == nil {
+		t.Fatal("expected Bucket to be non-nil")
+	}
+	if r1.Bucket.ID != 2085958499 {
+		t.Errorf("expected Bucket.ID 2085958499, got %d", r1.Bucket.ID)
+	}
+
+	// Verify creator
+	if r1.Creator == nil {
+		t.Fatal("expected Creator to be non-nil")
+	}
+	if r1.Creator.ID != 1049715915 {
+		t.Errorf("expected Creator.ID 1049715915, got %d", r1.Creator.ID)
+	}
+	if r1.Creator.Name != "Annie Bryan" {
+		t.Errorf("expected Creator.Name 'Annie Bryan', got %q", r1.Creator.Name)
+	}
+
+	// Verify second reply
+	r2 := replies[1]
+	if r2.ID != 1069479410 {
+		t.Errorf("expected ID 1069479410, got %d", r2.ID)
+	}
+	if r2.Content != "<div>Looks good! I've approved the proposal. Let's schedule a kickoff call.</div>" {
+		t.Errorf("unexpected content: %q", r2.Content)
+	}
+	if r2.Creator == nil {
+		t.Fatal("expected Creator to be non-nil for second reply")
+	}
+	if r2.Creator.Name != "Victor Cooper" {
+		t.Errorf("expected Creator.Name 'Victor Cooper', got %q", r2.Creator.Name)
+	}
+}
+
+func TestForwardReply_UnmarshalGet(t *testing.T) {
+	data := loadForwardsFixture(t, "reply_get.json")
+
+	var reply ForwardReply
+	if err := json.Unmarshal(data, &reply); err != nil {
+		t.Fatalf("failed to unmarshal reply_get.json: %v", err)
+	}
+
+	if reply.ID != 1069479400 {
+		t.Errorf("expected ID 1069479400, got %d", reply.ID)
+	}
+	if reply.Status != "active" {
+		t.Errorf("expected status 'active', got %q", reply.Status)
+	}
+	if reply.Type != "Inbox::Forward::Reply" {
+		t.Errorf("expected type 'Inbox::Forward::Reply', got %q", reply.Type)
+	}
+	if reply.Content != "<div>Thanks for forwarding this. I'll review and get back to you by EOD.</div>" {
+		t.Errorf("unexpected content: %q", reply.Content)
+	}
+
+	// Verify timestamps are parsed
+	if reply.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be non-zero")
+	}
+	if reply.UpdatedAt.IsZero() {
+		t.Error("expected UpdatedAt to be non-zero")
+	}
+
+	// Verify creator with full details
+	if reply.Creator == nil {
+		t.Fatal("expected Creator to be non-nil")
+	}
+	if reply.Creator.ID != 1049715915 {
+		t.Errorf("expected Creator.ID 1049715915, got %d", reply.Creator.ID)
+	}
+	if reply.Creator.Name != "Annie Bryan" {
+		t.Errorf("expected Creator.Name 'Annie Bryan', got %q", reply.Creator.Name)
+	}
+	if reply.Creator.EmailAddress != "annie@honchodesign.com" {
+		t.Errorf("expected Creator.EmailAddress 'annie@honchodesign.com', got %q", reply.Creator.EmailAddress)
+	}
+	if reply.Creator.Title != "Project Manager" {
+		t.Errorf("expected Creator.Title 'Project Manager', got %q", reply.Creator.Title)
+	}
+	if reply.Creator.Owner {
+		t.Error("expected Creator.Owner to be false")
+	}
+	if reply.Creator.Admin {
+		t.Error("expected Creator.Admin to be false")
+	}
+	// Verify creator with company
+	if reply.Creator.Company == nil {
+		t.Fatal("expected Creator.Company to be non-nil")
+	}
+	if reply.Creator.Company.Name != "Honcho Design" {
+		t.Errorf("expected Creator.Company.Name 'Honcho Design', got %q", reply.Creator.Company.Name)
+	}
+}

--- a/spec/fixtures/forwards/get.json
+++ b/spec/fixtures/forwards/get.json
@@ -1,0 +1,42 @@
+{
+  "id": 1069479380,
+  "status": "active",
+  "created_at": "2024-01-16T14:30:00.000Z",
+  "updated_at": "2024-01-16T14:30:00.000Z",
+  "subject": "Project proposal from client",
+  "content": "<div>Hi team,<br><br>Please review the attached proposal for the new project.</div>",
+  "from": "client@example.com",
+  "type": "Inbox::Forward",
+  "url": "https://3.basecampapi.com/195539477/buckets/2085958499/inbox_forwards/1069479380.json",
+  "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/inbox_forwards/1069479380",
+  "parent": {
+    "id": 1069479342,
+    "title": "Email Forwards",
+    "type": "Inbox",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/inboxes/1069479342.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/inboxes/1069479342"
+  },
+  "bucket": {
+    "id": 2085958499,
+    "name": "The Leto Laptop",
+    "type": "Project"
+  },
+  "creator": {
+    "id": 1049715914,
+    "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aeb392ebef54851145b2f82f5f4c0a11be1c08c2",
+    "name": "Victor Cooper",
+    "email_address": "victor@honchodesign.com",
+    "personable_type": "User",
+    "title": "Chief Strategist",
+    "bio": null,
+    "location": null,
+    "created_at": "2024-01-10T09:00:00.000Z",
+    "updated_at": "2024-01-10T09:00:00.000Z",
+    "admin": true,
+    "owner": true,
+    "client": false,
+    "employee": true,
+    "time_zone": "America/Chicago",
+    "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--e9c67c17e3fc5c36ae1eaeefe7cc2a3ba1b7f05a/avatar?v=1"
+  }
+}

--- a/spec/fixtures/forwards/inbox.json
+++ b/spec/fixtures/forwards/inbox.json
@@ -1,0 +1,33 @@
+{
+  "id": 1069479342,
+  "status": "active",
+  "created_at": "2024-01-15T10:30:00.000Z",
+  "updated_at": "2024-01-15T10:30:00.000Z",
+  "title": "Email Forwards",
+  "type": "Inbox",
+  "url": "https://3.basecampapi.com/195539477/buckets/2085958499/inboxes/1069479342.json",
+  "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/inboxes/1069479342",
+  "bucket": {
+    "id": 2085958499,
+    "name": "The Leto Laptop",
+    "type": "Project"
+  },
+  "creator": {
+    "id": 1049715914,
+    "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aeb392ebef54851145b2f82f5f4c0a11be1c08c2",
+    "name": "Victor Cooper",
+    "email_address": "victor@honchodesign.com",
+    "personable_type": "User",
+    "title": "Chief Strategist",
+    "bio": null,
+    "location": null,
+    "created_at": "2024-01-10T09:00:00.000Z",
+    "updated_at": "2024-01-10T09:00:00.000Z",
+    "admin": true,
+    "owner": true,
+    "client": false,
+    "employee": true,
+    "time_zone": "America/Chicago",
+    "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--e9c67c17e3fc5c36ae1eaeefe7cc2a3ba1b7f05a/avatar?v=1"
+  }
+}

--- a/spec/fixtures/forwards/list.json
+++ b/spec/fixtures/forwards/list.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": 1069479380,
+    "status": "active",
+    "created_at": "2024-01-16T14:30:00.000Z",
+    "updated_at": "2024-01-16T14:30:00.000Z",
+    "subject": "Project proposal from client",
+    "content": "<div>Hi team,<br><br>Please review the attached proposal for the new project.</div>",
+    "from": "client@example.com",
+    "type": "Inbox::Forward",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/inbox_forwards/1069479380.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/inbox_forwards/1069479380",
+    "parent": {
+      "id": 1069479342,
+      "title": "Email Forwards",
+      "type": "Inbox",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/inboxes/1069479342.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/inboxes/1069479342"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715914,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aeb392ebef54851145b2f82f5f4c0a11be1c08c2",
+      "name": "Victor Cooper",
+      "email_address": "victor@honchodesign.com",
+      "personable_type": "User",
+      "title": "Chief Strategist",
+      "admin": true,
+      "owner": true
+    }
+  },
+  {
+    "id": 1069479390,
+    "status": "active",
+    "created_at": "2024-01-17T09:15:00.000Z",
+    "updated_at": "2024-01-17T09:15:00.000Z",
+    "subject": "Invoice #12345",
+    "content": "<div>Please find attached the invoice for last month's services.</div>",
+    "from": "billing@vendor.com",
+    "type": "Inbox::Forward",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/inbox_forwards/1069479390.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/inbox_forwards/1069479390",
+    "parent": {
+      "id": 1069479342,
+      "title": "Email Forwards",
+      "type": "Inbox",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/inboxes/1069479342.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/inboxes/1069479342"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715915,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aeb392ebef54851145b2f82f5f4c0a11be1c08c3",
+      "name": "Annie Bryan",
+      "email_address": "annie@honchodesign.com",
+      "personable_type": "User",
+      "title": "Project Manager",
+      "admin": false,
+      "owner": false,
+      "company": {
+        "id": 1033447817,
+        "name": "Honcho Design"
+      }
+    }
+  }
+]

--- a/spec/fixtures/forwards/replies_list.json
+++ b/spec/fixtures/forwards/replies_list.json
@@ -1,0 +1,66 @@
+[
+  {
+    "id": 1069479400,
+    "status": "active",
+    "created_at": "2024-01-16T15:00:00.000Z",
+    "updated_at": "2024-01-16T15:00:00.000Z",
+    "content": "<div>Thanks for forwarding this. I'll review and get back to you by EOD.</div>",
+    "type": "Inbox::Forward::Reply",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/inbox_forwards/1069479380/replies/1069479400.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/inbox_forwards/1069479380/replies/1069479400",
+    "parent": {
+      "id": 1069479380,
+      "title": "Project proposal from client",
+      "type": "Inbox::Forward",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/inbox_forwards/1069479380.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/inbox_forwards/1069479380"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715915,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aeb392ebef54851145b2f82f5f4c0a11be1c08c3",
+      "name": "Annie Bryan",
+      "email_address": "annie@honchodesign.com",
+      "personable_type": "User",
+      "title": "Project Manager",
+      "admin": false,
+      "owner": false
+    }
+  },
+  {
+    "id": 1069479410,
+    "status": "active",
+    "created_at": "2024-01-16T17:30:00.000Z",
+    "updated_at": "2024-01-16T17:30:00.000Z",
+    "content": "<div>Looks good! I've approved the proposal. Let's schedule a kickoff call.</div>",
+    "type": "Inbox::Forward::Reply",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/inbox_forwards/1069479380/replies/1069479410.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/inbox_forwards/1069479380/replies/1069479410",
+    "parent": {
+      "id": 1069479380,
+      "title": "Project proposal from client",
+      "type": "Inbox::Forward",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/inbox_forwards/1069479380.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/inbox_forwards/1069479380"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715914,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aeb392ebef54851145b2f82f5f4c0a11be1c08c2",
+      "name": "Victor Cooper",
+      "email_address": "victor@honchodesign.com",
+      "personable_type": "User",
+      "title": "Chief Strategist",
+      "admin": true,
+      "owner": true
+    }
+  }
+]

--- a/spec/fixtures/forwards/reply_get.json
+++ b/spec/fixtures/forwards/reply_get.json
@@ -1,0 +1,44 @@
+{
+  "id": 1069479400,
+  "status": "active",
+  "created_at": "2024-01-16T15:00:00.000Z",
+  "updated_at": "2024-01-16T15:00:00.000Z",
+  "content": "<div>Thanks for forwarding this. I'll review and get back to you by EOD.</div>",
+  "type": "Inbox::Forward::Reply",
+  "url": "https://3.basecampapi.com/195539477/buckets/2085958499/inbox_forwards/1069479380/replies/1069479400.json",
+  "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/inbox_forwards/1069479380/replies/1069479400",
+  "parent": {
+    "id": 1069479380,
+    "title": "Project proposal from client",
+    "type": "Inbox::Forward",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/inbox_forwards/1069479380.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/inbox_forwards/1069479380"
+  },
+  "bucket": {
+    "id": 2085958499,
+    "name": "The Leto Laptop",
+    "type": "Project"
+  },
+  "creator": {
+    "id": 1049715915,
+    "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aeb392ebef54851145b2f82f5f4c0a11be1c08c3",
+    "name": "Annie Bryan",
+    "email_address": "annie@honchodesign.com",
+    "personable_type": "User",
+    "title": "Project Manager",
+    "bio": null,
+    "location": null,
+    "created_at": "2024-01-10T09:00:00.000Z",
+    "updated_at": "2024-01-10T09:00:00.000Z",
+    "admin": false,
+    "owner": false,
+    "client": false,
+    "employee": true,
+    "time_zone": "America/Chicago",
+    "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMtkkT4=--e9c67c17e3fc5c36ae1eaeefe7cc2a3ba1b7f05b/avatar?v=1",
+    "company": {
+      "id": 1033447817,
+      "name": "Honcho Design"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add ForwardsService with methods for email forwards API endpoints
- Implement Inbox, Forward, and ForwardReply structs
- Add Forwards() accessor to Client
- Include comprehensive test coverage with JSON fixtures

## API Methods
- `GetInbox(ctx, bucketID, inboxID)` - GET /buckets/{id}/inboxes/{id}.json
- `List(ctx, bucketID, inboxID)` - GET /buckets/{id}/inboxes/{id}/forwards.json
- `Get(ctx, bucketID, forwardID)` - GET /buckets/{id}/inbox_forwards/{id}.json
- `ListReplies(ctx, bucketID, forwardID)` - GET /buckets/{id}/inbox_forwards/{id}/replies.json
- `GetReply(ctx, bucketID, forwardID, replyID)` - GET /buckets/{id}/inbox_forwards/{id}/replies/{id}.json

## Test plan
- [x] All tests pass (`go test ./...`)
- [x] Go vet passes
- [x] golangci-lint passes with no issues