### PR TITLE
Expose X-Total-Count header in all paginated List methods

### DIFF
--- a/go/pkg/basecamp/example_test.go
+++ b/go/pkg/basecamp/example_test.go
@@ -135,12 +135,12 @@ func ExampleTodosService_List() {
 	todolistID := int64(789012)
 
 	// List all todos in a todolist
-	todos, err := client.ForAccount("12345").Todos().List(ctx, projectID, todolistID, nil)
+	todosResult, err := client.ForAccount("12345").Todos().List(ctx, projectID, todolistID, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	for _, t := range todos {
+	for _, t := range todosResult.Todos {
 		status := "[ ]"
 		if t.Completed {
 			status = "[x]"
@@ -258,12 +258,12 @@ func ExamplePeopleService_List() {
 	ctx := context.Background()
 
 	// List all people in the account
-	people, err := client.ForAccount("12345").People().List(ctx, nil)
+	peopleResult, err := client.ForAccount("12345").People().List(ctx, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	for _, p := range people {
+	for _, p := range peopleResult.People {
 		fmt.Printf("%s <%s>\n", p.Name, p.EmailAddress)
 	}
 }


### PR DESCRIPTION
## Summary

All List methods now return `*XxxListResult` types that include:
- The data slice (e.g., `Todos`, `Messages`, `People`)
- `Meta.TotalCount` from the `X-Total-Count` header

This enables callers to show accurate truncation notices like "showing 25 of 150 items" when results are limited by pagination.

## Methods Updated (25 total)

| Service | Method | New Return Type |
|---------|--------|-----------------|
| Todos | List | `*TodoListResult` |
| Messages | List | `*MessageListResult` |
| People | List, ListProjectPeople | `*PeopleListResult` |
| Todolists | List | `*TodolistListResult` |
| Comments | List | `*CommentListResult` |
| Events | List | `*EventListResult` |
| Recordings | List | `*RecordingListResult` |
| Vaults | List | `*VaultListResult` |
| Documents | List | `*DocumentListResult` |
| Uploads | List | `*UploadListResult` |
| Cards | List | `*CardListResult` |
| Forwards | List, ListReplies | `*ForwardListResult`, `*ForwardReplyListResult` |
| Webhooks | List | `*WebhookListResult` |
| MessageTypes | List | `*MessageTypeListResult` |
| Templates | List | `*TemplateListResult` |
| Campfires | List, ListLines | `*CampfireListResult`, `*CampfireLineListResult` |
| TodolistGroups | List | `*TodolistGroupListResult` |
| ClientApprovals | List | `*ClientApprovalListResult` |
| ClientCorrespondences | List | `*ClientCorrespondenceListResult` |
| ClientReplies | List | `*ClientReplyListResult` |
| Checkins | ListQuestions, ListAnswers | `*QuestionListResult`, `*AnswerListResult` |
| Schedules | ListEntries | `*ScheduleEntryListResult` |

## Breaking Change

This is a breaking change to the SDK API. Callers must update to destructure the result type:

```go
// Before
todos, err := client.Todos().List(ctx, projectID, todolistID, nil)
for _, t := range todos { ... }

// After
result, err := client.Todos().List(ctx, projectID, todolistID, nil)
for _, t := range result.Todos { ... }
// Access total count: result.Meta.TotalCount
```

## Test plan
- [x] `make` passes (vet, lint, tests)
- [x] Example tests updated