### PR TITLE
Fix: Add nil check for CreateWebhookRequest

### DIFF
--- a/go/pkg/basecamp/webhooks.go
+++ b/go/pkg/basecamp/webhooks.go
@@ -100,6 +100,10 @@ func (s *WebhooksService) Get(ctx context.Context, bucketID, webhookID int64) (*
 // bucketID is the project ID.
 // Returns the created webhook.
 func (s *WebhooksService) Create(ctx context.Context, bucketID int64, req *CreateWebhookRequest) (*Webhook, error) {
+	if req == nil {
+		return nil, ErrUsage("webhook request is required")
+	}
+
 	if err := s.client.RequireAccount(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Adds nil check at the start of `WebhooksService.Create` to prevent panic when called with a nil request
- Addresses Codex review feedback from PR #7

## Test plan
- [x] Existing tests pass
- [x] go vet passes