### PR TITLE
Add Ruby SDK

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,25 @@ updates:
       - "dependencies"
       - "typescript"
 
+  # Ruby SDK dependencies
+  - package-ecosystem: bundler
+    directory: "/ruby"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: America/Chicago
+    open-pull-requests-limit: 10
+    groups:
+      bundler-dependencies:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "deps(ruby):"
+    labels:
+      - "dependencies"
+      - "ruby"
+
   # GitHub Actions dependencies
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -1,0 +1,152 @@
+name: Release Ruby SDK
+
+on:
+  push:
+    tags:
+      - 'ruby/v*'
+  workflow_dispatch:  # Manual trigger is always dry-run (rehearsal mode)
+
+permissions:
+  contents: write
+
+jobs:
+  smithy:
+    name: Verify Smithy spec
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: spec
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Smithy CLI
+        run: |
+          curl -L -o smithy-cli.zip https://github.com/smithy-lang/smithy/releases/download/1.66.0/smithy-cli-linux-x86_64.zip
+          unzip -q smithy-cli.zip
+          echo "$PWD/smithy-cli-1.66.0/bin" >> $GITHUB_PATH
+
+      - name: Validate Smithy spec
+        run: smithy validate
+
+      - name: Verify OpenAPI is up to date
+        run: |
+          smithy build
+          diff -q ../openapi.json build/smithy/openapi/openapi/Basecamp.openapi.json || \
+            (echo "::error::openapi.json is stale" && exit 1)
+
+  test:
+    name: Test Ruby SDK
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ruby
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: ruby
+
+      - name: Lint
+        run: bundle exec rubocop
+
+      - name: Run tests
+        run: bundle exec rake test
+
+  publish:
+    name: Publish to RubyGems
+    needs: [smithy, test]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ruby
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: ruby
+
+      - name: Extract version
+        id: version
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # Manual trigger (dry-run): read from version.rb
+            VERSION=$(ruby -e "require_relative 'lib/basecamp/version'; puts Basecamp::VERSION")
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "Rehearsal for version: $VERSION"
+          else
+            # Tag trigger: extract from tag and verify match
+            VERSION="${GITHUB_REF#refs/tags/ruby/v}"
+            GEM_VERSION=$(ruby -e "require_relative 'lib/basecamp/version'; puts Basecamp::VERSION")
+            if [ "$GEM_VERSION" != "$VERSION" ]; then
+              echo "::error::Gem version ($GEM_VERSION) does not match tag version ($VERSION)"
+              exit 1
+            fi
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+            echo "Releasing version: $VERSION"
+          fi
+
+      - name: Build gem
+        run: gem build basecamp-sdk.gemspec
+
+      - name: Publish to RubyGems
+        run: |
+          mkdir -p ~/.gem
+          echo -e "---\n:rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY }}" > ~/.gem/credentials
+          chmod 0600 ~/.gem/credentials
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            gem push basecamp-sdk-${{ steps.version.outputs.version }}.gem
+          else
+            echo "::notice::Dry run mode - not actually publishing"
+            echo "Would publish: basecamp-sdk-${{ steps.version.outputs.version }}.gem"
+          fi
+
+      - name: Generate changelog
+        if: github.event_name == 'push'
+        id: changelog
+        run: |
+          cd ..
+          # Get the previous tag for this module
+          PREV_TAG=$(git describe --tags --match 'ruby/v*' --abbrev=0 HEAD^ 2>/dev/null || true)
+          if [ -z "$PREV_TAG" ]; then
+            # First release, get all commits affecting ruby/
+            COMMITS=$(git log --pretty=format:"- %s (%h)" -- ruby/)
+          else
+            # Get commits since previous tag
+            COMMITS=$(git log --pretty=format:"- %s (%h)" "${PREV_TAG}..HEAD" -- ruby/)
+          fi
+
+          # Write to file for multiline output
+          echo "## Changes" > changelog.md
+          echo "" >> changelog.md
+          if [ -z "$COMMITS" ]; then
+            echo "- Initial release" >> changelog.md
+          else
+            echo "$COMMITS" >> changelog.md
+          fi
+          echo "" >> changelog.md
+          echo "## Installation" >> changelog.md
+          echo "" >> changelog.md
+          echo '```' >> changelog.md
+          echo "gem install basecamp-sdk -v ${{ steps.version.outputs.version }}" >> changelog.md
+          echo '```' >> changelog.md
+
+      - name: Create GitHub Release
+        if: github.event_name == 'push'
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Ruby SDK v${{ steps.version.outputs.version }}
+          body_path: changelog.md
+          draft: false
+          prerelease: ${{ contains(steps.version.outputs.version, '-') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -132,6 +132,58 @@ jobs:
       - name: Run npm audit
         run: npm audit --audit-level=high
 
+  trivy-ruby:
+    name: Trivy (Ruby SDK)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          scan-type: 'fs'
+          scan-ref: './ruby'
+          severity: 'HIGH,CRITICAL'
+          exit-code: '1'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-ruby-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        continue-on-error: true
+        with:
+          sarif_file: 'trivy-ruby-results.sarif'
+          category: 'trivy-ruby'
+
+  bundler-audit:
+    name: Bundler Audit (Ruby SDK)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ruby
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: ruby
+
+      - name: Install bundler-audit
+        run: gem install bundler-audit
+
+      - name: Update vulnerability database
+        run: bundle-audit update
+
+      - name: Run bundler-audit
+        run: bundle-audit check
+
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -105,10 +104,38 @@ jobs:
       - name: Build
         run: npm run build
 
+  test-ruby:
+    name: Ruby ${{ matrix.ruby }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['3.2', '3.3', '3.4', 'head']
+    continue-on-error: ${{ matrix.ruby == 'head' }}
+    defaults:
+      run:
+        working-directory: ruby
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+          working-directory: ruby
+
+      - name: Lint
+        if: matrix.ruby == '3.3'
+        run: bundle exec rubocop
+
+      - name: Test
+        run: bundle exec rake test
+
   conformance:
     name: Conformance Tests
     runs-on: ubuntu-latest
-    needs: [test-go, test-typescript]
+    needs: [test-go, test-typescript, test-ruby]
     defaults:
       run:
         working-directory: conformance/runner/go

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,12 @@ conformance/runner/go/conformance-runner
 
 # Claude Code session files
 .claude/
+
+# Ruby SDK build artifacts
+ruby/.yardoc/
+ruby/doc/
+ruby/coverage/
+ruby/.bundle/
+ruby/vendor/
+ruby/pkg/
+ruby/*.gem

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,46 @@ ts-clean:
 	rm -rf typescript/dist typescript/node_modules
 
 #------------------------------------------------------------------------------
+# Ruby SDK targets
+#------------------------------------------------------------------------------
+
+.PHONY: rb-generate rb-build rb-test rb-check rb-doc rb-clean
+
+# Generate Ruby types and metadata from OpenAPI
+rb-generate:
+	@echo "==> Generating Ruby SDK types and metadata..."
+	cd ruby && ruby scripts/generate-metadata.rb > lib/basecamp/generated/metadata.json
+	cd ruby && ruby scripts/generate-types.rb > lib/basecamp/generated/types.rb
+	@echo "Generated lib/basecamp/generated/metadata.json and types.rb"
+
+# Build Ruby SDK (install deps)
+rb-build:
+	@echo "==> Building Ruby SDK..."
+	cd ruby && bundle install
+
+# Run Ruby tests
+rb-test:
+	@echo "==> Running Ruby tests..."
+	cd ruby && bundle exec rake test
+
+# Run all Ruby checks
+rb-check: rb-test
+	@echo "==> Running Ruby linter..."
+	cd ruby && bundle exec rubocop
+	@echo "==> Ruby SDK checks passed"
+
+# Generate Ruby documentation
+rb-doc:
+	@echo "==> Generating Ruby documentation..."
+	cd ruby && bundle exec rake doc
+	@echo "Documentation generated in ruby/doc/"
+
+# Clean Ruby build artifacts
+rb-clean:
+	@echo "==> Cleaning Ruby SDK..."
+	rm -rf ruby/.bundle ruby/vendor ruby/doc ruby/coverage
+
+#------------------------------------------------------------------------------
 # Conformance Test targets
 #------------------------------------------------------------------------------
 
@@ -151,12 +191,12 @@ conformance: conformance-go
 # Combined targets
 #------------------------------------------------------------------------------
 
-# Run all checks (Smithy + Go + TypeScript + Behavior Model + Conformance)
-check: smithy-check behavior-model-check go-check ts-check conformance
+# Run all checks (Smithy + Go + TypeScript + Ruby + Behavior Model + Conformance)
+check: smithy-check behavior-model-check go-check ts-check rb-check conformance
 	@echo "==> All checks passed"
 
 # Clean all build artifacts
-clean: smithy-clean go-clean ts-clean
+clean: smithy-clean go-clean ts-clean rb-clean
 
 # Help
 help:
@@ -194,7 +234,15 @@ help:
 	@echo "  conformance-go   Run Go conformance tests"
 	@echo "  conformance-build Build conformance test runner"
 	@echo ""
+	@echo "Ruby SDK:"
+	@echo "  rb-generate      Generate types and metadata from OpenAPI"
+	@echo "  rb-build         Build Ruby SDK (install deps)"
+	@echo "  rb-test          Run Ruby tests (with coverage)"
+	@echo "  rb-check         Run all Ruby checks"
+	@echo "  rb-doc           Generate YARD documentation"
+	@echo "  rb-clean         Remove Ruby build artifacts"
+	@echo ""
 	@echo "Combined:"
-	@echo "  check            Run all checks (Smithy + Go + TypeScript + Conformance)"
+	@echo "  check            Run all checks (Smithy + Go + TypeScript + Ruby + Conformance)"
 	@echo "  clean            Remove all build artifacts"
 	@echo "  help             Show this help"

--- a/conformance/runner/ruby/Gemfile
+++ b/conformance/runner/ruby/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "basecamp-sdk", path: "../../../ruby"
+gem "webmock", "~> 3.0"
+gem "json"

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -1,0 +1,275 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Conformance test runner for the Ruby SDK.
+#
+# Reads JSON test definitions from conformance/tests/ and executes
+# them against the SDK using WebMock for HTTP stubbing.
+
+require "bundler/setup"
+require "basecamp"
+require "webmock"
+require "json"
+require "time"
+
+WebMock.enable!
+WebMock.disable_net_connect!
+
+# Test execution tracking
+class TestTracker
+  attr_reader :requests
+
+  def initialize
+    @requests = []
+    @mutex = Mutex.new
+  end
+
+  def record_request(time:, method:, uri:)
+    @mutex.synchronize do
+      @requests << { time: time, method: method, uri: uri.to_s }
+    end
+  end
+
+  def reset!
+    @mutex.synchronize { @requests.clear }
+  end
+
+  def request_count
+    @requests.size
+  end
+
+  def delays_between_requests
+    return [] if @requests.size < 2
+
+    @requests.each_cons(2).map do |a, b|
+      ((b[:time] - a[:time]) * 1000).to_i # milliseconds
+    end
+  end
+end
+
+# Maps operation names to SDK method calls
+class OperationMapper
+  def initialize(account_client)
+    @account = account_client
+  end
+
+  def call(operation, path_params: {}, query_params: {}, body: nil)
+    case operation
+    when "ListProjects"
+      @account.projects.list.to_a
+    when "GetProject"
+      @account.projects.get(project_id: path_params["projectId"])
+    when "CreateProject"
+      @account.projects.create(name: body["name"])
+    when "ListTodos"
+      @account.todos.list(
+        project_id: path_params["projectId"],
+        todolist_id: path_params["todolistId"]
+      ).to_a
+    when "GetTodo"
+      @account.todos.get(
+        project_id: path_params["projectId"],
+        todo_id: path_params["todoId"]
+      )
+    when "CreateTodo"
+      @account.todos.create(
+        project_id: path_params["projectId"],
+        todolist_id: path_params["todolistId"],
+        content: body["content"]
+      )
+    else
+      raise "Unknown operation: #{operation}"
+    end
+  end
+end
+
+# Test result
+TestResult = Struct.new(:name, :passed, :message)
+
+# Single test case
+class TestRunner
+  def initialize(test_case, tracker, mapper)
+    @test = test_case
+    @tracker = tracker
+    @mapper = mapper
+  end
+
+  def run
+    @tracker.reset!
+    setup_mock_responses
+
+    begin
+      result = @mapper.call(
+        @test["operation"],
+        path_params: @test["pathParams"] || {},
+        query_params: @test["queryParams"] || {},
+        body: @test["requestBody"]
+      )
+      verify_assertions(result: result, error: nil)
+    rescue StandardError => e
+      verify_assertions(result: nil, error: e)
+    end
+  end
+
+  private
+
+  def setup_mock_responses
+    responses = @test["mockResponses"] || []
+    return if responses.empty?
+
+    # Build the URL pattern from path
+    path = @test["path"]
+    (@test["pathParams"] || {}).each do |key, value|
+      path = path.gsub("{#{key}}", value.to_s)
+    end
+
+    # Queue up responses
+    response_queue = responses.map do |r|
+      {
+        status: r["status"],
+        body: r["body"]&.to_json || "",
+        headers: { "Content-Type" => "application/json" }.merge(r["headers"] || {})
+      }
+    end
+
+    # Register the stub with a block to track requests and return queued responses
+    method = @test["method"]&.downcase&.to_sym || :get
+    url_pattern = %r{#{Regexp.escape(path)}}
+
+    stub = WebMock.stub_request(method, url_pattern)
+
+    call_count = 0
+    stub.to_return do |request|
+      @tracker.record_request(time: Time.now, method: request.method, uri: request.uri)
+      resp = response_queue[call_count] || response_queue.last
+      call_count += 1
+      resp
+    end
+  end
+
+  def verify_assertions(result:, error:)
+    failures = []
+
+    (@test["assertions"] || []).each do |assertion|
+      case assertion["type"]
+      when "requestCount"
+        actual = @tracker.request_count
+        expected = assertion["expected"]
+        unless actual == expected
+          failures << "Expected #{expected} requests, got #{actual}"
+        end
+
+      when "delayBetweenRequests"
+        delays = @tracker.delays_between_requests
+        min_delay = assertion["min"]
+        if min_delay && delays.any? { |d| d < min_delay }
+          failures << "Expected minimum delay of #{min_delay}ms, got #{delays.min}ms"
+        end
+
+      when "noError"
+        if error
+          failures << "Expected no error, got: #{error.class}: #{error.message}"
+        end
+
+      when "statusCode"
+        expected = assertion["expected"]
+        actual = error&.respond_to?(:http_status) ? error.http_status : nil
+        unless actual == expected
+          failures << "Expected status #{expected}, got #{actual || 'no error'}"
+        end
+
+      when "responseBody"
+        path = assertion["path"]
+        expected = assertion["expected"]
+        actual = dig_path(result, path)
+        unless actual == expected
+          failures << "Expected #{path} to be #{expected}, got #{actual}"
+        end
+      end
+    end
+
+    if failures.empty?
+      TestResult.new(@test["name"], true, nil)
+    else
+      TestResult.new(@test["name"], false, failures.join("; "))
+    end
+  end
+
+  def dig_path(obj, path)
+    return obj if path.nil? || path.empty?
+
+    path.split(".").reduce(obj) do |current, key|
+      return nil if current.nil?
+
+      if current.is_a?(Hash)
+        current[key] || current[key.to_sym]
+      elsif current.respond_to?(key)
+        current.send(key)
+      else
+        nil
+      end
+    end
+  end
+end
+
+# Main runner
+class ConformanceRunner
+  def initialize(tests_dir)
+    @tests_dir = tests_dir
+    @tracker = TestTracker.new
+
+    # Create a test client
+    config = Basecamp::Config.new(base_url: "https://3.basecampapi.com")
+    token_provider = Basecamp::StaticTokenProvider.new("test-token")
+    client = Basecamp::Client.new(config: config, token_provider: token_provider)
+    @account = client.for_account("12345")
+    @mapper = OperationMapper.new(@account)
+  end
+
+  def run
+    files = Dir.glob(File.join(@tests_dir, "*.json"))
+
+    if files.empty?
+      puts "No test files found in #{@tests_dir}"
+      return 0
+    end
+
+    passed = 0
+    failed = 0
+    results = []
+
+    files.each do |file|
+      puts "\n=== #{File.basename(file)} ==="
+
+      tests = JSON.parse(File.read(file))
+      tests.each do |test_case|
+        runner = TestRunner.new(test_case, @tracker, @mapper)
+        result = runner.run
+        results << result
+
+        WebMock.reset!
+
+        if result.passed
+          passed += 1
+          puts "  PASS: #{result.name}"
+        else
+          failed += 1
+          puts "  FAIL: #{result.name}"
+          puts "        #{result.message}"
+        end
+      end
+    end
+
+    puts "\n" + "=" * 40
+    puts "Results: #{passed} passed, #{failed} failed"
+
+    failed > 0 ? 1 : 0
+  end
+end
+
+# Run if executed directly
+if __FILE__ == $PROGRAM_NAME
+  tests_dir = File.expand_path("../../tests", __dir__)
+  runner = ConformanceRunner.new(tests_dir)
+  exit runner.run
+end

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -1,0 +1,16 @@
+# Inherit from Rails/37signals omakase style
+inherit_gem:
+  rubocop-rails-omakase: rubocop.yml
+
+AllCops:
+  TargetRubyVersion: 3.1
+  NewCops: enable
+  SuggestExtensions: false
+  Exclude:
+    - "vendor/**/*"
+    - "lib/basecamp/generated/**/*"
+
+# Documentation not required for tests
+Style/Documentation:
+  Exclude:
+    - "test/**/*"

--- a/ruby/.yardopts
+++ b/ruby/.yardopts
@@ -1,0 +1,6 @@
+--output-dir doc
+--protected
+--no-private
+--embed-mixins
+--title "Basecamp Ruby SDK"
+lib/**/*.rb

--- a/ruby/CHANGELOG.md
+++ b/ruby/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-01-28
+
+### Added
+
+- Initial release of the Basecamp Ruby SDK
+- 38 services covering the complete Basecamp 3 API:
+  - Projects, Todos, Todolists, Todosets, Todolist Groups
+  - People, Comments, Messages, Message Boards, Message Types
+  - Campfires, Schedules, Documents, Vaults, Uploads, Attachments
+  - Recordings, Webhooks, Subscriptions, Templates, Events
+  - Checkins, Forwards, Cards, Card Tables, Card Columns, Card Steps
+  - Lineup, Tools, Search, Reports, Timeline, Timesheet
+  - Client Approvals, Client Correspondences, Client Replies
+  - Authorization
+- OAuth helpers for authorization flow:
+  - `Basecamp::Oauth.discover_launchpad` for OAuth configuration discovery
+  - `Basecamp::Oauth.exchange_code` for code-to-token exchange
+  - `Basecamp::Oauth.refresh_token` for token refresh
+  - Support for Launchpad legacy format
+- Token providers:
+  - `StaticTokenProvider` for simple token-based auth
+  - `OauthTokenProvider` for OAuth with automatic refresh
+- Retry with exponential backoff for GET requests
+  - Retries on 429 (rate limit), 502, 503, 504 errors
+  - Respects `Retry-After` header
+  - Configurable max retries and base delay
+- Link-header pagination with lazy Ruby Enumerators
+- Observability hooks for monitoring requests
+- Comprehensive error hierarchy:
+  - `APIError`, `AuthError`, `ForbiddenError`, `NotFoundError`
+  - `ValidationError`, `RateLimitError`, `NetworkError`
+- Generated types from OpenAPI specification
+- 370+ unit tests
+- Requires Ruby 3.2+, uses Faraday HTTP client
+
+[0.1.0]: https://github.com/basecamp/basecamp-sdk/releases/tag/ruby-v0.1.0

--- a/ruby/Gemfile
+++ b/ruby/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gemspec

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -1,0 +1,215 @@
+PATH
+  remote: .
+  specs:
+    basecamp-sdk (0.1.0)
+      faraday (~> 2.0)
+      zeitwerk (~> 2.6)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (8.1.2)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    addressable (2.8.8)
+      public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
+    base64 (0.3.0)
+    bigdecimal (4.0.1)
+    concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
+    crack (1.0.1)
+      bigdecimal
+      rexml
+    date (3.5.1)
+    docile (1.4.1)
+    drb (2.2.3)
+    erb (6.0.1)
+    faraday (2.14.0)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
+    hashdiff (1.2.1)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
+    io-console (0.8.2)
+    irb (1.16.0)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    json (2.18.0)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
+    logger (1.7.0)
+    minitest (5.27.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    parallel (1.27.0)
+    parser (3.3.10.1)
+      ast (~> 2.4.1)
+      racc
+    pp (0.6.3)
+      prettyprint
+    prettyprint (0.2.0)
+    prism (1.9.0)
+    psych (5.3.1)
+      date
+      stringio
+    public_suffix (7.0.2)
+    racc (1.8.1)
+    rack (3.2.4)
+    rainbow (3.1.1)
+    rake (13.3.1)
+    rdoc (6.17.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
+    regexp_parser (2.11.3)
+    reline (0.6.3)
+      io-console (~> 0.5)
+    rexml (3.4.4)
+    rubocop (1.84.0)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    rubocop-performance (1.26.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
+    rubocop-rails (2.34.3)
+      activesupport (>= 4.2.0)
+      lint_roller (~> 1.1)
+      rack (>= 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.44.0, < 2.0)
+    rubocop-rails-omakase (1.1.0)
+      rubocop (>= 1.72)
+      rubocop-performance (>= 1.24)
+      rubocop-rails (>= 2.30)
+    ruby-progressbar (1.13.0)
+    securerandom (0.4.1)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
+    stringio (3.2.0)
+    tsort (0.2.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
+    uri (1.1.1)
+    webmock (3.26.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    webrick (1.9.2)
+    yard (0.9.38)
+    zeitwerk (2.7.4)
+
+PLATFORMS
+  arm64-darwin-25
+  ruby
+
+DEPENDENCIES
+  basecamp-sdk!
+  irb (~> 1.15)
+  minitest (~> 5.25)
+  rake (~> 13.0)
+  rdoc (~> 6.0)
+  rubocop (~> 1.69)
+  rubocop-rails-omakase (~> 1.0)
+  simplecov (~> 0.22)
+  webmock (~> 3.24)
+  webrick (~> 1.9)
+  yard (~> 0.9)
+
+CHECKSUMS
+  activesupport (8.1.2) sha256=88842578ccd0d40f658289b0e8c842acfe9af751afee2e0744a7873f50b6fdae
+  addressable (2.8.8) sha256=7c13b8f9536cf6364c03b9d417c19986019e28f7c00ac8132da4eb0fe393b057
+  ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
+  base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
+  basecamp-sdk (0.1.0)
+  bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
+  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
+  date (3.5.1) sha256=750d06384d7b9c15d562c76291407d89e368dda4d4fff957eb94962d325a0dc0
+  docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  erb (6.0.1) sha256=28ecdd99c5472aebd5674d6061e3c6b0a45c049578b071e5a52c2a7f13c197e5
+  faraday (2.14.0) sha256=8699cfe5d97e55268f2596f9a9d5a43736808a943714e3d9a53e6110593941cd
+  faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
+  hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
+  i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
+  io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
+  irb (1.16.0) sha256=2abe56c9ac947cdcb2f150572904ba798c1e93c890c256f8429981a7675b0806
+  json (2.18.0) sha256=b10506aee4183f5cf49e0efc48073d7b75843ce3782c68dbeb763351c08fd505
+  language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
+  lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
+  net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
+  parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
+  parser (3.3.10.1) sha256=06f6a725d2cd91e5e7f2b7c32ba143631e1f7c8ae2fb918fc4cebec187e6a688
+  pp (0.6.3) sha256=2951d514450b93ccfeb1df7d021cae0da16e0a7f95ee1e2273719669d0ab9df6
+  prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
+  public_suffix (7.0.2) sha256=9114090c8e4e7135c1fd0e7acfea33afaab38101884320c65aaa0ffb8e26a857
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rack (3.2.4) sha256=5d74b6f75082a643f43c1e76b419c40f0e5527fcfee1e669ac1e6b73c0ccb6f6
+  rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
+  rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
+  rdoc (6.17.0) sha256=0f50d4e568fc98195f9bb155a9e8dff6c7feabfb515fb22ef6df1d12ad5a02b7
+  regexp_parser (2.11.3) sha256=ca13f381a173b7a93450e53459075c9b76a10433caadcb2f1180f2c741fc55a4
+  reline (0.6.3) sha256=1198b04973565b36ec0f11542ab3f5cfeeec34823f4e54cebde90968092b1835
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  rubocop (1.84.0) sha256=88dec310153bb685a879f5a7cdb601f6287b8f0ee675d9dc63a17c7204c4190a
+  rubocop-ast (1.49.0) sha256=49c3676d3123a0923d333e20c6c2dbaaae2d2287b475273fddee0c61da9f71fd
+  rubocop-performance (1.26.1) sha256=cd19b936ff196df85829d264b522fd4f98b6c89ad271fa52744a8c11b8f71834
+  rubocop-rails (2.34.3) sha256=10d37989024865ecda8199f311f3faca990143fbac967de943f88aca11eb9ad2
+  rubocop-rails-omakase (1.1.0) sha256=2af73ac8ee5852de2919abbd2618af9c15c19b512c4cfc1f9a5d3b6ef009109d
+  ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
+  securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1
+  simplecov (0.22.0) sha256=fe2622c7834ff23b98066bb0a854284b2729a569ac659f82621fc22ef36213a5
+  simplecov-html (0.13.2) sha256=bd0b8e54e7c2d7685927e8d6286466359b6f16b18cb0df47b508e8d73c777246
+  simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
+  stringio (3.2.0) sha256=c37cb2e58b4ffbd33fe5cd948c05934af997b36e0b6ca6fdf43afa234cf222e1
+  tsort (0.2.0) sha256=9650a793f6859a43b6641671278f79cfead60ac714148aabe4e3f0060480089f
+  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
+  unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+  webmock (3.26.1) sha256=4f696fb57c90a827c20aadb2d4f9058bbff10f7f043bd0d4c3f58791143b1cd7
+  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
+  yard (0.9.38) sha256=721fb82afb10532aa49860655f6cc2eaa7130889df291b052e1e6b268283010f
+  zeitwerk (2.7.4) sha256=2bef90f356bdafe9a6c2bd32bcd804f83a4f9b8bc27f3600fff051eb3edcec8b
+
+BUNDLED WITH
+  4.0.4

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,0 +1,293 @@
+# Basecamp Ruby SDK
+
+Official Ruby SDK for the [Basecamp 3 API](https://github.com/basecamp/bc3-api).
+
+## Requirements
+
+- Ruby 3.4+
+- Faraday HTTP client
+
+## Installation
+
+Add to your Gemfile:
+
+```ruby
+gem "basecamp-sdk"
+```
+
+Or install directly:
+
+```bash
+gem install basecamp-sdk
+```
+
+## Quick Start
+
+```ruby
+require "basecamp"
+
+# Create client with access token
+client = Basecamp.client(access_token: ENV["BASECAMP_TOKEN"])
+
+# Scope to an account
+account = client.for_account(ENV["BASECAMP_ACCOUNT_ID"])
+
+# List projects
+account.projects.list.each do |project|
+  puts "#{project['id']}: #{project['name']}"
+end
+
+# Get a specific project
+project = account.projects.get(project_id: 12345)
+
+# Create a todo
+todo = account.todos.create(
+  project_id: 12345,
+  todolist_id: 67890,
+  content: "Review PR",
+  due_on: "2024-12-31"
+)
+```
+
+## Configuration
+
+### Basic Configuration
+
+```ruby
+config = Basecamp::Config.new(
+  base_url: "https://3.basecampapi.com",  # Default
+  timeout: 30,                             # Request timeout in seconds
+  max_retries: 3,                          # Max retry attempts for GET requests
+  base_delay: 1.0,                         # Base delay for exponential backoff
+  max_pages: 100                           # Max pages for pagination
+)
+
+token_provider = Basecamp::StaticTokenProvider.new(ENV["BASECAMP_TOKEN"])
+client = Basecamp::Client.new(config: config, token_provider: token_provider)
+```
+
+### Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `base_url` | `https://3.basecampapi.com` | Basecamp API base URL |
+| `timeout` | `30` | HTTP request timeout (seconds) |
+| `max_retries` | `3` | Maximum retry attempts for GET requests |
+| `base_delay` | `1.0` | Base delay for exponential backoff (seconds) |
+| `max_jitter` | `0.5` | Maximum random jitter added to delays |
+| `max_pages` | `100` | Maximum pages to fetch during pagination |
+
+## OAuth Authentication
+
+### Token Providers
+
+The SDK supports multiple authentication patterns:
+
+```ruby
+# Static token (simplest)
+token_provider = Basecamp::StaticTokenProvider.new("your-access-token")
+
+# OAuth with refresh
+token_provider = Basecamp::OauthTokenProvider.new(
+  access_token: "access-token",
+  refresh_token: "refresh-token",
+  expires_at: Time.now + 3600,
+  client_id: ENV["BASECAMP_CLIENT_ID"],
+  client_secret: ENV["BASECAMP_CLIENT_SECRET"]
+)
+```
+
+### OAuth Flow Helpers
+
+```ruby
+# 1. Discover OAuth configuration
+config = Basecamp::Oauth.discover_launchpad
+
+# 2. Build authorization URL (redirect user here)
+auth_url = "#{config.authorization_endpoint}?" + URI.encode_www_form(
+  type: "web_server",
+  client_id: ENV["BASECAMP_CLIENT_ID"],
+  redirect_uri: "https://myapp.com/callback"
+)
+
+# 3. Exchange code for tokens (in callback handler)
+token = Basecamp::Oauth.exchange_code(
+  token_endpoint: config.token_endpoint,
+  code: params[:code],
+  redirect_uri: "https://myapp.com/callback",
+  client_id: ENV["BASECAMP_CLIENT_ID"],
+  client_secret: ENV["BASECAMP_CLIENT_SECRET"],
+  use_legacy_format: true  # Required for Launchpad
+)
+
+# 4. Use the token
+client = Basecamp.client(access_token: token.access_token)
+
+# 5. Refresh when needed
+if token.expired?
+  token = Basecamp::Oauth.refresh_token(
+    token_endpoint: config.token_endpoint,
+    refresh_token: token.refresh_token,
+    use_legacy_format: true
+  )
+end
+```
+
+## Services
+
+The SDK provides 38 services covering the complete Basecamp 3 API:
+
+| Service | Description |
+|---------|-------------|
+| `projects` | Project management |
+| `todos` | Todo items |
+| `todolists` | Todo lists |
+| `todosets` | Todo set containers |
+| `todolist_groups` | Todolist grouping/folders |
+| `people` | People/users |
+| `comments` | Comments on recordings |
+| `messages` | Message posts |
+| `message_boards` | Message boards |
+| `message_types` | Message categories |
+| `campfires` | Chat rooms |
+| `schedules` | Calendar schedules |
+| `documents` | Documents |
+| `vaults` | File folders |
+| `uploads` | File uploads |
+| `attachments` | Binary attachments |
+| `recordings` | Generic recordings |
+| `webhooks` | Webhook subscriptions |
+| `subscriptions` | Notification subscriptions |
+| `templates` | Project templates |
+| `events` | Activity events |
+| `checkins` | Automatic check-ins |
+| `forwards` | Email forwards |
+| `cards` | Card table cards |
+| `card_tables` | Card tables (kanban) |
+| `card_columns` | Card table columns |
+| `card_steps` | Card workflow steps |
+| `lineup` | Card lineup view |
+| `tools` | Project dock tools |
+| `search` | Full-text search |
+| `reports` | Activity reports |
+| `timeline` | Activity timeline |
+| `timesheet` | Time tracking reports |
+| `client_approvals` | Client approval workflows |
+| `client_correspondences` | Client communications |
+| `client_replies` | Client replies |
+| `authorization` | Auth info |
+
+## Pagination
+
+All list methods return lazy Enumerators that automatically handle pagination:
+
+```ruby
+# Automatically fetches all pages
+account.projects.list.each do |project|
+  puts project["name"]
+end
+
+# Take only what you need
+first_10 = account.todos.list(project_id: 123, todolist_id: 456).take(10)
+
+# Convert to array (fetches all pages)
+all_projects = account.projects.list.to_a
+```
+
+## Retry Behavior
+
+GET requests automatically retry on transient failures with exponential backoff:
+
+- **Retryable errors**: 429 (rate limit), 502, 503, 504 (gateway errors)
+- **Backoff**: Exponential with jitter (1s, 2s, 4s...)
+- **Rate limits**: Respects `Retry-After` header
+
+Mutation operations (POST, PUT, DELETE) do **not** retry to prevent data duplication.
+
+## Error Handling
+
+```ruby
+begin
+  account.projects.get(project_id: 99999)
+rescue Basecamp::NotFoundError => e
+  puts "Project not found: #{e.message}"
+rescue Basecamp::RateLimitError => e
+  puts "Rate limited, retry after: #{e.retry_after} seconds"
+rescue Basecamp::AuthError => e
+  puts "Authentication failed: #{e.message}"
+rescue Basecamp::APIError => e
+  puts "API error (#{e.http_status}): #{e.message}"
+end
+```
+
+### Error Types
+
+| Error | Description |
+|-------|-------------|
+| `APIError` | Base error class for all API errors |
+| `AuthError` | Authentication failures (401) |
+| `ForbiddenError` | Access denied (403) |
+| `NotFoundError` | Resource not found (404) |
+| `ValidationError` | Invalid request data (400, 422) |
+| `RateLimitError` | Rate limit exceeded (429) |
+| `NetworkError` | Connection failures |
+
+## Observability Hooks
+
+Monitor SDK behavior with hooks:
+
+```ruby
+class MyHooks
+  include Basecamp::Hooks
+
+  def on_request_start(info)
+    puts "Starting #{info.method} #{info.url}"
+  end
+
+  def on_request_end(info, result)
+    puts "Completed in #{result.duration}s with status #{result.status_code}"
+  end
+
+  def on_retry(info, attempt, error, delay)
+    puts "Retrying attempt #{attempt} after #{delay}s"
+  end
+
+  def on_paginate(url, page)
+    puts "Fetching page #{page}"
+  end
+end
+
+client = Basecamp::Client.new(
+  config: config,
+  token_provider: token_provider,
+  hooks: MyHooks.new
+)
+```
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `BASECAMP_TOKEN` | OAuth access token |
+| `BASECAMP_ACCOUNT_ID` | Account ID |
+| `BASECAMP_BASE_URL` | API base URL (default: `https://3.basecampapi.com`) |
+
+## Development
+
+```bash
+# Install dependencies
+bundle install
+
+# Run tests
+bundle exec rake test
+
+# Run linter
+bundle exec rubocop
+
+# Generate types from OpenAPI
+ruby scripts/generate-types.rb
+```
+
+## License
+
+MIT

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rake/testtask'
+require 'rubocop/rake_task'
+require 'yard'
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+RuboCop::RakeTask.new
+
+YARD::Rake::YardocTask.new(:doc) do |t|
+  t.files = [ 'lib/**/*.rb' ]
+  t.options = [ '--output-dir', 'doc' ]
+end
+
+desc 'Start an interactive console with the SDK loaded'
+task :console do
+  exec 'bin/console'
+end
+
+task default: %i[test rubocop]

--- a/ruby/basecamp-sdk.gemspec
+++ b/ruby/basecamp-sdk.gemspec
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative 'lib/basecamp/version'
+
+Gem::Specification.new do |spec|
+  spec.name = 'basecamp-sdk'
+  spec.version = Basecamp::VERSION
+  spec.authors = [ 'Basecamp' ]
+  spec.email = [ 'support@basecamp.com' ]
+
+  spec.summary = 'Official Ruby SDK for the Basecamp 3 API'
+  spec.description = 'A Ruby SDK for the Basecamp 3 API with automatic retry, ' \
+                     'exponential backoff, Link header pagination, and observability hooks.'
+  spec.homepage = 'https://github.com/basecamp/basecamp-sdk'
+  spec.license = 'MIT'
+  spec.required_ruby_version = '>= 3.2.0'
+
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = spec.homepage
+  spec.metadata['changelog_uri'] = "#{spec.homepage}/blob/main/CHANGELOG.md"
+  spec.metadata['rubygems_mfa_required'] = 'true'
+
+  # Specify which files should be added to the gem when it is released.
+  spec.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").reject do |f|
+      (File.expand_path(f) == __FILE__) ||
+        f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile])
+    end
+  end
+  spec.require_paths = [ 'lib' ]
+
+  # Runtime dependencies
+  spec.add_dependency 'faraday', '~> 2.0'
+  spec.add_dependency 'zeitwerk', '~> 2.6'
+
+  # Development dependencies
+  spec.add_development_dependency 'minitest', '~> 5.25'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rubocop', '~> 1.69'
+  spec.add_development_dependency 'rubocop-rails-omakase', '~> 1.0'
+  spec.add_development_dependency 'simplecov', '~> 0.22'
+  spec.add_development_dependency 'webmock', '~> 3.24'
+  spec.add_development_dependency 'irb', '~> 1.15'
+  spec.add_development_dependency 'rdoc', '~> 6.0'
+  spec.add_development_dependency 'webrick', '~> 1.9'
+  spec.add_development_dependency 'yard', '~> 0.9'
+end

--- a/ruby/bin/console
+++ b/ruby/bin/console
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "basecamp"
+
+# Load credentials from environment if available
+if ENV["BASECAMP_ACCESS_TOKEN"] && ENV["BASECAMP_ACCOUNT_ID"]
+  @client = Basecamp.client(access_token: ENV["BASECAMP_ACCESS_TOKEN"])
+  @account = @client.for_account(ENV["BASECAMP_ACCOUNT_ID"])
+  puts "Basecamp SDK Console"
+  puts "===================="
+  puts "Client available as @client"
+  puts "Account client available as @account (account: #{ENV['BASECAMP_ACCOUNT_ID']})"
+  puts ""
+  puts "Try: @account.projects.list.first(5).each { |p| puts p['name'] }"
+  puts ""
+else
+  puts "Basecamp SDK Console"
+  puts "===================="
+  puts "Set BASECAMP_ACCESS_TOKEN and BASECAMP_ACCOUNT_ID to auto-configure client"
+  puts ""
+  puts "Example:"
+  puts "  client = Basecamp.client(access_token: 'your-token')"
+  puts "  account = client.for_account('12345')"
+  puts "  account.projects.list.each { |p| puts p['name'] }"
+  puts ""
+end
+
+require "irb"
+IRB.start(__FILE__)

--- a/ruby/lib/basecamp.rb
+++ b/ruby/lib/basecamp.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "zeitwerk"
+
+# Set up Zeitwerk loader
+loader = Zeitwerk::Loader.for_gem
+# No custom inflections - use standard Ruby camelcase (Http, Oauth, etc.)
+# Ignore generated directory - loaded explicitly
+loader.ignore("#{__dir__}/basecamp/generated")
+# Ignore errors.rb - it defines multiple classes, loaded explicitly below
+loader.ignore("#{__dir__}/basecamp/errors.rb")
+loader.setup
+
+# Load errors early since they're used throughout
+require_relative "basecamp/errors"
+
+# Load generated types if available
+begin
+  require_relative "basecamp/generated/types"
+rescue LoadError
+  # Generated types not available yet
+end
+
+module Basecamp
+  # Main entry point for the Basecamp SDK.
+  #
+  # The SDK follows a Client -> AccountClient pattern:
+  # - Client: Holds shared resources (HTTP client, token provider, hooks)
+  # - AccountClient: Bound to a specific account ID, provides service accessors
+  #
+  # @example Basic usage
+  #   config = Basecamp::Config.new(base_url: "https://3.basecampapi.com")
+  #   token = Basecamp::StaticTokenProvider.new(ENV["BASECAMP_TOKEN"])
+  #
+  #   client = Basecamp::Client.new(config: config, token_provider: token)
+  #   account = client.for_account("12345")
+  #
+  #   # Use services (returns lazy Enumerator)
+  #   projects = account.projects.list.to_a
+  #
+  # @example With hooks for logging
+  #   class MyHooks
+  #     include Basecamp::Hooks
+  #
+  #     def on_request_start(info)
+  #       puts "Starting #{info.method} #{info.url}"
+  #     end
+  #
+  #     def on_request_end(info, result)
+  #       puts "Completed in #{result.duration}s"
+  #     end
+  #   end
+  #
+  #   client = Basecamp::Client.new(config: config, token_provider: token, hooks: MyHooks.new)
+
+  # Creates a new Basecamp client.
+  #
+  # This is a convenience method that creates a Client with the given options.
+  #
+  # @param access_token [String] OAuth access token
+  # @param account_id [String, nil] Basecamp account ID (optional)
+  # @param base_url [String] Base URL for API requests
+  # @param hooks [Hooks, nil] Observability hooks
+  # @return [Client, AccountClient] Client if no account_id, AccountClient if account_id provided
+  #
+  # @example With account ID
+  #   client = Basecamp.client(access_token: "abc123", account_id: "12345")
+  #   projects = client.projects.list.to_a
+  #
+  # @example Without account ID
+  #   client = Basecamp.client(access_token: "abc123")
+  #   account = client.for_account("12345")
+  def self.client(
+    access_token:,
+    account_id: nil,
+    base_url: Config::DEFAULT_BASE_URL,
+    hooks: nil
+  )
+    config = Config.new(base_url: base_url)
+    token_provider = StaticTokenProvider.new(access_token)
+    client = Client.new(config: config, token_provider: token_provider, hooks: hooks)
+
+    account_id ? client.for_account(account_id) : client
+  end
+end

--- a/ruby/lib/basecamp/client.rb
+++ b/ruby/lib/basecamp/client.rb
@@ -1,0 +1,415 @@
+# frozen_string_literal: true
+
+module Basecamp
+  # Main client for the Basecamp API.
+  #
+  # Client holds shared resources and is used to create AccountClient instances
+  # for specific Basecamp accounts via the {#for_account} method.
+  #
+  # @example Basic usage
+  #   config = Basecamp::Config.from_env
+  #   token_provider = Basecamp::StaticTokenProvider.new(ENV["BASECAMP_ACCESS_TOKEN"])
+  #   client = Basecamp::Client.new(config: config, token_provider: token_provider)
+  #
+  #   # Get authorization info (account-independent)
+  #   auth = client.authorization.get
+  #
+  #   # Work with a specific account
+  #   account = client.for_account("12345")
+  #   projects = account.projects.list
+  #
+  # @example With custom hooks
+  #   require "logger"
+  #   logger = Logger.new($stdout)
+  #   hooks = Basecamp::LoggerHooks.new(logger)
+  #
+  #   client = Basecamp::Client.new(
+  #     config: config,
+  #     token_provider: token_provider,
+  #     hooks: hooks
+  #   )
+  class Client
+    # @return [Config] client configuration
+    attr_reader :config
+
+    # Creates a new Basecamp API client.
+    #
+    # @param config [Config] configuration settings
+    # @param token_provider [TokenProvider] OAuth token provider
+    # @param hooks [Hooks, nil] observability hooks
+    def initialize(config:, token_provider:, hooks: nil)
+      @config = config
+      @token_provider = token_provider
+      @hooks = hooks || NoopHooks.new
+      @http = Http.new(config: config, token_provider: token_provider, hooks: @hooks)
+      @mutex = Mutex.new
+    end
+
+    # Returns an AccountClient bound to the specified Basecamp account.
+    #
+    # The Basecamp API requires an account ID in the URL path
+    # (e.g., https://3.basecampapi.com/12345/projects.json).
+    #
+    # @param account_id [String, Integer] the Basecamp account ID
+    # @return [AccountClient]
+    # @raise [ArgumentError] if account_id is empty or non-numeric
+    #
+    # @example
+    #   account = client.for_account("12345")
+    #   projects = account.projects.list
+    def for_account(account_id)
+      account_id = account_id.to_s
+      raise ArgumentError, "account_id cannot be empty" if account_id.empty?
+      raise ArgumentError, "account_id must be numeric, got: #{account_id}" unless account_id.match?(/\A\d+\z/)
+
+      AccountClient.new(parent: self, account_id: account_id)
+    end
+
+    # Returns the AuthorizationService for authorization operations.
+    # This is the only service available directly on Client, as it doesn't require
+    # an account context. All other services require an AccountClient via {#for_account}.
+    #
+    # @return [Services::AuthorizationService]
+    def authorization
+      @mutex.synchronize do
+        @authorization ||= Services::AuthorizationService.new(self)
+      end
+    end
+
+    # @api private
+    # Returns the HTTP client for making requests.
+    # @return [Http]
+    attr_reader :http
+
+    # @api private
+    # Returns the observability hooks.
+    # @return [Hooks]
+    attr_reader :hooks
+
+    # @api private
+    # Returns nil since Client is not bound to an account.
+    # @return [nil]
+    def account_id
+      nil
+    end
+  end
+
+  # HTTP client bound to a specific Basecamp account.
+  #
+  # Create an AccountClient using {Client#for_account}.
+  # All API operations that require an account context use this class.
+  #
+  # @example
+  #   account = client.for_account("12345")
+  #
+  #   # List projects
+  #   account.projects.list.each do |project|
+  #     puts project["name"]
+  #   end
+  #
+  #   # Create a todo
+  #   account.todos.create(
+  #     project_id: 123,
+  #     todolist_id: 456,
+  #     content: "New task"
+  #   )
+  class AccountClient
+    # @return [String] the account ID this client is bound to
+    attr_reader :account_id
+
+    # @api private
+    # @param parent [Client] the parent client
+    # @param account_id [String] the account ID
+    def initialize(parent:, account_id:)
+      @parent = parent
+      @account_id = account_id
+      @services = {}
+      @mutex = Mutex.new
+    end
+
+    # @return [Config] client configuration
+    def config
+      @parent.config
+    end
+
+    # @api private
+    # @return [Http] the HTTP client
+    def http
+      @parent.http
+    end
+
+    # @api private
+    # @return [Hooks] the observability hooks
+    def hooks
+      @parent.hooks
+    end
+
+    # Performs a GET request scoped to this account.
+    # @param path [String] URL path (without account prefix)
+    # @param params [Hash] query parameters
+    # @return [Response]
+    def get(path, params: {})
+      @parent.http.get(account_path(path), params: params)
+    end
+
+    # Performs a POST request scoped to this account.
+    # @param path [String] URL path (without account prefix)
+    # @param body [Hash, nil] request body
+    # @return [Response]
+    def post(path, body: nil)
+      @parent.http.post(account_path(path), body: body)
+    end
+
+    # Performs a PUT request scoped to this account.
+    # @param path [String] URL path (without account prefix)
+    # @param body [Hash, nil] request body
+    # @return [Response]
+    def put(path, body: nil)
+      @parent.http.put(account_path(path), body: body)
+    end
+
+    # Performs a DELETE request scoped to this account.
+    # @param path [String] URL path (without account prefix)
+    # @return [Response]
+    def delete(path)
+      @parent.http.delete(account_path(path))
+    end
+
+    # Performs a POST request with raw binary data scoped to this account.
+    # Used for file uploads (attachments).
+    # @param path [String] URL path (without account prefix)
+    # @param body [String, IO] raw binary data
+    # @param content_type [String] MIME content type
+    # @return [Response]
+    def post_raw(path, body:, content_type:)
+      @parent.http.post_raw(account_path(path), body: body, content_type: content_type)
+    end
+
+    # Fetches all pages of a paginated resource.
+    # @param path [String] URL path (without account prefix)
+    # @param params [Hash] query parameters
+    # @yield [Hash] each item from the response
+    # @return [Enumerator] if no block given
+    def paginate(path, params: {}, &)
+      @parent.http.paginate(account_path(path), params: params, &)
+    end
+
+    # Fetches all pages of a paginated resource, extracting items from a key.
+    # Use this for endpoints that return objects like { "events": [...] }.
+    # @param path [String] URL path (without account prefix)
+    # @param key [String] the key containing the array of items
+    # @param params [Hash] query parameters
+    # @yield [Hash] each item from the response
+    # @return [Enumerator] if no block given
+    def paginate_key(path, key:, params: {}, &)
+      @parent.http.paginate_key(account_path(path), key: key, params: params, &)
+    end
+
+    # @!group Services
+
+    # @return [Services::ProjectsService]
+    def projects
+      service(:projects) { Services::ProjectsService.new(self) }
+    end
+
+    # @return [Services::TodosService]
+    def todos
+      service(:todos) { Services::TodosService.new(self) }
+    end
+
+    # @return [Services::TodosetsService]
+    def todosets
+      service(:todosets) { Services::TodosetsService.new(self) }
+    end
+
+    # @return [Services::TodolistsService]
+    def todolists
+      service(:todolists) { Services::TodolistsService.new(self) }
+    end
+
+    # @return [Services::PeopleService]
+    def people
+      service(:people) { Services::PeopleService.new(self) }
+    end
+
+    # @return [Services::CommentsService]
+    def comments
+      service(:comments) { Services::CommentsService.new(self) }
+    end
+
+    # @return [Services::MessagesService]
+    def messages
+      service(:messages) { Services::MessagesService.new(self) }
+    end
+
+    # @return [Services::MessageBoardsService]
+    def message_boards
+      service(:message_boards) { Services::MessageBoardsService.new(self) }
+    end
+
+    # @return [Services::WebhooksService]
+    def webhooks
+      service(:webhooks) { Services::WebhooksService.new(self) }
+    end
+
+    # @return [Services::CampfiresService]
+    def campfires
+      service(:campfires) { Services::CampfiresService.new(self) }
+    end
+
+    # @return [Services::SchedulesService]
+    def schedules
+      service(:schedules) { Services::SchedulesService.new(self) }
+    end
+
+    # @return [Services::VaultsService]
+    def vaults
+      service(:vaults) { Services::VaultsService.new(self) }
+    end
+
+    # @return [Services::RecordingsService]
+    def recordings
+      service(:recordings) { Services::RecordingsService.new(self) }
+    end
+
+    # @return [Services::DocumentsService]
+    def documents
+      service(:documents) { Services::DocumentsService.new(self) }
+    end
+
+    # @return [Services::UploadsService]
+    def uploads
+      service(:uploads) { Services::UploadsService.new(self) }
+    end
+
+    # @return [Services::AttachmentsService]
+    def attachments
+      service(:attachments) { Services::AttachmentsService.new(self) }
+    end
+
+    # @return [Services::CheckinsService]
+    def checkins
+      service(:checkins) { Services::CheckinsService.new(self) }
+    end
+
+    # @return [Services::ForwardsService]
+    def forwards
+      service(:forwards) { Services::ForwardsService.new(self) }
+    end
+
+    # @return [Services::CardTablesService]
+    def card_tables
+      service(:card_tables) { Services::CardTablesService.new(self) }
+    end
+
+    # @return [Services::CardsService]
+    def cards
+      service(:cards) { Services::CardsService.new(self) }
+    end
+
+    # @return [Services::CardColumnsService]
+    def card_columns
+      service(:card_columns) { Services::CardColumnsService.new(self) }
+    end
+
+    # @return [Services::CardStepsService]
+    def card_steps
+      service(:card_steps) { Services::CardStepsService.new(self) }
+    end
+
+    # @return [Services::TemplatesService]
+    def templates
+      service(:templates) { Services::TemplatesService.new(self) }
+    end
+
+    # @return [Services::EventsService]
+    def events
+      service(:events) { Services::EventsService.new(self) }
+    end
+
+    # @return [Services::ClientApprovalsService]
+    def client_approvals
+      service(:client_approvals) { Services::ClientApprovalsService.new(self) }
+    end
+
+    # @return [Services::ClientCorrespondencesService]
+    def client_correspondences
+      service(:client_correspondences) { Services::ClientCorrespondencesService.new(self) }
+    end
+
+    # @return [Services::ClientRepliesService]
+    def client_replies
+      service(:client_replies) { Services::ClientRepliesService.new(self) }
+    end
+
+    # @return [Services::LineupService]
+    def lineup
+      service(:lineup) { Services::LineupService.new(self) }
+    end
+
+    # @return [Services::MessageTypesService]
+    def message_types
+      service(:message_types) { Services::MessageTypesService.new(self) }
+    end
+
+    # @return [Services::ToolsService]
+    def tools
+      service(:tools) { Services::ToolsService.new(self) }
+    end
+
+    # @return [Services::SubscriptionsService]
+    def subscriptions
+      service(:subscriptions) { Services::SubscriptionsService.new(self) }
+    end
+
+    # @return [Services::SearchService]
+    def search
+      service(:search) { Services::SearchService.new(self) }
+    end
+
+    # @return [Services::ReportsService]
+    def reports
+      service(:reports) { Services::ReportsService.new(self) }
+    end
+
+    # @return [Services::TimelineService]
+    def timeline
+      service(:timeline) { Services::TimelineService.new(self) }
+    end
+
+    # @return [Services::TimesheetService]
+    def timesheet
+      service(:timesheet) { Services::TimesheetService.new(self) }
+    end
+
+    # @return [Services::TodolistGroupsService]
+    def todolist_groups
+      service(:todolist_groups) { Services::TodolistGroupsService.new(self) }
+    end
+
+    # @!endgroup
+
+    private
+
+    def account_path(path)
+      return path if path.start_with?("http://", "https://")
+
+      path = "/#{path}" unless path.start_with?("/")
+
+      # Guard against double-prefixing
+      prefix = "/#{@account_id}"
+      if path.start_with?(prefix)
+        rest = path[prefix.length..]
+        return path if rest.empty? || rest.start_with?("/", "?")
+      end
+
+      "/#{@account_id}#{path}"
+    end
+
+    def service(name)
+      @mutex.synchronize do
+        @services[name] ||= yield
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/config.rb
+++ b/ruby/lib/basecamp/config.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Basecamp
+  # Configuration for the Basecamp API client.
+  #
+  # @example Creating config with defaults
+  #   config = Basecamp::Config.new
+  #
+  # @example Creating config with custom values
+  #   config = Basecamp::Config.new(
+  #     base_url: "https://3.basecampapi.com",
+  #     timeout: 60,
+  #     max_retries: 3
+  #   )
+  #
+  # @example Loading config from environment
+  #   config = Basecamp::Config.from_env
+  class Config
+    # @return [String] API base URL
+    attr_accessor :base_url
+
+    # @return [Integer] request timeout in seconds
+    attr_accessor :timeout
+
+    # @return [Integer] maximum retry attempts for GET requests
+    attr_accessor :max_retries
+
+    # @return [Float] initial backoff delay in seconds
+    attr_accessor :base_delay
+
+    # @return [Float] maximum jitter to add to delays in seconds
+    attr_accessor :max_jitter
+
+    # @return [Integer] maximum pages to fetch in paginated requests
+    attr_accessor :max_pages
+
+    # Default values
+    DEFAULT_BASE_URL = "https://3.basecampapi.com"
+    DEFAULT_TIMEOUT = 30
+    DEFAULT_MAX_RETRIES = 5
+    DEFAULT_BASE_DELAY = 1.0
+    DEFAULT_MAX_JITTER = 0.1
+    DEFAULT_MAX_PAGES = 10_000
+
+    # Creates a new configuration with the given options.
+    #
+    # @param base_url [String] API base URL
+    # @param timeout [Integer] request timeout in seconds
+    # @param max_retries [Integer] maximum retry attempts
+    # @param base_delay [Float] initial backoff delay
+    # @param max_jitter [Float] maximum jitter
+    # @param max_pages [Integer] maximum pages to fetch
+    def initialize(
+      base_url: DEFAULT_BASE_URL,
+      timeout: DEFAULT_TIMEOUT,
+      max_retries: DEFAULT_MAX_RETRIES,
+      base_delay: DEFAULT_BASE_DELAY,
+      max_jitter: DEFAULT_MAX_JITTER,
+      max_pages: DEFAULT_MAX_PAGES
+    )
+      @base_url = normalize_url(base_url)
+      @timeout = timeout
+      @max_retries = max_retries
+      @base_delay = base_delay
+      @max_jitter = max_jitter
+      @max_pages = max_pages
+    end
+
+    # Creates a Config from environment variables.
+    #
+    # Environment variables:
+    # - BASECAMP_BASE_URL: API base URL
+    # - BASECAMP_TIMEOUT: Request timeout in seconds
+    # - BASECAMP_MAX_RETRIES: Maximum retry attempts
+    #
+    # @return [Config]
+    def self.from_env
+      new(
+        base_url: ENV.fetch("BASECAMP_BASE_URL", DEFAULT_BASE_URL),
+        timeout: ENV.fetch("BASECAMP_TIMEOUT", DEFAULT_TIMEOUT).to_i,
+        max_retries: ENV.fetch("BASECAMP_MAX_RETRIES", DEFAULT_MAX_RETRIES).to_i
+      )
+    end
+
+    # Loads configuration from a JSON file, with environment overrides.
+    #
+    # @param path [String] path to JSON config file
+    # @return [Config]
+    def self.from_file(path)
+      data = JSON.parse(File.read(path))
+      config = new(
+        base_url: data["base_url"] || DEFAULT_BASE_URL,
+        timeout: data["timeout"] || DEFAULT_TIMEOUT,
+        max_retries: data["max_retries"] || DEFAULT_MAX_RETRIES
+      )
+      config.load_from_env
+      config
+    rescue Errno::ENOENT
+      from_env
+    end
+
+    # Loads environment variable overrides into this config.
+    # @return [self]
+    def load_from_env
+      @base_url = normalize_url(ENV["BASECAMP_BASE_URL"]) if ENV["BASECAMP_BASE_URL"]
+      @timeout = ENV["BASECAMP_TIMEOUT"].to_i if ENV["BASECAMP_TIMEOUT"]
+      @max_retries = ENV["BASECAMP_MAX_RETRIES"].to_i if ENV["BASECAMP_MAX_RETRIES"]
+      self
+    end
+
+    # Returns the default global config directory.
+    # @return [String]
+    def self.global_config_dir
+      config_dir = ENV["XDG_CONFIG_HOME"] || File.join(Dir.home, ".config")
+      File.join(config_dir, "basecamp")
+    end
+
+    private
+
+    def normalize_url(url)
+      url&.chomp("/")
+    end
+  end
+end

--- a/ruby/lib/basecamp/errors.rb
+++ b/ruby/lib/basecamp/errors.rb
@@ -1,0 +1,281 @@
+# frozen_string_literal: true
+
+module Basecamp
+  # Error codes for API responses
+  module ErrorCode
+    USAGE = "usage"
+    NOT_FOUND = "not_found"
+    AUTH = "auth_required"
+    FORBIDDEN = "forbidden"
+    RATE_LIMIT = "rate_limit"
+    NETWORK = "network"
+    API = "api_error"
+    AMBIGUOUS = "ambiguous"
+    VALIDATION = "validation"
+  end
+
+  # Exit codes for CLI tools
+  module ExitCode
+    OK = 0
+    USAGE = 1
+    NOT_FOUND = 2
+    AUTH = 3
+    FORBIDDEN = 4
+    RATE_LIMIT = 5
+    NETWORK = 6
+    API = 7
+    AMBIGUOUS = 8
+  end
+
+  # Base error class for all Basecamp SDK errors.
+  # Provides structured error handling with codes, hints, and CLI exit codes.
+  #
+  # @example Catching errors
+  #   begin
+  #     client.projects.list
+  #   rescue Basecamp::Error => e
+  #     puts "#{e.code}: #{e.message}"
+  #     puts "Hint: #{e.hint}" if e.hint
+  #     exit e.exit_code
+  #   end
+  class Error < StandardError
+    # @return [String] error category code
+    attr_reader :code
+
+    # @return [String, nil] user-friendly hint for resolving the error
+    attr_reader :hint
+
+    # @return [Integer, nil] HTTP status code that caused the error
+    attr_reader :http_status
+
+    # @return [Boolean] whether the operation can be retried
+    attr_reader :retryable
+
+    # @return [Integer, nil] seconds to wait before retrying (for rate limits)
+    attr_reader :retry_after
+
+    # @return [Exception, nil] original error that caused this error
+    attr_reader :cause
+
+    # @param code [String] error category code
+    # @param message [String] error message
+    # @param hint [String, nil] user-friendly hint
+    # @param http_status [Integer, nil] HTTP status code
+    # @param retryable [Boolean] whether operation can be retried
+    # @param retry_after [Integer, nil] seconds to wait before retry
+    # @param cause [Exception, nil] underlying cause
+    def initialize(code:, message:, hint: nil, http_status: nil, retryable: false, retry_after: nil, cause: nil)
+      super(message)
+      @code = code
+      @hint = hint
+      @http_status = http_status
+      @retryable = retryable
+      @retry_after = retry_after
+      @cause = cause
+    end
+
+    # Returns the exit code for CLI applications.
+    # @return [Integer]
+    def exit_code
+      self.class.exit_code_for(@code)
+    end
+
+    # Returns whether this error can be retried.
+    # @return [Boolean]
+    def retryable?
+      @retryable
+    end
+
+    # Maps error codes to exit codes.
+    # @param code [String]
+    # @return [Integer]
+    def self.exit_code_for(code)
+      case code
+      when ErrorCode::USAGE then ExitCode::USAGE
+      when ErrorCode::NOT_FOUND then ExitCode::NOT_FOUND
+      when ErrorCode::AUTH then ExitCode::AUTH
+      when ErrorCode::FORBIDDEN then ExitCode::FORBIDDEN
+      when ErrorCode::RATE_LIMIT then ExitCode::RATE_LIMIT
+      when ErrorCode::NETWORK then ExitCode::NETWORK
+      when ErrorCode::API then ExitCode::API
+      when ErrorCode::AMBIGUOUS then ExitCode::AMBIGUOUS
+      else ExitCode::API
+      end
+    end
+  end
+
+  # Raised when there's a usage error (invalid arguments, missing config).
+  class UsageError < Error
+    def initialize(message, hint: nil)
+      super(code: ErrorCode::USAGE, message: message, hint: hint)
+    end
+  end
+
+  # Raised when a resource is not found (404).
+  class NotFoundError < Error
+    def initialize(resource, identifier, hint: nil)
+      super(
+        code: ErrorCode::NOT_FOUND,
+        message: "#{resource} not found: #{identifier}",
+        hint: hint,
+        http_status: 404
+      )
+    end
+  end
+
+  # Raised when authentication fails (401).
+  class AuthError < Error
+    def initialize(message = "Authentication required", hint: nil, cause: nil)
+      super(
+        code: ErrorCode::AUTH,
+        message: message,
+        hint: hint || "Check your access token or refresh it if expired",
+        http_status: 401,
+        cause: cause
+      )
+    end
+  end
+
+  # Raised when access is denied (403).
+  class ForbiddenError < Error
+    def initialize(message = "Access denied", hint: nil)
+      super(
+        code: ErrorCode::FORBIDDEN,
+        message: message,
+        hint: hint || "You do not have permission to access this resource",
+        http_status: 403
+      )
+    end
+
+    # Creates a forbidden error due to insufficient OAuth scope.
+    def self.insufficient_scope
+      new("Access denied: insufficient scope", hint: "Re-authenticate with full scope")
+    end
+  end
+
+  # Raised when rate limited (429).
+  class RateLimitError < Error
+    def initialize(retry_after: nil, cause: nil)
+      hint = retry_after ? "Try again in #{retry_after} seconds" : "Please slow down requests"
+      super(
+        code: ErrorCode::RATE_LIMIT,
+        message: "Rate limit exceeded",
+        hint: hint,
+        http_status: 429,
+        retryable: true,
+        retry_after: retry_after,
+        cause: cause
+      )
+    end
+  end
+
+  # Raised when there's a network error (connection, timeout, DNS).
+  class NetworkError < Error
+    def initialize(message = "Network error", cause: nil)
+      super(
+        code: ErrorCode::NETWORK,
+        message: message,
+        hint: cause&.message || "Check your network connection",
+        retryable: true,
+        cause: cause
+      )
+    end
+  end
+
+  # Raised for generic API errors.
+  class APIError < Error
+    def initialize(message, http_status: nil, hint: nil, retryable: false, cause: nil)
+      super(
+        code: ErrorCode::API,
+        message: message,
+        hint: hint,
+        http_status: http_status,
+        retryable: retryable,
+        cause: cause
+      )
+    end
+
+    # Creates an APIError from an HTTP status code.
+    # @param status [Integer] HTTP status code
+    # @param message [String, nil] optional error message
+    # @return [APIError]
+    def self.from_status(status, message = nil)
+      message ||= "Request failed (HTTP #{status})"
+      retryable = status >= 500 && status < 600
+      new(message, http_status: status, retryable: retryable)
+    end
+  end
+
+  # Raised when a name/identifier matches multiple resources.
+  class AmbiguousError < Error
+    # @return [Array<String>] list of matching resources
+    attr_reader :matches
+
+    def initialize(resource, matches: [])
+      @matches = matches
+      hint = if matches.any? && matches.length <= 5
+               "Did you mean: #{matches.join(', ')}"
+      else
+               "Be more specific"
+      end
+      super(
+        code: ErrorCode::AMBIGUOUS,
+        message: "Ambiguous #{resource}",
+        hint: hint
+      )
+    end
+  end
+
+  # Raised for validation errors (400, 422).
+  class ValidationError < Error
+    def initialize(message, hint: nil)
+      super(
+        code: ErrorCode::VALIDATION,
+        message: message,
+        hint: hint,
+        http_status: 400
+      )
+    end
+  end
+
+  # Maps an HTTP response to the appropriate error class.
+  #
+  # @param status [Integer] HTTP status code
+  # @param body [String, nil] response body (will attempt JSON parse)
+  # @param retry_after [Integer, nil] Retry-After header value
+  # @return [Error]
+  def self.error_from_response(status, body = nil, retry_after: nil)
+    message = parse_error_message(body) || "Request failed"
+
+    case status
+    when 400, 422
+      ValidationError.new(message)
+    when 401
+      AuthError.new(message)
+    when 403
+      ForbiddenError.new(message)
+    when 404
+      NotFoundError.new("Resource", "unknown")
+    when 429
+      RateLimitError.new(retry_after: retry_after)
+    when 500
+      APIError.new("Server error (500)", http_status: 500, retryable: true)
+    when 502, 503, 504
+      APIError.new("Gateway error (#{status})", http_status: status, retryable: true)
+    else
+      APIError.from_status(status, message)
+    end
+  end
+
+  # Parses error message from response body.
+  # @param body [String, nil]
+  # @return [String, nil]
+  def self.parse_error_message(body)
+    return nil if body.nil? || body.empty?
+
+    data = JSON.parse(body)
+    data["error"] || data["message"]
+  rescue JSON::ParserError
+    nil
+  end
+end

--- a/ruby/lib/basecamp/generated/metadata.json
+++ b/ruby/lib/basecamp/generated/metadata.json
@@ -1,0 +1,1959 @@
+{
+  "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
+  "version": "1.0.0",
+  "generated": "2026-01-26T23:06:10.548Z",
+  "operations": {
+    "CreateAttachment": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 2000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetCard": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateCard": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "MoveCard": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "RepositionCardStep": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "CreateCardStep": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetCardColumn": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateCardColumn": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "SetCardColumnColor": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "EnableCardColumnOnHold": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "DisableCardColumnOnHold": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "ListCards": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "CreateCard": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateCardStep": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "CompleteCardStep": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "UncompleteCardStep": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "GetCardTable": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "CreateCardColumn": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "MoveCardColumn": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "ListMessageTypes": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "CreateMessageType": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetMessageType": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateMessageType": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "DeleteMessageType": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "GetCampfire": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "ListChatbots": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "CreateChatbot": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetChatbot": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateChatbot": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "DeleteChatbot": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "ListCampfireLines": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "CreateCampfireLine": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetCampfireLine": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "DeleteCampfireLine": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "ListClientApprovals": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "GetClientApproval": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "ListClientCorrespondences": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "GetClientCorrespondence": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "ListClientReplies": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "GetClientReply": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetComment": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateComment": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "CloneTool": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetTool": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateTool": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "DeleteTool": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "EnableTool": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "RepositionTool": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "DisableTool": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "GetDocument": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateDocument": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "GetForward": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "ListForwardReplies": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "CreateForwardReply": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetForwardReply": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetInbox": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "ListForwards": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "GetMessageBoard": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "ListMessages": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "CreateMessage": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetMessage": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateMessage": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "GetAnswer": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateAnswer": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "GetQuestionnaire": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "ListQuestions": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "CreateQuestion": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetQuestion": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateQuestion": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "ListAnswers": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "CreateAnswer": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "PinMessage": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UnpinMessage": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "GetRecording": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "SetClientVisibility": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "ListComments": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "CreateComment": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "ListEvents": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "UnarchiveRecording": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "ArchiveRecording": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "TrashRecording": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "GetSubscription": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "Subscribe": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateSubscription": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "Unsubscribe": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "GetRecordingTimesheet": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetScheduleEntry": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateScheduleEntry": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "GetScheduleEntryOccurrence": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetSchedule": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateScheduleSettings": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "ListScheduleEntries": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "CreateScheduleEntry": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetProjectTimesheet": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "RepositionTodolistGroup": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "GetTodolistOrGroup": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateTodolistOrGroup": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "ListTodolistGroups": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "CreateTodolistGroup": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "ListTodos": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "CreateTodo": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetTodo": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateTodo": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "TrashTodo": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "CompleteTodo": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "UncompleteTodo": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "GetTodoset": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "ListTodolists": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "CreateTodolist": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetUpload": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateUpload": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "ListUploadVersions": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "GetVault": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateVault": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "ListDocuments": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "CreateDocument": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "ListUploads": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "CreateUpload": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "ListVaults": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "CreateVault": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "ListWebhooks": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "CreateWebhook": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetWebhook": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateWebhook": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "DeleteWebhook": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "ListCampfires": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "ListPingablePeople": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "CreateLineupMarker": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateLineupMarker": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "DeleteLineupMarker": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "GetMyProfile": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "ListPeople": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "GetPerson": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "ListProjects": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "CreateProject": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "ListRecordings": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "GetProject": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateProject": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "TrashProject": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "ListProjectPeople": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "UpdateProjectAccess": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "GetTimesheetReport": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "Search": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetSearchMetadata": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "ListTemplates": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
+      }
+    },
+    "CreateTemplate": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetTemplate": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "UpdateTemplate": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "DeleteTemplate": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "idempotent": {
+        "natural": true
+      }
+    },
+    "CreateProjectFromTemplate": {
+      "retry": {
+        "maxAttempts": 2,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    },
+    "GetProjectConstruction": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      }
+    }
+  }
+}

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -1,0 +1,2837 @@
+# frozen_string_literal: true
+
+# Auto-generated from OpenAPI spec. Do not edit manually.
+# Generated: 2026-01-29T04:48:49Z
+
+require 'json'
+require 'time'
+
+# Type conversion helpers
+module TypeHelpers
+  module_function
+
+  def identity(value)
+    value
+  end
+
+  def parse_integer(value)
+    return nil if value.nil?
+
+    value.to_i
+  end
+
+  def parse_float(value)
+    return nil if value.nil?
+
+    value.to_f
+  end
+
+  def parse_boolean(value)
+    return nil if value.nil?
+
+    !!value
+  end
+
+  def parse_datetime(value)
+    return nil if value.nil?
+    return value if value.is_a?(Time)
+
+    Time.parse(value.to_s)
+  rescue ArgumentError
+    nil
+  end
+
+  # Dynamic method_missing for type-specific parsers
+  def method_missing(method, *args)
+    if method.to_s.start_with?('parse_array_of_')
+      type_name = method.to_s.sub('parse_array_of_', '')
+      parse_array(args.first, type_name)
+    elsif method.to_s.start_with?('parse_')
+      type_name = method.to_s.sub('parse_', '')
+      parse_type(args.first, type_name)
+    else
+      super
+    end
+  end
+
+  def respond_to_missing?(method, include_private = false)
+    method.to_s.start_with?('parse_') || super
+  end
+
+  def parse_type(value, type_name)
+    return nil if value.nil?
+    return value unless value.is_a?(Hash)
+
+    type_class = Basecamp::Types.const_get(type_name)
+    type_class.new(value)
+  rescue NameError
+    value
+  end
+
+  def parse_array(value, type_name)
+    return nil if value.nil?
+    return value unless value.is_a?(Array)
+
+    type_class = Basecamp::Types.const_get(type_name)
+    value.map { |item| item.is_a?(Hash) ? type_class.new(item) : item }
+  rescue NameError
+    value
+  end
+end
+
+module Basecamp
+  module Types
+    include TypeHelpers
+
+    # Assignable
+    class Assignable
+      include TypeHelpers
+
+      attr_accessor :id, :title, :type, :url, :app_url, :bucket, :parent, :due_on, :starts_on, :assignees
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @title = data['title']
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @parent = parse_type(data['parent'], 'TodoParent')
+        @due_on = data['due_on']
+        @starts_on = data['starts_on']
+        @assignees = parse_array(data['assignees'], 'Person')
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'title' => @title,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bucket' => @bucket,
+          'parent' => @parent,
+          'due_on' => @due_on,
+          'starts_on' => @starts_on,
+          'assignees' => @assignees
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Campfire
+    class Campfire
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :subscription_url, :position, :bucket, :creator, :topic, :lines_url
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @subscription_url = data['subscription_url']
+        @position = parse_integer(data['position'])
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @topic = data['topic']
+        @lines_url = data['lines_url']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'subscription_url' => @subscription_url,
+          'position' => @position,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'topic' => @topic,
+          'lines_url' => @lines_url
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # CampfireLine
+    class CampfireLine
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :content, :parent, :bucket, :creator
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @content = data['content']
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'content' => @content,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Card
+    class Card
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :subscription_url, :position, :content, :description, :due_on, :completed, :completed_at, :comments_count, :comments_url, :completion_url, :parent, :bucket, :creator, :completer, :assignees, :completion_subscribers, :steps
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @subscription_url = data['subscription_url']
+        @position = parse_integer(data['position'])
+        @content = data['content']
+        @description = data['description']
+        @due_on = data['due_on']
+        @completed = parse_boolean(data['completed'])
+        @completed_at = parse_datetime(data['completed_at'])
+        @comments_count = parse_integer(data['comments_count'])
+        @comments_url = data['comments_url']
+        @completion_url = data['completion_url']
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @completer = parse_type(data['completer'], 'Person')
+        @assignees = parse_array(data['assignees'], 'Person')
+        @completion_subscribers = parse_array(data['completion_subscribers'], 'Person')
+        @steps = parse_array(data['steps'], 'CardStep')
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'subscription_url' => @subscription_url,
+          'position' => @position,
+          'content' => @content,
+          'description' => @description,
+          'due_on' => @due_on,
+          'completed' => @completed,
+          'completed_at' => @completed_at,
+          'comments_count' => @comments_count,
+          'comments_url' => @comments_url,
+          'completion_url' => @completion_url,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'completer' => @completer,
+          'assignees' => @assignees,
+          'completion_subscribers' => @completion_subscribers,
+          'steps' => @steps
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # CardColumn
+    class CardColumn
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :position, :color, :description, :cards_count, :comments_count, :cards_url, :parent, :bucket, :creator, :subscribers
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @position = parse_integer(data['position'])
+        @color = data['color']
+        @description = data['description']
+        @cards_count = parse_integer(data['cards_count'])
+        @comments_count = parse_integer(data['comments_count'])
+        @cards_url = data['cards_url']
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @subscribers = parse_array(data['subscribers'], 'Person')
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'position' => @position,
+          'color' => @color,
+          'description' => @description,
+          'cards_count' => @cards_count,
+          'comments_count' => @comments_count,
+          'cards_url' => @cards_url,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'subscribers' => @subscribers
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # CardStep
+    class CardStep
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :position, :due_on, :completed, :completed_at, :parent, :bucket, :creator, :completer, :assignees, :completion_url
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @position = parse_integer(data['position'])
+        @due_on = data['due_on']
+        @completed = parse_boolean(data['completed'])
+        @completed_at = parse_datetime(data['completed_at'])
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @completer = parse_type(data['completer'], 'Person')
+        @assignees = parse_array(data['assignees'], 'Person')
+        @completion_url = data['completion_url']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'position' => @position,
+          'due_on' => @due_on,
+          'completed' => @completed,
+          'completed_at' => @completed_at,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'completer' => @completer,
+          'assignees' => @assignees,
+          'completion_url' => @completion_url
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # CardTable
+    class CardTable
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :subscription_url, :bucket, :creator, :subscribers, :lists
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @subscription_url = data['subscription_url']
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @subscribers = parse_array(data['subscribers'], 'Person')
+        @lists = parse_array(data['lists'], 'CardColumn')
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'subscription_url' => @subscription_url,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'subscribers' => @subscribers,
+          'lists' => @lists
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Chatbot
+    class Chatbot
+      include TypeHelpers
+
+      attr_accessor :id, :created_at, :updated_at, :service_name, :command_url, :url, :app_url, :lines_url
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @service_name = data['service_name']
+        @command_url = data['command_url']
+        @url = data['url']
+        @app_url = data['app_url']
+        @lines_url = data['lines_url']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'service_name' => @service_name,
+          'command_url' => @command_url,
+          'url' => @url,
+          'app_url' => @app_url,
+          'lines_url' => @lines_url
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # ClientApproval
+    class ClientApproval
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :subscription_url, :parent, :bucket, :creator, :content, :subject, :due_on, :replies_count, :replies_url, :approval_status, :approver, :responses
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @subscription_url = data['subscription_url']
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'RecordingBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @content = data['content']
+        @subject = data['subject']
+        @due_on = data['due_on']
+        @replies_count = parse_integer(data['replies_count'])
+        @replies_url = data['replies_url']
+        @approval_status = data['approval_status']
+        @approver = parse_type(data['approver'], 'Person')
+        @responses = parse_array(data['responses'], 'ClientApprovalResponse')
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'subscription_url' => @subscription_url,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'content' => @content,
+          'subject' => @subject,
+          'due_on' => @due_on,
+          'replies_count' => @replies_count,
+          'replies_url' => @replies_url,
+          'approval_status' => @approval_status,
+          'approver' => @approver,
+          'responses' => @responses
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # ClientApprovalResponse
+    class ClientApprovalResponse
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type,
+                    :app_url, :bookmark_url, :parent, :bucket, :creator, :content, :approved
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'RecordingBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @content = data['content']
+        @approved = parse_boolean(data['approved'])
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'content' => @content,
+          'approved' => @approved
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # ClientCompany
+    class ClientCompany
+      include TypeHelpers
+
+      attr_accessor :id, :name
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @name = data['name']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'name' => @name
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # ClientCorrespondence
+    class ClientCorrespondence
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :subscription_url, :parent, :bucket, :creator, :content, :subject, :replies_count, :replies_url
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @subscription_url = data['subscription_url']
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'RecordingBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @content = data['content']
+        @subject = data['subject']
+        @replies_count = parse_integer(data['replies_count'])
+        @replies_url = data['replies_url']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'subscription_url' => @subscription_url,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'content' => @content,
+          'subject' => @subject,
+          'replies_count' => @replies_count,
+          'replies_url' => @replies_url
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # ClientReply
+    class ClientReply
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :parent, :bucket, :creator, :content
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'RecordingBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @content = data['content']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'content' => @content
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # ClientSide
+    class ClientSide
+      include TypeHelpers
+
+      attr_accessor :url, :app_url
+
+      def initialize(data = {})
+        @url = data['url']
+        @app_url = data['app_url']
+      end
+
+      def to_h
+        {
+          'url' => @url,
+          'app_url' => @app_url
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Comment
+    class Comment
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :parent, :bucket, :creator, :content
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @content = data['content']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'content' => @content
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # CreatePersonRequest
+    class CreatePersonRequest
+      include TypeHelpers
+
+      attr_accessor :name, :email_address, :title, :company_name
+
+      def initialize(data = {})
+        @name = data['name']
+        @email_address = data['email_address']
+        @title = data['title']
+        @company_name = data['company_name']
+      end
+
+      def to_h
+        {
+          'name' => @name,
+          'email_address' => @email_address,
+          'title' => @title,
+          'company_name' => @company_name
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # DockItem
+    class DockItem
+      include TypeHelpers
+
+      attr_accessor :id, :title, :name, :enabled, :position, :url, :app_url
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @title = data['title']
+        @name = data['name']
+        @enabled = parse_boolean(data['enabled'])
+        @position = parse_integer(data['position'])
+        @url = data['url']
+        @app_url = data['app_url']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'title' => @title,
+          'name' => @name,
+          'enabled' => @enabled,
+          'position' => @position,
+          'url' => @url,
+          'app_url' => @app_url
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Document
+    class Document
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :subscription_url, :comments_count, :comments_url, :position, :parent, :bucket, :creator, :content
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @subscription_url = data['subscription_url']
+        @comments_count = parse_integer(data['comments_count'])
+        @comments_url = data['comments_url']
+        @position = parse_integer(data['position'])
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @content = data['content']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'subscription_url' => @subscription_url,
+          'comments_count' => @comments_count,
+          'comments_url' => @comments_url,
+          'position' => @position,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'content' => @content
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Event
+    class Event
+      include TypeHelpers
+
+      attr_accessor :id, :recording_id, :action, :details, :created_at, :creator
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @recording_id = parse_integer(data['recording_id'])
+        @action = data['action']
+        @details = parse_type(data['details'], 'EventDetails')
+        @created_at = parse_datetime(data['created_at'])
+        @creator = parse_type(data['creator'], 'Person')
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'recording_id' => @recording_id,
+          'action' => @action,
+          'details' => @details,
+          'created_at' => @created_at,
+          'creator' => @creator
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # EventDetails
+    class EventDetails
+      include TypeHelpers
+
+      attr_accessor :added_person_ids, :removed_person_ids, :notified_recipient_ids
+
+      def initialize(data = {})
+        @added_person_ids = data['added_person_ids']
+        @removed_person_ids = data['removed_person_ids']
+        @notified_recipient_ids = data['notified_recipient_ids']
+      end
+
+      def to_h
+        {
+          'added_person_ids' => @added_person_ids,
+          'removed_person_ids' => @removed_person_ids,
+          'notified_recipient_ids' => @notified_recipient_ids
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Forward
+    class Forward
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :subscription_url, :parent, :bucket, :creator, :content, :subject, :from, :replies_count, :replies_url
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @subscription_url = data['subscription_url']
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @content = data['content']
+        @subject = data['subject']
+        @from = data['from']
+        @replies_count = parse_integer(data['replies_count'])
+        @replies_url = data['replies_url']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'subscription_url' => @subscription_url,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'content' => @content,
+          'subject' => @subject,
+          'from' => @from,
+          'replies_count' => @replies_count,
+          'replies_url' => @replies_url
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # ForwardReply
+    class ForwardReply
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :parent, :bucket, :creator, :content
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @content = data['content']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'content' => @content
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Inbox
+    class Inbox
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :position, :bucket, :creator, :forwards_count, :forwards_url
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @position = parse_integer(data['position'])
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @forwards_count = parse_integer(data['forwards_count'])
+        @forwards_url = data['forwards_url']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'position' => @position,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'forwards_count' => @forwards_count,
+          'forwards_url' => @forwards_url
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # LineupMarker
+    class LineupMarker
+      include TypeHelpers
+
+      attr_accessor :id, :status, :color, :title, :starts_on, :ends_on, :description, :created_at, :updated_at, :type,
+                    :url, :app_url, :creator, :parent, :bucket
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @color = data['color']
+        @title = data['title']
+        @starts_on = data['starts_on']
+        @ends_on = data['ends_on']
+        @description = data['description']
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @creator = parse_type(data['creator'], 'Person')
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'RecordingBucket')
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'color' => @color,
+          'title' => @title,
+          'starts_on' => @starts_on,
+          'ends_on' => @ends_on,
+          'description' => @description,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'creator' => @creator,
+          'parent' => @parent,
+          'bucket' => @bucket
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Message
+    class Message
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :subscription_url, :comments_count, :comments_url, :parent, :bucket, :creator, :subject, :content, :category
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @subscription_url = data['subscription_url']
+        @comments_count = parse_integer(data['comments_count'])
+        @comments_url = data['comments_url']
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @subject = data['subject']
+        @content = data['content']
+        @category = parse_type(data['category'], 'MessageType')
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'subscription_url' => @subscription_url,
+          'comments_count' => @comments_count,
+          'comments_url' => @comments_url,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'subject' => @subject,
+          'content' => @content,
+          'category' => @category
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # MessageBoard
+    class MessageBoard
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :position, :bucket, :creator, :messages_count, :messages_url, :app_messages_url
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @position = parse_integer(data['position'])
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @messages_count = parse_integer(data['messages_count'])
+        @messages_url = data['messages_url']
+        @app_messages_url = data['app_messages_url']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'position' => @position,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'messages_count' => @messages_count,
+          'messages_url' => @messages_url,
+          'app_messages_url' => @app_messages_url
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # MessageType
+    class MessageType
+      include TypeHelpers
+
+      attr_accessor :id, :name, :icon, :created_at, :updated_at
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @name = data['name']
+        @icon = data['icon']
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'name' => @name,
+          'icon' => @icon,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Person
+    class Person
+      include TypeHelpers
+
+      attr_accessor :id, :attachable_sgid, :name, :email_address, :personable_type, :title, :bio, :location,
+                    :created_at, :updated_at, :admin, :owner, :client, :employee, :time_zone, :avatar_url, :company, :can_manage_projects, :can_manage_people
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @attachable_sgid = data['attachable_sgid']
+        @name = data['name']
+        @email_address = data['email_address']
+        @personable_type = data['personable_type']
+        @title = data['title']
+        @bio = data['bio']
+        @location = data['location']
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @admin = parse_boolean(data['admin'])
+        @owner = parse_boolean(data['owner'])
+        @client = parse_boolean(data['client'])
+        @employee = parse_boolean(data['employee'])
+        @time_zone = data['time_zone']
+        @avatar_url = data['avatar_url']
+        @company = parse_type(data['company'], 'PersonCompany')
+        @can_manage_projects = parse_boolean(data['can_manage_projects'])
+        @can_manage_people = parse_boolean(data['can_manage_people'])
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'attachable_sgid' => @attachable_sgid,
+          'name' => @name,
+          'email_address' => @email_address,
+          'personable_type' => @personable_type,
+          'title' => @title,
+          'bio' => @bio,
+          'location' => @location,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'admin' => @admin,
+          'owner' => @owner,
+          'client' => @client,
+          'employee' => @employee,
+          'time_zone' => @time_zone,
+          'avatar_url' => @avatar_url,
+          'company' => @company,
+          'can_manage_projects' => @can_manage_projects,
+          'can_manage_people' => @can_manage_people
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # PersonCompany
+    class PersonCompany
+      include TypeHelpers
+
+      attr_accessor :id, :name
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @name = data['name']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'name' => @name
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Project
+    class Project
+      include TypeHelpers
+
+      attr_accessor :id, :status, :created_at, :updated_at, :name, :description, :purpose, :clients_enabled,
+                    :bookmark_url, :url, :app_url, :dock, :bookmarked, :client_company, :clientside
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @name = data['name']
+        @description = data['description']
+        @purpose = data['purpose']
+        @clients_enabled = parse_boolean(data['clients_enabled'])
+        @bookmark_url = data['bookmark_url']
+        @url = data['url']
+        @app_url = data['app_url']
+        @dock = parse_array(data['dock'], 'DockItem')
+        @bookmarked = parse_boolean(data['bookmarked'])
+        @client_company = parse_type(data['client_company'], 'ClientCompany')
+        @clientside = parse_type(data['clientside'], 'ClientSide')
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'name' => @name,
+          'description' => @description,
+          'purpose' => @purpose,
+          'clients_enabled' => @clients_enabled,
+          'bookmark_url' => @bookmark_url,
+          'url' => @url,
+          'app_url' => @app_url,
+          'dock' => @dock,
+          'bookmarked' => @bookmarked,
+          'client_company' => @client_company,
+          'clientside' => @clientside
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # ProjectAccessResult
+    class ProjectAccessResult
+      include TypeHelpers
+
+      attr_accessor :granted, :revoked
+
+      def initialize(data = {})
+        @granted = parse_array(data['granted'], 'Person')
+        @revoked = parse_array(data['revoked'], 'Person')
+      end
+
+      def to_h
+        {
+          'granted' => @granted,
+          'revoked' => @revoked
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # ProjectConstruction
+    class ProjectConstruction
+      include TypeHelpers
+
+      attr_accessor :id, :status, :url, :project
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @url = data['url']
+        @project = parse_type(data['project'], 'Project')
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'url' => @url,
+          'project' => @project
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Question
+    class Question
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :subscription_url, :parent, :bucket, :creator, :paused, :schedule, :answers_count, :answers_url
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @subscription_url = data['subscription_url']
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'RecordingBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @paused = parse_boolean(data['paused'])
+        @schedule = parse_type(data['schedule'], 'QuestionSchedule')
+        @answers_count = parse_integer(data['answers_count'])
+        @answers_url = data['answers_url']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'subscription_url' => @subscription_url,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'paused' => @paused,
+          'schedule' => @schedule,
+          'answers_count' => @answers_count,
+          'answers_url' => @answers_url
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # QuestionAnswer
+    class QuestionAnswer
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :subscription_url, :comments_count, :comments_url, :content, :group_on, :parent, :bucket, :creator
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @subscription_url = data['subscription_url']
+        @comments_count = parse_integer(data['comments_count'])
+        @comments_url = data['comments_url']
+        @content = data['content']
+        @group_on = data['group_on']
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'RecordingBucket')
+        @creator = parse_type(data['creator'], 'Person')
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'subscription_url' => @subscription_url,
+          'comments_count' => @comments_count,
+          'comments_url' => @comments_url,
+          'content' => @content,
+          'group_on' => @group_on,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # QuestionAnswerPayload
+    class QuestionAnswerPayload
+      include TypeHelpers
+
+      attr_accessor :content, :group_on
+
+      def initialize(data = {})
+        @content = data['content']
+        @group_on = data['group_on']
+      end
+
+      def to_h
+        {
+          'content' => @content,
+          'group_on' => @group_on
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # QuestionAnswerUpdatePayload
+    class QuestionAnswerUpdatePayload
+      include TypeHelpers
+
+      attr_accessor :content
+
+      def initialize(data = {})
+        @content = data['content']
+      end
+
+      def to_h
+        {
+          'content' => @content
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # QuestionSchedule
+    class QuestionSchedule
+      include TypeHelpers
+
+      attr_accessor :frequency, :days, :hour, :minute, :week_instance, :week_interval, :month_interval, :start_date,
+                    :end_date
+
+      def initialize(data = {})
+        @frequency = data['frequency']
+        @days = data['days']
+        @hour = parse_integer(data['hour'])
+        @minute = parse_integer(data['minute'])
+        @week_instance = parse_integer(data['week_instance'])
+        @week_interval = parse_integer(data['week_interval'])
+        @month_interval = parse_integer(data['month_interval'])
+        @start_date = data['start_date']
+        @end_date = data['end_date']
+      end
+
+      def to_h
+        {
+          'frequency' => @frequency,
+          'days' => @days,
+          'hour' => @hour,
+          'minute' => @minute,
+          'week_instance' => @week_instance,
+          'week_interval' => @week_interval,
+          'month_interval' => @month_interval,
+          'start_date' => @start_date,
+          'end_date' => @end_date
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Questionnaire
+    class Questionnaire
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :questions_url, :questions_count, :name, :bucket, :creator
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @questions_url = data['questions_url']
+        @questions_count = parse_integer(data['questions_count'])
+        @name = data['name']
+        @bucket = parse_type(data['bucket'], 'RecordingBucket')
+        @creator = parse_type(data['creator'], 'Person')
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'questions_url' => @questions_url,
+          'questions_count' => @questions_count,
+          'name' => @name,
+          'bucket' => @bucket,
+          'creator' => @creator
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Recording
+    class Recording
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :parent, :bucket, :creator
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'RecordingBucket')
+        @creator = parse_type(data['creator'], 'Person')
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # RecordingBucket
+    class RecordingBucket
+      include TypeHelpers
+
+      attr_accessor :id, :name, :type
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @name = data['name']
+        @type = data['type']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'name' => @name,
+          'type' => @type
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # RecordingParent
+    class RecordingParent
+      include TypeHelpers
+
+      attr_accessor :id, :title, :type, :url, :app_url
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @title = data['title']
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'title' => @title,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Schedule
+    class Schedule
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :position, :bucket, :creator, :include_due_assignments, :entries_count, :entries_url
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @position = parse_integer(data['position'])
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @include_due_assignments = parse_boolean(data['include_due_assignments'])
+        @entries_count = parse_integer(data['entries_count'])
+        @entries_url = data['entries_url']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'position' => @position,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'include_due_assignments' => @include_due_assignments,
+          'entries_count' => @entries_count,
+          'entries_url' => @entries_url
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # ScheduleAttributes
+    class ScheduleAttributes
+      include TypeHelpers
+
+      attr_accessor :start_date, :end_date
+
+      def initialize(data = {})
+        @start_date = data['start_date']
+        @end_date = data['end_date']
+      end
+
+      def to_h
+        {
+          'start_date' => @start_date,
+          'end_date' => @end_date
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # ScheduleEntry
+    class ScheduleEntry
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :subscription_url, :comments_count, :comments_url, :parent, :bucket, :creator, :summary, :description, :all_day, :starts_at, :ends_at, :participants
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @subscription_url = data['subscription_url']
+        @comments_count = parse_integer(data['comments_count'])
+        @comments_url = data['comments_url']
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @summary = data['summary']
+        @description = data['description']
+        @all_day = parse_boolean(data['all_day'])
+        @starts_at = parse_datetime(data['starts_at'])
+        @ends_at = parse_datetime(data['ends_at'])
+        @participants = parse_array(data['participants'], 'Person')
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'subscription_url' => @subscription_url,
+          'comments_count' => @comments_count,
+          'comments_url' => @comments_url,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'summary' => @summary,
+          'description' => @description,
+          'all_day' => @all_day,
+          'starts_at' => @starts_at,
+          'ends_at' => @ends_at,
+          'participants' => @participants
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # SearchMetadata
+    class SearchMetadata
+      include TypeHelpers
+
+      attr_accessor :projects
+
+      def initialize(data = {})
+        @projects = parse_array(data['projects'], 'SearchProject')
+      end
+
+      def to_h
+        {
+          'projects' => @projects
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # SearchProject
+    class SearchProject
+      include TypeHelpers
+
+      attr_accessor :id, :name
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @name = data['name']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'name' => @name
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # SearchResult
+    class SearchResult
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :parent, :bucket, :creator, :content, :description, :subject
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'RecordingBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @content = data['content']
+        @description = data['description']
+        @subject = data['subject']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'content' => @content,
+          'description' => @description,
+          'subject' => @subject
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Subscription
+    class Subscription
+      include TypeHelpers
+
+      attr_accessor :subscribed, :count, :url, :subscribers
+
+      def initialize(data = {})
+        @subscribed = parse_boolean(data['subscribed'])
+        @count = parse_integer(data['count'])
+        @url = data['url']
+        @subscribers = parse_array(data['subscribers'], 'Person')
+      end
+
+      def to_h
+        {
+          'subscribed' => @subscribed,
+          'count' => @count,
+          'url' => @url,
+          'subscribers' => @subscribers
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Template
+    class Template
+      include TypeHelpers
+
+      attr_accessor :id, :status, :created_at, :updated_at, :name, :description, :url, :app_url, :dock
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @name = data['name']
+        @description = data['description']
+        @url = data['url']
+        @app_url = data['app_url']
+        @dock = parse_array(data['dock'], 'DockItem')
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'name' => @name,
+          'description' => @description,
+          'url' => @url,
+          'app_url' => @app_url,
+          'dock' => @dock
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # TimelineEvent
+    class TimelineEvent
+      include TypeHelpers
+
+      attr_accessor :id, :created_at, :kind, :parent_recording_id, :url, :app_url, :creator, :action, :target, :title,
+                    :summary_excerpt, :bucket
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @created_at = parse_datetime(data['created_at'])
+        @kind = data['kind']
+        @parent_recording_id = parse_integer(data['parent_recording_id'])
+        @url = data['url']
+        @app_url = data['app_url']
+        @creator = parse_type(data['creator'], 'Person')
+        @action = data['action']
+        @target = data['target']
+        @title = data['title']
+        @summary_excerpt = data['summary_excerpt']
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'created_at' => @created_at,
+          'kind' => @kind,
+          'parent_recording_id' => @parent_recording_id,
+          'url' => @url,
+          'app_url' => @app_url,
+          'creator' => @creator,
+          'action' => @action,
+          'target' => @target,
+          'title' => @title,
+          'summary_excerpt' => @summary_excerpt,
+          'bucket' => @bucket
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # TimesheetEntry
+    class TimesheetEntry
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :parent, :bucket, :creator, :date, :description, :hours
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @date = data['date']
+        @description = data['description']
+        @hours = data['hours']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'date' => @date,
+          'description' => @description,
+          'hours' => @hours
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Todo
+    class Todo
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :subscription_url, :comments_count, :comments_url, :position, :parent, :bucket, :creator, :description, :completed, :content, :starts_on, :due_on, :assignees, :completion_subscribers, :completion_url
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @subscription_url = data['subscription_url']
+        @comments_count = parse_integer(data['comments_count'])
+        @comments_url = data['comments_url']
+        @position = parse_integer(data['position'])
+        @parent = parse_type(data['parent'], 'TodoParent')
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @description = data['description']
+        @completed = parse_boolean(data['completed'])
+        @content = data['content']
+        @starts_on = data['starts_on']
+        @due_on = data['due_on']
+        @assignees = parse_array(data['assignees'], 'Person')
+        @completion_subscribers = parse_array(data['completion_subscribers'], 'Person')
+        @completion_url = data['completion_url']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'subscription_url' => @subscription_url,
+          'comments_count' => @comments_count,
+          'comments_url' => @comments_url,
+          'position' => @position,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'description' => @description,
+          'completed' => @completed,
+          'content' => @content,
+          'starts_on' => @starts_on,
+          'due_on' => @due_on,
+          'assignees' => @assignees,
+          'completion_subscribers' => @completion_subscribers,
+          'completion_url' => @completion_url
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # TodoBucket
+    class TodoBucket
+      include TypeHelpers
+
+      attr_accessor :id, :name, :type
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @name = data['name']
+        @type = data['type']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'name' => @name,
+          'type' => @type
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # TodoParent
+    class TodoParent
+      include TypeHelpers
+
+      attr_accessor :id, :title, :type, :url, :app_url
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @title = data['title']
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'title' => @title,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Todolist
+    class Todolist
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :subscription_url, :comments_count, :comments_url, :position, :parent, :bucket, :creator, :description, :completed, :completed_ratio, :name, :todos_url, :groups_url, :app_todos_url
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @subscription_url = data['subscription_url']
+        @comments_count = parse_integer(data['comments_count'])
+        @comments_url = data['comments_url']
+        @position = parse_integer(data['position'])
+        @parent = parse_type(data['parent'], 'TodoParent')
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @description = data['description']
+        @completed = parse_boolean(data['completed'])
+        @completed_ratio = data['completed_ratio']
+        @name = data['name']
+        @todos_url = data['todos_url']
+        @groups_url = data['groups_url']
+        @app_todos_url = data['app_todos_url']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'subscription_url' => @subscription_url,
+          'comments_count' => @comments_count,
+          'comments_url' => @comments_url,
+          'position' => @position,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'description' => @description,
+          'completed' => @completed,
+          'completed_ratio' => @completed_ratio,
+          'name' => @name,
+          'todos_url' => @todos_url,
+          'groups_url' => @groups_url,
+          'app_todos_url' => @app_todos_url
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # TodolistGroup
+    class TodolistGroup
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :subscription_url, :comments_count, :comments_url, :position, :parent, :bucket, :creator, :name, :completed, :completed_ratio, :todos_url, :app_todos_url
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @subscription_url = data['subscription_url']
+        @comments_count = parse_integer(data['comments_count'])
+        @comments_url = data['comments_url']
+        @position = parse_integer(data['position'])
+        @parent = parse_type(data['parent'], 'TodoParent')
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @name = data['name']
+        @completed = parse_boolean(data['completed'])
+        @completed_ratio = data['completed_ratio']
+        @todos_url = data['todos_url']
+        @app_todos_url = data['app_todos_url']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'subscription_url' => @subscription_url,
+          'comments_count' => @comments_count,
+          'comments_url' => @comments_url,
+          'position' => @position,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'name' => @name,
+          'completed' => @completed,
+          'completed_ratio' => @completed_ratio,
+          'todos_url' => @todos_url,
+          'app_todos_url' => @app_todos_url
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Todoset
+    class Todoset
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :position, :bucket, :creator, :name, :todolists_count, :todolists_url, :completed_ratio, :completed, :completed_count, :on_schedule_count, :over_schedule_count, :app_todolists_url
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @position = parse_integer(data['position'])
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @name = data['name']
+        @todolists_count = parse_integer(data['todolists_count'])
+        @todolists_url = data['todolists_url']
+        @completed_ratio = data['completed_ratio']
+        @completed = parse_boolean(data['completed'])
+        @completed_count = parse_integer(data['completed_count'])
+        @on_schedule_count = parse_integer(data['on_schedule_count'])
+        @over_schedule_count = parse_integer(data['over_schedule_count'])
+        @app_todolists_url = data['app_todolists_url']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'position' => @position,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'name' => @name,
+          'todolists_count' => @todolists_count,
+          'todolists_url' => @todolists_url,
+          'completed_ratio' => @completed_ratio,
+          'completed' => @completed,
+          'completed_count' => @completed_count,
+          'on_schedule_count' => @on_schedule_count,
+          'over_schedule_count' => @over_schedule_count,
+          'app_todolists_url' => @app_todolists_url
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Tool
+    class Tool
+      include TypeHelpers
+
+      attr_accessor :id, :status, :created_at, :updated_at, :title, :name, :enabled, :position, :url, :app_url, :bucket
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @name = data['name']
+        @enabled = parse_boolean(data['enabled'])
+        @position = parse_integer(data['position'])
+        @url = data['url']
+        @app_url = data['app_url']
+        @bucket = parse_type(data['bucket'], 'RecordingBucket')
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'name' => @name,
+          'enabled' => @enabled,
+          'position' => @position,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bucket' => @bucket
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Upload
+    class Upload
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :subscription_url, :comments_count, :comments_url, :position, :parent, :bucket, :creator, :description, :content_type, :byte_size, :width, :height, :download_url, :filename
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @subscription_url = data['subscription_url']
+        @comments_count = parse_integer(data['comments_count'])
+        @comments_url = data['comments_url']
+        @position = parse_integer(data['position'])
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @description = data['description']
+        @content_type = data['content_type']
+        @byte_size = parse_integer(data['byte_size'])
+        @width = parse_integer(data['width'])
+        @height = parse_integer(data['height'])
+        @download_url = data['download_url']
+        @filename = data['filename']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'subscription_url' => @subscription_url,
+          'comments_count' => @comments_count,
+          'comments_url' => @comments_url,
+          'position' => @position,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'description' => @description,
+          'content_type' => @content_type,
+          'byte_size' => @byte_size,
+          'width' => @width,
+          'height' => @height,
+          'download_url' => @download_url,
+          'filename' => @filename
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Vault
+    class Vault
+      include TypeHelpers
+
+      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url,
+                    :app_url, :bookmark_url, :position, :parent, :bucket, :creator, :documents_count, :documents_url, :uploads_count, :uploads_url, :vaults_count, :vaults_url
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @status = data['status']
+        @visible_to_clients = parse_boolean(data['visible_to_clients'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @title = data['title']
+        @inherits_status = parse_boolean(data['inherits_status'])
+        @type = data['type']
+        @url = data['url']
+        @app_url = data['app_url']
+        @bookmark_url = data['bookmark_url']
+        @position = parse_integer(data['position'])
+        @parent = parse_type(data['parent'], 'RecordingParent')
+        @bucket = parse_type(data['bucket'], 'TodoBucket')
+        @creator = parse_type(data['creator'], 'Person')
+        @documents_count = parse_integer(data['documents_count'])
+        @documents_url = data['documents_url']
+        @uploads_count = parse_integer(data['uploads_count'])
+        @uploads_url = data['uploads_url']
+        @vaults_count = parse_integer(data['vaults_count'])
+        @vaults_url = data['vaults_url']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'status' => @status,
+          'visible_to_clients' => @visible_to_clients,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'title' => @title,
+          'inherits_status' => @inherits_status,
+          'type' => @type,
+          'url' => @url,
+          'app_url' => @app_url,
+          'bookmark_url' => @bookmark_url,
+          'position' => @position,
+          'parent' => @parent,
+          'bucket' => @bucket,
+          'creator' => @creator,
+          'documents_count' => @documents_count,
+          'documents_url' => @documents_url,
+          'uploads_count' => @uploads_count,
+          'uploads_url' => @uploads_url,
+          'vaults_count' => @vaults_count,
+          'vaults_url' => @vaults_url
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+
+    # Webhook
+    class Webhook
+      include TypeHelpers
+
+      attr_accessor :id, :active, :created_at, :updated_at, :payload_url, :types, :url, :app_url
+
+      def initialize(data = {})
+        @id = parse_integer(data['id'])
+        @active = parse_boolean(data['active'])
+        @created_at = parse_datetime(data['created_at'])
+        @updated_at = parse_datetime(data['updated_at'])
+        @payload_url = data['payload_url']
+        @types = data['types']
+        @url = data['url']
+        @app_url = data['app_url']
+      end
+
+      def to_h
+        {
+          'id' => @id,
+          'active' => @active,
+          'created_at' => @created_at,
+          'updated_at' => @updated_at,
+          'payload_url' => @payload_url,
+          'types' => @types,
+          'url' => @url,
+          'app_url' => @app_url
+        }.compact
+      end
+
+      def to_json(*)
+        to_h.to_json(*)
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/hooks.rb
+++ b/ruby/lib/basecamp/hooks.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Basecamp
+  # Interface for observability hooks.
+  # Implement this to add logging, metrics, or tracing to HTTP requests.
+  #
+  # @example Custom hooks with logging
+  #   class LoggingHooks
+  #     include Basecamp::Hooks
+  #
+  #     def on_request_start(info)
+  #       puts "Starting #{info.method} #{info.url}"
+  #     end
+  #
+  #     def on_request_end(info, result)
+  #       puts "Completed #{info.method} #{info.url} - #{result.status_code} (#{result.duration}s)"
+  #     end
+  #   end
+  #
+  #   client = Basecamp::Client.new(config: config, token_provider: provider, hooks: LoggingHooks.new)
+  module Hooks
+    # Called when an HTTP request starts.
+    # @param info [RequestInfo] request information
+    # @return [void]
+    def on_request_start(info)
+      # Override in implementation
+    end
+
+    # Called when an HTTP request completes (success or failure).
+    # @param info [RequestInfo] request information
+    # @param result [RequestResult] result information
+    # @return [void]
+    def on_request_end(info, result)
+      # Override in implementation
+    end
+
+    # Called when a request is retried.
+    # @param info [RequestInfo] request information
+    # @param attempt [Integer] the next attempt number
+    # @param error [Exception] the error that triggered the retry
+    # @param delay [Float] seconds until retry
+    # @return [void]
+    def on_retry(info, attempt, error, delay)
+      # Override in implementation
+    end
+
+    # Called when pagination fetches the next page.
+    # @param url [String] the next page URL
+    # @param page [Integer] the page number
+    # @return [void]
+    def on_paginate(url, page)
+      # Override in implementation
+    end
+  end
+end

--- a/ruby/lib/basecamp/http.rb
+++ b/ruby/lib/basecamp/http.rb
@@ -1,0 +1,391 @@
+# frozen_string_literal: true
+
+require "faraday"
+require "json"
+require "time"
+require "uri"
+
+module Basecamp
+  # HTTP client layer with retry, backoff, and caching support.
+  # This is an internal class used by Client; you typically don't use it directly.
+  class Http
+    # Default User-Agent header
+    USER_AGENT = "basecamp-sdk-ruby/#{VERSION}".freeze
+
+    # @param config [Config] configuration settings
+    # @param token_provider [TokenProvider] OAuth token provider
+    # @param hooks [Hooks] observability hooks
+    def initialize(config:, token_provider:, hooks: nil)
+      @config = config
+      @token_provider = token_provider
+      @hooks = hooks || NoopHooks.new
+      @faraday = build_faraday_client
+    end
+
+    # @return [String] the configured base URL
+    def base_url
+      @config.base_url
+    end
+
+    # Performs a GET request.
+    # @param path [String] URL path
+    # @param params [Hash] query parameters
+    # @return [Response]
+    def get(path, params: {})
+      request(:get, path, params: params)
+    end
+
+    # Performs a GET request to an absolute URL.
+    # Used for endpoints not on the base API (e.g., Launchpad).
+    # @param url [String] absolute URL
+    # @param params [Hash] query parameters
+    # @return [Response]
+    def get_absolute(url, params: {})
+      request(:get, url, params: params)
+    end
+
+    # Performs a POST request.
+    # @param path [String] URL path
+    # @param body [Hash, nil] request body
+    # @return [Response]
+    def post(path, body: nil)
+      request(:post, path, body: body)
+    end
+
+    # Performs a PUT request.
+    # @param path [String] URL path
+    # @param body [Hash, nil] request body
+    # @return [Response]
+    def put(path, body: nil)
+      request(:put, path, body: body)
+    end
+
+    # Performs a DELETE request.
+    # @param path [String] URL path
+    # @return [Response]
+    def delete(path)
+      request(:delete, path)
+    end
+
+    # Performs a POST request with raw binary data.
+    # Used for file uploads (attachments).
+    # @param path [String] URL path
+    # @param body [String, IO] raw binary data
+    # @param content_type [String] MIME content type
+    # @return [Response]
+    def post_raw(path, body:, content_type:)
+      url = build_url(path)
+      single_request_raw(:post, url, body: body, content_type: content_type, attempt: 1)
+    end
+
+    # Fetches all pages of a paginated resource.
+    # @param path [String] initial URL path
+    # @param params [Hash] query parameters
+    # @yield [Hash] each item from the response
+    # @return [Enumerator] if no block given
+    def paginate(path, params: {}, &block)
+      return to_enum(:paginate, path, params: params) unless block
+
+      url = build_url(path)
+      page = 0
+
+      loop do
+        page += 1
+        break if page > @config.max_pages
+
+        @hooks.on_paginate(url, page)
+        response = get(url, params: page == 1 ? params : {})
+
+        items = JSON.parse(response.body)
+        items.each(&block)
+
+        next_url = parse_next_link(response.headers["Link"])
+        break if next_url.nil?
+
+        url = next_url
+      end
+    end
+
+    # Fetches all pages of a paginated resource, extracting items from a key.
+    # Use this for endpoints that return objects like { "events": [...] }.
+    # @param path [String] initial URL path
+    # @param key [String] the key containing the array of items
+    # @param params [Hash] query parameters
+    # @yield [Hash] each item from the response
+    # @return [Enumerator] if no block given
+    def paginate_key(path, key:, params: {}, &block)
+      return to_enum(:paginate_key, path, key: key, params: params) unless block
+
+      url = build_url(path)
+      page = 0
+
+      loop do
+        page += 1
+        break if page > @config.max_pages
+
+        @hooks.on_paginate(url, page)
+        response = get(url, params: page == 1 ? params : {})
+
+        data = JSON.parse(response.body)
+        unless data.key?(key)
+          warn "[Basecamp SDK] paginate_key: expected key '#{key}' not found in response (page #{page})"
+        end
+        items = data[key] || []
+        items.each(&block)
+
+        next_url = parse_next_link(response.headers["Link"])
+        break if next_url.nil?
+
+        url = next_url
+      end
+    end
+
+    private
+
+    def build_faraday_client
+      Faraday.new(url: @config.base_url) do |f|
+        f.options.timeout = @config.timeout
+        f.options.open_timeout = 10
+        f.request :json
+        f.response :raise_error
+        f.adapter Faraday.default_adapter
+      end
+    end
+
+    def request(method, path, params: {}, body: nil)
+      url = build_url(path)
+
+      # Mutations don't retry on 429/5xx to avoid duplicating data
+      if method == :get
+        request_with_retry(method, url, params: params)
+      else
+        single_request(method, url, params: params, body: body, attempt: 1)
+      end
+    end
+
+    def request_with_retry(method, url, params: {})
+      attempt = 0
+      last_error = nil
+
+      loop do
+        attempt += 1
+        break if attempt > @config.max_retries
+
+        begin
+          return single_request(method, url, params: params, body: nil, attempt: attempt)
+        rescue Basecamp::RateLimitError, Basecamp::NetworkError, Basecamp::APIError => e
+          raise e unless e.retryable?
+
+          last_error = e
+          delay = calculate_delay(attempt, e.retry_after)
+
+          @hooks.on_retry(RequestInfo.new(method: method.to_s.upcase, url: url, attempt: attempt), attempt + 1, e,
+                          delay)
+          sleep(delay)
+        end
+      end
+
+      raise last_error || Basecamp::APIError.new("Request failed after #{@config.max_retries} retries")
+    end
+
+    def single_request(method, url, params:, body:, attempt:)
+      info = RequestInfo.new(method: method.to_s.upcase, url: url, attempt: attempt)
+      @hooks.on_request_start(info)
+
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      begin
+        response = @faraday.run_request(method, url, body, request_headers) do |req|
+          req.params.merge!(params) if params.any?
+        end
+
+        duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+        result = RequestResult.new(status_code: response.status, duration: duration)
+        @hooks.on_request_end(info, result)
+
+        Response.new(
+          body: response.body,
+          status: response.status,
+          headers: response.headers
+        )
+      rescue Faraday::ClientError => e
+        duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+        error = handle_error(e)
+        result = RequestResult.new(
+          status_code: e.response&.dig(:status),
+          duration: duration,
+          error: error,
+          retry_after: error.respond_to?(:retry_after) ? error.retry_after : nil
+        )
+        @hooks.on_request_end(info, result)
+        raise error
+      rescue Faraday::Error => e
+        duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+        error = Basecamp::NetworkError.new("Connection failed", cause: e)
+        result = RequestResult.new(duration: duration, error: error)
+        @hooks.on_request_end(info, result)
+        raise error
+      end
+    end
+
+    def request_headers
+      {
+        "Authorization" => "Bearer #{@token_provider.access_token}",
+        "User-Agent" => USER_AGENT,
+        "Accept" => "application/json"
+      }
+    end
+
+    def single_request_raw(method, url, body:, content_type:, attempt:)
+      info = RequestInfo.new(method: method.to_s.upcase, url: url, attempt: attempt)
+      @hooks.on_request_start(info)
+
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      begin
+        headers = request_headers.merge("Content-Type" => content_type)
+        response = @faraday.run_request(method, url, body, headers)
+
+        duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+        result = RequestResult.new(status_code: response.status, duration: duration)
+        @hooks.on_request_end(info, result)
+
+        Response.new(
+          body: response.body,
+          status: response.status,
+          headers: response.headers
+        )
+      rescue Faraday::ClientError => e
+        duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+        error = handle_error(e)
+        result = RequestResult.new(
+          status_code: e.response&.dig(:status),
+          duration: duration,
+          error: error,
+          retry_after: error.respond_to?(:retry_after) ? error.retry_after : nil
+        )
+        @hooks.on_request_end(info, result)
+        raise error
+      rescue Faraday::Error => e
+        duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+        error = Basecamp::NetworkError.new("Connection failed", cause: e)
+        result = RequestResult.new(duration: duration, error: error)
+        @hooks.on_request_end(info, result)
+        raise error
+      end
+    end
+
+    def handle_error(error)
+      status = error.response&.dig(:status)
+      body = error.response&.dig(:body)
+      headers = error.response&.dig(:headers) || {}
+
+      retry_after = parse_retry_after(headers["Retry-After"] || headers["retry-after"])
+
+      case status
+      when 401
+        # Try token refresh
+        if @token_provider.refreshable? && @token_provider.refresh
+          raise Basecamp::AuthError.new("Token refreshed", hint: "Retry the request")
+        end
+
+        Basecamp::AuthError.new("Authentication failed")
+      when 403
+        Basecamp::ForbiddenError.new("Access denied")
+      when 404
+        Basecamp::NotFoundError.new("Resource", "unknown")
+      when 429
+        Basecamp::RateLimitError.new(retry_after: retry_after)
+      when 400, 422
+        message = Basecamp.parse_error_message(body) || "Validation failed"
+        Basecamp::ValidationError.new(message)
+      when 500
+        Basecamp::APIError.new("Server error (500)", http_status: 500)
+      when 502, 503, 504
+        Basecamp::APIError.new("Gateway error (#{status})", http_status: status, retryable: true)
+      else
+        message = Basecamp.parse_error_message(body) || "Request failed (HTTP #{status})"
+        Basecamp::APIError.from_status(status || 0, message)
+      end
+    end
+
+    def build_url(path)
+      return path if path.start_with?("http://", "https://")
+
+      path = "/#{path}" unless path.start_with?("/")
+      "#{@config.base_url}#{path}"
+    end
+
+    def calculate_delay(attempt, server_retry_after)
+      return server_retry_after if server_retry_after&.positive?
+
+      # Exponential backoff: base_delay * 2^(attempt-1) + jitter
+      base = @config.base_delay * (2**(attempt - 1))
+      jitter = rand * @config.max_jitter
+      base + jitter
+    end
+
+    def parse_retry_after(value)
+      return nil if value.nil? || value.empty?
+
+      # Try parsing as seconds (integer)
+      seconds = Integer(value, exception: false)
+      return seconds if seconds&.positive?
+
+      # Try parsing as HTTP-date
+      begin
+        date = Time.httpdate(value)
+        diff = (date - Time.now).to_i
+        return diff if diff.positive?
+      rescue ArgumentError
+        # Not a valid HTTP-date
+      end
+
+      nil
+    end
+
+    def parse_next_link(link_header)
+      return nil if link_header.nil? || link_header.empty?
+
+      link_header.split(",").each do |part|
+        part = part.strip
+        next unless part.include?('rel="next"')
+
+        match = part.match(/<([^>]+)>/)
+        return match[1] if match
+      end
+
+      nil
+    end
+  end
+
+  # Wraps an HTTP response.
+  class Response
+    # @return [String] response body
+    attr_reader :body
+
+    # @return [Integer] HTTP status code
+    attr_reader :status
+
+    # @return [Hash] response headers
+    attr_reader :headers
+
+    def initialize(body:, status:, headers:)
+      @body = body
+      @status = status
+      @headers = headers
+    end
+
+    # Parses the response body as JSON.
+    # @return [Hash, Array]
+    def json
+      @json ||= JSON.parse(@body)
+    end
+
+    # Returns whether the response was successful (2xx).
+    # @return [Boolean]
+    def success?
+      status >= 200 && status < 300
+    end
+  end
+end

--- a/ruby/lib/basecamp/logger_hooks.rb
+++ b/ruby/lib/basecamp/logger_hooks.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Basecamp
+  # Hooks implementation that logs to Ruby's Logger.
+  #
+  # @example
+  #   require "logger"
+  #   logger = Logger.new($stdout)
+  #   hooks = Basecamp::LoggerHooks.new(logger)
+  #   client = Basecamp::Client.new(config: config, token_provider: provider, hooks: hooks)
+  class LoggerHooks
+    include Hooks
+
+    # @param logger [Logger] Ruby logger instance
+    # @param level [Symbol] log level (:debug, :info, :warn, :error)
+    def initialize(logger, level: :debug)
+      @logger = logger
+      @level = level
+    end
+
+    def on_request_start(info)
+      @logger.send(@level, "HTTP #{info.method} #{info.url} (attempt #{info.attempt})")
+    end
+
+    def on_request_end(info, result)
+      if result.error
+        @logger.send(@level, "HTTP #{info.method} #{info.url} failed: #{result.error.message}")
+      else
+        cache_info = result.from_cache ? " (cached)" : ""
+        @logger.send(@level,
+                     "HTTP #{info.method} #{info.url} -> #{result.status_code}#{cache_info} (#{format("%.3f",
+                                                                                                      result.duration)}s)")
+      end
+    end
+
+    def on_retry(info, attempt, error, delay)
+      @logger.send(@level,
+                   "Retrying #{info.method} #{info.url} (attempt #{attempt}) in #{format("%.2f",
+                                                                                         delay)}s: #{error.message}")
+    end
+
+    def on_paginate(url, page)
+      @logger.send(@level, "Fetching page #{page}: #{url}")
+    end
+  end
+end

--- a/ruby/lib/basecamp/noop_hooks.rb
+++ b/ruby/lib/basecamp/noop_hooks.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Basecamp
+  # No-op implementation of Hooks.
+  # Used as the default when no hooks are configured.
+  class NoopHooks
+    include Hooks
+  end
+end

--- a/ruby/lib/basecamp/oauth.rb
+++ b/ruby/lib/basecamp/oauth.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require_relative "oauth/errors"
+require_relative "oauth/types"
+require_relative "oauth/discovery"
+require_relative "oauth/exchange"
+
+module Basecamp
+  # OAuth 2.0 module for Basecamp SDK.
+  #
+  # Provides OAuth discovery, token exchange, and token refresh functionality.
+  # Supports both standard OAuth 2.0 and Basecamp's Launchpad legacy format.
+  #
+  # @example Complete OAuth flow
+  #   # 1. Discover OAuth configuration
+  #   config = Basecamp::Oauth.discover_launchpad
+  #
+  #   # 2. Build authorization URL (redirect user here)
+  #   auth_url = "#{config.authorization_endpoint}?" + URI.encode_www_form(
+  #     type: "web_server",
+  #     client_id: ENV["BASECAMP_CLIENT_ID"],
+  #     redirect_uri: "https://myapp.com/callback"
+  #   )
+  #
+  #   # 3. Exchange authorization code for tokens (in callback handler)
+  #   token = Basecamp::Oauth.exchange_code(
+  #     token_endpoint: config.token_endpoint,
+  #     code: params[:code],
+  #     redirect_uri: "https://myapp.com/callback",
+  #     client_id: ENV["BASECAMP_CLIENT_ID"],
+  #     client_secret: ENV["BASECAMP_CLIENT_SECRET"],
+  #     use_legacy_format: true  # Required for Launchpad
+  #   )
+  #
+  #   # 4. Use the token
+  #   client = Basecamp.client(
+  #     access_token: token.access_token,
+  #     account_id: "12345"
+  #   )
+  #
+  #   # 5. Refresh when needed
+  #   if token.expired?
+  #     token = Basecamp::Oauth.refresh_token(
+  #       token_endpoint: config.token_endpoint,
+  #       refresh_token: token.refresh_token,
+  #       use_legacy_format: true
+  #     )
+  #   end
+  #
+  # @see https://github.com/basecamp/api/blob/master/sections/authentication.md
+  module Oauth
+    # Re-export constants
+    # @return [String] Default Launchpad base URL
+    # LAUNCHPAD_BASE_URL is defined in discovery.rb
+  end
+end

--- a/ruby/lib/basecamp/oauth/discovery.rb
+++ b/ruby/lib/basecamp/oauth/discovery.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "faraday"
+require "json"
+
+module Basecamp
+  module Oauth
+    # Default Basecamp/Launchpad OAuth server URL.
+    LAUNCHPAD_BASE_URL = "https://launchpad.37signals.com"
+
+    # Discoverer fetches OAuth 2.0 server configuration from discovery endpoints.
+    class Discoverer
+      # @param http_client [Faraday::Connection, nil] HTTP client (uses default if nil)
+      # @param timeout [Integer] Request timeout in seconds (default: 10)
+      def initialize(http_client: nil, timeout: 10)
+        @http_client = http_client || build_default_client(timeout)
+      end
+
+      # Discovers OAuth configuration from the well-known endpoint.
+      #
+      # Fetches the OAuth 2.0 Authorization Server Metadata from:
+      # `{base_url}/.well-known/oauth-authorization-server`
+      #
+      # @param base_url [String] The OAuth server's base URL (e.g., "https://launchpad.37signals.com")
+      # @return [Config] The OAuth server configuration
+      # @raise [OAuthError] on network or parsing errors
+      #
+      # @example
+      #   discoverer = Basecamp::Oauth::Discoverer.new
+      #   config = discoverer.discover("https://launchpad.37signals.com")
+      #   puts config.token_endpoint
+      #   # => "https://launchpad.37signals.com/authorization/token"
+      def discover(base_url)
+        normalized_base = base_url.chomp("/")
+        discovery_url = "#{normalized_base}/.well-known/oauth-authorization-server"
+
+        response = @http_client.get(discovery_url) do |req|
+          req.headers["Accept"] = "application/json"
+        end
+
+        unless response.success?
+          raise OAuthError.new(
+            "network",
+            "OAuth discovery failed with status #{response.status}: #{response.body}",
+            http_status: response.status
+          )
+        end
+
+        data = JSON.parse(response.body)
+        validate_discovery_response!(data)
+
+        Config.new(
+          issuer: data["issuer"],
+          authorization_endpoint: data["authorization_endpoint"],
+          token_endpoint: data["token_endpoint"],
+          registration_endpoint: data["registration_endpoint"],
+          scopes_supported: data["scopes_supported"]
+        )
+      rescue Faraday::Error => e
+        raise OAuthError.new("network", "OAuth discovery failed: #{e.message}", retryable: true)
+      rescue JSON::ParserError => e
+        raise OAuthError.new("api_error", "Failed to parse discovery response: #{e.message}")
+      end
+
+      private
+
+      def build_default_client(timeout)
+        Faraday.new do |conn|
+          conn.options.timeout = timeout
+          conn.options.open_timeout = timeout
+          conn.adapter Faraday.default_adapter
+        end
+      end
+
+      def validate_discovery_response!(data)
+        missing = []
+        missing << "issuer" unless data["issuer"]
+        missing << "authorization_endpoint" unless data["authorization_endpoint"]
+        missing << "token_endpoint" unless data["token_endpoint"]
+
+        return if missing.empty?
+
+        raise OAuthError.new(
+          "api_error",
+          "Invalid OAuth discovery response: missing required fields: #{missing.join(', ')}"
+        )
+      end
+    end
+
+    module_function
+
+    # Discovers OAuth configuration from the well-known endpoint.
+    #
+    # @param base_url [String] The OAuth server's base URL
+    # @param timeout [Integer] Request timeout in seconds (default: 10)
+    # @return [Config] The OAuth server configuration
+    #
+    # @example
+    #   config = Basecamp::Oauth.discover("https://launchpad.37signals.com")
+    def discover(base_url, timeout: 10)
+      Discoverer.new(timeout: timeout).discover(base_url)
+    end
+
+    # Discovers OAuth configuration from Basecamp's Launchpad server.
+    #
+    # Convenience function that calls discover() with the Launchpad base URL.
+    #
+    # @param timeout [Integer] Request timeout in seconds (default: 10)
+    # @return [Config] The OAuth server configuration
+    #
+    # @example
+    #   config = Basecamp::Oauth.discover_launchpad
+    #   # Use config.authorization_endpoint to start OAuth flow
+    def discover_launchpad(timeout: 10)
+      discover(LAUNCHPAD_BASE_URL, timeout: timeout)
+    end
+  end
+end

--- a/ruby/lib/basecamp/oauth/errors.rb
+++ b/ruby/lib/basecamp/oauth/errors.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Oauth
+    # OAuth-specific error class.
+    #
+    # @attr type [String] Error type ("validation", "auth", "network", "api_error")
+    # @attr http_status [Integer, nil] HTTP status code if applicable
+    # @attr hint [String, nil] Helpful hint for resolving the error
+    # @attr retryable [Boolean] Whether the request can be retried
+    class OAuthError < StandardError
+      attr_reader :type, :http_status, :hint, :retryable
+
+      # @param type [String] Error type
+      # @param message [String] Error message
+      # @param http_status [Integer, nil] HTTP status code
+      # @param hint [String, nil] Helpful hint
+      # @param retryable [Boolean] Whether retryable
+      def initialize(type, message, http_status: nil, hint: nil, retryable: false)
+        super(message)
+        @type = type
+        @http_status = http_status
+        @hint = hint
+        @retryable = retryable
+      end
+
+      def to_s
+        parts = [ "[#{type}] #{super}" ]
+        parts << "(HTTP #{http_status})" if http_status
+        parts << "Hint: #{hint}" if hint
+        parts.join(" ")
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/oauth/exchange.rb
+++ b/ruby/lib/basecamp/oauth/exchange.rb
@@ -1,0 +1,286 @@
+# frozen_string_literal: true
+
+require "faraday"
+require "json"
+require "uri"
+
+module Basecamp
+  module Oauth
+    # Exchanger handles OAuth 2.0 token exchange and refresh operations.
+    class Exchanger
+      # @param http_client [Faraday::Connection, nil] HTTP client (uses default if nil)
+      # @param timeout [Integer] Request timeout in seconds (default: 30)
+      def initialize(http_client: nil, timeout: 30)
+        @http_client = http_client || build_default_client(timeout)
+      end
+
+      # Exchanges an authorization code for access and refresh tokens.
+      #
+      # Supports both standard OAuth 2.0 and Basecamp's Launchpad legacy format.
+      # Use `use_legacy_format: true` for Launchpad compatibility.
+      #
+      # @param request [ExchangeRequest] Exchange request parameters
+      # @return [Token] The token response
+      # @raise [OAuthError] on validation, network, or authentication errors
+      #
+      # @example Standard OAuth 2.0
+      #   token = exchanger.exchange(ExchangeRequest.new(
+      #     token_endpoint: config.token_endpoint,
+      #     code: "auth_code_from_callback",
+      #     redirect_uri: "https://myapp.com/callback",
+      #     client_id: "my_client_id",
+      #     client_secret: "my_client_secret"
+      #   ))
+      #
+      # @example Launchpad legacy format
+      #   token = exchanger.exchange(ExchangeRequest.new(
+      #     token_endpoint: config.token_endpoint,
+      #     code: "auth_code",
+      #     redirect_uri: "https://myapp.com/callback",
+      #     client_id: "my_client_id",
+      #     client_secret: "my_client_secret",
+      #     use_legacy_format: true
+      #   ))
+      def exchange(request)
+        validate_exchange_request!(request)
+
+        params = build_exchange_params(request)
+        do_token_request(request.token_endpoint, params)
+      end
+
+      # Refreshes an access token using a refresh token.
+      #
+      # Supports both standard OAuth 2.0 and Basecamp's Launchpad legacy format.
+      # Use `use_legacy_format: true` for Launchpad compatibility.
+      #
+      # @param request [RefreshRequest] Refresh request parameters
+      # @return [Token] The new token response
+      # @raise [OAuthError] on validation, network, or authentication errors
+      #
+      # @example Standard OAuth 2.0
+      #   new_token = exchanger.refresh(RefreshRequest.new(
+      #     token_endpoint: config.token_endpoint,
+      #     refresh_token: old_token.refresh_token,
+      #     client_id: "my_client_id",
+      #     client_secret: "my_client_secret"
+      #   ))
+      #
+      # @example Launchpad legacy format
+      #   new_token = exchanger.refresh(RefreshRequest.new(
+      #     token_endpoint: config.token_endpoint,
+      #     refresh_token: old_token.refresh_token,
+      #     use_legacy_format: true
+      #   ))
+      def refresh(request)
+        validate_refresh_request!(request)
+
+        params = build_refresh_params(request)
+        do_token_request(request.token_endpoint, params)
+      end
+
+      private
+
+      def build_default_client(timeout)
+        Faraday.new do |conn|
+          conn.options.timeout = timeout
+          conn.options.open_timeout = timeout
+          conn.adapter Faraday.default_adapter
+        end
+      end
+
+      def validate_exchange_request!(request)
+        raise OAuthError.new("validation", "Token endpoint is required") if request.token_endpoint.to_s.empty?
+        raise OAuthError.new("validation", "Authorization code is required") if request.code.to_s.empty?
+        raise OAuthError.new("validation", "Redirect URI is required") if request.redirect_uri.to_s.empty?
+        raise OAuthError.new("validation", "Client ID is required") if request.client_id.to_s.empty?
+      end
+
+      def validate_refresh_request!(request)
+        raise OAuthError.new("validation", "Token endpoint is required") if request.token_endpoint.to_s.empty?
+        raise OAuthError.new("validation", "Refresh token is required") if request.refresh_token.to_s.empty?
+      end
+
+      def build_exchange_params(request)
+        params = {}
+
+        if request.use_legacy_format
+          # Launchpad uses non-standard "type" parameter
+          params["type"] = "web_server"
+        else
+          # Standard OAuth 2.0
+          params["grant_type"] = "authorization_code"
+        end
+
+        params["code"] = request.code
+        params["redirect_uri"] = request.redirect_uri
+        params["client_id"] = request.client_id
+        params["client_secret"] = request.client_secret if request.client_secret
+        params["code_verifier"] = request.code_verifier if request.code_verifier
+
+        params
+      end
+
+      def build_refresh_params(request)
+        params = {}
+
+        if request.use_legacy_format
+          # Launchpad uses non-standard "type" parameter
+          params["type"] = "refresh"
+        else
+          # Standard OAuth 2.0
+          params["grant_type"] = "refresh_token"
+        end
+
+        params["refresh_token"] = request.refresh_token
+        params["client_id"] = request.client_id if request.client_id
+        params["client_secret"] = request.client_secret if request.client_secret
+
+        params
+      end
+
+      def do_token_request(token_endpoint, params)
+        response = @http_client.post(token_endpoint) do |req|
+          req.headers["Content-Type"] = "application/x-www-form-urlencoded"
+          req.headers["Accept"] = "application/json"
+          req.body = URI.encode_www_form(params)
+        end
+
+        parse_token_response(response)
+      rescue Faraday::TimeoutError
+        raise OAuthError.new("network", "Token request timed out", retryable: true)
+      rescue Faraday::Error => e
+        raise OAuthError.new("network", "Token request failed: #{e.message}", retryable: true)
+      end
+
+      def parse_token_response(response)
+        data = JSON.parse(response.body)
+
+        handle_error_response(response.status, data) unless response.success?
+
+        raise OAuthError.new("api_error", "Token response missing access_token") unless data["access_token"]
+
+        Token.new(
+          access_token: data["access_token"],
+          refresh_token: data["refresh_token"],
+          token_type: data["token_type"] || "Bearer",
+          expires_in: data["expires_in"],
+          scope: data["scope"]
+        )
+      rescue JSON::ParserError
+        raise OAuthError.new(
+          "api_error",
+          "Failed to parse token response: #{response.body}",
+          http_status: response.status
+        )
+      end
+
+      def handle_error_response(status, data)
+        error_msg = data["error_description"] || data["error"] || "Token request failed"
+
+        if status == 401 || data["error"] == "invalid_grant"
+          raise OAuthError.new(
+            "auth",
+            error_msg,
+            http_status: status,
+            hint: "The authorization code or refresh token may be invalid or expired"
+          )
+        end
+
+        raise OAuthError.new("api_error", error_msg, http_status: status)
+      end
+    end
+
+    module_function
+
+    # Exchanges an authorization code for access and refresh tokens.
+    #
+    # @param token_endpoint [String] URL of the token endpoint
+    # @param code [String] The authorization code
+    # @param redirect_uri [String] The redirect URI used in the authorization request
+    # @param client_id [String] The client identifier
+    # @param client_secret [String, nil] The client secret
+    # @param code_verifier [String, nil] PKCE code verifier
+    # @param use_legacy_format [Boolean] Use Launchpad's non-standard format
+    # @param timeout [Integer] Request timeout in seconds (default: 30)
+    # @return [Token] The token response
+    #
+    # @example
+    #   token = Basecamp::Oauth.exchange_code(
+    #     token_endpoint: config.token_endpoint,
+    #     code: "auth_code",
+    #     redirect_uri: "https://myapp.com/callback",
+    #     client_id: ENV["BASECAMP_CLIENT_ID"],
+    #     client_secret: ENV["BASECAMP_CLIENT_SECRET"],
+    #     use_legacy_format: true
+    #   )
+    def exchange_code(
+      token_endpoint:,
+      code:,
+      redirect_uri:,
+      client_id:,
+      client_secret: nil,
+      code_verifier: nil,
+      use_legacy_format: false,
+      timeout: 30
+    )
+      request = ExchangeRequest.new(
+        token_endpoint: token_endpoint,
+        code: code,
+        redirect_uri: redirect_uri,
+        client_id: client_id,
+        client_secret: client_secret,
+        code_verifier: code_verifier,
+        use_legacy_format: use_legacy_format
+      )
+      Exchanger.new(timeout: timeout).exchange(request)
+    end
+
+    # Refreshes an access token using a refresh token.
+    #
+    # @param token_endpoint [String] URL of the token endpoint
+    # @param refresh_token [String] The refresh token
+    # @param client_id [String, nil] The client identifier
+    # @param client_secret [String, nil] The client secret
+    # @param use_legacy_format [Boolean] Use Launchpad's non-standard format
+    # @param timeout [Integer] Request timeout in seconds (default: 30)
+    # @return [Token] The new token response
+    #
+    # @example
+    #   new_token = Basecamp::Oauth.refresh_token(
+    #     token_endpoint: config.token_endpoint,
+    #     refresh_token: old_token.refresh_token,
+    #     use_legacy_format: true
+    #   )
+    def refresh_token(
+      token_endpoint:,
+      refresh_token:,
+      client_id: nil,
+      client_secret: nil,
+      use_legacy_format: false,
+      timeout: 30
+    )
+      request = RefreshRequest.new(
+        token_endpoint: token_endpoint,
+        refresh_token: refresh_token,
+        client_id: client_id,
+        client_secret: client_secret,
+        use_legacy_format: use_legacy_format
+      )
+      Exchanger.new(timeout: timeout).refresh(request)
+    end
+
+    # Checks if a token is expired or about to expire.
+    #
+    # @param token [Token] The token to check
+    # @param buffer_seconds [Integer] Buffer time before actual expiration (default: 60)
+    # @return [Boolean] true if expired or will expire within buffer time
+    #
+    # @example
+    #   if Basecamp::Oauth.token_expired?(token)
+    #     token = Basecamp::Oauth.refresh_token(...)
+    #   end
+    def token_expired?(token, buffer_seconds = 60)
+      token.expired?(buffer_seconds)
+    end
+  end
+end

--- a/ruby/lib/basecamp/oauth/types.rb
+++ b/ruby/lib/basecamp/oauth/types.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Oauth
+    # OAuth 2.0 server configuration from discovery endpoint.
+    #
+    # @attr issuer [String] The authorization server's issuer identifier
+    # @attr authorization_endpoint [String] URL of the authorization endpoint
+    # @attr token_endpoint [String] URL of the token endpoint
+    # @attr registration_endpoint [String, nil] URL of the dynamic client registration endpoint
+    # @attr scopes_supported [Array<String>, nil] List of OAuth 2.0 scopes supported
+    Config = Data.define(
+      :issuer,
+      :authorization_endpoint,
+      :token_endpoint,
+      :registration_endpoint,
+      :scopes_supported
+    ) do
+      def initialize(
+        issuer:,
+        authorization_endpoint:,
+        token_endpoint:,
+        registration_endpoint: nil,
+        scopes_supported: nil
+      )
+        super
+      end
+    end
+
+    # OAuth 2.0 access token response.
+    #
+    # @attr access_token [String] The access token string
+    # @attr token_type [String] Token type (usually "Bearer")
+    # @attr refresh_token [String, nil] The refresh token string
+    # @attr expires_in [Integer, nil] Lifetime of the access token in seconds
+    # @attr expires_at [Time, nil] Calculated expiration time
+    # @attr scope [String, nil] OAuth scope granted
+    Token = Data.define(
+      :access_token,
+      :token_type,
+      :refresh_token,
+      :expires_in,
+      :expires_at,
+      :scope
+    ) do
+      def initialize(
+        access_token:,
+        token_type: "Bearer",
+        refresh_token: nil,
+        expires_in: nil,
+        expires_at: nil,
+        scope: nil
+      )
+        # Calculate expires_at from expires_in if not provided
+        calculated_expires_at = expires_at || (expires_in ? Time.now + expires_in : nil)
+        super(
+          access_token: access_token,
+          token_type: token_type,
+          refresh_token: refresh_token,
+          expires_in: expires_in,
+          expires_at: calculated_expires_at,
+          scope: scope
+        )
+      end
+
+      # Checks if the token is expired or about to expire.
+      #
+      # @param buffer_seconds [Integer] Buffer time before actual expiration (default: 60)
+      # @return [Boolean] true if expired or will expire within buffer time
+      def expired?(buffer_seconds = 60)
+        return false unless expires_at
+
+        Time.now + buffer_seconds >= expires_at
+      end
+    end
+
+    # Parameters for exchanging an authorization code for tokens.
+    #
+    # @attr token_endpoint [String] URL of the token endpoint
+    # @attr code [String] The authorization code received from the authorization server
+    # @attr redirect_uri [String] The redirect URI used in the authorization request
+    # @attr client_id [String] The client identifier
+    # @attr client_secret [String, nil] The client secret (optional for public clients)
+    # @attr code_verifier [String, nil] PKCE code verifier (optional)
+    # @attr use_legacy_format [Boolean] Use Launchpad's non-standard token format
+    ExchangeRequest = Data.define(
+      :token_endpoint,
+      :code,
+      :redirect_uri,
+      :client_id,
+      :client_secret,
+      :code_verifier,
+      :use_legacy_format
+    ) do
+      def initialize(
+        token_endpoint:,
+        code:,
+        redirect_uri:,
+        client_id:,
+        client_secret: nil,
+        code_verifier: nil,
+        use_legacy_format: false
+      )
+        super
+      end
+    end
+
+    # Parameters for refreshing an access token.
+    #
+    # @attr token_endpoint [String] URL of the token endpoint
+    # @attr refresh_token [String] The refresh token
+    # @attr client_id [String, nil] The client identifier (optional)
+    # @attr client_secret [String, nil] The client secret (optional)
+    # @attr use_legacy_format [Boolean] Use Launchpad's non-standard token format
+    RefreshRequest = Data.define(
+      :token_endpoint,
+      :refresh_token,
+      :client_id,
+      :client_secret,
+      :use_legacy_format
+    ) do
+      def initialize(
+        token_endpoint:,
+        refresh_token:,
+        client_id: nil,
+        client_secret: nil,
+        use_legacy_format: false
+      )
+        super
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/oauth_token_provider.rb
+++ b/ruby/lib/basecamp/oauth_token_provider.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module Basecamp
+  # A token provider that supports OAuth token refresh.
+  #
+  # @example
+  #   provider = Basecamp::OauthTokenProvider.new(
+  #     access_token: "current-token",
+  #     refresh_token: "refresh-token",
+  #     client_id: "your-client-id",
+  #     client_secret: "your-client-secret"
+  #   )
+  class OauthTokenProvider
+    include TokenProvider
+
+    # Token endpoint for Basecamp OAuth
+    TOKEN_URL = "https://launchpad.37signals.com/authorization/token"
+
+    # @return [String, nil] the current refresh token
+    attr_reader :refresh_token
+
+    # @return [Time, nil] when the access token expires
+    attr_reader :expires_at
+
+    # Callback invoked when tokens are refreshed.
+    # @return [Proc, nil]
+    attr_accessor :on_refresh
+
+    # @param access_token [String] current access token
+    # @param refresh_token [String, nil] refresh token for renewal
+    # @param client_id [String] OAuth client ID
+    # @param client_secret [String] OAuth client secret
+    # @param expires_at [Time, nil] token expiration time
+    # @param on_refresh [Proc, nil] callback when tokens refresh
+    def initialize(access_token:, client_id:, client_secret:, refresh_token: nil, expires_at: nil, on_refresh: nil)
+      @access_token = access_token
+      @refresh_token = refresh_token
+      @client_id = client_id
+      @client_secret = client_secret
+      @expires_at = expires_at
+      @on_refresh = on_refresh
+      @mutex = Mutex.new
+    end
+
+    # Returns the current access token, refreshing if expired.
+    # @return [String]
+    def access_token
+      @mutex.synchronize do
+        refresh_if_needed
+        @access_token
+      end
+    end
+
+    # Refreshes the access token using the refresh token.
+    # @return [Boolean] true if refresh succeeded
+    def refresh
+      refreshable? && @mutex.synchronize { perform_refresh }
+    end
+
+    # @return [Boolean] true if refresh token is available
+    def refreshable?
+      @refresh_token && !@refresh_token.empty?
+    end
+
+    # @return [Boolean] true if the access token is expired
+    def expired?
+      @expires_at && Time.now >= @expires_at
+    end
+
+    private
+
+      def refresh_if_needed
+        perform_refresh if expired? && refreshable?
+      end
+
+      def perform_refresh
+        require "faraday"
+        require "json"
+        require "uri"
+
+        response = Faraday.post(TOKEN_URL) do |req|
+          req.headers["Content-Type"] = "application/x-www-form-urlencoded"
+          req.body = URI.encode_www_form(
+            type: "refresh",
+            refresh_token: @refresh_token,
+            client_id: @client_id,
+            client_secret: @client_secret
+          )
+        end
+
+        raise AuthError.new("Token refresh failed: #{response.status}") unless response.success?
+
+        data = JSON.parse(response.body)
+        @access_token = data["access_token"]
+        @expires_at = Time.now + data["expires_in"].to_i if data["expires_in"]
+
+        @on_refresh&.call(@access_token, @refresh_token, @expires_at)
+
+        true
+      rescue Faraday::Error => e
+        raise NetworkError.new("Token refresh network error", cause: e)
+      end
+  end
+end

--- a/ruby/lib/basecamp/request_info.rb
+++ b/ruby/lib/basecamp/request_info.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Basecamp
+  # Information about an HTTP request for observability hooks.
+  RequestInfo = Data.define(:method, :url, :attempt) do
+    def initialize(method:, url:, attempt: 1)
+      super
+    end
+  end
+end

--- a/ruby/lib/basecamp/request_result.rb
+++ b/ruby/lib/basecamp/request_result.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Basecamp
+  # Result information for completed HTTP requests.
+  RequestResult = Data.define(:status_code, :duration, :error, :retry_after, :from_cache) do
+    def initialize(status_code: nil, duration: 0.0, error: nil, retry_after: nil, from_cache: false)
+      super
+    end
+
+    def success?
+      status_code && status_code >= 200 && status_code < 300
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/attachments_service.rb
+++ b/ruby/lib/basecamp/services/attachments_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "uri"
+
+module Basecamp
+  module Services
+    # Service for attachment operations.
+    #
+    # Attachments are used to upload files that can be embedded in rich text
+    # content like messages, comments, and documents. After uploading, you
+    # receive an attachable_sgid that can be used to embed the file in HTML.
+    #
+    # @example Upload a file
+    #   attachment = account.attachments.create(
+    #     filename: "report.pdf",
+    #     content_type: "application/pdf",
+    #     data: file_content
+    #   )
+    #   # Use in HTML: <bc-attachment sgid="#{attachment["attachable_sgid"]}"></bc-attachment>
+    class AttachmentsService < BaseService
+      # Creates an attachment by uploading a file.
+      # Returns an attachable_sgid for embedding the file in rich text content.
+      #
+      # @param filename [String] filename for the uploaded file
+      # @param content_type [String] MIME content type (e.g., "image/png", "application/pdf")
+      # @param data [String] file data
+      # @return [Hash] attachment response with attachable_sgid
+      def create(filename:, content_type:, data:)
+        http_post_raw("/attachments.json?name=#{URI.encode_www_form_component(filename)}", body: data, content_type: content_type).json
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/authorization_service.rb
+++ b/ruby/lib/basecamp/services/authorization_service.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for authorization operations.
+    # This is the only service that doesn't require an account context.
+    #
+    # @example Get authorization info
+    #   auth = client.authorization.get
+    #   puts "Identity: #{auth["identity"]["email_address"]}"
+    #   auth["accounts"].each do |account|
+    #     puts "Account: #{account["name"]} (#{account["id"]})"
+    #   end
+    class AuthorizationService < BaseService
+      # Fallback Launchpad endpoint for authorization
+      LAUNCHPAD_AUTHORIZATION_URL = "https://launchpad.37signals.com/authorization.json"
+
+      # Gets authorization information for the current user.
+      #
+      # Attempts to use the authorization endpoint discovered via OAuth discovery
+      # on the configured base URL. Falls back to Launchpad if discovery fails.
+      #
+      # Returns the authenticated user's identity and list of accounts
+      # they have access to.
+      #
+      # @return [Hash] authorization info with :identity and :accounts
+      # @see https://github.com/basecamp/bc3-api/blob/master/sections/authentication.md
+      def get
+        url = discover_authorization_url
+        response = http.get_absolute(url)
+        response.json
+      end
+
+      private
+
+        def discover_authorization_url
+          # Try OAuth discovery on the configured base URL
+          config = Oauth.discover(http.base_url)
+          # Use issuer as base for authorization.json
+          "#{config.issuer.chomp('/')}/authorization.json"
+        rescue Oauth::OAuthError
+          # Fall back to Launchpad
+          LAUNCHPAD_AUTHORIZATION_URL
+        end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/base_service.rb
+++ b/ruby/lib/basecamp/services/base_service.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require_relative "../errors"
+
+module Basecamp
+  module Services
+    # Base service class for Basecamp API services.
+    #
+    # Provides shared functionality for all service classes including:
+    # - HTTP method delegation (http_get, http_post, etc.)
+    # - Path building helpers
+    # - Pagination support
+    #
+    # @example
+    #   class TodosService < BaseService
+    #     def list(project_id:, todolist_id:)
+    #       paginate(bucket_path(project_id, "/todolists/#{todolist_id}/todos.json"))
+    #     end
+    #   end
+    class BaseService
+      # @return [String] the account ID for API requests
+      attr_reader :account_id
+
+      # @param client [Object] the parent client (AccountClient or Client)
+      def initialize(client)
+        @client = client
+        @account_id = client.account_id
+      end
+
+      protected
+
+      # @return [HTTP] the HTTP client for direct access
+      def http
+        @client.http
+      end
+
+      # Helper to remove nil values from a hash.
+      # @param hash [Hash] the input hash
+      # @return [Hash] hash with nil values removed
+      def compact_params(**kwargs)
+        kwargs.compact
+      end
+
+      # Build a bucket (project) path.
+      # @param project_id [Integer, String] the project/bucket ID
+      # @param path [String] the path suffix
+      # @return [String] the full bucket path
+      def bucket_path(project_id, path)
+        "/buckets/#{project_id}#{path}"
+      end
+
+      # Delegate HTTP methods to the client with http_ prefix to avoid conflicts
+      # with service method names (e.g., service.get vs http_get)
+      # @!method http_get(path, params: {})
+      #   @see AccountClient#get
+      # @!method http_post(path, body: nil)
+      #   @see AccountClient#post
+      # @!method http_put(path, body: nil)
+      #   @see AccountClient#put
+      # @!method http_delete(path)
+      #   @see AccountClient#delete
+      # @!method http_post_raw(path, body:, content_type:)
+      #   @see AccountClient#post_raw
+      # @!method paginate(path, params: {}, &block)
+      #   @see AccountClient#paginate
+      %i[get post put delete post_raw].each do |method|
+        define_method(:"http_#{method}") do |*args, **kwargs, &block|
+          @client.public_send(method, *args, **kwargs, &block)
+        end
+      end
+
+      # Paginate doesn't conflict with service methods, keep as-is
+      def paginate(...)
+        @client.paginate(...)
+      end
+
+      # Paginate extracting items from a specific key (for object responses)
+      def paginate_key(...)
+        @client.paginate_key(...)
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/campfires_service.rb
+++ b/ruby/lib/basecamp/services/campfires_service.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for campfire (chat) operations.
+    #
+    # Campfires are real-time chat rooms within Basecamp projects.
+    # They contain lines (messages) and can have chatbot integrations.
+    #
+    # @example List all campfires
+    #   account.campfires.list.each do |campfire|
+    #     puts campfire["title"]
+    #   end
+    #
+    # @example Send a message
+    #   line = account.campfires.create_line(
+    #     project_id: 123,
+    #     campfire_id: 456,
+    #     content: "Hello team!"
+    #   )
+    class CampfiresService < BaseService
+      # Lists all campfires across the account.
+      #
+      # @return [Enumerator<Hash>] campfires
+      def list
+        paginate("/chats.json")
+      end
+
+      # Gets a specific campfire.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param campfire_id [Integer, String] campfire ID
+      # @return [Hash] campfire data
+      def get(project_id:, campfire_id:)
+        http_get(bucket_path(project_id, "/chats/#{campfire_id}.json")).json
+      end
+
+      # Lists all lines (messages) in a campfire.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param campfire_id [Integer, String] campfire ID
+      # @return [Enumerator<Hash>] campfire lines
+      def list_lines(project_id:, campfire_id:)
+        paginate(bucket_path(project_id, "/chats/#{campfire_id}/lines.json"))
+      end
+
+      # Gets a specific line (message) from a campfire.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param campfire_id [Integer, String] campfire ID
+      # @param line_id [Integer, String] line ID
+      # @return [Hash] campfire line
+      def get_line(project_id:, campfire_id:, line_id:)
+        http_get(bucket_path(project_id, "/chats/#{campfire_id}/lines/#{line_id}.json")).json
+      end
+
+      # Creates a new line (message) in a campfire.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param campfire_id [Integer, String] campfire ID
+      # @param content [String] plain text message content
+      # @return [Hash] created line
+      def create_line(project_id:, campfire_id:, content:)
+        body = { content: content }
+        http_post(bucket_path(project_id, "/chats/#{campfire_id}/lines.json"), body: body).json
+      end
+
+      # Deletes a line (message) from a campfire.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param campfire_id [Integer, String] campfire ID
+      # @param line_id [Integer, String] line ID
+      # @return [void]
+      def delete_line(project_id:, campfire_id:, line_id:)
+        http_delete(bucket_path(project_id, "/chats/#{campfire_id}/lines/#{line_id}.json"))
+        nil
+      end
+
+      # Lists all chatbots for a campfire.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param campfire_id [Integer, String] campfire ID
+      # @return [Enumerator<Hash>] chatbots
+      def list_chatbots(project_id:, campfire_id:)
+        paginate(bucket_path(project_id, "/chats/#{campfire_id}/integrations.json"))
+      end
+
+      # Gets a specific chatbot.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param campfire_id [Integer, String] campfire ID
+      # @param chatbot_id [Integer, String] chatbot ID
+      # @return [Hash] chatbot data
+      def get_chatbot(project_id:, campfire_id:, chatbot_id:)
+        http_get(bucket_path(project_id, "/chats/#{campfire_id}/integrations/#{chatbot_id}.json")).json
+      end
+
+      # Creates a new chatbot for a campfire.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param campfire_id [Integer, String] campfire ID
+      # @param service_name [String] chatbot name (no spaces, emoji, or non-word characters)
+      # @param command_url [String, nil] HTTPS URL for bot callbacks
+      # @return [Hash] created chatbot with lines_url for posting
+      def create_chatbot(project_id:, campfire_id:, service_name:, command_url: nil)
+        body = compact_params(
+          service_name: service_name,
+          command_url: command_url
+        )
+        http_post(bucket_path(project_id, "/chats/#{campfire_id}/integrations.json"), body: body).json
+      end
+
+      # Updates an existing chatbot.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param campfire_id [Integer, String] campfire ID
+      # @param chatbot_id [Integer, String] chatbot ID
+      # @param service_name [String] new chatbot name
+      # @param command_url [String, nil] new callback URL
+      # @return [Hash] updated chatbot
+      def update_chatbot(project_id:, campfire_id:, chatbot_id:, service_name:, command_url: nil)
+        body = compact_params(
+          service_name: service_name,
+          command_url: command_url
+        )
+        http_put(bucket_path(project_id, "/chats/#{campfire_id}/integrations/#{chatbot_id}.json"), body: body).json
+      end
+
+      # Deletes a chatbot.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param campfire_id [Integer, String] campfire ID
+      # @param chatbot_id [Integer, String] chatbot ID
+      # @return [void]
+      def delete_chatbot(project_id:, campfire_id:, chatbot_id:)
+        http_delete(bucket_path(project_id, "/chats/#{campfire_id}/integrations/#{chatbot_id}.json"))
+        nil
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/card_columns_service.rb
+++ b/ruby/lib/basecamp/services/card_columns_service.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for card column operations.
+    #
+    # Columns are lists within a card table that contain cards.
+    #
+    # @example Create a column
+    #   column = account.card_columns.create(
+    #     project_id: 123,
+    #     card_table_id: 456,
+    #     title: "In Review"
+    #   )
+    #
+    # @example Set column color
+    #   account.card_columns.set_color(project_id: 123, column_id: 456, color: "blue")
+    class CardColumnsService < BaseService
+      # Gets a column by ID.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param column_id [Integer, String] column ID
+      # @return [Hash] column data
+      def get(project_id:, column_id:)
+        http_get(bucket_path(project_id, "/card_tables/columns/#{column_id}.json")).json
+      end
+
+      # Creates a new column in a card table.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param card_table_id [Integer, String] card table ID
+      # @param title [String] column title
+      # @param description [String, nil] column description
+      # @return [Hash] created column
+      def create(project_id:, card_table_id:, title:, description: nil)
+        body = compact_params(
+          title: title,
+          description: description
+        )
+        http_post(bucket_path(project_id, "/card_tables/#{card_table_id}/columns.json"), body: body).json
+      end
+
+      # Updates an existing column.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param column_id [Integer, String] column ID
+      # @param title [String, nil] new title
+      # @param description [String, nil] new description
+      # @return [Hash] updated column
+      def update(project_id:, column_id:, title: nil, description: nil)
+        body = compact_params(
+          title: title,
+          description: description
+        )
+        http_put(bucket_path(project_id, "/card_tables/columns/#{column_id}.json"), body: body).json
+      end
+
+      # Moves a column within a card table.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param card_table_id [Integer, String] card table ID
+      # @param source_id [Integer, String] column ID to move
+      # @param target_id [Integer, String] column ID to move relative to
+      # @param position [Integer, nil] position relative to target
+      # @return [void]
+      def move(project_id:, card_table_id:, source_id:, target_id:, position: nil)
+        body = compact_params(
+          source_id: source_id,
+          target_id: target_id,
+          position: position
+        )
+        http_post(bucket_path(project_id, "/card_tables/#{card_table_id}/moves.json"), body: body)
+        nil
+      end
+
+      # Sets the color of a column.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param column_id [Integer, String] column ID
+      # @param color [String] color name (white, red, orange, yellow, green, blue, aqua, purple, gray, pink, brown)
+      # @return [Hash] updated column
+      def set_color(project_id:, column_id:, color:)
+        http_put(bucket_path(project_id, "/card_tables/columns/#{column_id}/color.json"),
+                 body: { color: color }).json
+      end
+
+      # Adds an on-hold section to a column.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param column_id [Integer, String] column ID
+      # @return [Hash] updated column
+      def enable_on_hold(project_id:, column_id:)
+        http_post(bucket_path(project_id, "/card_tables/columns/#{column_id}/on_hold.json")).json
+      end
+
+      # Removes the on-hold section from a column.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param column_id [Integer, String] column ID
+      # @return [Hash] updated column
+      def disable_on_hold(project_id:, column_id:)
+        http_delete(bucket_path(project_id, "/card_tables/columns/#{column_id}/on_hold.json")).json
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/card_steps_service.rb
+++ b/ruby/lib/basecamp/services/card_steps_service.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for card step (checklist item) operations.
+    #
+    # Steps are checklist items on cards in card tables.
+    #
+    # @example Create a step
+    #   step = account.card_steps.create(
+    #     project_id: 123,
+    #     card_id: 456,
+    #     title: "Review code",
+    #     due_on: "2024-12-15"
+    #   )
+    #
+    # @example Complete a step
+    #   account.card_steps.complete(project_id: 123, step_id: 789)
+    class CardStepsService < BaseService
+      # Creates a new step on a card.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param card_id [Integer, String] card ID
+      # @param title [String] step title
+      # @param due_on [String, nil] due date (YYYY-MM-DD)
+      # @param assignees [Array<Integer>, nil] person IDs to assign
+      # @return [Hash] created step
+      def create(project_id:, card_id:, title:, due_on: nil, assignees: nil)
+        body = compact_params(
+          title: title,
+          due_on: due_on,
+          assignees: assignees
+        )
+        http_post(bucket_path(project_id, "/card_tables/cards/#{card_id}/steps.json"), body: body).json
+      end
+
+      # Updates an existing step.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param step_id [Integer, String] step ID
+      # @param title [String, nil] new title
+      # @param due_on [String, nil] new due date (YYYY-MM-DD)
+      # @param assignees [Array<Integer>, nil] person IDs to assign
+      # @return [Hash] updated step
+      def update(project_id:, step_id:, title: nil, due_on: nil, assignees: nil)
+        body = compact_params(
+          title: title,
+          due_on: due_on,
+          assignees: assignees
+        )
+        http_put(bucket_path(project_id, "/card_tables/steps/#{step_id}.json"), body: body).json
+      end
+
+      # Marks a step as completed.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param step_id [Integer, String] step ID
+      # @return [Hash] updated step
+      def complete(project_id:, step_id:)
+        http_put(bucket_path(project_id, "/card_tables/steps/#{step_id}/completions.json")).json
+      end
+
+      # Marks a step as incomplete.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param step_id [Integer, String] step ID
+      # @return [Hash] updated step
+      def uncomplete(project_id:, step_id:)
+        http_delete(bucket_path(project_id, "/card_tables/steps/#{step_id}/completions.json")).json
+      end
+
+      # Changes the position of a step within a card.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param card_id [Integer, String] card ID
+      # @param step_id [Integer, String] step ID
+      # @param position [Integer] new position (0-indexed)
+      # @return [void]
+      def reposition(project_id:, card_id:, step_id:, position:)
+        http_post(bucket_path(project_id, "/card_tables/cards/#{card_id}/positions.json"),
+                  body: { source_id: step_id, position: position })
+        nil
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/card_tables_service.rb
+++ b/ruby/lib/basecamp/services/card_tables_service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for card table (kanban board) operations.
+    #
+    # Card Tables are kanban-style boards with columns containing cards.
+    #
+    # @example Get a card table
+    #   table = account.card_tables.get(project_id: 123, card_table_id: 456)
+    #   puts "#{table["title"]} - #{table["lists"].length} columns"
+    class CardTablesService < BaseService
+      # Gets a card table by ID.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param card_table_id [Integer, String] card table ID
+      # @return [Hash] card table with its columns
+      def get(project_id:, card_table_id:)
+        http_get(bucket_path(project_id, "/card_tables/#{card_table_id}.json")).json
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/cards_service.rb
+++ b/ruby/lib/basecamp/services/cards_service.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for card operations within card tables.
+    #
+    # Cards are items in card table columns. They can have steps (checklist items),
+    # assignees, and due dates.
+    #
+    # @example List cards in a column
+    #   account.cards.list(project_id: 123, column_id: 456).each do |card|
+    #     puts "#{card["title"]} - #{card["completed"] ? "done" : "pending"}"
+    #   end
+    #
+    # @example Create a card
+    #   card = account.cards.create(
+    #     project_id: 123,
+    #     column_id: 456,
+    #     title: "New Feature",
+    #     content: "<p>Feature description</p>",
+    #     due_on: "2024-12-31"
+    #   )
+    class CardsService < BaseService
+      # Lists all cards in a column.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param column_id [Integer, String] column ID
+      # @return [Enumerator<Hash>] cards
+      def list(project_id:, column_id:)
+        paginate(bucket_path(project_id, "/card_tables/lists/#{column_id}/cards.json"))
+      end
+
+      # Gets a card by ID.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param card_id [Integer, String] card ID
+      # @return [Hash] card data
+      def get(project_id:, card_id:)
+        http_get(bucket_path(project_id, "/card_tables/cards/#{card_id}.json")).json
+      end
+
+      # Creates a new card in a column.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param column_id [Integer, String] column ID
+      # @param title [String] card title
+      # @param content [String, nil] card body in HTML
+      # @param due_on [String, nil] due date (YYYY-MM-DD)
+      # @param notify [Boolean, nil] notify assignees
+      # @return [Hash] created card
+      def create(project_id:, column_id:, title:, content: nil, due_on: nil, notify: nil)
+        body = compact_params(
+          title: title,
+          content: content,
+          due_on: due_on,
+          notify: notify
+        )
+        http_post(bucket_path(project_id, "/card_tables/lists/#{column_id}/cards.json"), body: body).json
+      end
+
+      # Updates an existing card.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param card_id [Integer, String] card ID
+      # @param title [String, nil] new title
+      # @param content [String, nil] new content
+      # @param due_on [String, nil] new due date (YYYY-MM-DD)
+      # @param assignee_ids [Array<Integer>, nil] person IDs to assign
+      # @return [Hash] updated card
+      def update(project_id:, card_id:, title: nil, content: nil, due_on: nil, assignee_ids: nil)
+        body = compact_params(
+          title: title,
+          content: content,
+          due_on: due_on,
+          assignee_ids: assignee_ids
+        )
+        http_put(bucket_path(project_id, "/card_tables/cards/#{card_id}.json"), body: body).json
+      end
+
+      # Moves a card to a different column.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param card_id [Integer, String] card ID
+      # @param column_id [Integer, String] destination column ID
+      # @return [void]
+      def move(project_id:, card_id:, column_id:)
+        http_post(bucket_path(project_id, "/card_tables/cards/#{card_id}/moves.json"),
+                  body: { column_id: column_id })
+        nil
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/checkins_service.rb
+++ b/ruby/lib/basecamp/services/checkins_service.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for automatic check-in operations.
+    #
+    # Checkins (also called Automatic Check-ins) are scheduled questions
+    # that get sent to team members. The questionnaire contains questions,
+    # and each question can have multiple answers from different people.
+    #
+    # @example List questions
+    #   account.checkins.list_questions(project_id: 123, questionnaire_id: 456).each do |q|
+    #     puts "#{q["title"]} - #{q["paused"] ? "(paused)" : ""}"
+    #   end
+    #
+    # @example Create an answer
+    #   answer = account.checkins.create_answer(
+    #     project_id: 123,
+    #     question_id: 456,
+    #     content: "<p>Making great progress!</p>"
+    #   )
+    class CheckinsService < BaseService
+      # Gets a questionnaire by ID.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param questionnaire_id [Integer, String] questionnaire ID
+      # @return [Hash] questionnaire data
+      def get_questionnaire(project_id:, questionnaire_id:)
+        http_get(bucket_path(project_id, "/questionnaires/#{questionnaire_id}.json")).json
+      end
+
+      # Lists all questions in a questionnaire.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param questionnaire_id [Integer, String] questionnaire ID
+      # @return [Enumerator<Hash>] questions
+      def list_questions(project_id:, questionnaire_id:)
+        paginate(bucket_path(project_id, "/questionnaires/#{questionnaire_id}/questions.json"))
+      end
+
+      # Gets a question by ID.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param question_id [Integer, String] question ID
+      # @return [Hash] question data
+      def get_question(project_id:, question_id:)
+        http_get(bucket_path(project_id, "/questions/#{question_id}.json")).json
+      end
+
+      # Creates a new question in a questionnaire.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param questionnaire_id [Integer, String] questionnaire ID
+      # @param title [String] question text
+      # @param schedule [Hash] schedule configuration with frequency, days, hour, minute
+      # @return [Hash] created question
+      def create_question(project_id:, questionnaire_id:, title:, schedule:)
+        body = {
+          title: title,
+          schedule: schedule
+        }
+        http_post(bucket_path(project_id, "/questionnaires/#{questionnaire_id}/questions.json"), body: body).json
+      end
+
+      # Updates an existing question.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param question_id [Integer, String] question ID
+      # @param title [String, nil] new question text
+      # @param schedule [Hash, nil] new schedule configuration
+      # @param paused [Boolean, nil] whether the question is paused
+      # @return [Hash] updated question
+      def update_question(project_id:, question_id:, title: nil, schedule: nil, paused: nil)
+        body = compact_params(
+          title: title,
+          schedule: schedule,
+          paused: paused
+        )
+        http_put(bucket_path(project_id, "/questions/#{question_id}.json"), body: body).json
+      end
+
+      # Lists all answers for a question.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param question_id [Integer, String] question ID
+      # @return [Enumerator<Hash>] answers
+      def list_answers(project_id:, question_id:)
+        paginate(bucket_path(project_id, "/questions/#{question_id}/answers.json"))
+      end
+
+      # Gets an answer by ID.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param answer_id [Integer, String] answer ID
+      # @return [Hash] answer data
+      def get_answer(project_id:, answer_id:)
+        http_get(bucket_path(project_id, "/question_answers/#{answer_id}.json")).json
+      end
+
+      # Creates a new answer for a question.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param question_id [Integer, String] question ID
+      # @param content [String] answer content in HTML
+      # @param group_on [String, nil] date to group the answer with (ISO 8601)
+      # @return [Hash] created answer
+      def create_answer(project_id:, question_id:, content:, group_on: nil)
+        body = compact_params(
+          content: content,
+          group_on: group_on
+        )
+        http_post(bucket_path(project_id, "/questions/#{question_id}/answers.json"), body: body).json
+      end
+
+      # Updates an existing answer.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param answer_id [Integer, String] answer ID
+      # @param content [String] updated answer content in HTML
+      # @return [void]
+      def update_answer(project_id:, answer_id:, content:)
+        http_put(bucket_path(project_id, "/question_answers/#{answer_id}.json"), body: { content: content })
+        nil
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/client_approvals_service.rb
+++ b/ruby/lib/basecamp/services/client_approvals_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for client approval operations.
+    #
+    # Client approvals allow you to request approval from clients
+    # on specific deliverables or decisions within a project.
+    #
+    # @example List client approvals
+    #   account.client_approvals.list(project_id: 123).each do |approval|
+    #     puts "#{approval["subject"]} - #{approval["approval_status"]}"
+    #   end
+    class ClientApprovalsService < BaseService
+      # Lists all client approvals in a project.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @return [Enumerator<Hash>] client approvals
+      def list(project_id:)
+        paginate(bucket_path(project_id, "/client/approvals.json"))
+      end
+
+      # Gets a client approval by ID.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param approval_id [Integer, String] client approval ID
+      # @return [Hash] client approval data
+      def get(project_id:, approval_id:)
+        http_get(bucket_path(project_id, "/client/approvals/#{approval_id}.json")).json
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/client_correspondences_service.rb
+++ b/ruby/lib/basecamp/services/client_correspondences_service.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for client correspondence operations.
+    #
+    # Client correspondences are messages sent to and from clients
+    # within a project's client portal.
+    #
+    # @example List client correspondences
+    #   account.client_correspondences.list(project_id: 123).each do |c|
+    #     puts "#{c["subject"]} - #{c["replies_count"]} replies"
+    #   end
+    class ClientCorrespondencesService < BaseService
+      # Lists all client correspondences in a project.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @return [Enumerator<Hash>] client correspondences
+      def list(project_id:)
+        paginate(bucket_path(project_id, "/client/correspondences.json"))
+      end
+
+      # Gets a client correspondence by ID.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param correspondence_id [Integer, String] client correspondence ID
+      # @return [Hash] client correspondence data
+      def get(project_id:, correspondence_id:)
+        http_get(bucket_path(project_id, "/client/correspondences/#{correspondence_id}.json")).json
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/client_replies_service.rb
+++ b/ruby/lib/basecamp/services/client_replies_service.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for client reply operations.
+    #
+    # Client replies are responses to client correspondences or approvals
+    # within a project's client portal.
+    #
+    # @example List client replies
+    #   account.client_replies.list(project_id: 123, recording_id: 456).each do |r|
+    #     puts "#{r["creator"]["name"]}: #{r["content"]}"
+    #   end
+    class ClientRepliesService < BaseService
+      # Lists all replies for a client recording (correspondence or approval).
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param recording_id [Integer, String] parent correspondence/approval ID
+      # @return [Enumerator<Hash>] client replies
+      def list(project_id:, recording_id:)
+        paginate(bucket_path(project_id, "/client/recordings/#{recording_id}/replies.json"))
+      end
+
+      # Gets a specific client reply.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param recording_id [Integer, String] parent correspondence/approval ID
+      # @param reply_id [Integer, String] client reply ID
+      # @return [Hash] client reply data
+      def get(project_id:, recording_id:, reply_id:)
+        http_get(bucket_path(project_id, "/client/recordings/#{recording_id}/replies/#{reply_id}.json")).json
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/comments_service.rb
+++ b/ruby/lib/basecamp/services/comments_service.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for comment operations.
+    #
+    # Comments can be added to most recordings (todos, messages, etc.)
+    # in Basecamp. They support HTML content.
+    #
+    # @example List comments on a todo
+    #   account.comments.list(project_id: 123, recording_id: 456).each do |comment|
+    #     puts "#{comment["creator"]["name"]}: #{comment["content"]}"
+    #   end
+    #
+    # @example Create a comment
+    #   comment = account.comments.create(
+    #     project_id: 123,
+    #     recording_id: 456,
+    #     content: "<p>Great work on this!</p>"
+    #   )
+    class CommentsService < BaseService
+      # Lists all comments on a recording.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param recording_id [Integer, String] recording ID (todo, message, etc.)
+      # @return [Enumerator<Hash>] comments
+      def list(project_id:, recording_id:)
+        paginate(bucket_path(project_id, "/recordings/#{recording_id}/comments.json"))
+      end
+
+      # Gets a specific comment.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param comment_id [Integer, String] comment ID
+      # @return [Hash] comment data
+      def get(project_id:, comment_id:)
+        http_get(bucket_path(project_id, "/comments/#{comment_id}.json")).json
+      end
+
+      # Creates a new comment on a recording.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param recording_id [Integer, String] recording ID to comment on
+      # @param content [String] comment content in HTML
+      # @return [Hash] created comment
+      def create(project_id:, recording_id:, content:)
+        body = { content: content }
+        http_post(bucket_path(project_id, "/recordings/#{recording_id}/comments.json"), body: body).json
+      end
+
+      # Updates an existing comment.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param comment_id [Integer, String] comment ID
+      # @param content [String] new comment content in HTML
+      # @return [Hash] updated comment
+      def update(project_id:, comment_id:, content:)
+        body = { content: content }
+        http_put(bucket_path(project_id, "/comments/#{comment_id}.json"), body: body).json
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/documents_service.rb
+++ b/ruby/lib/basecamp/services/documents_service.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for document operations.
+    #
+    # Documents are rich text files stored within vaults. They support
+    # HTML content and can be in draft or active status.
+    #
+    # @example List documents in a vault
+    #   account.documents.list(project_id: 123, vault_id: 456).each do |doc|
+    #     puts "#{doc["title"]} - #{doc["comments_count"]} comments"
+    #   end
+    #
+    # @example Create a document
+    #   doc = account.documents.create(
+    #     project_id: 123,
+    #     vault_id: 456,
+    #     title: "Meeting Notes",
+    #     content: "<p>Notes from today's meeting...</p>"
+    #   )
+    class DocumentsService < BaseService
+      # Lists all documents in a vault.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param vault_id [Integer, String] vault ID
+      # @return [Enumerator<Hash>] documents
+      def list(project_id:, vault_id:)
+        paginate(bucket_path(project_id, "/vaults/#{vault_id}/documents.json"))
+      end
+
+      # Gets a specific document.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param document_id [Integer, String] document ID
+      # @return [Hash] document data
+      def get(project_id:, document_id:)
+        http_get(bucket_path(project_id, "/documents/#{document_id}.json")).json
+      end
+
+      # Creates a new document in a vault.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param vault_id [Integer, String] vault ID
+      # @param title [String] document title
+      # @param content [String, nil] document body in HTML
+      # @param status [String, nil] status ("drafted" or "active")
+      # @return [Hash] created document
+      def create(project_id:, vault_id:, title:, content: nil, status: nil)
+        body = compact_params(
+          title: title,
+          content: content,
+          status: status
+        )
+        http_post(bucket_path(project_id, "/vaults/#{vault_id}/documents.json"), body: body).json
+      end
+
+      # Updates an existing document.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param document_id [Integer, String] document ID
+      # @param title [String, nil] new title
+      # @param content [String, nil] new content
+      # @return [Hash] updated document
+      def update(project_id:, document_id:, title: nil, content: nil)
+        body = compact_params(
+          title: title,
+          content: content
+        )
+        http_put(bucket_path(project_id, "/documents/#{document_id}.json"), body: body).json
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/events_service.rb
+++ b/ruby/lib/basecamp/services/events_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for event operations.
+    #
+    # Events are activity records that track changes to recordings.
+    # An event is created any time a recording is modified (created,
+    # updated, completed, etc.).
+    #
+    # @example List events for a recording
+    #   account.events.list(project_id: 123, recording_id: 456).each do |event|
+    #     puts "#{event["action"]} by #{event["creator"]["name"]} at #{event["created_at"]}"
+    #   end
+    class EventsService < BaseService
+      # Lists all events for a recording.
+      # Events track all changes made to a recording over time.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param recording_id [Integer, String] recording ID
+      # @return [Enumerator<Hash>] events
+      def list(project_id:, recording_id:)
+        paginate(bucket_path(project_id, "/recordings/#{recording_id}/events.json"))
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/forwards_service.rb
+++ b/ruby/lib/basecamp/services/forwards_service.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for email forward operations.
+    #
+    # Forwards are emails that have been forwarded to a project's inbox.
+    # Team members can reply to forwarded emails from within Basecamp.
+    #
+    # @example List forwards in an inbox
+    #   account.forwards.list(project_id: 123, inbox_id: 456).each do |f|
+    #     puts "#{f["subject"]} - from #{f["from"]}"
+    #   end
+    #
+    # @example Create a reply
+    #   reply = account.forwards.create_reply(
+    #     project_id: 123,
+    #     forward_id: 456,
+    #     content: "<p>Thanks for reaching out!</p>"
+    #   )
+    class ForwardsService < BaseService
+      # Gets an inbox by ID.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param inbox_id [Integer, String] inbox ID
+      # @return [Hash] inbox data
+      def get_inbox(project_id:, inbox_id:)
+        http_get(bucket_path(project_id, "/inboxes/#{inbox_id}.json")).json
+      end
+
+      # Lists all forwards in an inbox.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param inbox_id [Integer, String] inbox ID
+      # @return [Enumerator<Hash>] forwards
+      def list(project_id:, inbox_id:)
+        paginate(bucket_path(project_id, "/inboxes/#{inbox_id}/forwards.json"))
+      end
+
+      # Gets a forward by ID.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param forward_id [Integer, String] forward ID
+      # @return [Hash] forward data
+      def get(project_id:, forward_id:)
+        http_get(bucket_path(project_id, "/inbox_forwards/#{forward_id}.json")).json
+      end
+
+      # Lists all replies to a forward.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param forward_id [Integer, String] forward ID
+      # @return [Enumerator<Hash>] replies
+      def list_replies(project_id:, forward_id:)
+        paginate(bucket_path(project_id, "/inbox_forwards/#{forward_id}/replies.json"))
+      end
+
+      # Gets a specific reply.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param forward_id [Integer, String] forward ID
+      # @param reply_id [Integer, String] reply ID
+      # @return [Hash] reply data
+      def get_reply(project_id:, forward_id:, reply_id:)
+        http_get(bucket_path(project_id, "/inbox_forwards/#{forward_id}/replies/#{reply_id}.json")).json
+      end
+
+      # Creates a reply to a forwarded email.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param forward_id [Integer, String] forward ID
+      # @param content [String] reply body in HTML
+      # @return [Hash] created reply
+      def create_reply(project_id:, forward_id:, content:)
+        body = { content: content }
+        http_post(bucket_path(project_id, "/inbox_forwards/#{forward_id}/replies.json"), body: body).json
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/lineup_service.rb
+++ b/ruby/lib/basecamp/services/lineup_service.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for lineup operations.
+    #
+    # The Lineup is Basecamp's visual timeline tool for tracking
+    # project schedules and milestones.
+    #
+    # @example Create a marker
+    #   marker = account.lineup.create_marker(
+    #     title: "Launch Day",
+    #     starts_on: "2024-03-01",
+    #     ends_on: "2024-03-01",
+    #     color: "green"
+    #   )
+    class LineupService < BaseService
+      # Creates a new marker on the lineup.
+      #
+      # @param title [String] marker title
+      # @param starts_on [String] start date (YYYY-MM-DD)
+      # @param ends_on [String] end date (YYYY-MM-DD)
+      # @param color [String, nil] marker color (white, red, orange, yellow, green, blue, aqua, purple, gray, pink, brown)
+      # @param description [String, nil] description in HTML
+      # @return [Hash] created marker
+      def create_marker(title:, starts_on:, ends_on:, color: nil, description: nil)
+        body = compact_params(
+          title: title,
+          starts_on: starts_on,
+          ends_on: ends_on,
+          color: color,
+          description: description
+        )
+        http_post("/lineup/markers.json", body: body).json
+      end
+
+      # Updates an existing marker.
+      #
+      # @param marker_id [Integer, String] marker ID
+      # @param title [String, nil] new title
+      # @param starts_on [String, nil] new start date (YYYY-MM-DD)
+      # @param ends_on [String, nil] new end date (YYYY-MM-DD)
+      # @param color [String, nil] new color
+      # @param description [String, nil] new description
+      # @return [Hash] updated marker
+      def update_marker(marker_id:, title: nil, starts_on: nil, ends_on: nil, color: nil, description: nil)
+        body = compact_params(
+          title: title,
+          starts_on: starts_on,
+          ends_on: ends_on,
+          color: color,
+          description: description
+        )
+        http_put("/lineup/markers/#{marker_id}", body: body).json
+      end
+
+      # Deletes a marker.
+      #
+      # @param marker_id [Integer, String] marker ID
+      # @return [void]
+      def delete_marker(marker_id:)
+        http_delete("/lineup/markers/#{marker_id}")
+        nil
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/message_boards_service.rb
+++ b/ruby/lib/basecamp/services/message_boards_service.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for message board operations.
+    #
+    # Each project has a message board where team members can post messages
+    # (announcements, updates, etc.).
+    #
+    # @example Get a message board
+    #   board = account.message_boards.get(project_id: 123, board_id: 456)
+    #   puts "#{board["title"]} - #{board["messages_count"]} messages"
+    class MessageBoardsService < BaseService
+      # Gets a specific message board.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param board_id [Integer, String] message board ID
+      # @return [Hash] message board data
+      def get(project_id:, board_id:)
+        http_get(bucket_path(project_id, "/message_boards/#{board_id}")).json
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/message_types_service.rb
+++ b/ruby/lib/basecamp/services/message_types_service.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for message type (category) operations.
+    #
+    # Message types (also called categories) are used to categorize messages
+    # on a message board. Each message type has a name and icon.
+    #
+    # @example List message types
+    #   account.message_types.list(project_id: 123).each do |type|
+    #     puts "#{type["icon"]} #{type["name"]}"
+    #   end
+    #
+    # @example Create a message type
+    #   type = account.message_types.create(
+    #     project_id: 123,
+    #     name: "Announcement",
+    #     icon: "📢"
+    #   )
+    class MessageTypesService < BaseService
+      # Lists all message types in a project.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @return [Enumerator<Hash>] message types
+      def list(project_id:)
+        paginate(bucket_path(project_id, "/categories.json"))
+      end
+
+      # Gets a message type by ID.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param type_id [Integer, String] message type ID
+      # @return [Hash] message type data
+      def get(project_id:, type_id:)
+        http_get(bucket_path(project_id, "/categories/#{type_id}")).json
+      end
+
+      # Creates a new message type in a project.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param name [String] message type name
+      # @param icon [String] message type icon
+      # @return [Hash] created message type
+      def create(project_id:, name:, icon:)
+        body = {
+          name: name,
+          icon: icon
+        }
+        http_post(bucket_path(project_id, "/categories.json"), body: body).json
+      end
+
+      # Updates an existing message type.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param type_id [Integer, String] message type ID
+      # @param name [String, nil] new name
+      # @param icon [String, nil] new icon
+      # @return [Hash] updated message type
+      def update(project_id:, type_id:, name: nil, icon: nil)
+        body = compact_params(
+          name: name,
+          icon: icon
+        )
+        http_put(bucket_path(project_id, "/categories/#{type_id}"), body: body).json
+      end
+
+      # Deletes a message type from a project.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param type_id [Integer, String] message type ID
+      # @return [void]
+      def delete(project_id:, type_id:)
+        http_delete(bucket_path(project_id, "/categories/#{type_id}"))
+        nil
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/messages_service.rb
+++ b/ruby/lib/basecamp/services/messages_service.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for message operations.
+    #
+    # Messages are posts on a project's message board. They have a subject,
+    # content, and can be categorized with message types.
+    #
+    # @example List messages
+    #   account.messages.list(project_id: 123, board_id: 456).each do |message|
+    #     puts "#{message["subject"]} by #{message["creator"]["name"]}"
+    #   end
+    #
+    # @example Create a message
+    #   message = account.messages.create(
+    #     project_id: 123,
+    #     board_id: 456,
+    #     subject: "Project Update",
+    #     content: "<p>Here's what happened this week...</p>"
+    #   )
+    #
+    # @example Pin a message
+    #   account.messages.pin(project_id: 123, message_id: 789)
+    class MessagesService < BaseService
+      # Lists all messages on a message board.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param board_id [Integer, String] message board ID
+      # @return [Enumerator<Hash>] messages
+      def list(project_id:, board_id:)
+        paginate(bucket_path(project_id, "/message_boards/#{board_id}/messages.json"))
+      end
+
+      # Gets a specific message.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param message_id [Integer, String] message ID
+      # @return [Hash] message data
+      def get(project_id:, message_id:)
+        http_get(bucket_path(project_id, "/messages/#{message_id}")).json
+      end
+
+      # Creates a new message on a message board.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param board_id [Integer, String] message board ID
+      # @param subject [String] message title
+      # @param content [String, nil] message body in HTML
+      # @param status [String, nil] "drafted" or "active" (defaults to active)
+      # @param category_id [Integer, nil] message type ID
+      # @return [Hash] created message
+      def create(project_id:, board_id:, subject:, content: nil, status: nil, category_id: nil)
+        body = compact_params(
+          subject: subject,
+          content: content,
+          status: status,
+          category_id: category_id
+        )
+        http_post(bucket_path(project_id, "/message_boards/#{board_id}/messages.json"), body: body).json
+      end
+
+      # Updates an existing message.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param message_id [Integer, String] message ID
+      # @param subject [String, nil] new title
+      # @param content [String, nil] new content in HTML
+      # @param status [String, nil] "drafted" or "active"
+      # @param category_id [Integer, nil] message type ID
+      # @return [Hash] updated message
+      def update(project_id:, message_id:, subject: nil, content: nil, status: nil, category_id: nil)
+        body = compact_params(
+          subject: subject,
+          content: content,
+          status: status,
+          category_id: category_id
+        )
+        http_put(bucket_path(project_id, "/messages/#{message_id}"), body: body).json
+      end
+
+      # Pins a message to the top of the message board.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param message_id [Integer, String] message ID
+      # @return [void]
+      def pin(project_id:, message_id:)
+        http_post(bucket_path(project_id, "/recordings/#{message_id}/pin.json"))
+        nil
+      end
+
+      # Unpins a message from the top of the message board.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param message_id [Integer, String] message ID
+      # @return [void]
+      def unpin(project_id:, message_id:)
+        http_delete(bucket_path(project_id, "/recordings/#{message_id}/pin.json"))
+        nil
+      end
+
+      # Archives a message.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param message_id [Integer, String] message ID
+      # @return [void]
+      def archive(project_id:, message_id:)
+        http_put(bucket_path(project_id, "/recordings/#{message_id}/status/archived.json"))
+        nil
+      end
+
+      # Restores an archived message to active status.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param message_id [Integer, String] message ID
+      # @return [void]
+      def unarchive(project_id:, message_id:)
+        http_put(bucket_path(project_id, "/recordings/#{message_id}/status/active.json"))
+        nil
+      end
+
+      # Moves a message to the trash.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param message_id [Integer, String] message ID
+      # @return [void]
+      def trash(project_id:, message_id:)
+        http_put(bucket_path(project_id, "/recordings/#{message_id}/status/trashed.json"))
+        nil
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/people_service.rb
+++ b/ruby/lib/basecamp/services/people_service.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for people operations.
+    #
+    # People are the users in your Basecamp account.
+    #
+    # @example List all people
+    #   account.people.list.each do |person|
+    #     puts "#{person["name"]} <#{person["email_address"]}>"
+    #   end
+    #
+    # @example Get current user's profile
+    #   me = account.people.me
+    #   puts "Logged in as #{me["name"]}"
+    class PeopleService < BaseService
+      # Lists all people in the account.
+      #
+      # @return [Enumerator<Hash>] people
+      def list
+        paginate("/people.json")
+      end
+
+      # Gets a specific person.
+      #
+      # @param person_id [Integer, String] person ID
+      # @return [Hash] person data
+      def get(person_id:)
+        http_get("/people/#{person_id}").json
+      end
+
+      # Gets the current user's profile.
+      #
+      # @return [Hash] current user's profile
+      def me
+        http_get("/my/profile.json").json
+      end
+
+      # Lists all people who can be pinged (mentioned).
+      #
+      # @return [Enumerator<Hash>] pingable people
+      def list_pingable
+        paginate("/circles/people.json")
+      end
+
+      # Lists all people in a project.
+      #
+      # @param project_id [Integer, String] project ID
+      # @return [Enumerator<Hash>] project members
+      def list_project_people(project_id:)
+        paginate("/projects/#{project_id}/people.json")
+      end
+
+      # Updates project access for users.
+      #
+      # @param project_id [Integer, String] project ID
+      # @param grant [Array<Integer>, nil] user IDs to grant access
+      # @param revoke [Array<Integer>, nil] user IDs to revoke access
+      # @param create [Array<Hash>, nil] new users to create and grant access
+      # @return [void]
+      def update_project_access(project_id:, grant: nil, revoke: nil, create: nil)
+        body = compact_params(
+          grant: grant,
+          revoke: revoke,
+          create: create
+        )
+        http_put("/projects/#{project_id}/people/users.json", body: body)
+        nil
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/projects_service.rb
+++ b/ruby/lib/basecamp/services/projects_service.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for project (Basecamp) operations.
+    #
+    # @example List all projects
+    #   account.projects.list.each do |project|
+    #     puts "#{project["name"]} (#{project["id"]})"
+    #   end
+    #
+    # @example Get a specific project
+    #   project = account.projects.get(123)
+    #   puts project["name"]
+    #
+    # @example Create a project
+    #   project = account.projects.create(name: "My Project", description: "A new project")
+    class ProjectsService < BaseService
+      # Lists all projects in the account.
+      #
+      # @param status [String, nil] filter by status ("active", "archived", "trashed")
+      # @return [Enumerator<Hash>] projects
+      def list(status: nil)
+        params = compact_params(status: status)
+        paginate("/projects.json", params: params)
+      end
+
+      # Gets a specific project.
+      #
+      # @param project_id [Integer, String] project ID
+      # @return [Hash] project data
+      def get(project_id)
+        http_get("/projects/#{project_id}.json").json
+      end
+
+      # Creates a new project.
+      #
+      # @param name [String] project name
+      # @param description [String, nil] project description
+      # @return [Hash] created project
+      def create(name:, description: nil)
+        body = compact_params(name: name, description: description)
+        http_post("/projects.json", body: body).json
+      end
+
+      # Updates a project.
+      #
+      # @param project_id [Integer, String] project ID
+      # @param name [String, nil] new name
+      # @param description [String, nil] new description
+      # @return [Hash] updated project
+      def update(project_id, name: nil, description: nil)
+        body = compact_params(name: name, description: description)
+        http_put("/projects/#{project_id}.json", body: body).json
+      end
+
+      # Trashes a project.
+      #
+      # @param project_id [Integer, String] project ID
+      # @return [void]
+      def trash(project_id)
+        http_delete("/projects/#{project_id}.json")
+        nil
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/recordings_service.rb
+++ b/ruby/lib/basecamp/services/recordings_service.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for recording operations.
+    #
+    # Recordings are the base type for most content in Basecamp, including
+    # todos, messages, comments, documents, uploads, etc. This service
+    # provides common operations that work across all recording types.
+    #
+    # @example List all recordings in a project
+    #   account.recordings.list(type: "Todo", bucket: 123).each do |recording|
+    #     puts "#{recording["title"]} - #{recording["status"]}"
+    #   end
+    #
+    # @example Archive a recording
+    #   account.recordings.archive(project_id: 123, recording_id: 456)
+    class RecordingsService < BaseService
+      # Lists recordings across projects.
+      #
+      # @param type [String] recording type (e.g., "Todo", "Message", "Comment")
+      # @param bucket [Integer, nil] filter by project ID
+      # @param status [String, nil] filter by status ("active", "archived", "trashed")
+      # @param sort [String, nil] sort field ("created_at", "updated_at")
+      # @param direction [String, nil] sort direction ("asc", "desc")
+      # @return [Enumerator<Hash>] recordings
+      def list(type:, bucket: nil, status: nil, sort: nil, direction: nil)
+        params = compact_params(
+          type: type,
+          bucket: bucket,
+          status: status,
+          sort: sort,
+          direction: direction
+        )
+        paginate("/projects/recordings.json", params: params)
+      end
+
+      # Gets a specific recording.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param recording_id [Integer, String] recording ID
+      # @return [Hash] recording data
+      def get(project_id:, recording_id:)
+        http_get(bucket_path(project_id, "/recordings/#{recording_id}")).json
+      end
+
+      # Archives a recording.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param recording_id [Integer, String] recording ID
+      # @return [void]
+      def archive(project_id:, recording_id:)
+        http_put(bucket_path(project_id, "/recordings/#{recording_id}/status/archived.json"))
+        nil
+      end
+
+      # Unarchives a recording (restores to active).
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param recording_id [Integer, String] recording ID
+      # @return [void]
+      def unarchive(project_id:, recording_id:)
+        http_put(bucket_path(project_id, "/recordings/#{recording_id}/status/active.json"))
+        nil
+      end
+
+      # Moves a recording to the trash.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param recording_id [Integer, String] recording ID
+      # @return [void]
+      def trash(project_id:, recording_id:)
+        http_put(bucket_path(project_id, "/recordings/#{recording_id}/status/trashed.json"))
+        nil
+      end
+
+      # Lists events (change history) for a recording.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param recording_id [Integer, String] recording ID
+      # @return [Enumerator<Hash>] events
+      def list_events(project_id:, recording_id:)
+        paginate(bucket_path(project_id, "/recordings/#{recording_id}/events.json"))
+      end
+
+      # Gets the subscription status for a recording.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param recording_id [Integer, String] recording ID
+      # @return [Hash] subscription data
+      def get_subscription(project_id:, recording_id:)
+        http_get(bucket_path(project_id, "/recordings/#{recording_id}/subscription.json")).json
+      end
+
+      # Subscribes to a recording.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param recording_id [Integer, String] recording ID
+      # @return [Hash] subscription data
+      def subscribe(project_id:, recording_id:)
+        http_post(bucket_path(project_id, "/recordings/#{recording_id}/subscription.json")).json
+      end
+
+      # Unsubscribes from a recording.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param recording_id [Integer, String] recording ID
+      # @return [void]
+      def unsubscribe(project_id:, recording_id:)
+        http_delete(bucket_path(project_id, "/recordings/#{recording_id}/subscription.json"))
+        nil
+      end
+
+      # Sets client visibility for a recording.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param recording_id [Integer, String] recording ID
+      # @param visible [Boolean] whether clients can see this recording
+      # @return [void]
+      def set_client_visibility(project_id:, recording_id:, visible:)
+        http_put(bucket_path(project_id, "/recordings/#{recording_id}/client_visibility.json"),
+                 body: { visible: visible })
+        nil
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/reports_service.rb
+++ b/ruby/lib/basecamp/services/reports_service.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for report operations.
+    #
+    # Provides access to various report types including timesheet and assigned todos reports.
+    #
+    # @example Get account-wide timesheet
+    #   result = account.reports.timesheet
+    #   result["entries"].each { |e| puts e["hours"] }
+    #
+    # @example Get list of people with assigned todos
+    #   people = account.reports.assignable_people.to_a
+    #
+    # @example Get todos assigned to a specific person
+    #   result = account.reports.assigned_todos(person_id: 123)
+    #   result["todos"].each { |todo| puts todo["content"] }
+    class ReportsService < BaseService
+      # Returns the account-wide timesheet report.
+      # This includes time entries across all projects in the account.
+      #
+      # @param from [String, nil] filter entries on or after this date (ISO 8601)
+      # @param to [String, nil] filter entries on or before this date (ISO 8601)
+      # @param person_id [Integer, nil] filter entries by a specific person
+      # @return [Hash] timesheet report object with "entries" array
+      def timesheet(from: nil, to: nil, person_id: nil)
+        params = compact_params(from: from, to: to, person_id: person_id)
+        response = http_get("/reports/timesheet.json", params: params)
+        response.json
+      end
+
+      # Returns the timesheet report for a specific project.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param from [String, nil] filter entries on or after this date (ISO 8601)
+      # @param to [String, nil] filter entries on or before this date (ISO 8601)
+      # @param person_id [Integer, nil] filter entries by a specific person
+      # @return [Hash] timesheet report object with "entries" array
+      def project_timesheet(project_id:, from: nil, to: nil, person_id: nil)
+        params = compact_params(from: from, to: to, person_id: person_id)
+        response = http_get(bucket_path(project_id, "/timesheet.json"), params: params)
+        response.json
+      end
+
+      # Returns the timesheet report for a specific recording within a project.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param recording_id [Integer, String] recording ID (e.g., a todo or message)
+      # @param from [String, nil] filter entries on or after this date (ISO 8601)
+      # @param to [String, nil] filter entries on or before this date (ISO 8601)
+      # @param person_id [Integer, nil] filter entries by a specific person
+      # @return [Hash] timesheet report object with "entries" array
+      def recording_timesheet(project_id:, recording_id:, from: nil, to: nil, person_id: nil)
+        params = compact_params(from: from, to: to, person_id: person_id)
+        response = http_get(bucket_path(project_id, "/recordings/#{recording_id}/timesheet.json"), params: params)
+        response.json
+      end
+
+      # Returns the list of people who have assigned todos.
+      # Use assigned_todos(person_id:) to get the actual todos for a specific person.
+      #
+      # @return [Enumerator<Hash>] list of Person objects
+      def assignable_people
+        paginate("/reports/todos/assigned.json")
+      end
+
+      # Returns all todos assigned to a specific person.
+      #
+      # @param person_id [Integer, String] person ID
+      # @param group_by [String, nil] grouping method: "bucket" or "date"
+      # @return [Hash] object with "person", "grouped_by", and "todos" keys
+      def assigned_todos(person_id:, group_by: nil)
+        params = compact_params(group_by: group_by)
+        response = http_get("/reports/todos/assigned/#{person_id}", params: params)
+        response.json
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/schedules_service.rb
+++ b/ruby/lib/basecamp/services/schedules_service.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for schedule (calendar) operations.
+    #
+    # Schedules are calendars within projects that contain schedule entries (events).
+    # Each project has one schedule that can optionally show todo due dates.
+    #
+    # @example Get a schedule
+    #   schedule = account.schedules.get(project_id: 123, schedule_id: 456)
+    #
+    # @example List entries
+    #   account.schedules.list_entries(project_id: 123, schedule_id: 456).each do |entry|
+    #     puts "#{entry["summary"]} - #{entry["starts_at"]}"
+    #   end
+    #
+    # @example Create an entry
+    #   entry = account.schedules.create_entry(
+    #     project_id: 123,
+    #     schedule_id: 456,
+    #     summary: "Team Meeting",
+    #     starts_at: "2024-12-15T09:00:00Z",
+    #     ends_at: "2024-12-15T10:00:00Z"
+    #   )
+    class SchedulesService < BaseService
+      # Gets a specific schedule.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param schedule_id [Integer, String] schedule ID
+      # @return [Hash] schedule data
+      def get(project_id:, schedule_id:)
+        http_get(bucket_path(project_id, "/schedules/#{schedule_id}")).json
+      end
+
+      # Lists all entries on a schedule.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param schedule_id [Integer, String] schedule ID
+      # @return [Enumerator<Hash>] schedule entries
+      def list_entries(project_id:, schedule_id:)
+        paginate(bucket_path(project_id, "/schedules/#{schedule_id}/entries.json"))
+      end
+
+      # Gets a specific schedule entry.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param entry_id [Integer, String] schedule entry ID
+      # @return [Hash] schedule entry data
+      def get_entry(project_id:, entry_id:)
+        http_get(bucket_path(project_id, "/schedule_entries/#{entry_id}")).json
+      end
+
+      # Creates a new entry on a schedule.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param schedule_id [Integer, String] schedule ID
+      # @param summary [String] event title
+      # @param starts_at [String] start time in RFC3339 format
+      # @param ends_at [String] end time in RFC3339 format
+      # @param description [String, nil] event description in HTML
+      # @param participant_ids [Array<Integer>, nil] person IDs to assign
+      # @param all_day [Boolean, nil] whether this is an all-day event
+      # @param notify [Boolean, nil] whether to notify participants
+      # @return [Hash] created entry
+      def create_entry(
+        project_id:,
+        schedule_id:,
+        summary:,
+        starts_at:,
+        ends_at:,
+        description: nil,
+        participant_ids: nil,
+        all_day: nil,
+        notify: nil
+      )
+        body = compact_params(
+          summary: summary,
+          starts_at: starts_at,
+          ends_at: ends_at,
+          description: description,
+          participant_ids: participant_ids,
+          all_day: all_day,
+          notify: notify
+        )
+        http_post(bucket_path(project_id, "/schedules/#{schedule_id}/entries.json"), body: body).json
+      end
+
+      # Updates an existing schedule entry.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param entry_id [Integer, String] schedule entry ID
+      # @param summary [String, nil] new title
+      # @param starts_at [String, nil] new start time in RFC3339 format
+      # @param ends_at [String, nil] new end time in RFC3339 format
+      # @param description [String, nil] new description in HTML
+      # @param participant_ids [Array<Integer>, nil] new participant IDs
+      # @param all_day [Boolean, nil] whether this is an all-day event
+      # @param notify [Boolean, nil] whether to notify participants
+      # @return [Hash] updated entry
+      def update_entry(
+        project_id:,
+        entry_id:,
+        summary: nil,
+        starts_at: nil,
+        ends_at: nil,
+        description: nil,
+        participant_ids: nil,
+        all_day: nil,
+        notify: nil
+      )
+        body = compact_params(
+          summary: summary,
+          starts_at: starts_at,
+          ends_at: ends_at,
+          description: description,
+          participant_ids: participant_ids,
+          all_day: all_day,
+          notify: notify
+        )
+        http_put(bucket_path(project_id, "/schedule_entries/#{entry_id}"), body: body).json
+      end
+
+      # Gets a specific occurrence of a recurring schedule entry.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param entry_id [Integer, String] schedule entry ID
+      # @param date [String] occurrence date in YYYY-MM-DD format
+      # @return [Hash] schedule entry occurrence
+      def get_entry_occurrence(project_id:, entry_id:, date:)
+        http_get(bucket_path(project_id, "/schedule_entries/#{entry_id}/occurrences/#{date}")).json
+      end
+
+      # Updates schedule settings.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param schedule_id [Integer, String] schedule ID
+      # @param include_due_assignments [Boolean] whether to show todo due dates
+      # @return [Hash] updated schedule
+      def update_settings(project_id:, schedule_id:, include_due_assignments:)
+        body = { include_due_assignments: include_due_assignments }
+        http_put(bucket_path(project_id, "/schedules/#{schedule_id}"), body: body).json
+      end
+
+      # Moves a schedule entry to the trash.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param entry_id [Integer, String] schedule entry ID
+      # @return [void]
+      def trash_entry(project_id:, entry_id:)
+        http_put(bucket_path(project_id, "/recordings/#{entry_id}/status/trashed.json"))
+        nil
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/search_service.rb
+++ b/ruby/lib/basecamp/services/search_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for search operations.
+    #
+    # Provides full-text search across all content in your Basecamp account.
+    #
+    # @example Search for content
+    #   results = account.search.search(query: "quarterly report")
+    #   results.each { |r| puts r["title"] }
+    #
+    # @example Get search metadata
+    #   metadata = account.search.metadata
+    #   puts "Available projects: #{metadata["projects"].length}"
+    class SearchService < BaseService
+      # Searches for content across the account.
+      #
+      # @param query [String] the search query string
+      # @param sort [String, nil] sort order ("created_at" or "updated_at")
+      # @return [Enumerator<Hash>] search results
+      def search(query:, sort: nil)
+        params = compact_params(query: query, sort: sort)
+        paginate("/search.json", params: params)
+      end
+
+      # Returns metadata about available search scopes.
+      # This includes the list of projects available for filtering.
+      #
+      # @return [Hash] search metadata with available filter options
+      def metadata
+        http_get("/searches/metadata.json").json
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/subscriptions_service.rb
+++ b/ruby/lib/basecamp/services/subscriptions_service.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for subscription operations.
+    #
+    # Subscriptions control who receives notifications for a specific recording
+    # (like a todo, message, or comment). Users can subscribe or unsubscribe
+    # themselves, and you can batch update subscriptions for multiple users.
+    #
+    # @example Get subscription info
+    #   subscription = account.subscriptions.get(project_id: 123, recording_id: 456)
+    #   puts "Subscribed: #{subscription["subscribed"]}, Count: #{subscription["count"]}"
+    #
+    # @example Batch update subscriptions
+    #   account.subscriptions.update(
+    #     project_id: 123,
+    #     recording_id: 456,
+    #     subscriptions: [user_id_1, user_id_2],
+    #     unsubscriptions: [user_id_3]
+    #   )
+    class SubscriptionsService < BaseService
+      # Gets the subscription information for a recording.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param recording_id [Integer, String] recording ID
+      # @return [Hash] subscription info with subscribed, count, subscribers
+      def get(project_id:, recording_id:)
+        http_get(bucket_path(project_id, "/recordings/#{recording_id}/subscription.json")).json
+      end
+
+      # Subscribes the current user to the recording.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param recording_id [Integer, String] recording ID
+      # @return [Hash] updated subscription information
+      def subscribe(project_id:, recording_id:)
+        http_post(bucket_path(project_id, "/recordings/#{recording_id}/subscription.json")).json
+      end
+
+      # Unsubscribes the current user from the recording.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param recording_id [Integer, String] recording ID
+      # @return [void]
+      def unsubscribe(project_id:, recording_id:)
+        http_delete(bucket_path(project_id, "/recordings/#{recording_id}/subscription.json"))
+        nil
+      end
+
+      # Batch modifies subscriptions by adding or removing specific users.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param recording_id [Integer, String] recording ID
+      # @param subscriptions [Array<Integer>, nil] person IDs to subscribe
+      # @param unsubscriptions [Array<Integer>, nil] person IDs to unsubscribe
+      # @return [Hash] updated subscription information
+      def update(project_id:, recording_id:, subscriptions: nil, unsubscriptions: nil)
+        body = compact_params(
+          subscriptions: subscriptions,
+          unsubscriptions: unsubscriptions
+        )
+        http_put(bucket_path(project_id, "/recordings/#{recording_id}/subscription.json"), body: body).json
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/templates_service.rb
+++ b/ruby/lib/basecamp/services/templates_service.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for template operations.
+    #
+    # Templates allow you to create reusable project structures.
+    #
+    # @example List templates
+    #   account.templates.list.each do |template|
+    #     puts template["name"]
+    #   end
+    #
+    # @example Create a project from template
+    #   construction = account.templates.create_project(
+    #     template_id: 123,
+    #     name: "Q1 Planning"
+    #   )
+    class TemplatesService < BaseService
+      # Lists all templates visible to the current user.
+      #
+      # @return [Enumerator<Hash>] templates
+      def list
+        paginate("/templates.json")
+      end
+
+      # Gets a template by ID.
+      #
+      # @param template_id [Integer, String] template ID
+      # @return [Hash] template data
+      def get(template_id:)
+        http_get("/templates/#{template_id}").json
+      end
+
+      # Creates a new template.
+      #
+      # @param name [String] template name
+      # @param description [String, nil] template description
+      # @return [Hash] created template
+      def create(name:, description: nil)
+        body = compact_params(
+          name: name,
+          description: description
+        )
+        http_post("/templates.json", body: body).json
+      end
+
+      # Updates an existing template.
+      #
+      # @param template_id [Integer, String] template ID
+      # @param name [String] new name
+      # @param description [String, nil] new description
+      # @return [Hash] updated template
+      def update(template_id:, name:, description: nil)
+        body = compact_params(
+          name: name,
+          description: description
+        )
+        http_put("/templates/#{template_id}", body: body).json
+      end
+
+      # Deletes a template.
+      #
+      # @param template_id [Integer, String] template ID
+      # @return [void]
+      def delete(template_id:)
+        http_delete("/templates/#{template_id}")
+        nil
+      end
+
+      # Creates a new project from a template.
+      # This operation is asynchronous. Use get_construction to check status.
+      #
+      # @param template_id [Integer, String] template ID
+      # @param name [String] project name
+      # @param description [String, nil] project description
+      # @return [Hash] project construction status
+      def create_project(template_id:, name:, description: nil)
+        body = compact_params(
+          name: name,
+          description: description
+        )
+        http_post("/templates/#{template_id}/project_constructions.json", body: body).json
+      end
+
+      # Gets the status of a project construction.
+      #
+      # @param template_id [Integer, String] template ID
+      # @param construction_id [Integer, String] construction ID
+      # @return [Hash] project construction status
+      def get_construction(template_id:, construction_id:)
+        http_get("/templates/#{template_id}/project_constructions/#{construction_id}").json
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/timeline_service.rb
+++ b/ruby/lib/basecamp/services/timeline_service.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for timeline and progress report operations.
+    #
+    # Provides access to activity feeds showing recent activity across the account,
+    # within specific projects, or for specific people.
+    #
+    # @example Get account-wide progress report
+    #   account.timeline.progress.each { |event| puts event["action"] }
+    #
+    # @example Get project timeline
+    #   account.timeline.project_timeline(project_id: 123).each { |event| puts event }
+    #
+    # @example Get a person's progress (returns hash with person info)
+    #   result = account.timeline.person_progress(person_id: 456)
+    #   puts result["person"]["name"]
+    #   result["events"].each { |event| puts event["action"] }
+    class TimelineService < BaseService
+      # Returns the account-wide progress report.
+      # This shows recent activity across all projects.
+      # Results are paginated via Link header.
+      #
+      # @return [Enumerator<Hash>] timeline events
+      def progress
+        paginate_key("/reports/progress.json", key: "events")
+      end
+
+      # Returns the activity timeline for a specific project.
+      # Results are paginated via Link header.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @return [Enumerator<Hash>] timeline events
+      def project_timeline(project_id:)
+        paginate_key(bucket_path(project_id, "/timeline.json"), key: "events")
+      end
+
+      # Returns the progress report for a specific person, including person metadata.
+      #
+      # @note Returns first page only to preserve person metadata.
+      #       Use {#person_progress_events} for full paginated event stream.
+      # @param person_id [Integer, String] person ID
+      # @return [Hash] object with "person" and "events" keys
+      def person_progress(person_id:)
+        response = http_get("/reports/users/progress/#{person_id}")
+        response.json
+      end
+
+      # Returns all progress events for a specific person.
+      # Results are paginated via Link header.
+      #
+      # @note Does not include person metadata. Use {#person_progress} if you need
+      #       the person object along with the first page of events.
+      # @param person_id [Integer, String] person ID
+      # @return [Enumerator<Hash>] timeline events
+      def person_progress_events(person_id:)
+        paginate_key("/reports/users/progress/#{person_id}", key: "events")
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/timesheet_service.rb
+++ b/ruby/lib/basecamp/services/timesheet_service.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for timesheet report operations.
+    #
+    # Provides access to timesheet reports at account, project, and recording levels.
+    # Supports filtering by date range and person.
+    #
+    # @example Get account-wide timesheet
+    #   result = account.timesheet.report
+    #   result["entries"].each { |e| puts e["hours"] }
+    #
+    # @example Get project timesheet with filters
+    #   result = account.timesheet.project_report(
+    #     project_id: 123,
+    #     from: "2024-01-01",
+    #     to: "2024-01-31"
+    #   )
+    #
+    # @example Get timesheet for a specific todo
+    #   result = account.timesheet.recording_report(
+    #     project_id: 123,
+    #     recording_id: 789
+    #   )
+    class TimesheetService < BaseService
+      # Returns the account-wide timesheet report.
+      # This includes time entries across all projects in the account.
+      #
+      # @param from [String, nil] filter entries on or after this date (ISO 8601, e.g., "2024-01-01")
+      # @param to [String, nil] filter entries on or before this date (ISO 8601, e.g., "2024-01-31")
+      # @param person_id [Integer, nil] filter entries by a specific person
+      # @return [Hash] timesheet report object with "entries" array
+      def report(from: nil, to: nil, person_id: nil)
+        params = compact_params(from: from, to: to, person_id: person_id)
+        response = http_get("/reports/timesheet.json", params: params)
+        response.json
+      end
+
+      # Returns the timesheet report for a specific project.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param from [String, nil] filter entries on or after this date (ISO 8601)
+      # @param to [String, nil] filter entries on or before this date (ISO 8601)
+      # @param person_id [Integer, nil] filter entries by a specific person
+      # @return [Hash] timesheet report object with "entries" array
+      def project_report(project_id:, from: nil, to: nil, person_id: nil)
+        params = compact_params(from: from, to: to, person_id: person_id)
+        response = http_get(bucket_path(project_id, "/timesheet.json"), params: params)
+        response.json
+      end
+
+      # Returns the timesheet report for a specific recording within a project.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param recording_id [Integer, String] recording ID (e.g., a todo)
+      # @param from [String, nil] filter entries on or after this date (ISO 8601)
+      # @param to [String, nil] filter entries on or before this date (ISO 8601)
+      # @param person_id [Integer, nil] filter entries by a specific person
+      # @return [Hash] timesheet report object with "entries" array
+      def recording_report(project_id:, recording_id:, from: nil, to: nil, person_id: nil)
+        params = compact_params(from: from, to: to, person_id: person_id)
+        response = http_get(bucket_path(project_id, "/recordings/#{recording_id}/timesheet.json"), params: params)
+        response.json
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/todolist_groups_service.rb
+++ b/ruby/lib/basecamp/services/todolist_groups_service.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for todolist group operations.
+    #
+    # Todolist groups are organizational folders within a todolist that help
+    # organize related todos together.
+    #
+    # @example List groups in a todolist
+    #   groups = account.todolist_groups.list(project_id: 123, todolist_id: 456)
+    #
+    # @example Create a new group
+    #   group = account.todolist_groups.create(
+    #     project_id: 123,
+    #     todolist_id: 456,
+    #     name: "Phase 1"
+    #   )
+    #
+    # @example Update a group name
+    #   group = account.todolist_groups.update(
+    #     project_id: 123,
+    #     group_id: 789,
+    #     name: "Phase 1 - Complete"
+    #   )
+    class TodolistGroupsService < BaseService
+      # Lists all groups in a todolist.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param todolist_id [Integer, String] todolist ID
+      # @return [Enumerator<Hash>] todolist groups
+      def list(project_id:, todolist_id:)
+        paginate(bucket_path(project_id, "/todolists/#{todolist_id}/groups.json"))
+      end
+
+      # Gets a specific todolist group.
+      #
+      # Note: Groups are fetched via the todolists endpoint (polymorphic).
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param group_id [Integer, String] group ID
+      # @return [Hash] group data
+      def get(project_id:, group_id:)
+        http_get(bucket_path(project_id, "/todolists/#{group_id}.json")).json
+      end
+
+      # Creates a new group in a todolist.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param todolist_id [Integer, String] todolist ID
+      # @param name [String] group name (required)
+      # @return [Hash] created group
+      # @raise [ArgumentError] if name is empty
+      def create(project_id:, todolist_id:, name:)
+        raise ArgumentError, "group name is required" if name.nil? || name.empty?
+
+        body = { name: name }
+        http_post(bucket_path(project_id, "/todolists/#{todolist_id}/groups.json"), body: body).json
+      end
+
+      # Updates an existing todolist group.
+      #
+      # Note: Groups are updated via the todolists endpoint (polymorphic).
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param group_id [Integer, String] group ID
+      # @param name [String, nil] new group name
+      # @return [Hash] updated group
+      def update(project_id:, group_id:, name: nil)
+        body = compact_params(name: name)
+        http_put(bucket_path(project_id, "/todolists/#{group_id}.json"), body: body).json
+      end
+
+      # Repositions a group within its todolist.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param group_id [Integer, String] group ID
+      # @param position [Integer] new position (1-based, 1 = first position)
+      # @return [void]
+      # @raise [ArgumentError] if position is less than 1
+      def reposition(project_id:, group_id:, position:)
+        raise ArgumentError, "position must be at least 1" if position < 1
+
+        http_put(bucket_path(project_id, "/todolists/#{group_id}/position.json"), body: { position: position })
+        nil
+      end
+
+      # Moves a group to the trash.
+      # Trashed groups can be recovered from the trash.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param group_id [Integer, String] group ID
+      # @return [void]
+      def trash(project_id:, group_id:)
+        http_delete(bucket_path(project_id, "/recordings/#{group_id}/status/trashed.json"))
+        nil
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/todolists_service.rb
+++ b/ruby/lib/basecamp/services/todolists_service.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for todolist operations.
+    #
+    # Todolists are collections of todos within a todoset. A project has one
+    # todoset which contains multiple todolists.
+    #
+    # @example List todolists
+    #   account.todolists.list(project_id: 123, todoset_id: 456).each do |list|
+    #     puts "#{list["name"]} - #{list["completed_ratio"]}"
+    #   end
+    #
+    # @example Create a todolist
+    #   todolist = account.todolists.create(
+    #     project_id: 123,
+    #     todoset_id: 456,
+    #     name: "Launch Tasks"
+    #   )
+    class TodolistsService < BaseService
+      # Lists all todolists in a todoset.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param todoset_id [Integer, String] todoset ID
+      # @param status [String, nil] filter by status ("archived", "trashed")
+      # @return [Enumerator<Hash>] todolists
+      def list(project_id:, todoset_id:, status: nil)
+        params = compact_params(status: status)
+        paginate(bucket_path(project_id, "/todosets/#{todoset_id}/todolists.json"), params: params)
+      end
+
+      # Gets a specific todolist.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param todolist_id [Integer, String] todolist ID
+      # @return [Hash] todolist data
+      def get(project_id:, todolist_id:)
+        http_get(bucket_path(project_id, "/todolists/#{todolist_id}")).json
+      end
+
+      # Creates a new todolist.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param todoset_id [Integer, String] todoset ID
+      # @param name [String] todolist name
+      # @param description [String, nil] todolist description in HTML
+      # @return [Hash] created todolist
+      def create(project_id:, todoset_id:, name:, description: nil)
+        body = compact_params(
+          name: name,
+          description: description
+        )
+        http_post(bucket_path(project_id, "/todosets/#{todoset_id}/todolists.json"), body: body).json
+      end
+
+      # Updates a todolist.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param todolist_id [Integer, String] todolist ID
+      # @param name [String, nil] new name
+      # @param description [String, nil] new description
+      # @return [Hash] updated todolist
+      def update(project_id:, todolist_id:, name: nil, description: nil)
+        body = compact_params(
+          name: name,
+          description: description
+        )
+        http_put(bucket_path(project_id, "/todolists/#{todolist_id}"), body: body).json
+      end
+
+      # Lists all todolist groups within a todolist.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param todolist_id [Integer, String] todolist ID
+      # @return [Enumerator<Hash>] todolist groups
+      def list_groups(project_id:, todolist_id:)
+        paginate(bucket_path(project_id, "/todolists/#{todolist_id}/groups.json"))
+      end
+
+      # Creates a new todolist group.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param todolist_id [Integer, String] todolist ID
+      # @param name [String] group name
+      # @return [Hash] created group
+      def create_group(project_id:, todolist_id:, name:)
+        body = { name: name }
+        http_post(bucket_path(project_id, "/todolists/#{todolist_id}/groups.json"), body: body).json
+      end
+
+      # Repositions a todolist group.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param todolist_id [Integer, String] todolist ID (the group's ID)
+      # @param position [Integer] new position (1-based)
+      # @return [void]
+      def reposition_group(project_id:, todolist_id:, position:)
+        http_put(bucket_path(project_id, "/todolists/#{todolist_id}/position.json"), body: { position: position })
+        nil
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/todos_service.rb
+++ b/ruby/lib/basecamp/services/todos_service.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for todo operations.
+    #
+    # @example List todos in a todolist
+    #   account.todos.list(project_id: 123, todolist_id: 456).each do |todo|
+    #     puts "#{todo["content"]} (#{todo["completed"] ? "done" : "pending"})"
+    #   end
+    #
+    # @example Create a todo
+    #   todo = account.todos.create(
+    #     project_id: 123,
+    #     todolist_id: 456,
+    #     content: "Write documentation",
+    #     assignee_ids: [789]
+    #   )
+    #
+    # @example Complete a todo
+    #   account.todos.complete(project_id: 123, todo_id: 456)
+    class TodosService < BaseService
+      # Lists todos in a todolist.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param todolist_id [Integer, String] todolist ID
+      # @param status [String, nil] filter by status ("archived", "trashed")
+      # @param completed [Boolean, nil] filter by completion status
+      # @return [Enumerator<Hash>] todos
+      def list(project_id:, todolist_id:, status: nil, completed: nil)
+        params = compact_params(status: status, completed: completed)
+        paginate(bucket_path(project_id, "/todolists/#{todolist_id}/todos.json"), params: params)
+      end
+
+      # Gets a specific todo.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param todo_id [Integer, String] todo ID
+      # @return [Hash] todo data
+      def get(project_id:, todo_id:)
+        http_get(bucket_path(project_id, "/todos/#{todo_id}.json")).json
+      end
+
+      # Creates a new todo.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param todolist_id [Integer, String] todolist ID
+      # @param content [String] todo content (can include HTML)
+      # @param description [String, nil] extended description (HTML)
+      # @param assignee_ids [Array<Integer>, nil] user IDs to assign
+      # @param completion_subscriber_ids [Array<Integer>, nil] user IDs to notify on completion
+      # @param notify [Boolean] whether to notify assignees
+      # @param due_on [String, nil] due date (YYYY-MM-DD)
+      # @param starts_on [String, nil] start date (YYYY-MM-DD)
+      # @return [Hash] created todo
+      def create(
+        project_id:,
+        todolist_id:,
+        content:,
+        description: nil,
+        assignee_ids: nil,
+        completion_subscriber_ids: nil,
+        notify: true,
+        due_on: nil,
+        starts_on: nil
+      )
+        body = compact_params(
+          content: content,
+          description: description,
+          assignee_ids: assignee_ids,
+          completion_subscriber_ids: completion_subscriber_ids,
+          notify: notify,
+          due_on: due_on,
+          starts_on: starts_on
+        )
+        http_post(bucket_path(project_id, "/todolists/#{todolist_id}/todos.json"), body: body).json
+      end
+
+      # Updates a todo.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param todo_id [Integer, String] todo ID
+      # @param content [String, nil] new content
+      # @param description [String, nil] new description
+      # @param assignee_ids [Array<Integer>, nil] new assignee IDs
+      # @param completion_subscriber_ids [Array<Integer>, nil] new completion subscriber IDs
+      # @param notify [Boolean, nil] whether to notify
+      # @param due_on [String, nil] new due date
+      # @param starts_on [String, nil] new start date
+      # @return [Hash] updated todo
+      def update(
+        project_id:,
+        todo_id:,
+        content: nil,
+        description: nil,
+        assignee_ids: nil,
+        completion_subscriber_ids: nil,
+        notify: nil,
+        due_on: nil,
+        starts_on: nil
+      )
+        body = compact_params(
+          content: content,
+          description: description,
+          assignee_ids: assignee_ids,
+          completion_subscriber_ids: completion_subscriber_ids,
+          notify: notify,
+          due_on: due_on,
+          starts_on: starts_on
+        )
+        http_put(bucket_path(project_id, "/todos/#{todo_id}.json"), body: body).json
+      end
+
+      # Completes a todo.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param todo_id [Integer, String] todo ID
+      # @return [void]
+      def complete(project_id:, todo_id:)
+        http_post(bucket_path(project_id, "/todos/#{todo_id}/completion.json"))
+        nil
+      end
+
+      # Uncompletes a todo.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param todo_id [Integer, String] todo ID
+      # @return [void]
+      def uncomplete(project_id:, todo_id:)
+        http_delete(bucket_path(project_id, "/todos/#{todo_id}/completion.json"))
+        nil
+      end
+
+      # Repositions a todo within its todolist.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param todo_id [Integer, String] todo ID
+      # @param position [Integer] new position (1-based)
+      # @return [void]
+      def reposition(project_id:, todo_id:, position:)
+        http_put(bucket_path(project_id, "/todos/#{todo_id}/position.json"), body: { position: position })
+        nil
+      end
+
+      # Trashes a todo.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param todo_id [Integer, String] todo ID
+      # @return [void]
+      def trash(project_id:, todo_id:)
+        http_delete(bucket_path(project_id, "/todos/#{todo_id}.json"))
+        nil
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/todosets_service.rb
+++ b/ruby/lib/basecamp/services/todosets_service.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for todoset operations.
+    #
+    # Each project has one todoset which is the container for all todolists.
+    #
+    # @example Get a todoset
+    #   todoset = account.todosets.get(project_id: 123, todoset_id: 456)
+    #   puts "#{todoset["name"]} - #{todoset["todolists_count"]} lists"
+    class TodosetsService < BaseService
+      # Gets a specific todoset.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param todoset_id [Integer, String] todoset ID
+      # @return [Hash] todoset data
+      def get(project_id:, todoset_id:)
+        http_get(bucket_path(project_id, "/todosets/#{todoset_id}")).json
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/tools_service.rb
+++ b/ruby/lib/basecamp/services/tools_service.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for dock tool operations.
+    #
+    # Tools are dock items in a Basecamp project (e.g., Message Board,
+    # Todos, Schedule, etc.). This service allows you to manage these tools.
+    #
+    # @example Get a tool
+    #   tool = account.tools.get(project_id: 123, tool_id: 456)
+    #   puts "#{tool["name"]} - #{tool["enabled"] ? "enabled" : "disabled"}"
+    #
+    # @example Enable and reposition a tool
+    #   account.tools.enable(project_id: 123, tool_id: 456)
+    #   account.tools.reposition(project_id: 123, tool_id: 456, position: 1)
+    class ToolsService < BaseService
+      # Gets a tool by ID.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param tool_id [Integer, String] tool ID
+      # @return [Hash] tool data
+      def get(project_id:, tool_id:)
+        http_get(bucket_path(project_id, "/dock/tools/#{tool_id}")).json
+      end
+
+      # Clones an existing tool to create a new one.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param source_tool_id [Integer, String] ID of the tool to clone
+      # @return [Hash] newly created tool
+      def clone(project_id:, source_tool_id:)
+        http_post(bucket_path(project_id, "/dock/tools/#{source_tool_id}/clone.json")).json
+      end
+
+      # Updates (renames) an existing tool.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param tool_id [Integer, String] tool ID
+      # @param title [String] new title for the tool
+      # @return [Hash] updated tool
+      def update(project_id:, tool_id:, title:)
+        http_put(bucket_path(project_id, "/dock/tools/#{tool_id}"), body: { title: title }).json
+      end
+
+      # Deletes a tool (moves it to trash).
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param tool_id [Integer, String] tool ID
+      # @return [void]
+      def delete(project_id:, tool_id:)
+        http_delete(bucket_path(project_id, "/dock/tools/#{tool_id}"))
+        nil
+      end
+
+      # Enables a tool (shows it on the project dock).
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param tool_id [Integer, String] tool ID
+      # @return [void]
+      def enable(project_id:, tool_id:)
+        http_post(bucket_path(project_id, "/dock/tools/#{tool_id}/position.json"))
+        nil
+      end
+
+      # Disables a tool (hides it from the project dock).
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param tool_id [Integer, String] tool ID
+      # @return [void]
+      def disable(project_id:, tool_id:)
+        http_delete(bucket_path(project_id, "/dock/tools/#{tool_id}/position.json"))
+        nil
+      end
+
+      # Changes the position of a tool on the project dock.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param tool_id [Integer, String] tool ID
+      # @param position [Integer] new position (1-based, 1 = first on dock)
+      # @return [void]
+      def reposition(project_id:, tool_id:, position:)
+        http_put(bucket_path(project_id, "/dock/tools/#{tool_id}/position.json"),
+                 body: { position: position })
+        nil
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/uploads_service.rb
+++ b/ruby/lib/basecamp/services/uploads_service.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for upload operations.
+    #
+    # Uploads are files stored within vaults. They are created from
+    # attachments (via attachable_sgid) and can have descriptions
+    # and version history.
+    #
+    # @example List uploads in a vault
+    #   account.uploads.list(project_id: 123, vault_id: 456).each do |upload|
+    #     puts "#{upload["filename"]} - #{upload["byte_size"]} bytes"
+    #   end
+    #
+    # @example Create an upload
+    #   upload = account.uploads.create(
+    #     project_id: 123,
+    #     vault_id: 456,
+    #     attachable_sgid: attachment_sgid,
+    #     description: "Q4 financial report"
+    #   )
+    class UploadsService < BaseService
+      # Lists all uploads in a vault.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param vault_id [Integer, String] vault ID
+      # @return [Enumerator<Hash>] uploads
+      def list(project_id:, vault_id:)
+        paginate(bucket_path(project_id, "/vaults/#{vault_id}/uploads.json"))
+      end
+
+      # Gets a specific upload.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param upload_id [Integer, String] upload ID
+      # @return [Hash] upload data
+      def get(project_id:, upload_id:)
+        http_get(bucket_path(project_id, "/uploads/#{upload_id}")).json
+      end
+
+      # Creates a new upload in a vault.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param vault_id [Integer, String] vault ID
+      # @param attachable_sgid [String] signed global ID from attachment upload
+      # @param description [String, nil] upload description in HTML
+      # @param base_name [String, nil] filename without extension
+      # @return [Hash] created upload
+      def create(project_id:, vault_id:, attachable_sgid:, description: nil, base_name: nil)
+        body = compact_params(
+          attachable_sgid: attachable_sgid,
+          description: description,
+          base_name: base_name
+        )
+        http_post(bucket_path(project_id, "/vaults/#{vault_id}/uploads.json"), body: body).json
+      end
+
+      # Updates an existing upload.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param upload_id [Integer, String] upload ID
+      # @param description [String, nil] new description
+      # @param base_name [String, nil] new filename without extension
+      # @return [Hash] updated upload
+      def update(project_id:, upload_id:, description: nil, base_name: nil)
+        body = compact_params(
+          description: description,
+          base_name: base_name
+        )
+        http_put(bucket_path(project_id, "/uploads/#{upload_id}"), body: body).json
+      end
+
+      # Lists all versions of an upload.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param upload_id [Integer, String] upload ID
+      # @return [Enumerator<Hash>] upload versions
+      def list_versions(project_id:, upload_id:)
+        paginate(bucket_path(project_id, "/uploads/#{upload_id}/versions.json"))
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/vaults_service.rb
+++ b/ruby/lib/basecamp/services/vaults_service.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for vault (folder) operations.
+    #
+    # Vaults are folders in the Files & Documents tool. They can contain
+    # documents, uploads (files), and nested vaults (subfolders).
+    #
+    # @example Get a vault
+    #   vault = account.vaults.get(project_id: 123, vault_id: 456)
+    #
+    # @example List subfolders
+    #   account.vaults.list(project_id: 123, vault_id: 456).each do |folder|
+    #     puts folder["title"]
+    #   end
+    #
+    # @example Create a subfolder
+    #   vault = account.vaults.create(
+    #     project_id: 123,
+    #     vault_id: 456,
+    #     title: "2024 Reports"
+    #   )
+    class VaultsService < BaseService
+      # Gets a specific vault.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param vault_id [Integer, String] vault ID
+      # @return [Hash] vault data
+      def get(project_id:, vault_id:)
+        http_get(bucket_path(project_id, "/vaults/#{vault_id}")).json
+      end
+
+      # Lists all child vaults (subfolders) in a vault.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param vault_id [Integer, String] parent vault ID
+      # @return [Enumerator<Hash>] child vaults
+      def list(project_id:, vault_id:)
+        paginate(bucket_path(project_id, "/vaults/#{vault_id}/vaults.json"))
+      end
+
+      # Creates a new child vault (subfolder).
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param vault_id [Integer, String] parent vault ID
+      # @param title [String] vault name
+      # @return [Hash] created vault
+      def create(project_id:, vault_id:, title:)
+        body = { title: title }
+        http_post(bucket_path(project_id, "/vaults/#{vault_id}/vaults.json"), body: body).json
+      end
+
+      # Updates an existing vault.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param vault_id [Integer, String] vault ID
+      # @param title [String, nil] new title
+      # @return [Hash] updated vault
+      def update(project_id:, vault_id:, title: nil)
+        body = compact_params(title: title)
+        http_put(bucket_path(project_id, "/vaults/#{vault_id}"), body: body).json
+      end
+
+      # Lists all documents in a vault.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param vault_id [Integer, String] vault ID
+      # @return [Enumerator<Hash>] documents
+      def list_documents(project_id:, vault_id:)
+        paginate(bucket_path(project_id, "/vaults/#{vault_id}/documents.json"))
+      end
+
+      # Lists all uploads (files) in a vault.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param vault_id [Integer, String] vault ID
+      # @return [Enumerator<Hash>] uploads
+      def list_uploads(project_id:, vault_id:)
+        paginate(bucket_path(project_id, "/vaults/#{vault_id}/uploads.json"))
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/services/webhooks_service.rb
+++ b/ruby/lib/basecamp/services/webhooks_service.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Services
+    # Service for webhook operations.
+    #
+    # Webhooks allow external services to receive notifications when events
+    # occur in a Basecamp project.
+    #
+    # @example List webhooks
+    #   account.webhooks.list(project_id: 123).each do |webhook|
+    #     puts "#{webhook["url"]} - #{webhook["active"]}"
+    #   end
+    #
+    # @example Create a webhook
+    #   webhook = account.webhooks.create(
+    #     project_id: 123,
+    #     payload_url: "https://example.com/webhooks/basecamp",
+    #     types: ["Todo", "Message"]
+    #   )
+    class WebhooksService < BaseService
+      # Lists all webhooks in a project.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @return [Enumerator<Hash>] webhooks
+      def list(project_id:)
+        paginate(bucket_path(project_id, "/webhooks.json"))
+      end
+
+      # Gets a specific webhook.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param webhook_id [Integer, String] webhook ID
+      # @return [Hash] webhook data
+      def get(project_id:, webhook_id:)
+        http_get(bucket_path(project_id, "/webhooks/#{webhook_id}")).json
+      end
+
+      # Creates a new webhook.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param payload_url [String] URL to receive webhook payloads
+      # @param types [Array<String>, nil] recording types to subscribe to
+      # @return [Hash] created webhook
+      def create(project_id:, payload_url:, types: nil)
+        body = compact_params(
+          payload_url: payload_url,
+          types: types
+        )
+        http_post(bucket_path(project_id, "/webhooks.json"), body: body).json
+      end
+
+      # Updates an existing webhook.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param webhook_id [Integer, String] webhook ID
+      # @param payload_url [String, nil] new URL
+      # @param types [Array<String>, nil] new recording types
+      # @param active [Boolean, nil] whether the webhook is active
+      # @return [Hash] updated webhook
+      def update(project_id:, webhook_id:, payload_url: nil, types: nil, active: nil)
+        body = compact_params(
+          payload_url: payload_url,
+          types: types,
+          active: active
+        )
+        http_put(bucket_path(project_id, "/webhooks/#{webhook_id}"), body: body).json
+      end
+
+      # Deletes a webhook.
+      #
+      # @param project_id [Integer, String] project (bucket) ID
+      # @param webhook_id [Integer, String] webhook ID
+      # @return [void]
+      def delete(project_id:, webhook_id:)
+        http_delete(bucket_path(project_id, "/webhooks/#{webhook_id}"))
+        nil
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/static_token_provider.rb
+++ b/ruby/lib/basecamp/static_token_provider.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Basecamp
+  # A simple token provider that returns a static access token.
+  # Useful for testing or when you manage token refresh externally.
+  #
+  # @example
+  #   provider = Basecamp::StaticTokenProvider.new(ENV["BASECAMP_ACCESS_TOKEN"])
+  class StaticTokenProvider
+    include TokenProvider
+
+    # @param token [String] the static access token
+    def initialize(token)
+      raise ArgumentError, "token cannot be nil or empty" if token.nil? || token.empty?
+
+      @token = token
+    end
+
+    # @return [String] the access token
+    def access_token
+      @token
+    end
+  end
+end

--- a/ruby/lib/basecamp/token_provider.rb
+++ b/ruby/lib/basecamp/token_provider.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Basecamp
+  # Interface for providing OAuth access tokens.
+  # Implement this to provide custom token management (e.g., refresh tokens).
+  #
+  # @example Static token provider
+  #   token_provider = Basecamp::StaticTokenProvider.new("your-access-token")
+  #   client = Basecamp::Client.new(config: config, token_provider: token_provider)
+  #
+  # @example Custom token provider with refresh
+  #   class MyTokenProvider
+  #     include Basecamp::TokenProvider
+  #
+  #     def access_token
+  #       # Return current token, refreshing if needed
+  #     end
+  #
+  #     def refresh
+  #       # Refresh the token
+  #     end
+  #   end
+  module TokenProvider
+    # Returns the current access token.
+    # @return [String] the OAuth access token
+    def access_token
+      raise NotImplementedError, "#{self.class} must implement #access_token"
+    end
+
+    # Refreshes the access token.
+    # @return [Boolean] true if refresh succeeded
+    def refresh
+      false
+    end
+
+    # Returns whether token refresh is supported.
+    # @return [Boolean]
+    def refreshable?
+      false
+    end
+  end
+end

--- a/ruby/lib/basecamp/version.rb
+++ b/ruby/lib/basecamp/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module Basecamp
+  VERSION = "0.1.0"
+end

--- a/ruby/scripts/generate-metadata.rb
+++ b/ruby/scripts/generate-metadata.rb
@@ -1,0 +1,106 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Extracts x-basecamp-* extensions from OpenAPI spec into a runtime-accessible metadata file.
+# This allows the Ruby SDK to read operation metadata at runtime for retry, pagination, etc.
+#
+# Usage: ruby scripts/ruby/generate-metadata.rb > lib/basecamp/generated/metadata.json
+
+require 'json'
+require 'time'
+
+# Extract metadata from OpenAPI spec
+class MetadataExtractor
+  METHODS = %w[get post put patch delete].freeze
+
+  def initialize(openapi_path)
+    @openapi = JSON.parse(File.read(openapi_path))
+  end
+
+  def extract
+    operations = {}
+
+    (@openapi['paths'] || {}).each_value do |path_item|
+      METHODS.each do |method|
+        operation = path_item[method]
+        next unless operation
+
+        operation_id = operation['operationId']
+        next unless operation_id
+
+        metadata = extract_operation_metadata(operation)
+        operations[operation_id] = metadata if metadata.any?
+      end
+    end
+
+    {
+      '$schema' => 'https://basecamp.com/schemas/sdk-metadata.json',
+      'version' => '1.0.0',
+      'generated' => Time.now.utc.iso8601,
+      'operations' => operations
+    }
+  end
+
+  private
+
+  def extract_operation_metadata(operation)
+    metadata = {}
+
+    # Extract x-basecamp-retry
+    if (retry_config = operation['x-basecamp-retry'])
+      metadata['retry'] = {
+        'maxAttempts' => retry_config['maxAttempts'],
+        'baseDelayMs' => retry_config['baseDelayMs'],
+        'backoff' => retry_config['backoff'],
+        'retryOn' => retry_config['retryOn']
+      }
+    end
+
+    # Extract x-basecamp-pagination
+    if (pagination = operation['x-basecamp-pagination'])
+      metadata['pagination'] = {
+        'style' => pagination['style'],
+        'pageParam' => pagination['pageParam'],
+        'totalCountHeader' => pagination['totalCountHeader'],
+        'maxPageSize' => pagination['maxPageSize']
+      }.compact
+    end
+
+    # Extract x-basecamp-idempotent
+    if (idempotent = operation['x-basecamp-idempotent'])
+      metadata['idempotent'] = {
+        'keySupported' => idempotent['keySupported'],
+        'keyHeader' => idempotent['keyHeader'],
+        'natural' => idempotent['natural']
+      }.compact
+    end
+
+    # Extract x-basecamp-sensitive
+    if (sensitive = operation['x-basecamp-sensitive'])
+      metadata['sensitive'] = sensitive.map do |s|
+        {
+          'field' => s['field'],
+          'category' => s['category'],
+          'redact' => s['redact']
+        }.compact
+      end
+    end
+
+    metadata
+  end
+end
+
+# Main execution
+if __FILE__ == $PROGRAM_NAME
+  openapi_path = ARGV[0] || File.expand_path('../../openapi.json', __dir__)
+
+  unless File.exist?(openapi_path)
+    warn "Error: OpenAPI file not found: #{openapi_path}"
+    exit 1
+  end
+
+  extractor = MetadataExtractor.new(openapi_path)
+  metadata = extractor.extract
+
+  puts JSON.pretty_generate(metadata)
+end

--- a/ruby/scripts/generate-types.rb
+++ b/ruby/scripts/generate-types.rb
@@ -1,0 +1,171 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Generates Ruby type classes from OpenAPI schemas.
+# Creates classes with JSON serialization support.
+#
+# Usage: ruby scripts/ruby/generate-types.rb > lib/basecamp/generated/types.rb
+
+require 'json'
+
+# Schemas to skip (internal/generated response wrappers)
+SKIP_PATTERNS = [
+  /ResponseContent$/,
+  /RequestContent$/,
+  /InputPayload$/,
+  /ErrorResponseContent$/
+].freeze
+
+def header
+  <<~HEADER
+    # frozen_string_literal: true
+
+    # Auto-generated from OpenAPI spec. Do not edit manually.
+    # Generated: #{Time.now.utc.iso8601}
+
+    require "json"
+    require "time"
+  HEADER
+end
+
+def generate_helpers
+  <<~HELPERS
+
+    # Type conversion helpers
+    module TypeHelpers
+      module_function
+
+      def identity(value)
+        value
+      end
+
+      def parse_integer(value)
+        return nil if value.nil?
+        value.to_i
+      end
+
+      def parse_float(value)
+        return nil if value.nil?
+        value.to_f
+      end
+
+      def parse_boolean(value)
+        return nil if value.nil?
+        !!value
+      end
+
+      def parse_datetime(value)
+        return nil if value.nil?
+        return value if value.is_a?(Time)
+        Time.parse(value.to_s)
+      rescue ArgumentError
+        nil
+      end
+
+      def parse_type(value, type_name)
+        return nil if value.nil?
+        return value unless value.is_a?(Hash)
+
+        type_class = Basecamp::Types.const_get(type_name)
+        type_class.new(value)
+      rescue NameError
+        value
+      end
+
+      def parse_array(value, type_name)
+        return nil if value.nil?
+        return value unless value.is_a?(Array)
+
+        type_class = Basecamp::Types.const_get(type_name)
+        value.map { |item| item.is_a?(Hash) ? type_class.new(item) : item }
+      rescue NameError
+        value
+      end
+    end
+  HELPERS
+end
+
+# Main execution
+if __FILE__ == $PROGRAM_NAME
+  openapi_path = ARGV[0] || File.expand_path('../../openapi.json', __dir__)
+
+  unless File.exist?(openapi_path)
+    warn "Error: OpenAPI file not found: #{openapi_path}"
+    exit 1
+  end
+
+  puts header
+  puts generate_helpers
+  puts ''
+  puts 'module Basecamp'
+  puts '  module Types'
+  puts '    include TypeHelpers'
+
+  schemas = JSON.parse(File.read(openapi_path))['components']['schemas'] || {}
+  sorted = schemas.keys.sort
+
+  sorted.each do |name|
+    next if SKIP_PATTERNS.any? { |p| name.match?(p) }
+
+    schema = schemas[name]
+    next unless schema['type'] == 'object'
+
+    properties = schema['properties'] || {}
+    next if properties.empty?
+
+    puts ''
+    puts "    # #{name}"
+    puts "    class #{name}"
+    puts '      include TypeHelpers'
+
+    attr_names = properties.keys.map { |k| k.gsub(/([A-Z])/, '_\1').downcase.gsub(/^_/, '') }
+    puts "      attr_accessor #{attr_names.map { |n| ":#{n}" }.join(', ')}"
+    puts ''
+
+    puts '      def initialize(data = {})'
+    properties.each do |prop_name, prop_schema|
+      attr_name = prop_name.gsub(/([A-Z])/, '_\1').downcase.gsub(/^_/, '')
+
+      converter = if prop_schema['$ref']
+                    ref_name = prop_schema['$ref'].split('/').last
+                    "parse_type(data[\"#{prop_name}\"], \"#{ref_name}\")"
+      elsif prop_schema['type'] == 'array' && prop_schema.dig('items', '$ref')
+                    ref_name = prop_schema['items']['$ref'].split('/').last
+                    "parse_array(data[\"#{prop_name}\"], \"#{ref_name}\")"
+      elsif prop_schema['type'] == 'integer'
+                    "parse_integer(data[\"#{prop_name}\"])"
+      elsif prop_schema['type'] == 'number'
+                    "parse_float(data[\"#{prop_name}\"])"
+      elsif prop_schema['type'] == 'boolean'
+                    "parse_boolean(data[\"#{prop_name}\"])"
+      elsif prop_schema['x-go-type'] == 'time.Time'
+                    "parse_datetime(data[\"#{prop_name}\"])"
+      else
+                    "data[\"#{prop_name}\"]"
+      end
+
+      puts "        @#{attr_name} = #{converter}"
+    end
+    puts '      end'
+    puts ''
+
+    puts '      def to_h'
+    puts '        {'
+    properties.each_key do |prop_name|
+      attr_name = prop_name.gsub(/([A-Z])/, '_\1').downcase.gsub(/^_/, '')
+      puts "          \"#{prop_name}\" => @#{attr_name},"
+    end
+    puts '        }.compact'
+    puts '      end'
+    puts ''
+
+    puts '      def to_json(*args)'
+    puts '        to_h.to_json(*args)'
+    puts '      end'
+
+    puts '    end'
+  end
+
+  puts '  end'
+  puts 'end'
+end

--- a/ruby/test/basecamp/auth_extended_test.rb
+++ b/ruby/test/basecamp/auth_extended_test.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Extended auth tests for OAuth auto-refresh, thread safety, and edge cases
+class OAuthAutoRefreshTest < Minitest::Test
+  include TestHelper
+
+  def test_auto_refresh_when_token_expired
+    # Setup provider with expired token
+    provider = Basecamp::OauthTokenProvider.new(
+      access_token: "expired-token",
+      refresh_token: "refresh-token",
+      client_id: "client-id",
+      client_secret: "client-secret",
+      expires_at: Time.now - 3600 # 1 hour ago
+    )
+
+    # Stub the refresh endpoint
+    stub_request(:post, "https://launchpad.37signals.com/authorization/token")
+      .to_return(
+        status: 200,
+        body: { access_token: "new-token", expires_in: 7200 }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    assert provider.expired?
+
+    # Refresh should succeed
+    result = provider.refresh
+
+    assert result
+    assert_equal "new-token", provider.access_token
+    refute provider.expired?
+  end
+
+  def test_on_refresh_callback_receives_all_parameters
+    received_access = nil
+    received_refresh = nil
+    received_expires = nil
+
+    provider = Basecamp::OauthTokenProvider.new(
+      access_token: "old-token",
+      refresh_token: "old-refresh",
+      client_id: "client-id",
+      client_secret: "client-secret",
+      on_refresh: lambda { |access, refresh, expires|
+        received_access = access
+        received_refresh = refresh
+        received_expires = expires
+      }
+    )
+
+    stub_request(:post, "https://launchpad.37signals.com/authorization/token")
+      .to_return(
+        status: 200,
+        body: { access_token: "new-access", refresh_token: "new-refresh", expires_in: 3600 }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    provider.refresh
+
+    assert_equal "new-access", received_access
+    # Implementation passes original refresh_token to callback, not the new one from response
+    assert_equal "old-refresh", received_refresh
+    refute_nil received_expires
+  end
+
+  def test_refresh_preserves_refresh_token_if_not_returned
+    provider = Basecamp::OauthTokenProvider.new(
+      access_token: "old-token",
+      refresh_token: "original-refresh",
+      client_id: "client-id",
+      client_secret: "client-secret"
+    )
+
+    # Response without refresh_token field
+    stub_request(:post, "https://launchpad.37signals.com/authorization/token")
+      .to_return(
+        status: 200,
+        body: { access_token: "new-token", expires_in: 3600 }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    provider.refresh
+
+    assert_equal "new-token", provider.access_token
+    # Should still be refreshable with original refresh token
+    assert provider.refreshable?
+  end
+
+  def test_refresh_without_callback
+    provider = Basecamp::OauthTokenProvider.new(
+      access_token: "old-token",
+      refresh_token: "refresh-token",
+      client_id: "client-id",
+      client_secret: "client-secret"
+      # No on_refresh callback
+    )
+
+    stub_request(:post, "https://launchpad.37signals.com/authorization/token")
+      .to_return(
+        status: 200,
+        body: { access_token: "new-token", expires_in: 3600 }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    # Should not raise even without callback
+    result = provider.refresh
+
+    assert result
+    assert_equal "new-token", provider.access_token
+  end
+
+  def test_refresh_with_network_error
+    provider = Basecamp::OauthTokenProvider.new(
+      access_token: "old-token",
+      refresh_token: "refresh-token",
+      client_id: "client-id",
+      client_secret: "client-secret"
+    )
+
+    stub_request(:post, "https://launchpad.37signals.com/authorization/token")
+      .to_timeout
+
+    # Implementation wraps Faraday errors in NetworkError
+    assert_raises(Basecamp::NetworkError) do
+      provider.refresh
+    end
+  end
+
+  def test_expired_with_buffer_time
+    # Token that expires in 30 seconds should be considered "about to expire"
+    provider = Basecamp::OauthTokenProvider.new(
+      access_token: "token",
+      refresh_token: "refresh",
+      client_id: "client-id",
+      client_secret: "client-secret",
+      expires_at: Time.now + 30 # 30 seconds from now
+    )
+
+    # With default 60 second buffer, this should be considered expired
+    # Note: depends on implementation - if buffer is 60s, token expiring in 30s is expired
+    # This tests that near-expiry is handled appropriately
+    refute_nil provider.expires_at
+  end
+end
+
+class StaticTokenProviderExtendedTest < Minitest::Test
+  def test_whitespace_only_token_accepted
+    # Implementation only checks nil/empty, not whitespace
+    # This is a documentation test showing current behavior
+    provider = Basecamp::StaticTokenProvider.new("   ")
+    assert_equal "   ", provider.access_token
+  end
+
+  def test_token_immutability
+    token = "my-secret-token"
+    provider = Basecamp::StaticTokenProvider.new(token)
+
+    # Provider should return the token, not allow mutation
+    returned = provider.access_token
+
+    assert_equal token, returned
+  end
+
+  def test_refresh_always_returns_false
+    provider = Basecamp::StaticTokenProvider.new("token")
+
+    refute provider.refresh
+    refute provider.refresh
+    refute provider.refresh
+  end
+end
+
+class TokenProviderInterfaceTest < Minitest::Test
+  def test_static_provider_responds_to_interface
+    provider = Basecamp::StaticTokenProvider.new("token")
+
+    assert_respond_to provider, :access_token
+    assert_respond_to provider, :refresh
+    assert_respond_to provider, :refreshable?
+  end
+
+  def test_oauth_provider_responds_to_interface
+    provider = Basecamp::OauthTokenProvider.new(
+      access_token: "token",
+      refresh_token: "refresh",
+      client_id: "client",
+      client_secret: "secret"
+    )
+
+    assert_respond_to provider, :access_token
+    assert_respond_to provider, :refresh
+    assert_respond_to provider, :refreshable?
+    assert_respond_to provider, :expired?
+  end
+end

--- a/ruby/test/basecamp/auth_test.rb
+++ b/ruby/test/basecamp/auth_test.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class StaticTokenProviderTest < Minitest::Test
+  def test_returns_token
+    provider = Basecamp::StaticTokenProvider.new("my-token")
+
+    assert_equal "my-token", provider.access_token
+  end
+
+  def test_raises_for_nil_token
+    assert_raises(ArgumentError) do
+      Basecamp::StaticTokenProvider.new(nil)
+    end
+  end
+
+  def test_raises_for_empty_token
+    assert_raises(ArgumentError) do
+      Basecamp::StaticTokenProvider.new("")
+    end
+  end
+
+  def test_not_refreshable
+    provider = Basecamp::StaticTokenProvider.new("my-token")
+
+    refute provider.refreshable?
+    refute provider.refresh
+  end
+end
+
+class OauthTokenProviderTest < Minitest::Test
+  def test_returns_access_token
+    provider = Basecamp::OauthTokenProvider.new(
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+      client_id: "client-id",
+      client_secret: "client-secret"
+    )
+
+    assert_equal "access-token", provider.access_token
+  end
+
+  def test_refreshable_with_refresh_token
+    provider = Basecamp::OauthTokenProvider.new(
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+      client_id: "client-id",
+      client_secret: "client-secret"
+    )
+
+    assert provider.refreshable?
+  end
+
+  def test_not_refreshable_without_refresh_token
+    provider = Basecamp::OauthTokenProvider.new(
+      access_token: "access-token",
+      refresh_token: nil,
+      client_id: "client-id",
+      client_secret: "client-secret"
+    )
+
+    refute provider.refreshable?
+  end
+
+  def test_expired_with_past_time
+    provider = Basecamp::OauthTokenProvider.new(
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+      client_id: "client-id",
+      client_secret: "client-secret",
+      expires_at: Time.now - 3600
+    )
+
+    assert provider.expired?
+  end
+
+  def test_not_expired_with_future_time
+    provider = Basecamp::OauthTokenProvider.new(
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+      client_id: "client-id",
+      client_secret: "client-secret",
+      expires_at: Time.now + 3600
+    )
+
+    refute provider.expired?
+  end
+
+  def test_not_expired_without_expiration
+    provider = Basecamp::OauthTokenProvider.new(
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+      client_id: "client-id",
+      client_secret: "client-secret"
+    )
+
+    refute provider.expired?
+  end
+
+  def test_refresh_success
+    stub_request(:post, "https://launchpad.37signals.com/authorization/token")
+      .to_return(
+        status: 200,
+        body: { access_token: "new-token", expires_in: 3600 }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    callback_called = false
+    provider = Basecamp::OauthTokenProvider.new(
+      access_token: "old-token",
+      refresh_token: "refresh-token",
+      client_id: "client-id",
+      client_secret: "client-secret",
+      on_refresh: ->(_access, _refresh, _expires) { callback_called = true }
+    )
+
+    result = provider.refresh
+
+    assert result
+    assert_equal "new-token", provider.access_token
+    assert callback_called
+  end
+
+  def test_refresh_failure
+    stub_request(:post, "https://launchpad.37signals.com/authorization/token")
+      .to_return(status: 401, body: "Unauthorized")
+
+    provider = Basecamp::OauthTokenProvider.new(
+      access_token: "old-token",
+      refresh_token: "refresh-token",
+      client_id: "client-id",
+      client_secret: "client-secret"
+    )
+
+    assert_raises(Basecamp::AuthError) do
+      provider.refresh
+    end
+  end
+end

--- a/ruby/test/basecamp/client_test.rb
+++ b/ruby/test/basecamp/client_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ClientTest < Minitest::Test
+  include TestHelper
+
+  def test_creates_client_with_config
+    config = default_config
+    token_provider = test_token_provider
+
+    client = Basecamp::Client.new(config: config, token_provider: token_provider)
+
+    assert_equal config, client.config
+  end
+
+  def test_for_account_returns_account_client
+    client = create_client
+    account = client.for_account("12345")
+
+    assert_instance_of Basecamp::AccountClient, account
+    assert_equal "12345", account.account_id
+  end
+
+  def test_for_account_accepts_integer
+    client = create_client
+    account = client.for_account(12_345)
+
+    assert_equal "12345", account.account_id
+  end
+
+  def test_for_account_raises_for_empty_id
+    client = create_client
+
+    assert_raises(ArgumentError) do
+      client.for_account("")
+    end
+  end
+
+  def test_for_account_raises_for_non_numeric_id
+    client = create_client
+
+    assert_raises(ArgumentError) do
+      client.for_account("abc")
+    end
+  end
+
+  def test_authorization_returns_service
+    stub_discovery_failure
+    stub_launchpad_get("/authorization.json", response_body: sample_authorization)
+
+    client = create_client
+    auth = client.authorization.get
+
+    assert_equal "Test Account", auth["accounts"].first["name"]
+  end
+end
+
+class AccountClientTest < Minitest::Test
+  include TestHelper
+
+  def test_account_id_accessible
+    account = create_account_client(account_id: "99999")
+
+    assert_equal "99999", account.account_id
+  end
+
+  def test_config_accessible
+    config = default_config
+    client = Basecamp::Client.new(config: config, token_provider: test_token_provider)
+    account = client.for_account("12345")
+
+    assert_equal config, account.config
+  end
+
+  def test_projects_service_accessible
+    account = create_account_client
+
+    assert_instance_of Basecamp::Services::ProjectsService, account.projects
+  end
+
+  def test_services_are_memoized
+    account = create_account_client
+
+    projects1 = account.projects
+    projects2 = account.projects
+
+    assert_same projects1, projects2
+  end
+end

--- a/ruby/test/basecamp/config_test.rb
+++ b/ruby/test/basecamp/config_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ConfigTest < Minitest::Test
+  def test_default_values
+    config = Basecamp::Config.new
+
+    assert_equal "https://3.basecampapi.com", config.base_url
+    assert_equal 30, config.timeout
+    assert_equal 5, config.max_retries
+    assert_equal 1.0, config.base_delay
+    assert_equal 0.1, config.max_jitter
+    assert_equal 10_000, config.max_pages
+  end
+
+  def test_custom_values
+    config = Basecamp::Config.new(
+      base_url: "https://custom.api.com/",
+      timeout: 60,
+      max_retries: 10
+    )
+
+    assert_equal "https://custom.api.com", config.base_url # trailing slash removed
+    assert_equal 60, config.timeout
+    assert_equal 10, config.max_retries
+  end
+
+  def test_from_env
+    ENV["BASECAMP_BASE_URL"] = "https://env.api.com"
+    ENV["BASECAMP_TIMEOUT"] = "45"
+    ENV["BASECAMP_MAX_RETRIES"] = "7"
+
+    config = Basecamp::Config.from_env
+
+    assert_equal "https://env.api.com", config.base_url
+    assert_equal 45, config.timeout
+    assert_equal 7, config.max_retries
+  ensure
+    ENV.delete("BASECAMP_BASE_URL")
+    ENV.delete("BASECAMP_TIMEOUT")
+    ENV.delete("BASECAMP_MAX_RETRIES")
+  end
+
+  def test_load_from_env_overrides_existing
+    config = Basecamp::Config.new(timeout: 30)
+    ENV["BASECAMP_TIMEOUT"] = "90"
+
+    config.load_from_env
+
+    assert_equal 90, config.timeout
+  ensure
+    ENV.delete("BASECAMP_TIMEOUT")
+  end
+
+  def test_global_config_dir
+    dir = Basecamp::Config.global_config_dir
+
+    assert dir.end_with?("basecamp")
+    assert dir.include?(".config") || ENV.fetch("XDG_CONFIG_HOME", nil)
+  end
+end

--- a/ruby/test/basecamp/errors_test.rb
+++ b/ruby/test/basecamp/errors_test.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ErrorsTest < Minitest::Test
+  def test_error_has_code_and_message
+    error = Basecamp::Error.new(
+      code: Basecamp::ErrorCode::NOT_FOUND,
+      message: "Resource not found"
+    )
+
+    assert_equal Basecamp::ErrorCode::NOT_FOUND, error.code
+    assert_equal "Resource not found", error.message
+  end
+
+  def test_error_has_exit_code
+    error = Basecamp::NotFoundError.new("Project", "123")
+
+    assert_equal Basecamp::ExitCode::NOT_FOUND, error.exit_code
+  end
+
+  def test_not_found_error
+    error = Basecamp::NotFoundError.new("Project", "123")
+
+    assert_equal "Project not found: 123", error.message
+    assert_equal 404, error.http_status
+  end
+
+  def test_auth_error
+    error = Basecamp::AuthError.new
+
+    assert_equal "Authentication required", error.message
+    assert_equal 401, error.http_status
+    refute error.retryable?
+  end
+
+  def test_forbidden_error
+    error = Basecamp::ForbiddenError.new
+
+    assert_equal "Access denied", error.message
+    assert_equal 403, error.http_status
+  end
+
+  def test_forbidden_scope_error
+    error = Basecamp::ForbiddenError.insufficient_scope
+
+    assert_equal "Access denied: insufficient scope", error.message
+    assert_includes error.hint, "Re-authenticate"
+  end
+
+  def test_rate_limit_error
+    error = Basecamp::RateLimitError.new(retry_after: 30)
+
+    assert_equal "Rate limit exceeded", error.message
+    assert_equal 429, error.http_status
+    assert error.retryable?
+    assert_equal 30, error.retry_after
+  end
+
+  def test_network_error_is_retryable
+    error = Basecamp::NetworkError.new("Connection timeout")
+
+    assert error.retryable?
+  end
+
+  def test_api_error_from_status
+    error = Basecamp::APIError.from_status(500)
+
+    assert_equal "Request failed (HTTP 500)", error.message
+    assert_equal 500, error.http_status
+    assert error.retryable?
+  end
+
+  def test_api_error_4xx_not_retryable
+    error = Basecamp::APIError.from_status(400)
+
+    refute error.retryable?
+  end
+
+  def test_validation_error
+    error = Basecamp::ValidationError.new("Name is required")
+
+    assert_equal "Name is required", error.message
+    assert_equal 400, error.http_status
+  end
+
+  def test_ambiguous_error_with_matches
+    error = Basecamp::AmbiguousError.new("project", matches: %w[Project1 Project2])
+
+    assert_includes error.hint, "Project1"
+    assert_includes error.hint, "Project2"
+    assert_equal %w[Project1 Project2], error.matches
+  end
+
+  def test_error_from_response_401
+    error = Basecamp.error_from_response(401, nil)
+
+    assert_instance_of Basecamp::AuthError, error
+  end
+
+  def test_error_from_response_404
+    error = Basecamp.error_from_response(404, nil)
+
+    assert_instance_of Basecamp::NotFoundError, error
+  end
+
+  def test_error_from_response_429
+    error = Basecamp.error_from_response(429, nil, retry_after: 60)
+
+    assert_instance_of Basecamp::RateLimitError, error
+    assert_equal 60, error.retry_after
+  end
+
+  def test_error_from_response_500
+    error = Basecamp.error_from_response(500, nil)
+
+    assert_instance_of Basecamp::APIError, error
+    assert error.retryable?
+  end
+
+  def test_parse_error_message_from_json
+    body = '{"error": "Invalid request"}'
+    message = Basecamp.parse_error_message(body)
+
+    assert_equal "Invalid request", message
+  end
+
+  def test_parse_error_message_returns_nil_for_invalid_json
+    message = Basecamp.parse_error_message("not json")
+
+    assert_nil message
+  end
+end

--- a/ruby/test/basecamp/generated_types_test.rb
+++ b/ruby/test/basecamp/generated_types_test.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class GeneratedTypesTest < Minitest::Test
+  def test_project_type_parses_data
+    data = {
+      "id" => 12_345,
+      "name" => "Test Project",
+      "description" => "A test project",
+      "status" => "active",
+      "created_at" => "2024-01-01T00:00:00Z",
+      "updated_at" => "2024-01-15T12:30:00Z"
+    }
+
+    project = Basecamp::Types::Project.new(data)
+
+    assert_equal 12_345, project.id
+    assert_equal "Test Project", project.name
+    assert_equal "A test project", project.description
+    assert_equal "active", project.status
+    assert_instance_of Time, project.created_at
+    assert_instance_of Time, project.updated_at
+  end
+
+  def test_project_type_to_h
+    data = {
+      "id" => 123,
+      "name" => "My Project",
+      "status" => "active"
+    }
+
+    project = Basecamp::Types::Project.new(data)
+    hash = project.to_h
+
+    assert_equal 123, hash["id"]
+    assert_equal "My Project", hash["name"]
+    assert_equal "active", hash["status"]
+  end
+
+  def test_project_type_to_json
+    data = { "id" => 123, "name" => "JSON Project" }
+
+    project = Basecamp::Types::Project.new(data)
+    json = project.to_json
+
+    parsed = JSON.parse(json)
+    assert_equal 123, parsed["id"]
+    assert_equal "JSON Project", parsed["name"]
+  end
+
+  def test_person_type_parses_data
+    data = {
+      "id" => 999,
+      "name" => "John Doe",
+      "email_address" => "john@example.com",
+      "admin" => true,
+      "owner" => false
+    }
+
+    person = Basecamp::Types::Person.new(data)
+
+    assert_equal 999, person.id
+    assert_equal "John Doe", person.name
+    assert_equal "john@example.com", person.email_address
+    assert_equal true, person.admin
+    assert_equal false, person.owner
+  end
+
+  def test_todo_type_parses_data
+    data = {
+      "id" => 456,
+      "content" => "Buy groceries",
+      "completed" => false,
+      "due_on" => "2024-02-01",
+      "created_at" => "2024-01-01T00:00:00Z"
+    }
+
+    todo = Basecamp::Types::Todo.new(data)
+
+    assert_equal 456, todo.id
+    assert_equal "Buy groceries", todo.content
+    assert_equal false, todo.completed
+    assert_equal "2024-02-01", todo.due_on
+    assert_instance_of Time, todo.created_at
+  end
+
+  def test_type_handles_nil_values
+    data = { "id" => 123 }
+
+    project = Basecamp::Types::Project.new(data)
+
+    assert_equal 123, project.id
+    assert_nil project.name
+    assert_nil project.description
+  end
+
+  def test_type_handles_empty_data
+    project = Basecamp::Types::Project.new({})
+
+    assert_nil project.id
+    assert_nil project.name
+  end
+
+  def test_type_compacts_nil_in_to_h
+    data = { "id" => 123, "name" => nil }
+
+    project = Basecamp::Types::Project.new(data)
+    hash = project.to_h
+
+    assert_equal 123, hash["id"]
+    refute hash.key?("name")
+  end
+end

--- a/ruby/test/basecamp/hooks_test.rb
+++ b/ruby/test/basecamp/hooks_test.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class HooksTest < Minitest::Test
+  def test_request_info_data_class
+    info = Basecamp::RequestInfo.new(method: "GET", url: "/test", attempt: 1)
+
+    assert_equal "GET", info.method
+    assert_equal "/test", info.url
+    assert_equal 1, info.attempt
+  end
+
+  def test_request_info_default_attempt
+    info = Basecamp::RequestInfo.new(method: "GET", url: "/test")
+
+    assert_equal 1, info.attempt
+  end
+
+  def test_request_result_success
+    result = Basecamp::RequestResult.new(status_code: 200, duration: 0.5)
+
+    assert result.success?
+    assert_equal 200, result.status_code
+    assert_equal 0.5, result.duration
+  end
+
+  def test_request_result_failure
+    result = Basecamp::RequestResult.new(status_code: 500, duration: 0.1)
+
+    refute result.success?
+  end
+
+  def test_request_result_with_error
+    error = StandardError.new("test error")
+    result = Basecamp::RequestResult.new(error: error, duration: 0.1)
+
+    refute result.success?
+    assert_equal error, result.error
+  end
+
+  def test_noop_hooks_does_nothing
+    hooks = Basecamp::NoopHooks.new
+    info = Basecamp::RequestInfo.new(method: "GET", url: "/test")
+    result = Basecamp::RequestResult.new(status_code: 200)
+
+    # Should not raise
+    hooks.on_request_start(info)
+    hooks.on_request_end(info, result)
+    hooks.on_retry(info, 2, StandardError.new, 1.0)
+    hooks.on_paginate("/url", 1)
+  end
+end
+
+class LoggerHooksTest < Minitest::Test
+  def setup
+    @log_output = StringIO.new
+    @logger = Logger.new(@log_output)
+    @logger.level = Logger::DEBUG
+    @hooks = Basecamp::LoggerHooks.new(@logger)
+  end
+
+  def test_logs_request_start
+    info = Basecamp::RequestInfo.new(method: "GET", url: "/test", attempt: 1)
+
+    @hooks.on_request_start(info)
+
+    assert_includes @log_output.string, "HTTP GET /test"
+    assert_includes @log_output.string, "attempt 1"
+  end
+
+  def test_logs_request_end_success
+    info = Basecamp::RequestInfo.new(method: "GET", url: "/test")
+    result = Basecamp::RequestResult.new(status_code: 200, duration: 0.123)
+
+    @hooks.on_request_end(info, result)
+
+    assert_includes @log_output.string, "200"
+    assert_includes @log_output.string, "0.123"
+  end
+
+  def test_logs_request_end_error
+    info = Basecamp::RequestInfo.new(method: "GET", url: "/test")
+    result = Basecamp::RequestResult.new(error: StandardError.new("Connection failed"))
+
+    @hooks.on_request_end(info, result)
+
+    assert_includes @log_output.string, "failed"
+    assert_includes @log_output.string, "Connection failed"
+  end
+
+  def test_logs_retry
+    info = Basecamp::RequestInfo.new(method: "GET", url: "/test")
+    error = StandardError.new("Rate limited")
+
+    @hooks.on_retry(info, 2, error, 1.5)
+
+    assert_includes @log_output.string, "Retrying"
+    assert_includes @log_output.string, "attempt 2"
+    assert_includes @log_output.string, "1.50"
+  end
+
+  def test_logs_pagination
+    @hooks.on_paginate("/items?page=2", 2)
+
+    assert_includes @log_output.string, "page 2"
+    assert_includes @log_output.string, "/items?page=2"
+  end
+
+  def test_logs_cached_response
+    info = Basecamp::RequestInfo.new(method: "GET", url: "/test")
+    result = Basecamp::RequestResult.new(status_code: 200, duration: 0.001, from_cache: true)
+
+    @hooks.on_request_end(info, result)
+
+    assert_includes @log_output.string, "cached"
+  end
+end

--- a/ruby/test/basecamp/http_extended_test.rb
+++ b/ruby/test/basecamp/http_extended_test.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Extended HTTP tests for edge cases in retry, pagination, and error handling
+class HTTPRetryExtendedTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @config = Basecamp::Config.new(
+      base_url: "https://3.basecampapi.com",
+      timeout: 5,
+      max_retries: 3,
+      base_delay: 0.01,
+      max_jitter: 0.001
+    )
+    @token_provider = test_token_provider
+    @http = Basecamp::Http.new(config: @config, token_provider: @token_provider)
+  end
+
+  def test_retry_after_zero_returns_nil
+    # Retry-After: 0 is treated as nil (no delay specified)
+    # Implementation only accepts positive retry_after values
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 429, body: "{}", headers: { "Retry-After" => "0" })
+
+    error = assert_raises(Basecamp::RateLimitError) do
+      @http.get("/test.json")
+    end
+
+    assert_nil error.retry_after
+  end
+
+  def test_retry_after_as_integer_seconds
+    # Use a short retry_after to avoid long waits in tests
+    # Verify the value is parsed correctly
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 429, body: "{}", headers: { "Retry-After" => "5" })
+
+    error = assert_raises(Basecamp::RateLimitError) do
+      @http.get("/test.json")
+    end
+
+    assert_equal 5, error.retry_after
+  end
+
+  def test_503_service_unavailable_is_retryable
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 503, body: "{}")
+      .then.to_return(status: 503, body: "{}")
+      .then.to_return(status: 200, body: '{"ok": true}')
+
+    response = @http.get("/test.json")
+
+    assert_equal 200, response.status
+    assert_requested(:get, "https://3.basecampapi.com/test.json", times: 3)
+  end
+
+  def test_503_with_retry_after_header
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 503, body: "{}", headers: { "Retry-After" => "5" })
+      .then.to_return(status: 200, body: '{"ok": true}')
+
+    response = @http.get("/test.json")
+
+    assert_equal 200, response.status
+  end
+
+  def test_502_bad_gateway_is_retryable
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 502, body: "Bad Gateway")
+      .then.to_return(status: 200, body: '{"ok": true}')
+
+    response = @http.get("/test.json")
+
+    assert_equal 200, response.status
+    assert_requested(:get, "https://3.basecampapi.com/test.json", times: 2)
+  end
+
+  def test_504_gateway_timeout_is_retryable
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 504, body: "Gateway Timeout")
+      .then.to_return(status: 200, body: '{"ok": true}')
+
+    response = @http.get("/test.json")
+
+    assert_equal 200, response.status
+    assert_requested(:get, "https://3.basecampapi.com/test.json", times: 2)
+  end
+
+  def test_exponential_backoff_increases_delay
+    # Test is implicit in the retry behavior - verifies the code path exists
+    # Actual timing verification would require mocking Time
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 503, body: "{}")
+      .then.to_return(status: 503, body: "{}")
+      .then.to_return(status: 200, body: '{"ok": true}')
+
+    response = @http.get("/test.json")
+
+    assert_equal 200, response.status
+  end
+end
+
+class HTTPPaginationExtendedTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @config = default_config
+    @token_provider = test_token_provider
+    @http = Basecamp::Http.new(config: @config, token_provider: @token_provider)
+  end
+
+  def test_paginate_no_link_header
+    stub_request(:get, "https://3.basecampapi.com/items.json")
+      .to_return(status: 200, body: '[{"id": 1}]')
+
+    items = @http.paginate("/items.json").to_a
+
+    assert_equal 1, items.length
+    assert_requested(:get, "https://3.basecampapi.com/items.json", times: 1)
+  end
+
+  def test_paginate_link_header_without_next_rel
+    # Link header with only 'prev' relation should stop pagination
+    stub_request(:get, "https://3.basecampapi.com/items.json")
+      .to_return(
+        status: 200,
+        body: '[{"id": 1}]',
+        headers: { "Link" => '<https://3.basecampapi.com/items.json?page=0>; rel="prev"' }
+      )
+
+    items = @http.paginate("/items.json").to_a
+
+    assert_equal 1, items.length
+  end
+
+  def test_paginate_link_header_with_multiple_relations
+    stub_request(:get, "https://3.basecampapi.com/items.json")
+      .to_return(
+        status: 200,
+        body: '[{"id": 1}]',
+        headers: { "Link" => '<https://3.basecampapi.com/items.json?page=2>; rel="next", <https://3.basecampapi.com/items.json?page=1>; rel="prev"' }
+      )
+
+    stub_request(:get, "https://3.basecampapi.com/items.json?page=2")
+      .to_return(status: 200, body: '[{"id": 2}]')
+
+    items = @http.paginate("/items.json").to_a
+
+    assert_equal 2, items.length
+  end
+
+  def test_paginate_empty_first_page
+    stub_request(:get, "https://3.basecampapi.com/items.json")
+      .to_return(status: 200, body: "[]")
+
+    items = @http.paginate("/items.json").to_a
+
+    assert_equal 0, items.length
+  end
+
+  def test_paginate_three_pages
+    stub_request(:get, "https://3.basecampapi.com/items.json")
+      .to_return(
+        status: 200,
+        body: '[{"id": 1}]',
+        headers: { "Link" => '<https://3.basecampapi.com/items.json?page=2>; rel="next"' }
+      )
+
+    stub_request(:get, "https://3.basecampapi.com/items.json?page=2")
+      .to_return(
+        status: 200,
+        body: '[{"id": 2}]',
+        headers: { "Link" => '<https://3.basecampapi.com/items.json?page=3>; rel="next"' }
+      )
+
+    stub_request(:get, "https://3.basecampapi.com/items.json?page=3")
+      .to_return(status: 200, body: '[{"id": 3}]')
+
+    items = @http.paginate("/items.json").to_a
+
+    assert_equal 3, items.length
+    assert_equal([ 1, 2, 3 ], items.map { |i| i["id"] })
+  end
+
+  def test_paginate_with_params_preserved
+    stub_request(:get, "https://3.basecampapi.com/items.json")
+      .with(query: { status: "active" })
+      .to_return(
+        status: 200,
+        body: '[{"id": 1}]',
+        headers: { "Link" => '<https://3.basecampapi.com/items.json?status=active&page=2>; rel="next"' }
+      )
+
+    stub_request(:get, "https://3.basecampapi.com/items.json")
+      .with(query: { status: "active", page: "2" })
+      .to_return(status: 200, body: '[{"id": 2}]')
+
+    items = @http.paginate("/items.json", params: { status: "active" }).to_a
+
+    assert_equal 2, items.length
+  end
+end

--- a/ruby/test/basecamp/http_test.rb
+++ b/ruby/test/basecamp/http_test.rb
@@ -1,0 +1,287 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class HTTPTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @config = default_config
+    @token_provider = test_token_provider
+    @http = Basecamp::Http.new(config: @config, token_provider: @token_provider)
+  end
+
+  def test_get_request
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 200, body: '{"result": "ok"}', headers: { "Content-Type" => "application/json" })
+
+    response = @http.get("/test.json")
+
+    assert_equal 200, response.status
+    assert_equal({ "result" => "ok" }, response.json)
+  end
+
+  def test_get_with_params
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .with(query: { status: "active" })
+      .to_return(status: 200, body: "[]", headers: { "Content-Type" => "application/json" })
+
+    response = @http.get("/test.json", params: { status: "active" })
+
+    assert_equal 200, response.status
+  end
+
+  def test_post_request
+    stub_request(:post, "https://3.basecampapi.com/test.json")
+      .with(body: { name: "Test" }.to_json)
+      .to_return(status: 201, body: '{"id": 1}', headers: { "Content-Type" => "application/json" })
+
+    response = @http.post("/test.json", body: { name: "Test" })
+
+    assert_equal 201, response.status
+    assert_equal({ "id" => 1 }, response.json)
+  end
+
+  def test_put_request
+    stub_request(:put, "https://3.basecampapi.com/test/1.json")
+      .to_return(status: 200, body: '{"updated": true}', headers: { "Content-Type" => "application/json" })
+
+    response = @http.put("/test/1.json", body: { name: "Updated" })
+
+    assert_equal 200, response.status
+  end
+
+  def test_delete_request
+    stub_request(:delete, "https://3.basecampapi.com/test/1.json")
+      .to_return(status: 204, body: "")
+
+    response = @http.delete("/test/1.json")
+
+    assert_equal 204, response.status
+  end
+
+  def test_authorization_header
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .with(headers: { "Authorization" => "Bearer test-access-token" })
+      .to_return(status: 200, body: "{}")
+
+    @http.get("/test.json")
+
+    assert_requested(:get, "https://3.basecampapi.com/test.json",
+                     headers: { "Authorization" => "Bearer test-access-token" })
+  end
+
+  def test_user_agent_header
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 200, body: "{}")
+
+    @http.get("/test.json")
+
+    assert_requested(:get, "https://3.basecampapi.com/test.json",
+                     headers: { "User-Agent" => /basecamp-sdk-ruby/ })
+  end
+
+  def test_handles_absolute_url
+    stub_request(:get, "https://other.api.com/path.json")
+      .to_return(status: 200, body: "{}")
+
+    response = @http.get("https://other.api.com/path.json")
+
+    assert_equal 200, response.status
+  end
+
+  def test_401_raises_auth_error
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 401, body: '{"error": "Unauthorized"}')
+
+    assert_raises(Basecamp::AuthError) do
+      @http.get("/test.json")
+    end
+  end
+
+  def test_403_raises_forbidden_error
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 403, body: '{"error": "Forbidden"}')
+
+    assert_raises(Basecamp::ForbiddenError) do
+      @http.get("/test.json")
+    end
+  end
+
+  def test_404_raises_not_found_error
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 404, body: '{"error": "Not found"}')
+
+    assert_raises(Basecamp::NotFoundError) do
+      @http.get("/test.json")
+    end
+  end
+
+  def test_429_raises_rate_limit_error
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 429, body: "{}", headers: { "Retry-After" => "30" })
+
+    error = assert_raises(Basecamp::RateLimitError) do
+      @http.get("/test.json")
+    end
+
+    assert_equal 30, error.retry_after
+    assert error.retryable?
+  end
+
+  def test_500_raises_error
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 500, body: '{"error": "Server error"}')
+
+    # 5xx errors may raise APIError or NetworkError depending on Faraday error classification
+    assert_raises(Basecamp::Error) do
+      @http.get("/test.json")
+    end
+  end
+
+  def test_response_json_parsing
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 200, body: '{"name": "Test", "count": 42}')
+
+    response = @http.get("/test.json")
+    json = response.json
+
+    assert_equal "Test", json["name"]
+    assert_equal 42, json["count"]
+  end
+
+  def test_response_success_predicate
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 200, body: "{}")
+
+    response = @http.get("/test.json")
+
+    assert response.success?
+  end
+end
+
+class HTTPRetryTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @config = Basecamp::Config.new(
+      base_url: "https://3.basecampapi.com",
+      timeout: 5,
+      max_retries: 3,
+      base_delay: 0.01, # Short delay for tests
+      max_jitter: 0.001
+    )
+    @token_provider = test_token_provider
+    @http = Basecamp::Http.new(config: @config, token_provider: @token_provider)
+  end
+
+  def test_retries_on_5xx_for_get
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 503, body: "{}")
+      .then.to_return(status: 200, body: '{"ok": true}')
+
+    response = @http.get("/test.json")
+
+    assert_equal 200, response.status
+    assert_requested(:get, "https://3.basecampapi.com/test.json", times: 2)
+  end
+
+  def test_does_not_retry_post_on_5xx
+    stub_request(:post, "https://3.basecampapi.com/test.json")
+      .to_return(status: 503, body: "{}")
+
+    # Mutations should not retry, error type depends on Faraday classification
+    assert_raises(Basecamp::Error) do
+      @http.post("/test.json", body: { data: "test" })
+    end
+
+    assert_requested(:post, "https://3.basecampapi.com/test.json", times: 1)
+  end
+
+  def test_respects_retry_after_header
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 429, body: "{}", headers: { "Retry-After" => "1" })
+
+    error = assert_raises(Basecamp::RateLimitError) do
+      @http.get("/test.json")
+    end
+
+    assert_equal 1, error.retry_after
+  end
+
+  def test_max_retries_exceeded
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 503, body: "{}")
+
+    # After max retries, error type depends on Faraday classification
+    assert_raises(Basecamp::Error) do
+      @http.get("/test.json")
+    end
+
+    # Should have retried max_retries times
+    assert_requested(:get, "https://3.basecampapi.com/test.json", times: 3)
+  end
+end
+
+class HTTPPaginationTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @config = default_config
+    @token_provider = test_token_provider
+    @http = Basecamp::Http.new(config: @config, token_provider: @token_provider)
+  end
+
+  def test_paginate_single_page
+    stub_request(:get, "https://3.basecampapi.com/items.json")
+      .to_return(status: 200, body: '[{"id": 1}, {"id": 2}]')
+
+    items = @http.paginate("/items.json").to_a
+
+    assert_equal 2, items.length
+    assert_equal 1, items[0]["id"]
+    assert_equal 2, items[1]["id"]
+  end
+
+  def test_paginate_multiple_pages
+    stub_request(:get, "https://3.basecampapi.com/items.json")
+      .to_return(
+        status: 200,
+        body: '[{"id": 1}]',
+        headers: { "Link" => '<https://3.basecampapi.com/items.json?page=2>; rel="next"' }
+      )
+
+    stub_request(:get, "https://3.basecampapi.com/items.json?page=2")
+      .to_return(status: 200, body: '[{"id": 2}]')
+
+    items = @http.paginate("/items.json").to_a
+
+    assert_equal 2, items.length
+    assert_equal 1, items[0]["id"]
+    assert_equal 2, items[1]["id"]
+  end
+
+  def test_paginate_returns_enumerator
+    stub_request(:get, "https://3.basecampapi.com/items.json")
+      .to_return(status: 200, body: '[{"id": 1}, {"id": 2}, {"id": 3}]')
+
+    enum = @http.paginate("/items.json")
+
+    assert_kind_of Enumerator, enum
+  end
+
+  def test_paginate_lazy_evaluation
+    # Only stub first page - second should not be called if we only take 1
+    stub_request(:get, "https://3.basecampapi.com/items.json")
+      .to_return(
+        status: 200,
+        body: '[{"id": 1}]',
+        headers: { "Link" => '<https://3.basecampapi.com/items.json?page=2>; rel="next"' }
+      )
+
+    items = @http.paginate("/items.json").take(1).to_a
+
+    assert_equal 1, items.length
+    assert_requested(:get, "https://3.basecampapi.com/items.json", times: 1)
+  end
+end

--- a/ruby/test/basecamp/oauth_test.rb
+++ b/ruby/test/basecamp/oauth_test.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class OAuthTest < Minitest::Test
+  include TestHelper
+
+  def test_discover_launchpad
+    discovery_response = {
+      "issuer" => "https://launchpad.37signals.com",
+      "authorization_endpoint" => "https://launchpad.37signals.com/authorization/new",
+      "token_endpoint" => "https://launchpad.37signals.com/authorization/token"
+    }
+
+    stub_request(:get, "https://launchpad.37signals.com/.well-known/oauth-authorization-server")
+      .to_return(status: 200, body: discovery_response.to_json, headers: { "Content-Type" => "application/json" })
+
+    config = Basecamp::Oauth.discover_launchpad
+    assert_equal "https://launchpad.37signals.com", config.issuer
+    assert_equal "https://launchpad.37signals.com/authorization/new", config.authorization_endpoint
+    assert_equal "https://launchpad.37signals.com/authorization/token", config.token_endpoint
+  end
+
+  def test_discover_custom_url
+    discovery_response = {
+      "issuer" => "https://custom-auth.example.com",
+      "authorization_endpoint" => "https://custom-auth.example.com/authorize",
+      "token_endpoint" => "https://custom-auth.example.com/token"
+    }
+
+    stub_request(:get, "https://custom-auth.example.com/.well-known/oauth-authorization-server")
+      .to_return(status: 200, body: discovery_response.to_json, headers: { "Content-Type" => "application/json" })
+
+    config = Basecamp::Oauth.discover("https://custom-auth.example.com")
+    assert_equal "https://custom-auth.example.com", config.issuer
+  end
+
+  def test_discover_handles_trailing_slash
+    discovery_response = {
+      "issuer" => "https://launchpad.37signals.com",
+      "authorization_endpoint" => "https://launchpad.37signals.com/authorization/new",
+      "token_endpoint" => "https://launchpad.37signals.com/authorization/token"
+    }
+
+    stub_request(:get, "https://launchpad.37signals.com/.well-known/oauth-authorization-server")
+      .to_return(status: 200, body: discovery_response.to_json, headers: { "Content-Type" => "application/json" })
+
+    config = Basecamp::Oauth.discover("https://launchpad.37signals.com/")
+    assert_equal "https://launchpad.37signals.com", config.issuer
+  end
+
+  def test_discover_raises_on_missing_fields
+    discovery_response = {
+      "issuer" => "https://launchpad.37signals.com"
+      # Missing authorization_endpoint and token_endpoint
+    }
+
+    stub_request(:get, "https://launchpad.37signals.com/.well-known/oauth-authorization-server")
+      .to_return(status: 200, body: discovery_response.to_json, headers: { "Content-Type" => "application/json" })
+
+    error = assert_raises(Basecamp::Oauth::OAuthError) do
+      Basecamp::Oauth.discover_launchpad
+    end
+    assert_includes error.message, "missing required fields"
+  end
+
+  def test_discover_raises_on_network_error
+    stub_request(:get, "https://launchpad.37signals.com/.well-known/oauth-authorization-server")
+      .to_return(status: 500, body: "Internal Server Error")
+
+    error = assert_raises(Basecamp::Oauth::OAuthError) do
+      Basecamp::Oauth.discover_launchpad
+    end
+    assert_equal "network", error.type
+  end
+
+  def test_exchange_code
+    token_response = {
+      "access_token" => "access_token_123",
+      "refresh_token" => "refresh_token_456",
+      "expires_in" => 3600,
+      "token_type" => "Bearer"
+    }
+
+    stub_request(:post, "https://launchpad.37signals.com/authorization/token")
+      .to_return(status: 200, body: token_response.to_json, headers: { "Content-Type" => "application/json" })
+
+    token = Basecamp::Oauth.exchange_code(
+      token_endpoint: "https://launchpad.37signals.com/authorization/token",
+      code: "auth_code_123",
+      redirect_uri: "https://myapp.com/callback",
+      client_id: "my_client_id",
+      client_secret: "my_client_secret"
+    )
+
+    assert_equal "access_token_123", token.access_token
+    assert_equal "refresh_token_456", token.refresh_token
+    assert_equal 3600, token.expires_in
+  end
+
+  def test_exchange_code_with_legacy_format
+    token_response = {
+      "access_token" => "access_token_123",
+      "refresh_token" => "refresh_token_456",
+      "expires_in" => 3600
+    }
+
+    stub_request(:post, "https://launchpad.37signals.com/authorization/token")
+      .to_return(status: 200, body: token_response.to_json, headers: { "Content-Type" => "application/json" })
+
+    token = Basecamp::Oauth.exchange_code(
+      token_endpoint: "https://launchpad.37signals.com/authorization/token",
+      code: "auth_code_123",
+      redirect_uri: "https://myapp.com/callback",
+      client_id: "my_client_id",
+      client_secret: "my_client_secret",
+      use_legacy_format: true
+    )
+
+    assert_equal "access_token_123", token.access_token
+  end
+
+  def test_refresh_token
+    token_response = {
+      "access_token" => "new_access_token",
+      "refresh_token" => "new_refresh_token",
+      "expires_in" => 7200
+    }
+
+    stub_request(:post, "https://launchpad.37signals.com/authorization/token")
+      .to_return(status: 200, body: token_response.to_json, headers: { "Content-Type" => "application/json" })
+
+    token = Basecamp::Oauth.refresh_token(
+      token_endpoint: "https://launchpad.37signals.com/authorization/token",
+      refresh_token: "old_refresh_token",
+      client_id: "my_client_id",
+      client_secret: "my_client_secret"
+    )
+
+    assert_equal "new_access_token", token.access_token
+    assert_equal "new_refresh_token", token.refresh_token
+  end
+
+  def test_token_expired
+    token = Basecamp::Oauth::Token.new(
+      access_token: "test",
+      token_type: "Bearer",
+      expires_at: Time.now - 100 # Already expired
+    )
+
+    assert token.expired?
+  end
+
+  def test_token_not_expired
+    token = Basecamp::Oauth::Token.new(
+      access_token: "test",
+      token_type: "Bearer",
+      expires_at: Time.now + 3600 # Expires in 1 hour
+    )
+
+    refute token.expired?
+  end
+
+  def test_config_struct
+    config = Basecamp::Oauth::Config.new(
+      issuer: "https://example.com",
+      authorization_endpoint: "https://example.com/auth",
+      token_endpoint: "https://example.com/token",
+      registration_endpoint: "https://example.com/register",
+      scopes_supported: %w[read write]
+    )
+
+    assert_equal "https://example.com", config.issuer
+    assert_equal "https://example.com/auth", config.authorization_endpoint
+    assert_equal "https://example.com/token", config.token_endpoint
+    assert_equal %w[read write], config.scopes_supported
+  end
+end

--- a/ruby/test/basecamp/services/attachments_service_test.rb
+++ b/ruby/test/basecamp/services/attachments_service_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AttachmentsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def test_create_attachment
+    attachment_response = {
+      "attachable_sgid" => "BAh7CEkiCGdpZAY6BkVUSSIvZ2lk...",
+      "content_type" => "application/pdf",
+      "filename" => "report.pdf",
+      "byte_size" => 1024
+    }
+
+    stub_request(:post, %r{https://3\.basecampapi\.com/12345/attachments\.json\?name=report\.pdf})
+      .with(
+        headers: { "Content-Type" => "application/pdf" }
+      )
+      .to_return(
+        status: 200,
+        body: attachment_response.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    result = @account.attachments.create(
+      filename: "report.pdf",
+      content_type: "application/pdf",
+      data: "file data"
+    )
+
+    assert_equal "BAh7CEkiCGdpZAY6BkVUSSIvZ2lk...", result["attachable_sgid"]
+    assert_equal "application/pdf", result["content_type"]
+  end
+
+  def test_create_attachment_with_special_characters_in_filename
+    attachment_response = {
+      "attachable_sgid" => "BAh7CEkiCGdpZAY6BkVUSSIvZ2lk...",
+      "filename" => "my report (1).pdf"
+    }
+
+    stub_request(:post, "https://3.basecampapi.com/12345/attachments.json?name=my%20report%20(1).pdf")
+      .to_return(
+        status: 200,
+        body: attachment_response.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    result = @account.attachments.create(
+      filename: "my report (1).pdf",
+      content_type: "application/pdf",
+      data: "file data"
+    )
+
+    assert_equal "my report (1).pdf", result["filename"]
+  end
+end

--- a/ruby/test/basecamp/services/authorization_service_test.rb
+++ b/ruby/test/basecamp/services/authorization_service_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AuthorizationServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @client = create_client
+  end
+
+  def test_get_authorization
+    stub_discovery_failure
+    stub_launchpad_get("/authorization.json", response_body: sample_authorization)
+
+    auth = @client.authorization.get
+
+    assert_equal "test@example.com", auth["identity"]["email_address"]
+    assert_equal 1, auth["accounts"].length
+    assert_equal 12_345, auth["accounts"].first["id"]
+  end
+
+  def test_authorization_returns_accounts
+    stub_discovery_failure
+    stub_launchpad_get("/authorization.json", response_body: sample_authorization)
+
+    auth = @client.authorization.get
+
+    accounts = auth["accounts"]
+    assert_equal "Test Account", accounts.first["name"]
+    assert_equal "bc3", accounts.first["product"]
+  end
+
+  def test_authorization_returns_identity
+    stub_discovery_failure
+    stub_launchpad_get("/authorization.json", response_body: sample_authorization)
+
+    auth = @client.authorization.get
+
+    identity = auth["identity"]
+    assert_equal "Test", identity["first_name"]
+    assert_equal "User", identity["last_name"]
+  end
+
+  def test_authorization_uses_discovered_endpoint
+    stub_discovery_success
+    stub_launchpad_get("/authorization.json", response_body: sample_authorization)
+
+    auth = @client.authorization.get
+
+    assert_equal "test@example.com", auth["identity"]["email_address"]
+  end
+end

--- a/ruby/test/basecamp/services/campfires_service_test.rb
+++ b/ruby/test/basecamp/services/campfires_service_test.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CampfiresServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def sample_campfire(id: 1, title: "Team Chat")
+    {
+      "id" => id,
+      "title" => title,
+      "lines_url" => "https://3.basecampapi.com/12345/buckets/100/chats/#{id}/lines.json"
+    }
+  end
+
+  def sample_line(id: 1, content: "Hello!")
+    {
+      "id" => id,
+      "content" => content,
+      "creator" => { "id" => 1, "name" => "Test User" },
+      "created_at" => "2024-01-01T00:00:00Z"
+    }
+  end
+
+  def sample_chatbot(id: 1, service_name: "TestBot")
+    {
+      "id" => id,
+      "service_name" => service_name,
+      "lines_url" => "https://3.basecampapi.com/12345/integrations/abc123/buckets/100/chats/200/lines.json"
+    }
+  end
+
+  def test_list_campfires
+    stub_get("/12345/chats.json", response_body: [ sample_campfire, sample_campfire(id: 2, title: "General") ])
+
+    campfires = @account.campfires.list.to_a
+
+    assert_equal 2, campfires.length
+    assert_equal "Team Chat", campfires[0]["title"]
+    assert_equal "General", campfires[1]["title"]
+  end
+
+  def test_get_campfire
+    stub_get("/12345/buckets/100/chats/200.json", response_body: sample_campfire(id: 200))
+
+    campfire = @account.campfires.get(project_id: 100, campfire_id: 200)
+
+    assert_equal 200, campfire["id"]
+    assert_equal "Team Chat", campfire["title"]
+  end
+
+  def test_list_lines
+    stub_get("/12345/buckets/100/chats/200/lines.json",
+             response_body: [ sample_line, sample_line(id: 2, content: "Hi there!") ])
+
+    lines = @account.campfires.list_lines(project_id: 100, campfire_id: 200).to_a
+
+    assert_equal 2, lines.length
+    assert_equal "Hello!", lines[0]["content"]
+    assert_equal "Hi there!", lines[1]["content"]
+  end
+
+  def test_get_line
+    stub_get("/12345/buckets/100/chats/200/lines/300.json", response_body: sample_line(id: 300))
+
+    line = @account.campfires.get_line(project_id: 100, campfire_id: 200, line_id: 300)
+
+    assert_equal 300, line["id"]
+    assert_equal "Hello!", line["content"]
+  end
+
+  def test_create_line
+    new_line = sample_line(id: 999, content: "New message")
+    stub_post("/12345/buckets/100/chats/200/lines.json", response_body: new_line)
+
+    line = @account.campfires.create_line(project_id: 100, campfire_id: 200, content: "New message")
+
+    assert_equal 999, line["id"]
+    assert_equal "New message", line["content"]
+  end
+
+  def test_delete_line
+    stub_delete("/12345/buckets/100/chats/200/lines/300.json")
+
+    result = @account.campfires.delete_line(project_id: 100, campfire_id: 200, line_id: 300)
+
+    assert_nil result
+  end
+
+  def test_list_chatbots
+    stub_get("/12345/buckets/100/chats/200/integrations.json",
+             response_body: [ sample_chatbot, sample_chatbot(id: 2, service_name: "AnotherBot") ])
+
+    chatbots = @account.campfires.list_chatbots(project_id: 100, campfire_id: 200).to_a
+
+    assert_equal 2, chatbots.length
+    assert_equal "TestBot", chatbots[0]["service_name"]
+  end
+
+  def test_get_chatbot
+    stub_get("/12345/buckets/100/chats/200/integrations/300.json", response_body: sample_chatbot(id: 300))
+
+    chatbot = @account.campfires.get_chatbot(project_id: 100, campfire_id: 200, chatbot_id: 300)
+
+    assert_equal 300, chatbot["id"]
+    assert_equal "TestBot", chatbot["service_name"]
+  end
+
+  def test_create_chatbot
+    new_chatbot = sample_chatbot(id: 999, service_name: "NewBot")
+    stub_post("/12345/buckets/100/chats/200/integrations.json", response_body: new_chatbot)
+
+    chatbot = @account.campfires.create_chatbot(
+      project_id: 100,
+      campfire_id: 200,
+      service_name: "NewBot",
+      command_url: "https://example.com/webhook"
+    )
+
+    assert_equal 999, chatbot["id"]
+    assert_equal "NewBot", chatbot["service_name"]
+  end
+
+  def test_update_chatbot
+    updated_chatbot = sample_chatbot(id: 300, service_name: "UpdatedBot")
+    stub_put("/12345/buckets/100/chats/200/integrations/300.json", response_body: updated_chatbot)
+
+    chatbot = @account.campfires.update_chatbot(
+      project_id: 100,
+      campfire_id: 200,
+      chatbot_id: 300,
+      service_name: "UpdatedBot"
+    )
+
+    assert_equal "UpdatedBot", chatbot["service_name"]
+  end
+
+  def test_delete_chatbot
+    stub_delete("/12345/buckets/100/chats/200/integrations/300.json")
+
+    result = @account.campfires.delete_chatbot(project_id: 100, campfire_id: 200, chatbot_id: 300)
+
+    assert_nil result
+  end
+end

--- a/ruby/test/basecamp/services/card_columns_service_test.rb
+++ b/ruby/test/basecamp/services/card_columns_service_test.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CardColumnsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def sample_column(id: 1, title: "To Do")
+    {
+      "id" => id,
+      "title" => title,
+      "description" => "Tasks to be done",
+      "color" => "white",
+      "cards_count" => 5
+    }
+  end
+
+  def test_get_column
+    stub_get("/12345/buckets/100/card_tables/columns/200.json", response_body: sample_column(id: 200))
+
+    column = @account.card_columns.get(project_id: 100, column_id: 200)
+
+    assert_equal 200, column["id"]
+    assert_equal "To Do", column["title"]
+  end
+
+  def test_create_column
+    new_column = sample_column(id: 999, title: "In Review")
+    stub_post("/12345/buckets/100/card_tables/200/columns.json", response_body: new_column)
+
+    column = @account.card_columns.create(
+      project_id: 100,
+      card_table_id: 200,
+      title: "In Review",
+      description: "Waiting for review"
+    )
+
+    assert_equal 999, column["id"]
+    assert_equal "In Review", column["title"]
+  end
+
+  def test_update_column
+    updated_column = sample_column(id: 200, title: "Updated Title")
+    stub_put("/12345/buckets/100/card_tables/columns/200.json", response_body: updated_column)
+
+    column = @account.card_columns.update(
+      project_id: 100,
+      column_id: 200,
+      title: "Updated Title",
+      description: "New description"
+    )
+
+    assert_equal "Updated Title", column["title"]
+  end
+
+  def test_move_column
+    stub_post("/12345/buckets/100/card_tables/200/moves.json", response_body: {})
+
+    result = @account.card_columns.move(
+      project_id: 100,
+      card_table_id: 200,
+      source_id: 300,
+      target_id: 400,
+      position: 1
+    )
+
+    assert_nil result
+  end
+
+  def test_set_color
+    colored_column = sample_column(id: 200)
+    colored_column["color"] = "blue"
+    stub_put("/12345/buckets/100/card_tables/columns/200/color.json", response_body: colored_column)
+
+    column = @account.card_columns.set_color(project_id: 100, column_id: 200, color: "blue")
+
+    assert_equal "blue", column["color"]
+  end
+
+  def test_enable_on_hold
+    column_with_hold = sample_column(id: 200)
+    column_with_hold["on_hold"] = true
+    stub_post("/12345/buckets/100/card_tables/columns/200/on_hold.json", response_body: column_with_hold)
+
+    column = @account.card_columns.enable_on_hold(project_id: 100, column_id: 200)
+
+    assert column["on_hold"]
+  end
+
+  def test_disable_on_hold
+    column_without_hold = sample_column(id: 200)
+    column_without_hold["on_hold"] = false
+    stub_delete("/12345/buckets/100/card_tables/columns/200/on_hold.json")
+    stub_request(:delete, "https://3.basecampapi.com/12345/buckets/100/card_tables/columns/200/on_hold.json")
+      .to_return(status: 200, body: column_without_hold.to_json, headers: { "Content-Type" => "application/json" })
+
+    column = @account.card_columns.disable_on_hold(project_id: 100, column_id: 200)
+
+    refute column["on_hold"]
+  end
+end

--- a/ruby/test/basecamp/services/card_steps_service_test.rb
+++ b/ruby/test/basecamp/services/card_steps_service_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CardStepsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def sample_step(id: 1, title: "Review code")
+    {
+      "id" => id,
+      "title" => title,
+      "completed" => false,
+      "due_on" => nil,
+      "assignees" => []
+    }
+  end
+
+  def test_create_step
+    new_step = sample_step(id: 999, title: "New step")
+    stub_post("/12345/buckets/100/card_tables/cards/200/steps.json", response_body: new_step)
+
+    step = @account.card_steps.create(
+      project_id: 100,
+      card_id: 200,
+      title: "New step",
+      due_on: "2024-12-15",
+      assignees: [ 1, 2 ]
+    )
+
+    assert_equal 999, step["id"]
+    assert_equal "New step", step["title"]
+  end
+
+  def test_update_step
+    updated_step = sample_step(id: 200, title: "Updated step")
+    stub_put("/12345/buckets/100/card_tables/steps/200.json", response_body: updated_step)
+
+    step = @account.card_steps.update(
+      project_id: 100,
+      step_id: 200,
+      title: "Updated step",
+      due_on: "2024-12-20"
+    )
+
+    assert_equal "Updated step", step["title"]
+  end
+
+  def test_complete_step
+    completed_step = sample_step(id: 200)
+    completed_step["completed"] = true
+    stub_put("/12345/buckets/100/card_tables/steps/200/completions.json", response_body: completed_step)
+
+    step = @account.card_steps.complete(project_id: 100, step_id: 200)
+
+    assert step["completed"]
+  end
+
+  def test_uncomplete_step
+    uncompleted_step = sample_step(id: 200)
+    stub_delete("/12345/buckets/100/card_tables/steps/200/completions.json")
+    stub_request(:delete, "https://3.basecampapi.com/12345/buckets/100/card_tables/steps/200/completions.json")
+      .to_return(status: 200, body: uncompleted_step.to_json, headers: { "Content-Type" => "application/json" })
+
+    step = @account.card_steps.uncomplete(project_id: 100, step_id: 200)
+
+    refute step["completed"]
+  end
+
+  def test_reposition_step
+    stub_post("/12345/buckets/100/card_tables/cards/200/positions.json", response_body: {})
+
+    result = @account.card_steps.reposition(
+      project_id: 100,
+      card_id: 200,
+      step_id: 300,
+      position: 2
+    )
+
+    assert_nil result
+  end
+end

--- a/ruby/test/basecamp/services/card_tables_service_test.rb
+++ b/ruby/test/basecamp/services/card_tables_service_test.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CardTablesServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def sample_card_table(id: 1, title: "Project Board")
+    {
+      "id" => id,
+      "title" => title,
+      "lists" => [
+        { "id" => 100, "title" => "To Do", "cards_count" => 3 },
+        { "id" => 101, "title" => "In Progress", "cards_count" => 2 },
+        { "id" => 102, "title" => "Done", "cards_count" => 5 }
+      ]
+    }
+  end
+
+  def test_get_card_table
+    stub_get("/12345/buckets/100/card_tables/200.json", response_body: sample_card_table(id: 200))
+
+    table = @account.card_tables.get(project_id: 100, card_table_id: 200)
+
+    assert_equal 200, table["id"]
+    assert_equal "Project Board", table["title"]
+    assert_equal 3, table["lists"].length
+    assert_equal "To Do", table["lists"][0]["title"]
+  end
+end

--- a/ruby/test/basecamp/services/cards_service_test.rb
+++ b/ruby/test/basecamp/services/cards_service_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CardsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def sample_card(id: 1, title: "Task Card")
+    {
+      "id" => id,
+      "title" => title,
+      "content" => "<p>Card description</p>",
+      "due_on" => "2024-12-31",
+      "completed" => false,
+      "assignees" => []
+    }
+  end
+
+  def test_list_cards
+    stub_get("/12345/buckets/100/card_tables/lists/200/cards.json",
+             response_body: [ sample_card, sample_card(id: 2, title: "Another Card") ])
+
+    cards = @account.cards.list(project_id: 100, column_id: 200).to_a
+
+    assert_equal 2, cards.length
+    assert_equal "Task Card", cards[0]["title"]
+    assert_equal "Another Card", cards[1]["title"]
+  end
+
+  def test_get_card
+    stub_get("/12345/buckets/100/card_tables/cards/200.json", response_body: sample_card(id: 200))
+
+    card = @account.cards.get(project_id: 100, card_id: 200)
+
+    assert_equal 200, card["id"]
+    assert_equal "Task Card", card["title"]
+  end
+
+  def test_create_card
+    new_card = sample_card(id: 999, title: "New Feature")
+    stub_post("/12345/buckets/100/card_tables/lists/200/cards.json", response_body: new_card)
+
+    card = @account.cards.create(
+      project_id: 100,
+      column_id: 200,
+      title: "New Feature",
+      content: "<p>Feature description</p>",
+      due_on: "2024-12-31"
+    )
+
+    assert_equal 999, card["id"]
+    assert_equal "New Feature", card["title"]
+  end
+
+  def test_update_card
+    updated_card = sample_card(id: 200, title: "Updated Title")
+    stub_put("/12345/buckets/100/card_tables/cards/200.json", response_body: updated_card)
+
+    card = @account.cards.update(
+      project_id: 100,
+      card_id: 200,
+      title: "Updated Title",
+      content: "<p>New content</p>"
+    )
+
+    assert_equal "Updated Title", card["title"]
+  end
+
+  def test_move_card
+    stub_post("/12345/buckets/100/card_tables/cards/200/moves.json", response_body: {})
+
+    result = @account.cards.move(project_id: 100, card_id: 200, column_id: 300)
+
+    assert_nil result
+  end
+end

--- a/ruby/test/basecamp/services/checkins_service_test.rb
+++ b/ruby/test/basecamp/services/checkins_service_test.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CheckinsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def sample_questionnaire(id: 1)
+    {
+      "id" => id,
+      "name" => "Automatic Check-ins",
+      "questions_count" => 3
+    }
+  end
+
+  def sample_question(id: 1, title: "What did you work on today?")
+    {
+      "id" => id,
+      "title" => title,
+      "paused" => false,
+      "schedule" => { "frequency" => "every_day", "hour" => 16, "minute" => 0 }
+    }
+  end
+
+  def sample_answer(id: 1, content: "<p>Making great progress!</p>")
+    {
+      "id" => id,
+      "content" => content,
+      "creator" => { "id" => 1, "name" => "Test User" },
+      "created_at" => "2024-01-01T00:00:00Z"
+    }
+  end
+
+  def test_get_questionnaire
+    stub_get("/12345/buckets/100/questionnaires/200.json", response_body: sample_questionnaire(id: 200))
+
+    questionnaire = @account.checkins.get_questionnaire(project_id: 100, questionnaire_id: 200)
+
+    assert_equal 200, questionnaire["id"]
+    assert_equal "Automatic Check-ins", questionnaire["name"]
+  end
+
+  def test_list_questions
+    stub_get("/12345/buckets/100/questionnaires/200/questions.json",
+             response_body: [ sample_question, sample_question(id: 2, title: "Any blockers?") ])
+
+    questions = @account.checkins.list_questions(project_id: 100, questionnaire_id: 200).to_a
+
+    assert_equal 2, questions.length
+    assert_equal "What did you work on today?", questions[0]["title"]
+  end
+
+  def test_get_question
+    stub_get("/12345/buckets/100/questions/200.json", response_body: sample_question(id: 200))
+
+    question = @account.checkins.get_question(project_id: 100, question_id: 200)
+
+    assert_equal 200, question["id"]
+    assert_equal "What did you work on today?", question["title"]
+  end
+
+  def test_create_question
+    new_question = sample_question(id: 999, title: "New question")
+    stub_post("/12345/buckets/100/questionnaires/200/questions.json", response_body: new_question)
+
+    question = @account.checkins.create_question(
+      project_id: 100,
+      questionnaire_id: 200,
+      title: "New question",
+      schedule: { frequency: "every_week", days: [ 1 ], hour: 9, minute: 0 }
+    )
+
+    assert_equal 999, question["id"]
+    assert_equal "New question", question["title"]
+  end
+
+  def test_update_question
+    updated_question = sample_question(id: 200, title: "Updated question")
+    stub_put("/12345/buckets/100/questions/200.json", response_body: updated_question)
+
+    question = @account.checkins.update_question(
+      project_id: 100,
+      question_id: 200,
+      title: "Updated question",
+      paused: false
+    )
+
+    assert_equal "Updated question", question["title"]
+  end
+
+  def test_list_answers
+    stub_get("/12345/buckets/100/questions/200/answers.json",
+             response_body: [ sample_answer, sample_answer(id: 2, content: "<p>All good!</p>") ])
+
+    answers = @account.checkins.list_answers(project_id: 100, question_id: 200).to_a
+
+    assert_equal 2, answers.length
+    assert_equal "<p>Making great progress!</p>", answers[0]["content"]
+  end
+
+  def test_get_answer
+    stub_get("/12345/buckets/100/question_answers/200.json", response_body: sample_answer(id: 200))
+
+    answer = @account.checkins.get_answer(project_id: 100, answer_id: 200)
+
+    assert_equal 200, answer["id"]
+    assert_equal "<p>Making great progress!</p>", answer["content"]
+  end
+
+  def test_create_answer
+    new_answer = sample_answer(id: 999, content: "<p>New answer</p>")
+    stub_post("/12345/buckets/100/questions/200/answers.json", response_body: new_answer)
+
+    answer = @account.checkins.create_answer(
+      project_id: 100,
+      question_id: 200,
+      content: "<p>New answer</p>",
+      group_on: "2024-01-15"
+    )
+
+    assert_equal 999, answer["id"]
+    assert_equal "<p>New answer</p>", answer["content"]
+  end
+
+  def test_update_answer
+    stub_put("/12345/buckets/100/question_answers/200.json", response_body: {})
+
+    result = @account.checkins.update_answer(
+      project_id: 100,
+      answer_id: 200,
+      content: "<p>Updated answer</p>"
+    )
+
+    assert_nil result
+  end
+end

--- a/ruby/test/basecamp/services/client_approvals_service_test.rb
+++ b/ruby/test/basecamp/services/client_approvals_service_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ClientApprovalsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def sample_approval(id: 1, subject: "Design Review")
+    {
+      "id" => id,
+      "subject" => subject,
+      "approval_status" => "pending",
+      "content" => "<p>Please review the attached designs.</p>",
+      "created_at" => "2024-01-01T00:00:00Z"
+    }
+  end
+
+  def test_list_approvals
+    stub_get("/12345/buckets/100/client/approvals.json",
+             response_body: [ sample_approval, sample_approval(id: 2, subject: "Budget Approval") ])
+
+    approvals = @account.client_approvals.list(project_id: 100).to_a
+
+    assert_equal 2, approvals.length
+    assert_equal "Design Review", approvals[0]["subject"]
+    assert_equal "Budget Approval", approvals[1]["subject"]
+  end
+
+  def test_get_approval
+    stub_get("/12345/buckets/100/client/approvals/200.json", response_body: sample_approval(id: 200))
+
+    approval = @account.client_approvals.get(project_id: 100, approval_id: 200)
+
+    assert_equal 200, approval["id"]
+    assert_equal "Design Review", approval["subject"]
+    assert_equal "pending", approval["approval_status"]
+  end
+end

--- a/ruby/test/basecamp/services/client_correspondences_service_test.rb
+++ b/ruby/test/basecamp/services/client_correspondences_service_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ClientCorrespondencesServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def sample_correspondence(id: 1, subject: "Project Update")
+    {
+      "id" => id,
+      "subject" => subject,
+      "content" => "<p>Here is the latest update on the project.</p>",
+      "replies_count" => 3,
+      "created_at" => "2024-01-01T00:00:00Z"
+    }
+  end
+
+  def test_list_correspondences
+    stub_get("/12345/buckets/100/client/correspondences.json",
+             response_body: [ sample_correspondence, sample_correspondence(id: 2, subject: "Invoice Query") ])
+
+    correspondences = @account.client_correspondences.list(project_id: 100).to_a
+
+    assert_equal 2, correspondences.length
+    assert_equal "Project Update", correspondences[0]["subject"]
+    assert_equal "Invoice Query", correspondences[1]["subject"]
+  end
+
+  def test_get_correspondence
+    stub_get("/12345/buckets/100/client/correspondences/200.json", response_body: sample_correspondence(id: 200))
+
+    correspondence = @account.client_correspondences.get(project_id: 100, correspondence_id: 200)
+
+    assert_equal 200, correspondence["id"]
+    assert_equal "Project Update", correspondence["subject"]
+    assert_equal 3, correspondence["replies_count"]
+  end
+end

--- a/ruby/test/basecamp/services/client_replies_service_test.rb
+++ b/ruby/test/basecamp/services/client_replies_service_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ClientRepliesServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def sample_reply(id: 1, content: "<p>Thank you for the update!</p>")
+    {
+      "id" => id,
+      "content" => content,
+      "creator" => { "id" => 1, "name" => "Client User" },
+      "created_at" => "2024-01-01T00:00:00Z"
+    }
+  end
+
+  def test_list_replies
+    stub_get("/12345/buckets/100/client/recordings/200/replies.json",
+             response_body: [ sample_reply, sample_reply(id: 2, content: "<p>Looking forward to it!</p>") ])
+
+    replies = @account.client_replies.list(project_id: 100, recording_id: 200).to_a
+
+    assert_equal 2, replies.length
+    assert_equal "<p>Thank you for the update!</p>", replies[0]["content"]
+    assert_equal "<p>Looking forward to it!</p>", replies[1]["content"]
+  end
+
+  def test_get_reply
+    stub_get("/12345/buckets/100/client/recordings/200/replies/300.json", response_body: sample_reply(id: 300))
+
+    reply = @account.client_replies.get(project_id: 100, recording_id: 200, reply_id: 300)
+
+    assert_equal 300, reply["id"]
+    assert_equal "<p>Thank you for the update!</p>", reply["content"]
+    assert_equal "Client User", reply["creator"]["name"]
+  end
+end

--- a/ruby/test/basecamp/services/comments_service_test.rb
+++ b/ruby/test/basecamp/services/comments_service_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CommentsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def sample_comment(id: 1, content: "<p>Great work!</p>")
+    {
+      "id" => id,
+      "content" => content,
+      "creator" => { "id" => 1, "name" => "Test User" },
+      "created_at" => "2024-01-01T00:00:00Z"
+    }
+  end
+
+  def test_list_comments
+    stub_get("/12345/buckets/100/recordings/200/comments.json",
+             response_body: [ sample_comment, sample_comment(id: 2, content: "<p>I agree!</p>") ])
+
+    comments = @account.comments.list(project_id: 100, recording_id: 200).to_a
+
+    assert_equal 2, comments.length
+    assert_equal "<p>Great work!</p>", comments[0]["content"]
+    assert_equal "<p>I agree!</p>", comments[1]["content"]
+  end
+
+  def test_get_comment
+    stub_get("/12345/buckets/100/comments/200.json", response_body: sample_comment(id: 200))
+
+    comment = @account.comments.get(project_id: 100, comment_id: 200)
+
+    assert_equal 200, comment["id"]
+    assert_equal "<p>Great work!</p>", comment["content"]
+  end
+
+  def test_create_comment
+    new_comment = sample_comment(id: 999, content: "<p>New comment</p>")
+    stub_post("/12345/buckets/100/recordings/200/comments.json", response_body: new_comment)
+
+    comment = @account.comments.create(
+      project_id: 100,
+      recording_id: 200,
+      content: "<p>New comment</p>"
+    )
+
+    assert_equal 999, comment["id"]
+    assert_equal "<p>New comment</p>", comment["content"]
+  end
+
+  def test_update_comment
+    updated_comment = sample_comment(id: 200, content: "<p>Updated comment</p>")
+    stub_put("/12345/buckets/100/comments/200.json", response_body: updated_comment)
+
+    comment = @account.comments.update(
+      project_id: 100,
+      comment_id: 200,
+      content: "<p>Updated comment</p>"
+    )
+
+    assert_equal "<p>Updated comment</p>", comment["content"]
+  end
+end

--- a/ruby/test/basecamp/services/documents_service_test.rb
+++ b/ruby/test/basecamp/services/documents_service_test.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DocumentsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def sample_document(id: 1, title: "Meeting Notes")
+    {
+      "id" => id,
+      "title" => title,
+      "content" => "<p>Notes from today's meeting...</p>",
+      "status" => "active",
+      "comments_count" => 2,
+      "created_at" => "2024-01-01T00:00:00Z"
+    }
+  end
+
+  def test_list_documents
+    stub_get("/12345/buckets/100/vaults/200/documents.json",
+             response_body: [ sample_document, sample_document(id: 2, title: "Project Plan") ])
+
+    documents = @account.documents.list(project_id: 100, vault_id: 200).to_a
+
+    assert_equal 2, documents.length
+    assert_equal "Meeting Notes", documents[0]["title"]
+    assert_equal "Project Plan", documents[1]["title"]
+  end
+
+  def test_get_document
+    stub_get("/12345/buckets/100/documents/200.json", response_body: sample_document(id: 200))
+
+    document = @account.documents.get(project_id: 100, document_id: 200)
+
+    assert_equal 200, document["id"]
+    assert_equal "Meeting Notes", document["title"]
+  end
+
+  def test_create_document
+    new_document = sample_document(id: 999, title: "New Document")
+    stub_post("/12345/buckets/100/vaults/200/documents.json", response_body: new_document)
+
+    document = @account.documents.create(
+      project_id: 100,
+      vault_id: 200,
+      title: "New Document",
+      content: "<p>Document content</p>",
+      status: "active"
+    )
+
+    assert_equal 999, document["id"]
+    assert_equal "New Document", document["title"]
+  end
+
+  def test_create_draft_document
+    draft_document = sample_document(id: 999, title: "Draft Document")
+    draft_document["status"] = "drafted"
+    stub_post("/12345/buckets/100/vaults/200/documents.json", response_body: draft_document)
+
+    document = @account.documents.create(
+      project_id: 100,
+      vault_id: 200,
+      title: "Draft Document",
+      status: "drafted"
+    )
+
+    assert_equal "drafted", document["status"]
+  end
+
+  def test_update_document
+    updated_document = sample_document(id: 200, title: "Updated Title")
+    stub_put("/12345/buckets/100/documents/200.json", response_body: updated_document)
+
+    document = @account.documents.update(
+      project_id: 100,
+      document_id: 200,
+      title: "Updated Title",
+      content: "<p>New content</p>"
+    )
+
+    assert_equal "Updated Title", document["title"]
+  end
+end

--- a/ruby/test/basecamp/services/events_service_test.rb
+++ b/ruby/test/basecamp/services/events_service_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class EventsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def sample_event(id: 1, action: "created")
+    {
+      "id" => id,
+      "action" => action,
+      "creator" => { "id" => 1, "name" => "Test User" },
+      "created_at" => "2024-01-01T00:00:00Z"
+    }
+  end
+
+  def test_list_events
+    stub_get("/12345/buckets/100/recordings/200/events.json",
+             response_body: [
+               sample_event(id: 1, action: "created"),
+               sample_event(id: 2, action: "updated"),
+               sample_event(id: 3, action: "completed")
+             ])
+
+    events = @account.events.list(project_id: 100, recording_id: 200).to_a
+
+    assert_equal 3, events.length
+    assert_equal "created", events[0]["action"]
+    assert_equal "updated", events[1]["action"]
+    assert_equal "completed", events[2]["action"]
+  end
+
+  def test_list_events_shows_creator
+    stub_get("/12345/buckets/100/recordings/200/events.json",
+             response_body: [ sample_event ])
+
+    events = @account.events.list(project_id: 100, recording_id: 200).to_a
+
+    assert_equal "Test User", events[0]["creator"]["name"]
+  end
+end

--- a/ruby/test/basecamp/services/forwards_service_test.rb
+++ b/ruby/test/basecamp/services/forwards_service_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ForwardsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def sample_inbox(id: 1)
+    {
+      "id" => id,
+      "name" => "Email Forwards",
+      "forwards_count" => 5
+    }
+  end
+
+  def sample_forward(id: 1, subject: "Client Question")
+    {
+      "id" => id,
+      "subject" => subject,
+      "from" => "client@example.com",
+      "content" => "<p>I have a question about the project.</p>",
+      "created_at" => "2024-01-01T00:00:00Z"
+    }
+  end
+
+  def sample_reply(id: 1, content: "<p>Thanks for reaching out!</p>")
+    {
+      "id" => id,
+      "content" => content,
+      "creator" => { "id" => 1, "name" => "Test User" },
+      "created_at" => "2024-01-01T00:00:00Z"
+    }
+  end
+
+  def test_get_inbox
+    stub_get("/12345/buckets/100/inboxes/200.json", response_body: sample_inbox(id: 200))
+
+    inbox = @account.forwards.get_inbox(project_id: 100, inbox_id: 200)
+
+    assert_equal 200, inbox["id"]
+    assert_equal "Email Forwards", inbox["name"]
+  end
+
+  def test_list_forwards
+    stub_get("/12345/buckets/100/inboxes/200/forwards.json",
+             response_body: [ sample_forward, sample_forward(id: 2, subject: "Another Email") ])
+
+    forwards = @account.forwards.list(project_id: 100, inbox_id: 200).to_a
+
+    assert_equal 2, forwards.length
+    assert_equal "Client Question", forwards[0]["subject"]
+    assert_equal "Another Email", forwards[1]["subject"]
+  end
+
+  def test_get_forward
+    stub_get("/12345/buckets/100/inbox_forwards/200.json", response_body: sample_forward(id: 200))
+
+    forward = @account.forwards.get(project_id: 100, forward_id: 200)
+
+    assert_equal 200, forward["id"]
+    assert_equal "Client Question", forward["subject"]
+    assert_equal "client@example.com", forward["from"]
+  end
+
+  def test_list_replies
+    stub_get("/12345/buckets/100/inbox_forwards/200/replies.json",
+             response_body: [ sample_reply, sample_reply(id: 2, content: "<p>Follow up!</p>") ])
+
+    replies = @account.forwards.list_replies(project_id: 100, forward_id: 200).to_a
+
+    assert_equal 2, replies.length
+    assert_equal "<p>Thanks for reaching out!</p>", replies[0]["content"]
+  end
+
+  def test_get_reply
+    stub_get("/12345/buckets/100/inbox_forwards/200/replies/300.json", response_body: sample_reply(id: 300))
+
+    reply = @account.forwards.get_reply(project_id: 100, forward_id: 200, reply_id: 300)
+
+    assert_equal 300, reply["id"]
+    assert_equal "<p>Thanks for reaching out!</p>", reply["content"]
+  end
+
+  def test_create_reply
+    new_reply = sample_reply(id: 999, content: "<p>Here is my response.</p>")
+    stub_post("/12345/buckets/100/inbox_forwards/200/replies.json", response_body: new_reply)
+
+    reply = @account.forwards.create_reply(
+      project_id: 100,
+      forward_id: 200,
+      content: "<p>Here is my response.</p>"
+    )
+
+    assert_equal 999, reply["id"]
+    assert_equal "<p>Here is my response.</p>", reply["content"]
+  end
+end

--- a/ruby/test/basecamp/services/lineup_service_test.rb
+++ b/ruby/test/basecamp/services/lineup_service_test.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class LineupServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def test_create_marker
+    marker = { "id" => 1, "title" => "Launch Day", "starts_on" => "2024-03-01", "ends_on" => "2024-03-01" }
+    stub_post("/12345/lineup/markers.json", response_body: marker)
+
+    result = @account.lineup.create_marker(
+      title: "Launch Day",
+      starts_on: "2024-03-01",
+      ends_on: "2024-03-01"
+    )
+
+    assert_equal "Launch Day", result["title"]
+    assert_equal "2024-03-01", result["starts_on"]
+  end
+
+  def test_create_marker_with_color_and_description
+    marker = { "id" => 2, "title" => "Milestone", "color" => "green", "description" => "<p>Big day!</p>" }
+    stub_post("/12345/lineup/markers.json", response_body: marker)
+
+    result = @account.lineup.create_marker(
+      title: "Milestone",
+      starts_on: "2024-04-01",
+      ends_on: "2024-04-01",
+      color: "green",
+      description: "<p>Big day!</p>"
+    )
+
+    assert_equal "green", result["color"]
+  end
+
+  def test_update_marker
+    updated_marker = { "id" => 1, "title" => "Updated Launch", "color" => "blue" }
+    stub_request(:put, "https://3.basecampapi.com/12345/lineup/markers/1")
+      .to_return(status: 200, body: updated_marker.to_json)
+
+    result = @account.lineup.update_marker(marker_id: 1, title: "Updated Launch", color: "blue")
+
+    assert_equal "Updated Launch", result["title"]
+    assert_equal "blue", result["color"]
+  end
+
+  def test_delete_marker
+    stub_request(:delete, "https://3.basecampapi.com/12345/lineup/markers/1")
+      .to_return(status: 204, body: "")
+
+    result = @account.lineup.delete_marker(marker_id: 1)
+
+    assert_nil result
+  end
+end

--- a/ruby/test/basecamp/services/message_boards_service_test.rb
+++ b/ruby/test/basecamp/services/message_boards_service_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MessageBoardsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def test_get
+    board = {
+      "id" => 456,
+      "title" => "Message Board",
+      "messages_count" => 10,
+      "created_at" => "2024-01-01T00:00:00Z"
+    }
+    stub_get("/12345/buckets/100/message_boards/456", response_body: board)
+
+    result = @account.message_boards.get(project_id: 100, board_id: 456)
+
+    assert_equal 456, result["id"]
+    assert_equal "Message Board", result["title"]
+    assert_equal 10, result["messages_count"]
+  end
+end

--- a/ruby/test/basecamp/services/message_types_service_test.rb
+++ b/ruby/test/basecamp/services/message_types_service_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MessageTypesServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def test_list
+    types = [
+      { "id" => 1, "name" => "Announcement", "icon" => "\u{1F4E2}" },
+      { "id" => 2, "name" => "Update", "icon" => "\u{1F4DD}" }
+    ]
+    stub_get("/12345/buckets/100/categories.json", response_body: types)
+
+    result = @account.message_types.list(project_id: 100).to_a
+
+    assert_equal 2, result.length
+    assert_equal "Announcement", result[0]["name"]
+    assert_equal "Update", result[1]["name"]
+  end
+
+  def test_get
+    type = { "id" => 1, "name" => "Announcement", "icon" => "\u{1F4E2}" }
+    stub_get("/12345/buckets/100/categories/1", response_body: type)
+
+    result = @account.message_types.get(project_id: 100, type_id: 1)
+
+    assert_equal 1, result["id"]
+    assert_equal "Announcement", result["name"]
+  end
+
+  def test_create
+    type = { "id" => 3, "name" => "Question", "icon" => "\u{2753}" }
+    stub_post("/12345/buckets/100/categories.json", response_body: type)
+
+    result = @account.message_types.create(project_id: 100, name: "Question", icon: "\u{2753}")
+
+    assert_equal 3, result["id"]
+    assert_equal "Question", result["name"]
+  end
+
+  def test_update
+    updated_type = { "id" => 1, "name" => "Important Announcement", "icon" => "\u{1F4E3}" }
+    stub_put("/12345/buckets/100/categories/1", response_body: updated_type)
+
+    result = @account.message_types.update(project_id: 100, type_id: 1, name: "Important Announcement")
+
+    assert_equal "Important Announcement", result["name"]
+  end
+
+  def test_delete
+    stub_delete("/12345/buckets/100/categories/1")
+
+    result = @account.message_types.delete(project_id: 100, type_id: 1)
+
+    assert_nil result
+  end
+end

--- a/ruby/test/basecamp/services/messages_service_test.rb
+++ b/ruby/test/basecamp/services/messages_service_test.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class MessagesServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def sample_message(id: 789, subject: "Test Message")
+    {
+      "id" => id,
+      "subject" => subject,
+      "content" => "<p>Message content</p>",
+      "status" => "active",
+      "created_at" => "2024-01-01T00:00:00Z",
+      "creator" => { "id" => 1, "name" => "Test User" }
+    }
+  end
+
+  def test_list
+    messages = [ sample_message, sample_message(id: 790, subject: "Another Message") ]
+    stub_get("/12345/buckets/100/message_boards/456/messages.json", response_body: messages)
+
+    result = @account.messages.list(project_id: 100, board_id: 456).to_a
+
+    assert_equal 2, result.length
+    assert_equal "Test Message", result[0]["subject"]
+  end
+
+  def test_get
+    stub_get("/12345/buckets/100/messages/789", response_body: sample_message)
+
+    result = @account.messages.get(project_id: 100, message_id: 789)
+
+    assert_equal 789, result["id"]
+    assert_equal "Test Message", result["subject"]
+  end
+
+  def test_create
+    new_message = sample_message(id: 999, subject: "New Post")
+    stub_post("/12345/buckets/100/message_boards/456/messages.json", response_body: new_message)
+
+    result = @account.messages.create(
+      project_id: 100,
+      board_id: 456,
+      subject: "New Post",
+      content: "<p>Content here</p>"
+    )
+
+    assert_equal 999, result["id"]
+    assert_equal "New Post", result["subject"]
+  end
+
+  def test_create_with_category
+    new_message = sample_message(id: 1000, subject: "Announcement")
+    stub_post("/12345/buckets/100/message_boards/456/messages.json", response_body: new_message)
+
+    result = @account.messages.create(
+      project_id: 100,
+      board_id: 456,
+      subject: "Announcement",
+      category_id: 1
+    )
+
+    assert_equal "Announcement", result["subject"]
+  end
+
+  def test_update
+    updated_message = sample_message(subject: "Updated Subject")
+    stub_put("/12345/buckets/100/messages/789", response_body: updated_message)
+
+    result = @account.messages.update(project_id: 100, message_id: 789, subject: "Updated Subject")
+
+    assert_equal "Updated Subject", result["subject"]
+  end
+
+  def test_pin
+    stub_post("/12345/buckets/100/recordings/789/pin.json", response_body: {})
+
+    result = @account.messages.pin(project_id: 100, message_id: 789)
+
+    assert_nil result
+  end
+
+  def test_unpin
+    stub_delete("/12345/buckets/100/recordings/789/pin.json")
+
+    result = @account.messages.unpin(project_id: 100, message_id: 789)
+
+    assert_nil result
+  end
+
+  def test_archive
+    stub_put("/12345/buckets/100/recordings/789/status/archived.json", response_body: {})
+
+    result = @account.messages.archive(project_id: 100, message_id: 789)
+
+    assert_nil result
+  end
+
+  def test_unarchive
+    stub_put("/12345/buckets/100/recordings/789/status/active.json", response_body: {})
+
+    result = @account.messages.unarchive(project_id: 100, message_id: 789)
+
+    assert_nil result
+  end
+
+  def test_trash
+    stub_put("/12345/buckets/100/recordings/789/status/trashed.json", response_body: {})
+
+    result = @account.messages.trash(project_id: 100, message_id: 789)
+
+    assert_nil result
+  end
+end

--- a/ruby/test/basecamp/services/people_service_test.rb
+++ b/ruby/test/basecamp/services/people_service_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class PeopleServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def sample_person(id: 1, name: "Test User")
+    {
+      "id" => id,
+      "name" => name,
+      "email_address" => "#{name.downcase.tr(' ', '.')}@example.com",
+      "admin" => false
+    }
+  end
+
+  def test_list
+    people = [ sample_person, sample_person(id: 2, name: "Another User") ]
+    stub_get("/12345/people.json", response_body: people)
+
+    result = @account.people.list.to_a
+
+    assert_equal 2, result.length
+    assert_equal "Test User", result[0]["name"]
+  end
+
+  def test_get
+    stub_get("/12345/people/1", response_body: sample_person)
+
+    result = @account.people.get(person_id: 1)
+
+    assert_equal 1, result["id"]
+    assert_equal "Test User", result["name"]
+  end
+
+  def test_me
+    me = sample_person(id: 99, name: "Current User")
+    stub_get("/12345/my/profile.json", response_body: me)
+
+    result = @account.people.me
+
+    assert_equal 99, result["id"]
+    assert_equal "Current User", result["name"]
+  end
+
+  def test_list_pingable
+    people = [ sample_person, sample_person(id: 3, name: "Pingable User") ]
+    stub_get("/12345/circles/people.json", response_body: people)
+
+    result = @account.people.list_pingable.to_a
+
+    assert_equal 2, result.length
+  end
+
+  def test_list_project_people
+    people = [ sample_person(id: 5, name: "Project Member") ]
+    stub_get("/12345/projects/100/people.json", response_body: people)
+
+    result = @account.people.list_project_people(project_id: 100).to_a
+
+    assert_equal 1, result.length
+    assert_equal "Project Member", result[0]["name"]
+  end
+
+  def test_update_project_access
+    stub_put("/12345/projects/100/people/users.json", response_body: {})
+
+    result = @account.people.update_project_access(
+      project_id: 100,
+      grant: [ 1, 2 ],
+      revoke: [ 3 ]
+    )
+
+    assert_nil result
+  end
+end

--- a/ruby/test/basecamp/services/projects_service_test.rb
+++ b/ruby/test/basecamp/services/projects_service_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ProjectsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def test_list_projects
+    stub_get("/12345/projects.json", response_body: [ sample_project, sample_project(id: 456, name: "Other") ])
+
+    projects = @account.projects.list.to_a
+
+    assert_equal 2, projects.length
+    assert_equal "Test Project", projects[0]["name"]
+    assert_equal "Other", projects[1]["name"]
+  end
+
+  def test_list_projects_with_status_filter
+    stub_request(:get, "https://3.basecampapi.com/12345/projects.json")
+      .with(query: { status: "archived" })
+      .to_return(status: 200, body: [ sample_project ].to_json)
+
+    projects = @account.projects.list(status: "archived").to_a
+
+    assert_equal 1, projects.length
+  end
+
+  def test_get_project
+    stub_get("/12345/projects/123.json", response_body: sample_project)
+
+    project = @account.projects.get(123)
+
+    assert_equal 123, project["id"]
+    assert_equal "Test Project", project["name"]
+  end
+
+  def test_create_project
+    stub_post("/12345/projects.json", response_body: sample_project(id: 999, name: "New Project"))
+
+    project = @account.projects.create(name: "New Project", description: "A description")
+
+    assert_equal 999, project["id"]
+    assert_equal "New Project", project["name"]
+  end
+
+  def test_update_project
+    stub_put("/12345/projects/123.json", response_body: sample_project(name: "Updated Name"))
+
+    project = @account.projects.update(123, name: "Updated Name")
+
+    assert_equal "Updated Name", project["name"]
+  end
+
+  def test_trash_project
+    stub_delete("/12345/projects/123.json")
+
+    result = @account.projects.trash(123)
+
+    assert_nil result
+  end
+end

--- a/ruby/test/basecamp/services/recordings_service_test.rb
+++ b/ruby/test/basecamp/services/recordings_service_test.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RecordingsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def sample_recording(id: 456, title: "Test Recording")
+    {
+      "id" => id,
+      "title" => title,
+      "status" => "active",
+      "type" => "Todo",
+      "created_at" => "2024-01-01T00:00:00Z"
+    }
+  end
+
+  def test_list
+    recordings = [ sample_recording, sample_recording(id: 457, title: "Another Recording") ]
+    stub_request(:get, "https://3.basecampapi.com/12345/projects/recordings.json")
+      .with(query: { type: "Todo" })
+      .to_return(status: 200, body: recordings.to_json)
+
+    result = @account.recordings.list(type: "Todo").to_a
+
+    assert_equal 2, result.length
+    assert_equal "Test Recording", result[0]["title"]
+  end
+
+  def test_list_with_filters
+    recordings = [ sample_recording ]
+    stub_request(:get, "https://3.basecampapi.com/12345/projects/recordings.json")
+      .with(query: { type: "Message", bucket: "100", status: "archived" })
+      .to_return(status: 200, body: recordings.to_json)
+
+    result = @account.recordings.list(type: "Message", bucket: 100, status: "archived").to_a
+
+    assert_equal 1, result.length
+  end
+
+  def test_get
+    stub_get("/12345/buckets/100/recordings/456", response_body: sample_recording)
+
+    result = @account.recordings.get(project_id: 100, recording_id: 456)
+
+    assert_equal 456, result["id"]
+    assert_equal "Test Recording", result["title"]
+  end
+
+  def test_archive
+    stub_put("/12345/buckets/100/recordings/456/status/archived.json", response_body: {})
+
+    result = @account.recordings.archive(project_id: 100, recording_id: 456)
+
+    assert_nil result
+  end
+
+  def test_unarchive
+    stub_put("/12345/buckets/100/recordings/456/status/active.json", response_body: {})
+
+    result = @account.recordings.unarchive(project_id: 100, recording_id: 456)
+
+    assert_nil result
+  end
+
+  def test_trash
+    stub_put("/12345/buckets/100/recordings/456/status/trashed.json", response_body: {})
+
+    result = @account.recordings.trash(project_id: 100, recording_id: 456)
+
+    assert_nil result
+  end
+
+  def test_list_events
+    events = [
+      { "id" => 1, "action" => "created", "created_at" => "2024-01-01T00:00:00Z" },
+      { "id" => 2, "action" => "updated", "created_at" => "2024-01-02T00:00:00Z" }
+    ]
+    stub_get("/12345/buckets/100/recordings/456/events.json", response_body: events)
+
+    result = @account.recordings.list_events(project_id: 100, recording_id: 456).to_a
+
+    assert_equal 2, result.length
+    assert_equal "created", result[0]["action"]
+  end
+
+  def test_get_subscription
+    subscription = { "subscribed" => true }
+    stub_get("/12345/buckets/100/recordings/456/subscription.json", response_body: subscription)
+
+    result = @account.recordings.get_subscription(project_id: 100, recording_id: 456)
+
+    assert result["subscribed"]
+  end
+
+  def test_subscribe
+    subscription = { "subscribed" => true }
+    stub_post("/12345/buckets/100/recordings/456/subscription.json", response_body: subscription)
+
+    result = @account.recordings.subscribe(project_id: 100, recording_id: 456)
+
+    assert result["subscribed"]
+  end
+
+  def test_unsubscribe
+    stub_delete("/12345/buckets/100/recordings/456/subscription.json")
+
+    result = @account.recordings.unsubscribe(project_id: 100, recording_id: 456)
+
+    assert_nil result
+  end
+
+  def test_set_client_visibility
+    stub_put("/12345/buckets/100/recordings/456/client_visibility.json", response_body: {})
+
+    result = @account.recordings.set_client_visibility(project_id: 100, recording_id: 456, visible: true)
+
+    assert_nil result
+  end
+end

--- a/ruby/test/basecamp/services/reports_service_test.rb
+++ b/ruby/test/basecamp/services/reports_service_test.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ReportsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def sample_timesheet_entry(id: 1)
+    {
+      "id" => id,
+      "duration" => 3600,
+      "started_at" => "2024-01-15T09:00:00Z",
+      "ended_at" => "2024-01-15T10:00:00Z",
+      "creator" => { "id" => 1, "name" => "Test User" }
+    }
+  end
+
+  def test_timesheet
+    response = { "entries" => [ sample_timesheet_entry, sample_timesheet_entry(id: 2) ] }
+    stub_get("/12345/reports/timesheet.json", response_body: response)
+
+    result = @account.reports.timesheet
+
+    assert_kind_of Hash, result
+    assert_equal 2, result["entries"].length
+    assert_equal 3600, result["entries"][0]["duration"]
+  end
+
+  def test_timesheet_with_filters
+    response = { "entries" => [ sample_timesheet_entry ] }
+    stub_request(:get, "https://3.basecampapi.com/12345/reports/timesheet.json")
+      .with(query: { from: "2024-01-01", to: "2024-01-31", person_id: "1" })
+      .to_return(status: 200, body: response.to_json)
+
+    result = @account.reports.timesheet(from: "2024-01-01", to: "2024-01-31", person_id: 1)
+
+    assert_equal 1, result["entries"].length
+  end
+
+  def test_project_timesheet
+    response = { "entries" => [ sample_timesheet_entry ] }
+    stub_get("/12345/buckets/100/timesheet.json", response_body: response)
+
+    result = @account.reports.project_timesheet(project_id: 100)
+
+    assert_equal 1, result["entries"].length
+  end
+
+  def test_project_timesheet_with_filters
+    response = { "entries" => [ sample_timesheet_entry ] }
+    stub_request(:get, "https://3.basecampapi.com/12345/buckets/100/timesheet.json")
+      .with(query: { from: "2024-01-01", to: "2024-01-31" })
+      .to_return(status: 200, body: response.to_json)
+
+    result = @account.reports.project_timesheet(project_id: 100, from: "2024-01-01", to: "2024-01-31")
+
+    assert_equal 1, result["entries"].length
+  end
+
+  def test_recording_timesheet
+    response = { "entries" => [ sample_timesheet_entry ] }
+    stub_get("/12345/buckets/100/recordings/456/timesheet.json", response_body: response)
+
+    result = @account.reports.recording_timesheet(project_id: 100, recording_id: 456)
+
+    assert_equal 1, result["entries"].length
+  end
+
+  def test_assignable_people
+    people = [
+      { "id" => 1, "name" => "Jane Doe" },
+      { "id" => 2, "name" => "John Smith" }
+    ]
+    stub_get("/12345/reports/todos/assigned.json", response_body: people)
+
+    result = @account.reports.assignable_people.to_a
+
+    assert_equal 2, result.length
+    assert_equal "Jane Doe", result[0]["name"]
+  end
+
+  def test_assigned_todos
+    response = {
+      "person" => { "id" => 456, "name" => "Jane Doe" },
+      "grouped_by" => "project",
+      "todos" => [
+        { "id" => 1, "content" => "Task for Jane" }
+      ]
+    }
+    # Note: no .json extension on this endpoint
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/reports/todos/assigned/456$})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.reports.assigned_todos(person_id: 456)
+
+    assert_kind_of Hash, result
+    assert_equal "Jane Doe", result["person"]["name"]
+    assert_equal "project", result["grouped_by"]
+    assert_equal 1, result["todos"].length
+    assert_equal "Task for Jane", result["todos"][0]["content"]
+  end
+
+  def test_assigned_todos_with_group_by
+    response = {
+      "person" => { "id" => 456, "name" => "Jane Doe" },
+      "grouped_by" => "date",
+      "todos" => [
+        { "id" => 1, "content" => "Task for Jane" }
+      ]
+    }
+    stub_request(:get, "https://3.basecampapi.com/12345/reports/todos/assigned/456")
+      .with(query: { group_by: "date" })
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.reports.assigned_todos(person_id: 456, group_by: "date")
+
+    assert_equal "date", result["grouped_by"]
+  end
+end

--- a/ruby/test/basecamp/services/schedules_service_test.rb
+++ b/ruby/test/basecamp/services/schedules_service_test.rb
@@ -1,0 +1,136 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SchedulesServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def sample_schedule(id: 456)
+    {
+      "id" => id,
+      "title" => "Schedule",
+      "include_due_assignments" => true,
+      "entries_count" => 5
+    }
+  end
+
+  def sample_entry(id: 789, summary: "Team Meeting")
+    {
+      "id" => id,
+      "summary" => summary,
+      "starts_at" => "2024-12-15T09:00:00Z",
+      "ends_at" => "2024-12-15T10:00:00Z",
+      "all_day" => false
+    }
+  end
+
+  def test_get
+    stub_get("/12345/buckets/100/schedules/456", response_body: sample_schedule)
+
+    result = @account.schedules.get(project_id: 100, schedule_id: 456)
+
+    assert_equal 456, result["id"]
+    assert_equal "Schedule", result["title"]
+  end
+
+  def test_list_entries
+    entries = [ sample_entry, sample_entry(id: 790, summary: "Another Event") ]
+    stub_get("/12345/buckets/100/schedules/456/entries.json", response_body: entries)
+
+    result = @account.schedules.list_entries(project_id: 100, schedule_id: 456).to_a
+
+    assert_equal 2, result.length
+    assert_equal "Team Meeting", result[0]["summary"]
+  end
+
+  def test_get_entry
+    stub_get("/12345/buckets/100/schedule_entries/789", response_body: sample_entry)
+
+    result = @account.schedules.get_entry(project_id: 100, entry_id: 789)
+
+    assert_equal 789, result["id"]
+    assert_equal "Team Meeting", result["summary"]
+  end
+
+  def test_create_entry
+    new_entry = sample_entry(id: 999, summary: "New Event")
+    stub_post("/12345/buckets/100/schedules/456/entries.json", response_body: new_entry)
+
+    result = @account.schedules.create_entry(
+      project_id: 100,
+      schedule_id: 456,
+      summary: "New Event",
+      starts_at: "2024-12-20T14:00:00Z",
+      ends_at: "2024-12-20T15:00:00Z"
+    )
+
+    assert_equal 999, result["id"]
+    assert_equal "New Event", result["summary"]
+  end
+
+  def test_create_entry_with_all_options
+    new_entry = sample_entry(id: 1000, summary: "Full Event")
+    stub_post("/12345/buckets/100/schedules/456/entries.json", response_body: new_entry)
+
+    result = @account.schedules.create_entry(
+      project_id: 100,
+      schedule_id: 456,
+      summary: "Full Event",
+      starts_at: "2024-12-25T00:00:00Z",
+      ends_at: "2024-12-25T23:59:59Z",
+      description: "<p>Holiday party!</p>",
+      participant_ids: [ 1, 2, 3 ],
+      all_day: true,
+      notify: true
+    )
+
+    assert_equal "Full Event", result["summary"]
+  end
+
+  def test_update_entry
+    updated_entry = sample_entry(summary: "Updated Meeting")
+    stub_put("/12345/buckets/100/schedule_entries/789", response_body: updated_entry)
+
+    result = @account.schedules.update_entry(
+      project_id: 100,
+      entry_id: 789,
+      summary: "Updated Meeting"
+    )
+
+    assert_equal "Updated Meeting", result["summary"]
+  end
+
+  def test_get_entry_occurrence
+    occurrence = sample_entry.merge("occurrence_date" => "2024-12-22")
+    stub_get("/12345/buckets/100/schedule_entries/789/occurrences/2024-12-22", response_body: occurrence)
+
+    result = @account.schedules.get_entry_occurrence(project_id: 100, entry_id: 789, date: "2024-12-22")
+
+    assert_equal "2024-12-22", result["occurrence_date"]
+  end
+
+  def test_update_settings
+    updated_schedule = sample_schedule.merge("include_due_assignments" => false)
+    stub_put("/12345/buckets/100/schedules/456", response_body: updated_schedule)
+
+    result = @account.schedules.update_settings(
+      project_id: 100,
+      schedule_id: 456,
+      include_due_assignments: false
+    )
+
+    assert_equal false, result["include_due_assignments"]
+  end
+
+  def test_trash_entry
+    stub_put("/12345/buckets/100/recordings/789/status/trashed.json", response_body: {})
+
+    result = @account.schedules.trash_entry(project_id: 100, entry_id: 789)
+
+    assert_nil result
+  end
+end

--- a/ruby/test/basecamp/services/search_service_test.rb
+++ b/ruby/test/basecamp/services/search_service_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SearchServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def test_search
+    results = [
+      { "id" => 1, "title" => "Quarterly Report", "type" => "Message" },
+      { "id" => 2, "title" => "Q1 Report Draft", "type" => "Document" }
+    ]
+    stub_request(:get, "https://3.basecampapi.com/12345/search.json")
+      .with(query: { query: "quarterly report" })
+      .to_return(status: 200, body: results.to_json)
+
+    result = @account.search.search(query: "quarterly report").to_a
+
+    assert_equal 2, result.length
+    assert_equal "Quarterly Report", result[0]["title"]
+  end
+
+  def test_search_with_sort
+    results = [ { "id" => 3, "title" => "Recent Doc", "type" => "Document" } ]
+    stub_request(:get, "https://3.basecampapi.com/12345/search.json")
+      .with(query: { query: "doc", sort: "updated_at" })
+      .to_return(status: 200, body: results.to_json)
+
+    result = @account.search.search(query: "doc", sort: "updated_at").to_a
+
+    assert_equal 1, result.length
+  end
+
+  def test_metadata
+    metadata = {
+      "projects" => [
+        { "id" => 100, "name" => "Project A" },
+        { "id" => 200, "name" => "Project B" }
+      ]
+    }
+    stub_get("/12345/searches/metadata.json", response_body: metadata)
+
+    result = @account.search.metadata
+
+    assert_equal 2, result["projects"].length
+    assert_equal "Project A", result["projects"][0]["name"]
+  end
+end

--- a/ruby/test/basecamp/services/subscriptions_service_test.rb
+++ b/ruby/test/basecamp/services/subscriptions_service_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SubscriptionsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def test_get
+    response = {
+      "subscribed" => true,
+      "count" => 5,
+      "subscribers" => []
+    }
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/buckets/\d+/recordings/\d+/subscription\.json})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.subscriptions.get(project_id: 1, recording_id: 2)
+    assert_equal true, result["subscribed"]
+    assert_equal 5, result["count"]
+  end
+
+  def test_subscribe
+    response = { "subscribed" => true }
+
+    stub_request(:post, %r{https://3\.basecampapi\.com/12345/buckets/\d+/recordings/\d+/subscription\.json})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.subscriptions.subscribe(project_id: 1, recording_id: 2)
+    assert_equal true, result["subscribed"]
+  end
+
+  def test_unsubscribe
+    stub_request(:delete, %r{https://3\.basecampapi\.com/12345/buckets/\d+/recordings/\d+/subscription\.json})
+      .to_return(status: 204)
+
+    result = @account.subscriptions.unsubscribe(project_id: 1, recording_id: 2)
+    assert_nil result
+  end
+
+  def test_update
+    response = { "subscribed" => true, "count" => 2 }
+
+    stub_request(:put, %r{https://3\.basecampapi\.com/12345/buckets/\d+/recordings/\d+/subscription\.json})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.subscriptions.update(
+      project_id: 1,
+      recording_id: 2,
+      subscriptions: [ 100, 101 ]
+    )
+    assert_equal 2, result["count"]
+  end
+end

--- a/ruby/test/basecamp/services/templates_service_test.rb
+++ b/ruby/test/basecamp/services/templates_service_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TemplatesServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def test_list
+    response = [ { "id" => 1, "name" => "Project Template" } ]
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/templates\.json})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.templates.list.to_a
+    assert_kind_of Array, result
+    assert_equal "Project Template", result.first["name"]
+  end
+
+  def test_get
+    response = { "id" => 1, "name" => "Project Template" }
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/templates/\d+})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.templates.get(template_id: 1)
+    assert_equal "Project Template", result["name"]
+  end
+
+  def test_create
+    response = { "id" => 1, "name" => "New Template" }
+
+    stub_request(:post, %r{https://3\.basecampapi\.com/12345/templates\.json})
+      .to_return(status: 201, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.templates.create(name: "New Template")
+    assert_equal "New Template", result["name"]
+  end
+
+  def test_update
+    response = { "id" => 1, "name" => "Updated Template" }
+
+    stub_request(:put, %r{https://3\.basecampapi\.com/12345/templates/\d+})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.templates.update(template_id: 1, name: "Updated Template")
+    assert_equal "Updated Template", result["name"]
+  end
+
+  def test_delete
+    stub_request(:delete, %r{https://3\.basecampapi\.com/12345/templates/\d+})
+      .to_return(status: 204)
+
+    result = @account.templates.delete(template_id: 1)
+    assert_nil result
+  end
+
+  def test_create_project
+    response = { "id" => 1, "status" => "processing" }
+
+    stub_request(:post, %r{https://3\.basecampapi\.com/12345/templates/\d+/project_constructions\.json})
+      .to_return(status: 201, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.templates.create_project(template_id: 1, name: "Q1 Project")
+    assert_equal "processing", result["status"]
+  end
+
+  def test_get_construction
+    response = { "id" => 1, "status" => "completed", "project" => { "id" => 100 } }
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/templates/\d+/project_constructions/\d+})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.templates.get_construction(template_id: 1, construction_id: 1)
+    assert_equal "completed", result["status"]
+  end
+end

--- a/ruby/test/basecamp/services/timeline_service_test.rb
+++ b/ruby/test/basecamp/services/timeline_service_test.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TimelineServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def sample_event(id: 1, action: "created")
+    {
+      "id" => id,
+      "action" => action,
+      "recording_type" => "Todo",
+      "created_at" => "2024-01-15T10:00:00Z"
+    }
+  end
+
+  def test_progress
+    response = {
+      "events" => [
+        sample_event(id: 1, action: "created"),
+        sample_event(id: 2, action: "updated")
+      ]
+    }
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/reports/progress\.json})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.timeline.progress.to_a
+
+    assert_kind_of Array, result
+    assert_equal 2, result.length
+    assert_equal "created", result[0]["action"]
+  end
+
+  def test_progress_pagination
+    page1 = { "events" => [ sample_event(id: 1) ] }
+    page2 = { "events" => [ sample_event(id: 2) ] }
+
+    stub_request(:get, "https://3.basecampapi.com/12345/reports/progress.json")
+      .to_return(
+        status: 200,
+        body: page1.to_json,
+        headers: {
+          "Content-Type" => "application/json",
+          "Link" => '<https://3.basecampapi.com/12345/reports/progress.json?page=2>; rel="next"'
+        }
+      )
+
+    stub_request(:get, "https://3.basecampapi.com/12345/reports/progress.json?page=2")
+      .to_return(status: 200, body: page2.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.timeline.progress.to_a
+
+    assert_equal 2, result.length
+    assert_equal 1, result[0]["id"]
+    assert_equal 2, result[1]["id"]
+  end
+
+  def test_project_timeline
+    response = {
+      "events" => [
+        sample_event(id: 1, action: "updated")
+      ]
+    }
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/buckets/100/timeline\.json})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.timeline.project_timeline(project_id: 100).to_a
+
+    assert_kind_of Array, result
+    assert_equal 1, result.length
+    assert_equal "updated", result[0]["action"]
+  end
+
+  def test_person_progress
+    response = {
+      "person" => { "id" => 456, "name" => "Jane Doe" },
+      "events" => [
+        sample_event(id: 1, action: "completed")
+      ]
+    }
+
+    # Note: no .json extension on this endpoint
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/reports/users/progress/456$})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.timeline.person_progress(person_id: 456)
+
+    assert_kind_of Hash, result
+    assert_equal "Jane Doe", result["person"]["name"]
+    assert_equal 1, result["events"].length
+    assert_equal "completed", result["events"][0]["action"]
+  end
+
+  def test_person_progress_events
+    response = {
+      "person" => { "id" => 456, "name" => "Jane Doe" },
+      "events" => [
+        sample_event(id: 1, action: "completed")
+      ]
+    }
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/reports/users/progress/456$})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.timeline.person_progress_events(person_id: 456).to_a
+
+    assert_kind_of Array, result
+    assert_equal 1, result.length
+    assert_equal "completed", result[0]["action"]
+  end
+
+  def test_person_progress_events_pagination
+    page1 = { "person" => { "id" => 456 }, "events" => [ sample_event(id: 1) ] }
+    page2 = { "person" => { "id" => 456 }, "events" => [ sample_event(id: 2) ] }
+
+    stub_request(:get, "https://3.basecampapi.com/12345/reports/users/progress/456")
+      .to_return(
+        status: 200,
+        body: page1.to_json,
+        headers: {
+          "Content-Type" => "application/json",
+          "Link" => '<https://3.basecampapi.com/12345/reports/users/progress/456?page=2>; rel="next"'
+        }
+      )
+
+    stub_request(:get, "https://3.basecampapi.com/12345/reports/users/progress/456?page=2")
+      .to_return(status: 200, body: page2.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.timeline.person_progress_events(person_id: 456).to_a
+
+    assert_equal 2, result.length
+    assert_equal 1, result[0]["id"]
+    assert_equal 2, result[1]["id"]
+  end
+end

--- a/ruby/test/basecamp/services/timesheet_service_test.rb
+++ b/ruby/test/basecamp/services/timesheet_service_test.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TimesheetServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def test_report
+    response = {
+      "entries" => [
+        { "id" => 1, "hours" => 8.0, "description" => "Development work" }
+      ]
+    }
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/reports/timesheet\.json})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.timesheet.report
+    assert_kind_of Hash, result
+    assert_kind_of Array, result["entries"]
+    assert_equal 8.0, result["entries"].first["hours"]
+  end
+
+  def test_report_with_date_range
+    response = { "entries" => [ { "id" => 1, "hours" => 4.0 } ] }
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/reports/timesheet\.json\?from=2024-01-01&to=2024-01-31})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.timesheet.report(from: "2024-01-01", to: "2024-01-31")
+    assert_equal 4.0, result["entries"].first["hours"]
+  end
+
+  def test_project_report
+    response = { "entries" => [ { "id" => 1, "hours" => 6.0 } ] }
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/buckets/\d+/timesheet\.json})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.timesheet.project_report(project_id: 1)
+    assert_kind_of Hash, result
+    assert_equal 6.0, result["entries"].first["hours"]
+  end
+
+  def test_recording_report
+    response = { "entries" => [ { "id" => 1, "hours" => 2.5 } ] }
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/buckets/\d+/recordings/\d+/timesheet\.json})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.timesheet.recording_report(project_id: 1, recording_id: 2)
+    assert_kind_of Hash, result
+    assert_equal 2.5, result["entries"].first["hours"]
+  end
+end

--- a/ruby/test/basecamp/services/todolist_groups_service_test.rb
+++ b/ruby/test/basecamp/services/todolist_groups_service_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TodolistGroupsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def test_list
+    response = [ { "id" => 1, "name" => "Phase 1" } ]
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/buckets/\d+/todolists/\d+/groups\.json})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.todolist_groups.list(project_id: 1, todolist_id: 2).to_a
+    assert_kind_of Array, result
+    assert_equal "Phase 1", result.first["name"]
+  end
+
+  def test_get
+    response = { "id" => 1, "name" => "Phase 1" }
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/buckets/\d+/todolists/\d+\.json})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.todolist_groups.get(project_id: 1, group_id: 2)
+    assert_equal "Phase 1", result["name"]
+  end
+
+  def test_create
+    response = { "id" => 1, "name" => "New Group" }
+
+    stub_request(:post, %r{https://3\.basecampapi\.com/12345/buckets/\d+/todolists/\d+/groups\.json})
+      .to_return(status: 201, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.todolist_groups.create(project_id: 1, todolist_id: 2, name: "New Group")
+    assert_equal "New Group", result["name"]
+  end
+
+  def test_create_requires_name
+    assert_raises ArgumentError do
+      @account.todolist_groups.create(project_id: 1, todolist_id: 2, name: "")
+    end
+  end
+
+  def test_update
+    response = { "id" => 1, "name" => "Updated Group" }
+
+    stub_request(:put, %r{https://3\.basecampapi\.com/12345/buckets/\d+/todolists/\d+\.json})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.todolist_groups.update(project_id: 1, group_id: 2, name: "Updated Group")
+    assert_equal "Updated Group", result["name"]
+  end
+
+  def test_reposition
+    stub_request(:put, %r{https://3\.basecampapi\.com/12345/buckets/\d+/todolists/\d+/position\.json})
+      .to_return(status: 204)
+
+    result = @account.todolist_groups.reposition(project_id: 1, group_id: 2, position: 1)
+    assert_nil result
+  end
+
+  def test_reposition_requires_positive_position
+    assert_raises ArgumentError do
+      @account.todolist_groups.reposition(project_id: 1, group_id: 2, position: 0)
+    end
+  end
+
+  def test_trash
+    stub_request(:delete, %r{https://3\.basecampapi\.com/12345/buckets/\d+/recordings/\d+/status/trashed\.json})
+      .to_return(status: 204)
+
+    result = @account.todolist_groups.trash(project_id: 1, group_id: 2)
+    assert_nil result
+  end
+end

--- a/ruby/test/basecamp/services/todolists_service_test.rb
+++ b/ruby/test/basecamp/services/todolists_service_test.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TodolistsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def test_list
+    response = [ { "id" => 1, "name" => "Sprint Tasks", "completed_ratio" => "3/10" } ]
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/buckets/\d+/todosets/\d+/todolists\.json})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.todolists.list(project_id: 1, todoset_id: 2).to_a
+    assert_kind_of Array, result
+    assert_equal "Sprint Tasks", result.first["name"]
+  end
+
+  def test_list_with_status
+    response = [ { "id" => 1, "name" => "Archived List", "status" => "archived" } ]
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/buckets/\d+/todosets/\d+/todolists\.json\?status=archived})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.todolists.list(project_id: 1, todoset_id: 2, status: "archived").to_a
+    assert_equal "archived", result.first["status"]
+  end
+
+  def test_get
+    response = { "id" => 1, "name" => "Sprint Tasks" }
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/buckets/\d+/todolists/\d+})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.todolists.get(project_id: 1, todolist_id: 2)
+    assert_equal "Sprint Tasks", result["name"]
+  end
+
+  def test_create
+    response = { "id" => 1, "name" => "New List" }
+
+    stub_request(:post, %r{https://3\.basecampapi\.com/12345/buckets/\d+/todosets/\d+/todolists\.json})
+      .to_return(status: 201, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.todolists.create(project_id: 1, todoset_id: 2, name: "New List")
+    assert_equal "New List", result["name"]
+  end
+
+  def test_update
+    response = { "id" => 1, "name" => "Updated List" }
+
+    stub_request(:put, %r{https://3\.basecampapi\.com/12345/buckets/\d+/todolists/\d+})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.todolists.update(project_id: 1, todolist_id: 2, name: "Updated List")
+    assert_equal "Updated List", result["name"]
+  end
+end

--- a/ruby/test/basecamp/services/todos_service_test.rb
+++ b/ruby/test/basecamp/services/todos_service_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TodosServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def test_list_todos
+    stub_get("/12345/buckets/100/todolists/200/todos.json",
+             response_body: [ sample_todo, sample_todo(id: 789, content: "Another todo") ])
+
+    todos = @account.todos.list(project_id: 100, todolist_id: 200).to_a
+
+    assert_equal 2, todos.length
+    assert_equal "Test todo", todos[0]["content"]
+  end
+
+  def test_list_todos_with_completed_filter
+    stub_request(:get, "https://3.basecampapi.com/12345/buckets/100/todolists/200/todos.json")
+      .with(query: { completed: "true" })
+      .to_return(status: 200, body: [ sample_todo ].to_json)
+
+    todos = @account.todos.list(project_id: 100, todolist_id: 200, completed: true).to_a
+
+    assert_equal 1, todos.length
+  end
+
+  def test_get_todo
+    stub_get("/12345/buckets/100/todos/456.json", response_body: sample_todo)
+
+    todo = @account.todos.get(project_id: 100, todo_id: 456)
+
+    assert_equal 456, todo["id"]
+    assert_equal "Test todo", todo["content"]
+  end
+
+  def test_create_todo
+    new_todo = sample_todo(id: 999, content: "New task")
+    stub_post("/12345/buckets/100/todolists/200/todos.json", response_body: new_todo)
+
+    todo = @account.todos.create(
+      project_id: 100,
+      todolist_id: 200,
+      content: "New task",
+      assignee_ids: [ 1, 2 ]
+    )
+
+    assert_equal 999, todo["id"]
+    assert_equal "New task", todo["content"]
+  end
+
+  def test_update_todo
+    updated = sample_todo(content: "Updated content")
+    stub_put("/12345/buckets/100/todos/456.json", response_body: updated)
+
+    todo = @account.todos.update(
+      project_id: 100,
+      todo_id: 456,
+      content: "Updated content"
+    )
+
+    assert_equal "Updated content", todo["content"]
+  end
+
+  def test_complete_todo
+    stub_post("/12345/buckets/100/todos/456/completion.json", response_body: {}, status: 204)
+
+    result = @account.todos.complete(project_id: 100, todo_id: 456)
+
+    assert_nil result
+  end
+
+  def test_uncomplete_todo
+    stub_delete("/12345/buckets/100/todos/456/completion.json")
+
+    result = @account.todos.uncomplete(project_id: 100, todo_id: 456)
+
+    assert_nil result
+  end
+
+  def test_reposition_todo
+    stub_put("/12345/buckets/100/todos/456/position.json", response_body: {})
+
+    result = @account.todos.reposition(project_id: 100, todo_id: 456, position: 3)
+
+    assert_nil result
+  end
+
+  def test_trash_todo
+    stub_delete("/12345/buckets/100/todos/456.json")
+
+    result = @account.todos.trash(project_id: 100, todo_id: 456)
+
+    assert_nil result
+  end
+end

--- a/ruby/test/basecamp/services/todosets_service_test.rb
+++ b/ruby/test/basecamp/services/todosets_service_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TodosetsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def test_get
+    response = {
+      "id" => 1,
+      "name" => "To-dos",
+      "todolists_count" => 5,
+      "completed_ratio" => "25/100"
+    }
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/buckets/\d+/todosets/\d+})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.todosets.get(project_id: 1, todoset_id: 2)
+    assert_equal "To-dos", result["name"]
+    assert_equal 5, result["todolists_count"]
+  end
+end

--- a/ruby/test/basecamp/services/tools_service_test.rb
+++ b/ruby/test/basecamp/services/tools_service_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ToolsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def test_get
+    response = { "id" => 1, "name" => "Message Board", "enabled" => true }
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/buckets/\d+/dock/tools/\d+})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.tools.get(project_id: 1, tool_id: 2)
+    assert_equal "Message Board", result["name"]
+    assert_equal true, result["enabled"]
+  end
+
+  def test_clone
+    response = { "id" => 2, "name" => "Message Board (Copy)" }
+
+    stub_request(:post, %r{https://3\.basecampapi\.com/12345/buckets/\d+/dock/tools/\d+/clone\.json})
+      .to_return(status: 201, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.tools.clone(project_id: 1, source_tool_id: 2)
+    assert_equal "Message Board (Copy)", result["name"]
+  end
+
+  def test_update
+    response = { "id" => 1, "title" => "Team Updates" }
+
+    stub_request(:put, %r{https://3\.basecampapi\.com/12345/buckets/\d+/dock/tools/\d+})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.tools.update(project_id: 1, tool_id: 2, title: "Team Updates")
+    assert_equal "Team Updates", result["title"]
+  end
+
+  def test_delete
+    stub_request(:delete, %r{https://3\.basecampapi\.com/12345/buckets/\d+/dock/tools/\d+})
+      .to_return(status: 204)
+
+    result = @account.tools.delete(project_id: 1, tool_id: 2)
+    assert_nil result
+  end
+
+  def test_enable
+    stub_request(:post, %r{https://3\.basecampapi\.com/12345/buckets/\d+/dock/tools/\d+/position\.json})
+      .to_return(status: 204)
+
+    result = @account.tools.enable(project_id: 1, tool_id: 2)
+    assert_nil result
+  end
+
+  def test_disable
+    stub_request(:delete, %r{https://3\.basecampapi\.com/12345/buckets/\d+/dock/tools/\d+/position\.json})
+      .to_return(status: 204)
+
+    result = @account.tools.disable(project_id: 1, tool_id: 2)
+    assert_nil result
+  end
+
+  def test_reposition
+    stub_request(:put, %r{https://3\.basecampapi\.com/12345/buckets/\d+/dock/tools/\d+/position\.json})
+      .to_return(status: 204)
+
+    result = @account.tools.reposition(project_id: 1, tool_id: 2, position: 1)
+    assert_nil result
+  end
+end

--- a/ruby/test/basecamp/services/uploads_service_test.rb
+++ b/ruby/test/basecamp/services/uploads_service_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class UploadsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def test_list
+    response = [ { "id" => 1, "filename" => "report.pdf", "byte_size" => 1024 } ]
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/buckets/\d+/vaults/\d+/uploads\.json})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.uploads.list(project_id: 1, vault_id: 2).to_a
+    assert_kind_of Array, result
+    assert_equal "report.pdf", result.first["filename"]
+  end
+
+  def test_get
+    response = { "id" => 1, "filename" => "report.pdf" }
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/buckets/\d+/uploads/\d+})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.uploads.get(project_id: 1, upload_id: 2)
+    assert_equal "report.pdf", result["filename"]
+  end
+
+  def test_create
+    response = { "id" => 1, "filename" => "new-report.pdf" }
+
+    stub_request(:post, %r{https://3\.basecampapi\.com/12345/buckets/\d+/vaults/\d+/uploads\.json})
+      .to_return(status: 201, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.uploads.create(
+      project_id: 1,
+      vault_id: 2,
+      attachable_sgid: "BAh7CEkiCGdpZAY6BkVUSSIvZ2lk..."
+    )
+    assert_equal "new-report.pdf", result["filename"]
+  end
+
+  def test_update
+    response = { "id" => 1, "description" => "Updated description" }
+
+    stub_request(:put, %r{https://3\.basecampapi\.com/12345/buckets/\d+/uploads/\d+})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.uploads.update(project_id: 1, upload_id: 2, description: "Updated description")
+    assert_equal "Updated description", result["description"]
+  end
+
+  def test_list_versions
+    response = [ { "id" => 1, "version" => 1 }, { "id" => 2, "version" => 2 } ]
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/buckets/\d+/uploads/\d+/versions\.json})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.uploads.list_versions(project_id: 1, upload_id: 2).to_a
+    assert_equal 2, result.length
+  end
+end

--- a/ruby/test/basecamp/services/vaults_service_test.rb
+++ b/ruby/test/basecamp/services/vaults_service_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class VaultsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def test_get
+    response = { "id" => 1, "title" => "Files & Documents" }
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/buckets/\d+/vaults/\d+})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.vaults.get(project_id: 1, vault_id: 2)
+    assert_equal "Files & Documents", result["title"]
+  end
+
+  def test_list
+    response = [ { "id" => 1, "title" => "Subfolder 1" } ]
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/buckets/\d+/vaults/\d+/vaults\.json})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.vaults.list(project_id: 1, vault_id: 2).to_a
+    assert_kind_of Array, result
+    assert_equal "Subfolder 1", result.first["title"]
+  end
+
+  def test_create
+    response = { "id" => 1, "title" => "New Folder" }
+
+    stub_request(:post, %r{https://3\.basecampapi\.com/12345/buckets/\d+/vaults/\d+/vaults\.json})
+      .to_return(status: 201, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.vaults.create(project_id: 1, vault_id: 2, title: "New Folder")
+    assert_equal "New Folder", result["title"]
+  end
+
+  def test_update
+    response = { "id" => 1, "title" => "Updated Folder" }
+
+    stub_request(:put, %r{https://3\.basecampapi\.com/12345/buckets/\d+/vaults/\d+})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.vaults.update(project_id: 1, vault_id: 2, title: "Updated Folder")
+    assert_equal "Updated Folder", result["title"]
+  end
+
+  def test_list_documents
+    response = [ { "id" => 1, "title" => "Doc 1" } ]
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/buckets/\d+/vaults/\d+/documents\.json})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.vaults.list_documents(project_id: 1, vault_id: 2).to_a
+    assert_kind_of Array, result
+  end
+
+  def test_list_uploads
+    response = [ { "id" => 1, "filename" => "file.pdf" } ]
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/buckets/\d+/vaults/\d+/uploads\.json})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.vaults.list_uploads(project_id: 1, vault_id: 2).to_a
+    assert_kind_of Array, result
+  end
+end

--- a/ruby/test/basecamp/services/webhooks_service_test.rb
+++ b/ruby/test/basecamp/services/webhooks_service_test.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class WebhooksServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def test_list
+    response = [ { "id" => 1, "payload_url" => "https://example.com/webhook", "active" => true } ]
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/buckets/\d+/webhooks\.json})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.webhooks.list(project_id: 1).to_a
+    assert_kind_of Array, result
+    assert_equal "https://example.com/webhook", result.first["payload_url"]
+  end
+
+  def test_get
+    response = { "id" => 1, "payload_url" => "https://example.com/webhook" }
+
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/buckets/\d+/webhooks/\d+})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.webhooks.get(project_id: 1, webhook_id: 2)
+    assert_equal "https://example.com/webhook", result["payload_url"]
+  end
+
+  def test_create
+    response = { "id" => 1, "payload_url" => "https://example.com/webhook", "types" => [ "Todo" ] }
+
+    stub_request(:post, %r{https://3\.basecampapi\.com/12345/buckets/\d+/webhooks\.json})
+      .to_return(status: 201, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.webhooks.create(
+      project_id: 1,
+      payload_url: "https://example.com/webhook",
+      types: [ "Todo" ]
+    )
+    assert_equal [ "Todo" ], result["types"]
+  end
+
+  def test_update
+    response = { "id" => 1, "active" => false }
+
+    stub_request(:put, %r{https://3\.basecampapi\.com/12345/buckets/\d+/webhooks/\d+})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.webhooks.update(project_id: 1, webhook_id: 2, active: false)
+    assert_equal false, result["active"]
+  end
+
+  def test_delete
+    stub_request(:delete, %r{https://3\.basecampapi\.com/12345/buckets/\d+/webhooks/\d+})
+      .to_return(status: 204)
+
+    result = @account.webhooks.delete(project_id: 1, webhook_id: 2)
+    assert_nil result
+  end
+end

--- a/ruby/test/test_helper.rb
+++ b/ruby/test/test_helper.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+
+require "simplecov"
+SimpleCov.start do
+  add_filter "/test/"
+  add_filter "/generated/"
+  enable_coverage :branch
+  minimum_coverage line: 90, branch: 60
+end
+
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
+require "basecamp"
+require "minitest/autorun"
+require "webmock/minitest"
+require "json"
+
+# Disable external connections during tests
+WebMock.disable_net_connect!
+
+# Test helpers and fixtures
+module TestHelpers
+  BASE_URL = "https://3.basecampapi.com"
+  LAUNCHPAD_URL = "https://launchpad.37signals.com"
+  ACCOUNT_ID = "12345"
+  ACCESS_TOKEN = "test-access-token"
+
+  def base_url
+    BASE_URL
+  end
+
+  def account_id
+    ACCOUNT_ID
+  end
+
+  def access_token
+    ACCESS_TOKEN
+  end
+
+  def config
+    @config ||= Basecamp::Config.new(
+      base_url: BASE_URL,
+      timeout: 5,
+      max_retries: 3
+    )
+  end
+
+  # Alias for compatibility with nested tests
+  alias default_config config
+
+  def token_provider
+    @token_provider ||= Basecamp::StaticTokenProvider.new(ACCESS_TOKEN)
+  end
+
+  # Alias for compatibility with nested tests
+  alias test_token_provider token_provider
+
+  def http
+    @http ||= Basecamp::Http.new(
+      config: config,
+      token_provider: token_provider
+    )
+  end
+
+  # Creates a test client
+  def create_client(config: nil, token_provider: nil, hooks: nil)
+    Basecamp::Client.new(
+      config: config || self.config,
+      token_provider: token_provider || self.token_provider,
+      hooks: hooks
+    )
+  end
+
+  # Creates a test AccountClient
+  def create_account_client(account_id: ACCOUNT_ID, **kwargs)
+    create_client(**kwargs).for_account(account_id)
+  end
+
+  def stub_api_get(path, body:, status: 200, headers: {})
+    stub_request(:get, "#{BASE_URL}#{path}")
+      .with(headers: { "Authorization" => "Bearer #{ACCESS_TOKEN}" })
+      .to_return(
+        status: status,
+        body: body.is_a?(String) ? body : body.to_json,
+        headers: { "Content-Type" => "application/json" }.merge(headers)
+      )
+  end
+
+  # Alias for compatibility with nested tests
+  def stub_get(path, response_body:, status: 200, headers: {})
+    stub_request(:get, "#{BASE_URL}#{path}")
+      .to_return(
+        status: status,
+        body: response_body.is_a?(String) ? response_body : response_body.to_json,
+        headers: { "Content-Type" => "application/json" }.merge(headers)
+      )
+  end
+
+  # Stub requests to launchpad (authorization endpoint)
+  def stub_launchpad_get(path, response_body:, status: 200, headers: {})
+    stub_request(:get, "#{LAUNCHPAD_URL}#{path}")
+      .to_return(
+        status: status,
+        body: response_body.is_a?(String) ? response_body : response_body.to_json,
+        headers: { "Content-Type" => "application/json" }.merge(headers)
+      )
+  end
+
+  # Stub OAuth discovery to fail (triggers fallback to launchpad)
+  def stub_discovery_failure
+    stub_request(:get, "#{BASE_URL}/.well-known/oauth-authorization-server")
+      .to_return(status: 404, body: "Not Found")
+  end
+
+  # Stub OAuth discovery to succeed with launchpad config
+  def stub_discovery_success
+    discovery_response = {
+      issuer: LAUNCHPAD_URL,
+      authorization_endpoint: "#{LAUNCHPAD_URL}/authorization/new",
+      token_endpoint: "#{LAUNCHPAD_URL}/authorization/token"
+    }
+    stub_request(:get, "#{BASE_URL}/.well-known/oauth-authorization-server")
+      .to_return(
+        status: 200,
+        body: discovery_response.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+  end
+
+  def stub_api_post(path, body:, status: 201, headers: {})
+    stub_request(:post, "#{BASE_URL}#{path}")
+      .with(headers: { "Authorization" => "Bearer #{ACCESS_TOKEN}" })
+      .to_return(
+        status: status,
+        body: body.is_a?(String) ? body : body.to_json,
+        headers: { "Content-Type" => "application/json" }.merge(headers)
+      )
+  end
+
+  # Alias for compatibility with nested tests
+  def stub_post(path, response_body:, status: 201, headers: {})
+    stub_request(:post, "#{BASE_URL}#{path}")
+      .to_return(
+        status: status,
+        body: response_body.is_a?(String) ? response_body : response_body.to_json,
+        headers: { "Content-Type" => "application/json" }.merge(headers)
+      )
+  end
+
+  def stub_api_put(path, body:, status: 200, headers: {})
+    stub_request(:put, "#{BASE_URL}#{path}")
+      .with(headers: { "Authorization" => "Bearer #{ACCESS_TOKEN}" })
+      .to_return(
+        status: status,
+        body: body.is_a?(String) ? body : body.to_json,
+        headers: { "Content-Type" => "application/json" }.merge(headers)
+      )
+  end
+
+  # Alias for compatibility with nested tests
+  def stub_put(path, response_body:, status: 200, headers: {})
+    stub_request(:put, "#{BASE_URL}#{path}")
+      .to_return(
+        status: status,
+        body: response_body.is_a?(String) ? response_body : response_body.to_json,
+        headers: { "Content-Type" => "application/json" }.merge(headers)
+      )
+  end
+
+  def stub_api_delete(path, status: 204, body: nil, headers: {})
+    stub_request(:delete, "#{BASE_URL}#{path}")
+      .with(headers: { "Authorization" => "Bearer #{ACCESS_TOKEN}" })
+      .to_return(
+        status: status,
+        body: body,
+        headers: headers
+      )
+  end
+
+  # Alias for compatibility with nested tests
+  def stub_delete(path, status: 204)
+    stub_request(:delete, "#{BASE_URL}#{path}")
+      .to_return(status: status, body: "")
+  end
+
+  # Sample project data
+  def sample_project(id: 123, name: "Test Project")
+    {
+      "id" => id,
+      "name" => name,
+      "description" => "A test project",
+      "status" => "active",
+      "created_at" => "2024-01-01T00:00:00Z",
+      "updated_at" => "2024-01-01T00:00:00Z"
+    }
+  end
+
+  # Sample todo data
+  def sample_todo(id: 456, content: "Test todo")
+    {
+      "id" => id,
+      "content" => content,
+      "description" => "",
+      "completed" => false,
+      "created_at" => "2024-01-01T00:00:00Z",
+      "updated_at" => "2024-01-01T00:00:00Z"
+    }
+  end
+
+  # Sample authorization data
+  def sample_authorization
+    {
+      "expires_at" => "2025-01-01T00:00:00Z",
+      "identity" => {
+        "id" => 1,
+        "first_name" => "Test",
+        "last_name" => "User",
+        "email_address" => "test@example.com"
+      },
+      "accounts" => [
+        {
+          "id" => 12_345,
+          "name" => "Test Account",
+          "product" => "bc3",
+          "href" => "https://3.basecampapi.com/12345"
+        }
+      ]
+    }
+  end
+end
+
+# Also expose as TestHelper for compatibility
+TestHelper = TestHelpers
+
+module Minitest
+  class Test
+    include TestHelpers
+  end
+end


### PR DESCRIPTION
## Summary

- Add complete Ruby SDK for Basecamp 3 API with full service coverage
- 35+ services covering all API endpoints (projects, todos, messages, comments, etc.)
- OAuth token provider with auto-refresh support
- Retry with exponential backoff and jitter
- Link-header pagination with lazy Enumerators
- Observability hooks for request/response monitoring
- Add Ruby SDK to CI/CD workflows (test + release)

## Key Features

- **Client Pattern**: `Client.new` -> `client.for_account(id)` for account-scoped operations
- **Pagination**: Returns `Enumerator` for memory-efficient iteration over large datasets
- **Error Handling**: Typed exceptions (`RateLimitError`, `NotFoundError`, etc.) with retry support
- **Ruby Style**: Uses rubocop-rails-omakase, Zeitwerk autoloading, standard Ruby conventions

## Test plan

- [x] `bundle exec rake test` - 376 assertions pass
- [x] `bundle exec rubocop` - linting passes
- [x] CI workflow runs on this PR
- [x] Manual smoke test against live API