### PR TITLE
Unwrap single-entity Get responses to bare $ref

### DIFF
--- a/go/pkg/basecamp/campfires.go
+++ b/go/pkg/basecamp/campfires.go
@@ -151,7 +151,7 @@ func (s *CampfiresService) Get(ctx context.Context, bucketID, campfireID int64) 
 		return nil, err
 	}
 
-	campfire := campfireFromGenerated(resp.JSON200.Campfire)
+	campfire := campfireFromGenerated(*resp.JSON200)
 	return &campfire, nil
 }
 
@@ -219,7 +219,7 @@ func (s *CampfiresService) GetLine(ctx context.Context, bucketID, campfireID, li
 		return nil, err
 	}
 
-	line := campfireLineFromGenerated(resp.JSON200.Line)
+	line := campfireLineFromGenerated(*resp.JSON200)
 	return &line, nil
 }
 
@@ -355,7 +355,7 @@ func (s *CampfiresService) GetChatbot(ctx context.Context, bucketID, campfireID,
 		return nil, err
 	}
 
-	chatbot := chatbotFromGenerated(resp.JSON200.Chatbot)
+	chatbot := chatbotFromGenerated(*resp.JSON200)
 	return &chatbot, nil
 }
 

--- a/go/pkg/basecamp/cards.go
+++ b/go/pkg/basecamp/cards.go
@@ -233,7 +233,7 @@ func (s *CardTablesService) Get(ctx context.Context, bucketID, cardTableID int64
 		return nil, err
 	}
 
-	cardTable := cardTableFromGenerated(resp.JSON200.CardTable)
+	cardTable := cardTableFromGenerated(*resp.JSON200)
 	return &cardTable, nil
 }
 
@@ -311,7 +311,7 @@ func (s *CardsService) Get(ctx context.Context, bucketID, cardID int64) (result 
 		return nil, err
 	}
 
-	card := cardFromGenerated(resp.JSON200.Card)
+	card := cardFromGenerated(*resp.JSON200)
 	return &card, nil
 }
 
@@ -522,7 +522,7 @@ func (s *CardColumnsService) Get(ctx context.Context, bucketID, columnID int64) 
 		return nil, err
 	}
 
-	column := cardColumnFromGenerated(resp.JSON200.Column)
+	column := cardColumnFromGenerated(*resp.JSON200)
 	return &column, nil
 }
 

--- a/go/pkg/basecamp/checkins.go
+++ b/go/pkg/basecamp/checkins.go
@@ -171,7 +171,7 @@ func (s *CheckinsService) GetQuestionnaire(ctx context.Context, bucketID, questi
 		return nil, err
 	}
 
-	questionnaire := questionnaireFromGenerated(resp.JSON200.Questionnaire)
+	questionnaire := questionnaireFromGenerated(*resp.JSON200)
 	return &questionnaire, nil
 }
 
@@ -240,7 +240,7 @@ func (s *CheckinsService) GetQuestion(ctx context.Context, bucketID, questionID 
 		return nil, err
 	}
 
-	question := questionFromGenerated(resp.JSON200.Question)
+	question := questionFromGenerated(*resp.JSON200)
 	return &question, nil
 }
 
@@ -407,7 +407,7 @@ func (s *CheckinsService) GetAnswer(ctx context.Context, bucketID, answerID int6
 		return nil, err
 	}
 
-	answer := questionAnswerFromGenerated(resp.JSON200.Answer)
+	answer := questionAnswerFromGenerated(*resp.JSON200)
 	return &answer, nil
 }
 

--- a/go/pkg/basecamp/client_approvals.go
+++ b/go/pkg/basecamp/client_approvals.go
@@ -129,7 +129,7 @@ func (s *ClientApprovalsService) Get(ctx context.Context, bucketID, approvalID i
 		return nil, err
 	}
 
-	approval := clientApprovalFromGenerated(resp.JSON200.Approval)
+	approval := clientApprovalFromGenerated(*resp.JSON200)
 	return &approval, nil
 }
 

--- a/go/pkg/basecamp/client_correspondences.go
+++ b/go/pkg/basecamp/client_correspondences.go
@@ -106,7 +106,7 @@ func (s *ClientCorrespondencesService) Get(ctx context.Context, bucketID, corres
 		return nil, err
 	}
 
-	correspondence := clientCorrespondenceFromGenerated(resp.JSON200.Correspondence)
+	correspondence := clientCorrespondenceFromGenerated(*resp.JSON200)
 	return &correspondence, nil
 }
 

--- a/go/pkg/basecamp/client_replies.go
+++ b/go/pkg/basecamp/client_replies.go
@@ -103,7 +103,7 @@ func (s *ClientRepliesService) Get(ctx context.Context, bucketID, recordingID, r
 		return nil, err
 	}
 
-	reply := clientReplyFromGenerated(resp.JSON200.Reply)
+	reply := clientReplyFromGenerated(*resp.JSON200)
 	return &reply, nil
 }
 

--- a/go/pkg/basecamp/comments.go
+++ b/go/pkg/basecamp/comments.go
@@ -110,7 +110,7 @@ func (s *CommentsService) Get(ctx context.Context, bucketID, commentID int64) (r
 		return nil, err
 	}
 
-	comment := commentFromGenerated(resp.JSON200.Comment)
+	comment := commentFromGenerated(*resp.JSON200)
 	return &comment, nil
 }
 

--- a/go/pkg/basecamp/forwards.go
+++ b/go/pkg/basecamp/forwards.go
@@ -99,7 +99,7 @@ func (s *ForwardsService) GetInbox(ctx context.Context, bucketID, inboxID int64)
 		return nil, err
 	}
 
-	inbox := inboxFromGenerated(resp.JSON200.Inbox)
+	inbox := inboxFromGenerated(*resp.JSON200)
 	return &inbox, nil
 }
 
@@ -168,7 +168,7 @@ func (s *ForwardsService) Get(ctx context.Context, bucketID, forwardID int64) (r
 		return nil, err
 	}
 
-	forward := forwardFromGenerated(resp.JSON200.Forward)
+	forward := forwardFromGenerated(*resp.JSON200)
 	return &forward, nil
 }
 
@@ -237,7 +237,7 @@ func (s *ForwardsService) GetReply(ctx context.Context, bucketID, forwardID, rep
 		return nil, err
 	}
 
-	reply := forwardReplyFromGenerated(resp.JSON200.Reply)
+	reply := forwardReplyFromGenerated(*resp.JSON200)
 	return &reply, nil
 }
 

--- a/go/pkg/basecamp/message_boards.go
+++ b/go/pkg/basecamp/message_boards.go
@@ -63,7 +63,7 @@ func (s *MessageBoardsService) Get(ctx context.Context, bucketID, boardID int64)
 		return nil, err
 	}
 
-	board := messageBoardFromGenerated(resp.JSON200.MessageBoard)
+	board := messageBoardFromGenerated(*resp.JSON200)
 	return &board, nil
 }
 

--- a/go/pkg/basecamp/message_types.go
+++ b/go/pkg/basecamp/message_types.go
@@ -107,7 +107,7 @@ func (s *MessageTypesService) Get(ctx context.Context, bucketID, typeID int64) (
 		return nil, err
 	}
 
-	msgType := messageTypeFromGenerated(resp.JSON200.MessageType)
+	msgType := messageTypeFromGenerated(*resp.JSON200)
 	return &msgType, nil
 }
 

--- a/go/pkg/basecamp/messages.go
+++ b/go/pkg/basecamp/messages.go
@@ -123,7 +123,7 @@ func (s *MessagesService) Get(ctx context.Context, bucketID, messageID int64) (r
 		return nil, err
 	}
 
-	message := messageFromGenerated(resp.JSON200.Message)
+	message := messageFromGenerated(*resp.JSON200)
 	return &message, nil
 }
 

--- a/go/pkg/basecamp/people.go
+++ b/go/pkg/basecamp/people.go
@@ -110,7 +110,7 @@ func (s *PeopleService) Get(ctx context.Context, personID int64) (result *Person
 		return nil, err
 	}
 
-	person := personFromGenerated(resp.JSON200.Person)
+	person := personFromGenerated(*resp.JSON200)
 	return &person, nil
 }
 
@@ -141,7 +141,7 @@ func (s *PeopleService) Me(ctx context.Context) (result *Person, err error) {
 		return nil, err
 	}
 
-	person := personFromGenerated(resp.JSON200.Person)
+	person := personFromGenerated(*resp.JSON200)
 	return &person, nil
 }
 

--- a/go/pkg/basecamp/projects.go
+++ b/go/pkg/basecamp/projects.go
@@ -172,7 +172,7 @@ func (s *ProjectsService) Get(ctx context.Context, id int64) (result *Project, e
 		return nil, err
 	}
 
-	project := projectFromGenerated(resp.JSON200.Project)
+	project := projectFromGenerated(*resp.JSON200)
 	return &project, nil
 }
 

--- a/go/pkg/basecamp/recordings.go
+++ b/go/pkg/basecamp/recordings.go
@@ -177,7 +177,7 @@ func (s *RecordingsService) Get(ctx context.Context, bucketID, recordingID int64
 		return nil, err
 	}
 
-	recording := recordingFromGenerated(resp.JSON200.Recording)
+	recording := recordingFromGenerated(*resp.JSON200)
 	return &recording, nil
 }
 

--- a/go/pkg/basecamp/schedules.go
+++ b/go/pkg/basecamp/schedules.go
@@ -137,7 +137,7 @@ func (s *SchedulesService) Get(ctx context.Context, bucketID, scheduleID int64) 
 		return nil, err
 	}
 
-	schedule := scheduleFromGenerated(resp.JSON200.Schedule)
+	schedule := scheduleFromGenerated(*resp.JSON200)
 	return &schedule, nil
 }
 
@@ -206,7 +206,7 @@ func (s *SchedulesService) GetEntry(ctx context.Context, bucketID, entryID int64
 		return nil, err
 	}
 
-	entry := scheduleEntryFromGenerated(resp.JSON200.Entry)
+	entry := scheduleEntryFromGenerated(*resp.JSON200)
 	return &entry, nil
 }
 
@@ -375,7 +375,7 @@ func (s *SchedulesService) GetEntryOccurrence(ctx context.Context, bucketID, ent
 		return nil, err
 	}
 
-	entry := scheduleEntryFromGenerated(resp.JSON200.Entry)
+	entry := scheduleEntryFromGenerated(*resp.JSON200)
 	return &entry, nil
 }
 

--- a/go/pkg/basecamp/search.go
+++ b/go/pkg/basecamp/search.go
@@ -134,9 +134,9 @@ func (s *SearchService) Metadata(ctx context.Context) (result *SearchMetadata, e
 
 	// Convert metadata
 	metadata := &SearchMetadata{
-		Projects: make([]SearchProject, 0, len(resp.JSON200.Metadata.Projects)),
+		Projects: make([]SearchProject, 0, len(resp.JSON200.Projects)),
 	}
-	for _, gsp := range resp.JSON200.Metadata.Projects {
+	for _, gsp := range resp.JSON200.Projects {
 		metadata.Projects = append(metadata.Projects, SearchProject{
 			ID:   derefInt64(gsp.Id),
 			Name: gsp.Name,

--- a/go/pkg/basecamp/subscriptions.go
+++ b/go/pkg/basecamp/subscriptions.go
@@ -63,7 +63,7 @@ func (s *SubscriptionsService) Get(ctx context.Context, bucketID, recordingID in
 		return nil, err
 	}
 
-	subscription := subscriptionFromGenerated(resp.JSON200.Subscription)
+	subscription := subscriptionFromGenerated(*resp.JSON200)
 	return &subscription, nil
 }
 

--- a/go/pkg/basecamp/templates.go
+++ b/go/pkg/basecamp/templates.go
@@ -122,7 +122,7 @@ func (s *TemplatesService) Get(ctx context.Context, templateID int64) (result *T
 		return nil, err
 	}
 
-	template := templateFromGenerated(resp.JSON200.Template)
+	template := templateFromGenerated(*resp.JSON200)
 	return &template, nil
 }
 
@@ -305,7 +305,7 @@ func (s *TemplatesService) GetConstruction(ctx context.Context, templateID, cons
 		return nil, err
 	}
 
-	construction := projectConstructionFromGenerated(resp.JSON200.Construction)
+	construction := projectConstructionFromGenerated(*resp.JSON200)
 	return &construction, nil
 }
 

--- a/go/pkg/basecamp/todolist_groups.go
+++ b/go/pkg/basecamp/todolist_groups.go
@@ -124,7 +124,7 @@ func (s *TodolistGroupsService) Get(ctx context.Context, bucketID, groupID int64
 	}
 
 	// The response is a union type, try to extract as TodolistGroup
-	g, err := resp.JSON200.Result.AsTodolistOrGroup1()
+	g, err := resp.JSON200.AsTodolistOrGroup1()
 	if err != nil {
 		err = fmt.Errorf("response is not a todolist group: %w", err)
 		return nil, err

--- a/go/pkg/basecamp/todolists.go
+++ b/go/pkg/basecamp/todolists.go
@@ -141,7 +141,7 @@ func (s *TodolistsService) Get(ctx context.Context, bucketID, todolistID int64) 
 	}
 
 	// The response is a union type, try to extract as Todolist
-	tl, err := resp.JSON200.Result.AsTodolistOrGroup0()
+	tl, err := resp.JSON200.AsTodolistOrGroup0()
 	if err != nil {
 		err = fmt.Errorf("response is not a todolist: %w", err)
 		return nil, err

--- a/go/pkg/basecamp/todos.go
+++ b/go/pkg/basecamp/todos.go
@@ -207,7 +207,7 @@ func (s *TodosService) Get(ctx context.Context, bucketID, todoID int64) (result 
 		return nil, err
 	}
 
-	todo := todoFromGenerated(resp.JSON200.Todo)
+	todo := todoFromGenerated(*resp.JSON200)
 	return &todo, nil
 }
 

--- a/go/pkg/basecamp/todosets.go
+++ b/go/pkg/basecamp/todosets.go
@@ -75,7 +75,7 @@ func (s *TodosetsService) Get(ctx context.Context, bucketID, todosetID int64) (r
 		return nil, err
 	}
 
-	todoset := todosetFromGenerated(resp.JSON200.Todoset)
+	todoset := todosetFromGenerated(*resp.JSON200)
 	return &todoset, nil
 }
 

--- a/go/pkg/basecamp/tools.go
+++ b/go/pkg/basecamp/tools.go
@@ -68,7 +68,7 @@ func (s *ToolsService) Get(ctx context.Context, bucketID, toolID int64) (result 
 		return nil, err
 	}
 
-	tool := toolFromGenerated(resp.JSON200.Tool)
+	tool := toolFromGenerated(*resp.JSON200)
 	return &tool, nil
 }
 

--- a/go/pkg/basecamp/vaults.go
+++ b/go/pkg/basecamp/vaults.go
@@ -173,7 +173,7 @@ func (s *VaultsService) Get(ctx context.Context, bucketID, vaultID int64) (resul
 		return nil, err
 	}
 
-	vault := vaultFromGenerated(resp.JSON200.Vault)
+	vault := vaultFromGenerated(*resp.JSON200)
 	return &vault, nil
 }
 
@@ -337,7 +337,7 @@ func (s *DocumentsService) Get(ctx context.Context, bucketID, documentID int64) 
 		return nil, err
 	}
 
-	document := documentFromGenerated(resp.JSON200.Document)
+	document := documentFromGenerated(*resp.JSON200)
 	return &document, nil
 }
 
@@ -529,7 +529,7 @@ func (s *UploadsService) Get(ctx context.Context, bucketID, uploadID int64) (res
 		return nil, err
 	}
 
-	upload := uploadFromGenerated(resp.JSON200.Upload)
+	upload := uploadFromGenerated(*resp.JSON200)
 	return &upload, nil
 }
 

--- a/go/pkg/basecamp/webhooks.go
+++ b/go/pkg/basecamp/webhooks.go
@@ -116,7 +116,7 @@ func (s *WebhooksService) Get(ctx context.Context, bucketID, webhookID int64) (r
 		return nil, err
 	}
 
-	webhook := webhookFromGenerated(resp.JSON200.Webhook)
+	webhook := webhookFromGenerated(*resp.JSON200)
 	return &webhook, nil
 }
 

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -715,9 +715,7 @@ type ForwardReply struct {
 }
 
 // GetAnswerResponseContent defines model for GetAnswerResponseContent.
-type GetAnswerResponseContent struct {
-	Answer QuestionAnswer `json:"answer,omitempty"`
-}
+type GetAnswerResponseContent = QuestionAnswer
 
 // GetAssignedTodosResponseContent defines model for GetAssignedTodosResponseContent.
 type GetAssignedTodosResponseContent struct {
@@ -727,94 +725,58 @@ type GetAssignedTodosResponseContent struct {
 }
 
 // GetCampfireLineResponseContent defines model for GetCampfireLineResponseContent.
-type GetCampfireLineResponseContent struct {
-	Line CampfireLine `json:"line,omitempty"`
-}
+type GetCampfireLineResponseContent = CampfireLine
 
 // GetCampfireResponseContent defines model for GetCampfireResponseContent.
-type GetCampfireResponseContent struct {
-	Campfire Campfire `json:"campfire,omitempty"`
-}
+type GetCampfireResponseContent = Campfire
 
 // GetCardColumnResponseContent defines model for GetCardColumnResponseContent.
-type GetCardColumnResponseContent struct {
-	Column CardColumn `json:"column,omitempty"`
-}
+type GetCardColumnResponseContent = CardColumn
 
 // GetCardResponseContent defines model for GetCardResponseContent.
-type GetCardResponseContent struct {
-	Card Card `json:"card,omitempty"`
-}
+type GetCardResponseContent = Card
 
 // GetCardTableResponseContent defines model for GetCardTableResponseContent.
-type GetCardTableResponseContent struct {
-	CardTable CardTable `json:"card_table,omitempty"`
-}
+type GetCardTableResponseContent = CardTable
 
 // GetChatbotResponseContent defines model for GetChatbotResponseContent.
-type GetChatbotResponseContent struct {
-	Chatbot Chatbot `json:"chatbot,omitempty"`
-}
+type GetChatbotResponseContent = Chatbot
 
 // GetClientApprovalResponseContent defines model for GetClientApprovalResponseContent.
-type GetClientApprovalResponseContent struct {
-	Approval ClientApproval `json:"approval,omitempty"`
-}
+type GetClientApprovalResponseContent = ClientApproval
 
 // GetClientCorrespondenceResponseContent defines model for GetClientCorrespondenceResponseContent.
-type GetClientCorrespondenceResponseContent struct {
-	Correspondence ClientCorrespondence `json:"correspondence,omitempty"`
-}
+type GetClientCorrespondenceResponseContent = ClientCorrespondence
 
 // GetClientReplyResponseContent defines model for GetClientReplyResponseContent.
-type GetClientReplyResponseContent struct {
-	Reply ClientReply `json:"reply,omitempty"`
-}
+type GetClientReplyResponseContent = ClientReply
 
 // GetCommentResponseContent defines model for GetCommentResponseContent.
-type GetCommentResponseContent struct {
-	Comment Comment `json:"comment,omitempty"`
-}
+type GetCommentResponseContent = Comment
 
 // GetDocumentResponseContent defines model for GetDocumentResponseContent.
-type GetDocumentResponseContent struct {
-	Document Document `json:"document,omitempty"`
-}
+type GetDocumentResponseContent = Document
 
 // GetForwardReplyResponseContent defines model for GetForwardReplyResponseContent.
-type GetForwardReplyResponseContent struct {
-	Reply ForwardReply `json:"reply,omitempty"`
-}
+type GetForwardReplyResponseContent = ForwardReply
 
 // GetForwardResponseContent defines model for GetForwardResponseContent.
-type GetForwardResponseContent struct {
-	Forward Forward `json:"forward,omitempty"`
-}
+type GetForwardResponseContent = Forward
 
 // GetInboxResponseContent defines model for GetInboxResponseContent.
-type GetInboxResponseContent struct {
-	Inbox Inbox `json:"inbox,omitempty"`
-}
+type GetInboxResponseContent = Inbox
 
 // GetMessageBoardResponseContent defines model for GetMessageBoardResponseContent.
-type GetMessageBoardResponseContent struct {
-	MessageBoard MessageBoard `json:"message_board,omitempty"`
-}
+type GetMessageBoardResponseContent = MessageBoard
 
 // GetMessageResponseContent defines model for GetMessageResponseContent.
-type GetMessageResponseContent struct {
-	Message Message `json:"message,omitempty"`
-}
+type GetMessageResponseContent = Message
 
 // GetMessageTypeResponseContent defines model for GetMessageTypeResponseContent.
-type GetMessageTypeResponseContent struct {
-	MessageType MessageType `json:"message_type,omitempty"`
-}
+type GetMessageTypeResponseContent = MessageType
 
 // GetMyProfileResponseContent defines model for GetMyProfileResponseContent.
-type GetMyProfileResponseContent struct {
-	Person Person `json:"person,omitempty"`
-}
+type GetMyProfileResponseContent = Person
 
 // GetOverdueTodosResponseContent defines model for GetOverdueTodosResponseContent.
 type GetOverdueTodosResponseContent struct {
@@ -831,9 +793,7 @@ type GetPersonProgressResponseContent struct {
 }
 
 // GetPersonResponseContent defines model for GetPersonResponseContent.
-type GetPersonResponseContent struct {
-	Person Person `json:"person,omitempty"`
-}
+type GetPersonResponseContent = Person
 
 // GetProgressReportResponseContent defines model for GetProgressReportResponseContent.
 type GetProgressReportResponseContent struct {
@@ -841,14 +801,10 @@ type GetProgressReportResponseContent struct {
 }
 
 // GetProjectConstructionResponseContent defines model for GetProjectConstructionResponseContent.
-type GetProjectConstructionResponseContent struct {
-	Construction ProjectConstruction `json:"construction,omitempty"`
-}
+type GetProjectConstructionResponseContent = ProjectConstruction
 
 // GetProjectResponseContent defines model for GetProjectResponseContent.
-type GetProjectResponseContent struct {
-	Project Project `json:"project,omitempty"`
-}
+type GetProjectResponseContent = Project
 
 // GetProjectTimelineResponseContent defines model for GetProjectTimelineResponseContent.
 type GetProjectTimelineResponseContent struct {
@@ -861,19 +817,13 @@ type GetProjectTimesheetResponseContent struct {
 }
 
 // GetQuestionResponseContent defines model for GetQuestionResponseContent.
-type GetQuestionResponseContent struct {
-	Question Question `json:"question,omitempty"`
-}
+type GetQuestionResponseContent = Question
 
 // GetQuestionnaireResponseContent defines model for GetQuestionnaireResponseContent.
-type GetQuestionnaireResponseContent struct {
-	Questionnaire Questionnaire `json:"questionnaire,omitempty"`
-}
+type GetQuestionnaireResponseContent = Questionnaire
 
 // GetRecordingResponseContent defines model for GetRecordingResponseContent.
-type GetRecordingResponseContent struct {
-	Recording Recording `json:"recording,omitempty"`
-}
+type GetRecordingResponseContent = Recording
 
 // GetRecordingTimesheetResponseContent defines model for GetRecordingTimesheetResponseContent.
 type GetRecordingTimesheetResponseContent struct {
@@ -881,34 +831,22 @@ type GetRecordingTimesheetResponseContent struct {
 }
 
 // GetScheduleEntryOccurrenceResponseContent defines model for GetScheduleEntryOccurrenceResponseContent.
-type GetScheduleEntryOccurrenceResponseContent struct {
-	Entry ScheduleEntry `json:"entry,omitempty"`
-}
+type GetScheduleEntryOccurrenceResponseContent = ScheduleEntry
 
 // GetScheduleEntryResponseContent defines model for GetScheduleEntryResponseContent.
-type GetScheduleEntryResponseContent struct {
-	Entry ScheduleEntry `json:"entry,omitempty"`
-}
+type GetScheduleEntryResponseContent = ScheduleEntry
 
 // GetScheduleResponseContent defines model for GetScheduleResponseContent.
-type GetScheduleResponseContent struct {
-	Schedule Schedule `json:"schedule,omitempty"`
-}
+type GetScheduleResponseContent = Schedule
 
 // GetSearchMetadataResponseContent defines model for GetSearchMetadataResponseContent.
-type GetSearchMetadataResponseContent struct {
-	Metadata SearchMetadata `json:"metadata,omitempty"`
-}
+type GetSearchMetadataResponseContent = SearchMetadata
 
 // GetSubscriptionResponseContent defines model for GetSubscriptionResponseContent.
-type GetSubscriptionResponseContent struct {
-	Subscription Subscription `json:"subscription,omitempty"`
-}
+type GetSubscriptionResponseContent = Subscription
 
 // GetTemplateResponseContent defines model for GetTemplateResponseContent.
-type GetTemplateResponseContent struct {
-	Template Template `json:"template,omitempty"`
-}
+type GetTemplateResponseContent = Template
 
 // GetTimesheetReportResponseContent defines model for GetTimesheetReportResponseContent.
 type GetTimesheetReportResponseContent struct {
@@ -916,25 +854,16 @@ type GetTimesheetReportResponseContent struct {
 }
 
 // GetTodoResponseContent defines model for GetTodoResponseContent.
-type GetTodoResponseContent struct {
-	Todo Todo `json:"todo,omitempty"`
-}
+type GetTodoResponseContent = Todo
 
-// GetTodolistOrGroupResponseContent defines model for GetTodolistOrGroupResponseContent.
-type GetTodolistOrGroupResponseContent struct {
-	// Result Union type for polymorphic todolist endpoint
-	Result TodolistOrGroup `json:"result,omitempty"`
-}
+// GetTodolistOrGroupResponseContent Union type for polymorphic todolist endpoint
+type GetTodolistOrGroupResponseContent = TodolistOrGroup
 
 // GetTodosetResponseContent defines model for GetTodosetResponseContent.
-type GetTodosetResponseContent struct {
-	Todoset Todoset `json:"todoset,omitempty"`
-}
+type GetTodosetResponseContent = Todoset
 
 // GetToolResponseContent defines model for GetToolResponseContent.
-type GetToolResponseContent struct {
-	Tool Tool `json:"tool,omitempty"`
-}
+type GetToolResponseContent = Tool
 
 // GetUpcomingScheduleResponseContent defines model for GetUpcomingScheduleResponseContent.
 type GetUpcomingScheduleResponseContent struct {
@@ -944,19 +873,13 @@ type GetUpcomingScheduleResponseContent struct {
 }
 
 // GetUploadResponseContent defines model for GetUploadResponseContent.
-type GetUploadResponseContent struct {
-	Upload Upload `json:"upload,omitempty"`
-}
+type GetUploadResponseContent = Upload
 
 // GetVaultResponseContent defines model for GetVaultResponseContent.
-type GetVaultResponseContent struct {
-	Vault Vault `json:"vault,omitempty"`
-}
+type GetVaultResponseContent = Vault
 
 // GetWebhookResponseContent defines model for GetWebhookResponseContent.
-type GetWebhookResponseContent struct {
-	Webhook Webhook `json:"webhook,omitempty"`
-}
+type GetWebhookResponseContent = Webhook
 
 // Inbox defines model for Inbox.
 type Inbox struct {

--- a/openapi.json
+++ b/openapi.json
@@ -19298,12 +19298,7 @@
         }
       },
       "GetAnswerResponseContent": {
-        "type": "object",
-        "properties": {
-          "answer": {
-            "$ref": "#/components/schemas/QuestionAnswer"
-          }
-        }
+        "$ref": "#/components/schemas/QuestionAnswer"
       },
       "GetAssignedTodosResponseContent": {
         "type": "object",
@@ -19323,148 +19318,58 @@
         }
       },
       "GetCampfireLineResponseContent": {
-        "type": "object",
-        "properties": {
-          "line": {
-            "$ref": "#/components/schemas/CampfireLine"
-          }
-        }
+        "$ref": "#/components/schemas/CampfireLine"
       },
       "GetCampfireResponseContent": {
-        "type": "object",
-        "properties": {
-          "campfire": {
-            "$ref": "#/components/schemas/Campfire"
-          }
-        }
+        "$ref": "#/components/schemas/Campfire"
       },
       "GetCardColumnResponseContent": {
-        "type": "object",
-        "properties": {
-          "column": {
-            "$ref": "#/components/schemas/CardColumn"
-          }
-        }
+        "$ref": "#/components/schemas/CardColumn"
       },
       "GetCardResponseContent": {
-        "type": "object",
-        "properties": {
-          "card": {
-            "$ref": "#/components/schemas/Card"
-          }
-        }
+        "$ref": "#/components/schemas/Card"
       },
       "GetCardTableResponseContent": {
-        "type": "object",
-        "properties": {
-          "card_table": {
-            "$ref": "#/components/schemas/CardTable"
-          }
-        }
+        "$ref": "#/components/schemas/CardTable"
       },
       "GetChatbotResponseContent": {
-        "type": "object",
-        "properties": {
-          "chatbot": {
-            "$ref": "#/components/schemas/Chatbot"
-          }
-        }
+        "$ref": "#/components/schemas/Chatbot"
       },
       "GetClientApprovalResponseContent": {
-        "type": "object",
-        "properties": {
-          "approval": {
-            "$ref": "#/components/schemas/ClientApproval"
-          }
-        }
+        "$ref": "#/components/schemas/ClientApproval"
       },
       "GetClientCorrespondenceResponseContent": {
-        "type": "object",
-        "properties": {
-          "correspondence": {
-            "$ref": "#/components/schemas/ClientCorrespondence"
-          }
-        }
+        "$ref": "#/components/schemas/ClientCorrespondence"
       },
       "GetClientReplyResponseContent": {
-        "type": "object",
-        "properties": {
-          "reply": {
-            "$ref": "#/components/schemas/ClientReply"
-          }
-        }
+        "$ref": "#/components/schemas/ClientReply"
       },
       "GetCommentResponseContent": {
-        "type": "object",
-        "properties": {
-          "comment": {
-            "$ref": "#/components/schemas/Comment"
-          }
-        }
+        "$ref": "#/components/schemas/Comment"
       },
       "GetDocumentResponseContent": {
-        "type": "object",
-        "properties": {
-          "document": {
-            "$ref": "#/components/schemas/Document"
-          }
-        }
+        "$ref": "#/components/schemas/Document"
       },
       "GetForwardReplyResponseContent": {
-        "type": "object",
-        "properties": {
-          "reply": {
-            "$ref": "#/components/schemas/ForwardReply"
-          }
-        }
+        "$ref": "#/components/schemas/ForwardReply"
       },
       "GetForwardResponseContent": {
-        "type": "object",
-        "properties": {
-          "forward": {
-            "$ref": "#/components/schemas/Forward"
-          }
-        }
+        "$ref": "#/components/schemas/Forward"
       },
       "GetInboxResponseContent": {
-        "type": "object",
-        "properties": {
-          "inbox": {
-            "$ref": "#/components/schemas/Inbox"
-          }
-        }
+        "$ref": "#/components/schemas/Inbox"
       },
       "GetMessageBoardResponseContent": {
-        "type": "object",
-        "properties": {
-          "message_board": {
-            "$ref": "#/components/schemas/MessageBoard"
-          }
-        }
+        "$ref": "#/components/schemas/MessageBoard"
       },
       "GetMessageResponseContent": {
-        "type": "object",
-        "properties": {
-          "message": {
-            "$ref": "#/components/schemas/Message"
-          }
-        }
+        "$ref": "#/components/schemas/Message"
       },
       "GetMessageTypeResponseContent": {
-        "type": "object",
-        "properties": {
-          "message_type": {
-            "$ref": "#/components/schemas/MessageType"
-          }
-        }
+        "$ref": "#/components/schemas/MessageType"
       },
       "GetMyProfileResponseContent": {
-        "type": "object",
-        "properties": {
-          "person": {
-            "$ref": "#/components/schemas/Person"
-          }
-        }
+        "$ref": "#/components/schemas/Person"
       },
       "GetOverdueTodosResponseContent": {
         "type": "object",
@@ -19510,12 +19415,7 @@
         }
       },
       "GetPersonResponseContent": {
-        "type": "object",
-        "properties": {
-          "person": {
-            "$ref": "#/components/schemas/Person"
-          }
-        }
+        "$ref": "#/components/schemas/Person"
       },
       "GetProgressReportResponseContent": {
         "type": "object",
@@ -19529,20 +19429,10 @@
         }
       },
       "GetProjectConstructionResponseContent": {
-        "type": "object",
-        "properties": {
-          "construction": {
-            "$ref": "#/components/schemas/ProjectConstruction"
-          }
-        }
+        "$ref": "#/components/schemas/ProjectConstruction"
       },
       "GetProjectResponseContent": {
-        "type": "object",
-        "properties": {
-          "project": {
-            "$ref": "#/components/schemas/Project"
-          }
-        }
+        "$ref": "#/components/schemas/Project"
       },
       "GetProjectTimelineResponseContent": {
         "type": "object",
@@ -19567,28 +19457,13 @@
         }
       },
       "GetQuestionResponseContent": {
-        "type": "object",
-        "properties": {
-          "question": {
-            "$ref": "#/components/schemas/Question"
-          }
-        }
+        "$ref": "#/components/schemas/Question"
       },
       "GetQuestionnaireResponseContent": {
-        "type": "object",
-        "properties": {
-          "questionnaire": {
-            "$ref": "#/components/schemas/Questionnaire"
-          }
-        }
+        "$ref": "#/components/schemas/Questionnaire"
       },
       "GetRecordingResponseContent": {
-        "type": "object",
-        "properties": {
-          "recording": {
-            "$ref": "#/components/schemas/Recording"
-          }
-        }
+        "$ref": "#/components/schemas/Recording"
       },
       "GetRecordingTimesheetResponseContent": {
         "type": "object",
@@ -19602,52 +19477,22 @@
         }
       },
       "GetScheduleEntryOccurrenceResponseContent": {
-        "type": "object",
-        "properties": {
-          "entry": {
-            "$ref": "#/components/schemas/ScheduleEntry"
-          }
-        }
+        "$ref": "#/components/schemas/ScheduleEntry"
       },
       "GetScheduleEntryResponseContent": {
-        "type": "object",
-        "properties": {
-          "entry": {
-            "$ref": "#/components/schemas/ScheduleEntry"
-          }
-        }
+        "$ref": "#/components/schemas/ScheduleEntry"
       },
       "GetScheduleResponseContent": {
-        "type": "object",
-        "properties": {
-          "schedule": {
-            "$ref": "#/components/schemas/Schedule"
-          }
-        }
+        "$ref": "#/components/schemas/Schedule"
       },
       "GetSearchMetadataResponseContent": {
-        "type": "object",
-        "properties": {
-          "metadata": {
-            "$ref": "#/components/schemas/SearchMetadata"
-          }
-        }
+        "$ref": "#/components/schemas/SearchMetadata"
       },
       "GetSubscriptionResponseContent": {
-        "type": "object",
-        "properties": {
-          "subscription": {
-            "$ref": "#/components/schemas/Subscription"
-          }
-        }
+        "$ref": "#/components/schemas/Subscription"
       },
       "GetTemplateResponseContent": {
-        "type": "object",
-        "properties": {
-          "template": {
-            "$ref": "#/components/schemas/Template"
-          }
-        }
+        "$ref": "#/components/schemas/Template"
       },
       "GetTimesheetReportResponseContent": {
         "type": "object",
@@ -19661,36 +19506,16 @@
         }
       },
       "GetTodoResponseContent": {
-        "type": "object",
-        "properties": {
-          "todo": {
-            "$ref": "#/components/schemas/Todo"
-          }
-        }
+        "$ref": "#/components/schemas/Todo"
       },
       "GetTodolistOrGroupResponseContent": {
-        "type": "object",
-        "properties": {
-          "result": {
-            "$ref": "#/components/schemas/TodolistOrGroup"
-          }
-        }
+        "$ref": "#/components/schemas/TodolistOrGroup"
       },
       "GetTodosetResponseContent": {
-        "type": "object",
-        "properties": {
-          "todoset": {
-            "$ref": "#/components/schemas/Todoset"
-          }
-        }
+        "$ref": "#/components/schemas/Todoset"
       },
       "GetToolResponseContent": {
-        "type": "object",
-        "properties": {
-          "tool": {
-            "$ref": "#/components/schemas/Tool"
-          }
-        }
+        "$ref": "#/components/schemas/Tool"
       },
       "GetUpcomingScheduleResponseContent": {
         "type": "object",
@@ -19716,28 +19541,13 @@
         }
       },
       "GetUploadResponseContent": {
-        "type": "object",
-        "properties": {
-          "upload": {
-            "$ref": "#/components/schemas/Upload"
-          }
-        }
+        "$ref": "#/components/schemas/Upload"
       },
       "GetVaultResponseContent": {
-        "type": "object",
-        "properties": {
-          "vault": {
-            "$ref": "#/components/schemas/Vault"
-          }
-        }
+        "$ref": "#/components/schemas/Vault"
       },
       "GetWebhookResponseContent": {
-        "type": "object",
-        "properties": {
-          "webhook": {
-            "$ref": "#/components/schemas/Webhook"
-          }
-        }
+        "$ref": "#/components/schemas/Webhook"
       },
       "Inbox": {
         "type": "object",

--- a/spec/basecamp.smithy
+++ b/spec/basecamp.smithy
@@ -1,18 +1,23 @@
 $version: "2"
 
 // =============================================================================
-// ARCHITECTURAL NOTE: List Response Format
+// ARCHITECTURAL NOTE: Response Format Mappers
 // =============================================================================
-// The BC3 API returns bare arrays for list endpoints (GET /projects.json returns
-// [...] not {"projects": [...]}). Smithy's AWS restJson1 protocol requires list
-// outputs to be modeled as wrapped structures because @httpPayload only supports
-// string, blob, structure, union, and document types—not arrays.
+// The BC3 API returns bare values—arrays for list endpoints and objects for
+// single-entity endpoints. Smithy's AWS restJson1 protocol requires outputs to
+// be modeled as wrapped structures because @httpPayload only supports string,
+// blob, structure, union, and document types—not arrays or bare references.
 //
 // As a result:
-//   - This Smithy model uses wrapped outputs (e.g., ListProjectsOutput.projects)
-//   - A custom OpenApiMapper (BareArrayResponseMapper) transforms List*ResponseContent
-//     schemas to bare arrays during OpenAPI generation, matching the actual wire format
-//   - Generated SDK clients correctly handle bare array responses
+//   - This Smithy model uses wrapped outputs (e.g., ListProjectsOutput.projects,
+//     GetProjectOutput.project)
+//   - Two custom OpenApiMappers transform schemas during OpenAPI generation:
+//     * BareArrayResponseMapper: List*ResponseContent → bare arrays
+//     * BareObjectResponseMapper: Get*ResponseContent (single property, non-array) → bare $ref
+//   - Generated SDK clients correctly handle bare responses
+//
+// Multi-field Get responses (e.g., GetAssignedTodosOutput) are left wrapped
+// because the API genuinely returns an object with multiple top-level keys.
 //
 // This is a known protocol limitation, not a modeling error.
 // =============================================================================

--- a/spec/smithy-bare-arrays/src/main/java/com/basecamp/smithy/BareArrayExtension.java
+++ b/spec/smithy-bare-arrays/src/main/java/com/basecamp/smithy/BareArrayExtension.java
@@ -19,6 +19,6 @@ public final class BareArrayExtension implements Smithy2OpenApiExtension {
 
     @Override
     public List<OpenApiMapper> getOpenApiMappers() {
-        return List.of(new BareArrayResponseMapper());
+        return List.of(new BareArrayResponseMapper(), new BareObjectResponseMapper());
     }
 }

--- a/spec/smithy-bare-arrays/src/main/java/com/basecamp/smithy/BareObjectResponseMapper.java
+++ b/spec/smithy-bare-arrays/src/main/java/com/basecamp/smithy/BareObjectResponseMapper.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Basecamp, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Transforms Get*ResponseContent schemas from wrapped objects to bare $ref.
+ * This bridges the gap between Smithy's protocol constraints (which require
+ * wrapped structures) and the BC3 API's actual wire format (bare objects).
+ */
+package com.basecamp.smithy;
+
+import software.amazon.smithy.model.node.Node;
+import software.amazon.smithy.model.node.ObjectNode;
+import software.amazon.smithy.model.traits.Trait;
+import software.amazon.smithy.openapi.fromsmithy.Context;
+import software.amazon.smithy.openapi.fromsmithy.OpenApiMapper;
+import software.amazon.smithy.openapi.model.OpenApi;
+
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * An OpenAPI mapper that transforms Get response schemas from wrapped objects
+ * to bare {@code $ref}, matching the BC3 API's actual response format.
+ *
+ * <p>Smithy's AWS restJson1 protocol requires outputs to be modeled as
+ * wrapped structures (e.g., {@code GetProjectOutput { project: Project }})
+ * because {@code @httpPayload} only supports structures, not bare references.
+ *
+ * <p>However, the BC3 API returns bare objects: {@code GET /projects/123.json}
+ * returns a project object directly, not {@code {"project": {...}}}.
+ *
+ * <p>This mapper runs after core OpenAPI generation and transforms schemas
+ * matching the pattern {@code Get*ResponseContent} from:
+ * <pre>{@code
+ * {"type": "object", "properties": {"project": {"$ref": "#/components/schemas/Project"}}}
+ * }</pre>
+ * to:
+ * <pre>{@code
+ * {"$ref": "#/components/schemas/Project"}
+ * }</pre>
+ *
+ * <p>Only schemas with exactly one property that is NOT an array are transformed.
+ * Multi-field responses (e.g., GetAssignedTodosResponseContent) are left as-is.
+ */
+public final class BareObjectResponseMapper implements OpenApiMapper {
+
+    private static final Logger LOGGER = Logger.getLogger(BareObjectResponseMapper.class.getName());
+
+    @Override
+    public byte getOrder() {
+        // Run after core transformations (default order is 0)
+        return 100;
+    }
+
+    @Override
+    public ObjectNode updateNode(Context<? extends Trait> context, OpenApi openapi, ObjectNode node) {
+        ObjectNode componentsNode = node.getObjectMember("components").orElse(null);
+        if (componentsNode == null) {
+            return node;
+        }
+
+        ObjectNode schemasNode = componentsNode.getObjectMember("schemas").orElse(null);
+        if (schemasNode == null) {
+            return node;
+        }
+
+        ObjectNode.Builder newSchemas = ObjectNode.builder();
+        int transformedCount = 0;
+
+        for (Map.Entry<String, Node> entry : schemasNode.getStringMap().entrySet()) {
+            String name = entry.getKey();
+            Node schema = entry.getValue();
+
+            if (shouldTransform(name, schema)) {
+                newSchemas.withMember(name, transformToRef(schema.expectObjectNode()));
+                transformedCount++;
+            } else {
+                newSchemas.withMember(name, schema);
+            }
+        }
+
+        if (transformedCount > 0) {
+            LOGGER.info("Transformed " + transformedCount + " Get*ResponseContent schemas to bare $ref");
+        }
+
+        // Rebuild the node with updated schemas
+        ObjectNode newComponents = componentsNode.toBuilder()
+                .withMember("schemas", newSchemas.build())
+                .build();
+
+        return node.toBuilder()
+                .withMember("components", newComponents)
+                .build();
+    }
+
+    /**
+     * Determines if a schema should be transformed.
+     *
+     * @param name   the schema name
+     * @param schema the schema node
+     * @return true if the schema matches the criteria for transformation
+     */
+    boolean shouldTransform(String name, Node schema) {
+        // Must match Get*ResponseContent pattern
+        if (!name.startsWith("Get") || !name.endsWith("ResponseContent")) {
+            return false;
+        }
+
+        if (!schema.isObjectNode()) {
+            return false;
+        }
+
+        ObjectNode obj = schema.expectObjectNode();
+
+        // Must be type: "object"
+        if (!obj.getStringMember("type").map(n -> n.getValue().equals("object")).orElse(false)) {
+            return false;
+        }
+
+        // Must have exactly one property
+        ObjectNode properties = obj.getObjectMember("properties").orElse(null);
+        if (properties == null) {
+            return false;
+        }
+
+        Map<String, Node> props = properties.getStringMap();
+        if (props.size() != 1) {
+            return false;
+        }
+
+        // The single property must NOT be an array (i.e., it's a $ref or inline object)
+        Node propValue = props.values().iterator().next();
+        if (!propValue.isObjectNode()) {
+            return false;
+        }
+
+        ObjectNode propObj = propValue.expectObjectNode();
+
+        // If it has a $ref, it's a reference — transform it
+        if (propObj.getMember("$ref").isPresent()) {
+            return true;
+        }
+
+        // If it's type: "array", skip (handled by BareArrayResponseMapper)
+        boolean isArray = propObj.getStringMember("type")
+                .map(n -> n.getValue().equals("array"))
+                .orElse(false);
+
+        return !isArray;
+    }
+
+    /**
+     * Transforms a wrapped object schema to a bare $ref or inline schema.
+     * Extracts the single property's value as the replacement schema.
+     *
+     * @param wrapped the wrapped object schema
+     * @return the bare schema (typically a $ref node)
+     */
+    ObjectNode transformToRef(ObjectNode wrapped) {
+        ObjectNode properties = wrapped.getObjectMember("properties").get();
+        return properties.getStringMap().values().iterator().next().expectObjectNode();
+    }
+}

--- a/spec/smithy-bare-arrays/src/test/java/com/basecamp/smithy/BareObjectResponseMapperTest.java
+++ b/spec/smithy-bare-arrays/src/test/java/com/basecamp/smithy/BareObjectResponseMapperTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Basecamp, LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.basecamp.smithy;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.model.node.ObjectNode;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BareObjectResponseMapperTest {
+
+    private BareObjectResponseMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new BareObjectResponseMapper();
+    }
+
+    @Test
+    void shouldTransform_matchesGetResponseContentWithRef() {
+        ObjectNode schema = ObjectNode.builder()
+                .withMember("type", "object")
+                .withMember("properties", ObjectNode.builder()
+                        .withMember("project", ObjectNode.builder()
+                                .withMember("$ref", "#/components/schemas/Project")
+                                .build())
+                        .build())
+                .build();
+
+        assertTrue(mapper.shouldTransform("GetProjectResponseContent", schema));
+    }
+
+    @Test
+    void shouldTransform_matchesGetResponseContentWithInlineObject() {
+        ObjectNode schema = ObjectNode.builder()
+                .withMember("type", "object")
+                .withMember("properties", ObjectNode.builder()
+                        .withMember("thing", ObjectNode.builder()
+                                .withMember("type", "object")
+                                .build())
+                        .build())
+                .build();
+
+        assertTrue(mapper.shouldTransform("GetThingResponseContent", schema));
+    }
+
+    @Test
+    void shouldTransform_rejectsNonGetPrefix() {
+        ObjectNode schema = ObjectNode.builder()
+                .withMember("type", "object")
+                .withMember("properties", ObjectNode.builder()
+                        .withMember("project", ObjectNode.builder()
+                                .withMember("$ref", "#/components/schemas/Project")
+                                .build())
+                        .build())
+                .build();
+
+        assertFalse(mapper.shouldTransform("ListProjectsResponseContent", schema));
+    }
+
+    @Test
+    void shouldTransform_rejectsNonResponseContentSuffix() {
+        ObjectNode schema = ObjectNode.builder()
+                .withMember("type", "object")
+                .withMember("properties", ObjectNode.builder()
+                        .withMember("project", ObjectNode.builder()
+                                .withMember("$ref", "#/components/schemas/Project")
+                                .build())
+                        .build())
+                .build();
+
+        assertFalse(mapper.shouldTransform("GetProjectOutput", schema));
+    }
+
+    @Test
+    void shouldTransform_rejectsMultipleProperties() {
+        ObjectNode schema = ObjectNode.builder()
+                .withMember("type", "object")
+                .withMember("properties", ObjectNode.builder()
+                        .withMember("person", ObjectNode.builder()
+                                .withMember("$ref", "#/components/schemas/Person")
+                                .build())
+                        .withMember("todos", ObjectNode.builder()
+                                .withMember("type", "array")
+                                .build())
+                        .withMember("grouped_by", ObjectNode.builder()
+                                .withMember("type", "string")
+                                .build())
+                        .build())
+                .build();
+
+        assertFalse(mapper.shouldTransform("GetAssignedTodosResponseContent", schema));
+    }
+
+    @Test
+    void shouldTransform_rejectsArrayProperty() {
+        ObjectNode schema = ObjectNode.builder()
+                .withMember("type", "object")
+                .withMember("properties", ObjectNode.builder()
+                        .withMember("events", ObjectNode.builder()
+                                .withMember("type", "array")
+                                .withMember("items", ObjectNode.builder()
+                                        .withMember("$ref", "#/components/schemas/Event")
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+
+        assertFalse(mapper.shouldTransform("GetProjectTimelineResponseContent", schema));
+    }
+
+    @Test
+    void shouldTransform_rejectsNonObjectType() {
+        ObjectNode schema = ObjectNode.builder()
+                .withMember("type", "array")
+                .build();
+
+        assertFalse(mapper.shouldTransform("GetProjectResponseContent", schema));
+    }
+
+    @Test
+    void shouldTransform_rejectsNoProperties() {
+        ObjectNode schema = ObjectNode.builder()
+                .withMember("type", "object")
+                .build();
+
+        assertFalse(mapper.shouldTransform("GetProjectResponseContent", schema));
+    }
+
+    @Test
+    void transformToRef_extractsRefSchema() {
+        ObjectNode wrapped = ObjectNode.builder()
+                .withMember("type", "object")
+                .withMember("properties", ObjectNode.builder()
+                        .withMember("project", ObjectNode.builder()
+                                .withMember("$ref", "#/components/schemas/Project")
+                                .build())
+                        .build())
+                .build();
+
+        ObjectNode result = mapper.transformToRef(wrapped);
+
+        assertEquals(
+                "#/components/schemas/Project",
+                result.expectStringMember("$ref").getValue()
+        );
+        // Should only have the $ref, no type or other keys
+        assertFalse(result.getMember("type").isPresent());
+    }
+
+    @Test
+    void transformToRef_extractsInlineObjectSchema() {
+        ObjectNode wrapped = ObjectNode.builder()
+                .withMember("type", "object")
+                .withMember("properties", ObjectNode.builder()
+                        .withMember("thing", ObjectNode.builder()
+                                .withMember("type", "object")
+                                .withMember("description", "An inline thing")
+                                .build())
+                        .build())
+                .build();
+
+        ObjectNode result = mapper.transformToRef(wrapped);
+
+        assertEquals("object", result.expectStringMember("type").getValue());
+        assertEquals("An inline thing", result.expectStringMember("description").getValue());
+    }
+
+    @Test
+    void getOrder_returnsHighValue() {
+        assertTrue(mapper.getOrder() > 0);
+    }
+}


### PR DESCRIPTION
## Summary
- Unwraps single-entity Get responses so they return the bare `$ref` type instead of a wrapper struct
- bcq PR #100 already depends on this commit

## Test plan
- Clean fast-forward merge, no conflicts