### PR TITLE
Add Ruby 4.0 to CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2', '3.3', '3.4', 'head']
+        ruby: ['3.2', '3.3', '3.4', '4.0', 'head']
     continue-on-error: ${{ matrix.ruby == 'head' }}
     defaults:
       run:


### PR DESCRIPTION
## Summary
- Adds Ruby 4.0 to the CI test matrix alongside 3.2, 3.3, 3.4, and head
- Ruby 4.0 is required to pass (not allowed to fail like head)

## Test plan
- CI will run Ruby 4.0 tests on this PR