### PR TITLE
Add .localhost TLD support (RFC 6761)

### DIFF
--- a/go/pkg/basecamp/auth.go
+++ b/go/pkg/basecamp/auth.go
@@ -310,7 +310,7 @@ func (m *AuthManager) refreshLocked(ctx context.Context, origin string, creds *C
 	if tokenEndpoint == "" {
 		return ErrAuth("No token endpoint stored")
 	}
-	if err := requireHTTPSUnlessLocalhost(tokenEndpoint); err != nil {
+	if err := RequireSecureEndpoint(tokenEndpoint); err != nil {
 		return ErrAuth(fmt.Sprintf("Token endpoint must use HTTPS: %s", tokenEndpoint))
 	}
 

--- a/go/pkg/basecamp/authorization.go
+++ b/go/pkg/basecamp/authorization.go
@@ -112,7 +112,7 @@ func (s *AuthorizationService) GetInfo(ctx context.Context, opts *GetInfoOptions
 	if opts != nil && opts.Endpoint != "" {
 		endpoint = opts.Endpoint
 		// Validate custom endpoint uses HTTPS (allow localhost for testing)
-		if err := requireHTTPSUnlessLocalhost(endpoint); err != nil {
+		if err := RequireSecureEndpoint(endpoint); err != nil {
 			return nil, fmt.Errorf("authorization endpoint validation failed: %w", err)
 		}
 	}

--- a/ruby/lib/basecamp/config.rb
+++ b/ruby/lib/basecamp/config.rb
@@ -137,13 +137,7 @@ module Basecamp
     end
 
     def localhost?(url)
-      return false if url.nil?
-
-      uri = URI.parse(url)
-      host = uri.host&.downcase
-      host == "localhost" || host == "127.0.0.1" || host == "::1"
-    rescue URI::InvalidURIError
-      false
+      Basecamp::Security.localhost?(url)
     end
   end
 end

--- a/ruby/lib/basecamp/security.rb
+++ b/ruby/lib/basecamp/security.rb
@@ -63,7 +63,13 @@ module Basecamp
     def self.localhost?(url)
       uri = URI.parse(url.to_s)
       host = uri.host&.downcase
-      host == "localhost" || host == "127.0.0.1" || host == "::1"
+      return false if host.nil?
+
+      host == "localhost" ||
+        host == "127.0.0.1" ||
+        host == "::1" ||
+        host == "[::1]" ||
+        host.end_with?(".localhost")
     rescue URI::InvalidURIError
       false
     end

--- a/ruby/test/basecamp/security_test.rb
+++ b/ruby/test/basecamp/security_test.rb
@@ -34,6 +34,49 @@ class SecurityTruncateTest < Minitest::Test
   end
 end
 
+class SecurityLocalhostTest < Minitest::Test
+  def test_localhost_hostname
+    assert Basecamp::Security.localhost?("http://localhost:3000/path")
+  end
+
+  def test_localhost_127_0_0_1
+    assert Basecamp::Security.localhost?("http://127.0.0.1:3000/path")
+  end
+
+  def test_localhost_ipv6
+    assert Basecamp::Security.localhost?("http://[::1]:3000/path")
+  end
+
+  def test_localhost_tld
+    assert Basecamp::Security.localhost?("http://app.localhost/path")
+  end
+
+  def test_localhost_tld_subdomain
+    assert Basecamp::Security.localhost?("http://3.basecamp.localhost/path")
+  end
+
+  def test_localhost_tld_with_port
+    assert Basecamp::Security.localhost?("http://myapp.localhost:3000/api")
+  end
+
+  def test_not_localhost_remote_host
+    assert_not Basecamp::Security.localhost?("https://example.com/path")
+  end
+
+  def test_not_localhost_suffix_in_hostname
+    # "mylocalhost.com" should not match
+    assert_not Basecamp::Security.localhost?("https://mylocalhost.com/path")
+  end
+
+  def test_not_localhost_nil_host
+    assert_not Basecamp::Security.localhost?("/relative/path")
+  end
+
+  def test_not_localhost_invalid_uri
+    assert_not Basecamp::Security.localhost?("://bad")
+  end
+end
+
 class SecurityRequireHttpsTest < Minitest::Test
   def test_accepts_https
     Basecamp::Security.require_https!("https://example.com/path")

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -11,6 +11,7 @@ import { createRequire } from "node:module";
 import type { paths } from "./generated/schema.js";
 import type { BasecampHooks, RequestInfo, RequestResult } from "./hooks.js";
 import { BasecampError } from "./errors.js";
+import { isLocalhost } from "./security.js";
 
 // Use createRequire for JSON import (Node 18+ compatible)
 const require = createRequire(import.meta.url);
@@ -225,10 +226,7 @@ export function createBasecampClient(options: BasecampClientOptions): BasecampCl
   if (baseUrl) {
     try {
       const parsed = new URL(baseUrl);
-      const isLocalhost = parsed.hostname === "localhost" ||
-                          parsed.hostname === "127.0.0.1" ||
-                          parsed.hostname === "::1";
-      if (parsed.protocol !== "https:" && !isLocalhost) {
+      if (parsed.protocol !== "https:" && !isLocalhost(parsed.hostname)) {
         throw new BasecampError("usage", `Base URL must use HTTPS: ${baseUrl}`);
       }
     } catch (err) {

--- a/typescript/src/oauth/discovery.ts
+++ b/typescript/src/oauth/discovery.ts
@@ -5,6 +5,7 @@
  */
 
 import { BasecampError } from "../errors.js";
+import { isLocalhost } from "../security.js";
 import type { OAuthConfig } from "./types.js";
 
 /**
@@ -55,10 +56,7 @@ export async function discover(
   // Validate HTTPS before making any network request (allow localhost for testing)
   try {
     const parsed = new URL(baseUrl);
-    const isLocalhost = parsed.hostname === "localhost" ||
-                        parsed.hostname === "127.0.0.1" ||
-                        parsed.hostname === "::1";
-    if (parsed.protocol !== "https:" && !isLocalhost) {
+    if (parsed.protocol !== "https:" && !isLocalhost(parsed.hostname)) {
       throw new BasecampError("validation", `OAuth discovery base URL must use HTTPS: ${baseUrl}`);
     }
   } catch (err) {

--- a/typescript/src/oauth/exchange.ts
+++ b/typescript/src/oauth/exchange.ts
@@ -6,6 +6,7 @@
  */
 
 import { BasecampError } from "../errors.js";
+import { isLocalhost } from "../security.js";
 import type {
   ExchangeRequest,
   RefreshRequest,
@@ -170,10 +171,7 @@ export async function refreshToken(
 function requireHTTPS(url: string, label: string): void {
   try {
     const parsed = new URL(url);
-    const isLocalhost = parsed.hostname === "localhost" ||
-                        parsed.hostname === "127.0.0.1" ||
-                        parsed.hostname === "::1";
-    if (parsed.protocol !== "https:" && !isLocalhost) {
+    if (parsed.protocol !== "https:" && !isLocalhost(parsed.hostname)) {
       throw new BasecampError("validation", `${label} must use HTTPS: ${url}`);
     }
   } catch (err) {

--- a/typescript/src/security.ts
+++ b/typescript/src/security.ts
@@ -77,3 +77,40 @@ export function redactHeadersRecord(
 
   return result;
 }
+
+/**
+ * Checks if a hostname represents localhost for development/testing purposes.
+ *
+ * Matches:
+ * - "localhost" exactly
+ * - Any subdomain of localhost (e.g., "api.localhost", "dev.api.localhost")
+ * - IPv4 loopback "127.0.0.1"
+ * - IPv6 loopback "::1"
+ * - The .localhost TLD (RFC 6761) - any hostname ending in ".localhost"
+ *
+ * This is used to allow HTTP (non-HTTPS) connections during local development
+ * while enforcing HTTPS for all production traffic.
+ *
+ * @param hostname - The hostname to check (without port)
+ * @returns true if the hostname represents localhost
+ *
+ * @example
+ * ```ts
+ * isLocalhost("localhost");           // true
+ * isLocalhost("api.localhost");       // true
+ * isLocalhost("myapp.localhost");     // true
+ * isLocalhost("127.0.0.1");           // true
+ * isLocalhost("::1");                 // true
+ * isLocalhost("example.com");         // false
+ * isLocalhost("localhost.example.com"); // false
+ * ```
+ */
+export function isLocalhost(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return (
+    normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "::1" ||
+    normalized.endsWith(".localhost")
+  );
+}


### PR DESCRIPTION
## Summary
- Add `.localhost` TLD recognition to all three SDKs per RFC 6761
- URLs like `http://3.basecampapi.localhost:4001` are now treated as localhost
- Allows HTTP for development environments using `.localhost` subdomains

## Changes
- **Go**: Updated `isLocalhost()` in `security.go` + tests
- **Ruby**: Updated `localhost?()` in `security.rb` + tests  
- **TypeScript**: Added centralized `isLocalhost()` to `security.ts`, refactored inline checks in `client.ts`, `oauth/exchange.ts`, `oauth/discovery.ts` + tests

## Test plan
- [x] Go: `go test ./go/pkg/basecamp/... -v -run "TestIsLocalhost"` passes
- [x] Ruby: localhost tests pass (13 assertions)
- [x] TypeScript: `npm test -- -t "isLocalhost"` passes (6 tests)