### PR TITLE
Bump Go to 1.25.7 for crypto/tls fix (GO-2026-4337)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version-file: 'go/go.mod'
 
       - name: Run tests
         run: go test -v ./...
@@ -67,7 +67,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version-file: 'go/go.mod'
 
       - name: Extract version from tag
         id: version

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version-file: 'go/go.mod'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
@@ -100,7 +100,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version-file: 'go/go.mod'
 
       - name: Install gosec
         run: go install github.com/securego/gosec/v2/cmd/gosec@v2.22.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version-file: 'go/go.mod'
 
       - name: Build
         run: go build ./...
@@ -154,7 +154,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version-file: 'conformance/runner/go/go.mod'
 
       - name: Build conformance runner
         run: go build -o conformance-runner .
@@ -171,7 +171,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version-file: 'go/go.mod'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -192,7 +192,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version-file: 'go/go.mod'
 
       - name: Cache Go tools
         uses: actions/cache@v5
@@ -217,7 +217,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version-file: 'go/go.mod'
 
       - name: Test with race detector
         run: go test -race -v ./...
@@ -237,7 +237,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version-file: 'go/go.mod'
 
       - name: Cache Go tools
         uses: actions/cache@v5

--- a/conformance/runner/go/go.mod
+++ b/conformance/runner/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/basecamp/basecamp-sdk/conformance/runner/go
 
-go 1.25.0
+go 1.25.7
 
 require github.com/basecamp/basecamp-sdk/go v0.0.0
 

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.25.0
+go 1.25.7
 
 use (
 	./conformance/runner/go

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/basecamp/basecamp-sdk/go
 
-go 1.25.0
+go 1.25.7
 
 require (
 	github.com/oapi-codegen/runtime v1.1.2


### PR DESCRIPTION
## Summary

- Bumps Go from 1.25.0 to 1.25.7 in `go/go.mod`, `conformance/runner/go/go.mod`, and `go.work` to fix [CVE-2025-68121](https://pkg.go.dev/vuln/GO-2026-4337) — a `crypto/tls` vulnerability where session resumption may succeed when it should fail if `Config.ClientCAs` or `Config.RootCAs` are mutated between handshakes
- Switches all CI `setup-go` steps from `go-version: '1.25'` to `go-version-file` referencing `go.mod`, matching the approach in [basecamp-cli#135](https://github.com/basecamp/basecamp-cli/pull/135)

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` passes
- [x] `govulncheck ./...` reports 0 vulnerabilities
- [ ] CI passes on this PR