### PR TITLE
Disable HTTP caching by default in Go and TypeScript SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ Official SDKs for the [Basecamp 3 API](https://github.com/basecamp/bc3-api).
 | [Ruby](ruby/) | `ruby/` | Active | `basecamp-sdk` |
 | [TypeScript](typescript/) | `typescript/` | Active | `@basecamp/sdk` |
 
+| Feature | Go | TypeScript | Ruby |
+|---------|:--:|:----------:|:----:|
+| OAuth 2.0 Authentication | ✓ | ✓ | ✓ |
+| Static Token Authentication | ✓ | ✓ | ✓ |
+| ETag HTTP Caching (opt-in) | ✓ | ✓ | via Faraday† |
+| Automatic Retry with Backoff | ✓ | ✓ | ✓ |
+| Pagination Handling | ✓ | ✓ | ✓ |
+| Observability Hooks | ✓ | ✓ | ✓ |
+| Structured Errors | ✓ | ✓ | ✓ |
+
+† Ruby SDK uses Faraday - add caching via [faraday-http-cache](https://github.com/sourcelevel/faraday-http-cache)
+
+**Note:** HTTP caching is disabled by default. Enable explicitly via configuration:
+- **Go:** `cfg.CacheEnabled = true` or `BASECAMP_CACHE_ENABLED=true`
+- **TypeScript:** `enableCache: true` in client options
+
 All SDKs are generated from a single [Smithy](https://smithy.io/) specification, ensuring consistent behavior and API coverage across languages.
 
 ## Quick Start

--- a/go/README.md
+++ b/go/README.md
@@ -126,7 +126,7 @@ func main() {
 | `BASECAMP_TODOLIST_ID` | Default todolist ID | No |
 | `BASECAMP_BASE_URL` | API base URL | No (default: `https://3.basecampapi.com`) |
 | `BASECAMP_CACHE_DIR` | Cache directory path | No (default: `~/.cache/basecamp`) |
-| `BASECAMP_CACHE_ENABLED` | Enable HTTP caching | No (default: `true`) |
+| `BASECAMP_CACHE_ENABLED` | Enable HTTP caching | No (default: `false`) |
 | `BASECAMP_NO_KEYRING` | Disable system keyring | No |
 
 Note: Account ID is specified via `client.ForAccount(accountID)` rather than configuration.
@@ -345,7 +345,19 @@ if err != nil {
 
 ## Caching
 
-The SDK automatically caches GET responses using ETags:
+The SDK supports ETag-based caching for GET responses. **Caching is disabled by default** to avoid writing private data to disk unexpectedly.
+
+To enable caching:
+
+```go
+cfg := basecamp.DefaultConfig()
+cfg.CacheEnabled = true
+
+// Or via environment variable:
+// BASECAMP_CACHE_ENABLED=true
+```
+
+When enabled, the SDK caches GET responses using ETags:
 
 ```go
 // First request fetches from API
@@ -353,10 +365,6 @@ projects, _ := account.Projects().List(ctx, nil)
 
 // Second request uses cached data if unchanged (304 Not Modified)
 projects, _ = account.Projects().List(ctx, nil)
-
-// Disable caching
-cfg := basecamp.DefaultConfig()
-cfg.CacheEnabled = false
 ```
 
 ## Custom HTTP Client

--- a/go/pkg/basecamp/config.go
+++ b/go/pkg/basecamp/config.go
@@ -37,7 +37,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		BaseURL:      "https://3.basecampapi.com",
 		CacheDir:     filepath.Join(cacheDir, "basecamp"),
-		CacheEnabled: true,
+		CacheEnabled: false,
 	}
 }
 

--- a/ruby/test/basecamp/hooks_test.rb
+++ b/ruby/test/basecamp/hooks_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "logger"
 
 class HooksTest < Minitest::Test
   def test_request_info_data_class

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -181,7 +181,7 @@ export interface BasecampClientOptions {
   baseUrl?: string;
   /** User-Agent header (defaults to basecamp-sdk-ts/VERSION) */
   userAgent?: string;
-  /** Enable ETag-based caching (defaults to true) */
+  /** Enable ETag-based caching (defaults to false) */
   enableCache?: boolean;
   /** Enable automatic retry on 429/503 (defaults to true) */
   enableRetry?: boolean;
@@ -216,7 +216,7 @@ export function createBasecampClient(options: BasecampClientOptions): BasecampCl
     accessToken,
     baseUrl = `https://3.basecampapi.com/${accountId}`,
     userAgent = DEFAULT_USER_AGENT,
-    enableCache = true,
+    enableCache = false,
     enableRetry = true,
     hooks,
   } = options;

--- a/typescript/tests/security.test.ts
+++ b/typescript/tests/security.test.ts
@@ -428,6 +428,7 @@ describe("Cache auth isolation", () => {
     const client = createBasecampClient({
       accountId: "12345",
       accessToken: "token-cache-test",
+      enableCache: true,
     });
 
     // First request: populates cache with ETag


### PR DESCRIPTION
## Summary

- Change cache default from enabled to disabled in both Go and TypeScript SDKs
- Add feature capability table to main README showing SDK comparison
- Update documentation to reflect opt-in caching behavior

## Motivation

HTTP caching was enabled by default, which risked leaking private Basecamp data:
- **Go SDK**: Writes to disk (`~/.cache/basecamp/`) - HIGH risk
- **TypeScript SDK**: Stores in memory (Map) - Medium risk

Caching should be an explicit opt-in choice.

## Test plan

- [x] Go tests pass (`go test ./...`)
- [x] TypeScript tests pass (`npm test`) - updated security test to explicitly enable cache
- [x] Verified documentation accurately reflects new defaults