### PR TITLE
Add ClientRepliesService for client reply endpoints

### DIFF
--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -65,6 +65,7 @@ type Client struct {
 	attachments           *AttachmentsService
 	clientApprovals       *ClientApprovalsService
 	clientCorrespondences *ClientCorrespondencesService
+	clientReplies         *ClientRepliesService
 }
 
 // Response wraps an API response.
@@ -765,4 +766,12 @@ func (c *Client) ClientCorrespondences() *ClientCorrespondencesService {
 		c.clientCorrespondences = NewClientCorrespondencesService(c)
 	}
 	return c.clientCorrespondences
+}
+
+// ClientReplies returns the ClientRepliesService for client reply operations.
+func (c *Client) ClientReplies() *ClientRepliesService {
+	if c.clientReplies == nil {
+		c.clientReplies = NewClientRepliesService(c)
+	}
+	return c.clientReplies
 }

--- a/go/pkg/basecamp/client_replies.go
+++ b/go/pkg/basecamp/client_replies.go
@@ -1,0 +1,84 @@
+package basecamp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// ClientReply represents a reply to a client correspondence or approval.
+type ClientReply struct {
+	ID               int64     `json:"id"`
+	Status           string    `json:"status"`
+	VisibleToClients bool      `json:"visible_to_clients"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+	Title            string    `json:"title"`
+	InheritsStatus   bool      `json:"inherits_status"`
+	Type             string    `json:"type"`
+	URL              string    `json:"url"`
+	AppURL           string    `json:"app_url"`
+	BookmarkURL      string    `json:"bookmark_url"`
+	Parent           *Parent   `json:"parent,omitempty"`
+	Bucket           *Bucket   `json:"bucket,omitempty"`
+	Creator          *Person   `json:"creator,omitempty"`
+	Content          string    `json:"content"`
+}
+
+// ClientRepliesService handles client reply operations.
+type ClientRepliesService struct {
+	client *Client
+}
+
+// NewClientRepliesService creates a new ClientRepliesService.
+func NewClientRepliesService(client *Client) *ClientRepliesService {
+	return &ClientRepliesService{client: client}
+}
+
+// List returns all replies for a client recording (correspondence or approval).
+// bucketID is the project ID, recordingID is the parent correspondence/approval ID.
+func (s *ClientRepliesService) List(ctx context.Context, bucketID, recordingID int64) ([]ClientReply, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/client/recordings/%d/replies.json", bucketID, recordingID)
+	results, err := s.client.GetAll(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	replies := make([]ClientReply, 0, len(results))
+	for _, raw := range results {
+		var r ClientReply
+		if err := json.Unmarshal(raw, &r); err != nil {
+			return nil, fmt.Errorf("failed to parse client reply: %w", err)
+		}
+		replies = append(replies, r)
+	}
+
+	return replies, nil
+}
+
+// Get returns a specific client reply.
+// bucketID is the project ID, recordingID is the parent correspondence/approval ID,
+// replyID is the client reply ID.
+func (s *ClientRepliesService) Get(ctx context.Context, bucketID, recordingID, replyID int64) (*ClientReply, error) {
+	if err := s.client.RequireAccount(); err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/buckets/%d/client/recordings/%d/replies/%d.json", bucketID, recordingID, replyID)
+	resp, err := s.client.Get(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	var reply ClientReply
+	if err := resp.UnmarshalData(&reply); err != nil {
+		return nil, fmt.Errorf("failed to parse client reply: %w", err)
+	}
+
+	return &reply, nil
+}

--- a/go/pkg/basecamp/client_replies_test.go
+++ b/go/pkg/basecamp/client_replies_test.go
@@ -1,0 +1,177 @@
+package basecamp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func clientRepliesFixturesDir() string {
+	return filepath.Join("..", "..", "..", "spec", "fixtures", "client_replies")
+}
+
+func loadClientRepliesFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	path := filepath.Join(clientRepliesFixturesDir(), name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func TestClientReply_UnmarshalList(t *testing.T) {
+	data := loadClientRepliesFixture(t, "list.json")
+
+	var replies []ClientReply
+	if err := json.Unmarshal(data, &replies); err != nil {
+		t.Fatalf("failed to unmarshal list.json: %v", err)
+	}
+
+	if len(replies) != 1 {
+		t.Errorf("expected 1 reply, got %d", len(replies))
+	}
+
+	// Verify first reply
+	r := replies[0]
+	if r.ID != 1069479567 {
+		t.Errorf("expected ID 1069479567, got %d", r.ID)
+	}
+	if r.Status != "active" {
+		t.Errorf("expected status 'active', got %q", r.Status)
+	}
+	if r.Type != "Client::Reply" {
+		t.Errorf("expected type 'Client::Reply', got %q", r.Type)
+	}
+	if r.Title != "Re: Project kickoff!" {
+		t.Errorf("expected title 'Re: Project kickoff!', got %q", r.Title)
+	}
+	if !r.InheritsStatus {
+		t.Error("expected inherits_status to be true")
+	}
+	if r.VisibleToClients {
+		t.Error("expected visible_to_clients to be false")
+	}
+	if r.Content != "<div>Hi all - we're excited to get started too.</div>" {
+		t.Errorf("unexpected content: %q", r.Content)
+	}
+	if r.URL != "https://3.basecampapi.com/195539477/buckets/2085958500/client/replies/1069479567.json" {
+		t.Errorf("unexpected URL: %q", r.URL)
+	}
+	if r.AppURL != "https://3.basecamp.com/195539477/buckets/2085958500/client/correspondences/1069479566#__recording_1069479567" {
+		t.Errorf("unexpected AppURL: %q", r.AppURL)
+	}
+
+	// Verify parent
+	if r.Parent == nil {
+		t.Fatal("expected Parent to be non-nil")
+	}
+	if r.Parent.ID != 1069479566 {
+		t.Errorf("expected Parent.ID 1069479566, got %d", r.Parent.ID)
+	}
+	if r.Parent.Title != "Project kickoff!" {
+		t.Errorf("expected Parent.Title 'Project kickoff!', got %q", r.Parent.Title)
+	}
+	if r.Parent.Type != "Client::Correspondence" {
+		t.Errorf("expected Parent.Type 'Client::Correspondence', got %q", r.Parent.Type)
+	}
+
+	// Verify bucket
+	if r.Bucket == nil {
+		t.Fatal("expected Bucket to be non-nil")
+	}
+	if r.Bucket.ID != 2085958500 {
+		t.Errorf("expected Bucket.ID 2085958500, got %d", r.Bucket.ID)
+	}
+	if r.Bucket.Name != "The Leto Locator" {
+		t.Errorf("expected Bucket.Name 'The Leto Locator', got %q", r.Bucket.Name)
+	}
+
+	// Verify creator
+	if r.Creator == nil {
+		t.Fatal("expected Creator to be non-nil")
+	}
+	if r.Creator.ID != 1049715941 {
+		t.Errorf("expected Creator.ID 1049715941, got %d", r.Creator.ID)
+	}
+	if r.Creator.Name != "Stephen Early" {
+		t.Errorf("expected Creator.Name 'Stephen Early', got %q", r.Creator.Name)
+	}
+	if r.Creator.EmailAddress != "stephen@letobrand.com" {
+		t.Errorf("expected Creator.EmailAddress 'stephen@letobrand.com', got %q", r.Creator.EmailAddress)
+	}
+	if r.Creator.Company == nil {
+		t.Fatal("expected Creator.Company to be non-nil")
+	}
+	if r.Creator.Company.Name != "Leto Brand" {
+		t.Errorf("expected Creator.Company.Name 'Leto Brand', got %q", r.Creator.Company.Name)
+	}
+}
+
+func TestClientReply_UnmarshalGet(t *testing.T) {
+	data := loadClientRepliesFixture(t, "get.json")
+
+	var reply ClientReply
+	if err := json.Unmarshal(data, &reply); err != nil {
+		t.Fatalf("failed to unmarshal get.json: %v", err)
+	}
+
+	if reply.ID != 1069479571 {
+		t.Errorf("expected ID 1069479571, got %d", reply.ID)
+	}
+	if reply.Status != "active" {
+		t.Errorf("expected status 'active', got %q", reply.Status)
+	}
+	if reply.Type != "Client::Reply" {
+		t.Errorf("expected type 'Client::Reply', got %q", reply.Type)
+	}
+	if reply.Title != "Re: Project kickoff!" {
+		t.Errorf("expected title 'Re: Project kickoff!', got %q", reply.Title)
+	}
+
+	// Verify timestamps are parsed
+	if reply.CreatedAt.IsZero() {
+		t.Error("expected CreatedAt to be non-zero")
+	}
+	if reply.UpdatedAt.IsZero() {
+		t.Error("expected UpdatedAt to be non-zero")
+	}
+
+	// Verify creator
+	if reply.Creator == nil {
+		t.Fatal("expected Creator to be non-nil")
+	}
+	if reply.Creator.ID != 1049715915 {
+		t.Errorf("expected Creator.ID 1049715915, got %d", reply.Creator.ID)
+	}
+	if reply.Creator.Name != "Annie Bryan" {
+		t.Errorf("expected Creator.Name 'Annie Bryan', got %q", reply.Creator.Name)
+	}
+	if reply.Creator.EmailAddress != "annie@honchodesign.com" {
+		t.Errorf("expected Creator.EmailAddress 'annie@honchodesign.com', got %q", reply.Creator.EmailAddress)
+	}
+	if reply.Creator.Company == nil {
+		t.Fatal("expected Creator.Company to be non-nil")
+	}
+	if reply.Creator.Company.Name != "Honcho Design" {
+		t.Errorf("expected Creator.Company.Name 'Honcho Design', got %q", reply.Creator.Company.Name)
+	}
+
+	// Verify content
+	expectedContent := "<div>Hi Leto team, this it's Annie. I'll be your day to day contact for the project, so keep me on your speed dial (or speed email, perhaps more accurately!) Feel free to reach out to me with any questions at all, and I'll be posting up some outlines, timelines, etc. very shortly.</div>"
+	if reply.Content != expectedContent {
+		t.Errorf("unexpected content: %q", reply.Content)
+	}
+
+	// Verify parent
+	if reply.Parent == nil {
+		t.Fatal("expected Parent to be non-nil")
+	}
+	if reply.Parent.ID != 1069479566 {
+		t.Errorf("expected Parent.ID 1069479566, got %d", reply.Parent.ID)
+	}
+	if reply.Parent.Type != "Client::Correspondence" {
+		t.Errorf("expected Parent.Type 'Client::Correspondence', got %q", reply.Parent.Type)
+	}
+}

--- a/spec/fixtures/client_replies/get.json
+++ b/spec/fixtures/client_replies/get.json
@@ -1,0 +1,50 @@
+{
+  "id": 1069479571,
+  "status": "active",
+  "visible_to_clients": false,
+  "created_at": "2022-10-09T09:20:14.049Z",
+  "updated_at": "2022-10-09T09:20:14.049Z",
+  "title": "Re: Project kickoff!",
+  "inherits_status": true,
+  "type": "Client::Reply",
+  "url": "https://3.basecampapi.com/195539477/buckets/2085958500/client/replies/1069479571.json",
+  "app_url": "https://3.basecamp.com/195539477/buckets/2085958500/client/correspondences/1069479566#__recording_1069479571",
+  "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5NTcxP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--c711ae715330c9d458072698256fec0d86abd15e.json",
+  "parent": {
+    "id": 1069479566,
+    "title": "Project kickoff!",
+    "type": "Client::Correspondence",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958500/client/correspondences/1069479566.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958500/client/correspondences/1069479566"
+  },
+  "bucket": {
+    "id": 2085958500,
+    "name": "The Leto Locator",
+    "type": "Project"
+  },
+  "creator": {
+    "id": 1049715915,
+    "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aeb392ebf54ffd820e45f27add22bae3a8c7da56",
+    "name": "Annie Bryan",
+    "email_address": "annie@honchodesign.com",
+    "personable_type": "User",
+    "title": "Central Markets Manager",
+    "bio": "To open a store is easy, to keep it open is an art",
+    "location": null,
+    "created_at": "2022-11-22T08:23:21.911Z",
+    "updated_at": "2022-11-22T08:23:21.911Z",
+    "admin": false,
+    "owner": false,
+    "client": false,
+    "employee": true,
+    "time_zone": "America/Chicago",
+    "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMtkkT4=--9927c47a4cbee30a7f9aea667882496aba799149/avatar?v=1",
+    "company": {
+      "id": 1033447817,
+      "name": "Honcho Design"
+    },
+    "can_manage_projects": true,
+    "can_manage_people": true
+  },
+  "content": "<div>Hi Leto team, this it's Annie. I'll be your day to day contact for the project, so keep me on your speed dial (or speed email, perhaps more accurately!) Feel free to reach out to me with any questions at all, and I'll be posting up some outlines, timelines, etc. very shortly.</div>"
+}

--- a/spec/fixtures/client_replies/list.json
+++ b/spec/fixtures/client_replies/list.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": 1069479567,
+    "status": "active",
+    "visible_to_clients": false,
+    "created_at": "2022-10-09T10:36:14.049Z",
+    "updated_at": "2022-10-09T10:36:14.049Z",
+    "title": "Re: Project kickoff!",
+    "inherits_status": true,
+    "type": "Client::Reply",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958500/client/replies/1069479567.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958500/client/correspondences/1069479566#__recording_1069479567",
+    "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5NTY3P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--9ff5d4f77619de8b3657b8b4fbe22e9d0b7c2b5a.json",
+    "parent": {
+      "id": 1069479566,
+      "title": "Project kickoff!",
+      "type": "Client::Correspondence",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958500/client/correspondences/1069479566.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958500/client/correspondences/1069479566"
+    },
+    "bucket": {
+      "id": 2085958500,
+      "name": "The Leto Locator",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715941,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTQxP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--10099ab54fac5884db30b9bd897ea030023d4d0a",
+      "name": "Stephen Early",
+      "email_address": "stephen@letobrand.com",
+      "personable_type": "Client",
+      "title": "National Directives Director",
+      "bio": null,
+      "location": null,
+      "created_at": "2022-11-22T08:23:22.341Z",
+      "updated_at": "2022-11-22T08:23:22.341Z",
+      "admin": false,
+      "owner": false,
+      "client": false,
+      "employee": false,
+      "time_zone": "Etc/UTC",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBOVkkT4=--33e3fc268c87411378691c71b6f13658e0b40967/avatar?v=1",
+      "company": {
+        "id": 1033447818,
+        "name": "Leto Brand"
+      },
+      "can_manage_projects": false,
+      "can_manage_people": false
+    },
+    "content": "<div>Hi all - we're excited to get started too.</div>"
+  }
+]


### PR DESCRIPTION
## Summary
- Adds `ClientRepliesService` with `List` and `Get` methods for client reply endpoints
- Completes 100% coverage of all documented Basecamp 3 API endpoints

## Endpoints Added
- `GET /buckets/{id}/client/recordings/{id}/replies.json` → `ClientReplies().List(bucketID, recordingID)`
- `GET /buckets/{id}/client/recordings/{id}/replies/{id}.json` → `ClientReplies().Get(bucketID, recordingID, replyID)`

## Test plan
- [x] All existing tests pass
- [x] New unit tests for JSON unmarshaling added
- [x] Build compiles successfully