### PR TITLE
Add RecordingsService for cross-project recordings

### DIFF
--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -53,6 +53,7 @@ type Client struct {
 	timesheet       *TimesheetService
 	schedules       *SchedulesService
 	forwards        *ForwardsService
+	recordings      *RecordingsService
 }
 
 // Response wraps an API response.
@@ -654,4 +655,12 @@ func (c *Client) Forwards() *ForwardsService {
 		c.forwards = NewForwardsService(c)
 	}
 	return c.forwards
+}
+
+// Recordings returns the RecordingsService for recording operations.
+func (c *Client) Recordings() *RecordingsService {
+	if c.recordings == nil {
+		c.recordings = NewRecordingsService(c)
+	}
+	return c.recordings
 }

--- a/go/pkg/basecamp/recordings.go
+++ b/go/pkg/basecamp/recordings.go
@@ -1,0 +1,223 @@
+package basecamp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// RecordingType represents a type of recording in Basecamp.
+type RecordingType string
+
+// Recording types supported by the Basecamp API.
+const (
+	RecordingTypeComment        RecordingType = "Comment"
+	RecordingTypeDocument       RecordingType = "Document"
+	RecordingTypeKanbanCard     RecordingType = "Kanban::Card"
+	RecordingTypeKanbanStep     RecordingType = "Kanban::Step"
+	RecordingTypeMessage        RecordingType = "Message"
+	RecordingTypeQuestionAnswer RecordingType = "Question::Answer"
+	RecordingTypeScheduleEntry  RecordingType = "Schedule::Entry"
+	RecordingTypeTodo           RecordingType = "Todo"
+	RecordingTypeTodolist       RecordingType = "Todolist"
+	RecordingTypeUpload         RecordingType = "Upload"
+	RecordingTypeVault          RecordingType = "Vault"
+)
+
+// Recording represents a generic Basecamp recording.
+// Recordings are the base type for most content in Basecamp including
+// messages, todos, comments, documents, and more.
+type Recording struct {
+	ID               int64     `json:"id"`
+	Status           string    `json:"status"`
+	VisibleToClients bool      `json:"visible_to_clients"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+	Title            string    `json:"title"`
+	InheritsStatus   bool      `json:"inherits_status"`
+	Type             string    `json:"type"`
+	URL              string    `json:"url"`
+	AppURL           string    `json:"app_url"`
+	BookmarkURL      string    `json:"bookmark_url"`
+	Parent           *Parent   `json:"parent,omitempty"`
+	Bucket           *Bucket   `json:"bucket,omitempty"`
+	Creator          *Person   `json:"creator,omitempty"`
+}
+
+// RecordingsListOptions specifies options for listing recordings.
+type RecordingsListOptions struct {
+	// Bucket filters by project IDs (comma-separated or slice).
+	// Defaults to all active projects visible to the user.
+	Bucket []int64
+
+	// Status filters by recording status: "active", "archived", or "trashed".
+	// Defaults to "active".
+	Status string
+
+	// Sort specifies the sort field: "created_at" or "updated_at".
+	// Defaults to "created_at".
+	Sort string
+
+	// Direction specifies the sort direction: "desc" or "asc".
+	// Defaults to "desc".
+	Direction string
+}
+
+// SetClientVisibilityRequest specifies the parameters for setting client visibility.
+type SetClientVisibilityRequest struct {
+	VisibleToClients bool `json:"visible_to_clients"`
+}
+
+// RecordingsService handles recording operations.
+// Recordings are the base type for most content in Basecamp.
+type RecordingsService struct {
+	client *Client
+}
+
+// NewRecordingsService creates a new RecordingsService.
+func NewRecordingsService(client *Client) *RecordingsService {
+	return &RecordingsService{client: client}
+}
+
+// List returns all recordings of a given type across projects.
+// recordingType is required and specifies what type of recordings to list.
+// Use the RecordingType constants (e.g., RecordingTypeTodo, RecordingTypeMessage).
+func (s *RecordingsService) List(ctx context.Context, recordingType RecordingType, opts *RecordingsListOptions) ([]Recording, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	if recordingType == "" {
+		return nil, ErrUsage("recording type is required")
+	}
+
+	// Build query parameters
+	params := url.Values{}
+	params.Set("type", string(recordingType))
+
+	if opts != nil {
+		if len(opts.Bucket) > 0 {
+			bucketStrs := make([]string, len(opts.Bucket))
+			for i, b := range opts.Bucket {
+				bucketStrs[i] = fmt.Sprintf("%d", b)
+			}
+			params.Set("bucket", strings.Join(bucketStrs, ","))
+		}
+		if opts.Status != "" {
+			params.Set("status", opts.Status)
+		}
+		if opts.Sort != "" {
+			params.Set("sort", opts.Sort)
+		}
+		if opts.Direction != "" {
+			params.Set("direction", opts.Direction)
+		}
+	}
+
+	path := "/projects/recordings.json?" + params.Encode()
+	results, err := s.client.GetAll(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	recordings := make([]Recording, 0, len(results))
+	for _, raw := range results {
+		var r Recording
+		if err := json.Unmarshal(raw, &r); err != nil {
+			return nil, fmt.Errorf("failed to parse recording: %w", err)
+		}
+		recordings = append(recordings, r)
+	}
+
+	return recordings, nil
+}
+
+// Get returns a recording by ID.
+// bucketID is the project ID, recordingID is the recording ID.
+func (s *RecordingsService) Get(ctx context.Context, bucketID, recordingID int64) (*Recording, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/recordings/%d.json", bucketID, recordingID)
+	resp, err := s.client.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var recording Recording
+	if err := resp.UnmarshalData(&recording); err != nil {
+		return nil, fmt.Errorf("failed to parse recording: %w", err)
+	}
+
+	return &recording, nil
+}
+
+// Trash moves a recording to the trash.
+// bucketID is the project ID, recordingID is the recording ID.
+// Trashed recordings can be recovered from the trash.
+func (s *RecordingsService) Trash(ctx context.Context, bucketID, recordingID int64) error {
+	if err := s.client.RequireAccount(); err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/recordings/%d/status/trashed.json", bucketID, recordingID)
+	_, err := s.client.Put(ctx, path, nil)
+	return err
+}
+
+// Archive archives a recording.
+// bucketID is the project ID, recordingID is the recording ID.
+// Archived recordings are hidden but not deleted.
+func (s *RecordingsService) Archive(ctx context.Context, bucketID, recordingID int64) error {
+	if err := s.client.RequireAccount(); err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/recordings/%d/status/archived.json", bucketID, recordingID)
+	_, err := s.client.Put(ctx, path, nil)
+	return err
+}
+
+// Unarchive restores an archived recording to active status.
+// bucketID is the project ID, recordingID is the recording ID.
+func (s *RecordingsService) Unarchive(ctx context.Context, bucketID, recordingID int64) error {
+	if err := s.client.RequireAccount(); err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/recordings/%d/status/active.json", bucketID, recordingID)
+	_, err := s.client.Put(ctx, path, nil)
+	return err
+}
+
+// SetClientVisibility sets whether a recording is visible to clients.
+// bucketID is the project ID, recordingID is the recording ID.
+// visible specifies whether the recording should be visible to clients.
+// Returns the updated recording.
+// Note: Not all recordings support client visibility. Some inherit visibility from their parent.
+func (s *RecordingsService) SetClientVisibility(ctx context.Context, bucketID, recordingID int64, visible bool) (*Recording, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	req := &SetClientVisibilityRequest{
+		VisibleToClients: visible,
+	}
+
+	path := fmt.Sprintf("/buckets/%d/recordings/%d/client_visibility.json", bucketID, recordingID)
+	resp, err := s.client.Put(ctx, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var recording Recording
+	if err := resp.UnmarshalData(&recording); err != nil {
+		return nil, fmt.Errorf("failed to parse recording: %w", err)
+	}
+
+	return &recording, nil
+}

--- a/go/pkg/basecamp/recordings_test.go
+++ b/go/pkg/basecamp/recordings_test.go
@@ -1,0 +1,281 @@
+package basecamp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func recordingsFixturesDir() string {
+	return filepath.Join("..", "..", "..", "spec", "fixtures", "recordings")
+}
+
+func loadRecordingsFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	path := filepath.Join(recordingsFixturesDir(), name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func TestRecording_UnmarshalList(t *testing.T) {
+	data := loadRecordingsFixture(t, "list.json")
+
+	var recordings []Recording
+	if err := json.Unmarshal(data, &recordings); err != nil {
+		t.Fatalf("failed to unmarshal list.json: %v", err)
+	}
+
+	if len(recordings) != 2 {
+		t.Errorf("expected 2 recordings, got %d", len(recordings))
+	}
+
+	// Verify first recording
+	r1 := recordings[0]
+	if r1.ID != 1069479351 {
+		t.Errorf("expected ID 1069479351, got %d", r1.ID)
+	}
+	if r1.Status != "active" {
+		t.Errorf("expected status 'active', got %q", r1.Status)
+	}
+	if r1.VisibleToClients {
+		t.Error("expected VisibleToClients to be false")
+	}
+	if r1.Type != "Message" {
+		t.Errorf("expected type 'Message', got %q", r1.Type)
+	}
+	if r1.Title != "We won Leto!" {
+		t.Errorf("expected title 'We won Leto!', got %q", r1.Title)
+	}
+	if !r1.InheritsStatus {
+		t.Error("expected InheritsStatus to be true")
+	}
+	if r1.URL != "https://3.basecampapi.com/195539477/buckets/2085958499/messages/1069479351.json" {
+		t.Errorf("unexpected URL: %q", r1.URL)
+	}
+	if r1.AppURL != "https://3.basecamp.com/195539477/buckets/2085958499/messages/1069479351" {
+		t.Errorf("unexpected AppURL: %q", r1.AppURL)
+	}
+
+	// Verify parent
+	if r1.Parent == nil {
+		t.Fatal("expected Parent to be non-nil")
+	}
+	if r1.Parent.ID != 1069479338 {
+		t.Errorf("expected Parent.ID 1069479338, got %d", r1.Parent.ID)
+	}
+	if r1.Parent.Title != "Message Board" {
+		t.Errorf("expected Parent.Title 'Message Board', got %q", r1.Parent.Title)
+	}
+	if r1.Parent.Type != "Message::Board" {
+		t.Errorf("expected Parent.Type 'Message::Board', got %q", r1.Parent.Type)
+	}
+
+	// Verify bucket
+	if r1.Bucket == nil {
+		t.Fatal("expected Bucket to be non-nil")
+	}
+	if r1.Bucket.ID != 2085958499 {
+		t.Errorf("expected Bucket.ID 2085958499, got %d", r1.Bucket.ID)
+	}
+	if r1.Bucket.Name != "The Leto Laptop" {
+		t.Errorf("expected Bucket.Name 'The Leto Laptop', got %q", r1.Bucket.Name)
+	}
+	if r1.Bucket.Type != "Project" {
+		t.Errorf("expected Bucket.Type 'Project', got %q", r1.Bucket.Type)
+	}
+
+	// Verify creator
+	if r1.Creator == nil {
+		t.Fatal("expected Creator to be non-nil")
+	}
+	if r1.Creator.ID != 1049715914 {
+		t.Errorf("expected Creator.ID 1049715914, got %d", r1.Creator.ID)
+	}
+	if r1.Creator.Name != "Victor Cooper" {
+		t.Errorf("expected Creator.Name 'Victor Cooper', got %q", r1.Creator.Name)
+	}
+
+	// Verify second recording
+	r2 := recordings[1]
+	if r2.ID != 1069479400 {
+		t.Errorf("expected ID 1069479400, got %d", r2.ID)
+	}
+	if !r2.VisibleToClients {
+		t.Error("expected VisibleToClients to be true for second recording")
+	}
+	if r2.Creator == nil {
+		t.Fatal("expected Creator to be non-nil for second recording")
+	}
+	if r2.Creator.Name != "Annie Bryan" {
+		t.Errorf("expected Creator.Name 'Annie Bryan', got %q", r2.Creator.Name)
+	}
+}
+
+func TestRecording_UnmarshalGet(t *testing.T) {
+	data := loadRecordingsFixture(t, "get.json")
+
+	var recording Recording
+	if err := json.Unmarshal(data, &recording); err != nil {
+		t.Fatalf("failed to unmarshal get.json: %v", err)
+	}
+
+	if recording.ID != 1069479351 {
+		t.Errorf("expected ID 1069479351, got %d", recording.ID)
+	}
+	if recording.Status != "active" {
+		t.Errorf("expected status 'active', got %q", recording.Status)
+	}
+	if recording.VisibleToClients {
+		t.Error("expected VisibleToClients to be false")
+	}
+	if recording.Type != "Message" {
+		t.Errorf("expected type 'Message', got %q", recording.Type)
+	}
+	if recording.Title != "We won Leto!" {
+		t.Errorf("expected title 'We won Leto!', got %q", recording.Title)
+	}
+
+	// Verify timestamps are parsed
+	if recording.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be non-zero")
+	}
+	if recording.UpdatedAt.IsZero() {
+		t.Error("expected UpdatedAt to be non-zero")
+	}
+
+	// Verify creator with full details
+	if recording.Creator == nil {
+		t.Fatal("expected Creator to be non-nil")
+	}
+	if recording.Creator.ID != 1049715914 {
+		t.Errorf("expected Creator.ID 1049715914, got %d", recording.Creator.ID)
+	}
+	if recording.Creator.EmailAddress != "victor@honchodesign.com" {
+		t.Errorf("expected Creator.EmailAddress 'victor@honchodesign.com', got %q", recording.Creator.EmailAddress)
+	}
+	if recording.Creator.Title != "Chief Strategist" {
+		t.Errorf("expected Creator.Title 'Chief Strategist', got %q", recording.Creator.Title)
+	}
+	if !recording.Creator.Admin {
+		t.Error("expected Creator.Admin to be true")
+	}
+	if !recording.Creator.Owner {
+		t.Error("expected Creator.Owner to be true")
+	}
+}
+
+func TestRecording_UnmarshalClientVisibility(t *testing.T) {
+	data := loadRecordingsFixture(t, "client_visibility.json")
+
+	var recording Recording
+	if err := json.Unmarshal(data, &recording); err != nil {
+		t.Fatalf("failed to unmarshal client_visibility.json: %v", err)
+	}
+
+	if recording.ID != 1069479351 {
+		t.Errorf("expected ID 1069479351, got %d", recording.ID)
+	}
+	if !recording.VisibleToClients {
+		t.Error("expected VisibleToClients to be true after update")
+	}
+}
+
+func TestSetClientVisibilityRequest_Marshal(t *testing.T) {
+	req := SetClientVisibilityRequest{
+		VisibleToClients: true,
+	}
+
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal SetClientVisibilityRequest: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(out, &data); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	visible, ok := data["visible_to_clients"].(bool)
+	if !ok {
+		t.Fatal("expected visible_to_clients to be a boolean")
+	}
+	if !visible {
+		t.Error("expected visible_to_clients to be true")
+	}
+
+	// Test false case
+	reqFalse := SetClientVisibilityRequest{
+		VisibleToClients: false,
+	}
+
+	outFalse, err := json.Marshal(reqFalse)
+	if err != nil {
+		t.Fatalf("failed to marshal SetClientVisibilityRequest (false): %v", err)
+	}
+
+	var dataFalse map[string]interface{}
+	if err := json.Unmarshal(outFalse, &dataFalse); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	visibleFalse, ok := dataFalse["visible_to_clients"].(bool)
+	if !ok {
+		t.Fatal("expected visible_to_clients to be a boolean")
+	}
+	if visibleFalse {
+		t.Error("expected visible_to_clients to be false")
+	}
+}
+
+func TestRecordingType_Constants(t *testing.T) {
+	// Verify recording type constants are correct
+	tests := []struct {
+		typ      RecordingType
+		expected string
+	}{
+		{RecordingTypeComment, "Comment"},
+		{RecordingTypeDocument, "Document"},
+		{RecordingTypeKanbanCard, "Kanban::Card"},
+		{RecordingTypeKanbanStep, "Kanban::Step"},
+		{RecordingTypeMessage, "Message"},
+		{RecordingTypeQuestionAnswer, "Question::Answer"},
+		{RecordingTypeScheduleEntry, "Schedule::Entry"},
+		{RecordingTypeTodo, "Todo"},
+		{RecordingTypeTodolist, "Todolist"},
+		{RecordingTypeUpload, "Upload"},
+		{RecordingTypeVault, "Vault"},
+	}
+
+	for _, tc := range tests {
+		if string(tc.typ) != tc.expected {
+			t.Errorf("RecordingType %v: expected %q, got %q", tc.typ, tc.expected, string(tc.typ))
+		}
+	}
+}
+
+func TestRecordingsListOptions_BuildsQueryParams(t *testing.T) {
+	// This is a structural test to ensure the options fields exist
+	opts := RecordingsListOptions{
+		Bucket:    []int64{1, 2, 3},
+		Status:    "archived",
+		Sort:      "updated_at",
+		Direction: "asc",
+	}
+
+	if len(opts.Bucket) != 3 {
+		t.Errorf("expected 3 bucket IDs, got %d", len(opts.Bucket))
+	}
+	if opts.Status != "archived" {
+		t.Errorf("expected status 'archived', got %q", opts.Status)
+	}
+	if opts.Sort != "updated_at" {
+		t.Errorf("expected sort 'updated_at', got %q", opts.Sort)
+	}
+	if opts.Direction != "asc" {
+		t.Errorf("expected direction 'asc', got %q", opts.Direction)
+	}
+}

--- a/spec/fixtures/recordings/client_visibility.json
+++ b/spec/fixtures/recordings/client_visibility.json
@@ -1,0 +1,49 @@
+{
+  "id": 1069479351,
+  "status": "active",
+  "visible_to_clients": true,
+  "created_at": "2022-10-28T15:21:46.169Z",
+  "updated_at": "2022-10-28T16:00:00.000Z",
+  "title": "We won Leto!",
+  "inherits_status": true,
+  "type": "Message",
+  "url": "https://3.basecampapi.com/195539477/buckets/2085958499/messages/1069479351.json",
+  "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/messages/1069479351",
+  "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5MzUxP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--aabbccdd.json",
+  "parent": {
+    "id": 1069479338,
+    "title": "Message Board",
+    "type": "Message::Board",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/message_boards/1069479338.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/message_boards/1069479338"
+  },
+  "bucket": {
+    "id": 2085958499,
+    "name": "The Leto Laptop",
+    "type": "Project"
+  },
+  "creator": {
+    "id": 1049715914,
+    "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+    "name": "Victor Cooper",
+    "email_address": "victor@honchodesign.com",
+    "personable_type": "User",
+    "title": "Chief Strategist",
+    "bio": "Don't let your dreams be dreams",
+    "location": "Chicago, IL",
+    "created_at": "2022-11-22T08:23:21.732Z",
+    "updated_at": "2022-11-22T08:23:21.732Z",
+    "admin": true,
+    "owner": true,
+    "client": false,
+    "employee": true,
+    "time_zone": "America/Chicago",
+    "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+    "company": {
+      "id": 1033447817,
+      "name": "Honcho Design"
+    },
+    "can_manage_projects": true,
+    "can_manage_people": true
+  }
+}

--- a/spec/fixtures/recordings/get.json
+++ b/spec/fixtures/recordings/get.json
@@ -1,0 +1,49 @@
+{
+  "id": 1069479351,
+  "status": "active",
+  "visible_to_clients": false,
+  "created_at": "2022-10-28T15:21:46.169Z",
+  "updated_at": "2022-10-28T15:21:46.169Z",
+  "title": "We won Leto!",
+  "inherits_status": true,
+  "type": "Message",
+  "url": "https://3.basecampapi.com/195539477/buckets/2085958499/messages/1069479351.json",
+  "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/messages/1069479351",
+  "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5MzUxP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--aabbccdd.json",
+  "parent": {
+    "id": 1069479338,
+    "title": "Message Board",
+    "type": "Message::Board",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/message_boards/1069479338.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/message_boards/1069479338"
+  },
+  "bucket": {
+    "id": 2085958499,
+    "name": "The Leto Laptop",
+    "type": "Project"
+  },
+  "creator": {
+    "id": 1049715914,
+    "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+    "name": "Victor Cooper",
+    "email_address": "victor@honchodesign.com",
+    "personable_type": "User",
+    "title": "Chief Strategist",
+    "bio": "Don't let your dreams be dreams",
+    "location": "Chicago, IL",
+    "created_at": "2022-11-22T08:23:21.732Z",
+    "updated_at": "2022-11-22T08:23:21.732Z",
+    "admin": true,
+    "owner": true,
+    "client": false,
+    "employee": true,
+    "time_zone": "America/Chicago",
+    "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+    "company": {
+      "id": 1033447817,
+      "name": "Honcho Design"
+    },
+    "can_manage_projects": true,
+    "can_manage_people": true
+  }
+}

--- a/spec/fixtures/recordings/list.json
+++ b/spec/fixtures/recordings/list.json
@@ -1,0 +1,96 @@
+[
+  {
+    "id": 1069479351,
+    "status": "active",
+    "visible_to_clients": false,
+    "created_at": "2022-10-28T15:21:46.169Z",
+    "updated_at": "2022-10-28T15:21:46.169Z",
+    "title": "We won Leto!",
+    "inherits_status": true,
+    "type": "Message",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/messages/1069479351.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/messages/1069479351",
+    "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5MzUxP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--aabbccdd.json",
+    "parent": {
+      "id": 1069479338,
+      "title": "Message Board",
+      "type": "Message::Board",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/message_boards/1069479338.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/message_boards/1069479338"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715914,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+      "name": "Victor Cooper",
+      "email_address": "victor@honchodesign.com",
+      "personable_type": "User",
+      "title": "Chief Strategist",
+      "bio": "Don't let your dreams be dreams",
+      "location": "Chicago, IL",
+      "created_at": "2022-11-22T08:23:21.732Z",
+      "updated_at": "2022-11-22T08:23:21.732Z",
+      "admin": true,
+      "owner": true,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+      "company": {
+        "id": 1033447817,
+        "name": "Honcho Design"
+      },
+      "can_manage_projects": true,
+      "can_manage_people": true
+    }
+  },
+  {
+    "id": 1069479400,
+    "status": "active",
+    "visible_to_clients": true,
+    "created_at": "2022-10-29T10:15:30.000Z",
+    "updated_at": "2022-10-29T10:15:30.000Z",
+    "title": "Project kickoff notes",
+    "inherits_status": true,
+    "type": "Message",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/messages/1069479400.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/messages/1069479400",
+    "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5NDAwP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--aabbccdd.json",
+    "parent": {
+      "id": 1069479338,
+      "title": "Message Board",
+      "type": "Message::Board",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/message_boards/1069479338.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/message_boards/1069479338"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715915,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+      "name": "Annie Bryan",
+      "email_address": "annie@honchodesign.com",
+      "personable_type": "User",
+      "title": "Central Markets Manager",
+      "created_at": "2022-11-22T08:23:21.732Z",
+      "updated_at": "2022-11-22T08:23:21.732Z",
+      "admin": false,
+      "owner": false,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMtkkT4=--avatar",
+      "company": {
+        "id": 1033447817,
+        "name": "Honcho Design"
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- Add `RecordingsService` with methods: `List`, `Get`, `Trash`, `Archive`, `Unarchive`, and `SetClientVisibility`
- Add `RecordingType` constants for all supported Basecamp recording types (Comment, Document, Message, Todo, etc.)
- Add `Recordings()` accessor to `Client`
- Add comprehensive tests with JSON fixtures

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run`)
- [x] New tests verify JSON unmarshaling for list, get, and client visibility responses
- [x] Recording type constants match Basecamp API documentation