### PR TITLE
Swift SDK: Root Package.swift and JSONValue type

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,19 @@
+// swift-tools-version: 6.0
+// Distribution manifest — exposes the Basecamp library for SPM consumers.
+// For full development (generator, tests), use swift/Package.swift.
+import PackageDescription
+
+let package = Package(
+    name: "Basecamp",
+    platforms: [.iOS(.v16), .macOS(.v12)],
+    products: [
+        .library(name: "Basecamp", targets: ["Basecamp"]),
+    ],
+    targets: [
+        .target(
+            name: "Basecamp",
+            path: "swift/Sources/Basecamp",
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
+    ]
+)

--- a/swift/Sources/Basecamp/JSONValue.swift
+++ b/swift/Sources/Basecamp/JSONValue.swift
@@ -1,0 +1,35 @@
+/// Loose-typed JSON for endpoints without stable typed models.
+///
+/// Useful when extending the SDK with custom services for internal
+/// or experimental endpoints. Decodes any JSON value.
+///
+/// Numeric values are stored as `Double`, matching Foundation's
+/// `JSONSerialization` behavior. This means integers beyond 2^53
+/// may lose precision — use typed models for endpoints where large
+/// integer IDs are critical.
+///
+/// ```swift
+/// let result: JSONValue = try await request(info, method: "GET", path: "/internal/account.json")
+/// if case .object(let dict) = result, case .string(let name) = dict["name"] {
+///     print(name)
+/// }
+/// ```
+public enum JSONValue: Decodable, Sendable, Equatable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case object([String: JSONValue])
+    case array([JSONValue])
+    case null
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() { self = .null }
+        else if let b = try? container.decode(Bool.self) { self = .bool(b) }
+        else if let n = try? container.decode(Double.self) { self = .number(n) }
+        else if let s = try? container.decode(String.self) { self = .string(s) }
+        else if let a = try? container.decode([JSONValue].self) { self = .array(a) }
+        else if let o = try? container.decode([String: JSONValue].self) { self = .object(o) }
+        else { throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported JSON type") }
+    }
+}

--- a/swift/Tests/BasecampTests/JSONValueTests.swift
+++ b/swift/Tests/BasecampTests/JSONValueTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import Basecamp
+
+final class JSONValueTests: XCTestCase {
+
+    // MARK: - Primitives
+
+    func testDecodesString() throws {
+        let value = try decode(#""hello""#)
+        XCTAssertEqual(value, .string("hello"))
+    }
+
+    func testDecodesNumber() throws {
+        let value = try decode("42.5")
+        XCTAssertEqual(value, .number(42.5))
+    }
+
+    func testDecodesInteger() throws {
+        let value = try decode("7")
+        XCTAssertEqual(value, .number(7))
+    }
+
+    func testDecodesBoolTrue() throws {
+        XCTAssertEqual(try decode("true"), .bool(true))
+    }
+
+    func testDecodesBoolFalse() throws {
+        XCTAssertEqual(try decode("false"), .bool(false))
+    }
+
+    func testDecodesNull() throws {
+        XCTAssertEqual(try decode("null"), .null)
+    }
+
+    // MARK: - Containers
+
+    func testDecodesArray() throws {
+        let value = try decode(#"[1, "two", true]"#)
+        XCTAssertEqual(value, .array([.number(1), .string("two"), .bool(true)]))
+    }
+
+    func testDecodesEmptyArray() throws {
+        XCTAssertEqual(try decode("[]"), .array([]))
+    }
+
+    func testDecodesObject() throws {
+        let value = try decode(#"{"name": "Basecamp", "id": 999}"#)
+        XCTAssertEqual(value, .object(["name": .string("Basecamp"), "id": .number(999)]))
+    }
+
+    func testDecodesEmptyObject() throws {
+        XCTAssertEqual(try decode("{}"), .object([:]))
+    }
+
+    // MARK: - Nesting
+
+    func testDecodesNestedStructure() throws {
+        let json = #"{"users": [{"name": "DHH", "admin": true}], "count": 1}"#
+        let value = try decode(json)
+
+        let expected: JSONValue = .object([
+            "users": .array([
+                .object(["name": .string("DHH"), "admin": .bool(true)])
+            ]),
+            "count": .number(1)
+        ])
+        XCTAssertEqual(value, expected)
+    }
+
+    // MARK: - Equatable
+
+    func testDifferentCasesAreNotEqual() {
+        XCTAssertNotEqual(JSONValue.string("1"), JSONValue.number(1))
+        XCTAssertNotEqual(JSONValue.bool(true), JSONValue.number(1))
+        XCTAssertNotEqual(JSONValue.null, JSONValue.bool(false))
+    }
+
+    // MARK: - Helpers
+
+    private func decode(_ json: String) throws -> JSONValue {
+        try JSONDecoder().decode(JSONValue.self, from: Data(json.utf8))
+    }
+}


### PR DESCRIPTION
## Summary

- **Root `Package.swift`** — enables SPM consumers to resolve the `Basecamp` library directly from the monorepo URL. The SDK's own `Package.swift` lives at `swift/Package.swift`, which SPM can't find for remote package references. This is a stripped-down distribution manifest (library product only, no generator, no tests). SDK development continues via `cd swift && swift build/test`.

- **`JSONValue`** — a generic `Decodable` JSON container (Swift equivalent of Kotlin's `JsonElement`) for consumers extending the SDK with custom services for untyped or internal endpoints. Numbers are stored as `Double` (matching Foundation's `JSONSerialization`); the 2^53 precision limitation is documented.

Companion PR: https://github.com/basecamp/bc3-ios/pull/1259

## Test plan

- [x] `swift build` from monorepo root resolves via root Package.swift
- [x] `cd swift && swift build && swift test` still works for SDK development (79 tests, 0 failures)
- [x] `JSONValue` decodes all JSON primitives, arrays, objects, and null (12 tests in `JSONValueTests`)