### PR TITLE
Upgrade Go SDK to Go 1.26

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -82,7 +82,7 @@ jobs:
           go-version-file: 'go/go.mod'
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
 
       - name: Run govulncheck
         run: govulncheck ./...

--- a/conformance/runner/go/go.mod
+++ b/conformance/runner/go/go.mod
@@ -1,12 +1,12 @@
 module github.com/basecamp/basecamp-sdk/conformance/runner/go
 
-go 1.25.7
+go 1.26
 
 require github.com/basecamp/basecamp-sdk/go v0.0.0
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
-	github.com/google/uuid v1.5.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/oapi-codegen/runtime v1.1.2 // indirect
 )
 

--- a/conformance/runner/go/go.sum
+++ b/conformance/runner/go/go.sum
@@ -5,8 +5,8 @@ github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvF
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
-github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/juju/gnuflag v0.0.0-20171113085948-2ce1bb71843d/go.mod h1:2PavIy+JPciBPrBUjwbNvtwB6RQlve+hkpll6QSNmOE=
 github.com/oapi-codegen/runtime v1.1.2 h1:P2+CubHq8fO4Q6fV1tqDBZHCwpVpvPg7oKiYzQgXIyI=
 github.com/oapi-codegen/runtime v1.1.2/go.mod h1:SK9X900oXmPWilYR5/WKPzt3Kqxn/uS/+lbpREv+eCg=

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.25.7
+go 1.26
 
 use (
 	./conformance/runner/go

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/basecamp/basecamp-sdk/go
 
-go 1.25.7
+go 1.26
 
 require (
 	github.com/oapi-codegen/runtime v1.1.2

--- a/go/pkg/basecamp/attachments_test.go
+++ b/go/pkg/basecamp/attachments_test.go
@@ -49,7 +49,7 @@ func TestAttachmentResponse_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal AttachmentResponse: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}

--- a/go/pkg/basecamp/auth_race_test.go
+++ b/go/pkg/basecamp/auth_race_test.go
@@ -33,7 +33,7 @@ func TestAuthManager_ConcurrentAccess(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Hammer all AuthManager methods concurrently
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		wg.Add(4)
 
 		go func() {
@@ -77,7 +77,7 @@ func TestAuthManager_LogoutDuringRefresh(t *testing.T) {
 
 	var wg sync.WaitGroup
 
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		// Re-populate credentials with EXPIRED token to trigger refresh path
 		_ = store.Save(origin, &Credentials{
 			AccessToken:  "expired-token",
@@ -113,7 +113,7 @@ func TestAccountClient_ConcurrentServiceAccess(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Hammer service accessors concurrently
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		wg.Add(6)
 
 		go func() {

--- a/go/pkg/basecamp/authorization_test.go
+++ b/go/pkg/basecamp/authorization_test.go
@@ -11,7 +11,7 @@ import (
 func TestAuthorizationService_GetInfo(t *testing.T) {
 	tests := []struct {
 		name       string
-		response   interface{}
+		response   any
 		statusCode int
 		opts       *GetInfoOptions
 		wantErr    bool
@@ -19,14 +19,14 @@ func TestAuthorizationService_GetInfo(t *testing.T) {
 	}{
 		{
 			name: "successful response",
-			response: map[string]interface{}{
-				"identity": map[string]interface{}{
+			response: map[string]any{
+				"identity": map[string]any{
 					"id":            123,
 					"first_name":    "Test",
 					"last_name":     "User",
 					"email_address": "test@example.com",
 				},
-				"accounts": []map[string]interface{}{
+				"accounts": []map[string]any{
 					{"id": 1, "name": "Account 1", "product": "bc3"},
 					{"id": 2, "name": "Account 2", "product": "hey"},
 				},
@@ -37,12 +37,12 @@ func TestAuthorizationService_GetInfo(t *testing.T) {
 		},
 		{
 			name: "filter by product",
-			response: map[string]interface{}{
-				"identity": map[string]interface{}{
+			response: map[string]any{
+				"identity": map[string]any{
 					"id":         123,
 					"first_name": "Test",
 				},
-				"accounts": []map[string]interface{}{
+				"accounts": []map[string]any{
 					{"id": 1, "name": "Basecamp Account", "product": "bc3"},
 					{"id": 2, "name": "HEY Account", "product": "hey"},
 					{"id": 3, "name": "Another BC", "product": "bc3"},
@@ -55,7 +55,7 @@ func TestAuthorizationService_GetInfo(t *testing.T) {
 		},
 		{
 			name:       "unauthorized",
-			response:   map[string]interface{}{"error": "invalid token"},
+			response:   map[string]any{"error": "invalid token"},
 			statusCode: http.StatusUnauthorized,
 			wantErr:    true,
 		},
@@ -141,9 +141,9 @@ func TestAuthorizationService_GetInfo_AllowsLocalhostHTTP(t *testing.T) {
 	// Start a test server (which runs on localhost/127.0.0.1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"identity": map[string]interface{}{"id": 123},
-			"accounts": []map[string]interface{}{},
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"identity": map[string]any{"id": 123},
+			"accounts": []map[string]any{},
 		})
 	}))
 	defer server.Close()

--- a/go/pkg/basecamp/benchmark_test.go
+++ b/go/pkg/basecamp/benchmark_test.go
@@ -185,7 +185,7 @@ func BenchmarkJSONUnmarshalProjectList(b *testing.B) {
 	// Build JSON for 50 projects
 	var buf bytes.Buffer
 	buf.WriteString("[")
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		if i > 0 {
 			buf.WriteString(",")
 		}

--- a/go/pkg/basecamp/boosts_test.go
+++ b/go/pkg/basecamp/boosts_test.go
@@ -160,8 +160,8 @@ func TestCreateRecordingBoost_EmptyContent(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty content")
 	}
-	var apiErr *Error
-	if !errors.As(err, &apiErr) || apiErr.Code != CodeUsage {
+	apiErr, ok := errors.AsType[*Error](err)
+	if !ok || apiErr.Code != CodeUsage {
 		t.Errorf("expected usage error, got: %v", err)
 	}
 }
@@ -172,8 +172,8 @@ func TestCreateEventBoost_EmptyContent(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty content")
 	}
-	var apiErr *Error
-	if !errors.As(err, &apiErr) || apiErr.Code != CodeUsage {
+	apiErr, ok := errors.AsType[*Error](err)
+	if !ok || apiErr.Code != CodeUsage {
 		t.Errorf("expected usage error, got: %v", err)
 	}
 }
@@ -291,8 +291,8 @@ func TestBoostsService_Get_NotFound(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for 404")
 	}
-	var apiErr *Error
-	if !errors.As(err, &apiErr) || apiErr.Code != CodeNotFound {
+	apiErr, ok := errors.AsType[*Error](err)
+	if !ok || apiErr.Code != CodeNotFound {
 		t.Errorf("expected not_found error, got: %v", err)
 	}
 }
@@ -408,8 +408,8 @@ func TestBoostsService_Delete_NotFound(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for 404")
 	}
-	var apiErr *Error
-	if !errors.As(err, &apiErr) || apiErr.Code != CodeNotFound {
+	apiErr, ok := errors.AsType[*Error](err)
+	if !ok || apiErr.Code != CodeNotFound {
 		t.Errorf("expected not_found error, got: %v", err)
 	}
 }

--- a/go/pkg/basecamp/campfires_test.go
+++ b/go/pkg/basecamp/campfires_test.go
@@ -324,7 +324,7 @@ func TestCreateCampfireLineRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal CreateCampfireLineRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -360,7 +360,7 @@ func TestCreateCampfireLineRequest_MarshalWithContentType(t *testing.T) {
 		t.Fatalf("failed to marshal CreateCampfireLineRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -393,7 +393,7 @@ func TestCreateCampfireLineRequest_MarshalWithPlainContentType(t *testing.T) {
 		t.Fatalf("failed to marshal CreateCampfireLineRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -426,8 +426,8 @@ func TestCreateLine_EmptyContent(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for empty content")
 	}
-	var apiErr *Error
-	if !errors.As(err, &apiErr) || apiErr.Code != CodeUsage {
+	apiErr, ok := errors.AsType[*Error](err)
+	if !ok || apiErr.Code != CodeUsage {
 		t.Errorf("expected usage error, got: %v", err)
 	}
 }
@@ -440,8 +440,8 @@ func TestCreateLine_MultipleOptions(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for multiple options")
 	}
-	var apiErr *Error
-	if !errors.As(err, &apiErr) || apiErr.Code != CodeUsage {
+	apiErr, ok := errors.AsType[*Error](err)
+	if !ok || apiErr.Code != CodeUsage {
 		t.Errorf("expected usage error, got: %v", err)
 	}
 }
@@ -453,8 +453,8 @@ func TestCreateLine_InvalidContentType(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid content_type")
 	}
-	var apiErr *Error
-	if !errors.As(err, &apiErr) || apiErr.Code != CodeUsage {
+	apiErr, ok := errors.AsType[*Error](err)
+	if !ok || apiErr.Code != CodeUsage {
 		t.Errorf("expected usage error, got: %v", err)
 	}
 }
@@ -476,7 +476,7 @@ func testCampfiresServer(t *testing.T, handler http.HandlerFunc) *CampfiresServi
 }
 
 func TestCreateLine_NoOptions_Service(t *testing.T) {
-	var receivedBody map[string]interface{}
+	var receivedBody map[string]any
 	fixture := loadCampfiresFixture(t, "line_get.json")
 	svc := testCampfiresServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
@@ -510,7 +510,7 @@ func TestCreateLine_NoOptions_Service(t *testing.T) {
 }
 
 func TestCreateLine_HTMLOption_Service(t *testing.T) {
-	var receivedBody map[string]interface{}
+	var receivedBody map[string]any
 	fixture := loadCampfiresFixture(t, "line_get.json")
 	svc := testCampfiresServer(t, func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
@@ -534,7 +534,7 @@ func TestCreateLine_HTMLOption_Service(t *testing.T) {
 }
 
 func TestCreateLine_PlainOption_Service(t *testing.T) {
-	var receivedBody map[string]interface{}
+	var receivedBody map[string]any
 	fixture := loadCampfiresFixture(t, "line_get.json")
 	svc := testCampfiresServer(t, func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
@@ -655,7 +655,7 @@ func TestCreateChatbotRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal CreateChatbotRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -676,7 +676,7 @@ func TestCreateChatbotRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal CreateChatbotRequest without command_url: %v", err)
 	}
 
-	var dataNoURL map[string]interface{}
+	var dataNoURL map[string]any
 	if err := json.Unmarshal(outNoURL, &dataNoURL); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -700,7 +700,7 @@ func TestUpdateChatbotRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal UpdateChatbotRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}

--- a/go/pkg/basecamp/cards_test.go
+++ b/go/pkg/basecamp/cards_test.go
@@ -394,7 +394,7 @@ func TestCreateCardRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal CreateCardRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -423,7 +423,7 @@ func TestCreateCardRequest_MarshalMinimal(t *testing.T) {
 		t.Fatalf("failed to marshal CreateCardRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -455,7 +455,7 @@ func TestUpdateCardRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal UpdateCardRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -470,7 +470,7 @@ func TestUpdateCardRequest_Marshal(t *testing.T) {
 		t.Errorf("unexpected due_on: %v", data["due_on"])
 	}
 
-	assigneeIDs, ok := data["assignee_ids"].([]interface{})
+	assigneeIDs, ok := data["assignee_ids"].([]any)
 	if !ok {
 		t.Fatalf("expected assignee_ids to be an array, got %T", data["assignee_ids"])
 	}
@@ -511,7 +511,7 @@ func TestCreateColumnRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal CreateColumnRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -534,7 +534,7 @@ func TestSetColumnColorRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal SetColumnColorRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -587,7 +587,7 @@ func TestCreateStepRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal CreateStepRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -598,7 +598,7 @@ func TestCreateStepRequest_Marshal(t *testing.T) {
 	if data["due_on"] != "2024-02-15" {
 		t.Errorf("unexpected due_on: %v", data["due_on"])
 	}
-	assignees, ok := data["assignees"].([]interface{})
+	assignees, ok := data["assignees"].([]any)
 	if !ok || len(assignees) != 2 {
 		t.Errorf("unexpected assignees: %v", data["assignees"])
 	}
@@ -615,7 +615,7 @@ func TestUpdateStepRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal UpdateStepRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}

--- a/go/pkg/basecamp/checkins_test.go
+++ b/go/pkg/basecamp/checkins_test.go
@@ -428,7 +428,7 @@ func TestCreateQuestionRequest_Marshal(t *testing.T) {
 		t.Errorf("unexpected title: %v", data["title"])
 	}
 
-	schedule, ok := data["schedule"].(map[string]interface{})
+	schedule, ok := data["schedule"].(map[string]any)
 	if !ok {
 		t.Fatal("expected schedule to be a map")
 	}
@@ -444,7 +444,7 @@ func TestCreateQuestionRequest_Marshal(t *testing.T) {
 		t.Errorf("unexpected minute: %v", schedule["minute"])
 	}
 
-	days, ok := schedule["days"].([]interface{})
+	days, ok := schedule["days"].([]any)
 	if !ok {
 		t.Fatal("expected days to be an array")
 	}
@@ -487,7 +487,7 @@ func TestUpdateQuestionRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal UpdateQuestionRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -499,7 +499,7 @@ func TestUpdateQuestionRequest_Marshal(t *testing.T) {
 		t.Errorf("unexpected paused: %v", data["paused"])
 	}
 
-	schedule, ok := data["schedule"].(map[string]interface{})
+	schedule, ok := data["schedule"].(map[string]any)
 	if !ok {
 		t.Fatal("expected schedule to be a map")
 	}
@@ -519,7 +519,7 @@ func TestUpdateQuestionRequest_MarshalPartial(t *testing.T) {
 		t.Fatalf("failed to marshal UpdateQuestionRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -547,7 +547,7 @@ func TestCreateAnswerRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal CreateAnswerRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -584,7 +584,7 @@ func TestCreateAnswerRequest_MarshalMinimal(t *testing.T) {
 		t.Fatalf("failed to marshal CreateAnswerRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -608,7 +608,7 @@ func TestUpdateAnswerRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal UpdateAnswerRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -642,13 +642,13 @@ func TestCreateAnswerRequestWrapper_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal wrapper: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
 
 	// Verify the structure is wrapped in "question_answer" key
-	questionAnswer, ok := data["question_answer"].(map[string]interface{})
+	questionAnswer, ok := data["question_answer"].(map[string]any)
 	if !ok {
 		t.Fatal("expected question_answer to be a map")
 	}
@@ -673,13 +673,13 @@ func TestUpdateAnswerRequestWrapper_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal wrapper: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
 
 	// Verify the structure is wrapped in "question_answer" key
-	questionAnswer, ok := data["question_answer"].(map[string]interface{})
+	questionAnswer, ok := data["question_answer"].(map[string]any)
 	if !ok {
 		t.Fatal("expected question_answer to be a map")
 	}

--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -815,7 +815,7 @@ func parseNextLink(linkHeader string) string {
 		return ""
 	}
 
-	for _, part := range strings.Split(linkHeader, ",") {
+	for part := range strings.SplitSeq(linkHeader, ",") {
 		part = strings.TrimSpace(part)
 		if strings.Contains(part, `rel="next"`) {
 			// Extract URL between < and >

--- a/go/pkg/basecamp/comments_test.go
+++ b/go/pkg/basecamp/comments_test.go
@@ -174,7 +174,7 @@ func TestCreateCommentRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal CreateCommentRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -204,7 +204,7 @@ func TestUpdateCommentRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal UpdateCommentRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}

--- a/go/pkg/basecamp/doc.go
+++ b/go/pkg/basecamp/doc.go
@@ -131,8 +131,7 @@
 //
 //	resp, err := client.Get(ctx, "/projects/999.json")
 //	if err != nil {
-//	    var apiErr *basecamp.Error
-//	    if errors.As(err, &apiErr) {
+//	    if apiErr, ok := errors.AsType[*basecamp.Error](err); ok {
 //	        switch apiErr.Code {
 //	        case basecamp.CodeNotFound:
 //	            // Handle 404

--- a/go/pkg/basecamp/errors.go
+++ b/go/pkg/basecamp/errors.go
@@ -198,8 +198,7 @@ func ErrAmbiguous(resource string, matches []string) *Error {
 // AsError attempts to convert an error to an *Error.
 // If the error is not an *Error, it wraps it in one.
 func AsError(err error) *Error {
-	var e *Error
-	if errors.As(err, &e) {
+	if e, ok := errors.AsType[*Error](err); ok {
 		return e
 	}
 	return &Error{

--- a/go/pkg/basecamp/example_test.go
+++ b/go/pkg/basecamp/example_test.go
@@ -295,8 +295,7 @@ func Example_errorHandling() {
 	// Get a project that may not exist
 	project, err := client.ForAccount("12345").Projects().Get(ctx, 999999999)
 	if err != nil {
-		var apiErr *basecamp.Error
-		if errors.As(err, &apiErr) {
+		if apiErr, ok := errors.AsType[*basecamp.Error](err); ok {
 			switch apiErr.Code {
 			case basecamp.CodeNotFound:
 				fmt.Println("Project not found")

--- a/go/pkg/basecamp/forwards_test.go
+++ b/go/pkg/basecamp/forwards_test.go
@@ -373,7 +373,7 @@ func TestCreateForwardReplyRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal CreateForwardReplyRequest: %v", err)
 	}
 
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.Unmarshal(data, &result); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}

--- a/go/pkg/basecamp/lineup_test.go
+++ b/go/pkg/basecamp/lineup_test.go
@@ -119,7 +119,7 @@ func TestCreateMarkerRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal CreateMarkerRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestUpdateMarkerRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal UpdateMarkerRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestUpdateMarkerRequest_MarshalPartial(t *testing.T) {
 		t.Fatalf("failed to marshal UpdateMarkerRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}

--- a/go/pkg/basecamp/message_types_test.go
+++ b/go/pkg/basecamp/message_types_test.go
@@ -119,7 +119,7 @@ func TestCreateMessageTypeRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal CreateMessageTypeRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestUpdateMessageTypeRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal UpdateMessageTypeRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -193,7 +193,7 @@ func TestUpdateMessageTypeRequest_MarshalPartial(t *testing.T) {
 		t.Fatalf("failed to marshal UpdateMessageTypeRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}

--- a/go/pkg/basecamp/messages_test.go
+++ b/go/pkg/basecamp/messages_test.go
@@ -262,7 +262,7 @@ func TestCreateMessageRequest_MarshalMinimal(t *testing.T) {
 		t.Fatalf("failed to marshal CreateMessageRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -339,7 +339,7 @@ func TestUpdateMessageRequest_MarshalPartial(t *testing.T) {
 		t.Fatalf("failed to marshal UpdateMessageRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}

--- a/go/pkg/basecamp/oauth/oauth_test.go
+++ b/go/pkg/basecamp/oauth/oauth_test.go
@@ -14,7 +14,7 @@ import (
 func TestDiscoverer_Discover(t *testing.T) {
 	tests := []struct {
 		name       string
-		response   interface{}
+		response   any
 		statusCode int
 		wantErr    bool
 	}{
@@ -96,7 +96,7 @@ func TestExchanger_Exchange(t *testing.T) {
 	tests := []struct {
 		name            string
 		req             ExchangeRequest
-		response        interface{}
+		response        any
 		statusCode      int
 		wantErr         bool
 		wantLegacyParam bool
@@ -109,7 +109,7 @@ func TestExchanger_Exchange(t *testing.T) {
 				RedirectURI:   "http://localhost/callback",
 				ClientID:      "client123",
 			},
-			response: map[string]interface{}{
+			response: map[string]any{
 				"access_token":  "access123",
 				"refresh_token": "refresh123",
 				"token_type":    "Bearer",
@@ -127,7 +127,7 @@ func TestExchanger_Exchange(t *testing.T) {
 				ClientID:        "client123",
 				UseLegacyFormat: true,
 			},
-			response: map[string]interface{}{
+			response: map[string]any{
 				"access_token":  "access123",
 				"refresh_token": "refresh123",
 			},
@@ -143,7 +143,7 @@ func TestExchanger_Exchange(t *testing.T) {
 				RedirectURI:   "http://localhost/callback",
 				ClientID:      "client123",
 			},
-			response: map[string]interface{}{
+			response: map[string]any{
 				"error":             "invalid_grant",
 				"error_description": "The authorization code has expired",
 			},
@@ -228,7 +228,7 @@ func TestExchanger_Refresh(t *testing.T) {
 	tests := []struct {
 		name            string
 		req             RefreshRequest
-		response        interface{}
+		response        any
 		statusCode      int
 		wantErr         bool
 		wantLegacyParam bool
@@ -239,7 +239,7 @@ func TestExchanger_Refresh(t *testing.T) {
 				TokenEndpoint: "will be replaced",
 				RefreshToken:  "refresh123",
 			},
-			response: map[string]interface{}{
+			response: map[string]any{
 				"access_token":  "new_access123",
 				"refresh_token": "new_refresh123",
 				"expires_in":    3600,
@@ -254,7 +254,7 @@ func TestExchanger_Refresh(t *testing.T) {
 				RefreshToken:    "refresh123",
 				UseLegacyFormat: true,
 			},
-			response: map[string]interface{}{
+			response: map[string]any{
 				"access_token": "new_access123",
 			},
 			statusCode:      http.StatusOK,
@@ -317,7 +317,7 @@ func TestExchanger_Refresh(t *testing.T) {
 
 func TestToken_ExpiresAt(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"access_token": "access123",
 			"expires_in":   3600,
 		})
@@ -416,7 +416,7 @@ func TestExchanger_Exchange_TruncatesLargeErrorDescription(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		largeDesc := strings.Repeat("y", 10000)
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"error":             "invalid_grant",
 			"error_description": largeDesc,
 		})

--- a/go/pkg/basecamp/pagination_test.go
+++ b/go/pkg/basecamp/pagination_test.go
@@ -40,10 +40,7 @@ func (h *paginationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	count := h.pageSize
-	if remaining < h.pageSize {
-		count = remaining
-	}
+	count := min(remaining, h.pageSize)
 
 	items := make([]map[string]int, count)
 	for i := 0; i < count; i++ {
@@ -368,10 +365,7 @@ func (h *followPaginationHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	count := h.pageSize
-	if remaining < h.pageSize {
-		count = remaining
-	}
+	count := min(remaining, h.pageSize)
 
 	items := make([]map[string]int, count)
 	for i := 0; i < count; i++ {
@@ -772,10 +766,7 @@ func (h *relativePaginationHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	count := h.pageSize
-	if remaining < h.pageSize {
-		count = remaining
-	}
+	count := min(remaining, h.pageSize)
 
 	items := make([]map[string]int, count)
 	for i := 0; i < count; i++ {

--- a/go/pkg/basecamp/people_test.go
+++ b/go/pkg/basecamp/people_test.go
@@ -261,7 +261,7 @@ func TestCreatePersonRequest_MarshalOmitsEmpty(t *testing.T) {
 	}
 
 	// Verify that empty optional fields are omitted
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}

--- a/go/pkg/basecamp/recordings_test.go
+++ b/go/pkg/basecamp/recordings_test.go
@@ -194,7 +194,7 @@ func TestSetClientVisibilityRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal SetClientVisibilityRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestSetClientVisibilityRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal SetClientVisibilityRequest (false): %v", err)
 	}
 
-	var dataFalse map[string]interface{}
+	var dataFalse map[string]any
 	if err := json.Unmarshal(outFalse, &dataFalse); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}

--- a/go/pkg/basecamp/schedules_test.go
+++ b/go/pkg/basecamp/schedules_test.go
@@ -285,7 +285,7 @@ func TestCreateScheduleEntryRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal CreateScheduleEntryRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -307,7 +307,7 @@ func TestCreateScheduleEntryRequest_Marshal(t *testing.T) {
 	}
 
 	// Check participant_ids
-	pids, ok := data["participant_ids"].([]interface{})
+	pids, ok := data["participant_ids"].([]any)
 	if !ok {
 		t.Fatalf("expected participant_ids to be array, got %T", data["participant_ids"])
 	}
@@ -345,7 +345,7 @@ func TestCreateScheduleEntryRequest_MarshalMinimal(t *testing.T) {
 		t.Fatalf("failed to marshal CreateScheduleEntryRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -384,7 +384,7 @@ func TestUpdateScheduleEntryRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal UpdateScheduleEntryRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -427,7 +427,7 @@ func TestUpdateScheduleEntryRequest_MarshalPartial(t *testing.T) {
 		t.Fatalf("failed to marshal UpdateScheduleEntryRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -461,7 +461,7 @@ func TestUpdateScheduleSettingsRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal UpdateScheduleSettingsRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -490,7 +490,7 @@ func TestUpdateScheduleSettingsRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal UpdateScheduleSettingsRequest with false: %v", err)
 	}
 
-	var dataFalse map[string]interface{}
+	var dataFalse map[string]any
 	if err := json.Unmarshal(outFalse, &dataFalse); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}

--- a/go/pkg/basecamp/search_test.go
+++ b/go/pkg/basecamp/search_test.go
@@ -197,7 +197,7 @@ func TestSearchOptions_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal SearchOptions: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}

--- a/go/pkg/basecamp/security_test.go
+++ b/go/pkg/basecamp/security_test.go
@@ -190,7 +190,7 @@ func TestLargeResponseBody_ReturnsError(t *testing.T) {
 		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(422)
 			// MaxErrorBodyBytes is 1MB; write 2MB
-			for i := 0; i < 2*1024; i++ {
+			for range 2 * 1024 {
 				fmt.Fprint(w, strings.Repeat("x", 1024))
 			}
 		}))
@@ -348,8 +348,8 @@ func TestHandleError_TruncatesLargeErrorMessage(t *testing.T) {
 		t.Fatal("Expected error, got nil")
 	}
 
-	var apiErr *Error
-	if !errors.As(err, &apiErr) {
+	apiErr, ok := errors.AsType[*Error](err)
+	if !ok {
 		t.Fatalf("Expected *Error, got %T", err)
 	}
 

--- a/go/pkg/basecamp/subscriptions_test.go
+++ b/go/pkg/basecamp/subscriptions_test.go
@@ -175,7 +175,7 @@ func TestUpdateSubscriptionRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
 
-	subs, ok := data["subscriptions"].([]interface{})
+	subs, ok := data["subscriptions"].([]any)
 	if !ok {
 		t.Fatal("subscriptions should be an array")
 	}
@@ -187,7 +187,7 @@ func TestUpdateSubscriptionRequest_Marshal(t *testing.T) {
 		t.Errorf("expected subscription ID 1049715916, got %v", subs[0])
 	}
 
-	unsubs, ok := data["unsubscriptions"].([]interface{})
+	unsubs, ok := data["unsubscriptions"].([]any)
 	if !ok {
 		t.Fatal("unsubscriptions should be an array")
 	}
@@ -224,7 +224,7 @@ func TestUpdateSubscriptionRequest_MarshalOmitsEmpty(t *testing.T) {
 		t.Fatalf("failed to marshal UpdateSubscriptionRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}

--- a/go/pkg/basecamp/test_helpers_test.go
+++ b/go/pkg/basecamp/test_helpers_test.go
@@ -8,8 +8,8 @@ import (
 // unmarshalWithNumbers decodes JSON into a map preserving numbers as json.Number
 // which can be cleanly converted to int64 without float64 precision loss.
 // This is useful for testing JSON serialization where large IDs need to be preserved exactly.
-func unmarshalWithNumbers(data []byte) (map[string]interface{}, error) {
-	var result map[string]interface{}
+func unmarshalWithNumbers(data []byte) (map[string]any, error) {
+	var result map[string]any
 	decoder := json.NewDecoder(bytes.NewReader(data))
 	decoder.UseNumber()
 	return result, decoder.Decode(&result)

--- a/go/pkg/basecamp/timesheet_test.go
+++ b/go/pkg/basecamp/timesheet_test.go
@@ -240,7 +240,7 @@ func TestCreateTimesheetEntryRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal CreateTimesheetEntryRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -267,7 +267,7 @@ func TestCreateTimesheetEntryRequest_MarshalMinimal(t *testing.T) {
 		t.Fatalf("failed to marshal CreateTimesheetEntryRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -365,7 +365,7 @@ func TestUpdateTimesheetEntryRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal UpdateTimesheetEntryRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}

--- a/go/pkg/basecamp/todos_test.go
+++ b/go/pkg/basecamp/todos_test.go
@@ -270,7 +270,7 @@ func TestCreateTodoRequest_Marshal(t *testing.T) {
 	}
 
 	// Verify assignee_ids
-	assigneeIDs, ok := data["assignee_ids"].([]interface{})
+	assigneeIDs, ok := data["assignee_ids"].([]any)
 	if !ok {
 		t.Fatalf("expected assignee_ids to be array, got %T", data["assignee_ids"])
 	}
@@ -303,7 +303,7 @@ func TestCreateTodoRequest_MarshalMinimal(t *testing.T) {
 		t.Fatalf("failed to marshal CreateTodoRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -419,7 +419,7 @@ func TestUpdateTodoRequest_MarshalPartial(t *testing.T) {
 		t.Fatalf("failed to marshal UpdateTodoRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}
@@ -525,7 +525,7 @@ func TestCreateTodoRequest_CompletionSubscriberIDs(t *testing.T) {
 	}
 
 	// Verify completion_subscriber_ids is present
-	subscriberIDs, ok := data["completion_subscriber_ids"].([]interface{})
+	subscriberIDs, ok := data["completion_subscriber_ids"].([]any)
 	if !ok {
 		t.Fatalf("expected completion_subscriber_ids to be array, got %T", data["completion_subscriber_ids"])
 	}
@@ -578,7 +578,7 @@ func TestUpdateTodoRequest_CompletionSubscriberIDs(t *testing.T) {
 	}
 
 	// Verify completion_subscriber_ids is present
-	subscriberIDs, ok := data["completion_subscriber_ids"].([]interface{})
+	subscriberIDs, ok := data["completion_subscriber_ids"].([]any)
 	if !ok {
 		t.Fatalf("expected completion_subscriber_ids to be array, got %T", data["completion_subscriber_ids"])
 	}
@@ -599,7 +599,7 @@ func TestCreateTodoRequest_CompletionSubscriberIDs_Omitted(t *testing.T) {
 		t.Fatalf("failed to marshal CreateTodoRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}

--- a/go/pkg/basecamp/tools_test.go
+++ b/go/pkg/basecamp/tools_test.go
@@ -156,7 +156,7 @@ func TestUpdateToolRequest_Marshal(t *testing.T) {
 		t.Fatalf("failed to marshal UpdateToolRequest: %v", err)
 	}
 
-	var data map[string]interface{}
+	var data map[string]any
 	if err := json.Unmarshal(out, &data); err != nil {
 		t.Fatalf("failed to unmarshal to map: %v", err)
 	}

--- a/go/pkg/basecamp/vaults_test.go
+++ b/go/pkg/basecamp/vaults_test.go
@@ -541,7 +541,7 @@ func TestUploadsService_Download_MissingDownloadURL(t *testing.T) {
 		// Return an upload without a download_url
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"id":       1069479400,
 			"title":    "logo.png",
 			"filename": "logo.png",
@@ -576,7 +576,7 @@ func TestUploadsService_Download_S3Error(t *testing.T) {
 	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"id":           1069479400,
 			"title":        "logo.png",
 			"filename":     "logo.png",
@@ -617,7 +617,7 @@ func TestUploadsService_Download_Success(t *testing.T) {
 	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"id":           1069479400,
 			"title":        "logo.png",
 			"filename":     "logo.png",

--- a/go/pkg/basecamp/webhook_event_test.go
+++ b/go/pkg/basecamp/webhook_event_test.go
@@ -122,7 +122,7 @@ func TestWebhookEvent_UnmarshalMessageCopied(t *testing.T) {
 	if event.Details == nil {
 		t.Fatal("expected non-nil details")
 	}
-	detailsMap, ok := event.Details.(map[string]interface{})
+	detailsMap, ok := event.Details.(map[string]any)
 	if !ok {
 		t.Fatalf("expected details to be a map, got %T", event.Details)
 	}
@@ -185,7 +185,7 @@ func TestWebhookEvent_UnmarshalUnknownFuture(t *testing.T) {
 	if event.Details == nil {
 		t.Fatal("expected non-nil details")
 	}
-	detailsMap, ok := event.Details.(map[string]interface{})
+	detailsMap, ok := event.Details.(map[string]any)
 	if !ok {
 		t.Fatalf("expected details to be a map, got %T", event.Details)
 	}
@@ -200,7 +200,7 @@ func TestWebhookEvent_UnmarshalUnknownFuture(t *testing.T) {
 	if !ok {
 		t.Fatal("expected nested in details")
 	}
-	nestedMap, ok := nested.(map[string]interface{})
+	nestedMap, ok := nested.(map[string]any)
 	if !ok {
 		t.Fatal("expected nested to be a map")
 	}

--- a/go/pkg/basecamp/webhook_handler_test.go
+++ b/go/pkg/basecamp/webhook_handler_test.go
@@ -527,8 +527,8 @@ func TestWebhookReceiver_SignatureVerification(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error with invalid signature")
 	}
-	var verErr *WebhookVerificationError
-	if !errors.As(err, &verErr) {
+	_, ok := errors.AsType[*WebhookVerificationError](err)
+	if !ok {
 		t.Errorf("expected WebhookVerificationError, got %T: %v", err, err)
 	}
 
@@ -537,7 +537,8 @@ func TestWebhookReceiver_SignatureVerification(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error with missing signature")
 	}
-	if !errors.As(err, &verErr) {
+	_, ok = errors.AsType[*WebhookVerificationError](err)
+	if !ok {
 		t.Errorf("expected WebhookVerificationError, got %T: %v", err, err)
 	}
 }
@@ -645,8 +646,8 @@ func TestWebhookReceiver_InvalidJSON(t *testing.T) {
 		t.Fatal("expected error for invalid JSON")
 	}
 
-	var syntaxErr *json.SyntaxError
-	if !errors.As(err, &syntaxErr) {
+	_, ok := errors.AsType[*json.SyntaxError](err)
+	if !ok {
 		// It should be a wrapped parse error
 		if !strings.Contains(err.Error(), "failed to parse webhook event") {
 			t.Errorf("expected parse error, got %v", err)

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -15794,8 +15794,7 @@ func AsAPIError(err error) *APIError {
 	if err == nil {
 		return nil
 	}
-	var apiErr *APIError
-	if errors.As(err, &apiErr) {
+	if apiErr, ok := errors.AsType[*APIError](err); ok {
 		return apiErr
 	}
 	return &APIError{

--- a/go/templates/client.tmpl
+++ b/go/templates/client.tmpl
@@ -948,8 +948,7 @@ func AsAPIError(err error) *APIError {
 	if err == nil {
 		return nil
 	}
-	var apiErr *APIError
-	if errors.As(err, &apiErr) {
+	if apiErr, ok := errors.AsType[*APIError](err); ok {
 		return apiErr
 	}
 	return &APIError{


### PR DESCRIPTION
## Summary

- Bump `go.mod`, `go.work`, and conformance runner from Go 1.25.7 to Go 1.26
- Run `go fix ./...` modernizers: `interface{}` → `any`, `strings.Cut`, `min` builtin, `strings.Builder`
- Adopt `errors.AsType` in hand-written code, tests, doc examples, and the code generation template
- Regenerate `client.gen.go` from updated template; confirm `go fix` is a no-op on generated output

## Test plan

- [x] `make check` passes (fmt, vet, lint, tests) under Go 1.26
- [x] `go fix ./...` is idempotent (second run produces no changes)
- [x] `go fix ./pkg/generated/...` is a no-op after `make generate`