### PR TITLE
Add CardsService and CardTablesService for kanban boards

### DIFF
--- a/go/pkg/basecamp/cards.go
+++ b/go/pkg/basecamp/cards.go
@@ -1,0 +1,654 @@
+package basecamp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// CardTable represents a Basecamp card table (kanban board).
+type CardTable struct {
+	ID               int64         `json:"id"`
+	Status           string        `json:"status"`
+	VisibleToClients bool          `json:"visible_to_clients"`
+	CreatedAt        time.Time     `json:"created_at"`
+	UpdatedAt        time.Time     `json:"updated_at"`
+	Title            string        `json:"title"`
+	InheritsStatus   bool          `json:"inherits_status"`
+	Type             string        `json:"type"`
+	URL              string        `json:"url"`
+	AppURL           string        `json:"app_url"`
+	BookmarkURL      string        `json:"bookmark_url"`
+	SubscriptionURL  string        `json:"subscription_url"`
+	Bucket           *Bucket       `json:"bucket,omitempty"`
+	Creator          *Person       `json:"creator,omitempty"`
+	Subscribers      []Person      `json:"subscribers,omitempty"`
+	Lists            []CardColumn  `json:"lists,omitempty"`
+}
+
+// CardColumn represents a column in a card table.
+type CardColumn struct {
+	ID               int64     `json:"id"`
+	Status           string    `json:"status"`
+	VisibleToClients bool      `json:"visible_to_clients"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+	Title            string    `json:"title"`
+	InheritsStatus   bool      `json:"inherits_status"`
+	Type             string    `json:"type"`
+	URL              string    `json:"url"`
+	AppURL           string    `json:"app_url"`
+	BookmarkURL      string    `json:"bookmark_url"`
+	Position         int       `json:"position,omitempty"`
+	Color            string    `json:"color,omitempty"`
+	Description      string    `json:"description,omitempty"`
+	CardsCount       int       `json:"cards_count"`
+	CommentCount     int       `json:"comment_count"`
+	CardsURL         string    `json:"cards_url,omitempty"`
+	Parent           *Parent   `json:"parent,omitempty"`
+	Bucket           *Bucket   `json:"bucket,omitempty"`
+	Creator          *Person   `json:"creator,omitempty"`
+	Subscribers      []Person  `json:"subscribers,omitempty"`
+}
+
+// Card represents a card in a card table column.
+type Card struct {
+	ID                     int64      `json:"id"`
+	Status                 string     `json:"status"`
+	VisibleToClients       bool       `json:"visible_to_clients"`
+	CreatedAt              time.Time  `json:"created_at"`
+	UpdatedAt              time.Time  `json:"updated_at"`
+	Title                  string     `json:"title"`
+	InheritsStatus         bool       `json:"inherits_status"`
+	Type                   string     `json:"type"`
+	URL                    string     `json:"url"`
+	AppURL                 string     `json:"app_url"`
+	BookmarkURL            string     `json:"bookmark_url"`
+	SubscriptionURL        string     `json:"subscription_url,omitempty"`
+	Position               int        `json:"position"`
+	Content                string     `json:"content,omitempty"`
+	Description            string     `json:"description,omitempty"`
+	DueOn                  string     `json:"due_on,omitempty"`
+	Completed              bool       `json:"completed"`
+	CompletedAt            *time.Time `json:"completed_at,omitempty"`
+	CommentsCount          int        `json:"comments_count"`
+	CommentsURL            string     `json:"comments_url,omitempty"`
+	CommentCount           int        `json:"comment_count"`
+	CompletionURL          string     `json:"completion_url,omitempty"`
+	Parent                 *Parent    `json:"parent,omitempty"`
+	Bucket                 *Bucket    `json:"bucket,omitempty"`
+	Creator                *Person    `json:"creator,omitempty"`
+	Completer              *Person    `json:"completer,omitempty"`
+	Assignees              []Person   `json:"assignees,omitempty"`
+	CompletionSubscribers  []Person   `json:"completion_subscribers,omitempty"`
+	Steps                  []CardStep `json:"steps,omitempty"`
+}
+
+// CardStep represents a step (checklist item) on a card.
+type CardStep struct {
+	ID               int64      `json:"id"`
+	Status           string     `json:"status"`
+	VisibleToClients bool       `json:"visible_to_clients"`
+	CreatedAt        time.Time  `json:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+	Title            string     `json:"title"`
+	InheritsStatus   bool       `json:"inherits_status"`
+	Type             string     `json:"type"`
+	URL              string     `json:"url"`
+	AppURL           string     `json:"app_url"`
+	BookmarkURL      string     `json:"bookmark_url"`
+	Position         int        `json:"position"`
+	DueOn            string     `json:"due_on,omitempty"`
+	Completed        bool       `json:"completed"`
+	CompletedAt      *time.Time `json:"completed_at,omitempty"`
+	Parent           *Parent    `json:"parent,omitempty"`
+	Bucket           *Bucket    `json:"bucket,omitempty"`
+	Creator          *Person    `json:"creator,omitempty"`
+	Completer        *Person    `json:"completer,omitempty"`
+	Assignees        []Person   `json:"assignees,omitempty"`
+}
+
+// CreateCardRequest specifies the parameters for creating a card.
+type CreateCardRequest struct {
+	// Title is the card title (required).
+	Title string `json:"title"`
+	// Content is the card body in HTML (optional).
+	Content string `json:"content,omitempty"`
+	// DueOn is the due date in ISO 8601 format (optional).
+	DueOn string `json:"due_on,omitempty"`
+	// Notify when true, will notify assignees (optional).
+	Notify bool `json:"notify,omitempty"`
+}
+
+// UpdateCardRequest specifies the parameters for updating a card.
+type UpdateCardRequest struct {
+	// Title is the card title (optional).
+	Title string `json:"title,omitempty"`
+	// Content is the card body in HTML (optional).
+	Content string `json:"content,omitempty"`
+	// DueOn is the due date in ISO 8601 format (optional).
+	DueOn string `json:"due_on,omitempty"`
+	// AssigneeIDs is a list of person IDs to assign this card to (optional).
+	AssigneeIDs []int64 `json:"assignee_ids,omitempty"`
+}
+
+// MoveCardRequest specifies the parameters for moving a card.
+type MoveCardRequest struct {
+	// ColumnID is the destination column ID (required).
+	ColumnID int64 `json:"column_id"`
+}
+
+// CreateColumnRequest specifies the parameters for creating a column.
+type CreateColumnRequest struct {
+	// Title is the column title (required).
+	Title string `json:"title"`
+	// Description is the column description (optional).
+	Description string `json:"description,omitempty"`
+}
+
+// UpdateColumnRequest specifies the parameters for updating a column.
+type UpdateColumnRequest struct {
+	// Title is the column title (optional).
+	Title string `json:"title,omitempty"`
+	// Description is the column description (optional).
+	Description string `json:"description,omitempty"`
+}
+
+// MoveColumnRequest specifies the parameters for moving a column.
+type MoveColumnRequest struct {
+	// SourceID is the column ID to move (required).
+	SourceID int64 `json:"source_id"`
+	// TargetID is the column ID to move relative to (required).
+	TargetID int64 `json:"target_id"`
+	// Position is the position relative to target (optional).
+	Position int `json:"position,omitempty"`
+}
+
+// SetColumnColorRequest specifies the parameters for changing a column color.
+type SetColumnColorRequest struct {
+	// Color is the column color. Valid values: white, red, orange, yellow,
+	// green, blue, aqua, purple, gray, pink, brown (required).
+	Color string `json:"color"`
+}
+
+// CreateStepRequest specifies the parameters for creating a step.
+type CreateStepRequest struct {
+	// Title is the step title (required).
+	Title string `json:"title"`
+	// DueOn is the due date in ISO 8601 format (optional).
+	DueOn string `json:"due_on,omitempty"`
+	// Assignees is a comma-separated string of user IDs (optional).
+	Assignees string `json:"assignees,omitempty"`
+}
+
+// UpdateStepRequest specifies the parameters for updating a step.
+type UpdateStepRequest struct {
+	// Title is the step title (optional).
+	Title string `json:"title,omitempty"`
+	// DueOn is the due date in ISO 8601 format (optional).
+	DueOn string `json:"due_on,omitempty"`
+	// Assignees is a comma-separated string of user IDs (optional).
+	Assignees string `json:"assignees,omitempty"`
+}
+
+// CardTablesService handles card table operations.
+type CardTablesService struct {
+	client *Client
+}
+
+// NewCardTablesService creates a new CardTablesService.
+func NewCardTablesService(client *Client) *CardTablesService {
+	return &CardTablesService{client: client}
+}
+
+// Get returns a card table by ID.
+// bucketID is the project ID, cardTableID is the card table ID.
+func (s *CardTablesService) Get(ctx context.Context, bucketID, cardTableID int64) (*CardTable, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/card_tables/%d.json", bucketID, cardTableID)
+	resp, err := s.client.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var cardTable CardTable
+	if err := resp.UnmarshalData(&cardTable); err != nil {
+		return nil, fmt.Errorf("failed to parse card table: %w", err)
+	}
+
+	return &cardTable, nil
+}
+
+// CardsService handles card operations.
+type CardsService struct {
+	client *Client
+}
+
+// NewCardsService creates a new CardsService.
+func NewCardsService(client *Client) *CardsService {
+	return &CardsService{client: client}
+}
+
+// List returns all cards in a column.
+// bucketID is the project ID, columnID is the column ID.
+func (s *CardsService) List(ctx context.Context, bucketID, columnID int64) ([]Card, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/card_tables/lists/%d/cards.json", bucketID, columnID)
+	results, err := s.client.GetAll(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	cards := make([]Card, 0, len(results))
+	for _, raw := range results {
+		var c Card
+		if err := json.Unmarshal(raw, &c); err != nil {
+			return nil, fmt.Errorf("failed to parse card: %w", err)
+		}
+		cards = append(cards, c)
+	}
+
+	return cards, nil
+}
+
+// Get returns a card by ID.
+// bucketID is the project ID, cardID is the card ID.
+func (s *CardsService) Get(ctx context.Context, bucketID, cardID int64) (*Card, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/card_tables/cards/%d.json", bucketID, cardID)
+	resp, err := s.client.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var card Card
+	if err := resp.UnmarshalData(&card); err != nil {
+		return nil, fmt.Errorf("failed to parse card: %w", err)
+	}
+
+	return &card, nil
+}
+
+// Create creates a new card in a column.
+// bucketID is the project ID, columnID is the column ID.
+// Returns the created card.
+func (s *CardsService) Create(ctx context.Context, bucketID, columnID int64, req *CreateCardRequest) (*Card, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	if req == nil || req.Title == "" {
+		return nil, ErrUsage("card title is required")
+	}
+
+	path := fmt.Sprintf("/buckets/%d/card_tables/lists/%d/cards.json", bucketID, columnID)
+	resp, err := s.client.Post(ctx, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var card Card
+	if err := resp.UnmarshalData(&card); err != nil {
+		return nil, fmt.Errorf("failed to parse card: %w", err)
+	}
+
+	return &card, nil
+}
+
+// Update updates an existing card.
+// bucketID is the project ID, cardID is the card ID.
+// Returns the updated card.
+func (s *CardsService) Update(ctx context.Context, bucketID, cardID int64, req *UpdateCardRequest) (*Card, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	if req == nil {
+		return nil, ErrUsage("update request is required")
+	}
+
+	path := fmt.Sprintf("/buckets/%d/card_tables/cards/%d.json", bucketID, cardID)
+	resp, err := s.client.Put(ctx, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var card Card
+	if err := resp.UnmarshalData(&card); err != nil {
+		return nil, fmt.Errorf("failed to parse card: %w", err)
+	}
+
+	return &card, nil
+}
+
+// Move moves a card to a different column.
+// bucketID is the project ID, cardID is the card ID, columnID is the destination column ID.
+func (s *CardsService) Move(ctx context.Context, bucketID, cardID, columnID int64) error {
+	if err := s.client.RequireAccount(); err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/card_tables/cards/%d/moves.json", bucketID, cardID)
+	body := MoveCardRequest{ColumnID: columnID}
+	_, err := s.client.Post(ctx, path, body)
+	return err
+}
+
+// CardColumnsService handles card column operations.
+type CardColumnsService struct {
+	client *Client
+}
+
+// NewCardColumnsService creates a new CardColumnsService.
+func NewCardColumnsService(client *Client) *CardColumnsService {
+	return &CardColumnsService{client: client}
+}
+
+// Get returns a column by ID.
+// bucketID is the project ID, columnID is the column ID.
+func (s *CardColumnsService) Get(ctx context.Context, bucketID, columnID int64) (*CardColumn, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/card_tables/columns/%d.json", bucketID, columnID)
+	resp, err := s.client.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var column CardColumn
+	if err := resp.UnmarshalData(&column); err != nil {
+		return nil, fmt.Errorf("failed to parse column: %w", err)
+	}
+
+	return &column, nil
+}
+
+// Create creates a new column in a card table.
+// bucketID is the project ID, cardTableID is the card table ID.
+// Returns the created column.
+func (s *CardColumnsService) Create(ctx context.Context, bucketID, cardTableID int64, req *CreateColumnRequest) (*CardColumn, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	if req == nil || req.Title == "" {
+		return nil, ErrUsage("column title is required")
+	}
+
+	path := fmt.Sprintf("/buckets/%d/card_tables/%d/columns.json", bucketID, cardTableID)
+	resp, err := s.client.Post(ctx, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var column CardColumn
+	if err := resp.UnmarshalData(&column); err != nil {
+		return nil, fmt.Errorf("failed to parse column: %w", err)
+	}
+
+	return &column, nil
+}
+
+// Update updates an existing column.
+// bucketID is the project ID, columnID is the column ID.
+// Returns the updated column.
+func (s *CardColumnsService) Update(ctx context.Context, bucketID, columnID int64, req *UpdateColumnRequest) (*CardColumn, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	if req == nil {
+		return nil, ErrUsage("update request is required")
+	}
+
+	path := fmt.Sprintf("/buckets/%d/card_tables/columns/%d.json", bucketID, columnID)
+	resp, err := s.client.Put(ctx, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var column CardColumn
+	if err := resp.UnmarshalData(&column); err != nil {
+		return nil, fmt.Errorf("failed to parse column: %w", err)
+	}
+
+	return &column, nil
+}
+
+// Move moves a column within a card table.
+// bucketID is the project ID, cardTableID is the card table ID.
+func (s *CardColumnsService) Move(ctx context.Context, bucketID, cardTableID int64, req *MoveColumnRequest) error {
+	if err := s.client.RequireAccount(); err != nil {
+		return err
+	}
+
+	if req == nil {
+		return ErrUsage("move request is required")
+	}
+
+	path := fmt.Sprintf("/buckets/%d/card_tables/%d/moves.json", bucketID, cardTableID)
+	_, err := s.client.Post(ctx, path, req)
+	return err
+}
+
+// SetColor sets the color of a column.
+// bucketID is the project ID, columnID is the column ID.
+// Valid colors: white, red, orange, yellow, green, blue, aqua, purple, gray, pink, brown.
+// Returns the updated column.
+func (s *CardColumnsService) SetColor(ctx context.Context, bucketID, columnID int64, color string) (*CardColumn, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	if color == "" {
+		return nil, ErrUsage("color is required")
+	}
+
+	path := fmt.Sprintf("/buckets/%d/card_tables/columns/%d/color.json", bucketID, columnID)
+	body := SetColumnColorRequest{Color: color}
+	resp, err := s.client.Put(ctx, path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var column CardColumn
+	if err := resp.UnmarshalData(&column); err != nil {
+		return nil, fmt.Errorf("failed to parse column: %w", err)
+	}
+
+	return &column, nil
+}
+
+// EnableOnHold adds an on-hold section to a column.
+// bucketID is the project ID, columnID is the column ID.
+// Returns the updated column.
+func (s *CardColumnsService) EnableOnHold(ctx context.Context, bucketID, columnID int64) (*CardColumn, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/card_tables/columns/%d/on_hold.json", bucketID, columnID)
+	resp, err := s.client.Post(ctx, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var column CardColumn
+	if err := resp.UnmarshalData(&column); err != nil {
+		return nil, fmt.Errorf("failed to parse column: %w", err)
+	}
+
+	return &column, nil
+}
+
+// DisableOnHold removes the on-hold section from a column.
+// bucketID is the project ID, columnID is the column ID.
+// Returns the updated column.
+func (s *CardColumnsService) DisableOnHold(ctx context.Context, bucketID, columnID int64) (*CardColumn, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/card_tables/columns/%d/on_hold.json", bucketID, columnID)
+	resp, err := s.client.Delete(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var column CardColumn
+	if err := resp.UnmarshalData(&column); err != nil {
+		return nil, fmt.Errorf("failed to parse column: %w", err)
+	}
+
+	return &column, nil
+}
+
+// CardStepsService handles card step operations.
+type CardStepsService struct {
+	client *Client
+}
+
+// NewCardStepsService creates a new CardStepsService.
+func NewCardStepsService(client *Client) *CardStepsService {
+	return &CardStepsService{client: client}
+}
+
+// Create creates a new step on a card.
+// bucketID is the project ID, cardID is the card ID.
+// Returns the created step.
+func (s *CardStepsService) Create(ctx context.Context, bucketID, cardID int64, req *CreateStepRequest) (*CardStep, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	if req == nil || req.Title == "" {
+		return nil, ErrUsage("step title is required")
+	}
+
+	path := fmt.Sprintf("/buckets/%d/card_tables/cards/%d/steps.json", bucketID, cardID)
+	resp, err := s.client.Post(ctx, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var step CardStep
+	if err := resp.UnmarshalData(&step); err != nil {
+		return nil, fmt.Errorf("failed to parse step: %w", err)
+	}
+
+	return &step, nil
+}
+
+// Update updates an existing step.
+// bucketID is the project ID, stepID is the step ID.
+// Returns the updated step.
+func (s *CardStepsService) Update(ctx context.Context, bucketID, stepID int64, req *UpdateStepRequest) (*CardStep, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	if req == nil {
+		return nil, ErrUsage("update request is required")
+	}
+
+	path := fmt.Sprintf("/buckets/%d/card_tables/steps/%d.json", bucketID, stepID)
+	resp, err := s.client.Put(ctx, path, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var step CardStep
+	if err := resp.UnmarshalData(&step); err != nil {
+		return nil, fmt.Errorf("failed to parse step: %w", err)
+	}
+
+	return &step, nil
+}
+
+// Complete marks a step as completed.
+// bucketID is the project ID, stepID is the step ID.
+// Returns the updated step.
+func (s *CardStepsService) Complete(ctx context.Context, bucketID, stepID int64) (*CardStep, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/card_tables/steps/%d/completions.json", bucketID, stepID)
+	body := map[string]string{"completion": "on"}
+	resp, err := s.client.Put(ctx, path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var step CardStep
+	if err := resp.UnmarshalData(&step); err != nil {
+		return nil, fmt.Errorf("failed to parse step: %w", err)
+	}
+
+	return &step, nil
+}
+
+// Uncomplete marks a step as incomplete.
+// bucketID is the project ID, stepID is the step ID.
+// Returns the updated step.
+func (s *CardStepsService) Uncomplete(ctx context.Context, bucketID, stepID int64) (*CardStep, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/card_tables/steps/%d/completions.json", bucketID, stepID)
+	body := map[string]string{"completion": "off"}
+	resp, err := s.client.Put(ctx, path, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var step CardStep
+	if err := resp.UnmarshalData(&step); err != nil {
+		return nil, fmt.Errorf("failed to parse step: %w", err)
+	}
+
+	return &step, nil
+}
+
+// Reposition changes the position of a step within a card.
+// bucketID is the project ID, cardID is the card ID, stepID is the step ID.
+// position is 0-indexed.
+func (s *CardStepsService) Reposition(ctx context.Context, bucketID, cardID, stepID int64, position int) error {
+	if err := s.client.RequireAccount(); err != nil {
+		return err
+	}
+
+	if position < 0 {
+		return ErrUsage("position must be at least 0")
+	}
+
+	path := fmt.Sprintf("/buckets/%d/card_tables/cards/%d/positions.json", bucketID, cardID)
+	body := map[string]any{"source_id": stepID, "position": position}
+	_, err := s.client.Post(ctx, path, body)
+	return err
+}
+
+// Delete deletes a step (moves it to trash).
+// bucketID is the project ID, stepID is the step ID.
+func (s *CardStepsService) Delete(ctx context.Context, bucketID, stepID int64) error {
+	if err := s.client.RequireAccount(); err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/recordings/%d/status/trashed.json", bucketID, stepID)
+	_, err := s.client.Put(ctx, path, nil)
+	return err
+}

--- a/go/pkg/basecamp/cards_test.go
+++ b/go/pkg/basecamp/cards_test.go
@@ -1,0 +1,624 @@
+package basecamp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func cardsFixturesDir() string {
+	return filepath.Join("..", "..", "..", "spec", "fixtures", "cards")
+}
+
+func loadCardsFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	path := filepath.Join(cardsFixturesDir(), name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func TestCardTable_Unmarshal(t *testing.T) {
+	data := loadCardsFixture(t, "card_table.json")
+
+	var cardTable CardTable
+	if err := json.Unmarshal(data, &cardTable); err != nil {
+		t.Fatalf("failed to unmarshal card_table.json: %v", err)
+	}
+
+	if cardTable.ID != 1069479345 {
+		t.Errorf("expected ID 1069479345, got %d", cardTable.ID)
+	}
+	if cardTable.Status != "active" {
+		t.Errorf("expected status 'active', got %q", cardTable.Status)
+	}
+	if cardTable.Title != "Development Board" {
+		t.Errorf("expected title 'Development Board', got %q", cardTable.Title)
+	}
+	if cardTable.Type != "Kanban::Board" {
+		t.Errorf("expected type 'Kanban::Board', got %q", cardTable.Type)
+	}
+	if cardTable.URL != "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/1069479345.json" {
+		t.Errorf("unexpected URL: %q", cardTable.URL)
+	}
+	if cardTable.AppURL != "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/1069479345" {
+		t.Errorf("unexpected AppURL: %q", cardTable.AppURL)
+	}
+
+	// Verify bucket
+	if cardTable.Bucket == nil {
+		t.Fatal("expected Bucket to be non-nil")
+	}
+	if cardTable.Bucket.ID != 2085958499 {
+		t.Errorf("expected Bucket.ID 2085958499, got %d", cardTable.Bucket.ID)
+	}
+	if cardTable.Bucket.Name != "The Leto Laptop" {
+		t.Errorf("expected Bucket.Name 'The Leto Laptop', got %q", cardTable.Bucket.Name)
+	}
+
+	// Verify creator
+	if cardTable.Creator == nil {
+		t.Fatal("expected Creator to be non-nil")
+	}
+	if cardTable.Creator.ID != 1049715914 {
+		t.Errorf("expected Creator.ID 1049715914, got %d", cardTable.Creator.ID)
+	}
+	if cardTable.Creator.Name != "Victor Cooper" {
+		t.Errorf("expected Creator.Name 'Victor Cooper', got %q", cardTable.Creator.Name)
+	}
+
+	// Verify lists (columns)
+	if len(cardTable.Lists) != 3 {
+		t.Fatalf("expected 3 lists, got %d", len(cardTable.Lists))
+	}
+
+	// Verify triage column
+	triage := cardTable.Lists[0]
+	if triage.ID != 1069479346 {
+		t.Errorf("expected triage ID 1069479346, got %d", triage.ID)
+	}
+	if triage.Title != "Triage" {
+		t.Errorf("expected triage title 'Triage', got %q", triage.Title)
+	}
+	if triage.Type != "Kanban::Triage" {
+		t.Errorf("expected triage type 'Kanban::Triage', got %q", triage.Type)
+	}
+	if triage.CardsCount != 3 {
+		t.Errorf("expected triage cards_count 3, got %d", triage.CardsCount)
+	}
+
+	// Verify in progress column
+	inProgress := cardTable.Lists[1]
+	if inProgress.Title != "In Progress" {
+		t.Errorf("expected title 'In Progress', got %q", inProgress.Title)
+	}
+	if inProgress.Type != "Kanban::Column" {
+		t.Errorf("expected type 'Kanban::Column', got %q", inProgress.Type)
+	}
+	if inProgress.Color != "blue" {
+		t.Errorf("expected color 'blue', got %q", inProgress.Color)
+	}
+	if inProgress.Position != 1 {
+		t.Errorf("expected position 1, got %d", inProgress.Position)
+	}
+
+	// Verify done column
+	done := cardTable.Lists[2]
+	if done.Title != "Done" {
+		t.Errorf("expected title 'Done', got %q", done.Title)
+	}
+	if done.Type != "Kanban::DoneColumn" {
+		t.Errorf("expected type 'Kanban::DoneColumn', got %q", done.Type)
+	}
+	if done.Color != "green" {
+		t.Errorf("expected color 'green', got %q", done.Color)
+	}
+}
+
+func TestCard_UnmarshalList(t *testing.T) {
+	data := loadCardsFixture(t, "list.json")
+
+	var cards []Card
+	if err := json.Unmarshal(data, &cards); err != nil {
+		t.Fatalf("failed to unmarshal list.json: %v", err)
+	}
+
+	if len(cards) != 2 {
+		t.Errorf("expected 2 cards, got %d", len(cards))
+	}
+
+	// Verify first card
+	c1 := cards[0]
+	if c1.ID != 1069479350 {
+		t.Errorf("expected ID 1069479350, got %d", c1.ID)
+	}
+	if c1.Title != "Implement user authentication" {
+		t.Errorf("expected title 'Implement user authentication', got %q", c1.Title)
+	}
+	if c1.Type != "Kanban::Card" {
+		t.Errorf("expected type 'Kanban::Card', got %q", c1.Type)
+	}
+	if c1.DueOn != "2024-02-01" {
+		t.Errorf("expected due_on '2024-02-01', got %q", c1.DueOn)
+	}
+	if c1.Position != 1 {
+		t.Errorf("expected position 1, got %d", c1.Position)
+	}
+	if c1.Completed {
+		t.Error("expected completed to be false")
+	}
+	if c1.CommentsCount != 2 {
+		t.Errorf("expected comments_count 2, got %d", c1.CommentsCount)
+	}
+
+	// Verify parent (column)
+	if c1.Parent == nil {
+		t.Fatal("expected Parent to be non-nil")
+	}
+	if c1.Parent.ID != 1069479347 {
+		t.Errorf("expected Parent.ID 1069479347, got %d", c1.Parent.ID)
+	}
+	if c1.Parent.Title != "In Progress" {
+		t.Errorf("expected Parent.Title 'In Progress', got %q", c1.Parent.Title)
+	}
+	if c1.Parent.Type != "Kanban::Column" {
+		t.Errorf("expected Parent.Type 'Kanban::Column', got %q", c1.Parent.Type)
+	}
+
+	// Verify assignees
+	if len(c1.Assignees) != 1 {
+		t.Fatalf("expected 1 assignee, got %d", len(c1.Assignees))
+	}
+	if c1.Assignees[0].Name != "Annie Bryan" {
+		t.Errorf("expected assignee name 'Annie Bryan', got %q", c1.Assignees[0].Name)
+	}
+
+	// Verify steps
+	if len(c1.Steps) != 2 {
+		t.Fatalf("expected 2 steps, got %d", len(c1.Steps))
+	}
+	step1 := c1.Steps[0]
+	if step1.Title != "Set up OAuth providers" {
+		t.Errorf("expected step title 'Set up OAuth providers', got %q", step1.Title)
+	}
+	if !step1.Completed {
+		t.Error("expected first step to be completed")
+	}
+	if step1.Completer == nil {
+		t.Fatal("expected Completer to be non-nil")
+	}
+	if step1.Completer.Name != "Annie Bryan" {
+		t.Errorf("expected Completer.Name 'Annie Bryan', got %q", step1.Completer.Name)
+	}
+
+	step2 := c1.Steps[1]
+	if step2.Title != "Implement callback handlers" {
+		t.Errorf("expected step title 'Implement callback handlers', got %q", step2.Title)
+	}
+	if step2.Completed {
+		t.Error("expected second step to not be completed")
+	}
+
+	// Verify second card
+	c2 := cards[1]
+	if c2.ID != 1069479351 {
+		t.Errorf("expected ID 1069479351, got %d", c2.ID)
+	}
+	if c2.Title != "Design landing page" {
+		t.Errorf("expected title 'Design landing page', got %q", c2.Title)
+	}
+	if len(c2.Steps) != 0 {
+		t.Errorf("expected no steps, got %d", len(c2.Steps))
+	}
+}
+
+func TestCard_UnmarshalGet(t *testing.T) {
+	data := loadCardsFixture(t, "get.json")
+
+	var card Card
+	if err := json.Unmarshal(data, &card); err != nil {
+		t.Fatalf("failed to unmarshal get.json: %v", err)
+	}
+
+	if card.ID != 1069479350 {
+		t.Errorf("expected ID 1069479350, got %d", card.ID)
+	}
+	if card.Title != "Implement user authentication" {
+		t.Errorf("expected title 'Implement user authentication', got %q", card.Title)
+	}
+	if card.Type != "Kanban::Card" {
+		t.Errorf("expected type 'Kanban::Card', got %q", card.Type)
+	}
+
+	// Verify timestamps
+	if card.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be non-zero")
+	}
+	if card.UpdatedAt.IsZero() {
+		t.Error("expected UpdatedAt to be non-zero")
+	}
+
+	// Verify creator with full details
+	if card.Creator == nil {
+		t.Fatal("expected Creator to be non-nil")
+	}
+	if card.Creator.EmailAddress != "victor@honchodesign.com" {
+		t.Errorf("expected Creator.EmailAddress 'victor@honchodesign.com', got %q", card.Creator.EmailAddress)
+	}
+	if card.Creator.Title != "Chief Strategist" {
+		t.Errorf("expected Creator.Title 'Chief Strategist', got %q", card.Creator.Title)
+	}
+
+	// Verify assignees with details
+	if len(card.Assignees) != 1 {
+		t.Fatalf("expected 1 assignee, got %d", len(card.Assignees))
+	}
+	assignee := card.Assignees[0]
+	if assignee.EmailAddress != "annie@honchodesign.com" {
+		t.Errorf("expected assignee email 'annie@honchodesign.com', got %q", assignee.EmailAddress)
+	}
+
+	// Verify steps
+	if len(card.Steps) != 2 {
+		t.Fatalf("expected 2 steps, got %d", len(card.Steps))
+	}
+}
+
+func TestCardColumn_Unmarshal(t *testing.T) {
+	data := loadCardsFixture(t, "column.json")
+
+	var column CardColumn
+	if err := json.Unmarshal(data, &column); err != nil {
+		t.Fatalf("failed to unmarshal column.json: %v", err)
+	}
+
+	if column.ID != 1069479347 {
+		t.Errorf("expected ID 1069479347, got %d", column.ID)
+	}
+	if column.Title != "In Progress" {
+		t.Errorf("expected title 'In Progress', got %q", column.Title)
+	}
+	if column.Type != "Kanban::Column" {
+		t.Errorf("expected type 'Kanban::Column', got %q", column.Type)
+	}
+	if column.Color != "blue" {
+		t.Errorf("expected color 'blue', got %q", column.Color)
+	}
+	if column.Position != 1 {
+		t.Errorf("expected position 1, got %d", column.Position)
+	}
+	if column.Description != "Cards currently being worked on" {
+		t.Errorf("expected description 'Cards currently being worked on', got %q", column.Description)
+	}
+	if column.CardsCount != 2 {
+		t.Errorf("expected cards_count 2, got %d", column.CardsCount)
+	}
+
+	// Verify parent (card table)
+	if column.Parent == nil {
+		t.Fatal("expected Parent to be non-nil")
+	}
+	if column.Parent.ID != 1069479345 {
+		t.Errorf("expected Parent.ID 1069479345, got %d", column.Parent.ID)
+	}
+	if column.Parent.Title != "Development Board" {
+		t.Errorf("expected Parent.Title 'Development Board', got %q", column.Parent.Title)
+	}
+	if column.Parent.Type != "Kanban::Board" {
+		t.Errorf("expected Parent.Type 'Kanban::Board', got %q", column.Parent.Type)
+	}
+
+	// Verify subscribers
+	if len(column.Subscribers) != 1 {
+		t.Fatalf("expected 1 subscriber, got %d", len(column.Subscribers))
+	}
+	if column.Subscribers[0].Name != "Victor Cooper" {
+		t.Errorf("expected subscriber name 'Victor Cooper', got %q", column.Subscribers[0].Name)
+	}
+}
+
+func TestCardStep_Unmarshal(t *testing.T) {
+	data := loadCardsFixture(t, "step.json")
+
+	var step CardStep
+	if err := json.Unmarshal(data, &step); err != nil {
+		t.Fatalf("failed to unmarshal step.json: %v", err)
+	}
+
+	if step.ID != 1069479360 {
+		t.Errorf("expected ID 1069479360, got %d", step.ID)
+	}
+	if step.Title != "Set up OAuth providers" {
+		t.Errorf("expected title 'Set up OAuth providers', got %q", step.Title)
+	}
+	if step.Type != "Kanban::Step" {
+		t.Errorf("expected type 'Kanban::Step', got %q", step.Type)
+	}
+	if step.Position != 1 {
+		t.Errorf("expected position 1, got %d", step.Position)
+	}
+	if step.DueOn != "2024-01-20" {
+		t.Errorf("expected due_on '2024-01-20', got %q", step.DueOn)
+	}
+	if !step.Completed {
+		t.Error("expected completed to be true")
+	}
+	if step.CompletedAt == nil {
+		t.Fatal("expected CompletedAt to be non-nil")
+	}
+
+	// Verify parent (card)
+	if step.Parent == nil {
+		t.Fatal("expected Parent to be non-nil")
+	}
+	if step.Parent.ID != 1069479350 {
+		t.Errorf("expected Parent.ID 1069479350, got %d", step.Parent.ID)
+	}
+	if step.Parent.Type != "Kanban::Card" {
+		t.Errorf("expected Parent.Type 'Kanban::Card', got %q", step.Parent.Type)
+	}
+
+	// Verify completer
+	if step.Completer == nil {
+		t.Fatal("expected Completer to be non-nil")
+	}
+	if step.Completer.Name != "Annie Bryan" {
+		t.Errorf("expected Completer.Name 'Annie Bryan', got %q", step.Completer.Name)
+	}
+
+	// Verify assignees
+	if len(step.Assignees) != 1 {
+		t.Fatalf("expected 1 assignee, got %d", len(step.Assignees))
+	}
+	if step.Assignees[0].Name != "Annie Bryan" {
+		t.Errorf("expected assignee name 'Annie Bryan', got %q", step.Assignees[0].Name)
+	}
+}
+
+func TestCreateCardRequest_Marshal(t *testing.T) {
+	req := CreateCardRequest{
+		Title:   "New feature card",
+		Content: "<div>Description of the feature</div>",
+		DueOn:   "2024-03-01",
+		Notify:  true,
+	}
+
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal CreateCardRequest: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(out, &data); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	if data["title"] != "New feature card" {
+		t.Errorf("unexpected title: %v", data["title"])
+	}
+	if data["content"] != "<div>Description of the feature</div>" {
+		t.Errorf("unexpected content: %v", data["content"])
+	}
+	if data["due_on"] != "2024-03-01" {
+		t.Errorf("unexpected due_on: %v", data["due_on"])
+	}
+	if data["notify"] != true {
+		t.Errorf("unexpected notify: %v", data["notify"])
+	}
+}
+
+func TestCreateCardRequest_MarshalMinimal(t *testing.T) {
+	req := CreateCardRequest{
+		Title: "Simple card",
+	}
+
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal CreateCardRequest: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(out, &data); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	if data["title"] != "Simple card" {
+		t.Errorf("unexpected title: %v", data["title"])
+	}
+	if _, ok := data["content"]; ok {
+		t.Error("expected content to be omitted")
+	}
+	if _, ok := data["due_on"]; ok {
+		t.Error("expected due_on to be omitted")
+	}
+	if _, ok := data["notify"]; ok {
+		t.Error("expected notify to be omitted")
+	}
+}
+
+func TestUpdateCardRequest_Marshal(t *testing.T) {
+	req := UpdateCardRequest{
+		Title:       "Updated title",
+		Content:     "<div>Updated content</div>",
+		DueOn:       "2024-04-01",
+		AssigneeIDs: []int64{1049715914, 1049715915},
+	}
+
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal UpdateCardRequest: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(out, &data); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	if data["title"] != "Updated title" {
+		t.Errorf("unexpected title: %v", data["title"])
+	}
+	if data["content"] != "<div>Updated content</div>" {
+		t.Errorf("unexpected content: %v", data["content"])
+	}
+	if data["due_on"] != "2024-04-01" {
+		t.Errorf("unexpected due_on: %v", data["due_on"])
+	}
+
+	assigneeIDs, ok := data["assignee_ids"].([]interface{})
+	if !ok {
+		t.Fatalf("expected assignee_ids to be an array, got %T", data["assignee_ids"])
+	}
+	if len(assigneeIDs) != 2 {
+		t.Errorf("expected 2 assignee IDs, got %d", len(assigneeIDs))
+	}
+}
+
+func TestMoveCardRequest_Marshal(t *testing.T) {
+	req := MoveCardRequest{
+		ColumnID: 1069479348,
+	}
+
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal MoveCardRequest: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(out, &data); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	if data["column_id"] != float64(1069479348) {
+		t.Errorf("unexpected column_id: %v", data["column_id"])
+	}
+}
+
+func TestCreateColumnRequest_Marshal(t *testing.T) {
+	req := CreateColumnRequest{
+		Title:       "Review",
+		Description: "Cards ready for review",
+	}
+
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal CreateColumnRequest: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(out, &data); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	if data["title"] != "Review" {
+		t.Errorf("unexpected title: %v", data["title"])
+	}
+	if data["description"] != "Cards ready for review" {
+		t.Errorf("unexpected description: %v", data["description"])
+	}
+}
+
+func TestSetColumnColorRequest_Marshal(t *testing.T) {
+	req := SetColumnColorRequest{
+		Color: "purple",
+	}
+
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal SetColumnColorRequest: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(out, &data); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	if data["color"] != "purple" {
+		t.Errorf("unexpected color: %v", data["color"])
+	}
+}
+
+func TestMoveColumnRequest_Marshal(t *testing.T) {
+	req := MoveColumnRequest{
+		SourceID: 1069479347,
+		TargetID: 1069479348,
+		Position: 1,
+	}
+
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal MoveColumnRequest: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(out, &data); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	if data["source_id"] != float64(1069479347) {
+		t.Errorf("unexpected source_id: %v", data["source_id"])
+	}
+	if data["target_id"] != float64(1069479348) {
+		t.Errorf("unexpected target_id: %v", data["target_id"])
+	}
+	if data["position"] != float64(1) {
+		t.Errorf("unexpected position: %v", data["position"])
+	}
+}
+
+func TestCreateStepRequest_Marshal(t *testing.T) {
+	req := CreateStepRequest{
+		Title:     "Write tests",
+		DueOn:     "2024-02-15",
+		Assignees: "1049715914,1049715915",
+	}
+
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal CreateStepRequest: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(out, &data); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	if data["title"] != "Write tests" {
+		t.Errorf("unexpected title: %v", data["title"])
+	}
+	if data["due_on"] != "2024-02-15" {
+		t.Errorf("unexpected due_on: %v", data["due_on"])
+	}
+	if data["assignees"] != "1049715914,1049715915" {
+		t.Errorf("unexpected assignees: %v", data["assignees"])
+	}
+}
+
+func TestUpdateStepRequest_Marshal(t *testing.T) {
+	req := UpdateStepRequest{
+		Title: "Updated step title",
+		DueOn: "2024-02-20",
+	}
+
+	out, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("failed to marshal UpdateStepRequest: %v", err)
+	}
+
+	var data map[string]interface{}
+	if err := json.Unmarshal(out, &data); err != nil {
+		t.Fatalf("failed to unmarshal to map: %v", err)
+	}
+
+	if data["title"] != "Updated step title" {
+		t.Errorf("unexpected title: %v", data["title"])
+	}
+	if data["due_on"] != "2024-02-20" {
+		t.Errorf("unexpected due_on: %v", data["due_on"])
+	}
+	if _, ok := data["assignees"]; ok {
+		t.Error("expected assignees to be omitted")
+	}
+}

--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -58,6 +58,10 @@ type Client struct {
 	vaults          *VaultsService
 	documents       *DocumentsService
 	uploads         *UploadsService
+	cardTables      *CardTablesService
+	cards           *CardsService
+	cardColumns     *CardColumnsService
+	cardSteps       *CardStepsService
 }
 
 // Response wraps an API response.
@@ -699,4 +703,36 @@ func (c *Client) Uploads() *UploadsService {
 		c.uploads = NewUploadsService(c)
 	}
 	return c.uploads
+}
+
+// CardTables returns the CardTablesService for card table operations.
+func (c *Client) CardTables() *CardTablesService {
+	if c.cardTables == nil {
+		c.cardTables = NewCardTablesService(c)
+	}
+	return c.cardTables
+}
+
+// Cards returns the CardsService for card operations.
+func (c *Client) Cards() *CardsService {
+	if c.cards == nil {
+		c.cards = NewCardsService(c)
+	}
+	return c.cards
+}
+
+// CardColumns returns the CardColumnsService for card column operations.
+func (c *Client) CardColumns() *CardColumnsService {
+	if c.cardColumns == nil {
+		c.cardColumns = NewCardColumnsService(c)
+	}
+	return c.cardColumns
+}
+
+// CardSteps returns the CardStepsService for card step operations.
+func (c *Client) CardSteps() *CardStepsService {
+	if c.cardSteps == nil {
+		c.cardSteps = NewCardStepsService(c)
+	}
+	return c.cardSteps
 }

--- a/spec/fixtures/cards/card_table.json
+++ b/spec/fixtures/cards/card_table.json
@@ -1,0 +1,147 @@
+{
+  "id": 1069479345,
+  "status": "active",
+  "visible_to_clients": false,
+  "created_at": "2024-01-15T09:30:00.000-06:00",
+  "updated_at": "2024-01-20T14:45:00.000-06:00",
+  "title": "Development Board",
+  "inherits_status": true,
+  "type": "Kanban::Board",
+  "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/1069479345.json",
+  "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/1069479345",
+  "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5MzQ1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--abc123.json",
+  "subscription_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479345/subscription.json",
+  "bucket": {
+    "id": 2085958499,
+    "name": "The Leto Laptop",
+    "type": "Project"
+  },
+  "creator": {
+    "id": 1049715914,
+    "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--xyz456",
+    "name": "Victor Cooper",
+    "email_address": "victor@honchodesign.com",
+    "personable_type": "User",
+    "title": "Chief Strategist",
+    "bio": "Leading product strategy",
+    "location": "Chicago, IL",
+    "created_at": "2024-01-01T08:00:00.000-06:00",
+    "updated_at": "2024-01-15T10:00:00.000-06:00",
+    "admin": true,
+    "owner": true,
+    "client": false,
+    "employee": true,
+    "time_zone": "America/Chicago",
+    "avatar_url": "https://3.basecamp-static.com/avatar/123.jpg",
+    "can_ping": true,
+    "can_manage_projects": true,
+    "can_manage_people": true
+  },
+  "subscribers": [
+    {
+      "id": 1049715914,
+      "name": "Victor Cooper"
+    }
+  ],
+  "lists": [
+    {
+      "id": 1069479346,
+      "status": "active",
+      "visible_to_clients": false,
+      "created_at": "2024-01-15T09:30:00.000-06:00",
+      "updated_at": "2024-01-20T14:45:00.000-06:00",
+      "title": "Triage",
+      "inherits_status": true,
+      "type": "Kanban::Triage",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/columns/1069479346.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/columns/1069479346",
+      "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/triage.json",
+      "cards_count": 3,
+      "comment_count": 0,
+      "cards_url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/lists/1069479346/cards.json",
+      "parent": {
+        "id": 1069479345,
+        "title": "Development Board",
+        "type": "Kanban::Board",
+        "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/1069479345.json",
+        "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/1069479345"
+      },
+      "bucket": {
+        "id": 2085958499,
+        "name": "The Leto Laptop",
+        "type": "Project"
+      },
+      "creator": {
+        "id": 1049715914,
+        "name": "Victor Cooper"
+      }
+    },
+    {
+      "id": 1069479347,
+      "status": "active",
+      "visible_to_clients": false,
+      "created_at": "2024-01-15T09:31:00.000-06:00",
+      "updated_at": "2024-01-20T14:45:00.000-06:00",
+      "title": "In Progress",
+      "inherits_status": true,
+      "type": "Kanban::Column",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/columns/1069479347.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/columns/1069479347",
+      "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/inprogress.json",
+      "position": 1,
+      "color": "blue",
+      "cards_count": 2,
+      "comment_count": 0,
+      "cards_url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/lists/1069479347/cards.json",
+      "parent": {
+        "id": 1069479345,
+        "title": "Development Board",
+        "type": "Kanban::Board",
+        "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/1069479345.json",
+        "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/1069479345"
+      },
+      "bucket": {
+        "id": 2085958499,
+        "name": "The Leto Laptop",
+        "type": "Project"
+      },
+      "creator": {
+        "id": 1049715914,
+        "name": "Victor Cooper"
+      }
+    },
+    {
+      "id": 1069479348,
+      "status": "active",
+      "visible_to_clients": false,
+      "created_at": "2024-01-15T09:32:00.000-06:00",
+      "updated_at": "2024-01-20T14:45:00.000-06:00",
+      "title": "Done",
+      "inherits_status": true,
+      "type": "Kanban::DoneColumn",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/columns/1069479348.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/columns/1069479348",
+      "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/done.json",
+      "color": "green",
+      "cards_count": 5,
+      "comment_count": 0,
+      "cards_url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/lists/1069479348/cards.json",
+      "parent": {
+        "id": 1069479345,
+        "title": "Development Board",
+        "type": "Kanban::Board",
+        "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/1069479345.json",
+        "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/1069479345"
+      },
+      "bucket": {
+        "id": 2085958499,
+        "name": "The Leto Laptop",
+        "type": "Project"
+      },
+      "creator": {
+        "id": 1049715914,
+        "name": "Victor Cooper"
+      }
+    }
+  ]
+}

--- a/spec/fixtures/cards/column.json
+++ b/spec/fixtures/cards/column.json
@@ -1,0 +1,51 @@
+{
+  "id": 1069479347,
+  "status": "active",
+  "visible_to_clients": false,
+  "created_at": "2024-01-15T09:31:00.000-06:00",
+  "updated_at": "2024-01-20T14:45:00.000-06:00",
+  "title": "In Progress",
+  "inherits_status": true,
+  "type": "Kanban::Column",
+  "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/columns/1069479347.json",
+  "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/columns/1069479347",
+  "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/inprogress.json",
+  "position": 1,
+  "color": "blue",
+  "description": "Cards currently being worked on",
+  "cards_count": 2,
+  "comment_count": 0,
+  "cards_url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/lists/1069479347/cards.json",
+  "parent": {
+    "id": 1069479345,
+    "title": "Development Board",
+    "type": "Kanban::Board",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/1069479345.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/1069479345"
+  },
+  "bucket": {
+    "id": 2085958499,
+    "name": "The Leto Laptop",
+    "type": "Project"
+  },
+  "creator": {
+    "id": 1049715914,
+    "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--xyz456",
+    "name": "Victor Cooper",
+    "email_address": "victor@honchodesign.com",
+    "personable_type": "User",
+    "title": "Chief Strategist",
+    "admin": true,
+    "owner": true,
+    "client": false,
+    "employee": true,
+    "time_zone": "America/Chicago",
+    "avatar_url": "https://3.basecamp-static.com/avatar/123.jpg"
+  },
+  "subscribers": [
+    {
+      "id": 1049715914,
+      "name": "Victor Cooper"
+    }
+  ]
+}

--- a/spec/fixtures/cards/get.json
+++ b/spec/fixtures/cards/get.json
@@ -1,0 +1,144 @@
+{
+  "id": 1069479350,
+  "status": "active",
+  "visible_to_clients": false,
+  "created_at": "2024-01-16T10:00:00.000-06:00",
+  "updated_at": "2024-01-20T15:30:00.000-06:00",
+  "title": "Implement user authentication",
+  "inherits_status": true,
+  "type": "Kanban::Card",
+  "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+  "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350",
+  "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/card1.json",
+  "subscription_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479350/subscription.json",
+  "position": 1,
+  "content": "<div>Add OAuth2 login flow with Google and GitHub providers</div>",
+  "description": "Add OAuth2 login flow with Google and GitHub providers",
+  "due_on": "2024-02-01",
+  "completed": false,
+  "comments_count": 2,
+  "comments_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479350/comments.json",
+  "comment_count": 2,
+  "completion_url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350/completion.json",
+  "parent": {
+    "id": 1069479347,
+    "title": "In Progress",
+    "type": "Kanban::Column",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/columns/1069479347.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/columns/1069479347"
+  },
+  "bucket": {
+    "id": 2085958499,
+    "name": "The Leto Laptop",
+    "type": "Project"
+  },
+  "creator": {
+    "id": 1049715914,
+    "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--xyz456",
+    "name": "Victor Cooper",
+    "email_address": "victor@honchodesign.com",
+    "personable_type": "User",
+    "title": "Chief Strategist",
+    "bio": "Leading product strategy",
+    "location": "Chicago, IL",
+    "created_at": "2024-01-01T08:00:00.000-06:00",
+    "updated_at": "2024-01-15T10:00:00.000-06:00",
+    "admin": true,
+    "owner": true,
+    "client": false,
+    "employee": true,
+    "time_zone": "America/Chicago",
+    "avatar_url": "https://3.basecamp-static.com/avatar/123.jpg",
+    "can_ping": true,
+    "can_manage_projects": true,
+    "can_manage_people": true
+  },
+  "assignees": [
+    {
+      "id": 1049715915,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--abc789",
+      "name": "Annie Bryan",
+      "email_address": "annie@honchodesign.com",
+      "personable_type": "User",
+      "title": "Designer",
+      "admin": false,
+      "owner": false,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/avatar/456.jpg"
+    }
+  ],
+  "completion_subscribers": [],
+  "steps": [
+    {
+      "id": 1069479360,
+      "status": "active",
+      "visible_to_clients": false,
+      "created_at": "2024-01-16T10:05:00.000-06:00",
+      "updated_at": "2024-01-18T11:00:00.000-06:00",
+      "title": "Set up OAuth providers",
+      "inherits_status": true,
+      "type": "Kanban::Step",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/steps/1069479360.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/steps/1069479360",
+      "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/step1.json",
+      "position": 1,
+      "completed": true,
+      "completed_at": "2024-01-18T11:00:00.000-06:00",
+      "parent": {
+        "id": 1069479350,
+        "title": "Implement user authentication",
+        "type": "Kanban::Card",
+        "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+        "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350"
+      },
+      "bucket": {
+        "id": 2085958499,
+        "name": "The Leto Laptop",
+        "type": "Project"
+      },
+      "creator": {
+        "id": 1049715914,
+        "name": "Victor Cooper"
+      },
+      "completer": {
+        "id": 1049715915,
+        "name": "Annie Bryan"
+      },
+      "assignees": []
+    },
+    {
+      "id": 1069479361,
+      "status": "active",
+      "visible_to_clients": false,
+      "created_at": "2024-01-16T10:06:00.000-06:00",
+      "updated_at": "2024-01-16T10:06:00.000-06:00",
+      "title": "Implement callback handlers",
+      "inherits_status": true,
+      "type": "Kanban::Step",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/steps/1069479361.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/steps/1069479361",
+      "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/step2.json",
+      "position": 2,
+      "completed": false,
+      "parent": {
+        "id": 1069479350,
+        "title": "Implement user authentication",
+        "type": "Kanban::Card",
+        "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+        "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350"
+      },
+      "bucket": {
+        "id": 2085958499,
+        "name": "The Leto Laptop",
+        "type": "Project"
+      },
+      "creator": {
+        "id": 1049715914,
+        "name": "Victor Cooper"
+      },
+      "assignees": []
+    }
+  ]
+}

--- a/spec/fixtures/cards/list.json
+++ b/spec/fixtures/cards/list.json
@@ -1,0 +1,160 @@
+[
+  {
+    "id": 1069479350,
+    "status": "active",
+    "visible_to_clients": false,
+    "created_at": "2024-01-16T10:00:00.000-06:00",
+    "updated_at": "2024-01-20T15:30:00.000-06:00",
+    "title": "Implement user authentication",
+    "inherits_status": true,
+    "type": "Kanban::Card",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350",
+    "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/card1.json",
+    "subscription_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479350/subscription.json",
+    "position": 1,
+    "content": "<div>Add OAuth2 login flow with Google and GitHub providers</div>",
+    "description": "Add OAuth2 login flow with Google and GitHub providers",
+    "due_on": "2024-02-01",
+    "completed": false,
+    "comments_count": 2,
+    "comments_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479350/comments.json",
+    "comment_count": 2,
+    "completion_url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350/completion.json",
+    "parent": {
+      "id": 1069479347,
+      "title": "In Progress",
+      "type": "Kanban::Column",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/columns/1069479347.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/columns/1069479347"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715914,
+      "name": "Victor Cooper"
+    },
+    "assignees": [
+      {
+        "id": 1049715915,
+        "name": "Annie Bryan"
+      }
+    ],
+    "completion_subscribers": [],
+    "steps": [
+      {
+        "id": 1069479360,
+        "status": "active",
+        "visible_to_clients": false,
+        "created_at": "2024-01-16T10:05:00.000-06:00",
+        "updated_at": "2024-01-18T11:00:00.000-06:00",
+        "title": "Set up OAuth providers",
+        "inherits_status": true,
+        "type": "Kanban::Step",
+        "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/steps/1069479360.json",
+        "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/steps/1069479360",
+        "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/step1.json",
+        "position": 1,
+        "completed": true,
+        "completed_at": "2024-01-18T11:00:00.000-06:00",
+        "parent": {
+          "id": 1069479350,
+          "title": "Implement user authentication",
+          "type": "Kanban::Card",
+          "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+          "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350"
+        },
+        "bucket": {
+          "id": 2085958499,
+          "name": "The Leto Laptop",
+          "type": "Project"
+        },
+        "creator": {
+          "id": 1049715914,
+          "name": "Victor Cooper"
+        },
+        "completer": {
+          "id": 1049715915,
+          "name": "Annie Bryan"
+        },
+        "assignees": []
+      },
+      {
+        "id": 1069479361,
+        "status": "active",
+        "visible_to_clients": false,
+        "created_at": "2024-01-16T10:06:00.000-06:00",
+        "updated_at": "2024-01-16T10:06:00.000-06:00",
+        "title": "Implement callback handlers",
+        "inherits_status": true,
+        "type": "Kanban::Step",
+        "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/steps/1069479361.json",
+        "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/steps/1069479361",
+        "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/step2.json",
+        "position": 2,
+        "completed": false,
+        "parent": {
+          "id": 1069479350,
+          "title": "Implement user authentication",
+          "type": "Kanban::Card",
+          "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+          "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350"
+        },
+        "bucket": {
+          "id": 2085958499,
+          "name": "The Leto Laptop",
+          "type": "Project"
+        },
+        "creator": {
+          "id": 1049715914,
+          "name": "Victor Cooper"
+        },
+        "assignees": []
+      }
+    ]
+  },
+  {
+    "id": 1069479351,
+    "status": "active",
+    "visible_to_clients": false,
+    "created_at": "2024-01-17T09:00:00.000-06:00",
+    "updated_at": "2024-01-19T16:00:00.000-06:00",
+    "title": "Design landing page",
+    "inherits_status": true,
+    "type": "Kanban::Card",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479351.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479351",
+    "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/card2.json",
+    "subscription_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479351/subscription.json",
+    "position": 2,
+    "content": "<div>Create responsive landing page with hero section</div>",
+    "description": "Create responsive landing page with hero section",
+    "completed": false,
+    "comments_count": 0,
+    "comments_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479351/comments.json",
+    "comment_count": 0,
+    "completion_url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479351/completion.json",
+    "parent": {
+      "id": 1069479347,
+      "title": "In Progress",
+      "type": "Kanban::Column",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/columns/1069479347.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/columns/1069479347"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715915,
+      "name": "Annie Bryan"
+    },
+    "assignees": [],
+    "completion_subscribers": [],
+    "steps": []
+  }
+]

--- a/spec/fixtures/cards/step.json
+++ b/spec/fixtures/cards/step.json
@@ -1,0 +1,50 @@
+{
+  "id": 1069479360,
+  "status": "active",
+  "visible_to_clients": false,
+  "created_at": "2024-01-16T10:05:00.000-06:00",
+  "updated_at": "2024-01-18T11:00:00.000-06:00",
+  "title": "Set up OAuth providers",
+  "inherits_status": true,
+  "type": "Kanban::Step",
+  "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/steps/1069479360.json",
+  "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/steps/1069479360",
+  "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/step1.json",
+  "position": 1,
+  "due_on": "2024-01-20",
+  "completed": true,
+  "completed_at": "2024-01-18T11:00:00.000-06:00",
+  "parent": {
+    "id": 1069479350,
+    "title": "Implement user authentication",
+    "type": "Kanban::Card",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350"
+  },
+  "bucket": {
+    "id": 2085958499,
+    "name": "The Leto Laptop",
+    "type": "Project"
+  },
+  "creator": {
+    "id": 1049715914,
+    "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--xyz456",
+    "name": "Victor Cooper",
+    "email_address": "victor@honchodesign.com",
+    "personable_type": "User",
+    "title": "Chief Strategist",
+    "admin": true,
+    "owner": true
+  },
+  "completer": {
+    "id": 1049715915,
+    "name": "Annie Bryan",
+    "email_address": "annie@honchodesign.com"
+  },
+  "assignees": [
+    {
+      "id": 1049715915,
+      "name": "Annie Bryan"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `CardTablesService` with `Get` for retrieving card tables (kanban boards)
- Add `CardsService` with `List`, `Get`, `Create`, `Update`, `Move` operations
- Add `CardColumnsService` with `Get`, `Create`, `Update`, `Move`, `SetColor`, `EnableOnHold`, `DisableOnHold`
- Add `CardStepsService` with `Create`, `Update`, `Complete`, `Uncomplete`, `Reposition`, `Delete`
- Add comprehensive test fixtures for cards, columns, steps, and card tables
- Add client accessors: `Cards()`, `CardTables()`, `CardColumns()`, `CardSteps()`

## Test plan

- [x] All existing tests pass
- [x] New cards_test.go tests pass
- [x] golangci-lint shows no issues
- [x] go build succeeds