### PR TITLE
Required field support for TypeScript, Swift, Ruby, and Go SDKs

### DIFF
--- a/go/pkg/basecamp/boosts.go
+++ b/go/pkg/basecamp/boosts.go
@@ -269,13 +269,11 @@ func boostFromGenerated(gb generated.Boost) Boost {
 		CreatedAt: gb.CreatedAt,
 	}
 
-	if gb.Id != nil {
-		b.ID = *gb.Id
-	}
+	b.ID = gb.Id
 
-	if gb.Booster.Id != nil || gb.Booster.Name != "" {
+	if gb.Booster.Id != 0 || gb.Booster.Name != "" {
 		b.Booster = &Person{
-			ID:           derefInt64(gb.Booster.Id),
+			ID:           gb.Booster.Id,
 			Name:         gb.Booster.Name,
 			EmailAddress: gb.Booster.EmailAddress,
 			AvatarURL:    gb.Booster.AvatarUrl,
@@ -284,9 +282,9 @@ func boostFromGenerated(gb generated.Boost) Boost {
 		}
 	}
 
-	if gb.Recording.Id != nil || gb.Recording.Title != "" {
+	if gb.Recording.Id != 0 || gb.Recording.Title != "" {
 		b.Recording = &Parent{
-			ID:     derefInt64(gb.Recording.Id),
+			ID:     gb.Recording.Id,
 			Title:  gb.Recording.Title,
 			Type:   gb.Recording.Type,
 			URL:    gb.Recording.Url,

--- a/go/pkg/basecamp/campfires.go
+++ b/go/pkg/basecamp/campfires.go
@@ -554,21 +554,19 @@ func campfireFromGenerated(gc generated.Campfire) Campfire {
 		UpdatedAt:        gc.UpdatedAt,
 	}
 
-	if gc.Id != nil {
-		c.ID = *gc.Id
-	}
+	c.ID = gc.Id
 
-	if gc.Bucket.Id != nil || gc.Bucket.Name != "" {
+	if gc.Bucket.Id != 0 || gc.Bucket.Name != "" {
 		c.Bucket = &Bucket{
-			ID:   derefInt64(gc.Bucket.Id),
+			ID:   gc.Bucket.Id,
 			Name: gc.Bucket.Name,
 			Type: gc.Bucket.Type,
 		}
 	}
 
-	if gc.Creator.Id != nil || gc.Creator.Name != "" {
+	if gc.Creator.Id != 0 || gc.Creator.Name != "" {
 		c.Creator = &Person{
-			ID:           derefInt64(gc.Creator.Id),
+			ID:           gc.Creator.Id,
 			Name:         gc.Creator.Name,
 			EmailAddress: gc.Creator.EmailAddress,
 			AvatarURL:    gc.Creator.AvatarUrl,
@@ -595,13 +593,11 @@ func campfireLineFromGenerated(gl generated.CampfireLine) CampfireLine {
 		UpdatedAt:        gl.UpdatedAt,
 	}
 
-	if gl.Id != nil {
-		l.ID = *gl.Id
-	}
+	l.ID = gl.Id
 
-	if gl.Parent.Id != nil || gl.Parent.Title != "" {
+	if gl.Parent.Id != 0 || gl.Parent.Title != "" {
 		l.Parent = &Parent{
-			ID:     derefInt64(gl.Parent.Id),
+			ID:     gl.Parent.Id,
 			Title:  gl.Parent.Title,
 			Type:   gl.Parent.Type,
 			URL:    gl.Parent.Url,
@@ -609,17 +605,17 @@ func campfireLineFromGenerated(gl generated.CampfireLine) CampfireLine {
 		}
 	}
 
-	if gl.Bucket.Id != nil || gl.Bucket.Name != "" {
+	if gl.Bucket.Id != 0 || gl.Bucket.Name != "" {
 		l.Bucket = &Bucket{
-			ID:   derefInt64(gl.Bucket.Id),
+			ID:   gl.Bucket.Id,
 			Name: gl.Bucket.Name,
 			Type: gl.Bucket.Type,
 		}
 	}
 
-	if gl.Creator.Id != nil || gl.Creator.Name != "" {
+	if gl.Creator.Id != 0 || gl.Creator.Name != "" {
 		l.Creator = &Person{
-			ID:           derefInt64(gl.Creator.Id),
+			ID:           gl.Creator.Id,
 			Name:         gl.Creator.Name,
 			EmailAddress: gl.Creator.EmailAddress,
 			AvatarURL:    gl.Creator.AvatarUrl,
@@ -643,9 +639,7 @@ func chatbotFromGenerated(gc generated.Chatbot) Chatbot {
 		UpdatedAt:   gc.UpdatedAt,
 	}
 
-	if gc.Id != nil {
-		c.ID = *gc.Id
-	}
+	c.ID = gc.Id
 
 	return c
 }

--- a/go/pkg/basecamp/cards.go
+++ b/go/pkg/basecamp/cards.go
@@ -1148,21 +1148,21 @@ func cardTableFromGenerated(gc generated.CardTable) CardTable {
 		UpdatedAt:        gc.UpdatedAt,
 	}
 
-	if gc.Id != nil {
-		ct.ID = *gc.Id
+	if gc.Id != 0 {
+		ct.ID = gc.Id
 	}
 
-	if gc.Bucket.Id != nil || gc.Bucket.Name != "" {
+	if gc.Bucket.Id != 0 || gc.Bucket.Name != "" {
 		ct.Bucket = &Bucket{
-			ID:   derefInt64(gc.Bucket.Id),
+			ID:   gc.Bucket.Id,
 			Name: gc.Bucket.Name,
 			Type: gc.Bucket.Type,
 		}
 	}
 
-	if gc.Creator.Id != nil || gc.Creator.Name != "" {
+	if gc.Creator.Id != 0 || gc.Creator.Name != "" {
 		ct.Creator = &Person{
-			ID:           derefInt64(gc.Creator.Id),
+			ID:           gc.Creator.Id,
 			Name:         gc.Creator.Name,
 			EmailAddress: gc.Creator.EmailAddress,
 			AvatarURL:    gc.Creator.AvatarUrl,
@@ -1209,13 +1209,13 @@ func cardColumnFromGenerated(gc generated.CardColumn) CardColumn {
 		UpdatedAt:        gc.UpdatedAt,
 	}
 
-	if gc.Id != nil {
-		cc.ID = *gc.Id
+	if gc.Id != 0 {
+		cc.ID = gc.Id
 	}
 
-	if gc.Parent.Id != nil || gc.Parent.Title != "" {
+	if gc.Parent.Id != 0 || gc.Parent.Title != "" {
 		cc.Parent = &Parent{
-			ID:     derefInt64(gc.Parent.Id),
+			ID:     gc.Parent.Id,
 			Title:  gc.Parent.Title,
 			Type:   gc.Parent.Type,
 			URL:    gc.Parent.Url,
@@ -1223,17 +1223,17 @@ func cardColumnFromGenerated(gc generated.CardColumn) CardColumn {
 		}
 	}
 
-	if gc.Bucket.Id != nil || gc.Bucket.Name != "" {
+	if gc.Bucket.Id != 0 || gc.Bucket.Name != "" {
 		cc.Bucket = &Bucket{
-			ID:   derefInt64(gc.Bucket.Id),
+			ID:   gc.Bucket.Id,
 			Name: gc.Bucket.Name,
 			Type: gc.Bucket.Type,
 		}
 	}
 
-	if gc.Creator.Id != nil || gc.Creator.Name != "" {
+	if gc.Creator.Id != 0 || gc.Creator.Name != "" {
 		cc.Creator = &Person{
-			ID:           derefInt64(gc.Creator.Id),
+			ID:           gc.Creator.Id,
 			Name:         gc.Creator.Name,
 			EmailAddress: gc.Creator.EmailAddress,
 			AvatarURL:    gc.Creator.AvatarUrl,
@@ -1275,8 +1275,8 @@ func cardFromGenerated(gc generated.Card) Card {
 		UpdatedAt:        gc.UpdatedAt,
 	}
 
-	if gc.Id != nil {
-		c.ID = *gc.Id
+	if gc.Id != 0 {
+		c.ID = gc.Id
 	}
 
 	// Handle due_on - it's types.Date in generated, string in SDK
@@ -1289,9 +1289,9 @@ func cardFromGenerated(gc generated.Card) Card {
 		c.CompletedAt = &gc.CompletedAt
 	}
 
-	if gc.Parent.Id != nil || gc.Parent.Title != "" {
+	if gc.Parent.Id != 0 || gc.Parent.Title != "" {
 		c.Parent = &Parent{
-			ID:     derefInt64(gc.Parent.Id),
+			ID:     gc.Parent.Id,
 			Title:  gc.Parent.Title,
 			Type:   gc.Parent.Type,
 			URL:    gc.Parent.Url,
@@ -1299,17 +1299,17 @@ func cardFromGenerated(gc generated.Card) Card {
 		}
 	}
 
-	if gc.Bucket.Id != nil || gc.Bucket.Name != "" {
+	if gc.Bucket.Id != 0 || gc.Bucket.Name != "" {
 		c.Bucket = &Bucket{
-			ID:   derefInt64(gc.Bucket.Id),
+			ID:   gc.Bucket.Id,
 			Name: gc.Bucket.Name,
 			Type: gc.Bucket.Type,
 		}
 	}
 
-	if gc.Creator.Id != nil || gc.Creator.Name != "" {
+	if gc.Creator.Id != 0 || gc.Creator.Name != "" {
 		c.Creator = &Person{
-			ID:           derefInt64(gc.Creator.Id),
+			ID:           gc.Creator.Id,
 			Name:         gc.Creator.Name,
 			EmailAddress: gc.Creator.EmailAddress,
 			AvatarURL:    gc.Creator.AvatarUrl,
@@ -1318,9 +1318,9 @@ func cardFromGenerated(gc generated.Card) Card {
 		}
 	}
 
-	if gc.Completer.Id != nil || gc.Completer.Name != "" {
+	if gc.Completer.Id != 0 || gc.Completer.Name != "" {
 		c.Completer = &Person{
-			ID:           derefInt64(gc.Completer.Id),
+			ID:           gc.Completer.Id,
 			Name:         gc.Completer.Name,
 			EmailAddress: gc.Completer.EmailAddress,
 			AvatarURL:    gc.Completer.AvatarUrl,
@@ -1370,8 +1370,8 @@ func cardStepFromGenerated(gs generated.CardStep) CardStep {
 		UpdatedAt:        gs.UpdatedAt,
 	}
 
-	if gs.Id != nil {
-		s.ID = *gs.Id
+	if gs.Id != 0 {
+		s.ID = gs.Id
 	}
 
 	// Handle due_on - it's types.Date in generated, string in SDK
@@ -1384,9 +1384,9 @@ func cardStepFromGenerated(gs generated.CardStep) CardStep {
 		s.CompletedAt = &gs.CompletedAt
 	}
 
-	if gs.Parent.Id != nil || gs.Parent.Title != "" {
+	if gs.Parent.Id != 0 || gs.Parent.Title != "" {
 		s.Parent = &Parent{
-			ID:     derefInt64(gs.Parent.Id),
+			ID:     gs.Parent.Id,
 			Title:  gs.Parent.Title,
 			Type:   gs.Parent.Type,
 			URL:    gs.Parent.Url,
@@ -1394,17 +1394,17 @@ func cardStepFromGenerated(gs generated.CardStep) CardStep {
 		}
 	}
 
-	if gs.Bucket.Id != nil || gs.Bucket.Name != "" {
+	if gs.Bucket.Id != 0 || gs.Bucket.Name != "" {
 		s.Bucket = &Bucket{
-			ID:   derefInt64(gs.Bucket.Id),
+			ID:   gs.Bucket.Id,
 			Name: gs.Bucket.Name,
 			Type: gs.Bucket.Type,
 		}
 	}
 
-	if gs.Creator.Id != nil || gs.Creator.Name != "" {
+	if gs.Creator.Id != 0 || gs.Creator.Name != "" {
 		s.Creator = &Person{
-			ID:           derefInt64(gs.Creator.Id),
+			ID:           gs.Creator.Id,
 			Name:         gs.Creator.Name,
 			EmailAddress: gs.Creator.EmailAddress,
 			AvatarURL:    gs.Creator.AvatarUrl,
@@ -1413,9 +1413,9 @@ func cardStepFromGenerated(gs generated.CardStep) CardStep {
 		}
 	}
 
-	if gs.Completer.Id != nil || gs.Completer.Name != "" {
+	if gs.Completer.Id != 0 || gs.Completer.Name != "" {
 		s.Completer = &Person{
-			ID:           derefInt64(gs.Completer.Id),
+			ID:           gs.Completer.Id,
 			Name:         gs.Completer.Name,
 			EmailAddress: gs.Completer.EmailAddress,
 			AvatarURL:    gs.Completer.AvatarUrl,

--- a/go/pkg/basecamp/checkins.go
+++ b/go/pkg/basecamp/checkins.go
@@ -640,21 +640,21 @@ func questionnaireFromGenerated(gq generated.Questionnaire) Questionnaire {
 		Name:             gq.Name,
 	}
 
-	if gq.Id != nil {
-		q.ID = *gq.Id
+	if gq.Id != 0 {
+		q.ID = gq.Id
 	}
 
-	if gq.Bucket.Id != nil || gq.Bucket.Name != "" {
+	if gq.Bucket.Id != 0 || gq.Bucket.Name != "" {
 		q.Bucket = &Bucket{
-			ID:   derefInt64(gq.Bucket.Id),
+			ID:   gq.Bucket.Id,
 			Name: gq.Bucket.Name,
 			Type: gq.Bucket.Type,
 		}
 	}
 
-	if gq.Creator.Id != nil || gq.Creator.Name != "" {
+	if gq.Creator.Id != 0 || gq.Creator.Name != "" {
 		q.Creator = &Person{
-			ID:           derefInt64(gq.Creator.Id),
+			ID:           gq.Creator.Id,
 			Name:         gq.Creator.Name,
 			EmailAddress: gq.Creator.EmailAddress,
 			AvatarURL:    gq.Creator.AvatarUrl,
@@ -685,8 +685,8 @@ func questionFromGenerated(gq generated.Question) Question {
 		AnswersURL:       gq.AnswersUrl,
 	}
 
-	if gq.Id != nil {
-		q.ID = *gq.Id
+	if gq.Id != 0 {
+		q.ID = gq.Id
 	}
 
 	if gq.Schedule.Frequency != "" {
@@ -716,9 +716,9 @@ func questionFromGenerated(gq generated.Question) Question {
 		}
 	}
 
-	if gq.Parent.Id != nil || gq.Parent.Title != "" {
+	if gq.Parent.Id != 0 || gq.Parent.Title != "" {
 		q.Parent = &Parent{
-			ID:     derefInt64(gq.Parent.Id),
+			ID:     gq.Parent.Id,
 			Title:  gq.Parent.Title,
 			Type:   gq.Parent.Type,
 			URL:    gq.Parent.Url,
@@ -726,17 +726,17 @@ func questionFromGenerated(gq generated.Question) Question {
 		}
 	}
 
-	if gq.Bucket.Id != nil || gq.Bucket.Name != "" {
+	if gq.Bucket.Id != 0 || gq.Bucket.Name != "" {
 		q.Bucket = &Bucket{
-			ID:   derefInt64(gq.Bucket.Id),
+			ID:   gq.Bucket.Id,
 			Name: gq.Bucket.Name,
 			Type: gq.Bucket.Type,
 		}
 	}
 
-	if gq.Creator.Id != nil || gq.Creator.Name != "" {
+	if gq.Creator.Id != 0 || gq.Creator.Name != "" {
 		q.Creator = &Person{
-			ID:           derefInt64(gq.Creator.Id),
+			ID:           gq.Creator.Id,
 			Name:         gq.Creator.Name,
 			EmailAddress: gq.Creator.EmailAddress,
 			AvatarURL:    gq.Creator.AvatarUrl,
@@ -767,8 +767,8 @@ func questionAnswerFromGenerated(ga generated.QuestionAnswer) QuestionAnswer {
 		Content:          ga.Content,
 	}
 
-	if ga.Id != nil {
-		a.ID = *ga.Id
+	if ga.Id != 0 {
+		a.ID = ga.Id
 	}
 
 	// Convert date fields to strings
@@ -776,9 +776,9 @@ func questionAnswerFromGenerated(ga generated.QuestionAnswer) QuestionAnswer {
 		a.GroupOn = ga.GroupOn.String()
 	}
 
-	if ga.Parent.Id != nil || ga.Parent.Title != "" {
+	if ga.Parent.Id != 0 || ga.Parent.Title != "" {
 		a.Parent = &Parent{
-			ID:     derefInt64(ga.Parent.Id),
+			ID:     ga.Parent.Id,
 			Title:  ga.Parent.Title,
 			Type:   ga.Parent.Type,
 			URL:    ga.Parent.Url,
@@ -786,17 +786,17 @@ func questionAnswerFromGenerated(ga generated.QuestionAnswer) QuestionAnswer {
 		}
 	}
 
-	if ga.Bucket.Id != nil || ga.Bucket.Name != "" {
+	if ga.Bucket.Id != 0 || ga.Bucket.Name != "" {
 		a.Bucket = &Bucket{
-			ID:   derefInt64(ga.Bucket.Id),
+			ID:   ga.Bucket.Id,
 			Name: ga.Bucket.Name,
 			Type: ga.Bucket.Type,
 		}
 	}
 
-	if ga.Creator.Id != nil || ga.Creator.Name != "" {
+	if ga.Creator.Id != 0 || ga.Creator.Name != "" {
 		a.Creator = &Person{
-			ID:           derefInt64(ga.Creator.Id),
+			ID:           ga.Creator.Id,
 			Name:         ga.Creator.Name,
 			EmailAddress: ga.Creator.EmailAddress,
 			AvatarURL:    ga.Creator.AvatarUrl,

--- a/go/pkg/basecamp/client_approvals.go
+++ b/go/pkg/basecamp/client_approvals.go
@@ -169,8 +169,8 @@ func clientApprovalFromGenerated(ga generated.ClientApproval) ClientApproval {
 		ApprovalStatus:   ga.ApprovalStatus,
 	}
 
-	if ga.Id != nil {
-		a.ID = *ga.Id
+	if ga.Id != 0 {
+		a.ID = ga.Id
 	}
 
 	if !ga.DueOn.IsZero() {
@@ -178,9 +178,9 @@ func clientApprovalFromGenerated(ga generated.ClientApproval) ClientApproval {
 		a.DueOn = &dueOn
 	}
 
-	if ga.Parent.Id != nil || ga.Parent.Title != "" {
+	if ga.Parent.Id != 0 || ga.Parent.Title != "" {
 		a.Parent = &Parent{
-			ID:     derefInt64(ga.Parent.Id),
+			ID:     ga.Parent.Id,
 			Title:  ga.Parent.Title,
 			Type:   ga.Parent.Type,
 			URL:    ga.Parent.Url,
@@ -188,17 +188,17 @@ func clientApprovalFromGenerated(ga generated.ClientApproval) ClientApproval {
 		}
 	}
 
-	if ga.Bucket.Id != nil || ga.Bucket.Name != "" {
+	if ga.Bucket.Id != 0 || ga.Bucket.Name != "" {
 		a.Bucket = &Bucket{
-			ID:   derefInt64(ga.Bucket.Id),
+			ID:   ga.Bucket.Id,
 			Name: ga.Bucket.Name,
 			Type: ga.Bucket.Type,
 		}
 	}
 
-	if ga.Creator.Id != nil || ga.Creator.Name != "" {
+	if ga.Creator.Id != 0 || ga.Creator.Name != "" {
 		a.Creator = &Person{
-			ID:           derefInt64(ga.Creator.Id),
+			ID:           ga.Creator.Id,
 			Name:         ga.Creator.Name,
 			EmailAddress: ga.Creator.EmailAddress,
 			AvatarURL:    ga.Creator.AvatarUrl,
@@ -207,9 +207,9 @@ func clientApprovalFromGenerated(ga generated.ClientApproval) ClientApproval {
 		}
 	}
 
-	if ga.Approver.Id != nil || ga.Approver.Name != "" {
+	if ga.Approver.Id != 0 || ga.Approver.Name != "" {
 		a.Approver = &Person{
-			ID:           derefInt64(ga.Approver.Id),
+			ID:           ga.Approver.Id,
 			Name:         ga.Approver.Name,
 			EmailAddress: ga.Approver.EmailAddress,
 			AvatarURL:    ga.Approver.AvatarUrl,
@@ -238,25 +238,25 @@ func clientApprovalFromGenerated(ga generated.ClientApproval) ClientApproval {
 			if gr.Id != nil {
 				resp.ID = *gr.Id
 			}
-			if gr.Parent.Id != nil || gr.Parent.Title != "" {
+			if gr.Parent.Id != 0 || gr.Parent.Title != "" {
 				resp.Parent = &Parent{
-					ID:     derefInt64(gr.Parent.Id),
+					ID:     gr.Parent.Id,
 					Title:  gr.Parent.Title,
 					Type:   gr.Parent.Type,
 					URL:    gr.Parent.Url,
 					AppURL: gr.Parent.AppUrl,
 				}
 			}
-			if gr.Bucket.Id != nil || gr.Bucket.Name != "" {
+			if gr.Bucket.Id != 0 || gr.Bucket.Name != "" {
 				resp.Bucket = &Bucket{
-					ID:   derefInt64(gr.Bucket.Id),
+					ID:   gr.Bucket.Id,
 					Name: gr.Bucket.Name,
 					Type: gr.Bucket.Type,
 				}
 			}
-			if gr.Creator.Id != nil || gr.Creator.Name != "" {
+			if gr.Creator.Id != 0 || gr.Creator.Name != "" {
 				resp.Creator = &Person{
-					ID:           derefInt64(gr.Creator.Id),
+					ID:           gr.Creator.Id,
 					Name:         gr.Creator.Name,
 					EmailAddress: gr.Creator.EmailAddress,
 					AvatarURL:    gr.Creator.AvatarUrl,

--- a/go/pkg/basecamp/client_correspondences.go
+++ b/go/pkg/basecamp/client_correspondences.go
@@ -145,13 +145,13 @@ func clientCorrespondenceFromGenerated(gc generated.ClientCorrespondence) Client
 		RepliesURL:       gc.RepliesUrl,
 	}
 
-	if gc.Id != nil {
-		c.ID = *gc.Id
+	if gc.Id != 0 {
+		c.ID = gc.Id
 	}
 
-	if gc.Parent.Id != nil || gc.Parent.Title != "" {
+	if gc.Parent.Id != 0 || gc.Parent.Title != "" {
 		c.Parent = &Parent{
-			ID:     derefInt64(gc.Parent.Id),
+			ID:     gc.Parent.Id,
 			Title:  gc.Parent.Title,
 			Type:   gc.Parent.Type,
 			URL:    gc.Parent.Url,
@@ -159,17 +159,17 @@ func clientCorrespondenceFromGenerated(gc generated.ClientCorrespondence) Client
 		}
 	}
 
-	if gc.Bucket.Id != nil || gc.Bucket.Name != "" {
+	if gc.Bucket.Id != 0 || gc.Bucket.Name != "" {
 		c.Bucket = &Bucket{
-			ID:   derefInt64(gc.Bucket.Id),
+			ID:   gc.Bucket.Id,
 			Name: gc.Bucket.Name,
 			Type: gc.Bucket.Type,
 		}
 	}
 
-	if gc.Creator.Id != nil || gc.Creator.Name != "" {
+	if gc.Creator.Id != 0 || gc.Creator.Name != "" {
 		c.Creator = &Person{
-			ID:           derefInt64(gc.Creator.Id),
+			ID:           gc.Creator.Id,
 			Name:         gc.Creator.Name,
 			EmailAddress: gc.Creator.EmailAddress,
 			AvatarURL:    gc.Creator.AvatarUrl,

--- a/go/pkg/basecamp/client_replies.go
+++ b/go/pkg/basecamp/client_replies.go
@@ -138,13 +138,13 @@ func clientReplyFromGenerated(gr generated.ClientReply) ClientReply {
 		Content:          gr.Content,
 	}
 
-	if gr.Id != nil {
-		r.ID = *gr.Id
+	if gr.Id != 0 {
+		r.ID = gr.Id
 	}
 
-	if gr.Parent.Id != nil || gr.Parent.Title != "" {
+	if gr.Parent.Id != 0 || gr.Parent.Title != "" {
 		r.Parent = &Parent{
-			ID:     derefInt64(gr.Parent.Id),
+			ID:     gr.Parent.Id,
 			Title:  gr.Parent.Title,
 			Type:   gr.Parent.Type,
 			URL:    gr.Parent.Url,
@@ -152,17 +152,17 @@ func clientReplyFromGenerated(gr generated.ClientReply) ClientReply {
 		}
 	}
 
-	if gr.Bucket.Id != nil || gr.Bucket.Name != "" {
+	if gr.Bucket.Id != 0 || gr.Bucket.Name != "" {
 		r.Bucket = &Bucket{
-			ID:   derefInt64(gr.Bucket.Id),
+			ID:   gr.Bucket.Id,
 			Name: gr.Bucket.Name,
 			Type: gr.Bucket.Type,
 		}
 	}
 
-	if gr.Creator.Id != nil || gr.Creator.Name != "" {
+	if gr.Creator.Id != 0 || gr.Creator.Name != "" {
 		r.Creator = &Person{
-			ID:           derefInt64(gr.Creator.Id),
+			ID:           gr.Creator.Id,
 			Name:         gr.Creator.Name,
 			EmailAddress: gr.Creator.EmailAddress,
 			AvatarURL:    gr.Creator.AvatarUrl,

--- a/go/pkg/basecamp/comments.go
+++ b/go/pkg/basecamp/comments.go
@@ -312,14 +312,14 @@ func commentFromGenerated(gc generated.Comment) Comment {
 		UpdatedAt: gc.UpdatedAt,
 	}
 
-	if gc.Id != nil {
-		c.ID = *gc.Id
+	if gc.Id != 0 {
+		c.ID = gc.Id
 	}
 
 	// Convert nested types
-	if gc.Parent.Id != nil || gc.Parent.Title != "" {
+	if gc.Parent.Id != 0 || gc.Parent.Title != "" {
 		c.Parent = &Parent{
-			ID:     derefInt64(gc.Parent.Id),
+			ID:     gc.Parent.Id,
 			Title:  gc.Parent.Title,
 			Type:   gc.Parent.Type,
 			URL:    gc.Parent.Url,
@@ -327,17 +327,17 @@ func commentFromGenerated(gc generated.Comment) Comment {
 		}
 	}
 
-	if gc.Bucket.Id != nil || gc.Bucket.Name != "" {
+	if gc.Bucket.Id != 0 || gc.Bucket.Name != "" {
 		c.Bucket = &Bucket{
-			ID:   derefInt64(gc.Bucket.Id),
+			ID:   gc.Bucket.Id,
 			Name: gc.Bucket.Name,
 			Type: gc.Bucket.Type,
 		}
 	}
 
-	if gc.Creator.Id != nil || gc.Creator.Name != "" {
+	if gc.Creator.Id != 0 || gc.Creator.Name != "" {
 		c.Creator = &Person{
-			ID:           derefInt64(gc.Creator.Id),
+			ID:           gc.Creator.Id,
 			Name:         gc.Creator.Name,
 			EmailAddress: gc.Creator.EmailAddress,
 			AvatarURL:    gc.Creator.AvatarUrl,

--- a/go/pkg/basecamp/events.go
+++ b/go/pkg/basecamp/events.go
@@ -150,13 +150,13 @@ func (s *EventsService) List(ctx context.Context, bucketID, recordingID int64, o
 // eventFromGenerated converts a generated Event to our clean type.
 func eventFromGenerated(ge generated.Event) Event {
 	e := Event{
-		RecordingID: derefInt64(ge.RecordingId),
+		RecordingID: ge.RecordingId,
 		Action:      ge.Action,
 		CreatedAt:   ge.CreatedAt,
 	}
 
-	if ge.Id != nil {
-		e.ID = *ge.Id
+	if ge.Id != 0 {
+		e.ID = ge.Id
 	}
 
 	// Convert details
@@ -168,9 +168,9 @@ func eventFromGenerated(ge generated.Event) Event {
 		}
 	}
 
-	if ge.Creator.Id != nil || ge.Creator.Name != "" {
+	if ge.Creator.Id != 0 || ge.Creator.Name != "" {
 		e.Creator = &Person{
-			ID:           derefInt64(ge.Creator.Id),
+			ID:           ge.Creator.Id,
 			Name:         ge.Creator.Name,
 			EmailAddress: ge.Creator.EmailAddress,
 			AvatarURL:    ge.Creator.AvatarUrl,

--- a/go/pkg/basecamp/forwards.go
+++ b/go/pkg/basecamp/forwards.go
@@ -425,21 +425,21 @@ func inboxFromGenerated(gi generated.Inbox) Inbox {
 		AppURL:    gi.AppUrl,
 	}
 
-	if gi.Id != nil {
-		i.ID = *gi.Id
+	if gi.Id != 0 {
+		i.ID = gi.Id
 	}
 
-	if gi.Bucket.Id != nil || gi.Bucket.Name != "" {
+	if gi.Bucket.Id != 0 || gi.Bucket.Name != "" {
 		i.Bucket = &Bucket{
-			ID:   derefInt64(gi.Bucket.Id),
+			ID:   gi.Bucket.Id,
 			Name: gi.Bucket.Name,
 			Type: gi.Bucket.Type,
 		}
 	}
 
-	if gi.Creator.Id != nil || gi.Creator.Name != "" {
+	if gi.Creator.Id != 0 || gi.Creator.Name != "" {
 		i.Creator = &Person{
-			ID:           derefInt64(gi.Creator.Id),
+			ID:           gi.Creator.Id,
 			Name:         gi.Creator.Name,
 			EmailAddress: gi.Creator.EmailAddress,
 			AvatarURL:    gi.Creator.AvatarUrl,
@@ -465,13 +465,13 @@ func forwardFromGenerated(gf generated.Forward) Forward {
 		AppURL:    gf.AppUrl,
 	}
 
-	if gf.Id != nil {
-		f.ID = *gf.Id
+	if gf.Id != 0 {
+		f.ID = gf.Id
 	}
 
-	if gf.Parent.Id != nil || gf.Parent.Title != "" {
+	if gf.Parent.Id != 0 || gf.Parent.Title != "" {
 		f.Parent = &Parent{
-			ID:     derefInt64(gf.Parent.Id),
+			ID:     gf.Parent.Id,
 			Title:  gf.Parent.Title,
 			Type:   gf.Parent.Type,
 			URL:    gf.Parent.Url,
@@ -479,17 +479,17 @@ func forwardFromGenerated(gf generated.Forward) Forward {
 		}
 	}
 
-	if gf.Bucket.Id != nil || gf.Bucket.Name != "" {
+	if gf.Bucket.Id != 0 || gf.Bucket.Name != "" {
 		f.Bucket = &Bucket{
-			ID:   derefInt64(gf.Bucket.Id),
+			ID:   gf.Bucket.Id,
 			Name: gf.Bucket.Name,
 			Type: gf.Bucket.Type,
 		}
 	}
 
-	if gf.Creator.Id != nil || gf.Creator.Name != "" {
+	if gf.Creator.Id != 0 || gf.Creator.Name != "" {
 		f.Creator = &Person{
-			ID:           derefInt64(gf.Creator.Id),
+			ID:           gf.Creator.Id,
 			Name:         gf.Creator.Name,
 			EmailAddress: gf.Creator.EmailAddress,
 			AvatarURL:    gf.Creator.AvatarUrl,
@@ -513,13 +513,13 @@ func forwardReplyFromGenerated(gr generated.ForwardReply) ForwardReply {
 		AppURL:    gr.AppUrl,
 	}
 
-	if gr.Id != nil {
-		r.ID = *gr.Id
+	if gr.Id != 0 {
+		r.ID = gr.Id
 	}
 
-	if gr.Parent.Id != nil || gr.Parent.Title != "" {
+	if gr.Parent.Id != 0 || gr.Parent.Title != "" {
 		r.Parent = &Parent{
-			ID:     derefInt64(gr.Parent.Id),
+			ID:     gr.Parent.Id,
 			Title:  gr.Parent.Title,
 			Type:   gr.Parent.Type,
 			URL:    gr.Parent.Url,
@@ -527,17 +527,17 @@ func forwardReplyFromGenerated(gr generated.ForwardReply) ForwardReply {
 		}
 	}
 
-	if gr.Bucket.Id != nil || gr.Bucket.Name != "" {
+	if gr.Bucket.Id != 0 || gr.Bucket.Name != "" {
 		r.Bucket = &Bucket{
-			ID:   derefInt64(gr.Bucket.Id),
+			ID:   gr.Bucket.Id,
 			Name: gr.Bucket.Name,
 			Type: gr.Bucket.Type,
 		}
 	}
 
-	if gr.Creator.Id != nil || gr.Creator.Name != "" {
+	if gr.Creator.Id != 0 || gr.Creator.Name != "" {
 		r.Creator = &Person{
-			ID:           derefInt64(gr.Creator.Id),
+			ID:           gr.Creator.Id,
 			Name:         gr.Creator.Name,
 			EmailAddress: gr.Creator.EmailAddress,
 			AvatarURL:    gr.Creator.AvatarUrl,

--- a/go/pkg/basecamp/message_boards.go
+++ b/go/pkg/basecamp/message_boards.go
@@ -81,21 +81,21 @@ func messageBoardFromGenerated(gb generated.MessageBoard) MessageBoard {
 		UpdatedAt:     gb.UpdatedAt,
 	}
 
-	if gb.Id != nil {
-		mb.ID = *gb.Id
+	if gb.Id != 0 {
+		mb.ID = gb.Id
 	}
 
-	if gb.Bucket.Id != nil || gb.Bucket.Name != "" {
+	if gb.Bucket.Id != 0 || gb.Bucket.Name != "" {
 		mb.Bucket = &Bucket{
-			ID:   derefInt64(gb.Bucket.Id),
+			ID:   gb.Bucket.Id,
 			Name: gb.Bucket.Name,
 			Type: gb.Bucket.Type,
 		}
 	}
 
-	if gb.Creator.Id != nil || gb.Creator.Name != "" {
+	if gb.Creator.Id != 0 || gb.Creator.Name != "" {
 		mb.Creator = &Person{
-			ID:           derefInt64(gb.Creator.Id),
+			ID:           gb.Creator.Id,
 			Name:         gb.Creator.Name,
 			EmailAddress: gb.Creator.EmailAddress,
 			AvatarURL:    gb.Creator.AvatarUrl,

--- a/go/pkg/basecamp/message_types.go
+++ b/go/pkg/basecamp/message_types.go
@@ -251,8 +251,8 @@ func messageTypeFromGenerated(gt generated.MessageType) MessageType {
 		UpdatedAt: gt.UpdatedAt,
 	}
 
-	if gt.Id != nil {
-		mt.ID = *gt.Id
+	if gt.Id != 0 {
+		mt.ID = gt.Id
 	}
 
 	return mt

--- a/go/pkg/basecamp/messages.go
+++ b/go/pkg/basecamp/messages.go
@@ -432,14 +432,14 @@ func messageFromGenerated(gm generated.Message) Message {
 		UpdatedAt: gm.UpdatedAt,
 	}
 
-	if gm.Id != nil {
-		m.ID = *gm.Id
+	if gm.Id != 0 {
+		m.ID = gm.Id
 	}
 
 	// Convert nested types
-	if gm.Parent.Id != nil || gm.Parent.Title != "" {
+	if gm.Parent.Id != 0 || gm.Parent.Title != "" {
 		m.Parent = &Parent{
-			ID:     derefInt64(gm.Parent.Id),
+			ID:     gm.Parent.Id,
 			Title:  gm.Parent.Title,
 			Type:   gm.Parent.Type,
 			URL:    gm.Parent.Url,
@@ -447,17 +447,17 @@ func messageFromGenerated(gm generated.Message) Message {
 		}
 	}
 
-	if gm.Bucket.Id != nil || gm.Bucket.Name != "" {
+	if gm.Bucket.Id != 0 || gm.Bucket.Name != "" {
 		m.Bucket = &Bucket{
-			ID:   derefInt64(gm.Bucket.Id),
+			ID:   gm.Bucket.Id,
 			Name: gm.Bucket.Name,
 			Type: gm.Bucket.Type,
 		}
 	}
 
-	if gm.Creator.Id != nil || gm.Creator.Name != "" {
+	if gm.Creator.Id != 0 || gm.Creator.Name != "" {
 		m.Creator = &Person{
-			ID:           derefInt64(gm.Creator.Id),
+			ID:           gm.Creator.Id,
 			Name:         gm.Creator.Name,
 			EmailAddress: gm.Creator.EmailAddress,
 			AvatarURL:    gm.Creator.AvatarUrl,
@@ -466,9 +466,9 @@ func messageFromGenerated(gm generated.Message) Message {
 		}
 	}
 
-	if gm.Category.Id != nil || gm.Category.Name != "" {
+	if gm.Category.Id != 0 || gm.Category.Name != "" {
 		m.Category = &MessageType{
-			ID:        derefInt64(gm.Category.Id),
+			ID:        gm.Category.Id,
 			Name:      gm.Category.Name,
 			Icon:      gm.Category.Icon,
 			CreatedAt: gm.Category.CreatedAt,

--- a/go/pkg/basecamp/people.go
+++ b/go/pkg/basecamp/people.go
@@ -407,8 +407,8 @@ func personFromGenerated(gp generated.Person) Person {
 		CanManagePeople:   gp.CanManagePeople,
 	}
 
-	if gp.Id != nil {
-		p.ID = *gp.Id
+	if gp.Id != 0 {
+		p.ID = gp.Id
 	}
 
 	// Convert timestamps to strings (the SDK Person type uses strings for these)
@@ -420,9 +420,9 @@ func personFromGenerated(gp generated.Person) Person {
 	}
 
 	// Convert company
-	if gp.Company.Id != nil || gp.Company.Name != "" {
+	if gp.Company.Id != 0 || gp.Company.Name != "" {
 		p.Company = &PersonCompany{
-			ID:   derefInt64(gp.Company.Id),
+			ID:   gp.Company.Id,
 			Name: gp.Company.Name,
 		}
 	}

--- a/go/pkg/basecamp/projects.go
+++ b/go/pkg/basecamp/projects.go
@@ -369,8 +369,8 @@ func projectFromGenerated(gp generated.Project) Project {
 		UpdatedAt:      gp.UpdatedAt,
 	}
 
-	if gp.Id != nil {
-		p.ID = *gp.Id
+	if gp.Id != 0 {
+		p.ID = gp.Id
 	}
 
 	// Convert dock items
@@ -384,8 +384,8 @@ func projectFromGenerated(gp generated.Project) Project {
 				URL:     gd.Url,
 				AppURL:  gd.AppUrl,
 			}
-			if gd.Id != nil {
-				di.ID = *gd.Id
+			if gd.Id != 0 {
+				di.ID = gd.Id
 			}
 			if gd.Position != 0 {
 				pos := int(gd.Position)
@@ -396,9 +396,9 @@ func projectFromGenerated(gp generated.Project) Project {
 	}
 
 	// Convert client company
-	if gp.ClientCompany.Id != nil || gp.ClientCompany.Name != "" {
+	if gp.ClientCompany.Id != 0 || gp.ClientCompany.Name != "" {
 		p.ClientCompany = &ClientCompany{
-			ID:   derefInt64(gp.ClientCompany.Id),
+			ID:   gp.ClientCompany.Id,
 			Name: gp.ClientCompany.Name,
 		}
 	}

--- a/go/pkg/basecamp/recordings.go
+++ b/go/pkg/basecamp/recordings.go
@@ -378,13 +378,13 @@ func recordingFromGenerated(gr generated.Recording) Recording {
 		BookmarkURL:      gr.BookmarkUrl,
 	}
 
-	if gr.Id != nil {
-		r.ID = *gr.Id
+	if gr.Id != 0 {
+		r.ID = gr.Id
 	}
 
-	if gr.Parent.Id != nil || gr.Parent.Title != "" {
+	if gr.Parent.Id != 0 || gr.Parent.Title != "" {
 		r.Parent = &Parent{
-			ID:     derefInt64(gr.Parent.Id),
+			ID:     gr.Parent.Id,
 			Title:  gr.Parent.Title,
 			Type:   gr.Parent.Type,
 			URL:    gr.Parent.Url,
@@ -392,17 +392,17 @@ func recordingFromGenerated(gr generated.Recording) Recording {
 		}
 	}
 
-	if gr.Bucket.Id != nil || gr.Bucket.Name != "" {
+	if gr.Bucket.Id != 0 || gr.Bucket.Name != "" {
 		r.Bucket = &Bucket{
-			ID:   derefInt64(gr.Bucket.Id),
+			ID:   gr.Bucket.Id,
 			Name: gr.Bucket.Name,
 			Type: gr.Bucket.Type,
 		}
 	}
 
-	if gr.Creator.Id != nil || gr.Creator.Name != "" {
+	if gr.Creator.Id != 0 || gr.Creator.Name != "" {
 		r.Creator = &Person{
-			ID:           derefInt64(gr.Creator.Id),
+			ID:           gr.Creator.Id,
 			Name:         gr.Creator.Name,
 			EmailAddress: gr.Creator.EmailAddress,
 			AvatarURL:    gr.Creator.AvatarUrl,

--- a/go/pkg/basecamp/reports.go
+++ b/go/pkg/basecamp/reports.go
@@ -101,9 +101,9 @@ func (s *ReportsService) AssignedTodos(ctx context.Context, personID int64, opts
 		GroupedBy: resp.JSON200.GroupedBy,
 	}
 
-	if resp.JSON200.Person.Id != nil || resp.JSON200.Person.Name != "" {
+	if resp.JSON200.Person.Id != 0 || resp.JSON200.Person.Name != "" {
 		result.Person = &Person{
-			ID:           derefInt64(resp.JSON200.Person.Id),
+			ID:           resp.JSON200.Person.Id,
 			Name:         resp.JSON200.Person.Name,
 			EmailAddress: resp.JSON200.Person.EmailAddress,
 			AvatarURL:    resp.JSON200.Person.AvatarUrl,
@@ -277,17 +277,17 @@ func assignableFromGenerated(ga generated.Assignable) Assignable {
 		a.StartsOn = ga.StartsOn.String()
 	}
 
-	if ga.Bucket.Id != nil || ga.Bucket.Name != "" {
+	if ga.Bucket.Id != 0 || ga.Bucket.Name != "" {
 		a.Bucket = &Bucket{
-			ID:   derefInt64(ga.Bucket.Id),
+			ID:   ga.Bucket.Id,
 			Name: ga.Bucket.Name,
 			Type: ga.Bucket.Type,
 		}
 	}
 
-	if ga.Parent.Id != nil || ga.Parent.Title != "" {
+	if ga.Parent.Id != 0 || ga.Parent.Title != "" {
 		a.Parent = &Parent{
-			ID:     derefInt64(ga.Parent.Id),
+			ID:     ga.Parent.Id,
 			Title:  ga.Parent.Title,
 			Type:   ga.Parent.Type,
 			URL:    ga.Parent.Url,

--- a/go/pkg/basecamp/schedules.go
+++ b/go/pkg/basecamp/schedules.go
@@ -546,21 +546,21 @@ func scheduleFromGenerated(gs generated.Schedule) Schedule {
 		EntriesURL:            gs.EntriesUrl,
 	}
 
-	if gs.Id != nil {
-		s.ID = *gs.Id
+	if gs.Id != 0 {
+		s.ID = gs.Id
 	}
 
-	if gs.Bucket.Id != nil || gs.Bucket.Name != "" {
+	if gs.Bucket.Id != 0 || gs.Bucket.Name != "" {
 		s.Bucket = &Bucket{
-			ID:   derefInt64(gs.Bucket.Id),
+			ID:   gs.Bucket.Id,
 			Name: gs.Bucket.Name,
 			Type: gs.Bucket.Type,
 		}
 	}
 
-	if gs.Creator.Id != nil || gs.Creator.Name != "" {
+	if gs.Creator.Id != 0 || gs.Creator.Name != "" {
 		s.Creator = &Person{
-			ID:           derefInt64(gs.Creator.Id),
+			ID:           gs.Creator.Id,
 			Name:         gs.Creator.Name,
 			EmailAddress: gs.Creator.EmailAddress,
 			AvatarURL:    gs.Creator.AvatarUrl,
@@ -595,13 +595,13 @@ func scheduleEntryFromGenerated(ge generated.ScheduleEntry) ScheduleEntry {
 		Description:      ge.Description,
 	}
 
-	if ge.Id != nil {
-		e.ID = *ge.Id
+	if ge.Id != 0 {
+		e.ID = ge.Id
 	}
 
-	if ge.Parent.Id != nil || ge.Parent.Title != "" {
+	if ge.Parent.Id != 0 || ge.Parent.Title != "" {
 		e.Parent = &Parent{
-			ID:     derefInt64(ge.Parent.Id),
+			ID:     ge.Parent.Id,
 			Title:  ge.Parent.Title,
 			Type:   ge.Parent.Type,
 			URL:    ge.Parent.Url,
@@ -609,17 +609,17 @@ func scheduleEntryFromGenerated(ge generated.ScheduleEntry) ScheduleEntry {
 		}
 	}
 
-	if ge.Bucket.Id != nil || ge.Bucket.Name != "" {
+	if ge.Bucket.Id != 0 || ge.Bucket.Name != "" {
 		e.Bucket = &Bucket{
-			ID:   derefInt64(ge.Bucket.Id),
+			ID:   ge.Bucket.Id,
 			Name: ge.Bucket.Name,
 			Type: ge.Bucket.Type,
 		}
 	}
 
-	if ge.Creator.Id != nil || ge.Creator.Name != "" {
+	if ge.Creator.Id != 0 || ge.Creator.Name != "" {
 		e.Creator = &Person{
-			ID:           derefInt64(ge.Creator.Id),
+			ID:           ge.Creator.Id,
 			Name:         ge.Creator.Name,
 			EmailAddress: ge.Creator.EmailAddress,
 			AvatarURL:    ge.Creator.AvatarUrl,
@@ -639,8 +639,8 @@ func scheduleEntryFromGenerated(ge generated.ScheduleEntry) ScheduleEntry {
 				Admin:        gp.Admin,
 				Owner:        gp.Owner,
 			}
-			if gp.Id != nil {
-				p.ID = *gp.Id
+			if gp.Id != 0 {
+				p.ID = gp.Id
 			}
 			e.Participants = append(e.Participants, p)
 		}

--- a/go/pkg/basecamp/search.go
+++ b/go/pkg/basecamp/search.go
@@ -164,14 +164,14 @@ func searchResultFromGenerated(gsr generated.SearchResult) SearchResult {
 		Subject:          gsr.Subject,
 	}
 
-	if gsr.Id != nil {
-		sr.ID = *gsr.Id
+	if gsr.Id != 0 {
+		sr.ID = gsr.Id
 	}
 
 	// Convert nested types
-	if gsr.Parent.Id != nil || gsr.Parent.Title != "" {
+	if gsr.Parent.Id != 0 || gsr.Parent.Title != "" {
 		sr.Parent = &Parent{
-			ID:     derefInt64(gsr.Parent.Id),
+			ID:     gsr.Parent.Id,
 			Title:  gsr.Parent.Title,
 			Type:   gsr.Parent.Type,
 			URL:    gsr.Parent.Url,
@@ -179,17 +179,17 @@ func searchResultFromGenerated(gsr generated.SearchResult) SearchResult {
 		}
 	}
 
-	if gsr.Bucket.Id != nil || gsr.Bucket.Name != "" {
+	if gsr.Bucket.Id != 0 || gsr.Bucket.Name != "" {
 		sr.Bucket = &Bucket{
-			ID:   derefInt64(gsr.Bucket.Id),
+			ID:   gsr.Bucket.Id,
 			Name: gsr.Bucket.Name,
 			Type: gsr.Bucket.Type,
 		}
 	}
 
-	if gsr.Creator.Id != nil || gsr.Creator.Name != "" {
+	if gsr.Creator.Id != 0 || gsr.Creator.Name != "" {
 		sr.Creator = &Person{
-			ID:           derefInt64(gsr.Creator.Id),
+			ID:           gsr.Creator.Id,
 			Name:         gsr.Creator.Name,
 			EmailAddress: gsr.Creator.EmailAddress,
 			AvatarURL:    gsr.Creator.AvatarUrl,

--- a/go/pkg/basecamp/subscriptions.go
+++ b/go/pkg/basecamp/subscriptions.go
@@ -188,8 +188,8 @@ func subscriptionFromGenerated(gs generated.Subscription) Subscription {
 				Admin:        gp.Admin,
 				Owner:        gp.Owner,
 			}
-			if gp.Id != nil {
-				p.ID = *gp.Id
+			if gp.Id != 0 {
+				p.ID = gp.Id
 			}
 			s.Subscribers = append(s.Subscribers, p)
 		}

--- a/go/pkg/basecamp/templates.go
+++ b/go/pkg/basecamp/templates.go
@@ -334,8 +334,8 @@ func templateFromGenerated(gt generated.Template) Template {
 		Description: gt.Description,
 	}
 
-	if gt.Id != nil {
-		t.ID = *gt.Id
+	if gt.Id != 0 {
+		t.ID = gt.Id
 	}
 
 	return t
@@ -348,11 +348,11 @@ func projectConstructionFromGenerated(gc generated.ProjectConstruction) ProjectC
 		URL:    gc.Url,
 	}
 
-	if gc.Id != nil {
-		c.ID = *gc.Id
+	if gc.Id != 0 {
+		c.ID = gc.Id
 	}
 
-	if gc.Project.Id != nil || gc.Project.Name != "" {
+	if gc.Project.Id != 0 || gc.Project.Name != "" {
 		c.Project = &Project{
 			Name:        gc.Project.Name,
 			Description: gc.Project.Description,
@@ -363,9 +363,7 @@ func projectConstructionFromGenerated(gc generated.ProjectConstruction) ProjectC
 			URL:         gc.Project.Url,
 			AppURL:      gc.Project.AppUrl,
 		}
-		if gc.Project.Id != nil {
-			c.Project.ID = *gc.Project.Id
-		}
+		c.Project.ID = gc.Project.Id
 	}
 
 	return c

--- a/go/pkg/basecamp/timeline.go
+++ b/go/pkg/basecamp/timeline.go
@@ -138,9 +138,9 @@ func (s *TimelineService) PersonProgress(ctx context.Context, personID int64) (r
 
 	result = &PersonProgressResponse{}
 
-	if resp.JSON200.Person.Id != nil || resp.JSON200.Person.Name != "" {
+	if resp.JSON200.Person.Id != 0 || resp.JSON200.Person.Name != "" {
 		result.Person = &Person{
-			ID:           derefInt64(resp.JSON200.Person.Id),
+			ID:           resp.JSON200.Person.Id,
 			Name:         resp.JSON200.Person.Name,
 			EmailAddress: resp.JSON200.Person.EmailAddress,
 			AvatarURL:    resp.JSON200.Person.AvatarUrl,
@@ -178,9 +178,9 @@ func timelineEventFromGenerated(ge generated.TimelineEvent) TimelineEvent {
 
 	e.CreatedAt = ge.CreatedAt
 
-	if ge.Creator.Id != nil || ge.Creator.Name != "" {
+	if ge.Creator.Id != 0 || ge.Creator.Name != "" {
 		e.Creator = &Person{
-			ID:           derefInt64(ge.Creator.Id),
+			ID:           ge.Creator.Id,
 			Name:         ge.Creator.Name,
 			EmailAddress: ge.Creator.EmailAddress,
 			AvatarURL:    ge.Creator.AvatarUrl,
@@ -189,9 +189,9 @@ func timelineEventFromGenerated(ge generated.TimelineEvent) TimelineEvent {
 		}
 	}
 
-	if ge.Bucket.Id != nil || ge.Bucket.Name != "" {
+	if ge.Bucket.Id != 0 || ge.Bucket.Name != "" {
 		e.Bucket = &Bucket{
-			ID:   derefInt64(ge.Bucket.Id),
+			ID:   ge.Bucket.Id,
 			Name: ge.Bucket.Name,
 			Type: ge.Bucket.Type,
 		}

--- a/go/pkg/basecamp/timesheet.go
+++ b/go/pkg/basecamp/timesheet.go
@@ -365,13 +365,13 @@ func timesheetEntryFromGenerated(ge generated.TimesheetEntry) TimesheetEntry {
 		UpdatedAt:   ge.UpdatedAt,
 	}
 
-	if ge.Id != nil {
-		e.ID = *ge.Id
+	if ge.Id != 0 {
+		e.ID = ge.Id
 	}
 
-	if ge.Creator.Id != nil || ge.Creator.Name != "" {
+	if ge.Creator.Id != 0 || ge.Creator.Name != "" {
 		e.Creator = &Person{
-			ID:           derefInt64(ge.Creator.Id),
+			ID:           ge.Creator.Id,
 			Name:         ge.Creator.Name,
 			EmailAddress: ge.Creator.EmailAddress,
 			AvatarURL:    ge.Creator.AvatarUrl,
@@ -380,9 +380,9 @@ func timesheetEntryFromGenerated(ge generated.TimesheetEntry) TimesheetEntry {
 		}
 	}
 
-	if ge.Person.Id != nil || ge.Person.Name != "" {
+	if ge.Person.Id != 0 || ge.Person.Name != "" {
 		e.Person = &Person{
-			ID:           derefInt64(ge.Person.Id),
+			ID:           ge.Person.Id,
 			Name:         ge.Person.Name,
 			EmailAddress: ge.Person.EmailAddress,
 			AvatarURL:    ge.Person.AvatarUrl,
@@ -391,9 +391,9 @@ func timesheetEntryFromGenerated(ge generated.TimesheetEntry) TimesheetEntry {
 		}
 	}
 
-	if ge.Parent.Id != nil || ge.Parent.Title != "" {
+	if ge.Parent.Id != 0 || ge.Parent.Title != "" {
 		e.Parent = &Parent{
-			ID:     derefInt64(ge.Parent.Id),
+			ID:     ge.Parent.Id,
 			Title:  ge.Parent.Title,
 			Type:   ge.Parent.Type,
 			URL:    ge.Parent.Url,
@@ -401,9 +401,9 @@ func timesheetEntryFromGenerated(ge generated.TimesheetEntry) TimesheetEntry {
 		}
 	}
 
-	if ge.Bucket.Id != nil || ge.Bucket.Name != "" {
+	if ge.Bucket.Id != 0 || ge.Bucket.Name != "" {
 		e.Bucket = &Bucket{
-			ID:   derefInt64(ge.Bucket.Id),
+			ID:   ge.Bucket.Id,
 			Name: ge.Bucket.Name,
 			Type: ge.Bucket.Type,
 		}

--- a/go/pkg/basecamp/todolist_groups.go
+++ b/go/pkg/basecamp/todolist_groups.go
@@ -321,14 +321,14 @@ func todolistGroupFromGenerated(gg generated.TodolistGroup) TodolistGroup {
 		UpdatedAt:        gg.UpdatedAt,
 	}
 
-	if gg.Id != nil {
-		g.ID = *gg.Id
+	if gg.Id != 0 {
+		g.ID = gg.Id
 	}
 
 	// Convert nested types
-	if gg.Parent.Id != nil || gg.Parent.Title != "" {
+	if gg.Parent.Id != 0 || gg.Parent.Title != "" {
 		g.Parent = &Parent{
-			ID:     derefInt64(gg.Parent.Id),
+			ID:     gg.Parent.Id,
 			Title:  gg.Parent.Title,
 			Type:   gg.Parent.Type,
 			URL:    gg.Parent.Url,
@@ -336,17 +336,17 @@ func todolistGroupFromGenerated(gg generated.TodolistGroup) TodolistGroup {
 		}
 	}
 
-	if gg.Bucket.Id != nil || gg.Bucket.Name != "" {
+	if gg.Bucket.Id != 0 || gg.Bucket.Name != "" {
 		g.Bucket = &Bucket{
-			ID:   derefInt64(gg.Bucket.Id),
+			ID:   gg.Bucket.Id,
 			Name: gg.Bucket.Name,
 			Type: gg.Bucket.Type,
 		}
 	}
 
-	if gg.Creator.Id != nil || gg.Creator.Name != "" {
+	if gg.Creator.Id != 0 || gg.Creator.Name != "" {
 		g.Creator = &Person{
-			ID:           derefInt64(gg.Creator.Id),
+			ID:           gg.Creator.Id,
 			Name:         gg.Creator.Name,
 			EmailAddress: gg.Creator.EmailAddress,
 			AvatarURL:    gg.Creator.AvatarUrl,

--- a/go/pkg/basecamp/todolists.go
+++ b/go/pkg/basecamp/todolists.go
@@ -358,14 +358,14 @@ func todolistFromGenerated(gtl generated.Todolist) Todolist {
 		UpdatedAt:        gtl.UpdatedAt,
 	}
 
-	if gtl.Id != nil {
-		tl.ID = *gtl.Id
+	if gtl.Id != 0 {
+		tl.ID = gtl.Id
 	}
 
 	// Convert nested types
-	if gtl.Parent.Id != nil || gtl.Parent.Title != "" {
+	if gtl.Parent.Id != 0 || gtl.Parent.Title != "" {
 		tl.Parent = &Parent{
-			ID:     derefInt64(gtl.Parent.Id),
+			ID:     gtl.Parent.Id,
 			Title:  gtl.Parent.Title,
 			Type:   gtl.Parent.Type,
 			URL:    gtl.Parent.Url,
@@ -373,17 +373,17 @@ func todolistFromGenerated(gtl generated.Todolist) Todolist {
 		}
 	}
 
-	if gtl.Bucket.Id != nil || gtl.Bucket.Name != "" {
+	if gtl.Bucket.Id != 0 || gtl.Bucket.Name != "" {
 		tl.Bucket = &Bucket{
-			ID:   derefInt64(gtl.Bucket.Id),
+			ID:   gtl.Bucket.Id,
 			Name: gtl.Bucket.Name,
 			Type: gtl.Bucket.Type,
 		}
 	}
 
-	if gtl.Creator.Id != nil || gtl.Creator.Name != "" {
+	if gtl.Creator.Id != 0 || gtl.Creator.Name != "" {
 		tl.Creator = &Person{
-			ID:           derefInt64(gtl.Creator.Id),
+			ID:           gtl.Creator.Id,
 			Name:         gtl.Creator.Name,
 			EmailAddress: gtl.Creator.EmailAddress,
 			AvatarURL:    gtl.Creator.AvatarUrl,

--- a/go/pkg/basecamp/todos.go
+++ b/go/pkg/basecamp/todos.go
@@ -528,8 +528,8 @@ func todoFromGenerated(gt generated.Todo) Todo {
 		InheritsVis: gt.InheritsStatus,
 	}
 
-	if gt.Id != nil {
-		t.ID = *gt.Id
+	if gt.Id != 0 {
+		t.ID = gt.Id
 	}
 
 	// Convert date fields to strings
@@ -541,9 +541,9 @@ func todoFromGenerated(gt generated.Todo) Todo {
 	}
 
 	// Convert nested types
-	if gt.Parent.Id != nil || gt.Parent.Title != "" {
+	if gt.Parent.Id != 0 || gt.Parent.Title != "" {
 		t.Parent = &Parent{
-			ID:     derefInt64(gt.Parent.Id),
+			ID:     gt.Parent.Id,
 			Title:  gt.Parent.Title,
 			Type:   gt.Parent.Type,
 			URL:    gt.Parent.Url,
@@ -551,17 +551,17 @@ func todoFromGenerated(gt generated.Todo) Todo {
 		}
 	}
 
-	if gt.Bucket.Id != nil || gt.Bucket.Name != "" {
+	if gt.Bucket.Id != 0 || gt.Bucket.Name != "" {
 		t.Bucket = &Bucket{
-			ID:   derefInt64(gt.Bucket.Id),
+			ID:   gt.Bucket.Id,
 			Name: gt.Bucket.Name,
 			Type: gt.Bucket.Type,
 		}
 	}
 
-	if gt.Creator.Id != nil || gt.Creator.Name != "" {
+	if gt.Creator.Id != 0 || gt.Creator.Name != "" {
 		t.Creator = &Person{
-			ID:           derefInt64(gt.Creator.Id),
+			ID:           gt.Creator.Id,
 			Name:         gt.Creator.Name,
 			EmailAddress: gt.Creator.EmailAddress,
 			AvatarURL:    gt.Creator.AvatarUrl,

--- a/go/pkg/basecamp/todos_test.go
+++ b/go/pkg/basecamp/todos_test.go
@@ -622,7 +622,7 @@ func TestTodoFromGenerated_FullPopulated(t *testing.T) {
 	assigneeID := int64(44444)
 
 	gt := generated.Todo{
-		Id:             &id,
+		Id:             id,
 		Status:         "active",
 		Title:          "Test Todo",
 		Type:           "Todo",
@@ -639,19 +639,19 @@ func TestTodoFromGenerated_FullPopulated(t *testing.T) {
 		UpdatedAt:      time.Date(2024, 1, 5, 15, 30, 0, 0, time.UTC),
 		InheritsStatus: true,
 		Parent: generated.TodoParent{
-			Id:     &parentID,
+			Id:     parentID,
 			Title:  "Parent Todolist",
 			Type:   "Todolist",
 			Url:    "https://example.com/parent",
 			AppUrl: "https://example.com/app/parent",
 		},
 		Bucket: generated.TodoBucket{
-			Id:   &bucketID,
+			Id:   bucketID,
 			Name: "Test Project",
 			Type: "Project",
 		},
 		Creator: generated.Person{
-			Id:           &creatorID,
+			Id:           creatorID,
 			Name:         "Test Creator",
 			EmailAddress: "creator@example.com",
 			AvatarUrl:    "https://example.com/avatar",
@@ -660,7 +660,7 @@ func TestTodoFromGenerated_FullPopulated(t *testing.T) {
 		},
 		Assignees: []generated.Person{
 			{
-				Id:           &assigneeID,
+				Id:           assigneeID,
 				Name:         "Test Assignee",
 				EmailAddress: "assignee@example.com",
 			},
@@ -766,9 +766,9 @@ func TestTodoFromGenerated_FullPopulated(t *testing.T) {
 
 // TestTodoFromGenerated_NilFields tests conversion with nil optional fields.
 func TestTodoFromGenerated_NilFields(t *testing.T) {
-	// Create a generated.Todo with nil ID and empty nested structs
+	// Create a generated.Todo with zero ID and empty nested structs
 	gt := generated.Todo{
-		Id:      nil, // nil ID
+		Id:      0, // zero ID
 		Status:  "active",
 		Title:   "Minimal Todo",
 		Type:    "Todo",
@@ -780,9 +780,9 @@ func TestTodoFromGenerated_NilFields(t *testing.T) {
 
 	todo := todoFromGenerated(gt)
 
-	// Nil ID should result in 0
+	// Zero ID should result in 0
 	if todo.ID != 0 {
-		t.Errorf("expected ID 0 for nil input, got %d", todo.ID)
+		t.Errorf("expected ID 0 for zero input, got %d", todo.ID)
 	}
 
 	// Empty nested structs should NOT create non-nil pointers
@@ -802,7 +802,7 @@ func TestTodoFromGenerated_NilFields(t *testing.T) {
 func TestTodoFromGenerated_ZeroDates(t *testing.T) {
 	id := int64(12345)
 	gt := generated.Todo{
-		Id:       &id,
+		Id:       id,
 		Status:   "active",
 		Title:    "Todo without dates",
 		Type:     "Todo",
@@ -826,7 +826,7 @@ func TestTodoFromGenerated_ZeroDates(t *testing.T) {
 func TestTodoFromGenerated_EmptyAssignees(t *testing.T) {
 	id := int64(12345)
 	gt := generated.Todo{
-		Id:        &id,
+		Id:        id,
 		Status:    "active",
 		Title:     "Todo without assignees",
 		Type:      "Todo",
@@ -850,15 +850,15 @@ func TestTodoFromGenerated_MultipleAssignees(t *testing.T) {
 	id3 := int64(333)
 
 	gt := generated.Todo{
-		Id:      &id,
+		Id:      id,
 		Status:  "active",
 		Title:   "Todo with multiple assignees",
 		Type:    "Todo",
 		Content: "Content",
 		Assignees: []generated.Person{
-			{Id: &id1, Name: "Alice"},
-			{Id: &id2, Name: "Bob"},
-			{Id: &id3, Name: "Charlie"},
+			{Id: id1, Name: "Alice"},
+			{Id: id2, Name: "Bob"},
+			{Id: id3, Name: "Charlie"},
 		},
 	}
 
@@ -890,13 +890,13 @@ func TestTodoFromGenerated_PartialNestedFields(t *testing.T) {
 		Type:    "Todo",
 		Content: "Content",
 		Parent: generated.TodoParent{
-			Id: &parentID, // Only ID, no title
+			Id: parentID, // Only ID, no title
 		},
 		Bucket: generated.TodoBucket{
 			Name: "Project Name", // Only name, no ID
 		},
 		Creator: generated.Person{
-			Id: &creatorID, // Only ID, no name
+			Id: creatorID, // Only ID, no name
 		},
 	}
 

--- a/go/pkg/basecamp/todosets.go
+++ b/go/pkg/basecamp/todosets.go
@@ -103,8 +103,8 @@ func todosetFromGenerated(gts generated.Todoset) Todoset {
 		UpdatedAt:         gts.UpdatedAt,
 	}
 
-	if gts.Id != nil {
-		ts.ID = *gts.Id
+	if gts.Id != 0 {
+		ts.ID = gts.Id
 	}
 
 	if gts.Position != 0 {
@@ -113,17 +113,17 @@ func todosetFromGenerated(gts generated.Todoset) Todoset {
 	}
 
 	// Convert nested types
-	if gts.Bucket.Id != nil || gts.Bucket.Name != "" {
+	if gts.Bucket.Id != 0 || gts.Bucket.Name != "" {
 		ts.Bucket = &Bucket{
-			ID:   derefInt64(gts.Bucket.Id),
+			ID:   gts.Bucket.Id,
 			Name: gts.Bucket.Name,
 			Type: gts.Bucket.Type,
 		}
 	}
 
-	if gts.Creator.Id != nil || gts.Creator.Name != "" {
+	if gts.Creator.Id != 0 || gts.Creator.Name != "" {
 		ts.Creator = &Person{
-			ID:           derefInt64(gts.Creator.Id),
+			ID:           gts.Creator.Id,
 			Name:         gts.Creator.Name,
 			EmailAddress: gts.Creator.EmailAddress,
 			AvatarURL:    gts.Creator.AvatarUrl,

--- a/go/pkg/basecamp/tools.go
+++ b/go/pkg/basecamp/tools.go
@@ -275,8 +275,8 @@ func toolFromGenerated(gt generated.Tool) Tool {
 		AppURL:    gt.AppUrl,
 	}
 
-	if gt.Id != nil {
-		t.ID = *gt.Id
+	if gt.Id != 0 {
+		t.ID = gt.Id
 	}
 
 	if gt.Position != 0 {
@@ -284,9 +284,9 @@ func toolFromGenerated(gt generated.Tool) Tool {
 		t.Position = &pos
 	}
 
-	if gt.Bucket.Id != nil || gt.Bucket.Name != "" {
+	if gt.Bucket.Id != 0 || gt.Bucket.Name != "" {
 		t.Bucket = &Bucket{
-			ID:   derefInt64(gt.Bucket.Id),
+			ID:   gt.Bucket.Id,
 			Name: gt.Bucket.Name,
 			Type: gt.Bucket.Type,
 		}

--- a/go/pkg/basecamp/vaults.go
+++ b/go/pkg/basecamp/vaults.go
@@ -1020,13 +1020,13 @@ func vaultFromGenerated(gv generated.Vault) Vault {
 		UpdatedAt:        gv.UpdatedAt,
 	}
 
-	if gv.Id != nil {
-		v.ID = *gv.Id
+	if gv.Id != 0 {
+		v.ID = gv.Id
 	}
 
-	if gv.Parent.Id != nil || gv.Parent.Title != "" {
+	if gv.Parent.Id != 0 || gv.Parent.Title != "" {
 		v.Parent = &Parent{
-			ID:     derefInt64(gv.Parent.Id),
+			ID:     gv.Parent.Id,
 			Title:  gv.Parent.Title,
 			Type:   gv.Parent.Type,
 			URL:    gv.Parent.Url,
@@ -1034,17 +1034,17 @@ func vaultFromGenerated(gv generated.Vault) Vault {
 		}
 	}
 
-	if gv.Bucket.Id != nil || gv.Bucket.Name != "" {
+	if gv.Bucket.Id != 0 || gv.Bucket.Name != "" {
 		v.Bucket = &Bucket{
-			ID:   derefInt64(gv.Bucket.Id),
+			ID:   gv.Bucket.Id,
 			Name: gv.Bucket.Name,
 			Type: gv.Bucket.Type,
 		}
 	}
 
-	if gv.Creator.Id != nil || gv.Creator.Name != "" {
+	if gv.Creator.Id != 0 || gv.Creator.Name != "" {
 		v.Creator = &Person{
-			ID:           derefInt64(gv.Creator.Id),
+			ID:           gv.Creator.Id,
 			Name:         gv.Creator.Name,
 			EmailAddress: gv.Creator.EmailAddress,
 			AvatarURL:    gv.Creator.AvatarUrl,
@@ -1076,13 +1076,13 @@ func documentFromGenerated(gd generated.Document) Document {
 		UpdatedAt:        gd.UpdatedAt,
 	}
 
-	if gd.Id != nil {
-		d.ID = *gd.Id
+	if gd.Id != 0 {
+		d.ID = gd.Id
 	}
 
-	if gd.Parent.Id != nil || gd.Parent.Title != "" {
+	if gd.Parent.Id != 0 || gd.Parent.Title != "" {
 		d.Parent = &Parent{
-			ID:     derefInt64(gd.Parent.Id),
+			ID:     gd.Parent.Id,
 			Title:  gd.Parent.Title,
 			Type:   gd.Parent.Type,
 			URL:    gd.Parent.Url,
@@ -1090,17 +1090,17 @@ func documentFromGenerated(gd generated.Document) Document {
 		}
 	}
 
-	if gd.Bucket.Id != nil || gd.Bucket.Name != "" {
+	if gd.Bucket.Id != 0 || gd.Bucket.Name != "" {
 		d.Bucket = &Bucket{
-			ID:   derefInt64(gd.Bucket.Id),
+			ID:   gd.Bucket.Id,
 			Name: gd.Bucket.Name,
 			Type: gd.Bucket.Type,
 		}
 	}
 
-	if gd.Creator.Id != nil || gd.Creator.Name != "" {
+	if gd.Creator.Id != 0 || gd.Creator.Name != "" {
 		d.Creator = &Person{
-			ID:           derefInt64(gd.Creator.Id),
+			ID:           gd.Creator.Id,
 			Name:         gd.Creator.Name,
 			EmailAddress: gd.Creator.EmailAddress,
 			AvatarURL:    gd.Creator.AvatarUrl,
@@ -1138,13 +1138,13 @@ func uploadFromGenerated(gu generated.Upload) Upload {
 		UpdatedAt:        gu.UpdatedAt,
 	}
 
-	if gu.Id != nil {
-		u.ID = *gu.Id
+	if gu.Id != 0 {
+		u.ID = gu.Id
 	}
 
-	if gu.Parent.Id != nil || gu.Parent.Title != "" {
+	if gu.Parent.Id != 0 || gu.Parent.Title != "" {
 		u.Parent = &Parent{
-			ID:     derefInt64(gu.Parent.Id),
+			ID:     gu.Parent.Id,
 			Title:  gu.Parent.Title,
 			Type:   gu.Parent.Type,
 			URL:    gu.Parent.Url,
@@ -1152,17 +1152,17 @@ func uploadFromGenerated(gu generated.Upload) Upload {
 		}
 	}
 
-	if gu.Bucket.Id != nil || gu.Bucket.Name != "" {
+	if gu.Bucket.Id != 0 || gu.Bucket.Name != "" {
 		u.Bucket = &Bucket{
-			ID:   derefInt64(gu.Bucket.Id),
+			ID:   gu.Bucket.Id,
 			Name: gu.Bucket.Name,
 			Type: gu.Bucket.Type,
 		}
 	}
 
-	if gu.Creator.Id != nil || gu.Creator.Name != "" {
+	if gu.Creator.Id != 0 || gu.Creator.Name != "" {
 		u.Creator = &Person{
-			ID:           derefInt64(gu.Creator.Id),
+			ID:           gu.Creator.Id,
 			Name:         gu.Creator.Name,
 			EmailAddress: gu.Creator.EmailAddress,
 			AvatarURL:    gu.Creator.AvatarUrl,

--- a/go/pkg/basecamp/webhooks.go
+++ b/go/pkg/basecamp/webhooks.go
@@ -298,8 +298,8 @@ func webhookFromGenerated(gw generated.Webhook) Webhook {
 		URL:        gw.Url,
 	}
 
-	if gw.Id != nil {
-		w.ID = *gw.Id
+	if gw.Id != 0 {
+		w.ID = gw.Id
 	}
 
 	if len(gw.RecentDeliveries) > 0 {
@@ -358,8 +358,8 @@ func webhookEventFromGenerated(ge generated.WebhookEvent) WebhookEvent {
 		CommentsURL:      rec.CommentsUrl,
 		SubscriptionURL:  rec.SubscriptionUrl,
 	}
-	if rec.Id != nil {
-		event.Recording.ID = *rec.Id
+	if rec.Id != 0 {
+		event.Recording.ID = rec.Id
 	}
 	if !rec.CreatedAt.IsZero() {
 		event.Recording.CreatedAt = rec.CreatedAt.Format(time.RFC3339Nano)
@@ -367,29 +367,29 @@ func webhookEventFromGenerated(ge generated.WebhookEvent) WebhookEvent {
 	if !rec.UpdatedAt.IsZero() {
 		event.Recording.UpdatedAt = rec.UpdatedAt.Format(time.RFC3339Nano)
 	}
-	if rec.Parent.Id != nil {
+	if rec.Parent.Id != 0 {
 		event.Recording.Parent = &WebhookEventParent{
 			Title:  rec.Parent.Title,
 			Type:   rec.Parent.Type,
 			URL:    rec.Parent.Url,
 			AppURL: rec.Parent.AppUrl,
 		}
-		event.Recording.Parent.ID = *rec.Parent.Id
+		event.Recording.Parent.ID = rec.Parent.Id
 	}
-	if rec.Bucket.Id != nil {
+	if rec.Bucket.Id != 0 {
 		event.Recording.Bucket = &WebhookEventBucket{
 			Name: rec.Bucket.Name,
 			Type: rec.Bucket.Type,
 		}
-		event.Recording.Bucket.ID = *rec.Bucket.Id
+		event.Recording.Bucket.ID = rec.Bucket.Id
 	}
-	if rec.Creator.Id != nil {
+	if rec.Creator.Id != 0 {
 		p := webhookPersonFromGenerated(rec.Creator)
 		event.Recording.Creator = &p
 	}
 
 	// Map top-level creator
-	if ge.Creator.Id != nil {
+	if ge.Creator.Id != 0 {
 		event.Creator = webhookPersonFromGenerated(ge.Creator)
 	}
 
@@ -432,8 +432,8 @@ func webhookPersonFromGenerated(gp generated.Person) WebhookEventPerson {
 		CanAccessTimesheet:  gp.CanAccessTimesheet,
 		CanAccessHillCharts: gp.CanAccessHillCharts,
 	}
-	if gp.Id != nil {
-		p.ID = *gp.Id
+	if gp.Id != 0 {
+		p.ID = gp.Id
 	}
 	if gp.Bio != "" {
 		p.Bio = &gp.Bio
@@ -447,11 +447,11 @@ func webhookPersonFromGenerated(gp generated.Person) WebhookEventPerson {
 	if !gp.UpdatedAt.IsZero() {
 		p.UpdatedAt = gp.UpdatedAt.Format(time.RFC3339Nano)
 	}
-	if gp.Company.Id != nil {
+	if gp.Company.Id != 0 {
 		p.Company = &WebhookEventCompany{
 			Name: gp.Company.Name,
 		}
-		p.Company.ID = *gp.Company.Id
+		p.Company.ID = gp.Company.Id
 	}
 	return p
 }

--- a/go/pkg/basecamp/webhooks_test.go
+++ b/go/pkg/basecamp/webhooks_test.go
@@ -222,7 +222,7 @@ func TestWebhookPersonFromGenerated_AllFields(t *testing.T) {
 	updatedAt, _ := time.Parse(time.RFC3339, "2022-11-22T08:23:21Z")
 
 	gp := generated.Person{
-		Id:                  &personID,
+		Id:                  personID,
 		AttachableSgid:      "BAh7CEkiCGdpZAY6BkVU--abc123",
 		Name:                "Annie Bryan",
 		EmailAddress:        "annie@honcho.com",
@@ -238,7 +238,7 @@ func TestWebhookPersonFromGenerated_AllFields(t *testing.T) {
 		Employee:            false,
 		TimeZone:            "America/Chicago",
 		AvatarUrl:           "https://example.com/avatar.png",
-		Company:             generated.PersonCompany{Id: &companyID, Name: "Honcho Design"},
+		Company:             generated.PersonCompany{Id: companyID, Name: "Honcho Design"},
 		CanManageProjects:   true,
 		CanManagePeople:     false,
 		CanPing:             true,

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -48,61 +48,61 @@ type BadRequestErrorResponseContent struct {
 type Boost struct {
 	Booster   Person          `json:"booster,omitempty"`
 	Content   string          `json:"content,omitempty"`
-	CreatedAt time.Time       `json:"created_at,omitempty"`
-	Id        *int64          `json:"id,omitempty"`
+	CreatedAt time.Time       `json:"created_at"`
+	Id        int64           `json:"id"`
 	Recording RecordingParent `json:"recording,omitempty"`
 }
 
 // Campfire defines model for Campfire.
 type Campfire struct {
-	AppUrl           string     `json:"app_url,omitempty"`
+	AppUrl           string     `json:"app_url"`
 	BookmarkUrl      string     `json:"bookmark_url,omitempty"`
-	Bucket           TodoBucket `json:"bucket,omitempty"`
-	CreatedAt        time.Time  `json:"created_at,omitempty"`
-	Creator          Person     `json:"creator,omitempty"`
-	Id               *int64     `json:"id,omitempty"`
-	InheritsStatus   bool       `json:"inherits_status,omitempty"`
+	Bucket           TodoBucket `json:"bucket"`
+	CreatedAt        time.Time  `json:"created_at"`
+	Creator          Person     `json:"creator"`
+	Id               int64      `json:"id"`
+	InheritsStatus   bool       `json:"inherits_status"`
 	LinesUrl         string     `json:"lines_url,omitempty"`
 	Position         int32      `json:"position,omitempty"`
-	Status           string     `json:"status,omitempty"`
+	Status           string     `json:"status"`
 	SubscriptionUrl  string     `json:"subscription_url,omitempty"`
-	Title            string     `json:"title,omitempty"`
+	Title            string     `json:"title"`
 	Topic            string     `json:"topic,omitempty"`
-	Type             string     `json:"type,omitempty"`
-	UpdatedAt        time.Time  `json:"updated_at,omitempty"`
-	Url              string     `json:"url,omitempty"`
-	VisibleToClients bool       `json:"visible_to_clients,omitempty"`
+	Type             string     `json:"type"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+	Url              string     `json:"url"`
+	VisibleToClients bool       `json:"visible_to_clients"`
 }
 
 // CampfireLine defines model for CampfireLine.
 type CampfireLine struct {
-	AppUrl           string          `json:"app_url,omitempty"`
+	AppUrl           string          `json:"app_url"`
 	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
 	BoostsCount      int32           `json:"boosts_count,omitempty"`
 	BoostsUrl        string          `json:"boosts_url,omitempty"`
-	Bucket           TodoBucket      `json:"bucket,omitempty"`
-	Content          string          `json:"content,omitempty"`
-	CreatedAt        time.Time       `json:"created_at,omitempty"`
-	Creator          Person          `json:"creator,omitempty"`
-	Id               *int64          `json:"id,omitempty"`
-	InheritsStatus   bool            `json:"inherits_status,omitempty"`
-	Parent           RecordingParent `json:"parent,omitempty"`
-	Status           string          `json:"status,omitempty"`
-	Title            string          `json:"title,omitempty"`
-	Type             string          `json:"type,omitempty"`
-	UpdatedAt        time.Time       `json:"updated_at,omitempty"`
-	Url              string          `json:"url,omitempty"`
-	VisibleToClients bool            `json:"visible_to_clients,omitempty"`
+	Bucket           TodoBucket      `json:"bucket"`
+	Content          string          `json:"content"`
+	CreatedAt        time.Time       `json:"created_at"`
+	Creator          Person          `json:"creator"`
+	Id               int64           `json:"id"`
+	InheritsStatus   bool            `json:"inherits_status"`
+	Parent           RecordingParent `json:"parent"`
+	Status           string          `json:"status"`
+	Title            string          `json:"title"`
+	Type             string          `json:"type"`
+	UpdatedAt        time.Time       `json:"updated_at"`
+	Url              string          `json:"url"`
+	VisibleToClients bool            `json:"visible_to_clients"`
 }
 
 // Card defines model for Card.
 type Card struct {
-	AppUrl                string          `json:"app_url,omitempty"`
+	AppUrl                string          `json:"app_url"`
 	Assignees             []Person        `json:"assignees,omitempty"`
 	BookmarkUrl           string          `json:"bookmark_url,omitempty"`
 	BoostsCount           int32           `json:"boosts_count,omitempty"`
 	BoostsUrl             string          `json:"boosts_url,omitempty"`
-	Bucket                TodoBucket      `json:"bucket,omitempty"`
+	Bucket                TodoBucket      `json:"bucket"`
 	CommentsCount         int32           `json:"comments_count,omitempty"`
 	CommentsUrl           string          `json:"comments_url,omitempty"`
 	Completed             bool            `json:"completed,omitempty"`
@@ -111,131 +111,131 @@ type Card struct {
 	CompletionSubscribers []Person        `json:"completion_subscribers,omitempty"`
 	CompletionUrl         string          `json:"completion_url,omitempty"`
 	Content               string          `json:"content,omitempty"`
-	CreatedAt             time.Time       `json:"created_at,omitempty"`
-	Creator               Person          `json:"creator,omitempty"`
+	CreatedAt             time.Time       `json:"created_at"`
+	Creator               Person          `json:"creator"`
 	Description           string          `json:"description,omitempty"`
 	DueOn                 types.Date      `json:"due_on,omitempty"`
-	Id                    *int64          `json:"id,omitempty"`
-	InheritsStatus        bool            `json:"inherits_status,omitempty"`
-	Parent                RecordingParent `json:"parent,omitempty"`
+	Id                    int64           `json:"id"`
+	InheritsStatus        bool            `json:"inherits_status"`
+	Parent                RecordingParent `json:"parent"`
 	Position              int32           `json:"position,omitempty"`
-	Status                string          `json:"status,omitempty"`
+	Status                string          `json:"status"`
 	Steps                 []CardStep      `json:"steps,omitempty"`
 	SubscriptionUrl       string          `json:"subscription_url,omitempty"`
-	Title                 string          `json:"title,omitempty"`
-	Type                  string          `json:"type,omitempty"`
-	UpdatedAt             time.Time       `json:"updated_at,omitempty"`
-	Url                   string          `json:"url,omitempty"`
-	VisibleToClients      bool            `json:"visible_to_clients,omitempty"`
+	Title                 string          `json:"title"`
+	Type                  string          `json:"type"`
+	UpdatedAt             time.Time       `json:"updated_at"`
+	Url                   string          `json:"url"`
+	VisibleToClients      bool            `json:"visible_to_clients"`
 }
 
 // CardColumn defines model for CardColumn.
 type CardColumn struct {
-	AppUrl           string          `json:"app_url,omitempty"`
+	AppUrl           string          `json:"app_url"`
 	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	Bucket           TodoBucket      `json:"bucket,omitempty"`
+	Bucket           TodoBucket      `json:"bucket"`
 	CardsCount       int32           `json:"cards_count,omitempty"`
 	CardsUrl         string          `json:"cards_url,omitempty"`
 	Color            string          `json:"color,omitempty"`
 	CommentsCount    int32           `json:"comments_count,omitempty"`
-	CreatedAt        time.Time       `json:"created_at,omitempty"`
-	Creator          Person          `json:"creator,omitempty"`
+	CreatedAt        time.Time       `json:"created_at"`
+	Creator          Person          `json:"creator"`
 	Description      string          `json:"description,omitempty"`
-	Id               *int64          `json:"id,omitempty"`
-	InheritsStatus   bool            `json:"inherits_status,omitempty"`
-	Parent           RecordingParent `json:"parent,omitempty"`
+	Id               int64           `json:"id"`
+	InheritsStatus   bool            `json:"inherits_status"`
+	Parent           RecordingParent `json:"parent"`
 	Position         int32           `json:"position,omitempty"`
-	Status           string          `json:"status,omitempty"`
+	Status           string          `json:"status"`
 	Subscribers      []Person        `json:"subscribers,omitempty"`
-	Title            string          `json:"title,omitempty"`
-	Type             string          `json:"type,omitempty"`
-	UpdatedAt        time.Time       `json:"updated_at,omitempty"`
-	Url              string          `json:"url,omitempty"`
-	VisibleToClients bool            `json:"visible_to_clients,omitempty"`
+	Title            string          `json:"title"`
+	Type             string          `json:"type"`
+	UpdatedAt        time.Time       `json:"updated_at"`
+	Url              string          `json:"url"`
+	VisibleToClients bool            `json:"visible_to_clients"`
 }
 
 // CardStep defines model for CardStep.
 type CardStep struct {
-	AppUrl           string          `json:"app_url,omitempty"`
+	AppUrl           string          `json:"app_url"`
 	Assignees        []Person        `json:"assignees,omitempty"`
 	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	Bucket           TodoBucket      `json:"bucket,omitempty"`
+	Bucket           TodoBucket      `json:"bucket"`
 	Completed        bool            `json:"completed,omitempty"`
 	CompletedAt      time.Time       `json:"completed_at,omitempty"`
 	Completer        Person          `json:"completer,omitempty"`
 	CompletionUrl    string          `json:"completion_url,omitempty"`
-	CreatedAt        time.Time       `json:"created_at,omitempty"`
-	Creator          Person          `json:"creator,omitempty"`
+	CreatedAt        time.Time       `json:"created_at"`
+	Creator          Person          `json:"creator"`
 	DueOn            types.Date      `json:"due_on,omitempty"`
-	Id               *int64          `json:"id,omitempty"`
-	InheritsStatus   bool            `json:"inherits_status,omitempty"`
-	Parent           RecordingParent `json:"parent,omitempty"`
+	Id               int64           `json:"id"`
+	InheritsStatus   bool            `json:"inherits_status"`
+	Parent           RecordingParent `json:"parent"`
 	Position         int32           `json:"position,omitempty"`
-	Status           string          `json:"status,omitempty"`
-	Title            string          `json:"title,omitempty"`
-	Type             string          `json:"type,omitempty"`
-	UpdatedAt        time.Time       `json:"updated_at,omitempty"`
-	Url              string          `json:"url,omitempty"`
-	VisibleToClients bool            `json:"visible_to_clients,omitempty"`
+	Status           string          `json:"status"`
+	Title            string          `json:"title"`
+	Type             string          `json:"type"`
+	UpdatedAt        time.Time       `json:"updated_at"`
+	Url              string          `json:"url"`
+	VisibleToClients bool            `json:"visible_to_clients"`
 }
 
 // CardTable defines model for CardTable.
 type CardTable struct {
-	AppUrl           string       `json:"app_url,omitempty"`
+	AppUrl           string       `json:"app_url"`
 	BookmarkUrl      string       `json:"bookmark_url,omitempty"`
-	Bucket           TodoBucket   `json:"bucket,omitempty"`
-	CreatedAt        time.Time    `json:"created_at,omitempty"`
-	Creator          Person       `json:"creator,omitempty"`
-	Id               *int64       `json:"id,omitempty"`
-	InheritsStatus   bool         `json:"inherits_status,omitempty"`
+	Bucket           TodoBucket   `json:"bucket"`
+	CreatedAt        time.Time    `json:"created_at"`
+	Creator          Person       `json:"creator"`
+	Id               int64        `json:"id"`
+	InheritsStatus   bool         `json:"inherits_status"`
 	Lists            []CardColumn `json:"lists,omitempty"`
-	Status           string       `json:"status,omitempty"`
+	Status           string       `json:"status"`
 	Subscribers      []Person     `json:"subscribers,omitempty"`
 	SubscriptionUrl  string       `json:"subscription_url,omitempty"`
-	Title            string       `json:"title,omitempty"`
-	Type             string       `json:"type,omitempty"`
-	UpdatedAt        time.Time    `json:"updated_at,omitempty"`
-	Url              string       `json:"url,omitempty"`
-	VisibleToClients bool         `json:"visible_to_clients,omitempty"`
+	Title            string       `json:"title"`
+	Type             string       `json:"type"`
+	UpdatedAt        time.Time    `json:"updated_at"`
+	Url              string       `json:"url"`
+	VisibleToClients bool         `json:"visible_to_clients"`
 }
 
 // Chatbot defines model for Chatbot.
 type Chatbot struct {
 	AppUrl      string    `json:"app_url,omitempty"`
 	CommandUrl  string    `json:"command_url,omitempty"`
-	CreatedAt   time.Time `json:"created_at,omitempty"`
-	Id          *int64    `json:"id,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	Id          int64     `json:"id"`
 	LinesUrl    string    `json:"lines_url,omitempty"`
-	ServiceName string    `json:"service_name,omitempty"`
-	UpdatedAt   time.Time `json:"updated_at,omitempty"`
+	ServiceName string    `json:"service_name"`
+	UpdatedAt   time.Time `json:"updated_at"`
 	Url         string    `json:"url,omitempty"`
 }
 
 // ClientApproval defines model for ClientApproval.
 type ClientApproval struct {
-	AppUrl           string                   `json:"app_url,omitempty"`
+	AppUrl           string                   `json:"app_url"`
 	ApprovalStatus   string                   `json:"approval_status,omitempty"`
 	Approver         Person                   `json:"approver,omitempty"`
 	BookmarkUrl      string                   `json:"bookmark_url,omitempty"`
-	Bucket           RecordingBucket          `json:"bucket,omitempty"`
+	Bucket           RecordingBucket          `json:"bucket"`
 	Content          string                   `json:"content,omitempty"`
-	CreatedAt        time.Time                `json:"created_at,omitempty"`
-	Creator          Person                   `json:"creator,omitempty"`
+	CreatedAt        time.Time                `json:"created_at"`
+	Creator          Person                   `json:"creator"`
 	DueOn            types.Date               `json:"due_on,omitempty"`
-	Id               *int64                   `json:"id,omitempty"`
-	InheritsStatus   bool                     `json:"inherits_status,omitempty"`
-	Parent           RecordingParent          `json:"parent,omitempty"`
+	Id               int64                    `json:"id"`
+	InheritsStatus   bool                     `json:"inherits_status"`
+	Parent           RecordingParent          `json:"parent"`
 	RepliesCount     int32                    `json:"replies_count,omitempty"`
 	RepliesUrl       string                   `json:"replies_url,omitempty"`
 	Responses        []ClientApprovalResponse `json:"responses,omitempty"`
-	Status           string                   `json:"status,omitempty"`
+	Status           string                   `json:"status"`
 	Subject          string                   `json:"subject,omitempty"`
 	SubscriptionUrl  string                   `json:"subscription_url,omitempty"`
-	Title            string                   `json:"title,omitempty"`
-	Type             string                   `json:"type,omitempty"`
-	UpdatedAt        time.Time                `json:"updated_at,omitempty"`
-	Url              string                   `json:"url,omitempty"`
-	VisibleToClients bool                     `json:"visible_to_clients,omitempty"`
+	Title            string                   `json:"title"`
+	Type             string                   `json:"type"`
+	UpdatedAt        time.Time                `json:"updated_at"`
+	Url              string                   `json:"url"`
+	VisibleToClients bool                     `json:"visible_to_clients"`
 }
 
 // ClientApprovalResponse defines model for ClientApprovalResponse.
@@ -259,50 +259,50 @@ type ClientApprovalResponse struct {
 
 // ClientCompany defines model for ClientCompany.
 type ClientCompany struct {
-	Id   *int64 `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
+	Id   int64  `json:"id"`
+	Name string `json:"name"`
 }
 
 // ClientCorrespondence defines model for ClientCorrespondence.
 type ClientCorrespondence struct {
-	AppUrl           string          `json:"app_url,omitempty"`
+	AppUrl           string          `json:"app_url"`
 	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	Bucket           RecordingBucket `json:"bucket,omitempty"`
+	Bucket           RecordingBucket `json:"bucket"`
 	Content          string          `json:"content,omitempty"`
-	CreatedAt        time.Time       `json:"created_at,omitempty"`
-	Creator          Person          `json:"creator,omitempty"`
-	Id               *int64          `json:"id,omitempty"`
-	InheritsStatus   bool            `json:"inherits_status,omitempty"`
-	Parent           RecordingParent `json:"parent,omitempty"`
+	CreatedAt        time.Time       `json:"created_at"`
+	Creator          Person          `json:"creator"`
+	Id               int64           `json:"id"`
+	InheritsStatus   bool            `json:"inherits_status"`
+	Parent           RecordingParent `json:"parent"`
 	RepliesCount     int32           `json:"replies_count,omitempty"`
 	RepliesUrl       string          `json:"replies_url,omitempty"`
-	Status           string          `json:"status,omitempty"`
-	Subject          string          `json:"subject,omitempty"`
+	Status           string          `json:"status"`
+	Subject          string          `json:"subject"`
 	SubscriptionUrl  string          `json:"subscription_url,omitempty"`
-	Title            string          `json:"title,omitempty"`
-	Type             string          `json:"type,omitempty"`
-	UpdatedAt        time.Time       `json:"updated_at,omitempty"`
-	Url              string          `json:"url,omitempty"`
-	VisibleToClients bool            `json:"visible_to_clients,omitempty"`
+	Title            string          `json:"title"`
+	Type             string          `json:"type"`
+	UpdatedAt        time.Time       `json:"updated_at"`
+	Url              string          `json:"url"`
+	VisibleToClients bool            `json:"visible_to_clients"`
 }
 
 // ClientReply defines model for ClientReply.
 type ClientReply struct {
-	AppUrl           string          `json:"app_url,omitempty"`
+	AppUrl           string          `json:"app_url"`
 	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	Bucket           RecordingBucket `json:"bucket,omitempty"`
-	Content          string          `json:"content,omitempty"`
-	CreatedAt        time.Time       `json:"created_at,omitempty"`
-	Creator          Person          `json:"creator,omitempty"`
-	Id               *int64          `json:"id,omitempty"`
-	InheritsStatus   bool            `json:"inherits_status,omitempty"`
-	Parent           RecordingParent `json:"parent,omitempty"`
-	Status           string          `json:"status,omitempty"`
-	Title            string          `json:"title,omitempty"`
-	Type             string          `json:"type,omitempty"`
-	UpdatedAt        time.Time       `json:"updated_at,omitempty"`
-	Url              string          `json:"url,omitempty"`
-	VisibleToClients bool            `json:"visible_to_clients,omitempty"`
+	Bucket           RecordingBucket `json:"bucket"`
+	Content          string          `json:"content"`
+	CreatedAt        time.Time       `json:"created_at"`
+	Creator          Person          `json:"creator"`
+	Id               int64           `json:"id"`
+	InheritsStatus   bool            `json:"inherits_status"`
+	Parent           RecordingParent `json:"parent"`
+	Status           string          `json:"status"`
+	Title            string          `json:"title"`
+	Type             string          `json:"type"`
+	UpdatedAt        time.Time       `json:"updated_at"`
+	Url              string          `json:"url"`
+	VisibleToClients bool            `json:"visible_to_clients"`
 }
 
 // ClientSide This shape is deprecated since 2024-01: Use Client Visibility feature instead
@@ -321,23 +321,23 @@ type CloneToolResponseContent = Tool
 
 // Comment defines model for Comment.
 type Comment struct {
-	AppUrl           string          `json:"app_url,omitempty"`
+	AppUrl           string          `json:"app_url"`
 	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
 	BoostsCount      int32           `json:"boosts_count,omitempty"`
 	BoostsUrl        string          `json:"boosts_url,omitempty"`
-	Bucket           TodoBucket      `json:"bucket,omitempty"`
-	Content          string          `json:"content,omitempty"`
-	CreatedAt        time.Time       `json:"created_at,omitempty"`
-	Creator          Person          `json:"creator,omitempty"`
-	Id               *int64          `json:"id,omitempty"`
-	InheritsStatus   bool            `json:"inherits_status,omitempty"`
-	Parent           RecordingParent `json:"parent,omitempty"`
-	Status           string          `json:"status,omitempty"`
-	Title            string          `json:"title,omitempty"`
-	Type             string          `json:"type,omitempty"`
-	UpdatedAt        time.Time       `json:"updated_at,omitempty"`
-	Url              string          `json:"url,omitempty"`
-	VisibleToClients bool            `json:"visible_to_clients,omitempty"`
+	Bucket           TodoBucket      `json:"bucket"`
+	Content          string          `json:"content"`
+	CreatedAt        time.Time       `json:"created_at"`
+	Creator          Person          `json:"creator"`
+	Id               int64           `json:"id"`
+	InheritsStatus   bool            `json:"inherits_status"`
+	Parent           RecordingParent `json:"parent"`
+	Status           string          `json:"status"`
+	Title            string          `json:"title"`
+	Type             string          `json:"type"`
+	UpdatedAt        time.Time       `json:"updated_at"`
+	Url              string          `json:"url"`
+	VisibleToClients bool            `json:"visible_to_clients"`
 }
 
 // CreateAnswerResponseContent defines model for CreateAnswerResponseContent.
@@ -604,38 +604,38 @@ type DisableCardColumnOnHoldResponseContent = CardColumn
 
 // DockItem defines model for DockItem.
 type DockItem struct {
-	AppUrl   string `json:"app_url,omitempty"`
-	Enabled  bool   `json:"enabled,omitempty"`
-	Id       *int64 `json:"id,omitempty"`
-	Name     string `json:"name,omitempty"`
+	AppUrl   string `json:"app_url"`
+	Enabled  bool   `json:"enabled"`
+	Id       int64  `json:"id"`
+	Name     string `json:"name"`
 	Position int32  `json:"position,omitempty"`
-	Title    string `json:"title,omitempty"`
-	Url      string `json:"url,omitempty"`
+	Title    string `json:"title"`
+	Url      string `json:"url"`
 }
 
 // Document defines model for Document.
 type Document struct {
-	AppUrl           string          `json:"app_url,omitempty"`
+	AppUrl           string          `json:"app_url"`
 	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
 	BoostsCount      int32           `json:"boosts_count,omitempty"`
 	BoostsUrl        string          `json:"boosts_url,omitempty"`
-	Bucket           TodoBucket      `json:"bucket,omitempty"`
+	Bucket           TodoBucket      `json:"bucket"`
 	CommentsCount    int32           `json:"comments_count,omitempty"`
 	CommentsUrl      string          `json:"comments_url,omitempty"`
 	Content          string          `json:"content,omitempty"`
-	CreatedAt        time.Time       `json:"created_at,omitempty"`
-	Creator          Person          `json:"creator,omitempty"`
-	Id               *int64          `json:"id,omitempty"`
-	InheritsStatus   bool            `json:"inherits_status,omitempty"`
-	Parent           RecordingParent `json:"parent,omitempty"`
+	CreatedAt        time.Time       `json:"created_at"`
+	Creator          Person          `json:"creator"`
+	Id               int64           `json:"id"`
+	InheritsStatus   bool            `json:"inherits_status"`
+	Parent           RecordingParent `json:"parent"`
 	Position         int32           `json:"position,omitempty"`
-	Status           string          `json:"status,omitempty"`
+	Status           string          `json:"status"`
 	SubscriptionUrl  string          `json:"subscription_url,omitempty"`
-	Title            string          `json:"title,omitempty"`
-	Type             string          `json:"type,omitempty"`
-	UpdatedAt        time.Time       `json:"updated_at,omitempty"`
-	Url              string          `json:"url,omitempty"`
-	VisibleToClients bool            `json:"visible_to_clients,omitempty"`
+	Title            string          `json:"title"`
+	Type             string          `json:"type"`
+	UpdatedAt        time.Time       `json:"updated_at"`
+	Url              string          `json:"url"`
+	VisibleToClients bool            `json:"visible_to_clients"`
 }
 
 // EnableCardColumnOnHoldResponseContent defines model for EnableCardColumnOnHoldResponseContent.
@@ -643,14 +643,14 @@ type EnableCardColumnOnHoldResponseContent = CardColumn
 
 // Event defines model for Event.
 type Event struct {
-	Action      string       `json:"action,omitempty"`
+	Action      string       `json:"action"`
 	BoostsCount int32        `json:"boosts_count,omitempty"`
 	BoostsUrl   string       `json:"boosts_url,omitempty"`
-	CreatedAt   time.Time    `json:"created_at,omitempty"`
-	Creator     Person       `json:"creator,omitempty"`
+	CreatedAt   time.Time    `json:"created_at"`
+	Creator     Person       `json:"creator"`
 	Details     EventDetails `json:"details,omitempty"`
-	Id          *int64       `json:"id,omitempty"`
-	RecordingId *int64       `json:"recording_id,omitempty"`
+	Id          int64        `json:"id"`
+	RecordingId int64        `json:"recording_id"`
 }
 
 // EventDetails defines model for EventDetails.
@@ -668,47 +668,47 @@ type ForbiddenErrorResponseContent struct {
 
 // Forward defines model for Forward.
 type Forward struct {
-	AppUrl           string          `json:"app_url,omitempty"`
+	AppUrl           string          `json:"app_url"`
 	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	Bucket           TodoBucket      `json:"bucket,omitempty"`
+	Bucket           TodoBucket      `json:"bucket"`
 	Content          string          `json:"content,omitempty"`
-	CreatedAt        time.Time       `json:"created_at,omitempty"`
-	Creator          Person          `json:"creator,omitempty"`
+	CreatedAt        time.Time       `json:"created_at"`
+	Creator          Person          `json:"creator"`
 	From             string          `json:"from,omitempty"`
-	Id               *int64          `json:"id,omitempty"`
-	InheritsStatus   bool            `json:"inherits_status,omitempty"`
-	Parent           RecordingParent `json:"parent,omitempty"`
+	Id               int64           `json:"id"`
+	InheritsStatus   bool            `json:"inherits_status"`
+	Parent           RecordingParent `json:"parent"`
 	RepliesCount     int32           `json:"replies_count,omitempty"`
 	RepliesUrl       string          `json:"replies_url,omitempty"`
-	Status           string          `json:"status,omitempty"`
-	Subject          string          `json:"subject,omitempty"`
+	Status           string          `json:"status"`
+	Subject          string          `json:"subject"`
 	SubscriptionUrl  string          `json:"subscription_url,omitempty"`
-	Title            string          `json:"title,omitempty"`
-	Type             string          `json:"type,omitempty"`
-	UpdatedAt        time.Time       `json:"updated_at,omitempty"`
-	Url              string          `json:"url,omitempty"`
-	VisibleToClients bool            `json:"visible_to_clients,omitempty"`
+	Title            string          `json:"title"`
+	Type             string          `json:"type"`
+	UpdatedAt        time.Time       `json:"updated_at"`
+	Url              string          `json:"url"`
+	VisibleToClients bool            `json:"visible_to_clients"`
 }
 
 // ForwardReply defines model for ForwardReply.
 type ForwardReply struct {
-	AppUrl           string          `json:"app_url,omitempty"`
+	AppUrl           string          `json:"app_url"`
 	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
 	BoostsCount      int32           `json:"boosts_count,omitempty"`
 	BoostsUrl        string          `json:"boosts_url,omitempty"`
-	Bucket           TodoBucket      `json:"bucket,omitempty"`
-	Content          string          `json:"content,omitempty"`
-	CreatedAt        time.Time       `json:"created_at,omitempty"`
-	Creator          Person          `json:"creator,omitempty"`
-	Id               *int64          `json:"id,omitempty"`
-	InheritsStatus   bool            `json:"inherits_status,omitempty"`
-	Parent           RecordingParent `json:"parent,omitempty"`
-	Status           string          `json:"status,omitempty"`
-	Title            string          `json:"title,omitempty"`
-	Type             string          `json:"type,omitempty"`
-	UpdatedAt        time.Time       `json:"updated_at,omitempty"`
-	Url              string          `json:"url,omitempty"`
-	VisibleToClients bool            `json:"visible_to_clients,omitempty"`
+	Bucket           TodoBucket      `json:"bucket"`
+	Content          string          `json:"content"`
+	CreatedAt        time.Time       `json:"created_at"`
+	Creator          Person          `json:"creator"`
+	Id               int64           `json:"id"`
+	InheritsStatus   bool            `json:"inherits_status"`
+	Parent           RecordingParent `json:"parent"`
+	Status           string          `json:"status"`
+	Title            string          `json:"title"`
+	Type             string          `json:"type"`
+	UpdatedAt        time.Time       `json:"updated_at"`
+	Url              string          `json:"url"`
+	VisibleToClients bool            `json:"visible_to_clients"`
 }
 
 // GetAnswerResponseContent defines model for GetAnswerResponseContent.
@@ -882,22 +882,22 @@ type GetWebhookResponseContent = Webhook
 
 // Inbox defines model for Inbox.
 type Inbox struct {
-	AppUrl           string     `json:"app_url,omitempty"`
+	AppUrl           string     `json:"app_url"`
 	BookmarkUrl      string     `json:"bookmark_url,omitempty"`
-	Bucket           TodoBucket `json:"bucket,omitempty"`
-	CreatedAt        time.Time  `json:"created_at,omitempty"`
-	Creator          Person     `json:"creator,omitempty"`
+	Bucket           TodoBucket `json:"bucket"`
+	CreatedAt        time.Time  `json:"created_at"`
+	Creator          Person     `json:"creator"`
 	ForwardsCount    int32      `json:"forwards_count,omitempty"`
 	ForwardsUrl      string     `json:"forwards_url,omitempty"`
-	Id               *int64     `json:"id,omitempty"`
-	InheritsStatus   bool       `json:"inherits_status,omitempty"`
+	Id               int64      `json:"id"`
+	InheritsStatus   bool       `json:"inherits_status"`
 	Position         int32      `json:"position,omitempty"`
-	Status           string     `json:"status,omitempty"`
-	Title            string     `json:"title,omitempty"`
-	Type             string     `json:"type,omitempty"`
-	UpdatedAt        time.Time  `json:"updated_at,omitempty"`
-	Url              string     `json:"url,omitempty"`
-	VisibleToClients bool       `json:"visible_to_clients,omitempty"`
+	Status           string     `json:"status"`
+	Title            string     `json:"title"`
+	Type             string     `json:"type"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+	Url              string     `json:"url"`
+	VisibleToClients bool       `json:"visible_to_clients"`
 }
 
 // InternalServerErrorResponseContent defines model for InternalServerErrorResponseContent.
@@ -1010,58 +1010,58 @@ type ListWebhooksResponseContent = []Webhook
 
 // Message defines model for Message.
 type Message struct {
-	AppUrl           string          `json:"app_url,omitempty"`
+	AppUrl           string          `json:"app_url"`
 	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
 	BoostsCount      int32           `json:"boosts_count,omitempty"`
 	BoostsUrl        string          `json:"boosts_url,omitempty"`
-	Bucket           TodoBucket      `json:"bucket,omitempty"`
+	Bucket           TodoBucket      `json:"bucket"`
 	Category         MessageType     `json:"category,omitempty"`
 	CommentsCount    int32           `json:"comments_count,omitempty"`
 	CommentsUrl      string          `json:"comments_url,omitempty"`
-	Content          string          `json:"content,omitempty"`
-	CreatedAt        time.Time       `json:"created_at,omitempty"`
-	Creator          Person          `json:"creator,omitempty"`
-	Id               *int64          `json:"id,omitempty"`
-	InheritsStatus   bool            `json:"inherits_status,omitempty"`
-	Parent           RecordingParent `json:"parent,omitempty"`
-	Status           string          `json:"status,omitempty"`
-	Subject          string          `json:"subject,omitempty"`
+	Content          string          `json:"content"`
+	CreatedAt        time.Time       `json:"created_at"`
+	Creator          Person          `json:"creator"`
+	Id               int64           `json:"id"`
+	InheritsStatus   bool            `json:"inherits_status"`
+	Parent           RecordingParent `json:"parent"`
+	Status           string          `json:"status"`
+	Subject          string          `json:"subject"`
 	SubscriptionUrl  string          `json:"subscription_url,omitempty"`
-	Title            string          `json:"title,omitempty"`
-	Type             string          `json:"type,omitempty"`
-	UpdatedAt        time.Time       `json:"updated_at,omitempty"`
-	Url              string          `json:"url,omitempty"`
-	VisibleToClients bool            `json:"visible_to_clients,omitempty"`
+	Title            string          `json:"title"`
+	Type             string          `json:"type"`
+	UpdatedAt        time.Time       `json:"updated_at"`
+	Url              string          `json:"url"`
+	VisibleToClients bool            `json:"visible_to_clients"`
 }
 
 // MessageBoard defines model for MessageBoard.
 type MessageBoard struct {
 	AppMessagesUrl   string     `json:"app_messages_url,omitempty"`
-	AppUrl           string     `json:"app_url,omitempty"`
+	AppUrl           string     `json:"app_url"`
 	BookmarkUrl      string     `json:"bookmark_url,omitempty"`
-	Bucket           TodoBucket `json:"bucket,omitempty"`
-	CreatedAt        time.Time  `json:"created_at,omitempty"`
-	Creator          Person     `json:"creator,omitempty"`
-	Id               *int64     `json:"id,omitempty"`
-	InheritsStatus   bool       `json:"inherits_status,omitempty"`
+	Bucket           TodoBucket `json:"bucket"`
+	CreatedAt        time.Time  `json:"created_at"`
+	Creator          Person     `json:"creator"`
+	Id               int64      `json:"id"`
+	InheritsStatus   bool       `json:"inherits_status"`
 	MessagesCount    int32      `json:"messages_count,omitempty"`
 	MessagesUrl      string     `json:"messages_url,omitempty"`
 	Position         int32      `json:"position,omitempty"`
-	Status           string     `json:"status,omitempty"`
-	Title            string     `json:"title,omitempty"`
-	Type             string     `json:"type,omitempty"`
-	UpdatedAt        time.Time  `json:"updated_at,omitempty"`
-	Url              string     `json:"url,omitempty"`
-	VisibleToClients bool       `json:"visible_to_clients,omitempty"`
+	Status           string     `json:"status"`
+	Title            string     `json:"title"`
+	Type             string     `json:"type"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+	Url              string     `json:"url"`
+	VisibleToClients bool       `json:"visible_to_clients"`
 }
 
 // MessageType defines model for MessageType.
 type MessageType struct {
-	CreatedAt time.Time `json:"created_at,omitempty"`
-	Icon      string    `json:"icon,omitempty"`
-	Id        *int64    `json:"id,omitempty"`
-	Name      string    `json:"name,omitempty"`
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	Icon      string    `json:"icon"`
+	Id        int64     `json:"id"`
+	Name      string    `json:"name"`
+	UpdatedAt time.Time `json:"updated_at"`
 }
 
 // MoveCardColumnRequestContent defines model for MoveCardColumnRequestContent.
@@ -1103,9 +1103,9 @@ type Person struct {
 	CreatedAt           time.Time     `json:"created_at,omitempty"`
 	EmailAddress        string        `json:"email_address,omitempty"`
 	Employee            bool          `json:"employee,omitempty"`
-	Id                  *int64        `json:"id,omitempty"`
+	Id                  int64         `json:"id"`
 	Location            string        `json:"location,omitempty"`
-	Name                string        `json:"name,omitempty"`
+	Name                string        `json:"name"`
 	Owner               bool          `json:"owner,omitempty"`
 	PersonableType      string        `json:"personable_type,omitempty"`
 	TimeZone            string        `json:"time_zone,omitempty"`
@@ -1115,13 +1115,13 @@ type Person struct {
 
 // PersonCompany defines model for PersonCompany.
 type PersonCompany struct {
-	Id   *int64 `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
+	Id   int64  `json:"id"`
+	Name string `json:"name"`
 }
 
 // Project defines model for Project.
 type Project struct {
-	AppUrl         string        `json:"app_url,omitempty"`
+	AppUrl         string        `json:"app_url"`
 	BookmarkUrl    string        `json:"bookmark_url,omitempty"`
 	Bookmarked     bool          `json:"bookmarked,omitempty"`
 	ClientCompany  ClientCompany `json:"client_company,omitempty"`
@@ -1130,17 +1130,17 @@ type Project struct {
 	// Clientside This shape is deprecated since 2024-01: Use Client Visibility feature instead
 	// Deprecated: this property has been marked as deprecated upstream, but no `x-deprecated-reason` was set
 	Clientside  ClientSide `json:"clientside,omitempty"`
-	CreatedAt   time.Time  `json:"created_at,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
 	Description string     `json:"description,omitempty"`
 	Dock        []DockItem `json:"dock,omitempty"`
-	Id          *int64     `json:"id,omitempty"`
-	Name        string     `json:"name,omitempty"`
+	Id          int64      `json:"id"`
+	Name        string     `json:"name"`
 	Purpose     string     `json:"purpose,omitempty"`
 
 	// Status active|archived|trashed
-	Status    string    `json:"status,omitempty"`
-	UpdatedAt time.Time `json:"updated_at,omitempty"`
-	Url       string    `json:"url,omitempty"`
+	Status    string    `json:"status"`
+	UpdatedAt time.Time `json:"updated_at"`
+	Url       string    `json:"url"`
 }
 
 // ProjectAccessResult defines model for ProjectAccessResult.
@@ -1151,9 +1151,9 @@ type ProjectAccessResult struct {
 
 // ProjectConstruction defines model for ProjectConstruction.
 type ProjectConstruction struct {
-	Id      *int64  `json:"id,omitempty"`
+	Id      int64   `json:"id"`
 	Project Project `json:"project,omitempty"`
-	Status  string  `json:"status,omitempty"`
+	Status  string  `json:"status"`
 	Url     string  `json:"url,omitempty"`
 }
 
@@ -1161,48 +1161,48 @@ type ProjectConstruction struct {
 type Question struct {
 	AnswersCount     int32            `json:"answers_count,omitempty"`
 	AnswersUrl       string           `json:"answers_url,omitempty"`
-	AppUrl           string           `json:"app_url,omitempty"`
+	AppUrl           string           `json:"app_url"`
 	BookmarkUrl      string           `json:"bookmark_url,omitempty"`
-	Bucket           RecordingBucket  `json:"bucket,omitempty"`
-	CreatedAt        time.Time        `json:"created_at,omitempty"`
-	Creator          Person           `json:"creator,omitempty"`
-	Id               *int64           `json:"id,omitempty"`
-	InheritsStatus   bool             `json:"inherits_status,omitempty"`
-	Parent           RecordingParent  `json:"parent,omitempty"`
+	Bucket           RecordingBucket  `json:"bucket"`
+	CreatedAt        time.Time        `json:"created_at"`
+	Creator          Person           `json:"creator"`
+	Id               int64            `json:"id"`
+	InheritsStatus   bool             `json:"inherits_status"`
+	Parent           RecordingParent  `json:"parent"`
 	Paused           bool             `json:"paused,omitempty"`
 	Schedule         QuestionSchedule `json:"schedule,omitempty"`
-	Status           string           `json:"status,omitempty"`
+	Status           string           `json:"status"`
 	SubscriptionUrl  string           `json:"subscription_url,omitempty"`
-	Title            string           `json:"title,omitempty"`
-	Type             string           `json:"type,omitempty"`
-	UpdatedAt        time.Time        `json:"updated_at,omitempty"`
-	Url              string           `json:"url,omitempty"`
-	VisibleToClients bool             `json:"visible_to_clients,omitempty"`
+	Title            string           `json:"title"`
+	Type             string           `json:"type"`
+	UpdatedAt        time.Time        `json:"updated_at"`
+	Url              string           `json:"url"`
+	VisibleToClients bool             `json:"visible_to_clients"`
 }
 
 // QuestionAnswer defines model for QuestionAnswer.
 type QuestionAnswer struct {
-	AppUrl           string          `json:"app_url,omitempty"`
+	AppUrl           string          `json:"app_url"`
 	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
 	BoostsCount      int32           `json:"boosts_count,omitempty"`
 	BoostsUrl        string          `json:"boosts_url,omitempty"`
-	Bucket           RecordingBucket `json:"bucket,omitempty"`
+	Bucket           RecordingBucket `json:"bucket"`
 	CommentsCount    int32           `json:"comments_count,omitempty"`
 	CommentsUrl      string          `json:"comments_url,omitempty"`
-	Content          string          `json:"content,omitempty"`
-	CreatedAt        time.Time       `json:"created_at,omitempty"`
-	Creator          Person          `json:"creator,omitempty"`
+	Content          string          `json:"content"`
+	CreatedAt        time.Time       `json:"created_at"`
+	Creator          Person          `json:"creator"`
 	GroupOn          types.Date      `json:"group_on,omitempty"`
-	Id               *int64          `json:"id,omitempty"`
-	InheritsStatus   bool            `json:"inherits_status,omitempty"`
-	Parent           RecordingParent `json:"parent,omitempty"`
-	Status           string          `json:"status,omitempty"`
+	Id               int64           `json:"id"`
+	InheritsStatus   bool            `json:"inherits_status"`
+	Parent           RecordingParent `json:"parent"`
+	Status           string          `json:"status"`
 	SubscriptionUrl  string          `json:"subscription_url,omitempty"`
-	Title            string          `json:"title,omitempty"`
-	Type             string          `json:"type,omitempty"`
-	UpdatedAt        time.Time       `json:"updated_at,omitempty"`
-	Url              string          `json:"url,omitempty"`
-	VisibleToClients bool            `json:"visible_to_clients,omitempty"`
+	Title            string          `json:"title"`
+	Type             string          `json:"type"`
+	UpdatedAt        time.Time       `json:"updated_at"`
+	Url              string          `json:"url"`
+	VisibleToClients bool            `json:"visible_to_clients"`
 }
 
 // QuestionAnswerPayload defines model for QuestionAnswerPayload.
@@ -1239,22 +1239,22 @@ type QuestionSchedule struct {
 
 // Questionnaire defines model for Questionnaire.
 type Questionnaire struct {
-	AppUrl           string          `json:"app_url,omitempty"`
+	AppUrl           string          `json:"app_url"`
 	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	Bucket           RecordingBucket `json:"bucket,omitempty"`
-	CreatedAt        time.Time       `json:"created_at,omitempty"`
-	Creator          Person          `json:"creator,omitempty"`
-	Id               *int64          `json:"id,omitempty"`
-	InheritsStatus   bool            `json:"inherits_status,omitempty"`
-	Name             string          `json:"name,omitempty"`
+	Bucket           RecordingBucket `json:"bucket"`
+	CreatedAt        time.Time       `json:"created_at"`
+	Creator          Person          `json:"creator"`
+	Id               int64           `json:"id"`
+	InheritsStatus   bool            `json:"inherits_status"`
+	Name             string          `json:"name"`
 	QuestionsCount   int32           `json:"questions_count,omitempty"`
 	QuestionsUrl     string          `json:"questions_url,omitempty"`
-	Status           string          `json:"status,omitempty"`
-	Title            string          `json:"title,omitempty"`
-	Type             string          `json:"type,omitempty"`
-	UpdatedAt        time.Time       `json:"updated_at,omitempty"`
-	Url              string          `json:"url,omitempty"`
-	VisibleToClients bool            `json:"visible_to_clients,omitempty"`
+	Status           string          `json:"status"`
+	Title            string          `json:"title"`
+	Type             string          `json:"type"`
+	UpdatedAt        time.Time       `json:"updated_at"`
+	Url              string          `json:"url"`
+	VisibleToClients bool            `json:"visible_to_clients"`
 }
 
 // RateLimitErrorResponseContent defines model for RateLimitErrorResponseContent.
@@ -1266,40 +1266,40 @@ type RateLimitErrorResponseContent struct {
 
 // Recording defines model for Recording.
 type Recording struct {
-	AppUrl           string          `json:"app_url,omitempty"`
+	AppUrl           string          `json:"app_url"`
 	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	Bucket           RecordingBucket `json:"bucket,omitempty"`
+	Bucket           RecordingBucket `json:"bucket"`
 	CommentsCount    int32           `json:"comments_count,omitempty"`
 	CommentsUrl      string          `json:"comments_url,omitempty"`
 	Content          string          `json:"content,omitempty"`
-	CreatedAt        time.Time       `json:"created_at,omitempty"`
-	Creator          Person          `json:"creator,omitempty"`
-	Id               *int64          `json:"id,omitempty"`
-	InheritsStatus   bool            `json:"inherits_status,omitempty"`
-	Parent           RecordingParent `json:"parent,omitempty"`
-	Status           string          `json:"status,omitempty"`
+	CreatedAt        time.Time       `json:"created_at"`
+	Creator          Person          `json:"creator"`
+	Id               int64           `json:"id"`
+	InheritsStatus   bool            `json:"inherits_status"`
+	Parent           RecordingParent `json:"parent"`
+	Status           string          `json:"status"`
 	SubscriptionUrl  string          `json:"subscription_url,omitempty"`
-	Title            string          `json:"title,omitempty"`
-	Type             string          `json:"type,omitempty"`
-	UpdatedAt        time.Time       `json:"updated_at,omitempty"`
-	Url              string          `json:"url,omitempty"`
-	VisibleToClients bool            `json:"visible_to_clients,omitempty"`
+	Title            string          `json:"title"`
+	Type             string          `json:"type"`
+	UpdatedAt        time.Time       `json:"updated_at"`
+	Url              string          `json:"url"`
+	VisibleToClients bool            `json:"visible_to_clients"`
 }
 
 // RecordingBucket defines model for RecordingBucket.
 type RecordingBucket struct {
-	Id   *int64 `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
-	Type string `json:"type,omitempty"`
+	Id   int64  `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
 }
 
 // RecordingParent defines model for RecordingParent.
 type RecordingParent struct {
-	AppUrl string `json:"app_url,omitempty"`
-	Id     *int64 `json:"id,omitempty"`
-	Title  string `json:"title,omitempty"`
-	Type   string `json:"type,omitempty"`
-	Url    string `json:"url,omitempty"`
+	AppUrl string `json:"app_url"`
+	Id     int64  `json:"id"`
+	Title  string `json:"title"`
+	Type   string `json:"type"`
+	Url    string `json:"url"`
 }
 
 // RepositionCardStepRequestContent defines model for RepositionCardStepRequestContent.
@@ -1333,23 +1333,23 @@ type ResumeQuestionResponseContent struct {
 
 // Schedule defines model for Schedule.
 type Schedule struct {
-	AppUrl                string     `json:"app_url,omitempty"`
+	AppUrl                string     `json:"app_url"`
 	BookmarkUrl           string     `json:"bookmark_url,omitempty"`
-	Bucket                TodoBucket `json:"bucket,omitempty"`
-	CreatedAt             time.Time  `json:"created_at,omitempty"`
-	Creator               Person     `json:"creator,omitempty"`
+	Bucket                TodoBucket `json:"bucket"`
+	CreatedAt             time.Time  `json:"created_at"`
+	Creator               Person     `json:"creator"`
 	EntriesCount          int32      `json:"entries_count,omitempty"`
 	EntriesUrl            string     `json:"entries_url,omitempty"`
-	Id                    *int64     `json:"id,omitempty"`
+	Id                    int64      `json:"id"`
 	IncludeDueAssignments bool       `json:"include_due_assignments,omitempty"`
-	InheritsStatus        bool       `json:"inherits_status,omitempty"`
+	InheritsStatus        bool       `json:"inherits_status"`
 	Position              int32      `json:"position,omitempty"`
-	Status                string     `json:"status,omitempty"`
-	Title                 string     `json:"title,omitempty"`
-	Type                  string     `json:"type,omitempty"`
-	UpdatedAt             time.Time  `json:"updated_at,omitempty"`
-	Url                   string     `json:"url,omitempty"`
-	VisibleToClients      bool       `json:"visible_to_clients,omitempty"`
+	Status                string     `json:"status"`
+	Title                 string     `json:"title"`
+	Type                  string     `json:"type"`
+	UpdatedAt             time.Time  `json:"updated_at"`
+	Url                   string     `json:"url"`
+	VisibleToClients      bool       `json:"visible_to_clients"`
 }
 
 // ScheduleAttributes defines model for ScheduleAttributes.
@@ -1361,30 +1361,30 @@ type ScheduleAttributes struct {
 // ScheduleEntry defines model for ScheduleEntry.
 type ScheduleEntry struct {
 	AllDay           bool            `json:"all_day,omitempty"`
-	AppUrl           string          `json:"app_url,omitempty"`
+	AppUrl           string          `json:"app_url"`
 	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
 	BoostsCount      int32           `json:"boosts_count,omitempty"`
 	BoostsUrl        string          `json:"boosts_url,omitempty"`
-	Bucket           TodoBucket      `json:"bucket,omitempty"`
+	Bucket           TodoBucket      `json:"bucket"`
 	CommentsCount    int32           `json:"comments_count,omitempty"`
 	CommentsUrl      string          `json:"comments_url,omitempty"`
-	CreatedAt        time.Time       `json:"created_at,omitempty"`
-	Creator          Person          `json:"creator,omitempty"`
+	CreatedAt        time.Time       `json:"created_at"`
+	Creator          Person          `json:"creator"`
 	Description      string          `json:"description,omitempty"`
 	EndsAt           time.Time       `json:"ends_at,omitempty"`
-	Id               *int64          `json:"id,omitempty"`
-	InheritsStatus   bool            `json:"inherits_status,omitempty"`
-	Parent           RecordingParent `json:"parent,omitempty"`
+	Id               int64           `json:"id"`
+	InheritsStatus   bool            `json:"inherits_status"`
+	Parent           RecordingParent `json:"parent"`
 	Participants     []Person        `json:"participants,omitempty"`
 	StartsAt         time.Time       `json:"starts_at,omitempty"`
-	Status           string          `json:"status,omitempty"`
+	Status           string          `json:"status"`
 	SubscriptionUrl  string          `json:"subscription_url,omitempty"`
-	Summary          string          `json:"summary,omitempty"`
-	Title            string          `json:"title,omitempty"`
-	Type             string          `json:"type,omitempty"`
-	UpdatedAt        time.Time       `json:"updated_at,omitempty"`
-	Url              string          `json:"url,omitempty"`
-	VisibleToClients bool            `json:"visible_to_clients,omitempty"`
+	Summary          string          `json:"summary"`
+	Title            string          `json:"title"`
+	Type             string          `json:"type"`
+	UpdatedAt        time.Time       `json:"updated_at"`
+	Url              string          `json:"url"`
+	VisibleToClients bool            `json:"visible_to_clients"`
 }
 
 // SearchMetadata defines model for SearchMetadata.
@@ -1403,22 +1403,22 @@ type SearchResponseContent = []SearchResult
 
 // SearchResult defines model for SearchResult.
 type SearchResult struct {
-	AppUrl           string          `json:"app_url,omitempty"`
+	AppUrl           string          `json:"app_url"`
 	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
 	Bucket           RecordingBucket `json:"bucket,omitempty"`
 	Content          string          `json:"content,omitempty"`
 	CreatedAt        time.Time       `json:"created_at,omitempty"`
 	Creator          Person          `json:"creator,omitempty"`
 	Description      string          `json:"description,omitempty"`
-	Id               *int64          `json:"id,omitempty"`
+	Id               int64           `json:"id"`
 	InheritsStatus   bool            `json:"inherits_status,omitempty"`
 	Parent           RecordingParent `json:"parent,omitempty"`
 	Status           string          `json:"status,omitempty"`
 	Subject          string          `json:"subject,omitempty"`
-	Title            string          `json:"title,omitempty"`
-	Type             string          `json:"type,omitempty"`
+	Title            string          `json:"title"`
+	Type             string          `json:"type"`
 	UpdatedAt        time.Time       `json:"updated_at,omitempty"`
-	Url              string          `json:"url,omitempty"`
+	Url              string          `json:"url"`
 	VisibleToClients bool            `json:"visible_to_clients,omitempty"`
 }
 
@@ -1453,22 +1453,22 @@ type SubscribeResponseContent = Subscription
 
 // Subscription defines model for Subscription.
 type Subscription struct {
-	Count       int32    `json:"count,omitempty"`
-	Subscribed  bool     `json:"subscribed,omitempty"`
+	Count       int32    `json:"count"`
+	Subscribed  bool     `json:"subscribed"`
 	Subscribers []Person `json:"subscribers,omitempty"`
-	Url         string   `json:"url,omitempty"`
+	Url         string   `json:"url"`
 }
 
 // Template defines model for Template.
 type Template struct {
 	AppUrl      string     `json:"app_url,omitempty"`
-	CreatedAt   time.Time  `json:"created_at,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
 	Description string     `json:"description,omitempty"`
 	Dock        []DockItem `json:"dock,omitempty"`
-	Id          *int64     `json:"id,omitempty"`
-	Name        string     `json:"name,omitempty"`
+	Id          int64      `json:"id"`
+	Name        string     `json:"name"`
 	Status      string     `json:"status,omitempty"`
-	UpdatedAt   time.Time  `json:"updated_at,omitempty"`
+	UpdatedAt   time.Time  `json:"updated_at"`
 	Url         string     `json:"url,omitempty"`
 }
 
@@ -1490,134 +1490,134 @@ type TimelineEvent struct {
 
 // TimesheetEntry defines model for TimesheetEntry.
 type TimesheetEntry struct {
-	AppUrl           string          `json:"app_url,omitempty"`
+	AppUrl           string          `json:"app_url"`
 	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	Bucket           TodoBucket      `json:"bucket,omitempty"`
-	CreatedAt        time.Time       `json:"created_at,omitempty"`
-	Creator          Person          `json:"creator,omitempty"`
+	Bucket           TodoBucket      `json:"bucket"`
+	CreatedAt        time.Time       `json:"created_at"`
+	Creator          Person          `json:"creator"`
 	Date             string          `json:"date,omitempty"`
 	Description      string          `json:"description,omitempty"`
 	Hours            string          `json:"hours,omitempty"`
-	Id               *int64          `json:"id,omitempty"`
-	InheritsStatus   bool            `json:"inherits_status,omitempty"`
-	Parent           RecordingParent `json:"parent,omitempty"`
+	Id               int64           `json:"id"`
+	InheritsStatus   bool            `json:"inherits_status"`
+	Parent           RecordingParent `json:"parent"`
 	Person           Person          `json:"person,omitempty"`
-	Status           string          `json:"status,omitempty"`
-	Title            string          `json:"title,omitempty"`
-	Type             string          `json:"type,omitempty"`
-	UpdatedAt        time.Time       `json:"updated_at,omitempty"`
-	Url              string          `json:"url,omitempty"`
-	VisibleToClients bool            `json:"visible_to_clients,omitempty"`
+	Status           string          `json:"status"`
+	Title            string          `json:"title"`
+	Type             string          `json:"type"`
+	UpdatedAt        time.Time       `json:"updated_at"`
+	Url              string          `json:"url"`
+	VisibleToClients bool            `json:"visible_to_clients"`
 }
 
 // Todo defines model for Todo.
 type Todo struct {
-	AppUrl                string     `json:"app_url,omitempty"`
+	AppUrl                string     `json:"app_url"`
 	Assignees             []Person   `json:"assignees,omitempty"`
 	BookmarkUrl           string     `json:"bookmark_url,omitempty"`
 	BoostsCount           int32      `json:"boosts_count,omitempty"`
 	BoostsUrl             string     `json:"boosts_url,omitempty"`
-	Bucket                TodoBucket `json:"bucket,omitempty"`
+	Bucket                TodoBucket `json:"bucket"`
 	CommentsCount         int32      `json:"comments_count,omitempty"`
 	CommentsUrl           string     `json:"comments_url,omitempty"`
 	Completed             bool       `json:"completed,omitempty"`
 	CompletionSubscribers []Person   `json:"completion_subscribers,omitempty"`
 	CompletionUrl         string     `json:"completion_url,omitempty"`
-	Content               string     `json:"content,omitempty"`
-	CreatedAt             time.Time  `json:"created_at,omitempty"`
-	Creator               Person     `json:"creator,omitempty"`
+	Content               string     `json:"content"`
+	CreatedAt             time.Time  `json:"created_at"`
+	Creator               Person     `json:"creator"`
 	Description           string     `json:"description,omitempty"`
 	DueOn                 types.Date `json:"due_on,omitempty"`
-	Id                    *int64     `json:"id,omitempty"`
-	InheritsStatus        bool       `json:"inherits_status,omitempty"`
-	Parent                TodoParent `json:"parent,omitempty"`
+	Id                    int64      `json:"id"`
+	InheritsStatus        bool       `json:"inherits_status"`
+	Parent                TodoParent `json:"parent"`
 	Position              int32      `json:"position,omitempty"`
 	StartsOn              types.Date `json:"starts_on,omitempty"`
 
 	// Status active|archived|trashed
-	Status           string    `json:"status,omitempty"`
+	Status           string    `json:"status"`
 	SubscriptionUrl  string    `json:"subscription_url,omitempty"`
-	Title            string    `json:"title,omitempty"`
-	Type             string    `json:"type,omitempty"`
-	UpdatedAt        time.Time `json:"updated_at,omitempty"`
-	Url              string    `json:"url,omitempty"`
-	VisibleToClients bool      `json:"visible_to_clients,omitempty"`
+	Title            string    `json:"title"`
+	Type             string    `json:"type"`
+	UpdatedAt        time.Time `json:"updated_at"`
+	Url              string    `json:"url"`
+	VisibleToClients bool      `json:"visible_to_clients"`
 }
 
 // TodoBucket defines model for TodoBucket.
 type TodoBucket struct {
-	Id   *int64 `json:"id,omitempty"`
-	Name string `json:"name,omitempty"`
-	Type string `json:"type,omitempty"`
+	Id   int64  `json:"id"`
+	Name string `json:"name"`
+	Type string `json:"type"`
 }
 
 // TodoParent defines model for TodoParent.
 type TodoParent struct {
-	AppUrl string `json:"app_url,omitempty"`
-	Id     *int64 `json:"id,omitempty"`
-	Title  string `json:"title,omitempty"`
-	Type   string `json:"type,omitempty"`
-	Url    string `json:"url,omitempty"`
+	AppUrl string `json:"app_url"`
+	Id     int64  `json:"id"`
+	Title  string `json:"title"`
+	Type   string `json:"type"`
+	Url    string `json:"url"`
 }
 
 // Todolist defines model for Todolist.
 type Todolist struct {
 	AppTodosUrl    string     `json:"app_todos_url,omitempty"`
-	AppUrl         string     `json:"app_url,omitempty"`
+	AppUrl         string     `json:"app_url"`
 	BookmarkUrl    string     `json:"bookmark_url,omitempty"`
 	BoostsCount    int32      `json:"boosts_count,omitempty"`
 	BoostsUrl      string     `json:"boosts_url,omitempty"`
-	Bucket         TodoBucket `json:"bucket,omitempty"`
+	Bucket         TodoBucket `json:"bucket"`
 	CommentsCount  int32      `json:"comments_count,omitempty"`
 	CommentsUrl    string     `json:"comments_url,omitempty"`
 	Completed      bool       `json:"completed,omitempty"`
 	CompletedRatio string     `json:"completed_ratio,omitempty"`
-	CreatedAt      time.Time  `json:"created_at,omitempty"`
-	Creator        Person     `json:"creator,omitempty"`
+	CreatedAt      time.Time  `json:"created_at"`
+	Creator        Person     `json:"creator"`
 	Description    string     `json:"description,omitempty"`
 	GroupsUrl      string     `json:"groups_url,omitempty"`
-	Id             *int64     `json:"id,omitempty"`
-	InheritsStatus bool       `json:"inherits_status,omitempty"`
-	Name           string     `json:"name,omitempty"`
-	Parent         TodoParent `json:"parent,omitempty"`
+	Id             int64      `json:"id"`
+	InheritsStatus bool       `json:"inherits_status"`
+	Name           string     `json:"name"`
+	Parent         TodoParent `json:"parent"`
 	Position       int32      `json:"position,omitempty"`
 
 	// Status active|archived|trashed
-	Status           string    `json:"status,omitempty"`
+	Status           string    `json:"status"`
 	SubscriptionUrl  string    `json:"subscription_url,omitempty"`
-	Title            string    `json:"title,omitempty"`
+	Title            string    `json:"title"`
 	TodosUrl         string    `json:"todos_url,omitempty"`
-	Type             string    `json:"type,omitempty"`
-	UpdatedAt        time.Time `json:"updated_at,omitempty"`
-	Url              string    `json:"url,omitempty"`
-	VisibleToClients bool      `json:"visible_to_clients,omitempty"`
+	Type             string    `json:"type"`
+	UpdatedAt        time.Time `json:"updated_at"`
+	Url              string    `json:"url"`
+	VisibleToClients bool      `json:"visible_to_clients"`
 }
 
 // TodolistGroup defines model for TodolistGroup.
 type TodolistGroup struct {
 	AppTodosUrl      string     `json:"app_todos_url,omitempty"`
-	AppUrl           string     `json:"app_url,omitempty"`
+	AppUrl           string     `json:"app_url"`
 	BookmarkUrl      string     `json:"bookmark_url,omitempty"`
-	Bucket           TodoBucket `json:"bucket,omitempty"`
+	Bucket           TodoBucket `json:"bucket"`
 	CommentsCount    int32      `json:"comments_count,omitempty"`
 	CommentsUrl      string     `json:"comments_url,omitempty"`
 	Completed        bool       `json:"completed,omitempty"`
 	CompletedRatio   string     `json:"completed_ratio,omitempty"`
-	CreatedAt        time.Time  `json:"created_at,omitempty"`
-	Creator          Person     `json:"creator,omitempty"`
-	Id               *int64     `json:"id,omitempty"`
-	InheritsStatus   bool       `json:"inherits_status,omitempty"`
-	Name             string     `json:"name,omitempty"`
-	Parent           TodoParent `json:"parent,omitempty"`
+	CreatedAt        time.Time  `json:"created_at"`
+	Creator          Person     `json:"creator"`
+	Id               int64      `json:"id"`
+	InheritsStatus   bool       `json:"inherits_status"`
+	Name             string     `json:"name"`
+	Parent           TodoParent `json:"parent"`
 	Position         int32      `json:"position,omitempty"`
-	Status           string     `json:"status,omitempty"`
+	Status           string     `json:"status"`
 	SubscriptionUrl  string     `json:"subscription_url,omitempty"`
-	Title            string     `json:"title,omitempty"`
+	Title            string     `json:"title"`
 	TodosUrl         string     `json:"todos_url,omitempty"`
-	Type             string     `json:"type,omitempty"`
-	UpdatedAt        time.Time  `json:"updated_at,omitempty"`
-	Url              string     `json:"url,omitempty"`
-	VisibleToClients bool       `json:"visible_to_clients,omitempty"`
+	Type             string     `json:"type"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+	Url              string     `json:"url"`
+	VisibleToClients bool       `json:"visible_to_clients"`
 }
 
 // TodolistOrGroup Union type for polymorphic todolist endpoint
@@ -1638,42 +1638,42 @@ type TodolistOrGroup1 struct {
 // Todoset defines model for Todoset.
 type Todoset struct {
 	AppTodolistsUrl   string     `json:"app_todolists_url,omitempty"`
-	AppUrl            string     `json:"app_url,omitempty"`
+	AppUrl            string     `json:"app_url"`
 	BookmarkUrl       string     `json:"bookmark_url,omitempty"`
-	Bucket            TodoBucket `json:"bucket,omitempty"`
+	Bucket            TodoBucket `json:"bucket"`
 	Completed         bool       `json:"completed,omitempty"`
 	CompletedCount    int32      `json:"completed_count,omitempty"`
 	CompletedRatio    string     `json:"completed_ratio,omitempty"`
-	CreatedAt         time.Time  `json:"created_at,omitempty"`
-	Creator           Person     `json:"creator,omitempty"`
-	Id                *int64     `json:"id,omitempty"`
-	InheritsStatus    bool       `json:"inherits_status,omitempty"`
-	Name              string     `json:"name,omitempty"`
+	CreatedAt         time.Time  `json:"created_at"`
+	Creator           Person     `json:"creator"`
+	Id                int64      `json:"id"`
+	InheritsStatus    bool       `json:"inherits_status"`
+	Name              string     `json:"name"`
 	OnScheduleCount   int32      `json:"on_schedule_count,omitempty"`
 	OverScheduleCount int32      `json:"over_schedule_count,omitempty"`
 	Position          int32      `json:"position,omitempty"`
-	Status            string     `json:"status,omitempty"`
-	Title             string     `json:"title,omitempty"`
+	Status            string     `json:"status"`
+	Title             string     `json:"title"`
 	TodolistsCount    int32      `json:"todolists_count,omitempty"`
 	TodolistsUrl      string     `json:"todolists_url,omitempty"`
-	Type              string     `json:"type,omitempty"`
-	UpdatedAt         time.Time  `json:"updated_at,omitempty"`
-	Url               string     `json:"url,omitempty"`
-	VisibleToClients  bool       `json:"visible_to_clients,omitempty"`
+	Type              string     `json:"type"`
+	UpdatedAt         time.Time  `json:"updated_at"`
+	Url               string     `json:"url"`
+	VisibleToClients  bool       `json:"visible_to_clients"`
 }
 
 // Tool defines model for Tool.
 type Tool struct {
 	AppUrl    string          `json:"app_url,omitempty"`
 	Bucket    RecordingBucket `json:"bucket,omitempty"`
-	CreatedAt time.Time       `json:"created_at,omitempty"`
-	Enabled   bool            `json:"enabled,omitempty"`
-	Id        *int64          `json:"id,omitempty"`
-	Name      string          `json:"name,omitempty"`
+	CreatedAt time.Time       `json:"created_at"`
+	Enabled   bool            `json:"enabled"`
+	Id        int64           `json:"id"`
+	Name      string          `json:"name"`
 	Position  int32           `json:"position,omitempty"`
 	Status    string          `json:"status,omitempty"`
-	Title     string          `json:"title,omitempty"`
-	UpdatedAt time.Time       `json:"updated_at,omitempty"`
+	Title     string          `json:"title"`
+	UpdatedAt time.Time       `json:"updated_at"`
 	Url       string          `json:"url,omitempty"`
 }
 
@@ -1928,32 +1928,32 @@ type UpdateWebhookResponseContent = Webhook
 
 // Upload defines model for Upload.
 type Upload struct {
-	AppUrl           string          `json:"app_url,omitempty"`
+	AppUrl           string          `json:"app_url"`
 	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
 	BoostsCount      int32           `json:"boosts_count,omitempty"`
 	BoostsUrl        string          `json:"boosts_url,omitempty"`
-	Bucket           TodoBucket      `json:"bucket,omitempty"`
+	Bucket           TodoBucket      `json:"bucket"`
 	ByteSize         int64           `json:"byte_size,omitempty"`
 	CommentsCount    int32           `json:"comments_count,omitempty"`
 	CommentsUrl      string          `json:"comments_url,omitempty"`
 	ContentType      string          `json:"content_type,omitempty"`
-	CreatedAt        time.Time       `json:"created_at,omitempty"`
-	Creator          Person          `json:"creator,omitempty"`
+	CreatedAt        time.Time       `json:"created_at"`
+	Creator          Person          `json:"creator"`
 	Description      string          `json:"description,omitempty"`
 	DownloadUrl      string          `json:"download_url,omitempty"`
 	Filename         string          `json:"filename,omitempty"`
 	Height           int32           `json:"height,omitempty"`
-	Id               *int64          `json:"id,omitempty"`
-	InheritsStatus   bool            `json:"inherits_status,omitempty"`
-	Parent           RecordingParent `json:"parent,omitempty"`
+	Id               int64           `json:"id"`
+	InheritsStatus   bool            `json:"inherits_status"`
+	Parent           RecordingParent `json:"parent"`
 	Position         int32           `json:"position,omitempty"`
-	Status           string          `json:"status,omitempty"`
+	Status           string          `json:"status"`
 	SubscriptionUrl  string          `json:"subscription_url,omitempty"`
-	Title            string          `json:"title,omitempty"`
-	Type             string          `json:"type,omitempty"`
-	UpdatedAt        time.Time       `json:"updated_at,omitempty"`
-	Url              string          `json:"url,omitempty"`
-	VisibleToClients bool            `json:"visible_to_clients,omitempty"`
+	Title            string          `json:"title"`
+	Type             string          `json:"type"`
+	UpdatedAt        time.Time       `json:"updated_at"`
+	Url              string          `json:"url"`
+	VisibleToClients bool            `json:"visible_to_clients"`
 	Width            int32           `json:"width,omitempty"`
 }
 
@@ -1965,40 +1965,40 @@ type ValidationErrorResponseContent struct {
 
 // Vault defines model for Vault.
 type Vault struct {
-	AppUrl           string          `json:"app_url,omitempty"`
+	AppUrl           string          `json:"app_url"`
 	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	Bucket           TodoBucket      `json:"bucket,omitempty"`
-	CreatedAt        time.Time       `json:"created_at,omitempty"`
-	Creator          Person          `json:"creator,omitempty"`
+	Bucket           TodoBucket      `json:"bucket"`
+	CreatedAt        time.Time       `json:"created_at"`
+	Creator          Person          `json:"creator"`
 	DocumentsCount   int32           `json:"documents_count,omitempty"`
 	DocumentsUrl     string          `json:"documents_url,omitempty"`
-	Id               *int64          `json:"id,omitempty"`
-	InheritsStatus   bool            `json:"inherits_status,omitempty"`
+	Id               int64           `json:"id"`
+	InheritsStatus   bool            `json:"inherits_status"`
 	Parent           RecordingParent `json:"parent,omitempty"`
 	Position         int32           `json:"position,omitempty"`
-	Status           string          `json:"status,omitempty"`
-	Title            string          `json:"title,omitempty"`
-	Type             string          `json:"type,omitempty"`
-	UpdatedAt        time.Time       `json:"updated_at,omitempty"`
+	Status           string          `json:"status"`
+	Title            string          `json:"title"`
+	Type             string          `json:"type"`
+	UpdatedAt        time.Time       `json:"updated_at"`
 	UploadsCount     int32           `json:"uploads_count,omitempty"`
 	UploadsUrl       string          `json:"uploads_url,omitempty"`
-	Url              string          `json:"url,omitempty"`
+	Url              string          `json:"url"`
 	VaultsCount      int32           `json:"vaults_count,omitempty"`
 	VaultsUrl        string          `json:"vaults_url,omitempty"`
-	VisibleToClients bool            `json:"visible_to_clients,omitempty"`
+	VisibleToClients bool            `json:"visible_to_clients"`
 }
 
 // Webhook defines model for Webhook.
 type Webhook struct {
 	Active           bool              `json:"active,omitempty"`
-	AppUrl           string            `json:"app_url,omitempty"`
-	CreatedAt        time.Time         `json:"created_at,omitempty"`
-	Id               *int64            `json:"id,omitempty"`
-	PayloadUrl       string            `json:"payload_url,omitempty"`
+	AppUrl           string            `json:"app_url"`
+	CreatedAt        time.Time         `json:"created_at"`
+	Id               int64             `json:"id"`
+	PayloadUrl       string            `json:"payload_url"`
 	RecentDeliveries []WebhookDelivery `json:"recent_deliveries,omitempty"`
 	Types            []string          `json:"types,omitempty"`
-	UpdatedAt        time.Time         `json:"updated_at,omitempty"`
-	Url              string            `json:"url,omitempty"`
+	UpdatedAt        time.Time         `json:"updated_at"`
+	Url              string            `json:"url"`
 }
 
 // WebhookCopy Reference to a copied/moved recording in copy events.

--- a/ruby/lib/basecamp/generated/metadata.json
+++ b/ruby/lib/basecamp/generated/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-02-08T08:09:22Z",
+  "generated": "2026-02-13T21:03:57Z",
   "operations": {
     "CreateAttachment": {
       "retry": {

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Auto-generated from OpenAPI spec. Do not edit manually.
-# Generated: 2026-02-08T08:09:22Z
+# Generated: 2026-02-13T21:03:57Z
 
 require "json"
 require "time"
@@ -65,33 +65,33 @@ module Basecamp
     # Assignable
     class Assignable
       include TypeHelpers
-      attr_accessor :id, :title, :type, :url, :app_url, :bucket, :parent, :due_on, :starts_on, :assignees
+      attr_accessor :app_url, :assignees, :bucket, :due_on, :id, :parent, :starts_on, :title, :type, :url
 
       def initialize(data = {})
+        @app_url = data["app_url"]
+        @assignees = parse_array(data["assignees"], "Person")
+        @bucket = parse_type(data["bucket"], "TodoBucket")
+        @due_on = data["due_on"]
         @id = parse_integer(data["id"])
+        @parent = parse_type(data["parent"], "TodoParent")
+        @starts_on = data["starts_on"]
         @title = data["title"]
         @type = data["type"]
         @url = data["url"]
-        @app_url = data["app_url"]
-        @bucket = parse_type(data["bucket"], "TodoBucket")
-        @parent = parse_type(data["parent"], "TodoParent")
-        @due_on = data["due_on"]
-        @starts_on = data["starts_on"]
-        @assignees = parse_array(data["assignees"], "Person")
       end
 
       def to_h
         {
+          "app_url" => @app_url,
+          "assignees" => @assignees,
+          "bucket" => @bucket,
+          "due_on" => @due_on,
           "id" => @id,
+          "parent" => @parent,
+          "starts_on" => @starts_on,
           "title" => @title,
           "type" => @type,
           "url" => @url,
-          "app_url" => @app_url,
-          "bucket" => @bucket,
-          "parent" => @parent,
-          "due_on" => @due_on,
-          "starts_on" => @starts_on,
-          "assignees" => @assignees,
         }.compact
       end
 
@@ -103,22 +103,27 @@ module Basecamp
     # Boost
     class Boost
       include TypeHelpers
-      attr_accessor :id, :content, :created_at, :booster, :recording
+      attr_accessor :created_at, :id, :booster, :content, :recording
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[created_at id].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @content = data["content"]
         @created_at = parse_datetime(data["created_at"])
+        @id = parse_integer(data["id"])
         @booster = parse_type(data["booster"], "Person")
+        @content = data["content"]
         @recording = parse_type(data["recording"], "RecordingParent")
       end
 
       def to_h
         {
-          "id" => @id,
-          "content" => @content,
           "created_at" => @created_at,
+          "id" => @id,
           "booster" => @booster,
+          "content" => @content,
           "recording" => @recording,
         }.compact
       end
@@ -131,47 +136,52 @@ module Basecamp
     # Campfire
     class Campfire
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :subscription_url, :position, :bucket, :creator, :topic, :lines_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :lines_url, :position, :subscription_url, :topic
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @subscription_url = data["subscription_url"]
-        @position = parse_integer(data["position"])
         @bucket = parse_type(data["bucket"], "TodoBucket")
+        @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
-        @topic = data["topic"]
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @bookmark_url = data["bookmark_url"]
         @lines_url = data["lines_url"]
+        @position = parse_integer(data["position"])
+        @subscription_url = data["subscription_url"]
+        @topic = data["topic"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "subscription_url" => @subscription_url,
-          "position" => @position,
           "bucket" => @bucket,
+          "created_at" => @created_at,
           "creator" => @creator,
-          "topic" => @topic,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "bookmark_url" => @bookmark_url,
           "lines_url" => @lines_url,
+          "position" => @position,
+          "subscription_url" => @subscription_url,
+          "topic" => @topic,
         }.compact
       end
 
@@ -183,45 +193,50 @@ module Basecamp
     # CampfireLine
     class CampfireLine
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :content, :parent, :bucket, :creator, :boosts_count, :boosts_url
+      attr_accessor :app_url, :bucket, :content, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :boosts_count, :boosts_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket content created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @content = data["content"]
-        @parent = parse_type(data["parent"], "RecordingParent")
         @bucket = parse_type(data["bucket"], "TodoBucket")
+        @content = data["content"]
+        @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @bookmark_url = data["bookmark_url"]
         @boosts_count = parse_integer(data["boosts_count"])
         @boosts_url = data["boosts_url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "content" => @content,
-          "parent" => @parent,
           "bucket" => @bucket,
+          "content" => @content,
+          "created_at" => @created_at,
           "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "bookmark_url" => @bookmark_url,
           "boosts_count" => @boosts_count,
           "boosts_url" => @boosts_url,
         }.compact
@@ -235,73 +250,78 @@ module Basecamp
     # Card
     class Card
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :subscription_url, :position, :content, :description, :due_on, :completed, :completed_at, :comments_count, :comments_url, :completion_url, :parent, :bucket, :creator, :completer, :assignees, :completion_subscribers, :steps, :boosts_count, :boosts_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :assignees, :bookmark_url, :boosts_count, :boosts_url, :comments_count, :comments_url, :completed, :completed_at, :completer, :completion_subscribers, :completion_url, :content, :description, :due_on, :position, :steps, :subscription_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
+        @bucket = parse_type(data["bucket"], "TodoBucket")
+        @created_at = parse_datetime(data["created_at"])
+        @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @assignees = parse_array(data["assignees"], "Person")
         @bookmark_url = data["bookmark_url"]
-        @subscription_url = data["subscription_url"]
-        @position = parse_integer(data["position"])
+        @boosts_count = parse_integer(data["boosts_count"])
+        @boosts_url = data["boosts_url"]
+        @comments_count = parse_integer(data["comments_count"])
+        @comments_url = data["comments_url"]
+        @completed = parse_boolean(data["completed"])
+        @completed_at = parse_datetime(data["completed_at"])
+        @completer = parse_type(data["completer"], "Person")
+        @completion_subscribers = parse_array(data["completion_subscribers"], "Person")
+        @completion_url = data["completion_url"]
         @content = data["content"]
         @description = data["description"]
         @due_on = data["due_on"]
-        @completed = parse_boolean(data["completed"])
-        @completed_at = parse_datetime(data["completed_at"])
-        @comments_count = parse_integer(data["comments_count"])
-        @comments_url = data["comments_url"]
-        @completion_url = data["completion_url"]
-        @parent = parse_type(data["parent"], "RecordingParent")
-        @bucket = parse_type(data["bucket"], "TodoBucket")
-        @creator = parse_type(data["creator"], "Person")
-        @completer = parse_type(data["completer"], "Person")
-        @assignees = parse_array(data["assignees"], "Person")
-        @completion_subscribers = parse_array(data["completion_subscribers"], "Person")
+        @position = parse_integer(data["position"])
         @steps = parse_array(data["steps"], "CardStep")
-        @boosts_count = parse_integer(data["boosts_count"])
-        @boosts_url = data["boosts_url"]
+        @subscription_url = data["subscription_url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
+          "bucket" => @bucket,
+          "created_at" => @created_at,
+          "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "assignees" => @assignees,
           "bookmark_url" => @bookmark_url,
-          "subscription_url" => @subscription_url,
-          "position" => @position,
+          "boosts_count" => @boosts_count,
+          "boosts_url" => @boosts_url,
+          "comments_count" => @comments_count,
+          "comments_url" => @comments_url,
+          "completed" => @completed,
+          "completed_at" => @completed_at,
+          "completer" => @completer,
+          "completion_subscribers" => @completion_subscribers,
+          "completion_url" => @completion_url,
           "content" => @content,
           "description" => @description,
           "due_on" => @due_on,
-          "completed" => @completed,
-          "completed_at" => @completed_at,
-          "comments_count" => @comments_count,
-          "comments_url" => @comments_url,
-          "completion_url" => @completion_url,
-          "parent" => @parent,
-          "bucket" => @bucket,
-          "creator" => @creator,
-          "completer" => @completer,
-          "assignees" => @assignees,
-          "completion_subscribers" => @completion_subscribers,
+          "position" => @position,
           "steps" => @steps,
-          "boosts_count" => @boosts_count,
-          "boosts_url" => @boosts_url,
+          "subscription_url" => @subscription_url,
         }.compact
       end
 
@@ -313,54 +333,59 @@ module Basecamp
     # CardColumn
     class CardColumn
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :position, :color, :description, :cards_count, :comments_count, :cards_url, :parent, :bucket, :creator, :subscribers
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :cards_count, :cards_url, :color, :comments_count, :description, :position, :subscribers
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @position = parse_integer(data["position"])
-        @color = data["color"]
-        @description = data["description"]
-        @cards_count = parse_integer(data["cards_count"])
-        @comments_count = parse_integer(data["comments_count"])
-        @cards_url = data["cards_url"]
-        @parent = parse_type(data["parent"], "RecordingParent")
         @bucket = parse_type(data["bucket"], "TodoBucket")
+        @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @bookmark_url = data["bookmark_url"]
+        @cards_count = parse_integer(data["cards_count"])
+        @cards_url = data["cards_url"]
+        @color = data["color"]
+        @comments_count = parse_integer(data["comments_count"])
+        @description = data["description"]
+        @position = parse_integer(data["position"])
         @subscribers = parse_array(data["subscribers"], "Person")
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "position" => @position,
-          "color" => @color,
-          "description" => @description,
-          "cards_count" => @cards_count,
-          "comments_count" => @comments_count,
-          "cards_url" => @cards_url,
-          "parent" => @parent,
           "bucket" => @bucket,
+          "created_at" => @created_at,
           "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "bookmark_url" => @bookmark_url,
+          "cards_count" => @cards_count,
+          "cards_url" => @cards_url,
+          "color" => @color,
+          "comments_count" => @comments_count,
+          "description" => @description,
+          "position" => @position,
           "subscribers" => @subscribers,
         }.compact
       end
@@ -373,55 +398,60 @@ module Basecamp
     # CardStep
     class CardStep
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :position, :due_on, :completed, :completed_at, :parent, :bucket, :creator, :completer, :assignees, :completion_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :assignees, :bookmark_url, :completed, :completed_at, :completer, :completion_url, :due_on, :position
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
+        @bucket = parse_type(data["bucket"], "TodoBucket")
+        @created_at = parse_datetime(data["created_at"])
+        @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @assignees = parse_array(data["assignees"], "Person")
         @bookmark_url = data["bookmark_url"]
-        @position = parse_integer(data["position"])
-        @due_on = data["due_on"]
         @completed = parse_boolean(data["completed"])
         @completed_at = parse_datetime(data["completed_at"])
-        @parent = parse_type(data["parent"], "RecordingParent")
-        @bucket = parse_type(data["bucket"], "TodoBucket")
-        @creator = parse_type(data["creator"], "Person")
         @completer = parse_type(data["completer"], "Person")
-        @assignees = parse_array(data["assignees"], "Person")
         @completion_url = data["completion_url"]
+        @due_on = data["due_on"]
+        @position = parse_integer(data["position"])
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
+          "bucket" => @bucket,
+          "created_at" => @created_at,
+          "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "assignees" => @assignees,
           "bookmark_url" => @bookmark_url,
-          "position" => @position,
-          "due_on" => @due_on,
           "completed" => @completed,
           "completed_at" => @completed_at,
-          "parent" => @parent,
-          "bucket" => @bucket,
-          "creator" => @creator,
           "completer" => @completer,
-          "assignees" => @assignees,
           "completion_url" => @completion_url,
+          "due_on" => @due_on,
+          "position" => @position,
         }.compact
       end
 
@@ -433,45 +463,50 @@ module Basecamp
     # CardTable
     class CardTable
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :subscription_url, :bucket, :creator, :subscribers, :lists
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :lists, :subscribers, :subscription_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @subscription_url = data["subscription_url"]
         @bucket = parse_type(data["bucket"], "TodoBucket")
+        @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
-        @subscribers = parse_array(data["subscribers"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @bookmark_url = data["bookmark_url"]
         @lists = parse_array(data["lists"], "CardColumn")
+        @subscribers = parse_array(data["subscribers"], "Person")
+        @subscription_url = data["subscription_url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "subscription_url" => @subscription_url,
           "bucket" => @bucket,
+          "created_at" => @created_at,
           "creator" => @creator,
-          "subscribers" => @subscribers,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "bookmark_url" => @bookmark_url,
           "lists" => @lists,
+          "subscribers" => @subscribers,
+          "subscription_url" => @subscription_url,
         }.compact
       end
 
@@ -483,29 +518,34 @@ module Basecamp
     # Chatbot
     class Chatbot
       include TypeHelpers
-      attr_accessor :id, :created_at, :updated_at, :service_name, :command_url, :url, :app_url, :lines_url
+      attr_accessor :created_at, :id, :service_name, :updated_at, :app_url, :command_url, :lines_url, :url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[created_at id service_name updated_at].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
         @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
+        @id = parse_integer(data["id"])
         @service_name = data["service_name"]
-        @command_url = data["command_url"]
-        @url = data["url"]
+        @updated_at = parse_datetime(data["updated_at"])
         @app_url = data["app_url"]
+        @command_url = data["command_url"]
         @lines_url = data["lines_url"]
+        @url = data["url"]
       end
 
       def to_h
         {
-          "id" => @id,
           "created_at" => @created_at,
-          "updated_at" => @updated_at,
+          "id" => @id,
           "service_name" => @service_name,
-          "command_url" => @command_url,
-          "url" => @url,
+          "updated_at" => @updated_at,
           "app_url" => @app_url,
+          "command_url" => @command_url,
           "lines_url" => @lines_url,
+          "url" => @url,
         }.compact
       end
 
@@ -517,59 +557,64 @@ module Basecamp
     # ClientApproval
     class ClientApproval
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :subscription_url, :parent, :bucket, :creator, :content, :subject, :due_on, :replies_count, :replies_url, :approval_status, :approver, :responses
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :approval_status, :approver, :bookmark_url, :content, :due_on, :replies_count, :replies_url, :responses, :subject, :subscription_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @subscription_url = data["subscription_url"]
-        @parent = parse_type(data["parent"], "RecordingParent")
         @bucket = parse_type(data["bucket"], "RecordingBucket")
+        @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @approval_status = data["approval_status"]
+        @approver = parse_type(data["approver"], "Person")
+        @bookmark_url = data["bookmark_url"]
         @content = data["content"]
-        @subject = data["subject"]
         @due_on = data["due_on"]
         @replies_count = parse_integer(data["replies_count"])
         @replies_url = data["replies_url"]
-        @approval_status = data["approval_status"]
-        @approver = parse_type(data["approver"], "Person")
         @responses = parse_array(data["responses"], "ClientApprovalResponse")
+        @subject = data["subject"]
+        @subscription_url = data["subscription_url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "subscription_url" => @subscription_url,
-          "parent" => @parent,
           "bucket" => @bucket,
+          "created_at" => @created_at,
           "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "approval_status" => @approval_status,
+          "approver" => @approver,
+          "bookmark_url" => @bookmark_url,
           "content" => @content,
-          "subject" => @subject,
           "due_on" => @due_on,
           "replies_count" => @replies_count,
           "replies_url" => @replies_url,
-          "approval_status" => @approval_status,
-          "approver" => @approver,
           "responses" => @responses,
+          "subject" => @subject,
+          "subscription_url" => @subscription_url,
         }.compact
       end
 
@@ -581,43 +626,43 @@ module Basecamp
     # ClientApprovalResponse
     class ClientApprovalResponse
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :app_url, :bookmark_url, :parent, :bucket, :creator, :content, :approved
+      attr_accessor :app_url, :approved, :bookmark_url, :bucket, :content, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :visible_to_clients
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @parent = parse_type(data["parent"], "RecordingParent")
-        @bucket = parse_type(data["bucket"], "RecordingBucket")
-        @creator = parse_type(data["creator"], "Person")
-        @content = data["content"]
         @approved = parse_boolean(data["approved"])
+        @bookmark_url = data["bookmark_url"]
+        @bucket = parse_type(data["bucket"], "RecordingBucket")
+        @content = data["content"]
+        @created_at = parse_datetime(data["created_at"])
+        @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "parent" => @parent,
-          "bucket" => @bucket,
-          "creator" => @creator,
-          "content" => @content,
           "approved" => @approved,
+          "bookmark_url" => @bookmark_url,
+          "bucket" => @bucket,
+          "content" => @content,
+          "created_at" => @created_at,
+          "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "visible_to_clients" => @visible_to_clients,
         }.compact
       end
 
@@ -630,6 +675,11 @@ module Basecamp
     class ClientCompany
       include TypeHelpers
       attr_accessor :id, :name
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[id name].freeze
+      end
 
       def initialize(data = {})
         @id = parse_integer(data["id"])
@@ -651,51 +701,56 @@ module Basecamp
     # ClientCorrespondence
     class ClientCorrespondence
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :subscription_url, :parent, :bucket, :creator, :content, :subject, :replies_count, :replies_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :subject, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :content, :replies_count, :replies_url, :subscription_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status parent status subject title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @subscription_url = data["subscription_url"]
-        @parent = parse_type(data["parent"], "RecordingParent")
         @bucket = parse_type(data["bucket"], "RecordingBucket")
+        @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
-        @content = data["content"]
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @status = data["status"]
         @subject = data["subject"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @bookmark_url = data["bookmark_url"]
+        @content = data["content"]
         @replies_count = parse_integer(data["replies_count"])
         @replies_url = data["replies_url"]
+        @subscription_url = data["subscription_url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "subscription_url" => @subscription_url,
-          "parent" => @parent,
           "bucket" => @bucket,
+          "created_at" => @created_at,
           "creator" => @creator,
-          "content" => @content,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
           "subject" => @subject,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "bookmark_url" => @bookmark_url,
+          "content" => @content,
           "replies_count" => @replies_count,
           "replies_url" => @replies_url,
+          "subscription_url" => @subscription_url,
         }.compact
       end
 
@@ -707,43 +762,48 @@ module Basecamp
     # ClientReply
     class ClientReply
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :parent, :bucket, :creator, :content
+      attr_accessor :app_url, :bucket, :content, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket content created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @parent = parse_type(data["parent"], "RecordingParent")
         @bucket = parse_type(data["bucket"], "RecordingBucket")
-        @creator = parse_type(data["creator"], "Person")
         @content = data["content"]
+        @created_at = parse_datetime(data["created_at"])
+        @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @bookmark_url = data["bookmark_url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "parent" => @parent,
           "bucket" => @bucket,
-          "creator" => @creator,
           "content" => @content,
+          "created_at" => @created_at,
+          "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "bookmark_url" => @bookmark_url,
         }.compact
       end
 
@@ -755,17 +815,17 @@ module Basecamp
     # ClientSide
     class ClientSide
       include TypeHelpers
-      attr_accessor :url, :app_url
+      attr_accessor :app_url, :url
 
       def initialize(data = {})
-        @url = data["url"]
         @app_url = data["app_url"]
+        @url = data["url"]
       end
 
       def to_h
         {
-          "url" => @url,
           "app_url" => @app_url,
+          "url" => @url,
         }.compact
       end
 
@@ -777,45 +837,50 @@ module Basecamp
     # Comment
     class Comment
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :parent, :bucket, :creator, :content, :boosts_count, :boosts_url
+      attr_accessor :app_url, :bucket, :content, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :boosts_count, :boosts_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket content created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @parent = parse_type(data["parent"], "RecordingParent")
         @bucket = parse_type(data["bucket"], "TodoBucket")
-        @creator = parse_type(data["creator"], "Person")
         @content = data["content"]
+        @created_at = parse_datetime(data["created_at"])
+        @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @bookmark_url = data["bookmark_url"]
         @boosts_count = parse_integer(data["boosts_count"])
         @boosts_url = data["boosts_url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "parent" => @parent,
           "bucket" => @bucket,
-          "creator" => @creator,
           "content" => @content,
+          "created_at" => @created_at,
+          "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "bookmark_url" => @bookmark_url,
           "boosts_count" => @boosts_count,
           "boosts_url" => @boosts_url,
         }.compact
@@ -829,21 +894,26 @@ module Basecamp
     # CreatePersonRequest
     class CreatePersonRequest
       include TypeHelpers
-      attr_accessor :name, :email_address, :title, :company_name
+      attr_accessor :email_address, :name, :company_name, :title
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[email_address name].freeze
+      end
 
       def initialize(data = {})
-        @name = data["name"]
         @email_address = data["email_address"]
-        @title = data["title"]
+        @name = data["name"]
         @company_name = data["company_name"]
+        @title = data["title"]
       end
 
       def to_h
         {
-          "name" => @name,
           "email_address" => @email_address,
-          "title" => @title,
+          "name" => @name,
           "company_name" => @company_name,
+          "title" => @title,
         }.compact
       end
 
@@ -855,27 +925,32 @@ module Basecamp
     # DockItem
     class DockItem
       include TypeHelpers
-      attr_accessor :id, :title, :name, :enabled, :position, :url, :app_url
+      attr_accessor :app_url, :enabled, :id, :name, :title, :url, :position
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url enabled id name title url].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @title = data["title"]
-        @name = data["name"]
-        @enabled = parse_boolean(data["enabled"])
-        @position = parse_integer(data["position"])
-        @url = data["url"]
         @app_url = data["app_url"]
+        @enabled = parse_boolean(data["enabled"])
+        @id = parse_integer(data["id"])
+        @name = data["name"]
+        @title = data["title"]
+        @url = data["url"]
+        @position = parse_integer(data["position"])
       end
 
       def to_h
         {
-          "id" => @id,
-          "title" => @title,
-          "name" => @name,
-          "enabled" => @enabled,
-          "position" => @position,
-          "url" => @url,
           "app_url" => @app_url,
+          "enabled" => @enabled,
+          "id" => @id,
+          "name" => @name,
+          "title" => @title,
+          "url" => @url,
+          "position" => @position,
         }.compact
       end
 
@@ -887,55 +962,60 @@ module Basecamp
     # Document
     class Document
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :subscription_url, :comments_count, :comments_url, :position, :parent, :bucket, :creator, :content, :boosts_count, :boosts_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :boosts_count, :boosts_url, :comments_count, :comments_url, :content, :position, :subscription_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @subscription_url = data["subscription_url"]
-        @comments_count = parse_integer(data["comments_count"])
-        @comments_url = data["comments_url"]
-        @position = parse_integer(data["position"])
-        @parent = parse_type(data["parent"], "RecordingParent")
         @bucket = parse_type(data["bucket"], "TodoBucket")
+        @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
-        @content = data["content"]
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @bookmark_url = data["bookmark_url"]
         @boosts_count = parse_integer(data["boosts_count"])
         @boosts_url = data["boosts_url"]
+        @comments_count = parse_integer(data["comments_count"])
+        @comments_url = data["comments_url"]
+        @content = data["content"]
+        @position = parse_integer(data["position"])
+        @subscription_url = data["subscription_url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "subscription_url" => @subscription_url,
-          "comments_count" => @comments_count,
-          "comments_url" => @comments_url,
-          "position" => @position,
-          "parent" => @parent,
           "bucket" => @bucket,
+          "created_at" => @created_at,
           "creator" => @creator,
-          "content" => @content,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "bookmark_url" => @bookmark_url,
           "boosts_count" => @boosts_count,
           "boosts_url" => @boosts_url,
+          "comments_count" => @comments_count,
+          "comments_url" => @comments_url,
+          "content" => @content,
+          "position" => @position,
+          "subscription_url" => @subscription_url,
         }.compact
       end
 
@@ -947,29 +1027,34 @@ module Basecamp
     # Event
     class Event
       include TypeHelpers
-      attr_accessor :id, :recording_id, :action, :details, :created_at, :creator, :boosts_count, :boosts_url
+      attr_accessor :action, :created_at, :creator, :id, :recording_id, :boosts_count, :boosts_url, :details
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[action created_at creator id recording_id].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @recording_id = parse_integer(data["recording_id"])
         @action = data["action"]
-        @details = parse_type(data["details"], "EventDetails")
         @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @recording_id = parse_integer(data["recording_id"])
         @boosts_count = parse_integer(data["boosts_count"])
         @boosts_url = data["boosts_url"]
+        @details = parse_type(data["details"], "EventDetails")
       end
 
       def to_h
         {
-          "id" => @id,
-          "recording_id" => @recording_id,
           "action" => @action,
-          "details" => @details,
           "created_at" => @created_at,
           "creator" => @creator,
+          "id" => @id,
+          "recording_id" => @recording_id,
           "boosts_count" => @boosts_count,
           "boosts_url" => @boosts_url,
+          "details" => @details,
         }.compact
       end
 
@@ -981,19 +1066,19 @@ module Basecamp
     # EventDetails
     class EventDetails
       include TypeHelpers
-      attr_accessor :added_person_ids, :removed_person_ids, :notified_recipient_ids
+      attr_accessor :added_person_ids, :notified_recipient_ids, :removed_person_ids
 
       def initialize(data = {})
         @added_person_ids = data["added_person_ids"]
-        @removed_person_ids = data["removed_person_ids"]
         @notified_recipient_ids = data["notified_recipient_ids"]
+        @removed_person_ids = data["removed_person_ids"]
       end
 
       def to_h
         {
           "added_person_ids" => @added_person_ids,
-          "removed_person_ids" => @removed_person_ids,
           "notified_recipient_ids" => @notified_recipient_ids,
+          "removed_person_ids" => @removed_person_ids,
         }.compact
       end
 
@@ -1005,53 +1090,58 @@ module Basecamp
     # Forward
     class Forward
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :subscription_url, :parent, :bucket, :creator, :content, :subject, :from, :replies_count, :replies_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :subject, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :content, :from, :replies_count, :replies_url, :subscription_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status parent status subject title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @subscription_url = data["subscription_url"]
-        @parent = parse_type(data["parent"], "RecordingParent")
         @bucket = parse_type(data["bucket"], "TodoBucket")
+        @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
-        @content = data["content"]
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @status = data["status"]
         @subject = data["subject"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @bookmark_url = data["bookmark_url"]
+        @content = data["content"]
         @from = data["from"]
         @replies_count = parse_integer(data["replies_count"])
         @replies_url = data["replies_url"]
+        @subscription_url = data["subscription_url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "subscription_url" => @subscription_url,
-          "parent" => @parent,
           "bucket" => @bucket,
+          "created_at" => @created_at,
           "creator" => @creator,
-          "content" => @content,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
           "subject" => @subject,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "bookmark_url" => @bookmark_url,
+          "content" => @content,
           "from" => @from,
           "replies_count" => @replies_count,
           "replies_url" => @replies_url,
+          "subscription_url" => @subscription_url,
         }.compact
       end
 
@@ -1063,45 +1153,50 @@ module Basecamp
     # ForwardReply
     class ForwardReply
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :parent, :bucket, :creator, :content, :boosts_count, :boosts_url
+      attr_accessor :app_url, :bucket, :content, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :boosts_count, :boosts_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket content created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @parent = parse_type(data["parent"], "RecordingParent")
         @bucket = parse_type(data["bucket"], "TodoBucket")
-        @creator = parse_type(data["creator"], "Person")
         @content = data["content"]
+        @created_at = parse_datetime(data["created_at"])
+        @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @bookmark_url = data["bookmark_url"]
         @boosts_count = parse_integer(data["boosts_count"])
         @boosts_url = data["boosts_url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "parent" => @parent,
           "bucket" => @bucket,
-          "creator" => @creator,
           "content" => @content,
+          "created_at" => @created_at,
+          "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "bookmark_url" => @bookmark_url,
           "boosts_count" => @boosts_count,
           "boosts_url" => @boosts_url,
         }.compact
@@ -1115,45 +1210,50 @@ module Basecamp
     # Inbox
     class Inbox
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :position, :bucket, :creator, :forwards_count, :forwards_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :forwards_count, :forwards_url, :position
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @position = parse_integer(data["position"])
         @bucket = parse_type(data["bucket"], "TodoBucket")
+        @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @bookmark_url = data["bookmark_url"]
         @forwards_count = parse_integer(data["forwards_count"])
         @forwards_url = data["forwards_url"]
+        @position = parse_integer(data["position"])
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "position" => @position,
           "bucket" => @bucket,
+          "created_at" => @created_at,
           "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "bookmark_url" => @bookmark_url,
           "forwards_count" => @forwards_count,
           "forwards_url" => @forwards_url,
+          "position" => @position,
         }.compact
       end
 
@@ -1165,57 +1265,62 @@ module Basecamp
     # Message
     class Message
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :subscription_url, :comments_count, :comments_url, :parent, :bucket, :creator, :subject, :content, :category, :boosts_count, :boosts_url
+      attr_accessor :app_url, :bucket, :content, :created_at, :creator, :id, :inherits_status, :parent, :status, :subject, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :boosts_count, :boosts_url, :category, :comments_count, :comments_url, :subscription_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket content created_at creator id inherits_status parent status subject title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @subscription_url = data["subscription_url"]
-        @comments_count = parse_integer(data["comments_count"])
-        @comments_url = data["comments_url"]
-        @parent = parse_type(data["parent"], "RecordingParent")
         @bucket = parse_type(data["bucket"], "TodoBucket")
-        @creator = parse_type(data["creator"], "Person")
-        @subject = data["subject"]
         @content = data["content"]
-        @category = parse_type(data["category"], "MessageType")
+        @created_at = parse_datetime(data["created_at"])
+        @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @status = data["status"]
+        @subject = data["subject"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @bookmark_url = data["bookmark_url"]
         @boosts_count = parse_integer(data["boosts_count"])
         @boosts_url = data["boosts_url"]
+        @category = parse_type(data["category"], "MessageType")
+        @comments_count = parse_integer(data["comments_count"])
+        @comments_url = data["comments_url"]
+        @subscription_url = data["subscription_url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "subscription_url" => @subscription_url,
-          "comments_count" => @comments_count,
-          "comments_url" => @comments_url,
-          "parent" => @parent,
           "bucket" => @bucket,
-          "creator" => @creator,
-          "subject" => @subject,
           "content" => @content,
-          "category" => @category,
+          "created_at" => @created_at,
+          "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
+          "subject" => @subject,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "bookmark_url" => @bookmark_url,
           "boosts_count" => @boosts_count,
           "boosts_url" => @boosts_url,
+          "category" => @category,
+          "comments_count" => @comments_count,
+          "comments_url" => @comments_url,
+          "subscription_url" => @subscription_url,
         }.compact
       end
 
@@ -1227,47 +1332,52 @@ module Basecamp
     # MessageBoard
     class MessageBoard
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :position, :bucket, :creator, :messages_count, :messages_url, :app_messages_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :status, :title, :type, :updated_at, :url, :visible_to_clients, :app_messages_url, :bookmark_url, :messages_count, :messages_url, :position
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @position = parse_integer(data["position"])
         @bucket = parse_type(data["bucket"], "TodoBucket")
+        @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @app_messages_url = data["app_messages_url"]
+        @bookmark_url = data["bookmark_url"]
         @messages_count = parse_integer(data["messages_count"])
         @messages_url = data["messages_url"]
-        @app_messages_url = data["app_messages_url"]
+        @position = parse_integer(data["position"])
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "position" => @position,
           "bucket" => @bucket,
+          "created_at" => @created_at,
           "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "app_messages_url" => @app_messages_url,
+          "bookmark_url" => @bookmark_url,
           "messages_count" => @messages_count,
           "messages_url" => @messages_url,
-          "app_messages_url" => @app_messages_url,
+          "position" => @position,
         }.compact
       end
 
@@ -1279,22 +1389,27 @@ module Basecamp
     # MessageType
     class MessageType
       include TypeHelpers
-      attr_accessor :id, :name, :icon, :created_at, :updated_at
+      attr_accessor :created_at, :icon, :id, :name, :updated_at
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[created_at icon id name updated_at].freeze
+      end
 
       def initialize(data = {})
+        @created_at = parse_datetime(data["created_at"])
+        @icon = data["icon"]
         @id = parse_integer(data["id"])
         @name = data["name"]
-        @icon = data["icon"]
-        @created_at = parse_datetime(data["created_at"])
         @updated_at = parse_datetime(data["updated_at"])
       end
 
       def to_h
         {
+          "created_at" => @created_at,
+          "icon" => @icon,
           "id" => @id,
           "name" => @name,
-          "icon" => @icon,
-          "created_at" => @created_at,
           "updated_at" => @updated_at,
         }.compact
       end
@@ -1307,57 +1422,62 @@ module Basecamp
     # Person
     class Person
       include TypeHelpers
-      attr_accessor :id, :attachable_sgid, :name, :email_address, :personable_type, :title, :bio, :location, :created_at, :updated_at, :admin, :owner, :client, :employee, :time_zone, :avatar_url, :company, :can_manage_projects, :can_manage_people, :can_ping, :can_access_timesheet, :can_access_hill_charts
+      attr_accessor :id, :name, :admin, :attachable_sgid, :avatar_url, :bio, :can_access_hill_charts, :can_access_timesheet, :can_manage_people, :can_manage_projects, :can_ping, :client, :company, :created_at, :email_address, :employee, :location, :owner, :personable_type, :time_zone, :title, :updated_at
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[id name].freeze
+      end
 
       def initialize(data = {})
         @id = parse_integer(data["id"])
-        @attachable_sgid = data["attachable_sgid"]
         @name = data["name"]
-        @email_address = data["email_address"]
-        @personable_type = data["personable_type"]
-        @title = data["title"]
-        @bio = data["bio"]
-        @location = data["location"]
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
         @admin = parse_boolean(data["admin"])
-        @owner = parse_boolean(data["owner"])
-        @client = parse_boolean(data["client"])
-        @employee = parse_boolean(data["employee"])
-        @time_zone = data["time_zone"]
+        @attachable_sgid = data["attachable_sgid"]
         @avatar_url = data["avatar_url"]
-        @company = parse_type(data["company"], "PersonCompany")
-        @can_manage_projects = parse_boolean(data["can_manage_projects"])
-        @can_manage_people = parse_boolean(data["can_manage_people"])
-        @can_ping = parse_boolean(data["can_ping"])
-        @can_access_timesheet = parse_boolean(data["can_access_timesheet"])
+        @bio = data["bio"]
         @can_access_hill_charts = parse_boolean(data["can_access_hill_charts"])
+        @can_access_timesheet = parse_boolean(data["can_access_timesheet"])
+        @can_manage_people = parse_boolean(data["can_manage_people"])
+        @can_manage_projects = parse_boolean(data["can_manage_projects"])
+        @can_ping = parse_boolean(data["can_ping"])
+        @client = parse_boolean(data["client"])
+        @company = parse_type(data["company"], "PersonCompany")
+        @created_at = parse_datetime(data["created_at"])
+        @email_address = data["email_address"]
+        @employee = parse_boolean(data["employee"])
+        @location = data["location"]
+        @owner = parse_boolean(data["owner"])
+        @personable_type = data["personable_type"]
+        @time_zone = data["time_zone"]
+        @title = data["title"]
+        @updated_at = parse_datetime(data["updated_at"])
       end
 
       def to_h
         {
           "id" => @id,
-          "attachable_sgid" => @attachable_sgid,
           "name" => @name,
-          "email_address" => @email_address,
-          "personable_type" => @personable_type,
-          "title" => @title,
-          "bio" => @bio,
-          "location" => @location,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
           "admin" => @admin,
-          "owner" => @owner,
-          "client" => @client,
-          "employee" => @employee,
-          "time_zone" => @time_zone,
+          "attachable_sgid" => @attachable_sgid,
           "avatar_url" => @avatar_url,
-          "company" => @company,
-          "can_manage_projects" => @can_manage_projects,
-          "can_manage_people" => @can_manage_people,
-          "can_ping" => @can_ping,
-          "can_access_timesheet" => @can_access_timesheet,
+          "bio" => @bio,
           "can_access_hill_charts" => @can_access_hill_charts,
+          "can_access_timesheet" => @can_access_timesheet,
+          "can_manage_people" => @can_manage_people,
+          "can_manage_projects" => @can_manage_projects,
+          "can_ping" => @can_ping,
+          "client" => @client,
+          "company" => @company,
+          "created_at" => @created_at,
+          "email_address" => @email_address,
+          "employee" => @employee,
+          "location" => @location,
+          "owner" => @owner,
+          "personable_type" => @personable_type,
+          "time_zone" => @time_zone,
+          "title" => @title,
+          "updated_at" => @updated_at,
         }.compact
       end
 
@@ -1370,6 +1490,11 @@ module Basecamp
     class PersonCompany
       include TypeHelpers
       attr_accessor :id, :name
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[id name].freeze
+      end
 
       def initialize(data = {})
         @id = parse_integer(data["id"])
@@ -1391,43 +1516,48 @@ module Basecamp
     # Project
     class Project
       include TypeHelpers
-      attr_accessor :id, :status, :created_at, :updated_at, :name, :description, :purpose, :clients_enabled, :bookmark_url, :url, :app_url, :dock, :bookmarked, :client_company, :clientside
+      attr_accessor :app_url, :created_at, :id, :name, :status, :updated_at, :url, :bookmark_url, :bookmarked, :client_company, :clients_enabled, :clientside, :description, :dock, :purpose
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url created_at id name status updated_at url].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @name = data["name"]
-        @description = data["description"]
-        @purpose = data["purpose"]
-        @clients_enabled = parse_boolean(data["clients_enabled"])
-        @bookmark_url = data["bookmark_url"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @dock = parse_array(data["dock"], "DockItem")
+        @created_at = parse_datetime(data["created_at"])
+        @id = parse_integer(data["id"])
+        @name = data["name"]
+        @status = data["status"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @bookmark_url = data["bookmark_url"]
         @bookmarked = parse_boolean(data["bookmarked"])
         @client_company = parse_type(data["client_company"], "ClientCompany")
+        @clients_enabled = parse_boolean(data["clients_enabled"])
         @clientside = parse_type(data["clientside"], "ClientSide")
+        @description = data["description"]
+        @dock = parse_array(data["dock"], "DockItem")
+        @purpose = data["purpose"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "name" => @name,
-          "description" => @description,
-          "purpose" => @purpose,
-          "clients_enabled" => @clients_enabled,
-          "bookmark_url" => @bookmark_url,
-          "url" => @url,
           "app_url" => @app_url,
-          "dock" => @dock,
+          "created_at" => @created_at,
+          "id" => @id,
+          "name" => @name,
+          "status" => @status,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "bookmark_url" => @bookmark_url,
           "bookmarked" => @bookmarked,
           "client_company" => @client_company,
+          "clients_enabled" => @clients_enabled,
           "clientside" => @clientside,
+          "description" => @description,
+          "dock" => @dock,
+          "purpose" => @purpose,
         }.compact
       end
 
@@ -1461,21 +1591,26 @@ module Basecamp
     # ProjectConstruction
     class ProjectConstruction
       include TypeHelpers
-      attr_accessor :id, :status, :url, :project
+      attr_accessor :id, :status, :project, :url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[id status].freeze
+      end
 
       def initialize(data = {})
         @id = parse_integer(data["id"])
         @status = data["status"]
-        @url = data["url"]
         @project = parse_type(data["project"], "Project")
+        @url = data["url"]
       end
 
       def to_h
         {
           "id" => @id,
           "status" => @status,
-          "url" => @url,
           "project" => @project,
+          "url" => @url,
         }.compact
       end
 
@@ -1487,51 +1622,56 @@ module Basecamp
     # Question
     class Question
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :subscription_url, :parent, :bucket, :creator, :paused, :schedule, :answers_count, :answers_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :answers_count, :answers_url, :bookmark_url, :paused, :schedule, :subscription_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @subscription_url = data["subscription_url"]
-        @parent = parse_type(data["parent"], "RecordingParent")
         @bucket = parse_type(data["bucket"], "RecordingBucket")
+        @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
-        @paused = parse_boolean(data["paused"])
-        @schedule = parse_type(data["schedule"], "QuestionSchedule")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
         @answers_count = parse_integer(data["answers_count"])
         @answers_url = data["answers_url"]
+        @bookmark_url = data["bookmark_url"]
+        @paused = parse_boolean(data["paused"])
+        @schedule = parse_type(data["schedule"], "QuestionSchedule")
+        @subscription_url = data["subscription_url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "subscription_url" => @subscription_url,
-          "parent" => @parent,
           "bucket" => @bucket,
+          "created_at" => @created_at,
           "creator" => @creator,
-          "paused" => @paused,
-          "schedule" => @schedule,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
           "answers_count" => @answers_count,
           "answers_url" => @answers_url,
+          "bookmark_url" => @bookmark_url,
+          "paused" => @paused,
+          "schedule" => @schedule,
+          "subscription_url" => @subscription_url,
         }.compact
       end
 
@@ -1543,55 +1683,60 @@ module Basecamp
     # QuestionAnswer
     class QuestionAnswer
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :subscription_url, :comments_count, :comments_url, :content, :group_on, :parent, :bucket, :creator, :boosts_count, :boosts_url
+      attr_accessor :app_url, :bucket, :content, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :boosts_count, :boosts_url, :comments_count, :comments_url, :group_on, :subscription_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket content created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @subscription_url = data["subscription_url"]
-        @comments_count = parse_integer(data["comments_count"])
-        @comments_url = data["comments_url"]
-        @content = data["content"]
-        @group_on = data["group_on"]
-        @parent = parse_type(data["parent"], "RecordingParent")
         @bucket = parse_type(data["bucket"], "RecordingBucket")
+        @content = data["content"]
+        @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @bookmark_url = data["bookmark_url"]
         @boosts_count = parse_integer(data["boosts_count"])
         @boosts_url = data["boosts_url"]
+        @comments_count = parse_integer(data["comments_count"])
+        @comments_url = data["comments_url"]
+        @group_on = data["group_on"]
+        @subscription_url = data["subscription_url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "subscription_url" => @subscription_url,
-          "comments_count" => @comments_count,
-          "comments_url" => @comments_url,
-          "content" => @content,
-          "group_on" => @group_on,
-          "parent" => @parent,
           "bucket" => @bucket,
+          "content" => @content,
+          "created_at" => @created_at,
           "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "bookmark_url" => @bookmark_url,
           "boosts_count" => @boosts_count,
           "boosts_url" => @boosts_url,
+          "comments_count" => @comments_count,
+          "comments_url" => @comments_url,
+          "group_on" => @group_on,
+          "subscription_url" => @subscription_url,
         }.compact
       end
 
@@ -1604,6 +1749,11 @@ module Basecamp
     class QuestionAnswerPayload
       include TypeHelpers
       attr_accessor :content, :group_on
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[content].freeze
+      end
 
       def initialize(data = {})
         @content = data["content"]
@@ -1627,6 +1777,11 @@ module Basecamp
       include TypeHelpers
       attr_accessor :content
 
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[content].freeze
+      end
+
       def initialize(data = {})
         @content = data["content"]
       end
@@ -1645,21 +1800,21 @@ module Basecamp
     # QuestionReminder
     class QuestionReminder
       include TypeHelpers
-      attr_accessor :reminder_id, :remind_at, :group_on, :question
+      attr_accessor :group_on, :question, :remind_at, :reminder_id
 
       def initialize(data = {})
-        @reminder_id = parse_integer(data["reminder_id"])
-        @remind_at = parse_datetime(data["remind_at"])
         @group_on = data["group_on"]
         @question = parse_type(data["question"], "Question")
+        @remind_at = parse_datetime(data["remind_at"])
+        @reminder_id = parse_integer(data["reminder_id"])
       end
 
       def to_h
         {
-          "reminder_id" => @reminder_id,
-          "remind_at" => @remind_at,
           "group_on" => @group_on,
           "question" => @question,
+          "remind_at" => @remind_at,
+          "reminder_id" => @reminder_id,
         }.compact
       end
 
@@ -1671,31 +1826,31 @@ module Basecamp
     # QuestionSchedule
     class QuestionSchedule
       include TypeHelpers
-      attr_accessor :frequency, :days, :hour, :minute, :week_instance, :week_interval, :month_interval, :start_date, :end_date
+      attr_accessor :days, :end_date, :frequency, :hour, :minute, :month_interval, :start_date, :week_instance, :week_interval
 
       def initialize(data = {})
-        @frequency = data["frequency"]
         @days = data["days"]
+        @end_date = data["end_date"]
+        @frequency = data["frequency"]
         @hour = parse_integer(data["hour"])
         @minute = parse_integer(data["minute"])
-        @week_instance = parse_integer(data["week_instance"])
-        @week_interval = parse_integer(data["week_interval"])
         @month_interval = parse_integer(data["month_interval"])
         @start_date = data["start_date"]
-        @end_date = data["end_date"]
+        @week_instance = parse_integer(data["week_instance"])
+        @week_interval = parse_integer(data["week_interval"])
       end
 
       def to_h
         {
-          "frequency" => @frequency,
           "days" => @days,
+          "end_date" => @end_date,
+          "frequency" => @frequency,
           "hour" => @hour,
           "minute" => @minute,
-          "week_instance" => @week_instance,
-          "week_interval" => @week_interval,
           "month_interval" => @month_interval,
           "start_date" => @start_date,
-          "end_date" => @end_date,
+          "week_instance" => @week_instance,
+          "week_interval" => @week_interval,
         }.compact
       end
 
@@ -1707,45 +1862,50 @@ module Basecamp
     # Questionnaire
     class Questionnaire
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :questions_url, :questions_count, :name, :bucket, :creator
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :name, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :questions_count, :questions_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status name status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @questions_url = data["questions_url"]
-        @questions_count = parse_integer(data["questions_count"])
-        @name = data["name"]
         @bucket = parse_type(data["bucket"], "RecordingBucket")
+        @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @name = data["name"]
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @bookmark_url = data["bookmark_url"]
+        @questions_count = parse_integer(data["questions_count"])
+        @questions_url = data["questions_url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "questions_url" => @questions_url,
-          "questions_count" => @questions_count,
-          "name" => @name,
           "bucket" => @bucket,
+          "created_at" => @created_at,
           "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "name" => @name,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "bookmark_url" => @bookmark_url,
+          "questions_count" => @questions_count,
+          "questions_url" => @questions_url,
         }.compact
       end
 
@@ -1757,49 +1917,54 @@ module Basecamp
     # Recording
     class Recording
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :content, :comments_count, :comments_url, :subscription_url, :parent, :bucket, :creator
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :comments_count, :comments_url, :content, :subscription_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
+        @bucket = parse_type(data["bucket"], "RecordingBucket")
+        @created_at = parse_datetime(data["created_at"])
+        @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
         @bookmark_url = data["bookmark_url"]
-        @content = data["content"]
         @comments_count = parse_integer(data["comments_count"])
         @comments_url = data["comments_url"]
+        @content = data["content"]
         @subscription_url = data["subscription_url"]
-        @parent = parse_type(data["parent"], "RecordingParent")
-        @bucket = parse_type(data["bucket"], "RecordingBucket")
-        @creator = parse_type(data["creator"], "Person")
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
+          "bucket" => @bucket,
+          "created_at" => @created_at,
+          "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
           "bookmark_url" => @bookmark_url,
-          "content" => @content,
           "comments_count" => @comments_count,
           "comments_url" => @comments_url,
+          "content" => @content,
           "subscription_url" => @subscription_url,
-          "parent" => @parent,
-          "bucket" => @bucket,
-          "creator" => @creator,
         }.compact
       end
 
@@ -1812,6 +1977,11 @@ module Basecamp
     class RecordingBucket
       include TypeHelpers
       attr_accessor :id, :name, :type
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[id name type].freeze
+      end
 
       def initialize(data = {})
         @id = parse_integer(data["id"])
@@ -1835,23 +2005,28 @@ module Basecamp
     # RecordingParent
     class RecordingParent
       include TypeHelpers
-      attr_accessor :id, :title, :type, :url, :app_url
+      attr_accessor :app_url, :id, :title, :type, :url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url id title type url].freeze
+      end
 
       def initialize(data = {})
+        @app_url = data["app_url"]
         @id = parse_integer(data["id"])
         @title = data["title"]
         @type = data["type"]
         @url = data["url"]
-        @app_url = data["app_url"]
       end
 
       def to_h
         {
+          "app_url" => @app_url,
           "id" => @id,
           "title" => @title,
           "type" => @type,
           "url" => @url,
-          "app_url" => @app_url,
         }.compact
       end
 
@@ -1863,47 +2038,52 @@ module Basecamp
     # Schedule
     class Schedule
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :position, :bucket, :creator, :include_due_assignments, :entries_count, :entries_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :entries_count, :entries_url, :include_due_assignments, :position
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @position = parse_integer(data["position"])
         @bucket = parse_type(data["bucket"], "TodoBucket")
+        @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
-        @include_due_assignments = parse_boolean(data["include_due_assignments"])
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @bookmark_url = data["bookmark_url"]
         @entries_count = parse_integer(data["entries_count"])
         @entries_url = data["entries_url"]
+        @include_due_assignments = parse_boolean(data["include_due_assignments"])
+        @position = parse_integer(data["position"])
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "position" => @position,
           "bucket" => @bucket,
+          "created_at" => @created_at,
           "creator" => @creator,
-          "include_due_assignments" => @include_due_assignments,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "bookmark_url" => @bookmark_url,
           "entries_count" => @entries_count,
           "entries_url" => @entries_url,
+          "include_due_assignments" => @include_due_assignments,
+          "position" => @position,
         }.compact
       end
 
@@ -1915,17 +2095,17 @@ module Basecamp
     # ScheduleAttributes
     class ScheduleAttributes
       include TypeHelpers
-      attr_accessor :start_date, :end_date
+      attr_accessor :end_date, :start_date
 
       def initialize(data = {})
-        @start_date = data["start_date"]
         @end_date = data["end_date"]
+        @start_date = data["start_date"]
       end
 
       def to_h
         {
-          "start_date" => @start_date,
           "end_date" => @end_date,
+          "start_date" => @start_date,
         }.compact
       end
 
@@ -1937,63 +2117,68 @@ module Basecamp
     # ScheduleEntry
     class ScheduleEntry
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :subscription_url, :comments_count, :comments_url, :parent, :bucket, :creator, :summary, :description, :all_day, :starts_at, :ends_at, :participants, :boosts_count, :boosts_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :summary, :title, :type, :updated_at, :url, :visible_to_clients, :all_day, :bookmark_url, :boosts_count, :boosts_url, :comments_count, :comments_url, :description, :ends_at, :participants, :starts_at, :subscription_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status parent status summary title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @subscription_url = data["subscription_url"]
-        @comments_count = parse_integer(data["comments_count"])
-        @comments_url = data["comments_url"]
-        @parent = parse_type(data["parent"], "RecordingParent")
         @bucket = parse_type(data["bucket"], "TodoBucket")
+        @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @status = data["status"]
         @summary = data["summary"]
-        @description = data["description"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
         @all_day = parse_boolean(data["all_day"])
-        @starts_at = parse_datetime(data["starts_at"])
-        @ends_at = parse_datetime(data["ends_at"])
-        @participants = parse_array(data["participants"], "Person")
+        @bookmark_url = data["bookmark_url"]
         @boosts_count = parse_integer(data["boosts_count"])
         @boosts_url = data["boosts_url"]
+        @comments_count = parse_integer(data["comments_count"])
+        @comments_url = data["comments_url"]
+        @description = data["description"]
+        @ends_at = parse_datetime(data["ends_at"])
+        @participants = parse_array(data["participants"], "Person")
+        @starts_at = parse_datetime(data["starts_at"])
+        @subscription_url = data["subscription_url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "subscription_url" => @subscription_url,
-          "comments_count" => @comments_count,
-          "comments_url" => @comments_url,
-          "parent" => @parent,
           "bucket" => @bucket,
+          "created_at" => @created_at,
           "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
           "summary" => @summary,
-          "description" => @description,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
           "all_day" => @all_day,
-          "starts_at" => @starts_at,
-          "ends_at" => @ends_at,
-          "participants" => @participants,
+          "bookmark_url" => @bookmark_url,
           "boosts_count" => @boosts_count,
           "boosts_url" => @boosts_url,
+          "comments_count" => @comments_count,
+          "comments_url" => @comments_url,
+          "description" => @description,
+          "ends_at" => @ends_at,
+          "participants" => @participants,
+          "starts_at" => @starts_at,
+          "subscription_url" => @subscription_url,
         }.compact
       end
 
@@ -2047,47 +2232,52 @@ module Basecamp
     # SearchResult
     class SearchResult
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :parent, :bucket, :creator, :content, :description, :subject
+      attr_accessor :app_url, :id, :title, :type, :url, :bookmark_url, :bucket, :content, :created_at, :creator, :description, :inherits_status, :parent, :status, :subject, :updated_at, :visible_to_clients
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url id title type url].freeze
+      end
 
       def initialize(data = {})
+        @app_url = data["app_url"]
         @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
         @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
         @type = data["type"]
         @url = data["url"]
-        @app_url = data["app_url"]
         @bookmark_url = data["bookmark_url"]
-        @parent = parse_type(data["parent"], "RecordingParent")
         @bucket = parse_type(data["bucket"], "RecordingBucket")
-        @creator = parse_type(data["creator"], "Person")
         @content = data["content"]
+        @created_at = parse_datetime(data["created_at"])
+        @creator = parse_type(data["creator"], "Person")
         @description = data["description"]
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @status = data["status"]
         @subject = data["subject"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
       end
 
       def to_h
         {
+          "app_url" => @app_url,
           "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
           "title" => @title,
-          "inherits_status" => @inherits_status,
           "type" => @type,
           "url" => @url,
-          "app_url" => @app_url,
           "bookmark_url" => @bookmark_url,
-          "parent" => @parent,
           "bucket" => @bucket,
-          "creator" => @creator,
           "content" => @content,
+          "created_at" => @created_at,
+          "creator" => @creator,
           "description" => @description,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
           "subject" => @subject,
+          "updated_at" => @updated_at,
+          "visible_to_clients" => @visible_to_clients,
         }.compact
       end
 
@@ -2099,19 +2289,24 @@ module Basecamp
     # Subscription
     class Subscription
       include TypeHelpers
-      attr_accessor :subscribed, :count, :url, :subscribers
+      attr_accessor :count, :subscribed, :url, :subscribers
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[count subscribed url].freeze
+      end
 
       def initialize(data = {})
-        @subscribed = parse_boolean(data["subscribed"])
         @count = parse_integer(data["count"])
+        @subscribed = parse_boolean(data["subscribed"])
         @url = data["url"]
         @subscribers = parse_array(data["subscribers"], "Person")
       end
 
       def to_h
         {
-          "subscribed" => @subscribed,
           "count" => @count,
+          "subscribed" => @subscribed,
           "url" => @url,
           "subscribers" => @subscribers,
         }.compact
@@ -2125,31 +2320,36 @@ module Basecamp
     # Template
     class Template
       include TypeHelpers
-      attr_accessor :id, :status, :created_at, :updated_at, :name, :description, :url, :app_url, :dock
+      attr_accessor :created_at, :id, :name, :updated_at, :app_url, :description, :dock, :status, :url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[created_at id name updated_at].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
         @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
+        @id = parse_integer(data["id"])
         @name = data["name"]
-        @description = data["description"]
-        @url = data["url"]
+        @updated_at = parse_datetime(data["updated_at"])
         @app_url = data["app_url"]
+        @description = data["description"]
         @dock = parse_array(data["dock"], "DockItem")
+        @status = data["status"]
+        @url = data["url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
           "created_at" => @created_at,
-          "updated_at" => @updated_at,
+          "id" => @id,
           "name" => @name,
-          "description" => @description,
-          "url" => @url,
+          "updated_at" => @updated_at,
           "app_url" => @app_url,
+          "description" => @description,
           "dock" => @dock,
+          "status" => @status,
+          "url" => @url,
         }.compact
       end
 
@@ -2161,37 +2361,37 @@ module Basecamp
     # TimelineEvent
     class TimelineEvent
       include TypeHelpers
-      attr_accessor :id, :created_at, :kind, :parent_recording_id, :url, :app_url, :creator, :action, :target, :title, :summary_excerpt, :bucket
+      attr_accessor :action, :app_url, :bucket, :created_at, :creator, :id, :kind, :parent_recording_id, :summary_excerpt, :target, :title, :url
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
+        @action = data["action"]
+        @app_url = data["app_url"]
+        @bucket = parse_type(data["bucket"], "TodoBucket")
         @created_at = parse_datetime(data["created_at"])
+        @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
         @kind = data["kind"]
         @parent_recording_id = parse_integer(data["parent_recording_id"])
-        @url = data["url"]
-        @app_url = data["app_url"]
-        @creator = parse_type(data["creator"], "Person")
-        @action = data["action"]
+        @summary_excerpt = data["summary_excerpt"]
         @target = data["target"]
         @title = data["title"]
-        @summary_excerpt = data["summary_excerpt"]
-        @bucket = parse_type(data["bucket"], "TodoBucket")
+        @url = data["url"]
       end
 
       def to_h
         {
-          "id" => @id,
+          "action" => @action,
+          "app_url" => @app_url,
+          "bucket" => @bucket,
           "created_at" => @created_at,
+          "creator" => @creator,
+          "id" => @id,
           "kind" => @kind,
           "parent_recording_id" => @parent_recording_id,
-          "url" => @url,
-          "app_url" => @app_url,
-          "creator" => @creator,
-          "action" => @action,
+          "summary_excerpt" => @summary_excerpt,
           "target" => @target,
           "title" => @title,
-          "summary_excerpt" => @summary_excerpt,
-          "bucket" => @bucket,
+          "url" => @url,
         }.compact
       end
 
@@ -2203,23 +2403,28 @@ module Basecamp
     # TimesheetEntry
     class TimesheetEntry
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :parent, :bucket, :creator, :date, :description, :hours, :person
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :date, :description, :hours, :person
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @parent = parse_type(data["parent"], "RecordingParent")
         @bucket = parse_type(data["bucket"], "TodoBucket")
+        @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @bookmark_url = data["bookmark_url"]
         @date = data["date"]
         @description = data["description"]
         @hours = data["hours"]
@@ -2228,20 +2433,20 @@ module Basecamp
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "parent" => @parent,
           "bucket" => @bucket,
+          "created_at" => @created_at,
           "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "bookmark_url" => @bookmark_url,
           "date" => @date,
           "description" => @description,
           "hours" => @hours,
@@ -2257,69 +2462,74 @@ module Basecamp
     # Todo
     class Todo
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :subscription_url, :comments_count, :comments_url, :position, :parent, :bucket, :creator, :description, :completed, :content, :starts_on, :due_on, :assignees, :completion_subscribers, :completion_url, :boosts_count, :boosts_url
+      attr_accessor :app_url, :bucket, :content, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :assignees, :bookmark_url, :boosts_count, :boosts_url, :comments_count, :comments_url, :completed, :completion_subscribers, :completion_url, :description, :due_on, :position, :starts_on, :subscription_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket content created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @subscription_url = data["subscription_url"]
-        @comments_count = parse_integer(data["comments_count"])
-        @comments_url = data["comments_url"]
-        @position = parse_integer(data["position"])
-        @parent = parse_type(data["parent"], "TodoParent")
         @bucket = parse_type(data["bucket"], "TodoBucket")
-        @creator = parse_type(data["creator"], "Person")
-        @description = data["description"]
-        @completed = parse_boolean(data["completed"])
         @content = data["content"]
-        @starts_on = data["starts_on"]
-        @due_on = data["due_on"]
+        @created_at = parse_datetime(data["created_at"])
+        @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "TodoParent")
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
         @assignees = parse_array(data["assignees"], "Person")
-        @completion_subscribers = parse_array(data["completion_subscribers"], "Person")
-        @completion_url = data["completion_url"]
+        @bookmark_url = data["bookmark_url"]
         @boosts_count = parse_integer(data["boosts_count"])
         @boosts_url = data["boosts_url"]
+        @comments_count = parse_integer(data["comments_count"])
+        @comments_url = data["comments_url"]
+        @completed = parse_boolean(data["completed"])
+        @completion_subscribers = parse_array(data["completion_subscribers"], "Person")
+        @completion_url = data["completion_url"]
+        @description = data["description"]
+        @due_on = data["due_on"]
+        @position = parse_integer(data["position"])
+        @starts_on = data["starts_on"]
+        @subscription_url = data["subscription_url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "subscription_url" => @subscription_url,
-          "comments_count" => @comments_count,
-          "comments_url" => @comments_url,
-          "position" => @position,
-          "parent" => @parent,
           "bucket" => @bucket,
-          "creator" => @creator,
-          "description" => @description,
-          "completed" => @completed,
           "content" => @content,
-          "starts_on" => @starts_on,
-          "due_on" => @due_on,
+          "created_at" => @created_at,
+          "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
           "assignees" => @assignees,
-          "completion_subscribers" => @completion_subscribers,
-          "completion_url" => @completion_url,
+          "bookmark_url" => @bookmark_url,
           "boosts_count" => @boosts_count,
           "boosts_url" => @boosts_url,
+          "comments_count" => @comments_count,
+          "comments_url" => @comments_url,
+          "completed" => @completed,
+          "completion_subscribers" => @completion_subscribers,
+          "completion_url" => @completion_url,
+          "description" => @description,
+          "due_on" => @due_on,
+          "position" => @position,
+          "starts_on" => @starts_on,
+          "subscription_url" => @subscription_url,
         }.compact
       end
 
@@ -2332,6 +2542,11 @@ module Basecamp
     class TodoBucket
       include TypeHelpers
       attr_accessor :id, :name, :type
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[id name type].freeze
+      end
 
       def initialize(data = {})
         @id = parse_integer(data["id"])
@@ -2355,23 +2570,28 @@ module Basecamp
     # TodoParent
     class TodoParent
       include TypeHelpers
-      attr_accessor :id, :title, :type, :url, :app_url
+      attr_accessor :app_url, :id, :title, :type, :url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url id title type url].freeze
+      end
 
       def initialize(data = {})
+        @app_url = data["app_url"]
         @id = parse_integer(data["id"])
         @title = data["title"]
         @type = data["type"]
         @url = data["url"]
-        @app_url = data["app_url"]
       end
 
       def to_h
         {
+          "app_url" => @app_url,
           "id" => @id,
           "title" => @title,
           "type" => @type,
           "url" => @url,
-          "app_url" => @app_url,
         }.compact
       end
 
@@ -2383,67 +2603,72 @@ module Basecamp
     # Todolist
     class Todolist
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :subscription_url, :comments_count, :comments_url, :position, :parent, :bucket, :creator, :description, :completed, :completed_ratio, :name, :todos_url, :groups_url, :app_todos_url, :boosts_count, :boosts_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :name, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :app_todos_url, :bookmark_url, :boosts_count, :boosts_url, :comments_count, :comments_url, :completed, :completed_ratio, :description, :groups_url, :position, :subscription_url, :todos_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status name parent status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @subscription_url = data["subscription_url"]
-        @comments_count = parse_integer(data["comments_count"])
-        @comments_url = data["comments_url"]
-        @position = parse_integer(data["position"])
-        @parent = parse_type(data["parent"], "TodoParent")
         @bucket = parse_type(data["bucket"], "TodoBucket")
+        @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
-        @description = data["description"]
-        @completed = parse_boolean(data["completed"])
-        @completed_ratio = data["completed_ratio"]
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
         @name = data["name"]
-        @todos_url = data["todos_url"]
-        @groups_url = data["groups_url"]
+        @parent = parse_type(data["parent"], "TodoParent")
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
         @app_todos_url = data["app_todos_url"]
+        @bookmark_url = data["bookmark_url"]
         @boosts_count = parse_integer(data["boosts_count"])
         @boosts_url = data["boosts_url"]
+        @comments_count = parse_integer(data["comments_count"])
+        @comments_url = data["comments_url"]
+        @completed = parse_boolean(data["completed"])
+        @completed_ratio = data["completed_ratio"]
+        @description = data["description"]
+        @groups_url = data["groups_url"]
+        @position = parse_integer(data["position"])
+        @subscription_url = data["subscription_url"]
+        @todos_url = data["todos_url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "subscription_url" => @subscription_url,
-          "comments_count" => @comments_count,
-          "comments_url" => @comments_url,
-          "position" => @position,
-          "parent" => @parent,
           "bucket" => @bucket,
+          "created_at" => @created_at,
           "creator" => @creator,
-          "description" => @description,
-          "completed" => @completed,
-          "completed_ratio" => @completed_ratio,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
           "name" => @name,
-          "todos_url" => @todos_url,
-          "groups_url" => @groups_url,
+          "parent" => @parent,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
           "app_todos_url" => @app_todos_url,
+          "bookmark_url" => @bookmark_url,
           "boosts_count" => @boosts_count,
           "boosts_url" => @boosts_url,
+          "comments_count" => @comments_count,
+          "comments_url" => @comments_url,
+          "completed" => @completed,
+          "completed_ratio" => @completed_ratio,
+          "description" => @description,
+          "groups_url" => @groups_url,
+          "position" => @position,
+          "subscription_url" => @subscription_url,
+          "todos_url" => @todos_url,
         }.compact
       end
 
@@ -2455,59 +2680,64 @@ module Basecamp
     # TodolistGroup
     class TodolistGroup
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :subscription_url, :comments_count, :comments_url, :position, :parent, :bucket, :creator, :name, :completed, :completed_ratio, :todos_url, :app_todos_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :name, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :app_todos_url, :bookmark_url, :comments_count, :comments_url, :completed, :completed_ratio, :position, :subscription_url, :todos_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status name parent status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
+        @bucket = parse_type(data["bucket"], "TodoBucket")
+        @created_at = parse_datetime(data["created_at"])
+        @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @name = data["name"]
+        @parent = parse_type(data["parent"], "TodoParent")
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @app_todos_url = data["app_todos_url"]
         @bookmark_url = data["bookmark_url"]
-        @subscription_url = data["subscription_url"]
         @comments_count = parse_integer(data["comments_count"])
         @comments_url = data["comments_url"]
-        @position = parse_integer(data["position"])
-        @parent = parse_type(data["parent"], "TodoParent")
-        @bucket = parse_type(data["bucket"], "TodoBucket")
-        @creator = parse_type(data["creator"], "Person")
-        @name = data["name"]
         @completed = parse_boolean(data["completed"])
         @completed_ratio = data["completed_ratio"]
+        @position = parse_integer(data["position"])
+        @subscription_url = data["subscription_url"]
         @todos_url = data["todos_url"]
-        @app_todos_url = data["app_todos_url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
+          "bucket" => @bucket,
+          "created_at" => @created_at,
+          "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "name" => @name,
+          "parent" => @parent,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "app_todos_url" => @app_todos_url,
           "bookmark_url" => @bookmark_url,
-          "subscription_url" => @subscription_url,
           "comments_count" => @comments_count,
           "comments_url" => @comments_url,
-          "position" => @position,
-          "parent" => @parent,
-          "bucket" => @bucket,
-          "creator" => @creator,
-          "name" => @name,
           "completed" => @completed,
           "completed_ratio" => @completed_ratio,
+          "position" => @position,
+          "subscription_url" => @subscription_url,
           "todos_url" => @todos_url,
-          "app_todos_url" => @app_todos_url,
         }.compact
       end
 
@@ -2519,59 +2749,64 @@ module Basecamp
     # Todoset
     class Todoset
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :position, :bucket, :creator, :name, :todolists_count, :todolists_url, :completed_ratio, :completed, :completed_count, :on_schedule_count, :over_schedule_count, :app_todolists_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :name, :status, :title, :type, :updated_at, :url, :visible_to_clients, :app_todolists_url, :bookmark_url, :completed, :completed_count, :completed_ratio, :on_schedule_count, :over_schedule_count, :position, :todolists_count, :todolists_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status name status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @position = parse_integer(data["position"])
         @bucket = parse_type(data["bucket"], "TodoBucket")
+        @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
         @name = data["name"]
-        @todolists_count = parse_integer(data["todolists_count"])
-        @todolists_url = data["todolists_url"]
-        @completed_ratio = data["completed_ratio"]
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @app_todolists_url = data["app_todolists_url"]
+        @bookmark_url = data["bookmark_url"]
         @completed = parse_boolean(data["completed"])
         @completed_count = parse_integer(data["completed_count"])
+        @completed_ratio = data["completed_ratio"]
         @on_schedule_count = parse_integer(data["on_schedule_count"])
         @over_schedule_count = parse_integer(data["over_schedule_count"])
-        @app_todolists_url = data["app_todolists_url"]
+        @position = parse_integer(data["position"])
+        @todolists_count = parse_integer(data["todolists_count"])
+        @todolists_url = data["todolists_url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "position" => @position,
           "bucket" => @bucket,
+          "created_at" => @created_at,
           "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
           "name" => @name,
-          "todolists_count" => @todolists_count,
-          "todolists_url" => @todolists_url,
-          "completed_ratio" => @completed_ratio,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "app_todolists_url" => @app_todolists_url,
+          "bookmark_url" => @bookmark_url,
           "completed" => @completed,
           "completed_count" => @completed_count,
+          "completed_ratio" => @completed_ratio,
           "on_schedule_count" => @on_schedule_count,
           "over_schedule_count" => @over_schedule_count,
-          "app_todolists_url" => @app_todolists_url,
+          "position" => @position,
+          "todolists_count" => @todolists_count,
+          "todolists_url" => @todolists_url,
         }.compact
       end
 
@@ -2583,35 +2818,40 @@ module Basecamp
     # Tool
     class Tool
       include TypeHelpers
-      attr_accessor :id, :status, :created_at, :updated_at, :title, :name, :enabled, :position, :url, :app_url, :bucket
+      attr_accessor :created_at, :enabled, :id, :name, :title, :updated_at, :app_url, :bucket, :position, :status, :url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[created_at enabled id name title updated_at].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
         @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @name = data["name"]
         @enabled = parse_boolean(data["enabled"])
-        @position = parse_integer(data["position"])
-        @url = data["url"]
+        @id = parse_integer(data["id"])
+        @name = data["name"]
+        @title = data["title"]
+        @updated_at = parse_datetime(data["updated_at"])
         @app_url = data["app_url"]
         @bucket = parse_type(data["bucket"], "RecordingBucket")
+        @position = parse_integer(data["position"])
+        @status = data["status"]
+        @url = data["url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
           "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "name" => @name,
           "enabled" => @enabled,
-          "position" => @position,
-          "url" => @url,
+          "id" => @id,
+          "name" => @name,
+          "title" => @title,
+          "updated_at" => @updated_at,
           "app_url" => @app_url,
           "bucket" => @bucket,
+          "position" => @position,
+          "status" => @status,
+          "url" => @url,
         }.compact
       end
 
@@ -2623,67 +2863,72 @@ module Basecamp
     # Upload
     class Upload
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :subscription_url, :comments_count, :comments_url, :position, :parent, :bucket, :creator, :description, :content_type, :byte_size, :width, :height, :download_url, :filename, :boosts_count, :boosts_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :boosts_count, :boosts_url, :byte_size, :comments_count, :comments_url, :content_type, :description, :download_url, :filename, :height, :position, :subscription_url, :width
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @subscription_url = data["subscription_url"]
-        @comments_count = parse_integer(data["comments_count"])
-        @comments_url = data["comments_url"]
-        @position = parse_integer(data["position"])
-        @parent = parse_type(data["parent"], "RecordingParent")
         @bucket = parse_type(data["bucket"], "TodoBucket")
+        @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
-        @description = data["description"]
-        @content_type = data["content_type"]
-        @byte_size = parse_integer(data["byte_size"])
-        @width = parse_integer(data["width"])
-        @height = parse_integer(data["height"])
-        @download_url = data["download_url"]
-        @filename = data["filename"]
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @bookmark_url = data["bookmark_url"]
         @boosts_count = parse_integer(data["boosts_count"])
         @boosts_url = data["boosts_url"]
+        @byte_size = parse_integer(data["byte_size"])
+        @comments_count = parse_integer(data["comments_count"])
+        @comments_url = data["comments_url"]
+        @content_type = data["content_type"]
+        @description = data["description"]
+        @download_url = data["download_url"]
+        @filename = data["filename"]
+        @height = parse_integer(data["height"])
+        @position = parse_integer(data["position"])
+        @subscription_url = data["subscription_url"]
+        @width = parse_integer(data["width"])
       end
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "subscription_url" => @subscription_url,
-          "comments_count" => @comments_count,
-          "comments_url" => @comments_url,
-          "position" => @position,
-          "parent" => @parent,
           "bucket" => @bucket,
+          "created_at" => @created_at,
           "creator" => @creator,
-          "description" => @description,
-          "content_type" => @content_type,
-          "byte_size" => @byte_size,
-          "width" => @width,
-          "height" => @height,
-          "download_url" => @download_url,
-          "filename" => @filename,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "parent" => @parent,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "bookmark_url" => @bookmark_url,
           "boosts_count" => @boosts_count,
           "boosts_url" => @boosts_url,
+          "byte_size" => @byte_size,
+          "comments_count" => @comments_count,
+          "comments_url" => @comments_url,
+          "content_type" => @content_type,
+          "description" => @description,
+          "download_url" => @download_url,
+          "filename" => @filename,
+          "height" => @height,
+          "position" => @position,
+          "subscription_url" => @subscription_url,
+          "width" => @width,
         }.compact
       end
 
@@ -2695,26 +2940,31 @@ module Basecamp
     # Vault
     class Vault
       include TypeHelpers
-      attr_accessor :id, :status, :visible_to_clients, :created_at, :updated_at, :title, :inherits_status, :type, :url, :app_url, :bookmark_url, :position, :parent, :bucket, :creator, :documents_count, :documents_url, :uploads_count, :uploads_url, :vaults_count, :vaults_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :documents_count, :documents_url, :parent, :position, :uploads_count, :uploads_url, :vaults_count, :vaults_url
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url bucket created_at creator id inherits_status status title type updated_at url visible_to_clients].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @status = data["status"]
-        @visible_to_clients = parse_boolean(data["visible_to_clients"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @title = data["title"]
-        @inherits_status = parse_boolean(data["inherits_status"])
-        @type = data["type"]
-        @url = data["url"]
         @app_url = data["app_url"]
-        @bookmark_url = data["bookmark_url"]
-        @position = parse_integer(data["position"])
-        @parent = parse_type(data["parent"], "RecordingParent")
         @bucket = parse_type(data["bucket"], "TodoBucket")
+        @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
+        @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
+        @status = data["status"]
+        @title = data["title"]
+        @type = data["type"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @bookmark_url = data["bookmark_url"]
         @documents_count = parse_integer(data["documents_count"])
         @documents_url = data["documents_url"]
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @position = parse_integer(data["position"])
         @uploads_count = parse_integer(data["uploads_count"])
         @uploads_url = data["uploads_url"]
         @vaults_count = parse_integer(data["vaults_count"])
@@ -2723,23 +2973,23 @@ module Basecamp
 
       def to_h
         {
-          "id" => @id,
-          "status" => @status,
-          "visible_to_clients" => @visible_to_clients,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "title" => @title,
-          "inherits_status" => @inherits_status,
-          "type" => @type,
-          "url" => @url,
           "app_url" => @app_url,
-          "bookmark_url" => @bookmark_url,
-          "position" => @position,
-          "parent" => @parent,
           "bucket" => @bucket,
+          "created_at" => @created_at,
           "creator" => @creator,
+          "id" => @id,
+          "inherits_status" => @inherits_status,
+          "status" => @status,
+          "title" => @title,
+          "type" => @type,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "visible_to_clients" => @visible_to_clients,
+          "bookmark_url" => @bookmark_url,
           "documents_count" => @documents_count,
           "documents_url" => @documents_url,
+          "parent" => @parent,
+          "position" => @position,
           "uploads_count" => @uploads_count,
           "uploads_url" => @uploads_url,
           "vaults_count" => @vaults_count,
@@ -2755,31 +3005,36 @@ module Basecamp
     # Webhook
     class Webhook
       include TypeHelpers
-      attr_accessor :id, :active, :created_at, :updated_at, :payload_url, :types, :url, :app_url, :recent_deliveries
+      attr_accessor :app_url, :created_at, :id, :payload_url, :updated_at, :url, :active, :recent_deliveries, :types
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[app_url created_at id payload_url updated_at url].freeze
+      end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @active = parse_boolean(data["active"])
-        @created_at = parse_datetime(data["created_at"])
-        @updated_at = parse_datetime(data["updated_at"])
-        @payload_url = data["payload_url"]
-        @types = data["types"]
-        @url = data["url"]
         @app_url = data["app_url"]
+        @created_at = parse_datetime(data["created_at"])
+        @id = parse_integer(data["id"])
+        @payload_url = data["payload_url"]
+        @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
+        @active = parse_boolean(data["active"])
         @recent_deliveries = parse_array(data["recent_deliveries"], "WebhookDelivery")
+        @types = data["types"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "active" => @active,
-          "created_at" => @created_at,
-          "updated_at" => @updated_at,
-          "payload_url" => @payload_url,
-          "types" => @types,
-          "url" => @url,
           "app_url" => @app_url,
+          "created_at" => @created_at,
+          "id" => @id,
+          "payload_url" => @payload_url,
+          "updated_at" => @updated_at,
+          "url" => @url,
+          "active" => @active,
           "recent_deliveries" => @recent_deliveries,
+          "types" => @types,
         }.compact
       end
 
@@ -2791,21 +3046,21 @@ module Basecamp
     # WebhookCopy
     class WebhookCopy
       include TypeHelpers
-      attr_accessor :id, :url, :app_url, :bucket
+      attr_accessor :app_url, :bucket, :id, :url
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
-        @url = data["url"]
         @app_url = data["app_url"]
         @bucket = parse_type(data["bucket"], "WebhookCopyBucket")
+        @id = parse_integer(data["id"])
+        @url = data["url"]
       end
 
       def to_h
         {
-          "id" => @id,
-          "url" => @url,
           "app_url" => @app_url,
           "bucket" => @bucket,
+          "id" => @id,
+          "url" => @url,
         }.compact
       end
 
@@ -2837,19 +3092,19 @@ module Basecamp
     # WebhookDelivery
     class WebhookDelivery
       include TypeHelpers
-      attr_accessor :id, :created_at, :request, :response
+      attr_accessor :created_at, :id, :request, :response
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
         @created_at = parse_datetime(data["created_at"])
+        @id = parse_integer(data["id"])
         @request = parse_type(data["request"], "WebhookDeliveryRequest")
         @response = parse_type(data["response"], "WebhookDeliveryResponse")
       end
 
       def to_h
         {
-          "id" => @id,
           "created_at" => @created_at,
+          "id" => @id,
           "request" => @request,
           "response" => @response,
         }.compact
@@ -2863,17 +3118,17 @@ module Basecamp
     # WebhookDeliveryRequest
     class WebhookDeliveryRequest
       include TypeHelpers
-      attr_accessor :headers, :body
+      attr_accessor :body, :headers
 
       def initialize(data = {})
-        @headers = parse_type(data["headers"], "WebhookHeadersMap")
         @body = parse_type(data["body"], "WebhookEvent")
+        @headers = parse_type(data["headers"], "WebhookHeadersMap")
       end
 
       def to_h
         {
-          "headers" => @headers,
           "body" => @body,
+          "headers" => @headers,
         }.compact
       end
 
@@ -2885,18 +3140,18 @@ module Basecamp
     # WebhookDeliveryResponse
     class WebhookDeliveryResponse
       include TypeHelpers
-      attr_accessor :headers, :code, :message
+      attr_accessor :code, :headers, :message
 
       def initialize(data = {})
-        @headers = parse_type(data["headers"], "WebhookHeadersMap")
         @code = parse_integer(data["code"])
+        @headers = parse_type(data["headers"], "WebhookHeadersMap")
         @message = data["message"]
       end
 
       def to_h
         {
-          "headers" => @headers,
           "code" => @code,
+          "headers" => @headers,
           "message" => @message,
         }.compact
       end
@@ -2909,27 +3164,27 @@ module Basecamp
     # WebhookEvent
     class WebhookEvent
       include TypeHelpers
-      attr_accessor :id, :kind, :details, :created_at, :recording, :creator, :copy
+      attr_accessor :copy, :created_at, :creator, :details, :id, :kind, :recording
 
       def initialize(data = {})
+        @copy = parse_type(data["copy"], "WebhookCopy")
+        @created_at = parse_datetime(data["created_at"])
+        @creator = parse_type(data["creator"], "Person")
+        @details = data["details"]
         @id = parse_integer(data["id"])
         @kind = data["kind"]
-        @details = data["details"]
-        @created_at = parse_datetime(data["created_at"])
         @recording = parse_type(data["recording"], "Recording")
-        @creator = parse_type(data["creator"], "Person")
-        @copy = parse_type(data["copy"], "WebhookCopy")
       end
 
       def to_h
         {
+          "copy" => @copy,
+          "created_at" => @created_at,
+          "creator" => @creator,
+          "details" => @details,
           "id" => @id,
           "kind" => @kind,
-          "details" => @details,
-          "created_at" => @created_at,
           "recording" => @recording,
-          "creator" => @creator,
-          "copy" => @copy,
         }.compact
       end
 

--- a/swift/Sources/Basecamp/Generated/Models/Answer.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Answer.swift
@@ -2,25 +2,71 @@
 import Foundation
 
 public struct Answer: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: RecordingBucket
+    public let content: String
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let parent: RecordingParent
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var bookmarkUrl: String?
     public var boostsCount: Int32?
     public var boostsUrl: String?
-    public var bucket: RecordingBucket?
     public var commentsCount: Int32?
     public var commentsUrl: String?
-    public var content: String?
-    public var createdAt: String?
-    public var creator: Person?
     public var groupOn: String?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var parent: RecordingParent?
-    public var status: String?
     public var subscriptionUrl: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: RecordingBucket,
+        content: String,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        parent: RecordingParent,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        bookmarkUrl: String? = nil,
+        boostsCount: Int32? = nil,
+        boostsUrl: String? = nil,
+        commentsCount: Int32? = nil,
+        commentsUrl: String? = nil,
+        groupOn: String? = nil,
+        subscriptionUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.content = content
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.parent = parent
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.bookmarkUrl = bookmarkUrl
+        self.boostsCount = boostsCount
+        self.boostsUrl = boostsUrl
+        self.commentsCount = commentsCount
+        self.commentsUrl = commentsUrl
+        self.groupOn = groupOn
+        self.subscriptionUrl = subscriptionUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Boost.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Boost.swift
@@ -2,9 +2,23 @@
 import Foundation
 
 public struct Boost: Codable, Sendable {
+    public let createdAt: String
+    public let id: Int
     public var booster: Person?
     public var content: String?
-    public var createdAt: String?
-    public var id: Int?
     public var recording: RecordingParent?
+
+    public init(
+        createdAt: String,
+        id: Int,
+        booster: Person? = nil,
+        content: String? = nil,
+        recording: RecordingParent? = nil
+    ) {
+        self.createdAt = createdAt
+        self.id = id
+        self.booster = booster
+        self.content = content
+        self.recording = recording
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Campfire.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Campfire.swift
@@ -2,21 +2,59 @@
 import Foundation
 
 public struct Campfire: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var bookmarkUrl: String?
-    public var bucket: TodoBucket?
-    public var createdAt: String?
-    public var creator: Person?
-    public var id: Int?
-    public var inheritsStatus: Bool?
     public var linesUrl: String?
     public var position: Int32?
-    public var status: String?
     public var subscriptionUrl: String?
-    public var title: String?
     public var topic: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        bookmarkUrl: String? = nil,
+        linesUrl: String? = nil,
+        position: Int32? = nil,
+        subscriptionUrl: String? = nil,
+        topic: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.bookmarkUrl = bookmarkUrl
+        self.linesUrl = linesUrl
+        self.position = position
+        self.subscriptionUrl = subscriptionUrl
+        self.topic = topic
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/CampfireLine.swift
+++ b/swift/Sources/Basecamp/Generated/Models/CampfireLine.swift
@@ -2,21 +2,59 @@
 import Foundation
 
 public struct CampfireLine: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let content: String
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let parent: RecordingParent
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var bookmarkUrl: String?
     public var boostsCount: Int32?
     public var boostsUrl: String?
-    public var bucket: TodoBucket?
-    public var content: String?
-    public var createdAt: String?
-    public var creator: Person?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var parent: RecordingParent?
-    public var status: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        content: String,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        parent: RecordingParent,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        bookmarkUrl: String? = nil,
+        boostsCount: Int32? = nil,
+        boostsUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.content = content
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.parent = parent
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.bookmarkUrl = bookmarkUrl
+        self.boostsCount = boostsCount
+        self.boostsUrl = boostsUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Card.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Card.swift
@@ -2,12 +2,23 @@
 import Foundation
 
 public struct Card: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let parent: RecordingParent
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var assignees: [Person]?
     public var bookmarkUrl: String?
     public var boostsCount: Int32?
     public var boostsUrl: String?
-    public var bucket: TodoBucket?
     public var commentsCount: Int32?
     public var commentsUrl: String?
     public var completed: Bool?
@@ -16,20 +27,73 @@ public struct Card: Codable, Sendable {
     public var completionSubscribers: [Person]?
     public var completionUrl: String?
     public var content: String?
-    public var createdAt: String?
-    public var creator: Person?
     public var description: String?
     public var dueOn: String?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var parent: RecordingParent?
     public var position: Int32?
-    public var status: String?
     public var steps: [CardStep]?
     public var subscriptionUrl: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        parent: RecordingParent,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        assignees: [Person]? = nil,
+        bookmarkUrl: String? = nil,
+        boostsCount: Int32? = nil,
+        boostsUrl: String? = nil,
+        commentsCount: Int32? = nil,
+        commentsUrl: String? = nil,
+        completed: Bool? = nil,
+        completedAt: String? = nil,
+        completer: Person? = nil,
+        completionSubscribers: [Person]? = nil,
+        completionUrl: String? = nil,
+        content: String? = nil,
+        description: String? = nil,
+        dueOn: String? = nil,
+        position: Int32? = nil,
+        steps: [CardStep]? = nil,
+        subscriptionUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.parent = parent
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.assignees = assignees
+        self.bookmarkUrl = bookmarkUrl
+        self.boostsCount = boostsCount
+        self.boostsUrl = boostsUrl
+        self.commentsCount = commentsCount
+        self.commentsUrl = commentsUrl
+        self.completed = completed
+        self.completedAt = completedAt
+        self.completer = completer
+        self.completionSubscribers = completionSubscribers
+        self.completionUrl = completionUrl
+        self.content = content
+        self.description = description
+        self.dueOn = dueOn
+        self.position = position
+        self.steps = steps
+        self.subscriptionUrl = subscriptionUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/CardColumn.swift
+++ b/swift/Sources/Basecamp/Generated/Models/CardColumn.swift
@@ -2,25 +2,71 @@
 import Foundation
 
 public struct CardColumn: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let parent: RecordingParent
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var bookmarkUrl: String?
-    public var bucket: TodoBucket?
     public var cardsCount: Int32?
     public var cardsUrl: String?
     public var color: String?
     public var commentsCount: Int32?
-    public var createdAt: String?
-    public var creator: Person?
     public var description: String?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var parent: RecordingParent?
     public var position: Int32?
-    public var status: String?
     public var subscribers: [Person]?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        parent: RecordingParent,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        bookmarkUrl: String? = nil,
+        cardsCount: Int32? = nil,
+        cardsUrl: String? = nil,
+        color: String? = nil,
+        commentsCount: Int32? = nil,
+        description: String? = nil,
+        position: Int32? = nil,
+        subscribers: [Person]? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.parent = parent
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.bookmarkUrl = bookmarkUrl
+        self.cardsCount = cardsCount
+        self.cardsUrl = cardsUrl
+        self.color = color
+        self.commentsCount = commentsCount
+        self.description = description
+        self.position = position
+        self.subscribers = subscribers
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/CardStep.swift
+++ b/swift/Sources/Basecamp/Generated/Models/CardStep.swift
@@ -2,25 +2,71 @@
 import Foundation
 
 public struct CardStep: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let parent: RecordingParent
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var assignees: [Person]?
     public var bookmarkUrl: String?
-    public var bucket: TodoBucket?
     public var completed: Bool?
     public var completedAt: String?
     public var completer: Person?
     public var completionUrl: String?
-    public var createdAt: String?
-    public var creator: Person?
     public var dueOn: String?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var parent: RecordingParent?
     public var position: Int32?
-    public var status: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        parent: RecordingParent,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        assignees: [Person]? = nil,
+        bookmarkUrl: String? = nil,
+        completed: Bool? = nil,
+        completedAt: String? = nil,
+        completer: Person? = nil,
+        completionUrl: String? = nil,
+        dueOn: String? = nil,
+        position: Int32? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.parent = parent
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.assignees = assignees
+        self.bookmarkUrl = bookmarkUrl
+        self.completed = completed
+        self.completedAt = completedAt
+        self.completer = completer
+        self.completionUrl = completionUrl
+        self.dueOn = dueOn
+        self.position = position
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/CardTable.swift
+++ b/swift/Sources/Basecamp/Generated/Models/CardTable.swift
@@ -2,20 +2,56 @@
 import Foundation
 
 public struct CardTable: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var bookmarkUrl: String?
-    public var bucket: TodoBucket?
-    public var createdAt: String?
-    public var creator: Person?
-    public var id: Int?
-    public var inheritsStatus: Bool?
     public var lists: [CardColumn]?
-    public var status: String?
     public var subscribers: [Person]?
     public var subscriptionUrl: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        bookmarkUrl: String? = nil,
+        lists: [CardColumn]? = nil,
+        subscribers: [Person]? = nil,
+        subscriptionUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.bookmarkUrl = bookmarkUrl
+        self.lists = lists
+        self.subscribers = subscribers
+        self.subscriptionUrl = subscriptionUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Chatbot.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Chatbot.swift
@@ -2,12 +2,32 @@
 import Foundation
 
 public struct Chatbot: Codable, Sendable {
+    public let createdAt: String
+    public let id: Int
+    public let serviceName: String
+    public let updatedAt: String
     public var appUrl: String?
     public var commandUrl: String?
-    public var createdAt: String?
-    public var id: Int?
     public var linesUrl: String?
-    public var serviceName: String?
-    public var updatedAt: String?
     public var url: String?
+
+    public init(
+        createdAt: String,
+        id: Int,
+        serviceName: String,
+        updatedAt: String,
+        appUrl: String? = nil,
+        commandUrl: String? = nil,
+        linesUrl: String? = nil,
+        url: String? = nil
+    ) {
+        self.createdAt = createdAt
+        self.id = id
+        self.serviceName = serviceName
+        self.updatedAt = updatedAt
+        self.appUrl = appUrl
+        self.commandUrl = commandUrl
+        self.linesUrl = linesUrl
+        self.url = url
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/ClientApproval.swift
+++ b/swift/Sources/Basecamp/Generated/Models/ClientApproval.swift
@@ -2,27 +2,77 @@
 import Foundation
 
 public struct ClientApproval: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: RecordingBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let parent: RecordingParent
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var approvalStatus: String?
     public var approver: Person?
     public var bookmarkUrl: String?
-    public var bucket: RecordingBucket?
     public var content: String?
-    public var createdAt: String?
-    public var creator: Person?
     public var dueOn: String?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var parent: RecordingParent?
     public var repliesCount: Int32?
     public var repliesUrl: String?
     public var responses: [ClientApprovalResponse]?
-    public var status: String?
     public var subject: String?
     public var subscriptionUrl: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: RecordingBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        parent: RecordingParent,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        approvalStatus: String? = nil,
+        approver: Person? = nil,
+        bookmarkUrl: String? = nil,
+        content: String? = nil,
+        dueOn: String? = nil,
+        repliesCount: Int32? = nil,
+        repliesUrl: String? = nil,
+        responses: [ClientApprovalResponse]? = nil,
+        subject: String? = nil,
+        subscriptionUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.parent = parent
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.approvalStatus = approvalStatus
+        self.approver = approver
+        self.bookmarkUrl = bookmarkUrl
+        self.content = content
+        self.dueOn = dueOn
+        self.repliesCount = repliesCount
+        self.repliesUrl = repliesUrl
+        self.responses = responses
+        self.subject = subject
+        self.subscriptionUrl = subscriptionUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/ClientCompany.swift
+++ b/swift/Sources/Basecamp/Generated/Models/ClientCompany.swift
@@ -2,6 +2,11 @@
 import Foundation
 
 public struct ClientCompany: Codable, Sendable {
-    public var id: Int?
-    public var name: String?
+    public let id: Int
+    public let name: String
+
+    public init(id: Int, name: String) {
+        self.id = id
+        self.name = name
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/ClientCorrespondence.swift
+++ b/swift/Sources/Basecamp/Generated/Models/ClientCorrespondence.swift
@@ -2,23 +2,65 @@
 import Foundation
 
 public struct ClientCorrespondence: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: RecordingBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let parent: RecordingParent
+    public let status: String
+    public let subject: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var bookmarkUrl: String?
-    public var bucket: RecordingBucket?
     public var content: String?
-    public var createdAt: String?
-    public var creator: Person?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var parent: RecordingParent?
     public var repliesCount: Int32?
     public var repliesUrl: String?
-    public var status: String?
-    public var subject: String?
     public var subscriptionUrl: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: RecordingBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        parent: RecordingParent,
+        status: String,
+        subject: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        bookmarkUrl: String? = nil,
+        content: String? = nil,
+        repliesCount: Int32? = nil,
+        repliesUrl: String? = nil,
+        subscriptionUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.parent = parent
+        self.status = status
+        self.subject = subject
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.bookmarkUrl = bookmarkUrl
+        self.content = content
+        self.repliesCount = repliesCount
+        self.repliesUrl = repliesUrl
+        self.subscriptionUrl = subscriptionUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/ClientReply.swift
+++ b/swift/Sources/Basecamp/Generated/Models/ClientReply.swift
@@ -2,19 +2,53 @@
 import Foundation
 
 public struct ClientReply: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: RecordingBucket
+    public let content: String
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let parent: RecordingParent
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var bookmarkUrl: String?
-    public var bucket: RecordingBucket?
-    public var content: String?
-    public var createdAt: String?
-    public var creator: Person?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var parent: RecordingParent?
-    public var status: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: RecordingBucket,
+        content: String,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        parent: RecordingParent,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        bookmarkUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.content = content
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.parent = parent
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.bookmarkUrl = bookmarkUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Comment.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Comment.swift
@@ -2,21 +2,59 @@
 import Foundation
 
 public struct Comment: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let content: String
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let parent: RecordingParent
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var bookmarkUrl: String?
     public var boostsCount: Int32?
     public var boostsUrl: String?
-    public var bucket: TodoBucket?
-    public var content: String?
-    public var createdAt: String?
-    public var creator: Person?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var parent: RecordingParent?
-    public var status: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        content: String,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        parent: RecordingParent,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        bookmarkUrl: String? = nil,
+        boostsCount: Int32? = nil,
+        boostsUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.content = content
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.parent = parent
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.bookmarkUrl = bookmarkUrl
+        self.boostsCount = boostsCount
+        self.boostsUrl = boostsUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/CreatePersonRequest.swift
+++ b/swift/Sources/Basecamp/Generated/Models/CreatePersonRequest.swift
@@ -2,8 +2,20 @@
 import Foundation
 
 public struct CreatePersonRequest: Codable, Sendable {
+    public let emailAddress: String
+    public let name: String
     public var companyName: String?
-    public var emailAddress: String?
-    public var name: String?
     public var title: String?
+
+    public init(
+        emailAddress: String,
+        name: String,
+        companyName: String? = nil,
+        title: String? = nil
+    ) {
+        self.emailAddress = emailAddress
+        self.name = name
+        self.companyName = companyName
+        self.title = title
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/DockItem.swift
+++ b/swift/Sources/Basecamp/Generated/Models/DockItem.swift
@@ -2,11 +2,29 @@
 import Foundation
 
 public struct DockItem: Codable, Sendable {
-    public var appUrl: String?
-    public var enabled: Bool?
-    public var id: Int?
-    public var name: String?
+    public let appUrl: String
+    public let enabled: Bool
+    public let id: Int
+    public let name: String
+    public let title: String
+    public let url: String
     public var position: Int32?
-    public var title: String?
-    public var url: String?
+
+    public init(
+        appUrl: String,
+        enabled: Bool,
+        id: Int,
+        name: String,
+        title: String,
+        url: String,
+        position: Int32? = nil
+    ) {
+        self.appUrl = appUrl
+        self.enabled = enabled
+        self.id = id
+        self.name = name
+        self.title = title
+        self.url = url
+        self.position = position
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Document.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Document.swift
@@ -2,25 +2,71 @@
 import Foundation
 
 public struct Document: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let parent: RecordingParent
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var bookmarkUrl: String?
     public var boostsCount: Int32?
     public var boostsUrl: String?
-    public var bucket: TodoBucket?
     public var commentsCount: Int32?
     public var commentsUrl: String?
     public var content: String?
-    public var createdAt: String?
-    public var creator: Person?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var parent: RecordingParent?
     public var position: Int32?
-    public var status: String?
     public var subscriptionUrl: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        parent: RecordingParent,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        bookmarkUrl: String? = nil,
+        boostsCount: Int32? = nil,
+        boostsUrl: String? = nil,
+        commentsCount: Int32? = nil,
+        commentsUrl: String? = nil,
+        content: String? = nil,
+        position: Int32? = nil,
+        subscriptionUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.parent = parent
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.bookmarkUrl = bookmarkUrl
+        self.boostsCount = boostsCount
+        self.boostsUrl = boostsUrl
+        self.commentsCount = commentsCount
+        self.commentsUrl = commentsUrl
+        self.content = content
+        self.position = position
+        self.subscriptionUrl = subscriptionUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Event.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Event.swift
@@ -2,12 +2,32 @@
 import Foundation
 
 public struct Event: Codable, Sendable {
-    public var action: String?
+    public let action: String
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let recordingId: Int
     public var boostsCount: Int32?
     public var boostsUrl: String?
-    public var createdAt: String?
-    public var creator: Person?
     public var details: EventDetails?
-    public var id: Int?
-    public var recordingId: Int?
+
+    public init(
+        action: String,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        recordingId: Int,
+        boostsCount: Int32? = nil,
+        boostsUrl: String? = nil,
+        details: EventDetails? = nil
+    ) {
+        self.action = action
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.recordingId = recordingId
+        self.boostsCount = boostsCount
+        self.boostsUrl = boostsUrl
+        self.details = details
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Forward.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Forward.swift
@@ -2,24 +2,68 @@
 import Foundation
 
 public struct Forward: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let parent: RecordingParent
+    public let status: String
+    public let subject: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var bookmarkUrl: String?
-    public var bucket: TodoBucket?
     public var content: String?
-    public var createdAt: String?
-    public var creator: Person?
     public var from: String?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var parent: RecordingParent?
     public var repliesCount: Int32?
     public var repliesUrl: String?
-    public var status: String?
-    public var subject: String?
     public var subscriptionUrl: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        parent: RecordingParent,
+        status: String,
+        subject: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        bookmarkUrl: String? = nil,
+        content: String? = nil,
+        from: String? = nil,
+        repliesCount: Int32? = nil,
+        repliesUrl: String? = nil,
+        subscriptionUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.parent = parent
+        self.status = status
+        self.subject = subject
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.bookmarkUrl = bookmarkUrl
+        self.content = content
+        self.from = from
+        self.repliesCount = repliesCount
+        self.repliesUrl = repliesUrl
+        self.subscriptionUrl = subscriptionUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/ForwardReply.swift
+++ b/swift/Sources/Basecamp/Generated/Models/ForwardReply.swift
@@ -2,21 +2,59 @@
 import Foundation
 
 public struct ForwardReply: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let content: String
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let parent: RecordingParent
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var bookmarkUrl: String?
     public var boostsCount: Int32?
     public var boostsUrl: String?
-    public var bucket: TodoBucket?
-    public var content: String?
-    public var createdAt: String?
-    public var creator: Person?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var parent: RecordingParent?
-    public var status: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        content: String,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        parent: RecordingParent,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        bookmarkUrl: String? = nil,
+        boostsCount: Int32? = nil,
+        boostsUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.content = content
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.parent = parent
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.bookmarkUrl = bookmarkUrl
+        self.boostsCount = boostsCount
+        self.boostsUrl = boostsUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Inbox.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Inbox.swift
@@ -2,20 +2,56 @@
 import Foundation
 
 public struct Inbox: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var bookmarkUrl: String?
-    public var bucket: TodoBucket?
-    public var createdAt: String?
-    public var creator: Person?
     public var forwardsCount: Int32?
     public var forwardsUrl: String?
-    public var id: Int?
-    public var inheritsStatus: Bool?
     public var position: Int32?
-    public var status: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        bookmarkUrl: String? = nil,
+        forwardsCount: Int32? = nil,
+        forwardsUrl: String? = nil,
+        position: Int32? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.bookmarkUrl = bookmarkUrl
+        self.forwardsCount = forwardsCount
+        self.forwardsUrl = forwardsUrl
+        self.position = position
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Message.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Message.swift
@@ -2,26 +2,74 @@
 import Foundation
 
 public struct Message: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let content: String
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let parent: RecordingParent
+    public let status: String
+    public let subject: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var bookmarkUrl: String?
     public var boostsCount: Int32?
     public var boostsUrl: String?
-    public var bucket: TodoBucket?
     public var category: MessageType?
     public var commentsCount: Int32?
     public var commentsUrl: String?
-    public var content: String?
-    public var createdAt: String?
-    public var creator: Person?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var parent: RecordingParent?
-    public var status: String?
-    public var subject: String?
     public var subscriptionUrl: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        content: String,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        parent: RecordingParent,
+        status: String,
+        subject: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        bookmarkUrl: String? = nil,
+        boostsCount: Int32? = nil,
+        boostsUrl: String? = nil,
+        category: MessageType? = nil,
+        commentsCount: Int32? = nil,
+        commentsUrl: String? = nil,
+        subscriptionUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.content = content
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.parent = parent
+        self.status = status
+        self.subject = subject
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.bookmarkUrl = bookmarkUrl
+        self.boostsCount = boostsCount
+        self.boostsUrl = boostsUrl
+        self.category = category
+        self.commentsCount = commentsCount
+        self.commentsUrl = commentsUrl
+        self.subscriptionUrl = subscriptionUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/MessageBoard.swift
+++ b/swift/Sources/Basecamp/Generated/Models/MessageBoard.swift
@@ -2,21 +2,59 @@
 import Foundation
 
 public struct MessageBoard: Codable, Sendable {
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var appMessagesUrl: String?
-    public var appUrl: String?
     public var bookmarkUrl: String?
-    public var bucket: TodoBucket?
-    public var createdAt: String?
-    public var creator: Person?
-    public var id: Int?
-    public var inheritsStatus: Bool?
     public var messagesCount: Int32?
     public var messagesUrl: String?
     public var position: Int32?
-    public var status: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        appMessagesUrl: String? = nil,
+        bookmarkUrl: String? = nil,
+        messagesCount: Int32? = nil,
+        messagesUrl: String? = nil,
+        position: Int32? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.appMessagesUrl = appMessagesUrl
+        self.bookmarkUrl = bookmarkUrl
+        self.messagesCount = messagesCount
+        self.messagesUrl = messagesUrl
+        self.position = position
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/MessageType.swift
+++ b/swift/Sources/Basecamp/Generated/Models/MessageType.swift
@@ -2,9 +2,23 @@
 import Foundation
 
 public struct MessageType: Codable, Sendable {
-    public var createdAt: String?
-    public var icon: String?
-    public var id: Int?
-    public var name: String?
-    public var updatedAt: String?
+    public let createdAt: String
+    public let icon: String
+    public let id: Int
+    public let name: String
+    public let updatedAt: String
+
+    public init(
+        createdAt: String,
+        icon: String,
+        id: Int,
+        name: String,
+        updatedAt: String
+    ) {
+        self.createdAt = createdAt
+        self.icon = icon
+        self.id = id
+        self.name = name
+        self.updatedAt = updatedAt
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Person.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Person.swift
@@ -2,6 +2,8 @@
 import Foundation
 
 public struct Person: Codable, Sendable {
+    public let id: Int
+    public let name: String
     public var admin: Bool?
     public var attachableSgid: String?
     public var avatarUrl: String?
@@ -16,12 +18,58 @@ public struct Person: Codable, Sendable {
     public var createdAt: String?
     public var emailAddress: String?
     public var employee: Bool?
-    public var id: Int?
     public var location: String?
-    public var name: String?
     public var owner: Bool?
     public var personableType: String?
     public var timeZone: String?
     public var title: String?
     public var updatedAt: String?
+
+    public init(
+        id: Int,
+        name: String,
+        admin: Bool? = nil,
+        attachableSgid: String? = nil,
+        avatarUrl: String? = nil,
+        bio: String? = nil,
+        canAccessHillCharts: Bool? = nil,
+        canAccessTimesheet: Bool? = nil,
+        canManagePeople: Bool? = nil,
+        canManageProjects: Bool? = nil,
+        canPing: Bool? = nil,
+        client: Bool? = nil,
+        company: PersonCompany? = nil,
+        createdAt: String? = nil,
+        emailAddress: String? = nil,
+        employee: Bool? = nil,
+        location: String? = nil,
+        owner: Bool? = nil,
+        personableType: String? = nil,
+        timeZone: String? = nil,
+        title: String? = nil,
+        updatedAt: String? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.admin = admin
+        self.attachableSgid = attachableSgid
+        self.avatarUrl = avatarUrl
+        self.bio = bio
+        self.canAccessHillCharts = canAccessHillCharts
+        self.canAccessTimesheet = canAccessTimesheet
+        self.canManagePeople = canManagePeople
+        self.canManageProjects = canManageProjects
+        self.canPing = canPing
+        self.client = client
+        self.company = company
+        self.createdAt = createdAt
+        self.emailAddress = emailAddress
+        self.employee = employee
+        self.location = location
+        self.owner = owner
+        self.personableType = personableType
+        self.timeZone = timeZone
+        self.title = title
+        self.updatedAt = updatedAt
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/PersonCompany.swift
+++ b/swift/Sources/Basecamp/Generated/Models/PersonCompany.swift
@@ -2,6 +2,11 @@
 import Foundation
 
 public struct PersonCompany: Codable, Sendable {
-    public var id: Int?
-    public var name: String?
+    public let id: Int
+    public let name: String
+
+    public init(id: Int, name: String) {
+        self.id = id
+        self.name = name
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Project.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Project.swift
@@ -2,19 +2,53 @@
 import Foundation
 
 public struct Project: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let createdAt: String
+    public let id: Int
+    public let name: String
+    public let status: String
+    public let updatedAt: String
+    public let url: String
     public var bookmarkUrl: String?
     public var bookmarked: Bool?
     public var clientCompany: ClientCompany?
     public var clientsEnabled: Bool?
     public var clientside: ClientSide?
-    public var createdAt: String?
     public var description: String?
     public var dock: [DockItem]?
-    public var id: Int?
-    public var name: String?
     public var purpose: String?
-    public var status: String?
-    public var updatedAt: String?
-    public var url: String?
+
+    public init(
+        appUrl: String,
+        createdAt: String,
+        id: Int,
+        name: String,
+        status: String,
+        updatedAt: String,
+        url: String,
+        bookmarkUrl: String? = nil,
+        bookmarked: Bool? = nil,
+        clientCompany: ClientCompany? = nil,
+        clientsEnabled: Bool? = nil,
+        clientside: ClientSide? = nil,
+        description: String? = nil,
+        dock: [DockItem]? = nil,
+        purpose: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.createdAt = createdAt
+        self.id = id
+        self.name = name
+        self.status = status
+        self.updatedAt = updatedAt
+        self.url = url
+        self.bookmarkUrl = bookmarkUrl
+        self.bookmarked = bookmarked
+        self.clientCompany = clientCompany
+        self.clientsEnabled = clientsEnabled
+        self.clientside = clientside
+        self.description = description
+        self.dock = dock
+        self.purpose = purpose
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/ProjectConstruction.swift
+++ b/swift/Sources/Basecamp/Generated/Models/ProjectConstruction.swift
@@ -2,8 +2,20 @@
 import Foundation
 
 public struct ProjectConstruction: Codable, Sendable {
-    public var id: Int?
+    public let id: Int
+    public let status: String
     public var project: Project?
-    public var status: String?
     public var url: String?
+
+    public init(
+        id: Int,
+        status: String,
+        project: Project? = nil,
+        url: String? = nil
+    ) {
+        self.id = id
+        self.status = status
+        self.project = project
+        self.url = url
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Question.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Question.swift
@@ -2,23 +2,65 @@
 import Foundation
 
 public struct Question: Codable, Sendable {
+    public let appUrl: String
+    public let bucket: RecordingBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let parent: RecordingParent
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var answersCount: Int32?
     public var answersUrl: String?
-    public var appUrl: String?
     public var bookmarkUrl: String?
-    public var bucket: RecordingBucket?
-    public var createdAt: String?
-    public var creator: Person?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var parent: RecordingParent?
     public var paused: Bool?
     public var schedule: QuestionSchedule?
-    public var status: String?
     public var subscriptionUrl: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: RecordingBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        parent: RecordingParent,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        answersCount: Int32? = nil,
+        answersUrl: String? = nil,
+        bookmarkUrl: String? = nil,
+        paused: Bool? = nil,
+        schedule: QuestionSchedule? = nil,
+        subscriptionUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.parent = parent
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.answersCount = answersCount
+        self.answersUrl = answersUrl
+        self.bookmarkUrl = bookmarkUrl
+        self.paused = paused
+        self.schedule = schedule
+        self.subscriptionUrl = subscriptionUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Questionnaire.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Questionnaire.swift
@@ -2,20 +2,56 @@
 import Foundation
 
 public struct Questionnaire: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: RecordingBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let name: String
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var bookmarkUrl: String?
-    public var bucket: RecordingBucket?
-    public var createdAt: String?
-    public var creator: Person?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var name: String?
     public var questionsCount: Int32?
     public var questionsUrl: String?
-    public var status: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: RecordingBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        name: String,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        bookmarkUrl: String? = nil,
+        questionsCount: Int32? = nil,
+        questionsUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.name = name
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.bookmarkUrl = bookmarkUrl
+        self.questionsCount = questionsCount
+        self.questionsUrl = questionsUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Recording.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Recording.swift
@@ -2,22 +2,62 @@
 import Foundation
 
 public struct Recording: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: RecordingBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let parent: RecordingParent
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var bookmarkUrl: String?
-    public var bucket: RecordingBucket?
     public var commentsCount: Int32?
     public var commentsUrl: String?
     public var content: String?
-    public var createdAt: String?
-    public var creator: Person?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var parent: RecordingParent?
-    public var status: String?
     public var subscriptionUrl: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: RecordingBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        parent: RecordingParent,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        bookmarkUrl: String? = nil,
+        commentsCount: Int32? = nil,
+        commentsUrl: String? = nil,
+        content: String? = nil,
+        subscriptionUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.parent = parent
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.bookmarkUrl = bookmarkUrl
+        self.commentsCount = commentsCount
+        self.commentsUrl = commentsUrl
+        self.content = content
+        self.subscriptionUrl = subscriptionUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/RecordingBucket.swift
+++ b/swift/Sources/Basecamp/Generated/Models/RecordingBucket.swift
@@ -2,7 +2,13 @@
 import Foundation
 
 public struct RecordingBucket: Codable, Sendable {
-    public var id: Int?
-    public var name: String?
-    public var type: String?
+    public let id: Int
+    public let name: String
+    public let type: String
+
+    public init(id: Int, name: String, type: String) {
+        self.id = id
+        self.name = name
+        self.type = type
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/RecordingParent.swift
+++ b/swift/Sources/Basecamp/Generated/Models/RecordingParent.swift
@@ -2,9 +2,23 @@
 import Foundation
 
 public struct RecordingParent: Codable, Sendable {
-    public var appUrl: String?
-    public var id: Int?
-    public var title: String?
-    public var type: String?
-    public var url: String?
+    public let appUrl: String
+    public let id: Int
+    public let title: String
+    public let type: String
+    public let url: String
+
+    public init(
+        appUrl: String,
+        id: Int,
+        title: String,
+        type: String,
+        url: String
+    ) {
+        self.appUrl = appUrl
+        self.id = id
+        self.title = title
+        self.type = type
+        self.url = url
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Schedule.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Schedule.swift
@@ -2,21 +2,59 @@
 import Foundation
 
 public struct Schedule: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var bookmarkUrl: String?
-    public var bucket: TodoBucket?
-    public var createdAt: String?
-    public var creator: Person?
     public var entriesCount: Int32?
     public var entriesUrl: String?
-    public var id: Int?
     public var includeDueAssignments: Bool?
-    public var inheritsStatus: Bool?
     public var position: Int32?
-    public var status: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        bookmarkUrl: String? = nil,
+        entriesCount: Int32? = nil,
+        entriesUrl: String? = nil,
+        includeDueAssignments: Bool? = nil,
+        position: Int32? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.bookmarkUrl = bookmarkUrl
+        self.entriesCount = entriesCount
+        self.entriesUrl = entriesUrl
+        self.includeDueAssignments = includeDueAssignments
+        self.position = position
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/ScheduleEntry.swift
+++ b/swift/Sources/Basecamp/Generated/Models/ScheduleEntry.swift
@@ -2,29 +2,83 @@
 import Foundation
 
 public struct ScheduleEntry: Codable, Sendable {
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let parent: RecordingParent
+    public let status: String
+    public let summary: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var allDay: Bool?
-    public var appUrl: String?
     public var bookmarkUrl: String?
     public var boostsCount: Int32?
     public var boostsUrl: String?
-    public var bucket: TodoBucket?
     public var commentsCount: Int32?
     public var commentsUrl: String?
-    public var createdAt: String?
-    public var creator: Person?
     public var description: String?
     public var endsAt: String?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var parent: RecordingParent?
     public var participants: [Person]?
     public var startsAt: String?
-    public var status: String?
     public var subscriptionUrl: String?
-    public var summary: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        parent: RecordingParent,
+        status: String,
+        summary: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        allDay: Bool? = nil,
+        bookmarkUrl: String? = nil,
+        boostsCount: Int32? = nil,
+        boostsUrl: String? = nil,
+        commentsCount: Int32? = nil,
+        commentsUrl: String? = nil,
+        description: String? = nil,
+        endsAt: String? = nil,
+        participants: [Person]? = nil,
+        startsAt: String? = nil,
+        subscriptionUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.parent = parent
+        self.status = status
+        self.summary = summary
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.allDay = allDay
+        self.bookmarkUrl = bookmarkUrl
+        self.boostsCount = boostsCount
+        self.boostsUrl = boostsUrl
+        self.commentsCount = commentsCount
+        self.commentsUrl = commentsUrl
+        self.description = description
+        self.endsAt = endsAt
+        self.participants = participants
+        self.startsAt = startsAt
+        self.subscriptionUrl = subscriptionUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/SearchResult.swift
+++ b/swift/Sources/Basecamp/Generated/Models/SearchResult.swift
@@ -2,21 +2,59 @@
 import Foundation
 
 public struct SearchResult: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let id: Int
+    public let title: String
+    public let type: String
+    public let url: String
     public var bookmarkUrl: String?
     public var bucket: RecordingBucket?
     public var content: String?
     public var createdAt: String?
     public var creator: Person?
     public var description: String?
-    public var id: Int?
     public var inheritsStatus: Bool?
     public var parent: RecordingParent?
     public var status: String?
     public var subject: String?
-    public var title: String?
-    public var type: String?
     public var updatedAt: String?
-    public var url: String?
     public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        id: Int,
+        title: String,
+        type: String,
+        url: String,
+        bookmarkUrl: String? = nil,
+        bucket: RecordingBucket? = nil,
+        content: String? = nil,
+        createdAt: String? = nil,
+        creator: Person? = nil,
+        description: String? = nil,
+        inheritsStatus: Bool? = nil,
+        parent: RecordingParent? = nil,
+        status: String? = nil,
+        subject: String? = nil,
+        updatedAt: String? = nil,
+        visibleToClients: Bool? = nil
+    ) {
+        self.appUrl = appUrl
+        self.id = id
+        self.title = title
+        self.type = type
+        self.url = url
+        self.bookmarkUrl = bookmarkUrl
+        self.bucket = bucket
+        self.content = content
+        self.createdAt = createdAt
+        self.creator = creator
+        self.description = description
+        self.inheritsStatus = inheritsStatus
+        self.parent = parent
+        self.status = status
+        self.subject = subject
+        self.updatedAt = updatedAt
+        self.visibleToClients = visibleToClients
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Subscription.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Subscription.swift
@@ -2,8 +2,20 @@
 import Foundation
 
 public struct Subscription: Codable, Sendable {
-    public var count: Int32?
-    public var subscribed: Bool?
+    public let count: Int32
+    public let subscribed: Bool
+    public let url: String
     public var subscribers: [Person]?
-    public var url: String?
+
+    public init(
+        count: Int32,
+        subscribed: Bool,
+        url: String,
+        subscribers: [Person]? = nil
+    ) {
+        self.count = count
+        self.subscribed = subscribed
+        self.url = url
+        self.subscribers = subscribers
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Template.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Template.swift
@@ -2,13 +2,35 @@
 import Foundation
 
 public struct Template: Codable, Sendable {
+    public let createdAt: String
+    public let id: Int
+    public let name: String
+    public let updatedAt: String
     public var appUrl: String?
-    public var createdAt: String?
     public var description: String?
     public var dock: [DockItem]?
-    public var id: Int?
-    public var name: String?
     public var status: String?
-    public var updatedAt: String?
     public var url: String?
+
+    public init(
+        createdAt: String,
+        id: Int,
+        name: String,
+        updatedAt: String,
+        appUrl: String? = nil,
+        description: String? = nil,
+        dock: [DockItem]? = nil,
+        status: String? = nil,
+        url: String? = nil
+    ) {
+        self.createdAt = createdAt
+        self.id = id
+        self.name = name
+        self.updatedAt = updatedAt
+        self.appUrl = appUrl
+        self.description = description
+        self.dock = dock
+        self.status = status
+        self.url = url
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/TimesheetEntry.swift
+++ b/swift/Sources/Basecamp/Generated/Models/TimesheetEntry.swift
@@ -2,22 +2,62 @@
 import Foundation
 
 public struct TimesheetEntry: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let parent: RecordingParent
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var bookmarkUrl: String?
-    public var bucket: TodoBucket?
-    public var createdAt: String?
-    public var creator: Person?
     public var date: String?
     public var description: String?
     public var hours: String?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var parent: RecordingParent?
     public var person: Person?
-    public var status: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        parent: RecordingParent,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        bookmarkUrl: String? = nil,
+        date: String? = nil,
+        description: String? = nil,
+        hours: String? = nil,
+        person: Person? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.parent = parent
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.bookmarkUrl = bookmarkUrl
+        self.date = date
+        self.description = description
+        self.hours = hours
+        self.person = person
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Todo.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Todo.swift
@@ -2,32 +2,92 @@
 import Foundation
 
 public struct Todo: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let content: String
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let parent: TodoParent
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var assignees: [Person]?
     public var bookmarkUrl: String?
     public var boostsCount: Int32?
     public var boostsUrl: String?
-    public var bucket: TodoBucket?
     public var commentsCount: Int32?
     public var commentsUrl: String?
     public var completed: Bool?
     public var completionSubscribers: [Person]?
     public var completionUrl: String?
-    public var content: String?
-    public var createdAt: String?
-    public var creator: Person?
     public var description: String?
     public var dueOn: String?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var parent: TodoParent?
     public var position: Int32?
     public var startsOn: String?
-    public var status: String?
     public var subscriptionUrl: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        content: String,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        parent: TodoParent,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        assignees: [Person]? = nil,
+        bookmarkUrl: String? = nil,
+        boostsCount: Int32? = nil,
+        boostsUrl: String? = nil,
+        commentsCount: Int32? = nil,
+        commentsUrl: String? = nil,
+        completed: Bool? = nil,
+        completionSubscribers: [Person]? = nil,
+        completionUrl: String? = nil,
+        description: String? = nil,
+        dueOn: String? = nil,
+        position: Int32? = nil,
+        startsOn: String? = nil,
+        subscriptionUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.content = content
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.parent = parent
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.assignees = assignees
+        self.bookmarkUrl = bookmarkUrl
+        self.boostsCount = boostsCount
+        self.boostsUrl = boostsUrl
+        self.commentsCount = commentsCount
+        self.commentsUrl = commentsUrl
+        self.completed = completed
+        self.completionSubscribers = completionSubscribers
+        self.completionUrl = completionUrl
+        self.description = description
+        self.dueOn = dueOn
+        self.position = position
+        self.startsOn = startsOn
+        self.subscriptionUrl = subscriptionUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/TodoBucket.swift
+++ b/swift/Sources/Basecamp/Generated/Models/TodoBucket.swift
@@ -2,7 +2,13 @@
 import Foundation
 
 public struct TodoBucket: Codable, Sendable {
-    public var id: Int?
-    public var name: String?
-    public var type: String?
+    public let id: Int
+    public let name: String
+    public let type: String
+
+    public init(id: Int, name: String, type: String) {
+        self.id = id
+        self.name = name
+        self.type = type
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/TodoParent.swift
+++ b/swift/Sources/Basecamp/Generated/Models/TodoParent.swift
@@ -2,9 +2,23 @@
 import Foundation
 
 public struct TodoParent: Codable, Sendable {
-    public var appUrl: String?
-    public var id: Int?
-    public var title: String?
-    public var type: String?
-    public var url: String?
+    public let appUrl: String
+    public let id: Int
+    public let title: String
+    public let type: String
+    public let url: String
+
+    public init(
+        appUrl: String,
+        id: Int,
+        title: String,
+        type: String,
+        url: String
+    ) {
+        self.appUrl = appUrl
+        self.id = id
+        self.title = title
+        self.type = type
+        self.url = url
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Todolist.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Todolist.swift
@@ -2,31 +2,89 @@
 import Foundation
 
 public struct Todolist: Codable, Sendable {
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let name: String
+    public let parent: TodoParent
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var appTodosUrl: String?
-    public var appUrl: String?
     public var bookmarkUrl: String?
     public var boostsCount: Int32?
     public var boostsUrl: String?
-    public var bucket: TodoBucket?
     public var commentsCount: Int32?
     public var commentsUrl: String?
     public var completed: Bool?
     public var completedRatio: String?
-    public var createdAt: String?
-    public var creator: Person?
     public var description: String?
     public var groupsUrl: String?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var name: String?
-    public var parent: TodoParent?
     public var position: Int32?
-    public var status: String?
     public var subscriptionUrl: String?
-    public var title: String?
     public var todosUrl: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        name: String,
+        parent: TodoParent,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        appTodosUrl: String? = nil,
+        bookmarkUrl: String? = nil,
+        boostsCount: Int32? = nil,
+        boostsUrl: String? = nil,
+        commentsCount: Int32? = nil,
+        commentsUrl: String? = nil,
+        completed: Bool? = nil,
+        completedRatio: String? = nil,
+        description: String? = nil,
+        groupsUrl: String? = nil,
+        position: Int32? = nil,
+        subscriptionUrl: String? = nil,
+        todosUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.name = name
+        self.parent = parent
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.appTodosUrl = appTodosUrl
+        self.bookmarkUrl = bookmarkUrl
+        self.boostsCount = boostsCount
+        self.boostsUrl = boostsUrl
+        self.commentsCount = commentsCount
+        self.commentsUrl = commentsUrl
+        self.completed = completed
+        self.completedRatio = completedRatio
+        self.description = description
+        self.groupsUrl = groupsUrl
+        self.position = position
+        self.subscriptionUrl = subscriptionUrl
+        self.todosUrl = todosUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/TodolistGroup.swift
+++ b/swift/Sources/Basecamp/Generated/Models/TodolistGroup.swift
@@ -2,27 +2,77 @@
 import Foundation
 
 public struct TodolistGroup: Codable, Sendable {
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let name: String
+    public let parent: TodoParent
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var appTodosUrl: String?
-    public var appUrl: String?
     public var bookmarkUrl: String?
-    public var bucket: TodoBucket?
     public var commentsCount: Int32?
     public var commentsUrl: String?
     public var completed: Bool?
     public var completedRatio: String?
-    public var createdAt: String?
-    public var creator: Person?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var name: String?
-    public var parent: TodoParent?
     public var position: Int32?
-    public var status: String?
     public var subscriptionUrl: String?
-    public var title: String?
     public var todosUrl: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        name: String,
+        parent: TodoParent,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        appTodosUrl: String? = nil,
+        bookmarkUrl: String? = nil,
+        commentsCount: Int32? = nil,
+        commentsUrl: String? = nil,
+        completed: Bool? = nil,
+        completedRatio: String? = nil,
+        position: Int32? = nil,
+        subscriptionUrl: String? = nil,
+        todosUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.name = name
+        self.parent = parent
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.appTodosUrl = appTodosUrl
+        self.bookmarkUrl = bookmarkUrl
+        self.commentsCount = commentsCount
+        self.commentsUrl = commentsUrl
+        self.completed = completed
+        self.completedRatio = completedRatio
+        self.position = position
+        self.subscriptionUrl = subscriptionUrl
+        self.todosUrl = todosUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Todoset.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Todoset.swift
@@ -2,27 +2,77 @@
 import Foundation
 
 public struct Todoset: Codable, Sendable {
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let name: String
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var appTodolistsUrl: String?
-    public var appUrl: String?
     public var bookmarkUrl: String?
-    public var bucket: TodoBucket?
     public var completed: Bool?
     public var completedCount: Int32?
     public var completedRatio: String?
-    public var createdAt: String?
-    public var creator: Person?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var name: String?
     public var onScheduleCount: Int32?
     public var overScheduleCount: Int32?
     public var position: Int32?
-    public var status: String?
-    public var title: String?
     public var todolistsCount: Int32?
     public var todolistsUrl: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        name: String,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        appTodolistsUrl: String? = nil,
+        bookmarkUrl: String? = nil,
+        completed: Bool? = nil,
+        completedCount: Int32? = nil,
+        completedRatio: String? = nil,
+        onScheduleCount: Int32? = nil,
+        overScheduleCount: Int32? = nil,
+        position: Int32? = nil,
+        todolistsCount: Int32? = nil,
+        todolistsUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.name = name
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.appTodolistsUrl = appTodolistsUrl
+        self.bookmarkUrl = bookmarkUrl
+        self.completed = completed
+        self.completedCount = completedCount
+        self.completedRatio = completedRatio
+        self.onScheduleCount = onScheduleCount
+        self.overScheduleCount = overScheduleCount
+        self.position = position
+        self.todolistsCount = todolistsCount
+        self.todolistsUrl = todolistsUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Tool.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Tool.swift
@@ -2,15 +2,41 @@
 import Foundation
 
 public struct Tool: Codable, Sendable {
+    public let createdAt: String
+    public let enabled: Bool
+    public let id: Int
+    public let name: String
+    public let title: String
+    public let updatedAt: String
     public var appUrl: String?
     public var bucket: RecordingBucket?
-    public var createdAt: String?
-    public var enabled: Bool?
-    public var id: Int?
-    public var name: String?
     public var position: Int32?
     public var status: String?
-    public var title: String?
-    public var updatedAt: String?
     public var url: String?
+
+    public init(
+        createdAt: String,
+        enabled: Bool,
+        id: Int,
+        name: String,
+        title: String,
+        updatedAt: String,
+        appUrl: String? = nil,
+        bucket: RecordingBucket? = nil,
+        position: Int32? = nil,
+        status: String? = nil,
+        url: String? = nil
+    ) {
+        self.createdAt = createdAt
+        self.enabled = enabled
+        self.id = id
+        self.name = name
+        self.title = title
+        self.updatedAt = updatedAt
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.position = position
+        self.status = status
+        self.url = url
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Upload.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Upload.swift
@@ -2,31 +2,89 @@
 import Foundation
 
 public struct Upload: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let parent: RecordingParent
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var bookmarkUrl: String?
     public var boostsCount: Int32?
     public var boostsUrl: String?
-    public var bucket: TodoBucket?
     public var byteSize: Int?
     public var commentsCount: Int32?
     public var commentsUrl: String?
     public var contentType: String?
-    public var createdAt: String?
-    public var creator: Person?
     public var description: String?
     public var downloadUrl: String?
     public var filename: String?
     public var height: Int32?
-    public var id: Int?
-    public var inheritsStatus: Bool?
-    public var parent: RecordingParent?
     public var position: Int32?
-    public var status: String?
     public var subscriptionUrl: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
-    public var url: String?
-    public var visibleToClients: Bool?
     public var width: Int32?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        parent: RecordingParent,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        bookmarkUrl: String? = nil,
+        boostsCount: Int32? = nil,
+        boostsUrl: String? = nil,
+        byteSize: Int? = nil,
+        commentsCount: Int32? = nil,
+        commentsUrl: String? = nil,
+        contentType: String? = nil,
+        description: String? = nil,
+        downloadUrl: String? = nil,
+        filename: String? = nil,
+        height: Int32? = nil,
+        position: Int32? = nil,
+        subscriptionUrl: String? = nil,
+        width: Int32? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.parent = parent
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.bookmarkUrl = bookmarkUrl
+        self.boostsCount = boostsCount
+        self.boostsUrl = boostsUrl
+        self.byteSize = byteSize
+        self.commentsCount = commentsCount
+        self.commentsUrl = commentsUrl
+        self.contentType = contentType
+        self.description = description
+        self.downloadUrl = downloadUrl
+        self.filename = filename
+        self.height = height
+        self.position = position
+        self.subscriptionUrl = subscriptionUrl
+        self.width = width
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Vault.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Vault.swift
@@ -2,25 +2,71 @@
 import Foundation
 
 public struct Vault: Codable, Sendable {
-    public var appUrl: String?
+    public let appUrl: String
+    public let bucket: TodoBucket
+    public let createdAt: String
+    public let creator: Person
+    public let id: Int
+    public let inheritsStatus: Bool
+    public let status: String
+    public let title: String
+    public let type: String
+    public let updatedAt: String
+    public let url: String
+    public let visibleToClients: Bool
     public var bookmarkUrl: String?
-    public var bucket: TodoBucket?
-    public var createdAt: String?
-    public var creator: Person?
     public var documentsCount: Int32?
     public var documentsUrl: String?
-    public var id: Int?
-    public var inheritsStatus: Bool?
     public var parent: RecordingParent?
     public var position: Int32?
-    public var status: String?
-    public var title: String?
-    public var type: String?
-    public var updatedAt: String?
     public var uploadsCount: Int32?
     public var uploadsUrl: String?
-    public var url: String?
     public var vaultsCount: Int32?
     public var vaultsUrl: String?
-    public var visibleToClients: Bool?
+
+    public init(
+        appUrl: String,
+        bucket: TodoBucket,
+        createdAt: String,
+        creator: Person,
+        id: Int,
+        inheritsStatus: Bool,
+        status: String,
+        title: String,
+        type: String,
+        updatedAt: String,
+        url: String,
+        visibleToClients: Bool,
+        bookmarkUrl: String? = nil,
+        documentsCount: Int32? = nil,
+        documentsUrl: String? = nil,
+        parent: RecordingParent? = nil,
+        position: Int32? = nil,
+        uploadsCount: Int32? = nil,
+        uploadsUrl: String? = nil,
+        vaultsCount: Int32? = nil,
+        vaultsUrl: String? = nil
+    ) {
+        self.appUrl = appUrl
+        self.bucket = bucket
+        self.createdAt = createdAt
+        self.creator = creator
+        self.id = id
+        self.inheritsStatus = inheritsStatus
+        self.status = status
+        self.title = title
+        self.type = type
+        self.updatedAt = updatedAt
+        self.url = url
+        self.visibleToClients = visibleToClients
+        self.bookmarkUrl = bookmarkUrl
+        self.documentsCount = documentsCount
+        self.documentsUrl = documentsUrl
+        self.parent = parent
+        self.position = position
+        self.uploadsCount = uploadsCount
+        self.uploadsUrl = uploadsUrl
+        self.vaultsCount = vaultsCount
+        self.vaultsUrl = vaultsUrl
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Models/Webhook.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Webhook.swift
@@ -2,13 +2,35 @@
 import Foundation
 
 public struct Webhook: Codable, Sendable {
+    public let appUrl: String
+    public let createdAt: String
+    public let id: Int
+    public let payloadUrl: String
+    public let updatedAt: String
+    public let url: String
     public var active: Bool?
-    public var appUrl: String?
-    public var createdAt: String?
-    public var id: Int?
-    public var payloadUrl: String?
     public var recentDeliveries: [WebhookDelivery]?
     public var types: [String]?
-    public var updatedAt: String?
-    public var url: String?
+
+    public init(
+        appUrl: String,
+        createdAt: String,
+        id: Int,
+        payloadUrl: String,
+        updatedAt: String,
+        url: String,
+        active: Bool? = nil,
+        recentDeliveries: [WebhookDelivery]? = nil,
+        types: [String]? = nil
+    ) {
+        self.appUrl = appUrl
+        self.createdAt = createdAt
+        self.id = id
+        self.payloadUrl = payloadUrl
+        self.updatedAt = updatedAt
+        self.url = url
+        self.active = active
+        self.recentDeliveries = recentDeliveries
+        self.types = types
+    }
 }

--- a/swift/Tests/BasecampTests/GeneratedServiceTests.swift
+++ b/swift/Tests/BasecampTests/GeneratedServiceTests.swift
@@ -9,7 +9,11 @@ final class GeneratedServiceTests: XCTestCase {
     // MARK: - request<T> path (GET with JSON decode)
 
     func testGetProjectDecodesResponse() async throws {
-        let json: [String: Any] = ["id": 42, "name": "My Project", "status": "active"]
+        let json: [String: Any] = [
+            "id": 42, "name": "My Project", "status": "active",
+            "app_url": "https://3.basecamp.com/1/projects/42", "url": "https://3.basecampapi.com/1/projects/42.json",
+            "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+        ]
         let data = try JSONSerialization.data(withJSONObject: json)
 
         let transport = MockTransport(statusCode: 200, data: data)
@@ -28,7 +32,16 @@ final class GeneratedServiceTests: XCTestCase {
     // MARK: - request<T> path (POST with body)
 
     func testCreateTodoEncodesBodyAndDecodes() async throws {
-        let responseJSON: [String: Any] = ["id": 99, "content": "Buy milk", "completed": false]
+        let responseJSON: [String: Any] = [
+            "id": 99, "content": "Buy milk", "completed": false,
+            "app_url": "https://3.basecamp.com/1/buckets/1/todos/99", "url": "https://3.basecampapi.com/1/buckets/1/todos/99.json",
+            "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+            "status": "active", "title": "Buy milk", "type": "Todo",
+            "inherits_status": false, "visible_to_clients": false,
+            "bucket": ["id": 1, "name": "Project", "type": "Project"] as [String: Any],
+            "creator": ["id": 1, "name": "Test User"] as [String: Any],
+            "parent": ["id": 2, "title": "Todolist", "type": "Todolist", "app_url": "https://3.basecamp.com/1/buckets/1/todolists/2", "url": "https://3.basecampapi.com/1/buckets/1/todolists/2.json"] as [String: Any],
+        ]
         let responseData = try JSONSerialization.data(withJSONObject: responseJSON)
 
         let transport = MockTransport(statusCode: 201, data: responseData)
@@ -64,8 +77,12 @@ final class GeneratedServiceTests: XCTestCase {
 
     func testListProjectsReturnsPaginatedResult() async throws {
         let projects: [[String: Any]] = [
-            ["id": 1, "name": "Project A"],
-            ["id": 2, "name": "Project B"],
+            ["id": 1, "name": "Project A", "status": "active",
+             "app_url": "https://3.basecamp.com/1/projects/1", "url": "https://3.basecampapi.com/1/projects/1.json",
+             "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"],
+            ["id": 2, "name": "Project B", "status": "active",
+             "app_url": "https://3.basecamp.com/1/projects/2", "url": "https://3.basecampapi.com/1/projects/2.json",
+             "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z"],
         ]
         let data = try JSONSerialization.data(withJSONObject: projects)
 

--- a/swift/Tests/BasecampTests/HooksTests.swift
+++ b/swift/Tests/BasecampTests/HooksTests.swift
@@ -107,7 +107,16 @@ final class HooksTests: XCTestCase {
     func testOnOperationEndFiresOnceOnSuccess() async throws {
         let spy = SpyHooks()
 
-        let todo: [String: Any] = ["id": 1, "content": "Test"]
+        let todo: [String: Any] = [
+            "id": 1, "content": "Test",
+            "app_url": "https://3.basecamp.com/1/buckets/1/todos/1", "url": "https://3.basecampapi.com/1/buckets/1/todos/1.json",
+            "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+            "status": "active", "title": "Test", "type": "Todo",
+            "inherits_status": false, "visible_to_clients": false,
+            "bucket": ["id": 1, "name": "Project", "type": "Project"] as [String: Any],
+            "creator": ["id": 1, "name": "Test User"] as [String: Any],
+            "parent": ["id": 2, "title": "Todolist", "type": "Todolist", "app_url": "https://3.basecamp.com/1/buckets/1/todolists/2", "url": "https://3.basecampapi.com/1/buckets/1/todolists/2.json"] as [String: Any],
+        ]
         let data = try JSONSerialization.data(withJSONObject: todo)
         let transport = MockTransport(statusCode: 200, data: data)
         let account = makeTestAccountClient(transport: transport, hooks: spy)
@@ -123,7 +132,16 @@ final class HooksTests: XCTestCase {
 
     func testETagCacheHitReturnsSuccessfully() async throws {
         let spy = SpyHooks()
-        let todo: [String: Any] = ["id": 1, "content": "Cached"]
+        let todo: [String: Any] = [
+            "id": 1, "content": "Cached",
+            "app_url": "https://3.basecamp.com/1/buckets/1/todos/1", "url": "https://3.basecampapi.com/1/buckets/1/todos/1.json",
+            "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+            "status": "active", "title": "Cached", "type": "Todo",
+            "inherits_status": false, "visible_to_clients": false,
+            "bucket": ["id": 1, "name": "Project", "type": "Project"] as [String: Any],
+            "creator": ["id": 1, "name": "Test User"] as [String: Any],
+            "parent": ["id": 2, "title": "Todolist", "type": "Todolist", "app_url": "https://3.basecamp.com/1/buckets/1/todolists/2", "url": "https://3.basecampapi.com/1/buckets/1/todolists/2.json"] as [String: Any],
+        ]
         let cachedData = try JSONSerialization.data(withJSONObject: todo)
 
         let counter = RequestCounter()

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1389,6 +1389,7 @@
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2011,6 +2012,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.41.2",
@@ -2235,6 +2237,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2561,6 +2564,7 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -2597,6 +2601,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2628,6 +2633,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/typescript/src/generated/metadata.json
+++ b/typescript/src/generated/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-02-08T08:09:22.008Z",
+  "generated": "2026-02-13T21:04:02.667Z",
   "operations": {
     "CreateAttachment": {
       "retry": {

--- a/typescript/src/generated/openapi-stripped.json
+++ b/typescript/src/generated/openapi-stripped.json
@@ -10591,7 +10591,33 @@
                         "todolist": {
                           "id": 987654,
                           "status": "active",
-                          "name": "Launch Tasks"
+                          "name": "Launch Tasks",
+                          "visible_to_clients": false,
+                          "created_at": "2025-01-01T00:00:00Z",
+                          "updated_at": "2025-01-01T00:00:00Z",
+                          "title": "Launch Tasks",
+                          "inherits_status": true,
+                          "type": "Todolist",
+                          "url": "https://3.basecampapi.com/999/buckets/12345678/todolists/987654.json",
+                          "app_url": "https://3.basecamp.com/999/buckets/12345678/todolists/987654",
+                          "creator": {
+                            "id": 1,
+                            "name": "Someone",
+                            "created_at": "2025-01-01T00:00:00Z",
+                            "updated_at": "2025-01-01T00:00:00Z"
+                          },
+                          "bucket": {
+                            "id": 12345678,
+                            "name": "My Project",
+                            "type": "Project"
+                          },
+                          "parent": {
+                            "id": 99999,
+                            "title": "To-dos",
+                            "type": "Todoset",
+                            "url": "https://3.basecampapi.com/999/buckets/12345678/todosets/99999.json",
+                            "app_url": "https://3.basecamp.com/999/buckets/12345678/todosets/99999"
+                          }
                         }
                       }
                     }
@@ -10604,7 +10630,33 @@
                         "group": {
                           "id": 111222,
                           "status": "active",
-                          "name": "Q1 Milestones"
+                          "name": "Q1 Milestones",
+                          "visible_to_clients": false,
+                          "created_at": "2025-01-01T00:00:00Z",
+                          "updated_at": "2025-01-01T00:00:00Z",
+                          "title": "Q1 Milestones",
+                          "inherits_status": true,
+                          "type": "TodolistGroup",
+                          "url": "https://3.basecampapi.com/999/buckets/12345678/todolists/111222.json",
+                          "app_url": "https://3.basecamp.com/999/buckets/12345678/todolists/111222",
+                          "creator": {
+                            "id": 1,
+                            "name": "Someone",
+                            "created_at": "2025-01-01T00:00:00Z",
+                            "updated_at": "2025-01-01T00:00:00Z"
+                          },
+                          "bucket": {
+                            "id": 12345678,
+                            "name": "My Project",
+                            "type": "Project"
+                          },
+                          "parent": {
+                            "id": 99999,
+                            "title": "To-dos",
+                            "type": "Todoset",
+                            "url": "https://3.basecampapi.com/999/buckets/12345678/todosets/99999.json",
+                            "app_url": "https://3.basecamp.com/999/buckets/12345678/todosets/99999"
+                          }
                         }
                       }
                     }
@@ -17106,7 +17158,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "title": {
             "type": "string"
@@ -17127,10 +17180,20 @@
             "$ref": "#/components/schemas/TodoParent"
           },
           "due_on": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "types.Date",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "starts_on": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "types.Date",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "assignees": {
             "type": "array",
@@ -17159,13 +17222,19 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "content": {
             "type": "string"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "booster": {
             "$ref": "#/components/schemas/Person"
@@ -17173,14 +17242,19 @@
           "recording": {
             "$ref": "#/components/schemas/RecordingParent"
           }
-        }
+        },
+        "required": [
+          "created_at",
+          "id"
+        ]
       },
       "Campfire": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -17189,10 +17263,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -17231,14 +17315,29 @@
           "lines_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "CampfireLine": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -17247,10 +17346,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -17289,14 +17398,31 @@
           "boosts_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "content",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "parent",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "Card": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -17305,10 +17431,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -17342,13 +17478,23 @@
             "type": "string"
           },
           "due_on": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "types.Date",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "completed": {
             "type": "boolean"
           },
           "completed_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "comments_count": {
             "type": "integer",
@@ -17397,14 +17543,30 @@
           "boosts_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "parent",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "CardColumn": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -17413,10 +17575,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -17472,14 +17644,30 @@
               "$ref": "#/components/schemas/Person"
             }
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "parent",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "CardStep": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -17488,10 +17676,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -17516,13 +17714,23 @@
             "format": "int32"
           },
           "due_on": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "types.Date",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "completed": {
             "type": "boolean"
           },
           "completed_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "parent": {
             "$ref": "#/components/schemas/RecordingParent"
@@ -17545,14 +17753,30 @@
           "completion_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "parent",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "CardTable": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -17561,10 +17785,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -17605,20 +17839,45 @@
               "$ref": "#/components/schemas/CardColumn"
             }
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "Chatbot": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "service_name": {
             "type": "string"
@@ -17635,14 +17894,21 @@
           "lines_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "created_at",
+          "id",
+          "service_name",
+          "updated_at"
+        ]
       },
       "ClientApproval": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -17651,10 +17917,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -17693,7 +17969,12 @@
             "type": "string"
           },
           "due_on": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "types.Date",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "replies_count": {
             "type": "integer",
@@ -17714,14 +17995,30 @@
               "$ref": "#/components/schemas/ClientApprovalResponse"
             }
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "parent",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "ClientApprovalResponse": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -17730,10 +18027,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -17772,19 +18079,25 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "name": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
       },
       "ClientCorrespondence": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -17793,10 +18106,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -17841,14 +18164,31 @@
           "replies_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "parent",
+          "status",
+          "subject",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "ClientReply": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -17857,10 +18197,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -17892,7 +18242,23 @@
           "content": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "content",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "parent",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "ClientSide": {
         "type": "object",
@@ -17912,7 +18278,8 @@
         "properties": {
           "source_recording_id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           }
         },
         "required": [
@@ -17927,7 +18294,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -17936,10 +18304,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -17978,7 +18356,23 @@
           "boosts_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "content",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "parent",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "CreateAnswerResponseContent": {
         "$ref": "#/components/schemas/QuestionAnswer"
@@ -18039,10 +18433,16 @@
             "type": "string"
           },
           "due_on": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "types.Date",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "notify": {
-            "type": "boolean"
+            "type": "boolean",
+            "x-go-type-skip-optional-pointer": false
           }
         },
         "required": [
@@ -18059,7 +18459,12 @@
             "type": "string"
           },
           "due_on": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "types.Date",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "assignees": {
             "type": "array",
@@ -18186,7 +18591,8 @@
           },
           "category_id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           }
         },
         "required": [
@@ -18312,10 +18718,20 @@
             "type": "string"
           },
           "starts_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "ends_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "description": {
             "type": "string"
@@ -18328,10 +18744,12 @@
             }
           },
           "all_day": {
-            "type": "boolean"
+            "type": "boolean",
+            "x-go-type-skip-optional-pointer": false
           },
           "notify": {
-            "type": "boolean"
+            "type": "boolean",
+            "x-go-type-skip-optional-pointer": false
           }
         },
         "required": [
@@ -18374,7 +18792,8 @@
           },
           "person_id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           }
         },
         "required": [
@@ -18409,13 +18828,24 @@
             }
           },
           "notify": {
-            "type": "boolean"
+            "type": "boolean",
+            "x-go-type-skip-optional-pointer": false
           },
           "due_on": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "types.Date",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "starts_on": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "types.Date",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            },
+            "x-go-type-skip-optional-pointer": true
           }
         },
         "required": [
@@ -18503,7 +18933,8 @@
             }
           },
           "active": {
-            "type": "boolean"
+            "type": "boolean",
+            "x-go-type-skip-optional-pointer": false
           }
         },
         "required": [
@@ -18522,7 +18953,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "title": {
             "type": "string"
@@ -18543,14 +18975,23 @@
           "app_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "enabled",
+          "id",
+          "name",
+          "title",
+          "url"
+        ]
       },
       "Document": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -18559,10 +19000,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -18615,7 +19066,22 @@
           "boosts_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "parent",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "EnableCardColumnOnHoldResponseContent": {
         "$ref": "#/components/schemas/CardColumn"
@@ -18625,11 +19091,13 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "recording_id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "action": {
             "type": "string"
@@ -18638,7 +19106,12 @@
             "$ref": "#/components/schemas/EventDetails"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "creator": {
             "$ref": "#/components/schemas/Person"
@@ -18650,7 +19123,14 @@
           "boosts_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "action",
+          "created_at",
+          "creator",
+          "id",
+          "recording_id"
+        ]
       },
       "EventDetails": {
         "type": "object",
@@ -18697,7 +19177,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -18706,10 +19187,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -18757,14 +19248,31 @@
           "replies_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "parent",
+          "status",
+          "subject",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "ForwardReply": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -18773,10 +19281,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -18815,7 +19333,23 @@
           "boosts_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "content",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "parent",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "GetAnswerResponseContent": {
         "$ref": "#/components/schemas/QuestionAnswer"
@@ -19067,7 +19601,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -19076,10 +19611,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -19116,7 +19661,21 @@
           "forwards_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "InternalServerErrorResponseContent": {
         "type": "object",
@@ -19341,7 +19900,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -19350,10 +19910,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -19408,14 +19978,32 @@
           "boosts_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "content",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "parent",
+          "status",
+          "subject",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "MessageBoard": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -19424,10 +20012,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -19467,14 +20065,29 @@
           "app_messages_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "MessageType": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "name": {
             "type": "string"
@@ -19483,23 +20096,42 @@
             "type": "string"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           }
-        }
+        },
+        "required": [
+          "created_at",
+          "icon",
+          "id",
+          "name",
+          "updated_at"
+        ]
       },
       "MoveCardColumnRequestContent": {
         "type": "object",
         "properties": {
           "source_id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "target_id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "position": {
             "type": "integer",
@@ -19516,7 +20148,8 @@
         "properties": {
           "column_id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           }
         },
         "required": [
@@ -19550,7 +20183,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "attachable_sgid": {
             "type": "string"
@@ -19599,10 +20233,20 @@
             }
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "admin": {
             "type": "boolean"
@@ -19645,37 +20289,57 @@
           "can_access_hill_charts": {
             "type": "boolean"
           }
-        }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
       },
       "PersonCompany": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "name": {
             "type": "string",
             "format": "password"
           }
-        }
+        },
+        "required": [
+          "id",
+          "name"
+        ]
       },
       "Project": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string",
             "description": "active|archived|trashed"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "name": {
             "type": "string"
@@ -19714,7 +20378,16 @@
             "$ref": "#/components/schemas/ClientSide",
             "deprecated": true
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "created_at",
+          "id",
+          "name",
+          "status",
+          "updated_at",
+          "url"
+        ]
       },
       "ProjectAccessResult": {
         "type": "object",
@@ -19738,7 +20411,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -19749,14 +20423,19 @@
           "project": {
             "$ref": "#/components/schemas/Project"
           }
-        }
+        },
+        "required": [
+          "id",
+          "status"
+        ]
       },
       "Question": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -19765,10 +20444,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -19813,14 +20502,30 @@
           "answers_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "parent",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "QuestionAnswer": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -19829,10 +20534,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -19866,7 +20581,12 @@
             "type": "string"
           },
           "group_on": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "types.Date",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "parent": {
             "$ref": "#/components/schemas/RecordingParent"
@@ -19884,7 +20604,23 @@
           "boosts_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "content",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "parent",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "QuestionAnswerPayload": {
         "type": "object",
@@ -19893,7 +20629,12 @@
             "type": "string"
           },
           "group_on": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "types.Date",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            },
+            "x-go-type-skip-optional-pointer": true
           }
         },
         "required": [
@@ -19916,13 +20657,24 @@
         "properties": {
           "reminder_id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "remind_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "group_on": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "types.Date",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "question": {
             "$ref": "#/components/schemas/Question"
@@ -19975,7 +20727,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -19984,10 +20737,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -20023,7 +20786,22 @@
           "creator": {
             "$ref": "#/components/schemas/Person"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "name",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "RateLimitErrorResponseContent": {
         "type": "object",
@@ -20048,7 +20826,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -20057,10 +20836,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -20102,14 +20891,30 @@
           "creator": {
             "$ref": "#/components/schemas/Person"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "parent",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "RecordingBucket": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "name": {
             "type": "string"
@@ -20117,14 +20922,20 @@
           "type": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ]
       },
       "RecordingParent": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "title": {
             "type": "string"
@@ -20138,14 +20949,22 @@
           "app_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "id",
+          "title",
+          "type",
+          "url"
+        ]
       },
       "RepositionCardStepRequestContent": {
         "type": "object",
         "properties": {
           "source_id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "position": {
             "type": "integer",
@@ -20168,7 +20987,8 @@
           "parent_id": {
             "type": "integer",
             "description": "Optional todolist ID to move the todo to a different parent",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           }
         },
         "required": [
@@ -20212,7 +21032,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -20221,10 +21042,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -20264,7 +21095,21 @@
           "entries_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "ScheduleAttributes": {
         "type": "object",
@@ -20282,7 +21127,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -20291,10 +21137,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -20343,10 +21199,20 @@
             "type": "boolean"
           },
           "starts_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "ends_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "participants": {
             "type": "array",
@@ -20361,7 +21227,23 @@
           "boosts_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "parent",
+          "status",
+          "summary",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "SearchMetadata": {
         "type": "object",
@@ -20379,7 +21261,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "name": {
             "type": "string"
@@ -20397,7 +21280,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -20406,10 +21290,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -20447,7 +21341,14 @@
           "subject": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "id",
+          "title",
+          "type",
+          "url"
+        ]
       },
       "SetCardColumnColorRequestContent": {
         "type": "object",
@@ -20515,23 +21416,39 @@
               "$ref": "#/components/schemas/Person"
             }
           }
-        }
+        },
+        "required": [
+          "count",
+          "subscribed",
+          "url"
+        ]
       },
       "Template": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "name": {
             "type": "string"
@@ -20551,24 +21468,37 @@
               "$ref": "#/components/schemas/DockItem"
             }
           }
-        }
+        },
+        "required": [
+          "created_at",
+          "id",
+          "name",
+          "updated_at"
+        ]
       },
       "TimelineEvent": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "kind": {
             "type": "string"
           },
           "parent_recording_id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "url": {
             "type": "string"
@@ -20601,7 +21531,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -20610,10 +21541,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -20654,14 +21595,30 @@
           "person": {
             "$ref": "#/components/schemas/Person"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "parent",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "Todo": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string",
@@ -20671,10 +21628,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -20727,10 +21694,20 @@
             "type": "string"
           },
           "starts_on": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "types.Date",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "due_on": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "types.Date",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "assignees": {
             "type": "array",
@@ -20754,14 +21731,31 @@
           "boosts_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "content",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "parent",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "TodoBucket": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "name": {
             "type": "string"
@@ -20769,14 +21763,20 @@
           "type": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "id",
+          "name",
+          "type"
+        ]
       },
       "TodoParent": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "title": {
             "type": "string"
@@ -20790,14 +21790,22 @@
           "app_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "id",
+          "title",
+          "type",
+          "url"
+        ]
       },
       "Todolist": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string",
@@ -20807,10 +21815,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -20881,14 +21899,31 @@
           "boosts_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "name",
+          "parent",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "TodolistGroup": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -20897,10 +21932,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -20958,7 +22003,23 @@
           "app_todos_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "name",
+          "parent",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "TodolistOrGroup": {
         "description": "Union type for polymorphic todolist endpoint",
@@ -20994,7 +22055,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -21003,10 +22065,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -21067,23 +22139,49 @@
           "app_todolists_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "name",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "Tool": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -21107,7 +22205,15 @@
           "bucket": {
             "$ref": "#/components/schemas/RecordingBucket"
           }
-        }
+        },
+        "required": [
+          "created_at",
+          "enabled",
+          "id",
+          "name",
+          "title",
+          "updated_at"
+        ]
       },
       "UnauthorizedErrorResponseContent": {
         "type": "object",
@@ -21147,7 +22253,12 @@
             "type": "string"
           },
           "due_on": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "types.Date",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "assignee_ids": {
             "type": "array",
@@ -21168,7 +22279,12 @@
             "type": "string"
           },
           "due_on": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "types.Date",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "assignees": {
             "type": "array",
@@ -21253,7 +22369,8 @@
           },
           "category_id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           }
         }
       },
@@ -21331,11 +22448,13 @@
         "properties": {
           "notify_on_answer": {
             "type": "boolean",
-            "description": "Notify when someone answers"
+            "description": "Notify when someone answers",
+            "x-go-type-skip-optional-pointer": false
           },
           "digest_include_unanswered": {
             "type": "boolean",
-            "description": "Include unanswered in digest"
+            "description": "Include unanswered in digest",
+            "x-go-type-skip-optional-pointer": false
           }
         }
       },
@@ -21360,7 +22479,8 @@
             "$ref": "#/components/schemas/QuestionSchedule"
           },
           "paused": {
-            "type": "boolean"
+            "type": "boolean",
+            "x-go-type-skip-optional-pointer": false
           }
         }
       },
@@ -21374,10 +22494,20 @@
             "type": "string"
           },
           "starts_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "ends_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "description": {
             "type": "string"
@@ -21390,10 +22520,12 @@
             }
           },
           "all_day": {
-            "type": "boolean"
+            "type": "boolean",
+            "x-go-type-skip-optional-pointer": false
           },
           "notify": {
-            "type": "boolean"
+            "type": "boolean",
+            "x-go-type-skip-optional-pointer": false
           }
         }
       },
@@ -21464,7 +22596,8 @@
           },
           "person_id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           }
         }
       },
@@ -21495,13 +22628,24 @@
             }
           },
           "notify": {
-            "type": "boolean"
+            "type": "boolean",
+            "x-go-type-skip-optional-pointer": false
           },
           "due_on": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "types.Date",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "starts_on": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "types.Date",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            },
+            "x-go-type-skip-optional-pointer": true
           }
         }
       },
@@ -21576,7 +22720,8 @@
             }
           },
           "active": {
-            "type": "boolean"
+            "type": "boolean",
+            "x-go-type-skip-optional-pointer": false
           }
         }
       },
@@ -21588,7 +22733,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -21597,10 +22743,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -21674,7 +22830,22 @@
           "boosts_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "parent",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "ValidationErrorResponseContent": {
         "type": "object",
@@ -21695,7 +22866,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "status": {
             "type": "string"
@@ -21704,10 +22876,20 @@
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "title": {
             "type": "string"
@@ -21761,23 +22943,48 @@
           "vaults_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "bucket",
+          "created_at",
+          "creator",
+          "id",
+          "inherits_status",
+          "status",
+          "title",
+          "type",
+          "updated_at",
+          "url",
+          "visible_to_clients"
+        ]
       },
       "Webhook": {
         "type": "object",
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "active": {
             "type": "boolean"
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "updated_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "payload_url": {
             "type": "string"
@@ -21800,7 +23007,15 @@
               "$ref": "#/components/schemas/WebhookDelivery"
             }
           }
-        }
+        },
+        "required": [
+          "app_url",
+          "created_at",
+          "id",
+          "payload_url",
+          "updated_at",
+          "url"
+        ]
       },
       "WebhookCopy": {
         "type": "object",
@@ -21808,7 +23023,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "url": {
             "type": "string"
@@ -21826,7 +23042,8 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           }
         }
       },
@@ -21835,10 +23052,16 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "request": {
             "$ref": "#/components/schemas/WebhookDeliveryRequest"
@@ -21880,14 +23103,20 @@
         "properties": {
           "id": {
             "type": "integer",
-            "format": "int64"
+            "format": "int64",
+            "x-go-type-skip-optional-pointer": false
           },
           "kind": {
             "type": "string"
           },
           "details": {},
           "created_at": {
-            "type": "string"
+            "type": "string",
+            "x-go-type": "time.Time",
+            "x-go-type-import": {
+              "path": "time"
+            },
+            "x-go-type-skip-optional-pointer": true
           },
           "recording": {
             "$ref": "#/components/schemas/Recording"

--- a/typescript/src/generated/schema.d.ts
+++ b/typescript/src/generated/schema.d.ts
@@ -2203,66 +2203,66 @@ export interface components {
         };
         Boost: {
             /** Format: int64 */
-            id?: number;
+            id: number;
             content?: string;
-            created_at?: string;
+            created_at: string;
             booster?: components["schemas"]["Person"];
             recording?: components["schemas"]["RecordingParent"];
         };
         Campfire: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             subscription_url?: string;
             /** Format: int32 */
             position?: number;
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
             topic?: string;
             lines_url?: string;
         };
         CampfireLine: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
-            content?: string;
-            parent?: components["schemas"]["RecordingParent"];
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
+            content: string;
+            parent: components["schemas"]["RecordingParent"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
             /** Format: int32 */
             boosts_count?: number;
             boosts_url?: string;
         };
         Card: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             subscription_url?: string;
             /** Format: int32 */
@@ -2276,9 +2276,9 @@ export interface components {
             comments_count?: number;
             comments_url?: string;
             completion_url?: string;
-            parent?: components["schemas"]["RecordingParent"];
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
+            parent: components["schemas"]["RecordingParent"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
             completer?: components["schemas"]["Person"];
             assignees?: components["schemas"]["Person"][];
             completion_subscribers?: components["schemas"]["Person"][];
@@ -2289,16 +2289,16 @@ export interface components {
         };
         CardColumn: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             /** Format: int32 */
             position?: number;
@@ -2309,61 +2309,61 @@ export interface components {
             /** Format: int32 */
             comments_count?: number;
             cards_url?: string;
-            parent?: components["schemas"]["RecordingParent"];
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
+            parent: components["schemas"]["RecordingParent"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
             subscribers?: components["schemas"]["Person"][];
         };
         CardStep: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             /** Format: int32 */
             position?: number;
             due_on?: string;
             completed?: boolean;
             completed_at?: string;
-            parent?: components["schemas"]["RecordingParent"];
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
+            parent: components["schemas"]["RecordingParent"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
             completer?: components["schemas"]["Person"];
             assignees?: components["schemas"]["Person"][];
             completion_url?: string;
         };
         CardTable: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             subscription_url?: string;
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
             subscribers?: components["schemas"]["Person"][];
             lists?: components["schemas"]["CardColumn"][];
         };
         Chatbot: {
             /** Format: int64 */
-            id?: number;
-            created_at?: string;
-            updated_at?: string;
-            service_name?: string;
+            id: number;
+            created_at: string;
+            updated_at: string;
+            service_name: string;
             command_url?: string;
             url?: string;
             app_url?: string;
@@ -2371,21 +2371,21 @@ export interface components {
         };
         ClientApproval: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             subscription_url?: string;
-            parent?: components["schemas"]["RecordingParent"];
-            bucket?: components["schemas"]["RecordingBucket"];
-            creator?: components["schemas"]["Person"];
+            parent: components["schemas"]["RecordingParent"];
+            bucket: components["schemas"]["RecordingBucket"];
+            creator: components["schemas"]["Person"];
             content?: string;
             subject?: string;
             due_on?: string;
@@ -2416,49 +2416,49 @@ export interface components {
         };
         ClientCompany: {
             /** Format: int64 */
-            id?: number;
-            name?: string;
+            id: number;
+            name: string;
         };
         ClientCorrespondence: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             subscription_url?: string;
-            parent?: components["schemas"]["RecordingParent"];
-            bucket?: components["schemas"]["RecordingBucket"];
-            creator?: components["schemas"]["Person"];
+            parent: components["schemas"]["RecordingParent"];
+            bucket: components["schemas"]["RecordingBucket"];
+            creator: components["schemas"]["Person"];
             content?: string;
-            subject?: string;
+            subject: string;
             /** Format: int32 */
             replies_count?: number;
             replies_url?: string;
         };
         ClientReply: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
-            parent?: components["schemas"]["RecordingParent"];
-            bucket?: components["schemas"]["RecordingBucket"];
-            creator?: components["schemas"]["Person"];
-            content?: string;
+            parent: components["schemas"]["RecordingParent"];
+            bucket: components["schemas"]["RecordingBucket"];
+            creator: components["schemas"]["Person"];
+            content: string;
         };
         /**
          * @deprecated
@@ -2475,21 +2475,21 @@ export interface components {
         CloneToolResponseContent: components["schemas"]["Tool"];
         Comment: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
-            parent?: components["schemas"]["RecordingParent"];
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
-            content?: string;
+            parent: components["schemas"]["RecordingParent"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
+            content: string;
             /** Format: int32 */
             boosts_count?: number;
             boosts_url?: string;
@@ -2654,27 +2654,27 @@ export interface components {
         DisableCardColumnOnHoldResponseContent: components["schemas"]["CardColumn"];
         DockItem: {
             /** Format: int64 */
-            id?: number;
-            title?: string;
-            name?: string;
-            enabled?: boolean;
+            id: number;
+            title: string;
+            name: string;
+            enabled: boolean;
             /** Format: int32 */
             position?: number;
-            url?: string;
-            app_url?: string;
+            url: string;
+            app_url: string;
         };
         Document: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             subscription_url?: string;
             /** Format: int32 */
@@ -2682,9 +2682,9 @@ export interface components {
             comments_url?: string;
             /** Format: int32 */
             position?: number;
-            parent?: components["schemas"]["RecordingParent"];
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
+            parent: components["schemas"]["RecordingParent"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
             content?: string;
             /** Format: int32 */
             boosts_count?: number;
@@ -2693,13 +2693,13 @@ export interface components {
         EnableCardColumnOnHoldResponseContent: components["schemas"]["CardColumn"];
         Event: {
             /** Format: int64 */
-            id?: number;
+            id: number;
             /** Format: int64 */
-            recording_id?: number;
-            action?: string;
+            recording_id: number;
+            action: string;
             details?: components["schemas"]["EventDetails"];
-            created_at?: string;
-            creator?: components["schemas"]["Person"];
+            created_at: string;
+            creator: components["schemas"]["Person"];
             /** Format: int32 */
             boosts_count?: number;
             boosts_url?: string;
@@ -2715,23 +2715,23 @@ export interface components {
         };
         Forward: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             subscription_url?: string;
-            parent?: components["schemas"]["RecordingParent"];
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
+            parent: components["schemas"]["RecordingParent"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
             content?: string;
-            subject?: string;
+            subject: string;
             from?: string;
             /** Format: int32 */
             replies_count?: number;
@@ -2739,21 +2739,21 @@ export interface components {
         };
         ForwardReply: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
-            parent?: components["schemas"]["RecordingParent"];
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
-            content?: string;
+            parent: components["schemas"]["RecordingParent"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
+            content: string;
             /** Format: int32 */
             boosts_count?: number;
             boosts_url?: string;
@@ -2827,21 +2827,21 @@ export interface components {
         GetWebhookResponseContent: components["schemas"]["Webhook"];
         Inbox: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             /** Format: int32 */
             position?: number;
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
             /** Format: int32 */
             forwards_count?: number;
             forwards_url?: string;
@@ -2886,26 +2886,26 @@ export interface components {
         ListWebhooksResponseContent: components["schemas"]["Webhook"][];
         Message: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             subscription_url?: string;
             /** Format: int32 */
             comments_count?: number;
             comments_url?: string;
-            parent?: components["schemas"]["RecordingParent"];
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
-            subject?: string;
-            content?: string;
+            parent: components["schemas"]["RecordingParent"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
+            subject: string;
+            content: string;
             category?: components["schemas"]["MessageType"];
             /** Format: int32 */
             boosts_count?: number;
@@ -2913,21 +2913,21 @@ export interface components {
         };
         MessageBoard: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             /** Format: int32 */
             position?: number;
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
             /** Format: int32 */
             messages_count?: number;
             messages_url?: string;
@@ -2935,11 +2935,11 @@ export interface components {
         };
         MessageType: {
             /** Format: int64 */
-            id?: number;
-            name?: string;
-            icon?: string;
-            created_at?: string;
-            updated_at?: string;
+            id: number;
+            name: string;
+            icon: string;
+            created_at: string;
+            updated_at: string;
         };
         MoveCardColumnRequestContent: {
             /** Format: int64 */
@@ -2962,10 +2962,10 @@ export interface components {
         };
         Person: {
             /** Format: int64 */
-            id?: number;
+            id: number;
             attachable_sgid?: string;
             /** Format: password */
-            name?: string;
+            name: string;
             /** Format: password */
             email_address?: string;
             personable_type?: string;
@@ -2993,24 +2993,24 @@ export interface components {
         };
         PersonCompany: {
             /** Format: int64 */
-            id?: number;
+            id: number;
             /** Format: password */
-            name?: string;
+            name: string;
         };
         Project: {
             /** Format: int64 */
-            id?: number;
+            id: number;
             /** @description active|archived|trashed */
-            status?: string;
-            created_at?: string;
-            updated_at?: string;
-            name?: string;
+            status: string;
+            created_at: string;
+            updated_at: string;
+            name: string;
             description?: string;
             purpose?: string;
             clients_enabled?: boolean;
             bookmark_url?: string;
-            url?: string;
-            app_url?: string;
+            url: string;
+            app_url: string;
             dock?: components["schemas"]["DockItem"][];
             bookmarked?: boolean;
             client_company?: components["schemas"]["ClientCompany"];
@@ -3023,28 +3023,28 @@ export interface components {
         };
         ProjectConstruction: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
+            id: number;
+            status: string;
             url?: string;
             project?: components["schemas"]["Project"];
         };
         Question: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             subscription_url?: string;
-            parent?: components["schemas"]["RecordingParent"];
-            bucket?: components["schemas"]["RecordingBucket"];
-            creator?: components["schemas"]["Person"];
+            parent: components["schemas"]["RecordingParent"];
+            bucket: components["schemas"]["RecordingBucket"];
+            creator: components["schemas"]["Person"];
             paused?: boolean;
             schedule?: components["schemas"]["QuestionSchedule"];
             /** Format: int32 */
@@ -3053,26 +3053,26 @@ export interface components {
         };
         QuestionAnswer: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             subscription_url?: string;
             /** Format: int32 */
             comments_count?: number;
             comments_url?: string;
-            content?: string;
+            content: string;
             group_on?: string;
-            parent?: components["schemas"]["RecordingParent"];
-            bucket?: components["schemas"]["RecordingBucket"];
-            creator?: components["schemas"]["Person"];
+            parent: components["schemas"]["RecordingParent"];
+            bucket: components["schemas"]["RecordingBucket"];
+            creator: components["schemas"]["Person"];
             /** Format: int32 */
             boosts_count?: number;
             boosts_url?: string;
@@ -3109,23 +3109,23 @@ export interface components {
         };
         Questionnaire: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             questions_url?: string;
             /** Format: int32 */
             questions_count?: number;
-            name?: string;
-            bucket?: components["schemas"]["RecordingBucket"];
-            creator?: components["schemas"]["Person"];
+            name: string;
+            bucket: components["schemas"]["RecordingBucket"];
+            creator: components["schemas"]["Person"];
         };
         RateLimitErrorResponseContent: {
             error: string;
@@ -3135,39 +3135,39 @@ export interface components {
         };
         Recording: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             content?: string;
             /** Format: int32 */
             comments_count?: number;
             comments_url?: string;
             subscription_url?: string;
-            parent?: components["schemas"]["RecordingParent"];
-            bucket?: components["schemas"]["RecordingBucket"];
-            creator?: components["schemas"]["Person"];
+            parent: components["schemas"]["RecordingParent"];
+            bucket: components["schemas"]["RecordingBucket"];
+            creator: components["schemas"]["Person"];
         };
         RecordingBucket: {
             /** Format: int64 */
-            id?: number;
-            name?: string;
-            type?: string;
+            id: number;
+            name: string;
+            type: string;
         };
         RecordingParent: {
             /** Format: int64 */
-            id?: number;
-            title?: string;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            title: string;
+            type: string;
+            url: string;
+            app_url: string;
         };
         RepositionCardStepRequestContent: {
             /** Format: int64 */
@@ -3200,21 +3200,21 @@ export interface components {
         };
         Schedule: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             /** Format: int32 */
             position?: number;
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
             include_due_assignments?: boolean;
             /** Format: int32 */
             entries_count?: number;
@@ -3226,25 +3226,25 @@ export interface components {
         };
         ScheduleEntry: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             subscription_url?: string;
             /** Format: int32 */
             comments_count?: number;
             comments_url?: string;
-            parent?: components["schemas"]["RecordingParent"];
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
-            summary?: string;
+            parent: components["schemas"]["RecordingParent"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
+            summary: string;
             description?: string;
             all_day?: boolean;
             starts_at?: string;
@@ -3265,16 +3265,16 @@ export interface components {
         SearchResponseContent: components["schemas"]["SearchResult"][];
         SearchResult: {
             /** Format: int64 */
-            id?: number;
+            id: number;
             status?: string;
             visible_to_clients?: boolean;
             created_at?: string;
             updated_at?: string;
-            title?: string;
+            title: string;
             inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             parent?: components["schemas"]["RecordingParent"];
             bucket?: components["schemas"]["RecordingBucket"];
@@ -3299,19 +3299,19 @@ export interface components {
         SetClientVisibilityResponseContent: components["schemas"]["Recording"];
         SubscribeResponseContent: components["schemas"]["Subscription"];
         Subscription: {
-            subscribed?: boolean;
+            subscribed: boolean;
             /** Format: int32 */
-            count?: number;
-            url?: string;
+            count: number;
+            url: string;
             subscribers?: components["schemas"]["Person"][];
         };
         Template: {
             /** Format: int64 */
-            id?: number;
+            id: number;
             status?: string;
-            created_at?: string;
-            updated_at?: string;
-            name?: string;
+            created_at: string;
+            updated_at: string;
+            name: string;
             description?: string;
             url?: string;
             app_url?: string;
@@ -3335,20 +3335,20 @@ export interface components {
         };
         TimesheetEntry: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
-            parent?: components["schemas"]["RecordingParent"];
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
+            parent: components["schemas"]["RecordingParent"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
             date?: string;
             description?: string;
             hours?: string;
@@ -3356,17 +3356,17 @@ export interface components {
         };
         Todo: {
             /** Format: int64 */
-            id?: number;
+            id: number;
             /** @description active|archived|trashed */
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             subscription_url?: string;
             /** Format: int32 */
@@ -3374,12 +3374,12 @@ export interface components {
             comments_url?: string;
             /** Format: int32 */
             position?: number;
-            parent?: components["schemas"]["TodoParent"];
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
+            parent: components["schemas"]["TodoParent"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
             description?: string;
             completed?: boolean;
-            content?: string;
+            content: string;
             starts_on?: string;
             due_on?: string;
             assignees?: components["schemas"]["Person"][];
@@ -3391,31 +3391,31 @@ export interface components {
         };
         TodoBucket: {
             /** Format: int64 */
-            id?: number;
-            name?: string;
-            type?: string;
+            id: number;
+            name: string;
+            type: string;
         };
         TodoParent: {
             /** Format: int64 */
-            id?: number;
-            title?: string;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            title: string;
+            type: string;
+            url: string;
+            app_url: string;
         };
         Todolist: {
             /** Format: int64 */
-            id?: number;
+            id: number;
             /** @description active|archived|trashed */
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             subscription_url?: string;
             /** Format: int32 */
@@ -3423,13 +3423,13 @@ export interface components {
             comments_url?: string;
             /** Format: int32 */
             position?: number;
-            parent?: components["schemas"]["TodoParent"];
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
+            parent: components["schemas"]["TodoParent"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
             description?: string;
             completed?: boolean;
             completed_ratio?: string;
-            name?: string;
+            name: string;
             todos_url?: string;
             groups_url?: string;
             app_todos_url?: string;
@@ -3439,16 +3439,16 @@ export interface components {
         };
         TodolistGroup: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             subscription_url?: string;
             /** Format: int32 */
@@ -3456,10 +3456,10 @@ export interface components {
             comments_url?: string;
             /** Format: int32 */
             position?: number;
-            parent?: components["schemas"]["TodoParent"];
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
-            name?: string;
+            parent: components["schemas"]["TodoParent"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
+            name: string;
             completed?: boolean;
             completed_ratio?: string;
             todos_url?: string;
@@ -3473,22 +3473,22 @@ export interface components {
         };
         Todoset: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             /** Format: int32 */
             position?: number;
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
-            name?: string;
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
+            name: string;
             /** Format: int32 */
             todolists_count?: number;
             todolists_url?: string;
@@ -3504,13 +3504,13 @@ export interface components {
         };
         Tool: {
             /** Format: int64 */
-            id?: number;
+            id: number;
             status?: string;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            name?: string;
-            enabled?: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            name: string;
+            enabled: boolean;
             /** Format: int32 */
             position?: number;
             url?: string;
@@ -3671,16 +3671,16 @@ export interface components {
         UpdateWebhookResponseContent: components["schemas"]["Webhook"];
         Upload: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             subscription_url?: string;
             /** Format: int32 */
@@ -3688,9 +3688,9 @@ export interface components {
             comments_url?: string;
             /** Format: int32 */
             position?: number;
-            parent?: components["schemas"]["RecordingParent"];
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
+            parent: components["schemas"]["RecordingParent"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
             description?: string;
             content_type?: string;
             /** Format: int64 */
@@ -3711,22 +3711,22 @@ export interface components {
         };
         Vault: {
             /** Format: int64 */
-            id?: number;
-            status?: string;
-            visible_to_clients?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            title?: string;
-            inherits_status?: boolean;
-            type?: string;
-            url?: string;
-            app_url?: string;
+            id: number;
+            status: string;
+            visible_to_clients: boolean;
+            created_at: string;
+            updated_at: string;
+            title: string;
+            inherits_status: boolean;
+            type: string;
+            url: string;
+            app_url: string;
             bookmark_url?: string;
             /** Format: int32 */
             position?: number;
             parent?: components["schemas"]["RecordingParent"];
-            bucket?: components["schemas"]["TodoBucket"];
-            creator?: components["schemas"]["Person"];
+            bucket: components["schemas"]["TodoBucket"];
+            creator: components["schemas"]["Person"];
             /** Format: int32 */
             documents_count?: number;
             documents_url?: string;
@@ -3739,14 +3739,14 @@ export interface components {
         };
         Webhook: {
             /** Format: int64 */
-            id?: number;
+            id: number;
             active?: boolean;
-            created_at?: string;
-            updated_at?: string;
-            payload_url?: string;
+            created_at: string;
+            updated_at: string;
+            payload_url: string;
             types?: string[];
-            url?: string;
-            app_url?: string;
+            url: string;
+            app_url: string;
             recent_deliveries?: components["schemas"]["WebhookDelivery"][];
         };
         /** @description Reference to a copied/moved recording in copy events. */


### PR DESCRIPTION
## Summary

Consume the `required` arrays added to `openapi.json` in #100 across all remaining language SDKs (Kotlin was done in #101):

- **TypeScript**: Regenerated schema types — 473 fields change from optional (`id?: number`) to required (`id: number`)
- **Swift**: Updated `emitEntityModel()` to emit `public let` for required fields, `public var` for optional, with memberwise `init`. Regenerated all 48 entity model files
- **Ruby**: Updated `generate-types.rb` to order required fields first and add `self.required_fields` class method. Regenerated `types.rb`
- **Go**: Regenerated `client.gen.go` (required fields drop `omitempty`, ID fields become `int64` not `*int64`). Updated ~30 service files and 2 test files to remove nil checks and pointer dereferences

## Test plan

- [x] `make check` passes (all SDK checks, conformance tests, drift checks, linting)
- [x] `make ts-check` — TypeScript typecheck + tests
- [x] `make swift-check` — Swift build + tests
- [x] `make rb-check` — Ruby tests + rubocop
- [x] `make go-check` — Go vet + lint + tests