### PR TITLE
Address PR #35 review feedback

### DIFF
--- a/go/pkg/basecamp/cards.go
+++ b/go/pkg/basecamp/cards.go
@@ -301,9 +301,11 @@ func (s *CardsService) Create(ctx context.Context, bucketID, columnID int64, req
 		body.Content = req.Content
 	}
 	if req.DueOn != "" {
-		if t, err := time.Parse("2006-01-02", req.DueOn); err == nil {
-			body.DueOn = t
+		t, err := time.Parse("2006-01-02", req.DueOn)
+		if err != nil {
+			return nil, ErrUsage("card due_on must be in YYYY-MM-DD format")
 		}
+		body.DueOn = t
 	}
 	if req.Notify {
 		body.Notify = req.Notify
@@ -344,9 +346,11 @@ func (s *CardsService) Update(ctx context.Context, bucketID, cardID int64, req *
 		body.Content = req.Content
 	}
 	if req.DueOn != "" {
-		if t, err := time.Parse("2006-01-02", req.DueOn); err == nil {
-			body.DueOn = t
+		t, err := time.Parse("2006-01-02", req.DueOn)
+		if err != nil {
+			return nil, ErrUsage("card due_on must be in YYYY-MM-DD format")
 		}
+		body.DueOn = t
 	}
 	if len(req.AssigneeIDs) > 0 {
 		body.AssigneeIds = req.AssigneeIDs
@@ -663,9 +667,11 @@ func (s *CardStepsService) Create(ctx context.Context, bucketID, cardID int64, r
 		Assignees: req.Assignees,
 	}
 	if req.DueOn != "" {
-		if t, err := time.Parse("2006-01-02", req.DueOn); err == nil {
-			body.DueOn = t
+		t, err := time.Parse("2006-01-02", req.DueOn)
+		if err != nil {
+			return nil, ErrUsage("step due_on must be in YYYY-MM-DD format")
 		}
+		body.DueOn = t
 	}
 
 	resp, err := s.client.gen.CreateCardStepWithResponse(ctx, bucketID, cardID, body)
@@ -700,9 +706,11 @@ func (s *CardStepsService) Update(ctx context.Context, bucketID, stepID int64, r
 		Assignees: req.Assignees,
 	}
 	if req.DueOn != "" {
-		if t, err := time.Parse("2006-01-02", req.DueOn); err == nil {
-			body.DueOn = t
+		t, err := time.Parse("2006-01-02", req.DueOn)
+		if err != nil {
+			return nil, ErrUsage("step due_on must be in YYYY-MM-DD format")
 		}
+		body.DueOn = t
 	}
 
 	resp, err := s.client.gen.UpdateCardStepWithResponse(ctx, bucketID, stepID, body)

--- a/go/pkg/basecamp/timesheet.go
+++ b/go/pkg/basecamp/timesheet.go
@@ -42,18 +42,22 @@ func NewTimesheetService(client *Client) *TimesheetService {
 }
 
 // buildTimesheetParams builds query parameters for the generated client.
+// Returns nil if no filters are specified to avoid serializing zero values.
 func (s *TimesheetService) buildTimesheetParams(opts *TimesheetReportOptions) *generated.GetTimesheetReportParams {
 	if opts == nil {
 		return nil
 	}
 
-	params := &generated.GetTimesheetReportParams{
+	// Only create params if there are actual filter values
+	if opts.From == "" && opts.To == "" && opts.PersonID == 0 {
+		return nil
+	}
+
+	return &generated.GetTimesheetReportParams{
 		From:     opts.From,
 		To:       opts.To,
 		PersonId: opts.PersonID,
 	}
-
-	return params
 }
 
 // Report returns the account-wide timesheet report.

--- a/go/pkg/basecamp/todos.go
+++ b/go/pkg/basecamp/todos.go
@@ -142,9 +142,10 @@ func (s *TodosService) List(ctx context.Context, bucketID, todolistID int64, opt
 		return nil, err
 	}
 
-	params := &generated.ListTodosParams{}
+	// Only pass params when there are actual filters to avoid serializing zero values
+	var params *generated.ListTodosParams
 	if opts != nil && opts.Status != "" {
-		params.Status = opts.Status
+		params = &generated.ListTodosParams{Status: opts.Status}
 	}
 
 	resp, err := s.client.gen.ListTodosWithResponse(ctx, bucketID, todolistID, params)


### PR DESCRIPTION
## Summary

Fixes issues raised in post-merge review of PR #35:

- **cards.go**: Return `ErrUsage` on invalid `DueOn` date format instead of silently ignoring parse errors
- **timesheet.go**: Return `nil` params when no filters specified to avoid serializing zero values with `prefer-skip-optional-pointer`
- **todos.go**: Only pass `ListTodosParams` when `Status` filter is actually set

## Test plan

- [x] `go build ./...` passes
- [x] CI passes