### PR TITLE
Add HTTP mock registry for testing

### DIFF
--- a/go/internal/testing/doc.go
+++ b/go/internal/testing/doc.go
@@ -1,0 +1,73 @@
+// Package testing provides HTTP mocking utilities for SDK tests.
+//
+// This package is inspired by the httpmock package from gh-cli and provides
+// a Registry type for stubbing HTTP requests and responses in tests.
+//
+// # Basic Usage
+//
+// Create a Registry and register request/response stubs:
+//
+//	func TestMyFeature(t *testing.T) {
+//	    reg := testing.NewRegistry(t)
+//
+//	    reg.Register(
+//	        testing.REST("GET", "projects.json"),
+//	        testing.RespondJSON([]Project{{ID: 1, Name: "Test"}}),
+//	    )
+//
+//	    client := basecamp.NewClient(cfg, token,
+//	        basecamp.WithTransport(reg))
+//
+//	    // ... use client ...
+//
+//	    reg.Verify(t) // Fails if any stubs were not matched
+//	}
+//
+// # Matchers
+//
+// Matchers determine which requests a stub should respond to:
+//
+//   - REST(method, path) - Match by HTTP method and path
+//   - MatchPath(path) - Match by path only
+//   - MatchMethod(method) - Match by HTTP method only
+//   - MatchPathPattern(regex) - Match path using regular expression
+//   - MatchQuery(method, path, query) - Match by method, path, and query params
+//   - MatchHeader(name, value) - Match by request header
+//   - MatchJSONBody(method, path, callback) - Match by JSON request body
+//   - And(matchers...) - All matchers must match
+//   - Or(matchers...) - Any matcher can match
+//
+// # Responders
+//
+// Responders generate HTTP responses for matched requests:
+//
+//   - RespondJSON(body) - Return 200 OK with JSON body
+//   - StatusJSON(status, body) - Return specific status with JSON body
+//   - StringResponse(body) - Return 200 OK with string body
+//   - StatusStringResponse(status, body) - Return specific status with string body
+//   - RespondError(status, message) - Return error response
+//   - RespondNotFound() - Return 404 Not Found
+//   - RespondRateLimit(retryAfter) - Return 429 Too Many Requests
+//   - WithPagination(responder, nextURL) - Add Link header for pagination
+//   - RESTPayload(status, body, callback) - Capture request payload
+//   - Sequence(responders...) - Return different responses per call
+//
+// # Verification
+//
+// After your test completes, call Verify to ensure all registered stubs
+// were matched. This helps catch cases where expected requests were never made.
+//
+// # Multiple Requests
+//
+// For endpoints called multiple times, register multiple stubs - they are
+// matched and consumed in registration order:
+//
+//	reg.Register(testing.REST("GET", "items.json"), testing.RespondJSON(page1))
+//	reg.Register(testing.REST("GET", "items.json"), testing.RespondJSON(page2))
+//
+// # Excluding Requests
+//
+// Use Exclude to fail the test if certain requests are made:
+//
+//	reg.Exclude(testing.MatchPathPrefix("/admin"))
+package testing

--- a/go/internal/testing/matchers.go
+++ b/go/internal/testing/matchers.go
@@ -1,0 +1,159 @@
+package testing
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// MatchAny matches any request.
+func MatchAny(*http.Request) bool {
+	return true
+}
+
+// MatchPath returns a matcher that matches requests to the given path.
+// The path should include a leading slash (e.g., "/projects.json").
+// The path is matched against req.URL.EscapedPath().
+func MatchPath(path string) Matcher {
+	return func(req *http.Request) bool {
+		return req.URL.EscapedPath() == path
+	}
+}
+
+// MatchMethod returns a matcher that matches requests with the given HTTP method.
+func MatchMethod(method string) Matcher {
+	return func(req *http.Request) bool {
+		return strings.EqualFold(req.Method, method)
+	}
+}
+
+// REST returns a matcher that matches requests with the given HTTP method and path.
+// The path should NOT include a leading slash; one will be added automatically.
+// For example: REST("GET", "projects.json") matches GET /projects.json
+func REST(method, path string) Matcher {
+	return func(req *http.Request) bool {
+		if !strings.EqualFold(req.Method, method) {
+			return false
+		}
+		return req.URL.EscapedPath() == "/"+path
+	}
+}
+
+// MatchPathPrefix returns a matcher that matches requests whose path starts with the given prefix.
+func MatchPathPrefix(prefix string) Matcher {
+	return func(req *http.Request) bool {
+		return strings.HasPrefix(req.URL.EscapedPath(), prefix)
+	}
+}
+
+// MatchPathPattern returns a matcher that matches requests whose path matches the given regex.
+func MatchPathPattern(pattern string) Matcher {
+	re := regexp.MustCompile(pattern)
+	return func(req *http.Request) bool {
+		return re.MatchString(req.URL.EscapedPath())
+	}
+}
+
+// MatchHost returns a matcher that matches requests to the given host.
+func MatchHost(host string) Matcher {
+	return func(req *http.Request) bool {
+		return strings.EqualFold(req.Host, host)
+	}
+}
+
+// MatchQuery returns a matcher that matches requests with the given query parameters.
+// Only the specified parameters are checked; additional query parameters are allowed.
+func MatchQuery(method, path string, query url.Values) Matcher {
+	return func(req *http.Request) bool {
+		if !REST(method, path)(req) {
+			return false
+		}
+
+		actualQuery := req.URL.Query()
+		for param := range query {
+			if actualQuery.Get(param) != query.Get(param) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// MatchHeader returns a matcher that matches requests with the given header value.
+func MatchHeader(header, value string) Matcher {
+	return func(req *http.Request) bool {
+		return req.Header.Get(header) == value
+	}
+}
+
+// And combines multiple matchers with AND logic.
+// All matchers must match for the combined matcher to match.
+func And(matchers ...Matcher) Matcher {
+	return func(req *http.Request) bool {
+		for _, m := range matchers {
+			if !m(req) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// Or combines multiple matchers with OR logic.
+// Any matcher matching will cause the combined matcher to match.
+func Or(matchers ...Matcher) Matcher {
+	return func(req *http.Request) bool {
+		for _, m := range matchers {
+			if m(req) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// WithHost decorates a matcher to also check the request host.
+func WithHost(matcher Matcher, host string) Matcher {
+	return And(matcher, MatchHost(host))
+}
+
+// readBody reads the request body and restores it for subsequent reads.
+func readBody(req *http.Request) ([]byte, error) {
+	if req.Body == nil {
+		return nil, nil
+	}
+	bodyCopy := &bytes.Buffer{}
+	r := io.TeeReader(req.Body, bodyCopy)
+	req.Body = io.NopCloser(bodyCopy)
+	return io.ReadAll(r)
+}
+
+// decodeJSONBody reads and decodes the JSON request body.
+func decodeJSONBody(req *http.Request, dest interface{}) error {
+	b, err := readBody(req)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, dest)
+}
+
+// MatchJSONBody returns a matcher that matches requests with JSON body content.
+// The callback receives the decoded JSON and returns true if it matches.
+func MatchJSONBody(method, path string, cb func(body map[string]interface{}) bool) Matcher {
+	return func(req *http.Request) bool {
+		if !REST(method, path)(req) {
+			return false
+		}
+
+		var bodyData map[string]interface{}
+		if err := decodeJSONBody(req, &bodyData); err != nil {
+			return false
+		}
+
+		return cb(bodyData)
+	}
+}

--- a/go/internal/testing/matchers_test.go
+++ b/go/internal/testing/matchers_test.go
@@ -1,0 +1,334 @@
+package testing
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestMatchAny(t *testing.T) {
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.example.com/anything", nil)
+	if !MatchAny(req) {
+		t.Error("MatchAny should match any request")
+	}
+}
+
+func TestMatchPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		reqPath  string
+		expected bool
+	}{
+		{"exact match", "/projects.json", "/projects.json", true},
+		{"no match", "/projects.json", "/users.json", false},
+		{"path with id", "/projects/123.json", "/projects/123.json", true},
+		{"missing leading slash", "/projects.json", "projects.json", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher := MatchPath(tt.path)
+			req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.example.com"+tt.reqPath, nil)
+
+			if matcher(req) != tt.expected {
+				t.Errorf("MatchPath(%q) for path %q = %v, expected %v",
+					tt.path, tt.reqPath, matcher(req), tt.expected)
+			}
+		})
+	}
+}
+
+func TestMatchMethod(t *testing.T) {
+	tests := []struct {
+		name      string
+		method    string
+		reqMethod string
+		expected  bool
+	}{
+		{"exact match", "GET", "GET", true},
+		{"case insensitive", "get", "GET", true},
+		{"no match", "POST", "GET", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher := MatchMethod(tt.method)
+			req, _ := http.NewRequestWithContext(context.Background(), tt.reqMethod, "https://api.example.com/test", nil)
+
+			if matcher(req) != tt.expected {
+				t.Errorf("MatchMethod(%q) for method %q = %v, expected %v",
+					tt.method, tt.reqMethod, matcher(req), tt.expected)
+			}
+		})
+	}
+}
+
+func TestREST(t *testing.T) {
+	tests := []struct {
+		name      string
+		method    string
+		path      string
+		reqMethod string
+		reqPath   string
+		expected  bool
+	}{
+		{"GET match", "GET", "projects.json", "GET", "/projects.json", true},
+		{"POST match", "POST", "projects.json", "POST", "/projects.json", true},
+		{"method mismatch", "GET", "projects.json", "POST", "/projects.json", false},
+		{"path mismatch", "GET", "projects.json", "GET", "/users.json", false},
+		{"path with account id", "GET", "12345/projects.json", "GET", "/12345/projects.json", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher := REST(tt.method, tt.path)
+			req, _ := http.NewRequestWithContext(context.Background(), tt.reqMethod, "https://api.example.com"+tt.reqPath, nil)
+
+			if matcher(req) != tt.expected {
+				t.Errorf("REST(%q, %q) for %s %s = %v, expected %v",
+					tt.method, tt.path, tt.reqMethod, tt.reqPath, matcher(req), tt.expected)
+			}
+		})
+	}
+}
+
+func TestMatchPathPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		reqPath  string
+		expected bool
+	}{
+		{"exact prefix", "/projects", "/projects/123", true},
+		{"with json extension", "/projects", "/projects.json", true},
+		{"no match", "/users", "/projects.json", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher := MatchPathPrefix(tt.prefix)
+			req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.example.com"+tt.reqPath, nil)
+
+			if matcher(req) != tt.expected {
+				t.Errorf("MatchPathPrefix(%q) for path %q = %v, expected %v",
+					tt.prefix, tt.reqPath, matcher(req), tt.expected)
+			}
+		})
+	}
+}
+
+func TestMatchPathPattern(t *testing.T) {
+	tests := []struct {
+		name     string
+		pattern  string
+		reqPath  string
+		expected bool
+	}{
+		{"simple pattern", `/projects/\d+\.json`, "/projects/123.json", true},
+		{"no match", `/projects/\d+\.json`, "/projects/abc.json", false},
+		{"any bucket id", `/buckets/\d+/todos`, "/buckets/999/todos", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher := MatchPathPattern(tt.pattern)
+			req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.example.com"+tt.reqPath, nil)
+
+			if matcher(req) != tt.expected {
+				t.Errorf("MatchPathPattern(%q) for path %q = %v, expected %v",
+					tt.pattern, tt.reqPath, matcher(req), tt.expected)
+			}
+		})
+	}
+}
+
+func TestMatchQuery(t *testing.T) {
+	matcher := MatchQuery("GET", "projects.json", url.Values{
+		"status": []string{"active"},
+	})
+
+	tests := []struct {
+		name     string
+		url      string
+		expected bool
+	}{
+		{"with matching query", "https://api.example.com/projects.json?status=active", true},
+		{"with extra query params", "https://api.example.com/projects.json?status=active&page=1", true},
+		{"wrong query value", "https://api.example.com/projects.json?status=archived", false},
+		{"missing query param", "https://api.example.com/projects.json", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequestWithContext(context.Background(), "GET", tt.url, nil)
+
+			if matcher(req) != tt.expected {
+				t.Errorf("MatchQuery for %s = %v, expected %v", tt.url, matcher(req), tt.expected)
+			}
+		})
+	}
+}
+
+func TestMatchHeader(t *testing.T) {
+	matcher := MatchHeader("Authorization", "Bearer token123")
+
+	tests := []struct {
+		name     string
+		header   string
+		value    string
+		expected bool
+	}{
+		{"matching header", "Authorization", "Bearer token123", true},
+		{"wrong value", "Authorization", "Bearer other", false},
+		{"missing header", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.example.com/test", nil)
+			if tt.header != "" {
+				req.Header.Set(tt.header, tt.value)
+			}
+
+			if matcher(req) != tt.expected {
+				t.Errorf("MatchHeader for header=%q, value=%q = %v, expected %v",
+					tt.header, tt.value, matcher(req), tt.expected)
+			}
+		})
+	}
+}
+
+func TestAnd(t *testing.T) {
+	matcher := And(
+		MatchMethod("GET"),
+		MatchPath("/projects.json"),
+	)
+
+	tests := []struct {
+		name     string
+		method   string
+		path     string
+		expected bool
+	}{
+		{"both match", "GET", "/projects.json", true},
+		{"method mismatch", "POST", "/projects.json", false},
+		{"path mismatch", "GET", "/users.json", false},
+		{"both mismatch", "POST", "/users.json", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequestWithContext(context.Background(), tt.method, "https://api.example.com"+tt.path, nil)
+
+			if matcher(req) != tt.expected {
+				t.Errorf("And matcher for %s %s = %v, expected %v",
+					tt.method, tt.path, matcher(req), tt.expected)
+			}
+		})
+	}
+}
+
+func TestOr(t *testing.T) {
+	matcher := Or(
+		MatchPath("/projects.json"),
+		MatchPath("/users.json"),
+	)
+
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{"first match", "/projects.json", true},
+		{"second match", "/users.json", true},
+		{"neither match", "/todos.json", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.example.com"+tt.path, nil)
+
+			if matcher(req) != tt.expected {
+				t.Errorf("Or matcher for path %s = %v, expected %v",
+					tt.path, matcher(req), tt.expected)
+			}
+		})
+	}
+}
+
+func TestWithHost(t *testing.T) {
+	matcher := WithHost(MatchPath("/projects.json"), "api.basecamp.com")
+
+	tests := []struct {
+		name     string
+		host     string
+		path     string
+		expected bool
+	}{
+		{"matching host and path", "api.basecamp.com", "/projects.json", true},
+		{"wrong host", "evil.com", "/projects.json", false},
+		{"wrong path", "api.basecamp.com", "/users.json", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://"+tt.host+tt.path, nil)
+
+			if matcher(req) != tt.expected {
+				t.Errorf("WithHost matcher for host=%s, path=%s = %v, expected %v",
+					tt.host, tt.path, matcher(req), tt.expected)
+			}
+		})
+	}
+}
+
+func TestMatchJSONBody(t *testing.T) {
+	matcher := MatchJSONBody("POST", "projects.json", func(body map[string]interface{}) bool {
+		name, ok := body["name"].(string)
+		return ok && name == "New Project"
+	})
+
+	tests := []struct {
+		name     string
+		method   string
+		path     string
+		body     string
+		expected bool
+	}{
+		{
+			name:     "matching body",
+			method:   "POST",
+			path:     "/projects.json",
+			body:     `{"name": "New Project"}`,
+			expected: true,
+		},
+		{
+			name:     "wrong name",
+			method:   "POST",
+			path:     "/projects.json",
+			body:     `{"name": "Other Project"}`,
+			expected: false,
+		},
+		{
+			name:     "wrong method",
+			method:   "GET",
+			path:     "/projects.json",
+			body:     `{"name": "New Project"}`,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequestWithContext(context.Background(), tt.method, "https://api.example.com"+tt.path, strings.NewReader(tt.body))
+
+			if matcher(req) != tt.expected {
+				t.Errorf("MatchJSONBody for %s %s with body %s = %v, expected %v",
+					tt.method, tt.path, tt.body, matcher(req), tt.expected)
+			}
+		})
+	}
+}

--- a/go/internal/testing/registry.go
+++ b/go/internal/testing/registry.go
@@ -1,0 +1,212 @@
+// Package testing provides HTTP mocking utilities for SDK tests.
+//
+// NOTE: This package is intentionally named "testing" to match the domain
+// (test utilities). Since it lives in internal/, shadowing the stdlib testing
+// package is acceptable - test files import both with aliases if needed.
+//
+// The Registry type is the central mock server that intercepts HTTP requests
+// and returns stubbed responses. It implements http.RoundTripper so it can be
+// used directly as an HTTP client transport.
+//
+// Basic usage:
+//
+//	func TestMyFeature(t *testing.T) {
+//	    reg := testing.NewRegistry(t)
+//
+//	    reg.Register(
+//	        testing.MatchPath("/projects.json"),
+//	        testing.RespondJSON([]Project{{ID: 1, Name: "Test"}}),
+//	    )
+//
+//	    client := basecamp.NewClient(cfg, token,
+//	        basecamp.WithTransport(reg))
+//
+//	    // ... use client ...
+//
+//	    reg.Verify(t) // Fails if stubs weren't matched
+//	}
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"runtime/debug"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// Matcher is a function that determines if an HTTP request matches a stub.
+type Matcher func(req *http.Request) bool
+
+// Responder is a function that generates an HTTP response for a matched request.
+type Responder func(req *http.Request) (*http.Response, error)
+
+// Stub represents a registered request/response pair.
+type Stub struct {
+	// Stack is the call stack where this stub was registered (for debugging)
+	Stack string
+	// Matcher determines if a request matches this stub
+	Matcher Matcher
+	// Responder generates the response for matched requests
+	Responder Responder
+	// matched tracks whether this stub was used
+	matched bool
+	// exclude marks this stub as an exclusion (should fail if matched)
+	exclude bool
+}
+
+// Registry is a mock HTTP server that records requests and returns stubbed responses.
+// It implements http.RoundTripper for use as an HTTP client transport.
+type Registry struct {
+	mu sync.Mutex
+	t  *testing.T
+
+	stubs []*Stub
+	// Requests records all requests that were made to the registry
+	Requests []*http.Request
+}
+
+// NewRegistry creates a new Registry for testing.
+func NewRegistry(t *testing.T) *Registry {
+	return &Registry{t: t}
+}
+
+// Register adds a stub to the registry.
+// When a request matches the matcher, the responder will be called to generate the response.
+func (r *Registry) Register(m Matcher, resp Responder) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stubs = append(r.stubs, &Stub{
+		Stack:     string(debug.Stack()),
+		Matcher:   m,
+		Responder: resp,
+	})
+}
+
+// Exclude registers a matcher that will fail the test if matched.
+// Use this to ensure certain requests are NOT made during a test.
+// Panics if the Registry was created without a *testing.T (NewRegistry(nil)).
+func (r *Registry) Exclude(m Matcher) {
+	if r.t == nil {
+		panic("Exclude requires a non-nil *testing.T; use NewRegistry(t) instead of NewRegistry(nil)")
+	}
+
+	registrationStack := string(debug.Stack())
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	excludedStub := &Stub{
+		Matcher: m,
+		Responder: func(req *http.Request) (*http.Response, error) {
+			callStack := string(debug.Stack())
+
+			var errMsg strings.Builder
+			errMsg.WriteString("HTTP call was made when it should have been excluded:\n")
+			errMsg.WriteString(fmt.Sprintf("Request URL: %s\n", req.URL))
+			errMsg.WriteString(fmt.Sprintf("Was excluded by: %s\n", registrationStack))
+			errMsg.WriteString(fmt.Sprintf("Was called from: %s\n", callStack))
+
+			r.t.Error(errMsg.String())
+			r.t.FailNow()
+			return nil, nil
+		},
+		exclude: true,
+	}
+	r.stubs = append(r.stubs, excludedStub)
+}
+
+// Testing is the interface for test assertion methods.
+type Testing interface {
+	Errorf(string, ...interface{})
+	Helper()
+}
+
+// Verify checks that all registered stubs were matched.
+// Call this at the end of a test to ensure all expected requests were made.
+func (r *Registry) Verify(t Testing) {
+	t.Helper()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	var unmatchedStubStacks []string
+	for _, s := range r.stubs {
+		if !s.matched && !s.exclude {
+			unmatchedStubStacks = append(unmatchedStubStacks, s.Stack)
+		}
+	}
+	if len(unmatchedStubStacks) > 0 {
+		stacks := strings.Builder{}
+		for i, stack := range unmatchedStubStacks {
+			stacks.WriteString(fmt.Sprintf("Stub %d:\n", i+1))
+			stacks.WriteString(fmt.Sprintf("\t%s", stack))
+			if stack != unmatchedStubStacks[len(unmatchedStubStacks)-1] {
+				stacks.WriteString("\n")
+			}
+		}
+		t.Errorf("%d HTTP stubs unmatched, stacks:\n%s", len(unmatchedStubStacks), stacks.String())
+	}
+}
+
+// RoundTrip implements http.RoundTripper.
+// It finds the first matching stub and returns its response.
+func (r *Registry) RoundTrip(req *http.Request) (*http.Response, error) {
+	var stub *Stub
+
+	r.mu.Lock()
+	for _, s := range r.stubs {
+		if s.matched || !s.Matcher(req) {
+			continue
+		}
+		stub = s
+		break
+	}
+
+	if stub != nil {
+		stub.matched = true
+	}
+
+	if stub == nil {
+		r.mu.Unlock()
+		return nil, fmt.Errorf("no registered HTTP stubs matched %s %s", req.Method, req.URL)
+	}
+
+	r.Requests = append(r.Requests, req)
+	r.mu.Unlock()
+
+	return stub.Responder(req)
+}
+
+// Client returns an *http.Client that uses this registry as its transport.
+func (r *Registry) Client() *http.Client {
+	return &http.Client{
+		Transport: r,
+	}
+}
+
+// Reset clears all stubs and recorded requests.
+func (r *Registry) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.stubs = nil
+	r.Requests = nil
+}
+
+// RequestCount returns the number of requests that have been made.
+func (r *Registry) RequestCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.Requests)
+}
+
+// LastRequest returns the most recent request, or nil if none were made.
+func (r *Registry) LastRequest() *http.Request {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.Requests) == 0 {
+		return nil
+	}
+	return r.Requests[len(r.Requests)-1]
+}

--- a/go/internal/testing/registry_test.go
+++ b/go/internal/testing/registry_test.go
@@ -1,0 +1,181 @@
+package testing
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestRegistry_RoundTrip_MatchesStub(t *testing.T) {
+	reg := NewRegistry(t)
+
+	reg.Register(
+		REST("GET", "projects.json"),
+		RespondJSON(map[string]string{"name": "Test Project"}),
+	)
+
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.example.com/projects.json", nil)
+	resp, err := reg.RoundTrip(req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "Test Project") {
+		t.Errorf("expected body to contain 'Test Project', got %s", body)
+	}
+
+	if reg.RequestCount() != 1 {
+		t.Errorf("expected 1 request, got %d", reg.RequestCount())
+	}
+
+	reg.Verify(t)
+}
+
+func TestRegistry_RoundTrip_NoMatchingStub(t *testing.T) {
+	reg := NewRegistry(t)
+
+	reg.Register(
+		REST("GET", "projects.json"),
+		RespondJSON(nil),
+	)
+
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.example.com/users.json", nil)
+	resp, err := reg.RoundTrip(req)
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close()
+	}
+
+	if err == nil {
+		t.Fatal("expected error for unmatched request")
+	}
+	if !strings.Contains(err.Error(), "no registered HTTP stubs matched") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestRegistry_Verify_UnmatchedStubs(t *testing.T) {
+	// Use a fake t to capture errors without failing this test
+	fakeT := &fakeT{}
+	reg := NewRegistry(nil)
+
+	reg.Register(
+		REST("GET", "projects.json"),
+		RespondJSON(nil),
+	)
+
+	reg.Verify(fakeT)
+
+	if !fakeT.failed {
+		t.Error("expected Verify to fail for unmatched stub")
+	}
+	// The format string contains %d for the count
+	if !strings.Contains(fakeT.errorMsg, "%d HTTP stubs unmatched") {
+		t.Errorf("unexpected error message: %s", fakeT.errorMsg)
+	}
+}
+
+func TestRegistry_Client(t *testing.T) {
+	reg := NewRegistry(t)
+
+	reg.Register(
+		REST("GET", "test.json"),
+		StatusStringResponse(http.StatusCreated, "created"),
+	)
+
+	client := reg.Client()
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.example.com/test.json", nil)
+	resp, err := client.Do(req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("expected status 201, got %d", resp.StatusCode)
+	}
+
+	reg.Verify(t)
+}
+
+func TestRegistry_Reset(t *testing.T) {
+	reg := NewRegistry(t)
+
+	reg.Register(
+		REST("GET", "projects.json"),
+		RespondJSON(nil),
+	)
+
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.example.com/projects.json", nil)
+	resp, _ := reg.RoundTrip(req)
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close()
+	}
+
+	if reg.RequestCount() != 1 {
+		t.Errorf("expected 1 request before reset, got %d", reg.RequestCount())
+	}
+
+	reg.Reset()
+
+	if reg.RequestCount() != 0 {
+		t.Errorf("expected 0 requests after reset, got %d", reg.RequestCount())
+	}
+}
+
+func TestRegistry_LastRequest(t *testing.T) {
+	reg := NewRegistry(t)
+
+	reg.Register(MatchAny, RespondJSON(nil))
+	reg.Register(MatchAny, RespondJSON(nil))
+
+	req1, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.example.com/first", nil)
+	resp1, _ := reg.RoundTrip(req1)
+	if resp1 != nil && resp1.Body != nil {
+		resp1.Body.Close()
+	}
+
+	req2, _ := http.NewRequestWithContext(context.Background(), "POST", "https://api.example.com/second", nil)
+	resp2, _ := reg.RoundTrip(req2)
+	if resp2 != nil && resp2.Body != nil {
+		resp2.Body.Close()
+	}
+
+	last := reg.LastRequest()
+	if last == nil {
+		t.Fatal("expected last request to be non-nil")
+	}
+	if last.URL.Path != "/second" {
+		t.Errorf("expected last request path /second, got %s", last.URL.Path)
+	}
+}
+
+func TestRegistry_LastRequest_Empty(t *testing.T) {
+	reg := NewRegistry(t)
+
+	if reg.LastRequest() != nil {
+		t.Error("expected LastRequest to return nil when no requests made")
+	}
+}
+
+// fakeT is a minimal testing.T implementation for testing Verify behavior
+type fakeT struct {
+	failed   bool
+	errorMsg string
+}
+
+func (f *fakeT) Helper() {}
+
+func (f *fakeT) Errorf(format string, args ...interface{}) {
+	f.failed = true
+	f.errorMsg = format
+}

--- a/go/internal/testing/responders.go
+++ b/go/internal/testing/responders.go
@@ -1,0 +1,184 @@
+package testing
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync/atomic"
+)
+
+// StringResponse returns a responder that returns a 200 response with the given string body.
+func StringResponse(body string) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		return httpResponse(http.StatusOK, req, bytes.NewBufferString(body)), nil
+	}
+}
+
+// StatusStringResponse returns a responder with the given status code and string body.
+func StatusStringResponse(status int, body string) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		return httpResponse(status, req, bytes.NewBufferString(body)), nil
+	}
+}
+
+// BinaryResponse returns a responder that returns a 200 response with the given binary body.
+func BinaryResponse(body []byte) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		return httpResponse(http.StatusOK, req, bytes.NewBuffer(body)), nil
+	}
+}
+
+// RespondJSON returns a responder that returns a 200 response with a JSON body.
+// The body is marshaled to JSON automatically.
+func RespondJSON(body interface{}) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal JSON response: %w", err)
+		}
+		header := http.Header{
+			"Content-Type": []string{"application/json"},
+		}
+		return httpResponseWithHeader(http.StatusOK, req, bytes.NewBuffer(b), header), nil
+	}
+}
+
+// StatusJSON returns a responder with the given status code and JSON body.
+func StatusJSON(status int, body interface{}) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal JSON response: %w", err)
+		}
+		header := http.Header{
+			"Content-Type": []string{"application/json"},
+		}
+		return httpResponseWithHeader(status, req, bytes.NewBuffer(b), header), nil
+	}
+}
+
+// RespondError returns a responder that returns an API error response.
+// The error is formatted as {"error": "message"}.
+func RespondError(status int, message string) Responder {
+	return StatusJSON(status, map[string]string{"error": message})
+}
+
+// RespondNotFound returns a 404 Not Found response.
+func RespondNotFound() Responder {
+	return RespondError(http.StatusNotFound, "Not found")
+}
+
+// RespondUnauthorized returns a 401 Unauthorized response.
+func RespondUnauthorized() Responder {
+	return RespondError(http.StatusUnauthorized, "Unauthorized")
+}
+
+// RespondForbidden returns a 403 Forbidden response.
+func RespondForbidden() Responder {
+	return RespondError(http.StatusForbidden, "Forbidden")
+}
+
+// RespondRateLimit returns a 429 Too Many Requests response with a Retry-After header.
+func RespondRateLimit(retryAfter int) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		b, _ := json.Marshal(map[string]string{"error": "Rate limit exceeded"})
+		header := http.Header{
+			"Content-Type": []string{"application/json"},
+			"Retry-After":  []string{fmt.Sprintf("%d", retryAfter)},
+		}
+		return httpResponseWithHeader(http.StatusTooManyRequests, req, bytes.NewBuffer(b), header), nil
+	}
+}
+
+// RespondServerError returns a 500 Internal Server Error response.
+func RespondServerError() Responder {
+	return RespondError(http.StatusInternalServerError, "Internal server error")
+}
+
+// FileResponse returns a responder that reads the response body from a file.
+func FileResponse(filename string) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		f, err := os.Open(filename)
+		if err != nil {
+			return nil, fmt.Errorf("failed to open fixture file %s: %w", filename, err)
+		}
+		return httpResponse(http.StatusOK, req, f), nil
+	}
+}
+
+// WithHeader decorates a responder to add a response header.
+func WithHeader(responder Responder, header, value string) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		resp, err := responder(req)
+		if err != nil {
+			return nil, err
+		}
+		if resp.Header == nil {
+			resp.Header = make(http.Header)
+		}
+		resp.Header.Set(header, value)
+		return resp, nil
+	}
+}
+
+// WithPagination decorates a responder to add a Link header for pagination.
+func WithPagination(responder Responder, nextURL string) Responder {
+	if nextURL == "" {
+		return responder
+	}
+	return WithHeader(responder, "Link", fmt.Sprintf(`<%s>; rel="next"`, nextURL))
+}
+
+// RESTPayload returns a responder that decodes the request JSON body
+// and passes it to a callback before returning the response.
+// This is useful for verifying request payloads in tests.
+func RESTPayload(responseStatus int, responseBody string, cb func(payload map[string]interface{})) Responder {
+	return func(req *http.Request) (*http.Response, error) {
+		bodyData := make(map[string]interface{})
+		if err := decodeJSONBody(req, &bodyData); err != nil {
+			return nil, fmt.Errorf("failed to decode request body: %w", err)
+		}
+		cb(bodyData)
+
+		header := http.Header{
+			"Content-Type": []string{"application/json"},
+		}
+		return httpResponseWithHeader(responseStatus, req, bytes.NewBufferString(responseBody), header), nil
+	}
+}
+
+// Sequence returns a responder that returns different responses on each call.
+// After all responses are exhausted, it returns the last response repeatedly.
+// This responder is safe for concurrent use.
+func Sequence(responders ...Responder) Responder {
+	if len(responders) == 0 {
+		panic("Sequence requires at least one responder")
+	}
+	var callCount int64
+	return func(req *http.Request) (*http.Response, error) {
+		idx := int(atomic.AddInt64(&callCount, 1)) - 1
+		if idx >= len(responders) {
+			idx = len(responders) - 1
+		}
+		return responders[idx](req)
+	}
+}
+
+// httpResponse creates an HTTP response with the given status, request, and body.
+func httpResponse(status int, req *http.Request, body io.Reader) *http.Response {
+	return httpResponseWithHeader(status, req, body, http.Header{})
+}
+
+// httpResponseWithHeader creates an HTTP response with the given status, request, body, and headers.
+func httpResponseWithHeader(status int, req *http.Request, body io.Reader, header http.Header) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Status:     http.StatusText(status),
+		Request:    req,
+		Body:       io.NopCloser(body),
+		Header:     header,
+	}
+}

--- a/go/internal/testing/responders_test.go
+++ b/go/internal/testing/responders_test.go
@@ -1,0 +1,277 @@
+package testing
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestStringResponse(t *testing.T) {
+	responder := StringResponse("hello world")
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.example.com/test", nil)
+
+	resp, err := responder(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "hello world" {
+		t.Errorf("expected body 'hello world', got %q", body)
+	}
+}
+
+func TestStatusStringResponse(t *testing.T) {
+	responder := StatusStringResponse(http.StatusCreated, "created")
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", "https://api.example.com/test", nil)
+
+	resp, err := responder(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("expected status 201, got %d", resp.StatusCode)
+	}
+}
+
+func TestRespondJSON(t *testing.T) {
+	data := map[string]interface{}{
+		"id":   123,
+		"name": "Test Project",
+	}
+	responder := RespondJSON(data)
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.example.com/test", nil)
+
+	resp, err := responder(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type 'application/json', got %q", ct)
+	}
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if result["name"] != "Test Project" {
+		t.Errorf("expected name 'Test Project', got %v", result["name"])
+	}
+}
+
+func TestStatusJSON(t *testing.T) {
+	data := map[string]string{"message": "created"}
+	responder := StatusJSON(http.StatusCreated, data)
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", "https://api.example.com/test", nil)
+
+	resp, err := responder(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("expected status 201, got %d", resp.StatusCode)
+	}
+
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("expected Content-Type 'application/json', got %q", ct)
+	}
+}
+
+func TestRespondError(t *testing.T) {
+	responder := RespondError(http.StatusBadRequest, "Invalid request")
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", "https://api.example.com/test", nil)
+
+	resp, err := responder(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", resp.StatusCode)
+	}
+
+	var result map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if result["error"] != "Invalid request" {
+		t.Errorf("expected error 'Invalid request', got %q", result["error"])
+	}
+}
+
+func TestRespondNotFound(t *testing.T) {
+	responder := RespondNotFound()
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.example.com/test", nil)
+
+	resp, err := responder(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestRespondRateLimit(t *testing.T) {
+	responder := RespondRateLimit(30)
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.example.com/test", nil)
+
+	resp, err := responder(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("expected status 429, got %d", resp.StatusCode)
+	}
+
+	if ra := resp.Header.Get("Retry-After"); ra != "30" {
+		t.Errorf("expected Retry-After '30', got %q", ra)
+	}
+}
+
+func TestWithHeader(t *testing.T) {
+	responder := WithHeader(StringResponse("body"), "X-Custom", "value123")
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.example.com/test", nil)
+
+	resp, err := responder(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if h := resp.Header.Get("X-Custom"); h != "value123" {
+		t.Errorf("expected X-Custom 'value123', got %q", h)
+	}
+}
+
+func TestWithPagination(t *testing.T) {
+	responder := WithPagination(RespondJSON([]int{1, 2, 3}), "https://api.example.com/test?page=2")
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.example.com/test", nil)
+
+	resp, err := responder(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	link := resp.Header.Get("Link")
+	if link != `<https://api.example.com/test?page=2>; rel="next"` {
+		t.Errorf("unexpected Link header: %q", link)
+	}
+}
+
+func TestWithPaginationEmpty(t *testing.T) {
+	// Empty nextURL should return the original responder unchanged
+	responder := WithPagination(RespondJSON([]int{1, 2, 3}), "")
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.example.com/test", nil)
+
+	resp, err := responder(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if link := resp.Header.Get("Link"); link != "" {
+		t.Errorf("expected no Link header, got %q", link)
+	}
+}
+
+func TestRESTPayload(t *testing.T) {
+	var capturedPayload map[string]interface{}
+
+	responder := RESTPayload(http.StatusCreated, `{"id": 1}`, func(payload map[string]interface{}) {
+		capturedPayload = payload
+	})
+
+	body := `{"name": "Test", "description": "A test project"}`
+	req, _ := http.NewRequestWithContext(context.Background(), "POST", "https://api.example.com/test", strings.NewReader(body))
+
+	resp, err := responder(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("expected status 201, got %d", resp.StatusCode)
+	}
+
+	if capturedPayload["name"] != "Test" {
+		t.Errorf("expected captured name 'Test', got %v", capturedPayload["name"])
+	}
+	if capturedPayload["description"] != "A test project" {
+		t.Errorf("expected captured description 'A test project', got %v", capturedPayload["description"])
+	}
+}
+
+func TestSequence(t *testing.T) {
+	responder := Sequence(
+		StatusStringResponse(http.StatusOK, "first"),
+		StatusStringResponse(http.StatusCreated, "second"),
+		StatusStringResponse(http.StatusAccepted, "third"),
+	)
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://api.example.com/test", nil)
+
+	// First call
+	resp, _ := responder(req)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("first call: expected status 200, got %d", resp.StatusCode)
+	}
+
+	// Second call
+	resp, _ = responder(req)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Errorf("second call: expected status 201, got %d", resp.StatusCode)
+	}
+
+	// Third call
+	resp, _ = responder(req)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Errorf("third call: expected status 202, got %d", resp.StatusCode)
+	}
+
+	// Fourth call (should repeat last)
+	resp, _ = responder(req)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Errorf("fourth call: expected status 202 (last response), got %d", resp.StatusCode)
+	}
+}
+
+func TestSequence_PanicOnEmpty(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected Sequence to panic with no responders")
+		}
+	}()
+
+	Sequence()
+}

--- a/go/pkg/basecamp/registry_example_test.go
+++ b/go/pkg/basecamp/registry_example_test.go
@@ -1,0 +1,253 @@
+package basecamp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	httpmock "github.com/basecamp/basecamp-sdk/go/internal/testing"
+)
+
+// These tests demonstrate using the httpmock.Registry for low-level HTTP
+// mocking when testing code that makes direct HTTP calls (like the Client's
+// Get/Post methods) rather than using the generated OpenAPI client.
+//
+// For testing the high-level service methods (Projects().List, etc.), use
+// httptest.NewServer as shown in the _WithServer tests below.
+
+// TestClient_Get_WithRegistry demonstrates using the Registry for direct HTTP calls.
+func TestClient_Get_WithRegistry(t *testing.T) {
+	reg := httpmock.NewRegistry(t)
+
+	// Stub a GET request
+	reg.Register(
+		httpmock.REST("GET", "12345/custom-endpoint.json"),
+		httpmock.RespondJSON(map[string]interface{}{
+			"message": "Hello, World!",
+		}),
+	)
+
+	cfg := DefaultConfig()
+	cfg.BaseURL = "https://3.basecampapi.com"
+	token := &StaticTokenProvider{Token: "test-token"}
+	client := NewClient(cfg, token, WithTransport(reg))
+
+	// Use the low-level Get method
+	account := client.ForAccount("12345")
+	resp, err := account.Get(context.Background(), "/custom-endpoint.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var result map[string]string
+	if err := resp.UnmarshalData(&result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if result["message"] != "Hello, World!" {
+		t.Errorf("expected 'Hello, World!', got %q", result["message"])
+	}
+
+	reg.Verify(t)
+}
+
+// TestClient_Post_WithRegistry demonstrates testing POST with the Registry.
+func TestClient_Post_WithRegistry(t *testing.T) {
+	reg := httpmock.NewRegistry(t)
+
+	var capturedPayload map[string]interface{}
+
+	// Stub POST and capture the payload
+	reg.Register(
+		httpmock.REST("POST", "12345/items.json"),
+		httpmock.RESTPayload(201, `{"id": 1, "name": "Created"}`, func(payload map[string]interface{}) {
+			capturedPayload = payload
+		}),
+	)
+
+	cfg := DefaultConfig()
+	cfg.BaseURL = "https://3.basecampapi.com"
+	token := &StaticTokenProvider{Token: "test-token"}
+	client := NewClient(cfg, token, WithTransport(reg))
+
+	account := client.ForAccount("12345")
+	_, err := account.Post(context.Background(), "/items.json", map[string]string{
+		"name": "Test Item",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the captured payload
+	if capturedPayload["name"] != "Test Item" {
+		t.Errorf("expected name 'Test Item', got %v", capturedPayload["name"])
+	}
+
+	reg.Verify(t)
+}
+
+// TestClient_ErrorResponse_WithRegistry demonstrates testing error responses.
+func TestClient_ErrorResponse_WithRegistry(t *testing.T) {
+	reg := httpmock.NewRegistry(t)
+
+	reg.Register(
+		httpmock.REST("GET", "12345/missing.json"),
+		httpmock.RespondNotFound(),
+	)
+
+	cfg := DefaultConfig()
+	cfg.BaseURL = "https://3.basecampapi.com"
+	token := &StaticTokenProvider{Token: "test-token"}
+	client := NewClient(cfg, token, WithTransport(reg))
+
+	account := client.ForAccount("12345")
+	_, err := account.Get(context.Background(), "/missing.json")
+
+	if err == nil {
+		t.Fatal("expected error for 404 response")
+	}
+
+	// The SDK returns an *Error for 404 responses
+	apiErr, ok := err.(*Error)
+	if !ok {
+		t.Fatalf("expected *Error, got %T: %v", err, err)
+	}
+	if apiErr.Code != CodeNotFound {
+		t.Errorf("expected CodeNotFound, got %s", apiErr.Code)
+	}
+
+	reg.Verify(t)
+}
+
+// TestClient_MultipleRequests_WithRegistry demonstrates registering
+// multiple stubs for successive calls to the same endpoint.
+func TestClient_MultipleRequests_WithRegistry(t *testing.T) {
+	reg := httpmock.NewRegistry(t)
+
+	// Register multiple stubs for successive calls
+	// Each stub is matched and consumed in order
+	reg.Register(
+		httpmock.REST("GET", "12345/counter.json"),
+		httpmock.RespondJSON(map[string]int{"count": 1}),
+	)
+	reg.Register(
+		httpmock.REST("GET", "12345/counter.json"),
+		httpmock.RespondJSON(map[string]int{"count": 2}),
+	)
+
+	cfg := DefaultConfig()
+	cfg.BaseURL = "https://3.basecampapi.com"
+	token := &StaticTokenProvider{Token: "test-token"}
+	client := NewClient(cfg, token, WithTransport(reg))
+
+	account := client.ForAccount("12345")
+
+	// First call
+	resp1, err := account.Get(context.Background(), "/counter.json")
+	if err != nil {
+		t.Fatalf("unexpected error on first call: %v", err)
+	}
+	var result1 map[string]int
+	_ = resp1.UnmarshalData(&result1)
+	if result1["count"] != 1 {
+		t.Errorf("first call: expected count 1, got %d", result1["count"])
+	}
+
+	// Second call
+	resp2, err := account.Get(context.Background(), "/counter.json")
+	if err != nil {
+		t.Fatalf("unexpected error on second call: %v", err)
+	}
+	var result2 map[string]int
+	_ = resp2.UnmarshalData(&result2)
+	if result2["count"] != 2 {
+		t.Errorf("second call: expected count 2, got %d", result2["count"])
+	}
+
+	reg.Verify(t)
+}
+
+// TestProjects_List_WithServer demonstrates testing service methods with httptest.
+// This is the recommended pattern for testing high-level service methods that
+// use the generated OpenAPI client internally.
+func TestProjects_List_WithServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the request path
+		expectedPath := "/12345/projects.json"
+		if r.URL.Path != expectedPath {
+			t.Errorf("expected path %s, got %s", expectedPath, r.URL.Path)
+		}
+
+		// Verify auth header
+		if auth := r.Header.Get("Authorization"); auth != "Bearer test-token" {
+			t.Errorf("expected Authorization header 'Bearer test-token', got %q", auth)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+			{"id": 1, "name": "Project One", "status": "active"},
+			{"id": 2, "name": "Project Two", "status": "active"},
+		})
+	}))
+	defer server.Close()
+
+	cfg := DefaultConfig()
+	cfg.BaseURL = server.URL
+	token := &StaticTokenProvider{Token: "test-token"}
+	client := NewClient(cfg, token)
+
+	account := client.ForAccount("12345")
+	result, err := account.Projects().List(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Projects) != 2 {
+		t.Errorf("expected 2 projects, got %d", len(result.Projects))
+	}
+	if result.Projects[0].Name != "Project One" {
+		t.Errorf("expected first project name 'Project One', got %q", result.Projects[0].Name)
+	}
+}
+
+// TestProjects_Get_WithServer demonstrates testing a single resource fetch.
+func TestProjects_Get_WithServer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The OpenAPI generated client may not include .json extension
+		// Check for both forms
+		expectedPathWithExt := "/12345/projects/999.json"
+		expectedPathNoExt := "/12345/projects/999"
+		if r.URL.Path != expectedPathWithExt && r.URL.Path != expectedPathNoExt {
+			t.Errorf("expected path %s or %s, got %s", expectedPathWithExt, expectedPathNoExt, r.URL.Path)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":          999,
+			"name":        "The Leto Laptop",
+			"description": "Laptop product launch.",
+			"status":      "active",
+		})
+	}))
+	defer server.Close()
+
+	cfg := DefaultConfig()
+	cfg.BaseURL = server.URL
+	token := &StaticTokenProvider{Token: "test-token"}
+	client := NewClient(cfg, token)
+
+	account := client.ForAccount("12345")
+	project, err := account.Projects().Get(context.Background(), 999)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if project.ID != 999 {
+		t.Errorf("expected project ID 999, got %d", project.ID)
+	}
+	if project.Name != "The Leto Laptop" {
+		t.Errorf("expected project name 'The Leto Laptop', got %q", project.Name)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a first-party HTTP mock registry for testing SDK integrations, inspired by gh-cli's httpmock package.

### New `internal/testing` package with:
- **Registry**: HTTP RoundTripper that matches requests against registered stubs
- **Matchers**: `REST()`, `MatchPath()`, `MatchMethod()`, `MatchHeader()`, `MatchJSONBody()`, etc.
- **Responders**: `RespondJSON()`, `StatusJSON()`, `RespondError()`, `WithPagination()`, `Sequence()`, etc.
- **Verification**: `Verify(t)` fails tests if registered stubs weren't matched

### Usage example:
```go
reg := testing.NewRegistry(t)

reg.Register(
    testing.REST("GET", "projects.json"),
    testing.RespondJSON([]map[string]any{{"id": 1, "name": "Test"}}),
)

client := basecamp.NewClient(cfg, token, 
    basecamp.WithHTTPClient(reg.Client()))

// ... use client ...

reg.Verify(t)  // Fails if stub wasn't matched
```

### Files added:
- `internal/testing/registry.go` - Core registry and RoundTripper
- `internal/testing/matchers.go` - Request matchers
- `internal/testing/responders.go` - Response builders
- `internal/testing/doc.go` - Package documentation
- Tests for all components

## Test plan
- [x] All tests pass
- [x] `make` passes (lint, vet, test)
- [x] Example usage in `pkg/basecamp/registry_example_test.go`