### PR TITLE
Fix: Use correct bucket-scoped endpoints for timesheet reports

### DIFF
--- a/go/pkg/basecamp/timesheet.go
+++ b/go/pkg/basecamp/timesheet.go
@@ -97,7 +97,7 @@ func (s *TimesheetService) ProjectReport(ctx context.Context, projectID int64, o
 		return nil, err
 	}
 
-	path := fmt.Sprintf("/projects/%d/timesheet.json", projectID) + s.buildQueryParams(opts)
+	path := fmt.Sprintf("/buckets/%d/timesheet.json", projectID) + s.buildQueryParams(opts)
 	results, err := s.client.GetAll(ctx, path)
 	if err != nil {
 		return nil, err
@@ -122,7 +122,7 @@ func (s *TimesheetService) RecordingReport(ctx context.Context, projectID, recor
 		return nil, err
 	}
 
-	path := fmt.Sprintf("/projects/%d/recordings/%d/timesheet.json", projectID, recordingID) + s.buildQueryParams(opts)
+	path := fmt.Sprintf("/buckets/%d/recordings/%d/timesheet.json", projectID, recordingID) + s.buildQueryParams(opts)
 	results, err := s.client.GetAll(ctx, path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- Fix `ProjectReport` to use `/buckets/:id/timesheet.json` instead of `/projects/:id/timesheet.json`
- Fix `RecordingReport` to use `/buckets/:bucket_id/recordings/:recording_id/timesheet.json` instead of `/projects/:id/recordings/:id/timesheet.json`

This follows the SDK convention of using `/buckets/` for bucket-scoped resources, consistent with other services.

Addresses Codex review feedback on PR #15.

## Test plan
- [x] All existing tests pass
- [x] Verified endpoint paths match SDK conventions used by other services (recordings, comments, etc.)