### PR TITLE
Fix TypeScript build error in attachments service

### DIFF
--- a/typescript/src/services/attachments.ts
+++ b/typescript/src/services/attachments.ts
@@ -113,7 +113,11 @@ export class AttachmentsService extends BaseService {
         this.client.POST("/attachments.json", {
           params: {
             query: { name: req.filename },
-            header: { "Content-Type": req.contentType },
+            // Type assertion needed: path-level types say `header?: never` but
+            // operation-level types correctly require Content-Type header.
+            // TODO: Revisit if openapi-typescript generator is updated to fix
+            // the path/operation parameter merge conflict.
+            header: { "Content-Type": req.contentType } as { "Content-Type": string },
           },
           body: req.data as unknown as string,
           // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/typescript/tests/services/attachments.test.ts
+++ b/typescript/tests/services/attachments.test.ts
@@ -60,6 +60,25 @@ describe("AttachmentsService", () => {
       expect(capturedUrl).toContain("name=report.xlsx");
     });
 
+    it("should set Content-Type header to the file's MIME type", async () => {
+      let capturedContentType: string | null = null;
+
+      server.use(
+        http.post(`${BASE_URL}/attachments.json`, ({ request }) => {
+          capturedContentType = request.headers.get("Content-Type");
+          return HttpResponse.json({ attachable_sgid: "test-sgid" });
+        })
+      );
+
+      await service.create({
+        filename: "image.png",
+        contentType: "image/png",
+        data: new Uint8Array([1, 2, 3, 4]),
+      });
+
+      expect(capturedContentType).toBe("image/png");
+    });
+
     it("should throw validation error when filename is missing", async () => {
       await expect(
         service.create({


### PR DESCRIPTION
## Summary

- Fix TypeScript build error caused by conflicting types in generated OpenAPI schema
- Add type assertion to resolve path-level `header?: never` vs operation-level `header: { "Content-Type": string }` conflict

## Test plan

- [x] `npm run build` passes
- [x] `npm run test` - all 316 tests pass
- [x] `npm run lint` - no warnings or errors
- [x] `make` - all checks pass including conformance tests