### PR TITLE
Add layered config loading with multi-host support

### DIFF
--- a/go/pkg/basecamp/auth.go
+++ b/go/pkg/basecamp/auth.go
@@ -223,7 +223,7 @@ type AuthManager struct {
 func NewAuthManager(cfg *Config, httpClient *http.Client) *AuthManager {
 	return &AuthManager{
 		cfg:        cfg,
-		store:      NewCredentialStore(globalConfigDir()),
+		store:      NewCredentialStore(GlobalConfigDir()),
 		httpClient: httpClient,
 	}
 }

--- a/go/pkg/basecamp/config.go
+++ b/go/pkg/basecamp/config.go
@@ -1,6 +1,7 @@
 package basecamp
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -13,6 +14,9 @@ type Config struct {
 	// BaseURL is the API base URL (e.g., "https://3.basecampapi.com").
 	BaseURL string `json:"base_url"`
 
+	// AccountID is the default account ID.
+	AccountID string `json:"account_id"`
+
 	// ProjectID is the default project/bucket ID.
 	ProjectID string `json:"project_id"`
 
@@ -24,10 +28,64 @@ type Config struct {
 
 	// CacheEnabled controls whether HTTP caching is enabled.
 	CacheEnabled bool `json:"cache_enabled"`
+
+	// Format is the default output format.
+	Format string `json:"format"`
+
+	// Scope is the OAuth scope.
+	Scope string `json:"scope"`
+
+	// Host settings (multiple environments)
+	Hosts       map[string]*HostConfig `json:"hosts,omitempty"`
+	DefaultHost string                 `json:"default_host,omitempty"`
+
+	// Sources tracks where each value came from (for debugging).
+	Sources map[string]Source `json:"-"`
+}
+
+// HostConfig holds configuration for a specific host/environment.
+type HostConfig struct {
+	BaseURL  string `json:"base_url"`
+	ClientID string `json:"client_id,omitempty"`
+}
+
+// Source indicates where a config value came from.
+type Source string
+
+const (
+	SourceDefault Source = "default"
+	SourceSystem  Source = "system"
+	SourceGlobal  Source = "global"
+	SourceRepo    Source = "repo"
+	SourceLocal   Source = "local"
+	SourceEnv     Source = "env"
+	SourceFlag    Source = "flag"
+)
+
+// LoadOptions holds options for loading configuration.
+type LoadOptions struct {
+	// Account overrides the account_id from any source.
+	Account string
+	// Project overrides the project_id from any source.
+	Project string
+	// Todolist overrides the todolist_id from any source.
+	Todolist string
+	// BaseURL overrides the base_url from any source.
+	BaseURL string
+	// CacheDir overrides the cache_dir from any source.
+	CacheDir string
+	// Format overrides the format from any source.
+	Format string
 }
 
 // DefaultConfig returns a Config with sensible defaults.
+// This is maintained for backwards compatibility.
 func DefaultConfig() *Config {
+	return defaultConfig()
+}
+
+// defaultConfig creates a new config with default values.
+func defaultConfig() *Config {
 	cacheDir := os.Getenv("XDG_CACHE_HOME")
 	if cacheDir == "" {
 		home, _ := os.UserHomeDir()
@@ -36,14 +94,18 @@ func DefaultConfig() *Config {
 
 	return &Config{
 		BaseURL:      "https://3.basecampapi.com",
+		Scope:        "read",
 		CacheDir:     filepath.Join(cacheDir, "basecamp"),
 		CacheEnabled: false,
+		Format:       "auto",
+		Sources:      make(map[string]Source),
 	}
 }
 
 // LoadConfig loads configuration from a JSON file.
+// This is maintained for backwards compatibility.
 func LoadConfig(path string) (*Config, error) {
-	cfg := DefaultConfig()
+	cfg := defaultConfig()
 
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -62,35 +124,317 @@ func LoadConfig(path string) (*Config, error) {
 
 // LoadConfigFromEnv loads configuration from environment variables.
 // Environment variables override any values already set in the config.
+// This is maintained for backwards compatibility.
 func (c *Config) LoadConfigFromEnv() {
+	loadFromEnv(c)
+}
+
+// Load loads configuration from all sources with proper precedence.
+// Precedence: flags > env > local > repo > global > system > defaults
+//
+// File locations:
+//   - System: /etc/basecamp/config.json
+//   - Global: ~/.config/basecamp/config.json (XDG-compliant)
+//   - Repo: .basecamp/config.json at git root
+//   - Local: .basecamp/config.json in current and parent directories
+func Load(opts LoadOptions) (*Config, error) {
+	cfg := defaultConfig()
+
+	// Load from file layers (system -> global -> repo -> local)
+	loadFromFile(cfg, systemConfigPath(), SourceSystem)
+	loadFromFile(cfg, GlobalConfigPath(), SourceGlobal)
+
+	repoPath := repoConfigPath()
+	if repoPath != "" {
+		loadFromFile(cfg, repoPath, SourceRepo)
+	}
+
+	// Load all local configs from root to current (closer overrides)
+	// This allows nested directories to override parent directories
+	localPaths := localConfigPaths(repoPath)
+	for _, path := range localPaths {
+		loadFromFile(cfg, path, SourceLocal)
+	}
+
+	// Load from environment
+	loadFromEnv(cfg)
+
+	// Apply flag overrides
+	applyOverrides(cfg, opts)
+
+	return cfg, nil
+}
+
+// loadFromFile loads configuration from a JSON file into cfg.
+func loadFromFile(cfg *Config, path string, source Source) {
+	data, err := os.ReadFile(path) //nolint:gosec // G304: Path is from trusted config locations
+	if err != nil {
+		return // File doesn't exist, skip
+	}
+
+	// Use json.Decoder with UseNumber to preserve precision for large numeric IDs
+	var fileCfg map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(&fileCfg); err != nil {
+		return // Invalid JSON, skip
+	}
+
+	if v, ok := fileCfg["base_url"].(string); ok && v != "" {
+		cfg.BaseURL = v
+		cfg.Sources["base_url"] = source
+	}
+	if v := getStringOrNumber(fileCfg, "account_id"); v != "" {
+		cfg.AccountID = v
+		cfg.Sources["account_id"] = source
+	}
+	if v := getStringOrNumber(fileCfg, "project_id"); v != "" {
+		cfg.ProjectID = v
+		cfg.Sources["project_id"] = source
+	}
+	if v := getStringOrNumber(fileCfg, "todolist_id"); v != "" {
+		cfg.TodolistID = v
+		cfg.Sources["todolist_id"] = source
+	}
+	if v, ok := fileCfg["scope"].(string); ok && v != "" {
+		cfg.Scope = v
+		cfg.Sources["scope"] = source
+	}
+	if v, ok := fileCfg["cache_dir"].(string); ok && v != "" {
+		cfg.CacheDir = v
+		cfg.Sources["cache_dir"] = source
+	}
+	if v, ok := fileCfg["cache_enabled"].(bool); ok {
+		cfg.CacheEnabled = v
+		cfg.Sources["cache_enabled"] = source
+	}
+	if v, ok := fileCfg["format"].(string); ok && v != "" {
+		cfg.Format = v
+		cfg.Sources["format"] = source
+	}
+	if v, ok := fileCfg["default_host"].(string); ok && v != "" {
+		cfg.DefaultHost = v
+		cfg.Sources["default_host"] = source
+	}
+	if v, ok := fileCfg["hosts"].(map[string]any); ok {
+		if cfg.Hosts == nil {
+			cfg.Hosts = make(map[string]*HostConfig)
+		}
+		for name, hostData := range v {
+			if hostMap, ok := hostData.(map[string]any); ok {
+				hostConfig := &HostConfig{}
+				if baseURL, ok := hostMap["base_url"].(string); ok && baseURL != "" {
+					hostConfig.BaseURL = baseURL
+				} else {
+					// Skip hosts with empty or missing base_url
+					continue
+				}
+				if clientID, ok := hostMap["client_id"].(string); ok {
+					hostConfig.ClientID = clientID
+				}
+				cfg.Hosts[name] = hostConfig
+			}
+		}
+		cfg.Sources["hosts"] = source
+	}
+}
+
+// loadFromEnv loads configuration from environment variables.
+func loadFromEnv(cfg *Config) {
+	if cfg.Sources == nil {
+		cfg.Sources = make(map[string]Source)
+	}
+
 	if v := os.Getenv("BASECAMP_BASE_URL"); v != "" {
-		c.BaseURL = v
+		cfg.BaseURL = v
+		cfg.Sources["base_url"] = SourceEnv
+	}
+	if v := os.Getenv("BASECAMP_ACCOUNT_ID"); v != "" {
+		cfg.AccountID = v
+		cfg.Sources["account_id"] = SourceEnv
 	}
 	if v := os.Getenv("BASECAMP_PROJECT_ID"); v != "" {
-		c.ProjectID = v
+		cfg.ProjectID = v
+		cfg.Sources["project_id"] = SourceEnv
 	}
 	if v := os.Getenv("BASECAMP_TODOLIST_ID"); v != "" {
-		c.TodolistID = v
+		cfg.TodolistID = v
+		cfg.Sources["todolist_id"] = SourceEnv
 	}
 	if v := os.Getenv("BASECAMP_CACHE_DIR"); v != "" {
-		c.CacheDir = v
+		cfg.CacheDir = v
+		cfg.Sources["cache_dir"] = SourceEnv
 	}
 	if v := os.Getenv("BASECAMP_CACHE_ENABLED"); v != "" {
-		c.CacheEnabled = strings.ToLower(v) == "true" || v == "1"
+		cfg.CacheEnabled = strings.ToLower(v) == "true" || v == "1"
+		cfg.Sources["cache_enabled"] = SourceEnv
+	}
+	if v := os.Getenv("BASECAMP_SCOPE"); v != "" {
+		cfg.Scope = v
+		cfg.Sources["scope"] = SourceEnv
+	}
+	if v := os.Getenv("BASECAMP_FORMAT"); v != "" {
+		cfg.Format = v
+		cfg.Sources["format"] = SourceEnv
 	}
 }
 
-// NormalizeBaseURL ensures consistent URL format (no trailing slash).
-func NormalizeBaseURL(url string) string {
-	return strings.TrimSuffix(url, "/")
+// getStringOrNumber extracts a value that may be either a string or number in JSON.
+// Uses json.Number to preserve precision for large numeric IDs.
+func getStringOrNumber(m map[string]any, key string) string {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return ""
+	}
+	switch val := v.(type) {
+	case string:
+		return val
+	case json.Number:
+		// json.Number preserves full precision for large integers
+		return val.String()
+	case float64:
+		// Fallback for standard JSON unmarshaling (loses precision for large IDs)
+		// If the value is an integer, format without decimals
+		if val == float64(int64(val)) {
+			return fmt.Sprintf("%.0f", val)
+		}
+		return fmt.Sprintf("%g", val)
+	case int:
+		return fmt.Sprintf("%d", val)
+	case int64:
+		return fmt.Sprintf("%d", val)
+	default:
+		return ""
+	}
 }
 
-// globalConfigDir returns the global config directory path.
-func globalConfigDir() string {
+// applyOverrides applies command-line flag overrides to the config.
+func applyOverrides(cfg *Config, o LoadOptions) {
+	if o.Account != "" {
+		cfg.AccountID = o.Account
+		cfg.Sources["account_id"] = SourceFlag
+	}
+	if o.Project != "" {
+		cfg.ProjectID = o.Project
+		cfg.Sources["project_id"] = SourceFlag
+	}
+	if o.Todolist != "" {
+		cfg.TodolistID = o.Todolist
+		cfg.Sources["todolist_id"] = SourceFlag
+	}
+	if o.BaseURL != "" {
+		cfg.BaseURL = o.BaseURL
+		cfg.Sources["base_url"] = SourceFlag
+	}
+	if o.CacheDir != "" {
+		cfg.CacheDir = o.CacheDir
+		cfg.Sources["cache_dir"] = SourceFlag
+	}
+	if o.Format != "" {
+		cfg.Format = o.Format
+		cfg.Sources["format"] = SourceFlag
+	}
+}
+
+// Path helpers
+
+func systemConfigPath() string {
+	return "/etc/basecamp/config.json"
+}
+
+// GlobalConfigPath returns the path to the global config file.
+func GlobalConfigPath() string {
+	return filepath.Join(GlobalConfigDir(), "config.json")
+}
+
+func repoConfigPath() string {
+	// Walk up to find .git directory, then look for .basecamp/config.json
+	dir, _ := os.Getwd()
+	for {
+		gitPath := filepath.Join(dir, ".git")
+		if _, err := os.Stat(gitPath); err == nil {
+			cfgPath := filepath.Join(dir, ".basecamp", "config.json")
+			if _, err := os.Stat(cfgPath); err == nil {
+				return cfgPath
+			}
+			return ""
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// localConfigPaths returns all .basecamp/config.json paths from root to current directory,
+// excluding the repo config path (already loaded as SourceRepo).
+// Paths are returned in order from furthest ancestor to closest, so closer configs override.
+func localConfigPaths(repoConfigPath string) []string {
+	dir, _ := os.Getwd()
+	var paths []string
+
+	// Collect all paths walking up
+	for {
+		cfgPath := filepath.Join(dir, ".basecamp", "config.json")
+		if _, err := os.Stat(cfgPath); err == nil {
+			// Skip if this is the repo config (already loaded)
+			if cfgPath != repoConfigPath {
+				paths = append(paths, cfgPath)
+			}
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	// Reverse so paths go from root to current (closer overrides)
+	for i, j := 0, len(paths)-1; i < j; i, j = i+1, j-1 {
+		paths[i], paths[j] = paths[j], paths[i]
+	}
+
+	return paths
+}
+
+// GlobalConfigDir returns the global config directory path.
+func GlobalConfigDir() string {
 	configDir := os.Getenv("XDG_CONFIG_HOME")
 	if configDir == "" {
 		home, _ := os.UserHomeDir()
 		configDir = filepath.Join(home, ".config")
 	}
 	return filepath.Join(configDir, "basecamp")
+}
+
+// NormalizeBaseURL ensures consistent URL format (no trailing slashes).
+func NormalizeBaseURL(url string) string {
+	return strings.TrimRight(url, "/")
+}
+
+// GetSource returns the source of a configuration value.
+func (c *Config) GetSource(key string) Source {
+	if c.Sources == nil {
+		return SourceDefault
+	}
+	if src, ok := c.Sources[key]; ok {
+		return src
+	}
+	return SourceDefault
+}
+
+// GetHost returns the host configuration for the given name.
+// If name is empty, it returns the default host configuration.
+// Returns nil if no matching host is found.
+func (c *Config) GetHost(name string) *HostConfig {
+	if name == "" {
+		name = c.DefaultHost
+	}
+	if name == "" || c.Hosts == nil {
+		return nil
+	}
+	return c.Hosts[name]
 }

--- a/go/pkg/basecamp/config_test.go
+++ b/go/pkg/basecamp/config_test.go
@@ -1,0 +1,573 @@
+package basecamp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.BaseURL != "https://3.basecampapi.com" {
+		t.Errorf("BaseURL = %q, want %q", cfg.BaseURL, "https://3.basecampapi.com")
+	}
+	if cfg.Scope != "read" {
+		t.Errorf("Scope = %q, want %q", cfg.Scope, "read")
+	}
+	if cfg.Format != "auto" {
+		t.Errorf("Format = %q, want %q", cfg.Format, "auto")
+	}
+	if cfg.CacheEnabled != false {
+		t.Errorf("CacheEnabled = %v, want false", cfg.CacheEnabled)
+	}
+	if cfg.Sources == nil {
+		t.Error("Sources should not be nil")
+	}
+}
+
+func TestLoadFromEnv(t *testing.T) {
+	// Save and restore environment
+	envVars := []string{
+		"BASECAMP_BASE_URL",
+		"BASECAMP_ACCOUNT_ID",
+		"BASECAMP_PROJECT_ID",
+		"BASECAMP_TODOLIST_ID",
+		"BASECAMP_CACHE_DIR",
+		"BASECAMP_CACHE_ENABLED",
+		"BASECAMP_SCOPE",
+		"BASECAMP_FORMAT",
+	}
+	saved := make(map[string]string)
+	for _, k := range envVars {
+		saved[k] = os.Getenv(k)
+		os.Unsetenv(k)
+	}
+	defer func() {
+		for k, v := range saved {
+			if v != "" {
+				os.Setenv(k, v)
+			} else {
+				os.Unsetenv(k)
+			}
+		}
+	}()
+
+	t.Run("BASECAMP_* variables", func(t *testing.T) {
+		os.Setenv("BASECAMP_BASE_URL", "https://custom.api.com")
+		os.Setenv("BASECAMP_ACCOUNT_ID", "12345")
+		os.Setenv("BASECAMP_PROJECT_ID", "67890")
+		os.Setenv("BASECAMP_TODOLIST_ID", "11111")
+		os.Setenv("BASECAMP_CACHE_DIR", "/tmp/cache")
+		os.Setenv("BASECAMP_CACHE_ENABLED", "true")
+		defer func() {
+			for _, k := range envVars {
+				os.Unsetenv(k)
+			}
+		}()
+
+		cfg := DefaultConfig()
+		cfg.LoadConfigFromEnv()
+
+		if cfg.BaseURL != "https://custom.api.com" {
+			t.Errorf("BaseURL = %q, want %q", cfg.BaseURL, "https://custom.api.com")
+		}
+		if cfg.AccountID != "12345" {
+			t.Errorf("AccountID = %q, want %q", cfg.AccountID, "12345")
+		}
+		if cfg.ProjectID != "67890" {
+			t.Errorf("ProjectID = %q, want %q", cfg.ProjectID, "67890")
+		}
+		if cfg.TodolistID != "11111" {
+			t.Errorf("TodolistID = %q, want %q", cfg.TodolistID, "11111")
+		}
+		if cfg.CacheDir != "/tmp/cache" {
+			t.Errorf("CacheDir = %q, want %q", cfg.CacheDir, "/tmp/cache")
+		}
+		if cfg.CacheEnabled != true {
+			t.Errorf("CacheEnabled = %v, want true", cfg.CacheEnabled)
+		}
+		if cfg.Sources["base_url"] != SourceEnv {
+			t.Errorf("Sources[base_url] = %q, want %q", cfg.Sources["base_url"], SourceEnv)
+		}
+	})
+
+	t.Run("cache enabled values", func(t *testing.T) {
+		tests := []struct {
+			value string
+			want  bool
+		}{
+			{"true", true},
+			{"True", true},
+			{"TRUE", true},
+			{"1", true},
+			{"false", false},
+			{"0", false},
+			{"", false},
+		}
+
+		for _, tt := range tests {
+			os.Unsetenv("BASECAMP_CACHE_ENABLED")
+
+			if tt.value != "" {
+				os.Setenv("BASECAMP_CACHE_ENABLED", tt.value)
+			}
+
+			cfg := DefaultConfig()
+			cfg.LoadConfigFromEnv()
+
+			if cfg.CacheEnabled != tt.want {
+				t.Errorf("BASECAMP_CACHE_ENABLED=%q: CacheEnabled = %v, want %v", tt.value, cfg.CacheEnabled, tt.want)
+			}
+		}
+	})
+}
+
+func TestLoadConfigFromFile(t *testing.T) {
+	t.Run("loads valid JSON file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfgPath := filepath.Join(tmpDir, "config.json")
+		// Note: LoadConfig uses json.Unmarshal directly which requires string fields.
+		// For numeric IDs, use the layered Load() function which handles number->string.
+		content := `{
+			"base_url": "https://test.api.com",
+			"account_id": "12345",
+			"project_id": "67890",
+			"cache_enabled": true
+		}`
+		if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to write test config: %v", err)
+		}
+
+		cfg, err := LoadConfig(cfgPath)
+		if err != nil {
+			t.Fatalf("LoadConfig failed: %v", err)
+		}
+
+		if cfg.BaseURL != "https://test.api.com" {
+			t.Errorf("BaseURL = %q, want %q", cfg.BaseURL, "https://test.api.com")
+		}
+		if cfg.AccountID != "12345" {
+			t.Errorf("AccountID = %q, want %q", cfg.AccountID, "12345")
+		}
+		if cfg.ProjectID != "67890" {
+			t.Errorf("ProjectID = %q, want %q", cfg.ProjectID, "67890")
+		}
+		if cfg.CacheEnabled != true {
+			t.Errorf("CacheEnabled = %v, want true", cfg.CacheEnabled)
+		}
+	})
+
+	t.Run("returns defaults for non-existent file", func(t *testing.T) {
+		cfg, err := LoadConfig("/nonexistent/path/config.json")
+		if err != nil {
+			t.Fatalf("LoadConfig failed: %v", err)
+		}
+
+		if cfg.BaseURL != "https://3.basecampapi.com" {
+			t.Errorf("BaseURL = %q, want default", cfg.BaseURL)
+		}
+	})
+
+	t.Run("returns error for invalid JSON", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		cfgPath := filepath.Join(tmpDir, "config.json")
+		if err := os.WriteFile(cfgPath, []byte("not valid json"), 0644); err != nil {
+			t.Fatalf("failed to write test config: %v", err)
+		}
+
+		_, err := LoadConfig(cfgPath)
+		if err == nil {
+			t.Error("expected error for invalid JSON")
+		}
+	})
+}
+
+func TestLoadWithOverrides(t *testing.T) {
+	// Clear environment variables that might interfere
+	envVars := []string{
+		"BASECAMP_BASE_URL",
+		"BASECAMP_ACCOUNT_ID",
+		"BASECAMP_PROJECT_ID",
+		"BASECAMP_TODOLIST_ID",
+		"BASECAMP_CACHE_DIR",
+	}
+	for _, k := range envVars {
+		os.Unsetenv(k)
+	}
+
+	cfg, err := Load(LoadOptions{
+		Account:  "99999",
+		Project:  "88888",
+		Todolist: "77777",
+		BaseURL:  "https://override.api.com",
+		CacheDir: "/custom/cache",
+		Format:   "json",
+	})
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if cfg.AccountID != "99999" {
+		t.Errorf("AccountID = %q, want %q", cfg.AccountID, "99999")
+	}
+	if cfg.ProjectID != "88888" {
+		t.Errorf("ProjectID = %q, want %q", cfg.ProjectID, "88888")
+	}
+	if cfg.TodolistID != "77777" {
+		t.Errorf("TodolistID = %q, want %q", cfg.TodolistID, "77777")
+	}
+	if cfg.BaseURL != "https://override.api.com" {
+		t.Errorf("BaseURL = %q, want %q", cfg.BaseURL, "https://override.api.com")
+	}
+	if cfg.CacheDir != "/custom/cache" {
+		t.Errorf("CacheDir = %q, want %q", cfg.CacheDir, "/custom/cache")
+	}
+	if cfg.Format != "json" {
+		t.Errorf("Format = %q, want %q", cfg.Format, "json")
+	}
+
+	// Check sources
+	if cfg.Sources["account_id"] != SourceFlag {
+		t.Errorf("Sources[account_id] = %q, want %q", cfg.Sources["account_id"], SourceFlag)
+	}
+	if cfg.Sources["base_url"] != SourceFlag {
+		t.Errorf("Sources[base_url] = %q, want %q", cfg.Sources["base_url"], SourceFlag)
+	}
+}
+
+func TestLoadLayeredPrecedence(t *testing.T) {
+	// Create a temporary directory structure for testing
+	tmpDir := t.TempDir()
+
+	// Create global config directory
+	globalDir := filepath.Join(tmpDir, ".config", "basecamp")
+	if err := os.MkdirAll(globalDir, 0755); err != nil {
+		t.Fatalf("failed to create global config dir: %v", err)
+	}
+
+	// Create global config
+	globalCfg := `{"account_id": "global-account", "project_id": "global-project"}`
+	if err := os.WriteFile(filepath.Join(globalDir, "config.json"), []byte(globalCfg), 0644); err != nil {
+		t.Fatalf("failed to write global config: %v", err)
+	}
+
+	// Save and set XDG_CONFIG_HOME
+	origXDG := os.Getenv("XDG_CONFIG_HOME")
+	os.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, ".config"))
+	defer os.Setenv("XDG_CONFIG_HOME", origXDG)
+
+	// Clear environment variables
+	os.Unsetenv("BASECAMP_ACCOUNT_ID")
+	os.Unsetenv("BASECAMP_PROJECT_ID")
+
+	t.Run("global config loaded", func(t *testing.T) {
+		cfg, err := Load(LoadOptions{})
+		if err != nil {
+			t.Fatalf("Load failed: %v", err)
+		}
+
+		if cfg.AccountID != "global-account" {
+			t.Errorf("AccountID = %q, want %q", cfg.AccountID, "global-account")
+		}
+		if cfg.Sources["account_id"] != SourceGlobal {
+			t.Errorf("Sources[account_id] = %q, want %q", cfg.Sources["account_id"], SourceGlobal)
+		}
+	})
+
+	t.Run("env overrides global", func(t *testing.T) {
+		os.Setenv("BASECAMP_ACCOUNT_ID", "env-account")
+		defer os.Unsetenv("BASECAMP_ACCOUNT_ID")
+
+		cfg, err := Load(LoadOptions{})
+		if err != nil {
+			t.Fatalf("Load failed: %v", err)
+		}
+
+		if cfg.AccountID != "env-account" {
+			t.Errorf("AccountID = %q, want %q", cfg.AccountID, "env-account")
+		}
+		if cfg.Sources["account_id"] != SourceEnv {
+			t.Errorf("Sources[account_id] = %q, want %q", cfg.Sources["account_id"], SourceEnv)
+		}
+		// Project should still come from global
+		if cfg.ProjectID != "global-project" {
+			t.Errorf("ProjectID = %q, want %q", cfg.ProjectID, "global-project")
+		}
+	})
+
+	t.Run("flag overrides env", func(t *testing.T) {
+		os.Setenv("BASECAMP_ACCOUNT_ID", "env-account")
+		defer os.Unsetenv("BASECAMP_ACCOUNT_ID")
+
+		cfg, err := Load(LoadOptions{Account: "flag-account"})
+		if err != nil {
+			t.Fatalf("Load failed: %v", err)
+		}
+
+		if cfg.AccountID != "flag-account" {
+			t.Errorf("AccountID = %q, want %q", cfg.AccountID, "flag-account")
+		}
+		if cfg.Sources["account_id"] != SourceFlag {
+			t.Errorf("Sources[account_id] = %q, want %q", cfg.Sources["account_id"], SourceFlag)
+		}
+	})
+}
+
+func TestGetStringOrNumber(t *testing.T) {
+	tests := []struct {
+		name  string
+		input map[string]any
+		key   string
+		want  string
+	}{
+		{
+			name:  "string value",
+			input: map[string]any{"id": "12345"},
+			key:   "id",
+			want:  "12345",
+		},
+		{
+			name:  "float64 value (JSON number)",
+			input: map[string]any{"id": float64(12345)},
+			key:   "id",
+			want:  "12345",
+		},
+		{
+			name:  "int value",
+			input: map[string]any{"id": 12345},
+			key:   "id",
+			want:  "12345",
+		},
+		{
+			name:  "missing key",
+			input: map[string]any{"other": "value"},
+			key:   "id",
+			want:  "",
+		},
+		{
+			name:  "nil value",
+			input: map[string]any{"id": nil},
+			key:   "id",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getStringOrNumber(tt.input, tt.key)
+			if got != tt.want {
+				t.Errorf("getStringOrNumber() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHostConfig(t *testing.T) {
+	t.Run("GetHost returns correct host", func(t *testing.T) {
+		cfg := &Config{
+			Hosts: map[string]*HostConfig{
+				"production": {BaseURL: "https://prod.api.com", ClientID: "prod-client"},
+				"staging":    {BaseURL: "https://staging.api.com", ClientID: "staging-client"},
+			},
+			DefaultHost: "production",
+		}
+
+		host := cfg.GetHost("staging")
+		if host == nil {
+			t.Fatal("GetHost returned nil")
+		}
+		if host.BaseURL != "https://staging.api.com" {
+			t.Errorf("BaseURL = %q, want %q", host.BaseURL, "https://staging.api.com")
+		}
+	})
+
+	t.Run("GetHost returns default when name is empty", func(t *testing.T) {
+		cfg := &Config{
+			Hosts: map[string]*HostConfig{
+				"production": {BaseURL: "https://prod.api.com"},
+				"staging":    {BaseURL: "https://staging.api.com"},
+			},
+			DefaultHost: "production",
+		}
+
+		host := cfg.GetHost("")
+		if host == nil {
+			t.Fatal("GetHost returned nil")
+		}
+		if host.BaseURL != "https://prod.api.com" {
+			t.Errorf("BaseURL = %q, want %q", host.BaseURL, "https://prod.api.com")
+		}
+	})
+
+	t.Run("GetHost returns nil for unknown host", func(t *testing.T) {
+		cfg := &Config{
+			Hosts: map[string]*HostConfig{
+				"production": {BaseURL: "https://prod.api.com"},
+			},
+		}
+
+		host := cfg.GetHost("unknown")
+		if host != nil {
+			t.Errorf("GetHost returned %v, want nil", host)
+		}
+	})
+
+	t.Run("GetHost returns nil when no hosts", func(t *testing.T) {
+		cfg := &Config{}
+
+		host := cfg.GetHost("any")
+		if host != nil {
+			t.Errorf("GetHost returned %v, want nil", host)
+		}
+	})
+}
+
+func TestGetSource(t *testing.T) {
+	t.Run("returns source for tracked key", func(t *testing.T) {
+		cfg := &Config{
+			Sources: map[string]Source{
+				"base_url":   SourceEnv,
+				"account_id": SourceFlag,
+			},
+		}
+
+		if src := cfg.GetSource("base_url"); src != SourceEnv {
+			t.Errorf("GetSource(base_url) = %q, want %q", src, SourceEnv)
+		}
+		if src := cfg.GetSource("account_id"); src != SourceFlag {
+			t.Errorf("GetSource(account_id) = %q, want %q", src, SourceFlag)
+		}
+	})
+
+	t.Run("returns default for untracked key", func(t *testing.T) {
+		cfg := &Config{
+			Sources: map[string]Source{
+				"base_url": SourceEnv,
+			},
+		}
+
+		if src := cfg.GetSource("project_id"); src != SourceDefault {
+			t.Errorf("GetSource(project_id) = %q, want %q", src, SourceDefault)
+		}
+	})
+
+	t.Run("returns default when Sources is nil", func(t *testing.T) {
+		cfg := &Config{}
+
+		if src := cfg.GetSource("base_url"); src != SourceDefault {
+			t.Errorf("GetSource(base_url) = %q, want %q", src, SourceDefault)
+		}
+	})
+}
+
+func TestNormalizeBaseURL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"https://api.com/", "https://api.com"},
+		{"https://api.com", "https://api.com"},
+		{"https://api.com///", "https://api.com"},
+	}
+
+	for _, tt := range tests {
+		got := NormalizeBaseURL(tt.input)
+		if got != tt.want {
+			t.Errorf("NormalizeBaseURL(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestGlobalConfigDir(t *testing.T) {
+	t.Run("uses XDG_CONFIG_HOME when set", func(t *testing.T) {
+		orig := os.Getenv("XDG_CONFIG_HOME")
+		os.Setenv("XDG_CONFIG_HOME", "/custom/config")
+		defer os.Setenv("XDG_CONFIG_HOME", orig)
+
+		got := GlobalConfigDir()
+		want := "/custom/config/basecamp"
+		if got != want {
+			t.Errorf("GlobalConfigDir() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("uses ~/.config when XDG_CONFIG_HOME not set", func(t *testing.T) {
+		orig := os.Getenv("XDG_CONFIG_HOME")
+		os.Unsetenv("XDG_CONFIG_HOME")
+		defer os.Setenv("XDG_CONFIG_HOME", orig)
+
+		home, _ := os.UserHomeDir()
+		want := filepath.Join(home, ".config", "basecamp")
+
+		got := GlobalConfigDir()
+		if got != want {
+			t.Errorf("GlobalConfigDir() = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestLoadFromFileWithHosts(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgPath := filepath.Join(tmpDir, "config.json")
+
+	content := `{
+		"base_url": "https://default.api.com",
+		"default_host": "production",
+		"hosts": {
+			"production": {
+				"base_url": "https://prod.api.com",
+				"client_id": "prod-client"
+			},
+			"staging": {
+				"base_url": "https://staging.api.com",
+				"client_id": "staging-client"
+			},
+			"invalid": {
+				"client_id": "no-base-url"
+			}
+		}
+	}`
+	if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	cfg := defaultConfig()
+	loadFromFile(cfg, cfgPath, SourceGlobal)
+
+	if cfg.DefaultHost != "production" {
+		t.Errorf("DefaultHost = %q, want %q", cfg.DefaultHost, "production")
+	}
+
+	if len(cfg.Hosts) != 2 {
+		t.Errorf("len(Hosts) = %d, want 2 (invalid should be skipped)", len(cfg.Hosts))
+	}
+
+	prod := cfg.Hosts["production"]
+	if prod == nil {
+		t.Fatal("Hosts[production] is nil")
+	}
+	if prod.BaseURL != "https://prod.api.com" {
+		t.Errorf("production.BaseURL = %q, want %q", prod.BaseURL, "https://prod.api.com")
+	}
+	if prod.ClientID != "prod-client" {
+		t.Errorf("production.ClientID = %q, want %q", prod.ClientID, "prod-client")
+	}
+
+	staging := cfg.Hosts["staging"]
+	if staging == nil {
+		t.Fatal("Hosts[staging] is nil")
+	}
+	if staging.BaseURL != "https://staging.api.com" {
+		t.Errorf("staging.BaseURL = %q, want %q", staging.BaseURL, "https://staging.api.com")
+	}
+
+	// Invalid host (no base_url) should be skipped
+	if cfg.Hosts["invalid"] != nil {
+		t.Error("Hosts[invalid] should be nil (skipped due to missing base_url)")
+	}
+
+	if cfg.Sources["hosts"] != SourceGlobal {
+		t.Errorf("Sources[hosts] = %q, want %q", cfg.Sources["hosts"], SourceGlobal)
+	}
+}


### PR DESCRIPTION
## Summary

Ports the basecamp-cli config system to the SDK, bringing sophisticated configuration capabilities:

- **Layered precedence**: flags > env > local > repo > global > system > defaults
- **Multi-host support**: Named host configurations (production, dev, staging)
- **Source tracking**: Know where each config value came from for debugging
- **XDG-compliant**: Uses standard `~/.config/basecamp/` location
- **Backwards compatible**: `DefaultConfig()` and `LoadConfigFromEnv()` still work

### Config files loaded from:
- `/etc/basecamp/config.json` (system)
- `~/.config/basecamp/config.json` (global)  
- `.basecamp/config.json` at git root (repo)
- `.basecamp/config.json` in any parent directory (local)

### New API:
```go
// Load from all sources with precedence
cfg, err := basecamp.Load(basecamp.LoadOptions{
    Account: "12345",  // flag override
})

// See where values came from
fmt.Println(cfg.Sources["account_id"])  // "env", "global", etc.

// Multi-host support
cfg.Hosts["production"].BaseURL
```

## Test plan
- [x] All existing tests pass
- [x] New config_test.go covers layered loading
- [x] `make` passes (lint, vet, test)