### PR TITLE
Observability hooks: ChainHooks and operation-level tracking

### DIFF
--- a/ruby/lib/basecamp.rb
+++ b/ruby/lib/basecamp.rb
@@ -15,10 +15,13 @@ loader.collapse("#{__dir__}/basecamp/generated")
 
 # Ignore errors.rb - it defines multiple classes, loaded explicitly below
 loader.ignore("#{__dir__}/basecamp/errors.rb")
+# Ignore operation_info.rb - defines both OperationInfo and OperationResult
+loader.ignore("#{__dir__}/basecamp/operation_info.rb")
 loader.setup
 
 # Load infrastructure that generated services depend on
 require_relative "basecamp/errors"
+require_relative "basecamp/operation_info"
 require_relative "basecamp/services/base_service"
 require_relative "basecamp/services/authorization_service"
 

--- a/ruby/lib/basecamp/chain_hooks.rb
+++ b/ruby/lib/basecamp/chain_hooks.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Basecamp
+  # Composes multiple Hooks implementations, calling them in sequence.
+  # Start events are called in order; end events are called in reverse order.
+  class ChainHooks
+    include Hooks
+
+    def initialize(*hooks)
+      @hooks = hooks
+    end
+
+    def on_operation_start(info)
+      @hooks.each { |h| safe_call { h.on_operation_start(info) } }
+    end
+
+    def on_operation_end(info, result)
+      @hooks.reverse_each { |h| safe_call { h.on_operation_end(info, result) } }
+    end
+
+    def on_request_start(info)
+      @hooks.each { |h| safe_call { h.on_request_start(info) } }
+    end
+
+    def on_request_end(info, result)
+      @hooks.reverse_each { |h| safe_call { h.on_request_end(info, result) } }
+    end
+
+    def on_retry(info, attempt, error, delay)
+      @hooks.each { |h| safe_call { h.on_retry(info, attempt, error, delay) } }
+    end
+
+    def on_paginate(url, page)
+      @hooks.each { |h| safe_call { h.on_paginate(url, page) } }
+    end
+
+    private
+
+    def safe_call
+      yield
+    rescue => e
+      warn "Basecamp::ChainHooks: hook raised #{e.class}: #{e.message}"
+    end
+  end
+end

--- a/ruby/lib/basecamp/generated/services/attachments_service.rb
+++ b/ruby/lib/basecamp/generated/services/attachments_service.rb
@@ -15,7 +15,9 @@ module Basecamp
       # @param name [String] name
       # @return [Hash] response data
       def create(data:, content_type:, name:)
-        http_post_raw("/attachments.json?name=#{URI.encode_www_form_component(name.to_s)}", body: data, content_type: content_type).json
+        with_operation(service: "attachments", operation: "create", is_mutation: true) do
+          http_post_raw("/attachments.json?name=#{URI.encode_www_form_component(name.to_s)}", body: data, content_type: content_type).json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/boosts_service.rb
+++ b/ruby/lib/basecamp/generated/services/boosts_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param boost_id [Integer] boost id ID
       # @return [Hash] response data
       def get_boost(project_id:, boost_id:)
-        http_get(bucket_path(project_id, "/boosts/#{boost_id}")).json
+        with_operation(service: "boosts", operation: "get_boost", is_mutation: false, project_id: project_id, resource_id: boost_id) do
+          http_get(bucket_path(project_id, "/boosts/#{boost_id}")).json
+        end
       end
 
       # Delete a boost
@@ -20,8 +22,10 @@ module Basecamp
       # @param boost_id [Integer] boost id ID
       # @return [void]
       def delete_boost(project_id:, boost_id:)
-        http_delete(bucket_path(project_id, "/boosts/#{boost_id}"))
-        nil
+        with_operation(service: "boosts", operation: "delete_boost", is_mutation: true, project_id: project_id, resource_id: boost_id) do
+          http_delete(bucket_path(project_id, "/boosts/#{boost_id}"))
+          nil
+        end
       end
 
       # List boosts on a recording
@@ -29,7 +33,9 @@ module Basecamp
       # @param recording_id [Integer] recording id ID
       # @return [Enumerator<Hash>] paginated results
       def list_recording_boosts(project_id:, recording_id:)
-        paginate(bucket_path(project_id, "/recordings/#{recording_id}/boosts.json"))
+        wrap_paginated(service: "boosts", operation: "list_recording_boosts", is_mutation: false, project_id: project_id, resource_id: recording_id) do
+          paginate(bucket_path(project_id, "/recordings/#{recording_id}/boosts.json"))
+        end
       end
 
       # Create a boost on a recording
@@ -38,7 +44,9 @@ module Basecamp
       # @param content [String] content
       # @return [Hash] response data
       def create_recording_boost(project_id:, recording_id:, content:)
-        http_post(bucket_path(project_id, "/recordings/#{recording_id}/boosts.json"), body: compact_params(content: content)).json
+        with_operation(service: "boosts", operation: "create_recording_boost", is_mutation: true, project_id: project_id, resource_id: recording_id) do
+          http_post(bucket_path(project_id, "/recordings/#{recording_id}/boosts.json"), body: compact_params(content: content)).json
+        end
       end
 
       # List boosts on a specific event within a recording
@@ -47,7 +55,9 @@ module Basecamp
       # @param event_id [Integer] event id ID
       # @return [Enumerator<Hash>] paginated results
       def list_event_boosts(project_id:, recording_id:, event_id:)
-        paginate(bucket_path(project_id, "/recordings/#{recording_id}/events/#{event_id}/boosts.json"))
+        wrap_paginated(service: "boosts", operation: "list_event_boosts", is_mutation: false, project_id: project_id, resource_id: event_id) do
+          paginate(bucket_path(project_id, "/recordings/#{recording_id}/events/#{event_id}/boosts.json"))
+        end
       end
 
       # Create a boost on a specific event within a recording
@@ -57,7 +67,9 @@ module Basecamp
       # @param content [String] content
       # @return [Hash] response data
       def create_event_boost(project_id:, recording_id:, event_id:, content:)
-        http_post(bucket_path(project_id, "/recordings/#{recording_id}/events/#{event_id}/boosts.json"), body: compact_params(content: content)).json
+        with_operation(service: "boosts", operation: "create_event_boost", is_mutation: true, project_id: project_id, resource_id: event_id) do
+          http_post(bucket_path(project_id, "/recordings/#{recording_id}/events/#{event_id}/boosts.json"), body: compact_params(content: content)).json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/campfires_service.rb
+++ b/ruby/lib/basecamp/generated/services/campfires_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param campfire_id [Integer] campfire id ID
       # @return [Hash] response data
       def get(project_id:, campfire_id:)
-        http_get(bucket_path(project_id, "/chats/#{campfire_id}")).json
+        with_operation(service: "campfires", operation: "get", is_mutation: false, project_id: project_id, resource_id: campfire_id) do
+          http_get(bucket_path(project_id, "/chats/#{campfire_id}")).json
+        end
       end
 
       # List all chatbots for a campfire
@@ -20,7 +22,9 @@ module Basecamp
       # @param campfire_id [Integer] campfire id ID
       # @return [Enumerator<Hash>] paginated results
       def list_chatbots(project_id:, campfire_id:)
-        paginate(bucket_path(project_id, "/chats/#{campfire_id}/integrations.json"))
+        wrap_paginated(service: "campfires", operation: "list_chatbots", is_mutation: false, project_id: project_id, resource_id: campfire_id) do
+          paginate(bucket_path(project_id, "/chats/#{campfire_id}/integrations.json"))
+        end
       end
 
       # Create a new chatbot for a campfire
@@ -30,7 +34,9 @@ module Basecamp
       # @param command_url [String, nil] command url
       # @return [Hash] response data
       def create_chatbot(project_id:, campfire_id:, service_name:, command_url: nil)
-        http_post(bucket_path(project_id, "/chats/#{campfire_id}/integrations.json"), body: compact_params(service_name: service_name, command_url: command_url)).json
+        with_operation(service: "campfires", operation: "create_chatbot", is_mutation: true, project_id: project_id, resource_id: campfire_id) do
+          http_post(bucket_path(project_id, "/chats/#{campfire_id}/integrations.json"), body: compact_params(service_name: service_name, command_url: command_url)).json
+        end
       end
 
       # Get a chatbot by ID
@@ -39,7 +45,9 @@ module Basecamp
       # @param chatbot_id [Integer] chatbot id ID
       # @return [Hash] response data
       def get_chatbot(project_id:, campfire_id:, chatbot_id:)
-        http_get(bucket_path(project_id, "/chats/#{campfire_id}/integrations/#{chatbot_id}")).json
+        with_operation(service: "campfires", operation: "get_chatbot", is_mutation: false, project_id: project_id, resource_id: chatbot_id) do
+          http_get(bucket_path(project_id, "/chats/#{campfire_id}/integrations/#{chatbot_id}")).json
+        end
       end
 
       # Update an existing chatbot
@@ -50,7 +58,9 @@ module Basecamp
       # @param command_url [String, nil] command url
       # @return [Hash] response data
       def update_chatbot(project_id:, campfire_id:, chatbot_id:, service_name:, command_url: nil)
-        http_put(bucket_path(project_id, "/chats/#{campfire_id}/integrations/#{chatbot_id}"), body: compact_params(service_name: service_name, command_url: command_url)).json
+        with_operation(service: "campfires", operation: "update_chatbot", is_mutation: true, project_id: project_id, resource_id: chatbot_id) do
+          http_put(bucket_path(project_id, "/chats/#{campfire_id}/integrations/#{chatbot_id}"), body: compact_params(service_name: service_name, command_url: command_url)).json
+        end
       end
 
       # Delete a chatbot
@@ -59,8 +69,10 @@ module Basecamp
       # @param chatbot_id [Integer] chatbot id ID
       # @return [void]
       def delete_chatbot(project_id:, campfire_id:, chatbot_id:)
-        http_delete(bucket_path(project_id, "/chats/#{campfire_id}/integrations/#{chatbot_id}"))
-        nil
+        with_operation(service: "campfires", operation: "delete_chatbot", is_mutation: true, project_id: project_id, resource_id: chatbot_id) do
+          http_delete(bucket_path(project_id, "/chats/#{campfire_id}/integrations/#{chatbot_id}"))
+          nil
+        end
       end
 
       # List all lines (messages) in a campfire
@@ -68,7 +80,9 @@ module Basecamp
       # @param campfire_id [Integer] campfire id ID
       # @return [Enumerator<Hash>] paginated results
       def list_lines(project_id:, campfire_id:)
-        paginate(bucket_path(project_id, "/chats/#{campfire_id}/lines.json"))
+        wrap_paginated(service: "campfires", operation: "list_lines", is_mutation: false, project_id: project_id, resource_id: campfire_id) do
+          paginate(bucket_path(project_id, "/chats/#{campfire_id}/lines.json"))
+        end
       end
 
       # Create a new line (message) in a campfire
@@ -78,7 +92,9 @@ module Basecamp
       # @param content_type [String, nil] content type
       # @return [Hash] response data
       def create_line(project_id:, campfire_id:, content:, content_type: nil)
-        http_post(bucket_path(project_id, "/chats/#{campfire_id}/lines.json"), body: compact_params(content: content, content_type: content_type)).json
+        with_operation(service: "campfires", operation: "create_line", is_mutation: true, project_id: project_id, resource_id: campfire_id) do
+          http_post(bucket_path(project_id, "/chats/#{campfire_id}/lines.json"), body: compact_params(content: content, content_type: content_type)).json
+        end
       end
 
       # Get a campfire line by ID
@@ -87,7 +103,9 @@ module Basecamp
       # @param line_id [Integer] line id ID
       # @return [Hash] response data
       def get_line(project_id:, campfire_id:, line_id:)
-        http_get(bucket_path(project_id, "/chats/#{campfire_id}/lines/#{line_id}")).json
+        with_operation(service: "campfires", operation: "get_line", is_mutation: false, project_id: project_id, resource_id: line_id) do
+          http_get(bucket_path(project_id, "/chats/#{campfire_id}/lines/#{line_id}")).json
+        end
       end
 
       # Delete a campfire line
@@ -96,14 +114,18 @@ module Basecamp
       # @param line_id [Integer] line id ID
       # @return [void]
       def delete_line(project_id:, campfire_id:, line_id:)
-        http_delete(bucket_path(project_id, "/chats/#{campfire_id}/lines/#{line_id}"))
-        nil
+        with_operation(service: "campfires", operation: "delete_line", is_mutation: true, project_id: project_id, resource_id: line_id) do
+          http_delete(bucket_path(project_id, "/chats/#{campfire_id}/lines/#{line_id}"))
+          nil
+        end
       end
 
       # List all campfires across the account
       # @return [Enumerator<Hash>] paginated results
       def list()
-        paginate("/chats.json")
+        wrap_paginated(service: "campfires", operation: "list", is_mutation: false) do
+          paginate("/chats.json")
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/card_columns_service.rb
+++ b/ruby/lib/basecamp/generated/services/card_columns_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param column_id [Integer] column id ID
       # @return [Hash] response data
       def get(project_id:, column_id:)
-        http_get(bucket_path(project_id, "/card_tables/columns/#{column_id}")).json
+        with_operation(service: "cardcolumns", operation: "get", is_mutation: false, project_id: project_id, resource_id: column_id) do
+          http_get(bucket_path(project_id, "/card_tables/columns/#{column_id}")).json
+        end
       end
 
       # Update an existing column
@@ -22,7 +24,9 @@ module Basecamp
       # @param description [String, nil] description
       # @return [Hash] response data
       def update(project_id:, column_id:, title: nil, description: nil)
-        http_put(bucket_path(project_id, "/card_tables/columns/#{column_id}"), body: compact_params(title: title, description: description)).json
+        with_operation(service: "cardcolumns", operation: "update", is_mutation: true, project_id: project_id, resource_id: column_id) do
+          http_put(bucket_path(project_id, "/card_tables/columns/#{column_id}"), body: compact_params(title: title, description: description)).json
+        end
       end
 
       # Set the color of a column
@@ -31,7 +35,9 @@ module Basecamp
       # @param color [String] Valid colors: white, red, orange, yellow, green, blue, aqua, purple, gray, pink, brown
       # @return [Hash] response data
       def set_color(project_id:, column_id:, color:)
-        http_put(bucket_path(project_id, "/card_tables/columns/#{column_id}/color.json"), body: compact_params(color: color)).json
+        with_operation(service: "cardcolumns", operation: "set_color", is_mutation: true, project_id: project_id, resource_id: column_id) do
+          http_put(bucket_path(project_id, "/card_tables/columns/#{column_id}/color.json"), body: compact_params(color: color)).json
+        end
       end
 
       # Enable on-hold section in a column
@@ -39,7 +45,9 @@ module Basecamp
       # @param column_id [Integer] column id ID
       # @return [Hash] response data
       def enable_on_hold(project_id:, column_id:)
-        http_post(bucket_path(project_id, "/card_tables/columns/#{column_id}/on_hold.json")).json
+        with_operation(service: "cardcolumns", operation: "enable_on_hold", is_mutation: true, project_id: project_id, resource_id: column_id) do
+          http_post(bucket_path(project_id, "/card_tables/columns/#{column_id}/on_hold.json")).json
+        end
       end
 
       # Disable on-hold section in a column
@@ -47,7 +55,9 @@ module Basecamp
       # @param column_id [Integer] column id ID
       # @return [Hash] response data
       def disable_on_hold(project_id:, column_id:)
-        http_delete(bucket_path(project_id, "/card_tables/columns/#{column_id}/on_hold.json")).json
+        with_operation(service: "cardcolumns", operation: "disable_on_hold", is_mutation: true, project_id: project_id, resource_id: column_id) do
+          http_delete(bucket_path(project_id, "/card_tables/columns/#{column_id}/on_hold.json")).json
+        end
       end
 
       # Subscribe to a card column (watch for changes)
@@ -55,8 +65,10 @@ module Basecamp
       # @param column_id [Integer] column id ID
       # @return [void]
       def subscribe_to_column(project_id:, column_id:)
-        http_post(bucket_path(project_id, "/card_tables/lists/#{column_id}/subscription.json"))
-        nil
+        with_operation(service: "cardcolumns", operation: "subscribe_to_column", is_mutation: true, project_id: project_id, resource_id: column_id) do
+          http_post(bucket_path(project_id, "/card_tables/lists/#{column_id}/subscription.json"))
+          nil
+        end
       end
 
       # Unsubscribe from a card column (stop watching for changes)
@@ -64,8 +76,10 @@ module Basecamp
       # @param column_id [Integer] column id ID
       # @return [void]
       def unsubscribe_from_column(project_id:, column_id:)
-        http_delete(bucket_path(project_id, "/card_tables/lists/#{column_id}/subscription.json"))
-        nil
+        with_operation(service: "cardcolumns", operation: "unsubscribe_from_column", is_mutation: true, project_id: project_id, resource_id: column_id) do
+          http_delete(bucket_path(project_id, "/card_tables/lists/#{column_id}/subscription.json"))
+          nil
+        end
       end
 
       # Create a column in a card table
@@ -75,7 +89,9 @@ module Basecamp
       # @param description [String, nil] description
       # @return [Hash] response data
       def create(project_id:, card_table_id:, title:, description: nil)
-        http_post(bucket_path(project_id, "/card_tables/#{card_table_id}/columns.json"), body: compact_params(title: title, description: description)).json
+        with_operation(service: "cardcolumns", operation: "create", is_mutation: true, project_id: project_id, resource_id: card_table_id) do
+          http_post(bucket_path(project_id, "/card_tables/#{card_table_id}/columns.json"), body: compact_params(title: title, description: description)).json
+        end
       end
 
       # Move a column within a card table
@@ -86,8 +102,10 @@ module Basecamp
       # @param position [Integer, nil] position
       # @return [void]
       def move(project_id:, card_table_id:, source_id:, target_id:, position: nil)
-        http_post(bucket_path(project_id, "/card_tables/#{card_table_id}/moves.json"), body: compact_params(source_id: source_id, target_id: target_id, position: position))
-        nil
+        with_operation(service: "cardcolumns", operation: "move", is_mutation: true, project_id: project_id, resource_id: card_table_id) do
+          http_post(bucket_path(project_id, "/card_tables/#{card_table_id}/moves.json"), body: compact_params(source_id: source_id, target_id: target_id, position: position))
+          nil
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/card_steps_service.rb
+++ b/ruby/lib/basecamp/generated/services/card_steps_service.rb
@@ -14,8 +14,10 @@ module Basecamp
       # @param position [Integer] 0-indexed position
       # @return [void]
       def reposition(project_id:, card_id:, source_id:, position:)
-        http_post(bucket_path(project_id, "/card_tables/cards/#{card_id}/positions.json"), body: compact_params(source_id: source_id, position: position))
-        nil
+        with_operation(service: "cardsteps", operation: "reposition", is_mutation: true, project_id: project_id, resource_id: card_id) do
+          http_post(bucket_path(project_id, "/card_tables/cards/#{card_id}/positions.json"), body: compact_params(source_id: source_id, position: position))
+          nil
+        end
       end
 
       # Create a step on a card
@@ -26,7 +28,9 @@ module Basecamp
       # @param assignees [Array, nil] assignees
       # @return [Hash] response data
       def create(project_id:, card_id:, title:, due_on: nil, assignees: nil)
-        http_post(bucket_path(project_id, "/card_tables/cards/#{card_id}/steps.json"), body: compact_params(title: title, due_on: due_on, assignees: assignees)).json
+        with_operation(service: "cardsteps", operation: "create", is_mutation: true, project_id: project_id, resource_id: card_id) do
+          http_post(bucket_path(project_id, "/card_tables/cards/#{card_id}/steps.json"), body: compact_params(title: title, due_on: due_on, assignees: assignees)).json
+        end
       end
 
       # Update an existing step
@@ -37,7 +41,9 @@ module Basecamp
       # @param assignees [Array, nil] assignees
       # @return [Hash] response data
       def update(project_id:, step_id:, title: nil, due_on: nil, assignees: nil)
-        http_put(bucket_path(project_id, "/card_tables/steps/#{step_id}"), body: compact_params(title: title, due_on: due_on, assignees: assignees)).json
+        with_operation(service: "cardsteps", operation: "update", is_mutation: true, project_id: project_id, resource_id: step_id) do
+          http_put(bucket_path(project_id, "/card_tables/steps/#{step_id}"), body: compact_params(title: title, due_on: due_on, assignees: assignees)).json
+        end
       end
 
       # Set card step completion status (PUT with completion: "on" to complete, "" to uncomplete)
@@ -46,7 +52,9 @@ module Basecamp
       # @param completion [String] Set to "on" to complete the step, "" (empty) to uncomplete
       # @return [Hash] response data
       def set_completion(project_id:, step_id:, completion:)
-        http_put(bucket_path(project_id, "/card_tables/steps/#{step_id}/completions.json"), body: compact_params(completion: completion)).json
+        with_operation(service: "cardsteps", operation: "set_completion", is_mutation: true, project_id: project_id, resource_id: step_id) do
+          http_put(bucket_path(project_id, "/card_tables/steps/#{step_id}/completions.json"), body: compact_params(completion: completion)).json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/card_tables_service.rb
+++ b/ruby/lib/basecamp/generated/services/card_tables_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param card_table_id [Integer] card table id ID
       # @return [Hash] response data
       def get(project_id:, card_table_id:)
-        http_get(bucket_path(project_id, "/card_tables/#{card_table_id}")).json
+        with_operation(service: "cardtables", operation: "get", is_mutation: false, project_id: project_id, resource_id: card_table_id) do
+          http_get(bucket_path(project_id, "/card_tables/#{card_table_id}")).json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/cards_service.rb
+++ b/ruby/lib/basecamp/generated/services/cards_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param card_id [Integer] card id ID
       # @return [Hash] response data
       def get(project_id:, card_id:)
-        http_get(bucket_path(project_id, "/card_tables/cards/#{card_id}")).json
+        with_operation(service: "cards", operation: "get", is_mutation: false, project_id: project_id, resource_id: card_id) do
+          http_get(bucket_path(project_id, "/card_tables/cards/#{card_id}")).json
+        end
       end
 
       # Update an existing card
@@ -24,7 +26,9 @@ module Basecamp
       # @param assignee_ids [Array, nil] assignee ids
       # @return [Hash] response data
       def update(project_id:, card_id:, title: nil, content: nil, due_on: nil, assignee_ids: nil)
-        http_put(bucket_path(project_id, "/card_tables/cards/#{card_id}"), body: compact_params(title: title, content: content, due_on: due_on, assignee_ids: assignee_ids)).json
+        with_operation(service: "cards", operation: "update", is_mutation: true, project_id: project_id, resource_id: card_id) do
+          http_put(bucket_path(project_id, "/card_tables/cards/#{card_id}"), body: compact_params(title: title, content: content, due_on: due_on, assignee_ids: assignee_ids)).json
+        end
       end
 
       # Move a card to a different column
@@ -33,8 +37,10 @@ module Basecamp
       # @param column_id [Integer] column id
       # @return [void]
       def move(project_id:, card_id:, column_id:)
-        http_post(bucket_path(project_id, "/card_tables/cards/#{card_id}/moves.json"), body: compact_params(column_id: column_id))
-        nil
+        with_operation(service: "cards", operation: "move", is_mutation: true, project_id: project_id, resource_id: card_id) do
+          http_post(bucket_path(project_id, "/card_tables/cards/#{card_id}/moves.json"), body: compact_params(column_id: column_id))
+          nil
+        end
       end
 
       # List cards in a column
@@ -42,7 +48,9 @@ module Basecamp
       # @param column_id [Integer] column id ID
       # @return [Enumerator<Hash>] paginated results
       def list(project_id:, column_id:)
-        paginate(bucket_path(project_id, "/card_tables/lists/#{column_id}/cards.json"))
+        wrap_paginated(service: "cards", operation: "list", is_mutation: false, project_id: project_id, resource_id: column_id) do
+          paginate(bucket_path(project_id, "/card_tables/lists/#{column_id}/cards.json"))
+        end
       end
 
       # Create a card in a column
@@ -54,7 +62,9 @@ module Basecamp
       # @param notify [Boolean, nil] notify
       # @return [Hash] response data
       def create(project_id:, column_id:, title:, content: nil, due_on: nil, notify: nil)
-        http_post(bucket_path(project_id, "/card_tables/lists/#{column_id}/cards.json"), body: compact_params(title: title, content: content, due_on: due_on, notify: notify)).json
+        with_operation(service: "cards", operation: "create", is_mutation: true, project_id: project_id, resource_id: column_id) do
+          http_post(bucket_path(project_id, "/card_tables/lists/#{column_id}/cards.json"), body: compact_params(title: title, content: content, due_on: due_on, notify: notify)).json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/checkins_service.rb
+++ b/ruby/lib/basecamp/generated/services/checkins_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param answer_id [Integer] answer id ID
       # @return [Hash] response data
       def get_answer(project_id:, answer_id:)
-        http_get(bucket_path(project_id, "/question_answers/#{answer_id}")).json
+        with_operation(service: "checkins", operation: "get_answer", is_mutation: false, project_id: project_id, resource_id: answer_id) do
+          http_get(bucket_path(project_id, "/question_answers/#{answer_id}")).json
+        end
       end
 
       # Update an existing answer
@@ -21,8 +23,10 @@ module Basecamp
       # @param content [String] content
       # @return [void]
       def update_answer(project_id:, answer_id:, content:)
-        http_put(bucket_path(project_id, "/question_answers/#{answer_id}"), body: compact_params(content: content))
-        nil
+        with_operation(service: "checkins", operation: "update_answer", is_mutation: true, project_id: project_id, resource_id: answer_id) do
+          http_put(bucket_path(project_id, "/question_answers/#{answer_id}"), body: compact_params(content: content))
+          nil
+        end
       end
 
       # Get a questionnaire (automatic check-ins container) by id
@@ -30,7 +34,9 @@ module Basecamp
       # @param questionnaire_id [Integer] questionnaire id ID
       # @return [Hash] response data
       def get_questionnaire(project_id:, questionnaire_id:)
-        http_get(bucket_path(project_id, "/questionnaires/#{questionnaire_id}")).json
+        with_operation(service: "checkins", operation: "get_questionnaire", is_mutation: false, project_id: project_id, resource_id: questionnaire_id) do
+          http_get(bucket_path(project_id, "/questionnaires/#{questionnaire_id}")).json
+        end
       end
 
       # List all questions in a questionnaire
@@ -38,7 +44,9 @@ module Basecamp
       # @param questionnaire_id [Integer] questionnaire id ID
       # @return [Enumerator<Hash>] paginated results
       def list_questions(project_id:, questionnaire_id:)
-        paginate(bucket_path(project_id, "/questionnaires/#{questionnaire_id}/questions.json"))
+        wrap_paginated(service: "checkins", operation: "list_questions", is_mutation: false, project_id: project_id, resource_id: questionnaire_id) do
+          paginate(bucket_path(project_id, "/questionnaires/#{questionnaire_id}/questions.json"))
+        end
       end
 
       # Create a new question in a questionnaire
@@ -48,7 +56,9 @@ module Basecamp
       # @param schedule [String] schedule
       # @return [Hash] response data
       def create_question(project_id:, questionnaire_id:, title:, schedule:)
-        http_post(bucket_path(project_id, "/questionnaires/#{questionnaire_id}/questions.json"), body: compact_params(title: title, schedule: schedule)).json
+        with_operation(service: "checkins", operation: "create_question", is_mutation: true, project_id: project_id, resource_id: questionnaire_id) do
+          http_post(bucket_path(project_id, "/questionnaires/#{questionnaire_id}/questions.json"), body: compact_params(title: title, schedule: schedule)).json
+        end
       end
 
       # Get a single question by id
@@ -56,7 +66,9 @@ module Basecamp
       # @param question_id [Integer] question id ID
       # @return [Hash] response data
       def get_question(project_id:, question_id:)
-        http_get(bucket_path(project_id, "/questions/#{question_id}")).json
+        with_operation(service: "checkins", operation: "get_question", is_mutation: false, project_id: project_id, resource_id: question_id) do
+          http_get(bucket_path(project_id, "/questions/#{question_id}")).json
+        end
       end
 
       # Update an existing question
@@ -67,7 +79,9 @@ module Basecamp
       # @param paused [Boolean, nil] paused
       # @return [Hash] response data
       def update_question(project_id:, question_id:, title: nil, schedule: nil, paused: nil)
-        http_put(bucket_path(project_id, "/questions/#{question_id}"), body: compact_params(title: title, schedule: schedule, paused: paused)).json
+        with_operation(service: "checkins", operation: "update_question", is_mutation: true, project_id: project_id, resource_id: question_id) do
+          http_put(bucket_path(project_id, "/questions/#{question_id}"), body: compact_params(title: title, schedule: schedule, paused: paused)).json
+        end
       end
 
       # List all answers for a question
@@ -75,7 +89,9 @@ module Basecamp
       # @param question_id [Integer] question id ID
       # @return [Enumerator<Hash>] paginated results
       def list_answers(project_id:, question_id:)
-        paginate(bucket_path(project_id, "/questions/#{question_id}/answers.json"))
+        wrap_paginated(service: "checkins", operation: "list_answers", is_mutation: false, project_id: project_id, resource_id: question_id) do
+          paginate(bucket_path(project_id, "/questions/#{question_id}/answers.json"))
+        end
       end
 
       # Create a new answer for a question
@@ -85,7 +101,9 @@ module Basecamp
       # @param group_on [String, nil] group on (YYYY-MM-DD)
       # @return [Hash] response data
       def create_answer(project_id:, question_id:, content:, group_on: nil)
-        http_post(bucket_path(project_id, "/questions/#{question_id}/answers.json"), body: compact_params(content: content, group_on: group_on)).json
+        with_operation(service: "checkins", operation: "create_answer", is_mutation: true, project_id: project_id, resource_id: question_id) do
+          http_post(bucket_path(project_id, "/questions/#{question_id}/answers.json"), body: compact_params(content: content, group_on: group_on)).json
+        end
       end
 
       # List all people who have answered a question (answerers)
@@ -93,7 +111,9 @@ module Basecamp
       # @param question_id [Integer] question id ID
       # @return [Enumerator<Hash>] paginated results
       def answerers(project_id:, question_id:)
-        paginate(bucket_path(project_id, "/questions/#{question_id}/answers/by.json"))
+        wrap_paginated(service: "checkins", operation: "answerers", is_mutation: false, project_id: project_id, resource_id: question_id) do
+          paginate(bucket_path(project_id, "/questions/#{question_id}/answers/by.json"))
+        end
       end
 
       # Get all answers from a specific person for a question
@@ -102,7 +122,9 @@ module Basecamp
       # @param person_id [Integer] person id ID
       # @return [Enumerator<Hash>] paginated results
       def by_person(project_id:, question_id:, person_id:)
-        paginate(bucket_path(project_id, "/questions/#{question_id}/answers/by/#{person_id}"))
+        wrap_paginated(service: "checkins", operation: "by_person", is_mutation: false, project_id: project_id, resource_id: person_id) do
+          paginate(bucket_path(project_id, "/questions/#{question_id}/answers/by/#{person_id}"))
+        end
       end
 
       # Update notification settings for a check-in question
@@ -112,7 +134,9 @@ module Basecamp
       # @param digest_include_unanswered [Boolean, nil] Include unanswered in digest
       # @return [Hash] response data
       def update_notification_settings(project_id:, question_id:, notify_on_answer: nil, digest_include_unanswered: nil)
-        http_put(bucket_path(project_id, "/questions/#{question_id}/notification_settings.json"), body: compact_params(notify_on_answer: notify_on_answer, digest_include_unanswered: digest_include_unanswered)).json
+        with_operation(service: "checkins", operation: "update_notification_settings", is_mutation: true, project_id: project_id, resource_id: question_id) do
+          http_put(bucket_path(project_id, "/questions/#{question_id}/notification_settings.json"), body: compact_params(notify_on_answer: notify_on_answer, digest_include_unanswered: digest_include_unanswered)).json
+        end
       end
 
       # Pause a check-in question (stops sending reminders)
@@ -120,7 +144,9 @@ module Basecamp
       # @param question_id [Integer] question id ID
       # @return [Hash] response data
       def pause(project_id:, question_id:)
-        http_post(bucket_path(project_id, "/questions/#{question_id}/pause.json")).json
+        with_operation(service: "checkins", operation: "pause", is_mutation: true, project_id: project_id, resource_id: question_id) do
+          http_post(bucket_path(project_id, "/questions/#{question_id}/pause.json")).json
+        end
       end
 
       # Resume a paused check-in question (resumes sending reminders)
@@ -128,13 +154,17 @@ module Basecamp
       # @param question_id [Integer] question id ID
       # @return [Hash] response data
       def resume(project_id:, question_id:)
-        http_delete(bucket_path(project_id, "/questions/#{question_id}/pause.json")).json
+        with_operation(service: "checkins", operation: "resume", is_mutation: true, project_id: project_id, resource_id: question_id) do
+          http_delete(bucket_path(project_id, "/questions/#{question_id}/pause.json")).json
+        end
       end
 
       # Get pending check-in reminders for the current user
       # @return [Enumerator<Hash>] paginated results
       def reminders()
-        paginate("/my/question_reminders.json")
+        wrap_paginated(service: "checkins", operation: "reminders", is_mutation: false) do
+          paginate("/my/question_reminders.json")
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/client_approvals_service.rb
+++ b/ruby/lib/basecamp/generated/services/client_approvals_service.rb
@@ -11,7 +11,9 @@ module Basecamp
       # @param project_id [Integer] project id ID
       # @return [Enumerator<Hash>] paginated results
       def list(project_id:)
-        paginate(bucket_path(project_id, "/client/approvals.json"))
+        wrap_paginated(service: "clientapprovals", operation: "list", is_mutation: false, project_id: project_id) do
+          paginate(bucket_path(project_id, "/client/approvals.json"))
+        end
       end
 
       # Get a single client approval by id
@@ -19,7 +21,9 @@ module Basecamp
       # @param approval_id [Integer] approval id ID
       # @return [Hash] response data
       def get(project_id:, approval_id:)
-        http_get(bucket_path(project_id, "/client/approvals/#{approval_id}")).json
+        with_operation(service: "clientapprovals", operation: "get", is_mutation: false, project_id: project_id, resource_id: approval_id) do
+          http_get(bucket_path(project_id, "/client/approvals/#{approval_id}")).json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/client_correspondences_service.rb
+++ b/ruby/lib/basecamp/generated/services/client_correspondences_service.rb
@@ -11,7 +11,9 @@ module Basecamp
       # @param project_id [Integer] project id ID
       # @return [Enumerator<Hash>] paginated results
       def list(project_id:)
-        paginate(bucket_path(project_id, "/client/correspondences.json"))
+        wrap_paginated(service: "clientcorrespondences", operation: "list", is_mutation: false, project_id: project_id) do
+          paginate(bucket_path(project_id, "/client/correspondences.json"))
+        end
       end
 
       # Get a single client correspondence by id
@@ -19,7 +21,9 @@ module Basecamp
       # @param correspondence_id [Integer] correspondence id ID
       # @return [Hash] response data
       def get(project_id:, correspondence_id:)
-        http_get(bucket_path(project_id, "/client/correspondences/#{correspondence_id}")).json
+        with_operation(service: "clientcorrespondences", operation: "get", is_mutation: false, project_id: project_id, resource_id: correspondence_id) do
+          http_get(bucket_path(project_id, "/client/correspondences/#{correspondence_id}")).json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/client_replies_service.rb
+++ b/ruby/lib/basecamp/generated/services/client_replies_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param recording_id [Integer] recording id ID
       # @return [Enumerator<Hash>] paginated results
       def list(project_id:, recording_id:)
-        paginate(bucket_path(project_id, "/client/recordings/#{recording_id}/replies.json"))
+        wrap_paginated(service: "clientreplies", operation: "list", is_mutation: false, project_id: project_id, resource_id: recording_id) do
+          paginate(bucket_path(project_id, "/client/recordings/#{recording_id}/replies.json"))
+        end
       end
 
       # Get a single client reply by id
@@ -21,7 +23,9 @@ module Basecamp
       # @param reply_id [Integer] reply id ID
       # @return [Hash] response data
       def get(project_id:, recording_id:, reply_id:)
-        http_get(bucket_path(project_id, "/client/recordings/#{recording_id}/replies/#{reply_id}")).json
+        with_operation(service: "clientreplies", operation: "get", is_mutation: false, project_id: project_id, resource_id: reply_id) do
+          http_get(bucket_path(project_id, "/client/recordings/#{recording_id}/replies/#{reply_id}")).json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/client_visibility_service.rb
+++ b/ruby/lib/basecamp/generated/services/client_visibility_service.rb
@@ -13,7 +13,9 @@ module Basecamp
       # @param visible_to_clients [Boolean] visible to clients
       # @return [Hash] response data
       def set_visibility(project_id:, recording_id:, visible_to_clients:)
-        http_put(bucket_path(project_id, "/recordings/#{recording_id}/client_visibility.json"), body: compact_params(visible_to_clients: visible_to_clients)).json
+        with_operation(service: "clientvisibility", operation: "set_visibility", is_mutation: true, project_id: project_id, resource_id: recording_id) do
+          http_put(bucket_path(project_id, "/recordings/#{recording_id}/client_visibility.json"), body: compact_params(visible_to_clients: visible_to_clients)).json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/comments_service.rb
+++ b/ruby/lib/basecamp/generated/services/comments_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param comment_id [Integer] comment id ID
       # @return [Hash] response data
       def get(project_id:, comment_id:)
-        http_get(bucket_path(project_id, "/comments/#{comment_id}")).json
+        with_operation(service: "comments", operation: "get", is_mutation: false, project_id: project_id, resource_id: comment_id) do
+          http_get(bucket_path(project_id, "/comments/#{comment_id}")).json
+        end
       end
 
       # Update an existing comment
@@ -21,7 +23,9 @@ module Basecamp
       # @param content [String] content
       # @return [Hash] response data
       def update(project_id:, comment_id:, content:)
-        http_put(bucket_path(project_id, "/comments/#{comment_id}"), body: compact_params(content: content)).json
+        with_operation(service: "comments", operation: "update", is_mutation: true, project_id: project_id, resource_id: comment_id) do
+          http_put(bucket_path(project_id, "/comments/#{comment_id}"), body: compact_params(content: content)).json
+        end
       end
 
       # List comments on a recording
@@ -29,7 +33,9 @@ module Basecamp
       # @param recording_id [Integer] recording id ID
       # @return [Enumerator<Hash>] paginated results
       def list(project_id:, recording_id:)
-        paginate(bucket_path(project_id, "/recordings/#{recording_id}/comments.json"))
+        wrap_paginated(service: "comments", operation: "list", is_mutation: false, project_id: project_id, resource_id: recording_id) do
+          paginate(bucket_path(project_id, "/recordings/#{recording_id}/comments.json"))
+        end
       end
 
       # Create a new comment on a recording
@@ -38,7 +44,9 @@ module Basecamp
       # @param content [String] content
       # @return [Hash] response data
       def create(project_id:, recording_id:, content:)
-        http_post(bucket_path(project_id, "/recordings/#{recording_id}/comments.json"), body: compact_params(content: content)).json
+        with_operation(service: "comments", operation: "create", is_mutation: true, project_id: project_id, resource_id: recording_id) do
+          http_post(bucket_path(project_id, "/recordings/#{recording_id}/comments.json"), body: compact_params(content: content)).json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/documents_service.rb
+++ b/ruby/lib/basecamp/generated/services/documents_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param document_id [Integer] document id ID
       # @return [Hash] response data
       def get(project_id:, document_id:)
-        http_get(bucket_path(project_id, "/documents/#{document_id}")).json
+        with_operation(service: "documents", operation: "get", is_mutation: false, project_id: project_id, resource_id: document_id) do
+          http_get(bucket_path(project_id, "/documents/#{document_id}")).json
+        end
       end
 
       # Update an existing document
@@ -22,7 +24,9 @@ module Basecamp
       # @param content [String, nil] content
       # @return [Hash] response data
       def update(project_id:, document_id:, title: nil, content: nil)
-        http_put(bucket_path(project_id, "/documents/#{document_id}"), body: compact_params(title: title, content: content)).json
+        with_operation(service: "documents", operation: "update", is_mutation: true, project_id: project_id, resource_id: document_id) do
+          http_put(bucket_path(project_id, "/documents/#{document_id}"), body: compact_params(title: title, content: content)).json
+        end
       end
 
       # List documents in a vault
@@ -30,7 +34,9 @@ module Basecamp
       # @param vault_id [Integer] vault id ID
       # @return [Enumerator<Hash>] paginated results
       def list(project_id:, vault_id:)
-        paginate(bucket_path(project_id, "/vaults/#{vault_id}/documents.json"))
+        wrap_paginated(service: "documents", operation: "list", is_mutation: false, project_id: project_id, resource_id: vault_id) do
+          paginate(bucket_path(project_id, "/vaults/#{vault_id}/documents.json"))
+        end
       end
 
       # Create a new document in a vault
@@ -41,7 +47,9 @@ module Basecamp
       # @param status [String, nil] active|drafted
       # @return [Hash] response data
       def create(project_id:, vault_id:, title:, content: nil, status: nil)
-        http_post(bucket_path(project_id, "/vaults/#{vault_id}/documents.json"), body: compact_params(title: title, content: content, status: status)).json
+        with_operation(service: "documents", operation: "create", is_mutation: true, project_id: project_id, resource_id: vault_id) do
+          http_post(bucket_path(project_id, "/vaults/#{vault_id}/documents.json"), body: compact_params(title: title, content: content, status: status)).json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/events_service.rb
+++ b/ruby/lib/basecamp/generated/services/events_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param recording_id [Integer] recording id ID
       # @return [Enumerator<Hash>] paginated results
       def list(project_id:, recording_id:)
-        paginate(bucket_path(project_id, "/recordings/#{recording_id}/events.json"))
+        wrap_paginated(service: "events", operation: "list", is_mutation: false, project_id: project_id, resource_id: recording_id) do
+          paginate(bucket_path(project_id, "/recordings/#{recording_id}/events.json"))
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/forwards_service.rb
+++ b/ruby/lib/basecamp/generated/services/forwards_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param forward_id [Integer] forward id ID
       # @return [Hash] response data
       def get(project_id:, forward_id:)
-        http_get(bucket_path(project_id, "/inbox_forwards/#{forward_id}")).json
+        with_operation(service: "forwards", operation: "get", is_mutation: false, project_id: project_id, resource_id: forward_id) do
+          http_get(bucket_path(project_id, "/inbox_forwards/#{forward_id}")).json
+        end
       end
 
       # List all replies to a forward
@@ -20,7 +22,9 @@ module Basecamp
       # @param forward_id [Integer] forward id ID
       # @return [Enumerator<Hash>] paginated results
       def list_replies(project_id:, forward_id:)
-        paginate(bucket_path(project_id, "/inbox_forwards/#{forward_id}/replies.json"))
+        wrap_paginated(service: "forwards", operation: "list_replies", is_mutation: false, project_id: project_id, resource_id: forward_id) do
+          paginate(bucket_path(project_id, "/inbox_forwards/#{forward_id}/replies.json"))
+        end
       end
 
       # Create a reply to a forward
@@ -29,7 +33,9 @@ module Basecamp
       # @param content [String] content
       # @return [Hash] response data
       def create_reply(project_id:, forward_id:, content:)
-        http_post(bucket_path(project_id, "/inbox_forwards/#{forward_id}/replies.json"), body: compact_params(content: content)).json
+        with_operation(service: "forwards", operation: "create_reply", is_mutation: true, project_id: project_id, resource_id: forward_id) do
+          http_post(bucket_path(project_id, "/inbox_forwards/#{forward_id}/replies.json"), body: compact_params(content: content)).json
+        end
       end
 
       # Get a forward reply by ID
@@ -38,7 +44,9 @@ module Basecamp
       # @param reply_id [Integer] reply id ID
       # @return [Hash] response data
       def get_reply(project_id:, forward_id:, reply_id:)
-        http_get(bucket_path(project_id, "/inbox_forwards/#{forward_id}/replies/#{reply_id}")).json
+        with_operation(service: "forwards", operation: "get_reply", is_mutation: false, project_id: project_id, resource_id: reply_id) do
+          http_get(bucket_path(project_id, "/inbox_forwards/#{forward_id}/replies/#{reply_id}")).json
+        end
       end
 
       # Get an inbox by ID
@@ -46,7 +54,9 @@ module Basecamp
       # @param inbox_id [Integer] inbox id ID
       # @return [Hash] response data
       def get_inbox(project_id:, inbox_id:)
-        http_get(bucket_path(project_id, "/inboxes/#{inbox_id}")).json
+        with_operation(service: "forwards", operation: "get_inbox", is_mutation: false, project_id: project_id, resource_id: inbox_id) do
+          http_get(bucket_path(project_id, "/inboxes/#{inbox_id}")).json
+        end
       end
 
       # List all forwards in an inbox
@@ -54,7 +64,9 @@ module Basecamp
       # @param inbox_id [Integer] inbox id ID
       # @return [Enumerator<Hash>] paginated results
       def list(project_id:, inbox_id:)
-        paginate(bucket_path(project_id, "/inboxes/#{inbox_id}/forwards.json"))
+        wrap_paginated(service: "forwards", operation: "list", is_mutation: false, project_id: project_id, resource_id: inbox_id) do
+          paginate(bucket_path(project_id, "/inboxes/#{inbox_id}/forwards.json"))
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/lineup_service.rb
+++ b/ruby/lib/basecamp/generated/services/lineup_service.rb
@@ -12,8 +12,10 @@ module Basecamp
       # @param date [String] date
       # @return [void]
       def create(name:, date:)
-        http_post("/lineup/markers.json", body: compact_params(name: name, date: date))
-        nil
+        with_operation(service: "lineup", operation: "create", is_mutation: true) do
+          http_post("/lineup/markers.json", body: compact_params(name: name, date: date))
+          nil
+        end
       end
 
       # Update an existing lineup marker
@@ -22,16 +24,20 @@ module Basecamp
       # @param date [String, nil] date
       # @return [void]
       def update(marker_id:, name: nil, date: nil)
-        http_put("/lineup/markers/#{marker_id}", body: compact_params(name: name, date: date))
-        nil
+        with_operation(service: "lineup", operation: "update", is_mutation: true, resource_id: marker_id) do
+          http_put("/lineup/markers/#{marker_id}", body: compact_params(name: name, date: date))
+          nil
+        end
       end
 
       # Delete a lineup marker
       # @param marker_id [Integer] marker id ID
       # @return [void]
       def delete(marker_id:)
-        http_delete("/lineup/markers/#{marker_id}")
-        nil
+        with_operation(service: "lineup", operation: "delete", is_mutation: true, resource_id: marker_id) do
+          http_delete("/lineup/markers/#{marker_id}")
+          nil
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/message_boards_service.rb
+++ b/ruby/lib/basecamp/generated/services/message_boards_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param board_id [Integer] board id ID
       # @return [Hash] response data
       def get(project_id:, board_id:)
-        http_get(bucket_path(project_id, "/message_boards/#{board_id}")).json
+        with_operation(service: "messageboards", operation: "get", is_mutation: false, project_id: project_id, resource_id: board_id) do
+          http_get(bucket_path(project_id, "/message_boards/#{board_id}")).json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/message_types_service.rb
+++ b/ruby/lib/basecamp/generated/services/message_types_service.rb
@@ -11,7 +11,9 @@ module Basecamp
       # @param project_id [Integer] project id ID
       # @return [Enumerator<Hash>] paginated results
       def list(project_id:)
-        paginate(bucket_path(project_id, "/categories.json"))
+        wrap_paginated(service: "messagetypes", operation: "list", is_mutation: false, project_id: project_id) do
+          paginate(bucket_path(project_id, "/categories.json"))
+        end
       end
 
       # Create a new message type in a project
@@ -20,7 +22,9 @@ module Basecamp
       # @param icon [String] icon
       # @return [Hash] response data
       def create(project_id:, name:, icon:)
-        http_post(bucket_path(project_id, "/categories.json"), body: compact_params(name: name, icon: icon)).json
+        with_operation(service: "messagetypes", operation: "create", is_mutation: true, project_id: project_id) do
+          http_post(bucket_path(project_id, "/categories.json"), body: compact_params(name: name, icon: icon)).json
+        end
       end
 
       # Get a single message type by id
@@ -28,7 +32,9 @@ module Basecamp
       # @param type_id [Integer] type id ID
       # @return [Hash] response data
       def get(project_id:, type_id:)
-        http_get(bucket_path(project_id, "/categories/#{type_id}")).json
+        with_operation(service: "messagetypes", operation: "get", is_mutation: false, project_id: project_id, resource_id: type_id) do
+          http_get(bucket_path(project_id, "/categories/#{type_id}")).json
+        end
       end
 
       # Update an existing message type
@@ -38,7 +44,9 @@ module Basecamp
       # @param icon [String, nil] icon
       # @return [Hash] response data
       def update(project_id:, type_id:, name: nil, icon: nil)
-        http_put(bucket_path(project_id, "/categories/#{type_id}"), body: compact_params(name: name, icon: icon)).json
+        with_operation(service: "messagetypes", operation: "update", is_mutation: true, project_id: project_id, resource_id: type_id) do
+          http_put(bucket_path(project_id, "/categories/#{type_id}"), body: compact_params(name: name, icon: icon)).json
+        end
       end
 
       # Delete a message type
@@ -46,8 +54,10 @@ module Basecamp
       # @param type_id [Integer] type id ID
       # @return [void]
       def delete(project_id:, type_id:)
-        http_delete(bucket_path(project_id, "/categories/#{type_id}"))
-        nil
+        with_operation(service: "messagetypes", operation: "delete", is_mutation: true, project_id: project_id, resource_id: type_id) do
+          http_delete(bucket_path(project_id, "/categories/#{type_id}"))
+          nil
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/messages_service.rb
+++ b/ruby/lib/basecamp/generated/services/messages_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param board_id [Integer] board id ID
       # @return [Enumerator<Hash>] paginated results
       def list(project_id:, board_id:)
-        paginate(bucket_path(project_id, "/message_boards/#{board_id}/messages.json"))
+        wrap_paginated(service: "messages", operation: "list", is_mutation: false, project_id: project_id, resource_id: board_id) do
+          paginate(bucket_path(project_id, "/message_boards/#{board_id}/messages.json"))
+        end
       end
 
       # Create a new message on a message board
@@ -24,7 +26,9 @@ module Basecamp
       # @param category_id [Integer, nil] category id
       # @return [Hash] response data
       def create(project_id:, board_id:, subject:, content: nil, status: nil, category_id: nil)
-        http_post(bucket_path(project_id, "/message_boards/#{board_id}/messages.json"), body: compact_params(subject: subject, content: content, status: status, category_id: category_id)).json
+        with_operation(service: "messages", operation: "create", is_mutation: true, project_id: project_id, resource_id: board_id) do
+          http_post(bucket_path(project_id, "/message_boards/#{board_id}/messages.json"), body: compact_params(subject: subject, content: content, status: status, category_id: category_id)).json
+        end
       end
 
       # Get a single message by id
@@ -32,7 +36,9 @@ module Basecamp
       # @param message_id [Integer] message id ID
       # @return [Hash] response data
       def get(project_id:, message_id:)
-        http_get(bucket_path(project_id, "/messages/#{message_id}")).json
+        with_operation(service: "messages", operation: "get", is_mutation: false, project_id: project_id, resource_id: message_id) do
+          http_get(bucket_path(project_id, "/messages/#{message_id}")).json
+        end
       end
 
       # Update an existing message
@@ -44,7 +50,9 @@ module Basecamp
       # @param category_id [Integer, nil] category id
       # @return [Hash] response data
       def update(project_id:, message_id:, subject: nil, content: nil, status: nil, category_id: nil)
-        http_put(bucket_path(project_id, "/messages/#{message_id}"), body: compact_params(subject: subject, content: content, status: status, category_id: category_id)).json
+        with_operation(service: "messages", operation: "update", is_mutation: true, project_id: project_id, resource_id: message_id) do
+          http_put(bucket_path(project_id, "/messages/#{message_id}"), body: compact_params(subject: subject, content: content, status: status, category_id: category_id)).json
+        end
       end
 
       # Pin a message to the top of the message board
@@ -52,8 +60,10 @@ module Basecamp
       # @param message_id [Integer] message id ID
       # @return [void]
       def pin(project_id:, message_id:)
-        http_post(bucket_path(project_id, "/recordings/#{message_id}/pin.json"))
-        nil
+        with_operation(service: "messages", operation: "pin", is_mutation: true, project_id: project_id, resource_id: message_id) do
+          http_post(bucket_path(project_id, "/recordings/#{message_id}/pin.json"))
+          nil
+        end
       end
 
       # Unpin a message from the message board
@@ -61,8 +71,10 @@ module Basecamp
       # @param message_id [Integer] message id ID
       # @return [void]
       def unpin(project_id:, message_id:)
-        http_delete(bucket_path(project_id, "/recordings/#{message_id}/pin.json"))
-        nil
+        with_operation(service: "messages", operation: "unpin", is_mutation: true, project_id: project_id, resource_id: message_id) do
+          http_delete(bucket_path(project_id, "/recordings/#{message_id}/pin.json"))
+          nil
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/people_service.rb
+++ b/ruby/lib/basecamp/generated/services/people_service.rb
@@ -10,33 +10,43 @@ module Basecamp
       # List all account users who can be pinged
       # @return [Enumerator<Hash>] paginated results
       def list_pingable()
-        paginate("/circles/people.json")
+        wrap_paginated(service: "people", operation: "list_pingable", is_mutation: false) do
+          paginate("/circles/people.json")
+        end
       end
 
       # Get the current authenticated user's profile
       # @return [Hash] response data
       def my_profile()
-        http_get("/my/profile.json").json
+        with_operation(service: "people", operation: "my_profile", is_mutation: false) do
+          http_get("/my/profile.json").json
+        end
       end
 
       # List all people visible to the current user
       # @return [Enumerator<Hash>] paginated results
       def list()
-        paginate("/people.json")
+        wrap_paginated(service: "people", operation: "list", is_mutation: false) do
+          paginate("/people.json")
+        end
       end
 
       # Get a person by ID
       # @param person_id [Integer] person id ID
       # @return [Hash] response data
       def get(person_id:)
-        http_get("/people/#{person_id}").json
+        with_operation(service: "people", operation: "get", is_mutation: false, resource_id: person_id) do
+          http_get("/people/#{person_id}").json
+        end
       end
 
       # List all active people on a project
       # @param project_id [Integer] project id ID
       # @return [Enumerator<Hash>] paginated results
       def list_for_project(project_id:)
-        paginate("/projects/#{project_id}/people.json")
+        wrap_paginated(service: "people", operation: "list_for_project", is_mutation: false, project_id: project_id) do
+          paginate("/projects/#{project_id}/people.json")
+        end
       end
 
       # Update project access (grant/revoke/create people)
@@ -46,13 +56,17 @@ module Basecamp
       # @param create [Array, nil] create
       # @return [Hash] response data
       def update_project_access(project_id:, grant: nil, revoke: nil, create: nil)
-        http_put("/projects/#{project_id}/people/users.json", body: compact_params(grant: grant, revoke: revoke, create: create)).json
+        with_operation(service: "people", operation: "update_project_access", is_mutation: true, project_id: project_id) do
+          http_put("/projects/#{project_id}/people/users.json", body: compact_params(grant: grant, revoke: revoke, create: create)).json
+        end
       end
 
       # List people who can be assigned todos
       # @return [Hash] response data
       def list_assignable()
-        http_get("/reports/todos/assigned.json").json
+        with_operation(service: "people", operation: "list_assignable", is_mutation: false) do
+          http_get("/reports/todos/assigned.json").json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/projects_service.rb
+++ b/ruby/lib/basecamp/generated/services/projects_service.rb
@@ -11,8 +11,10 @@ module Basecamp
       # @param status [String, nil] active|archived|trashed
       # @return [Enumerator<Hash>] paginated results
       def list(status: nil)
-        params = compact_params(status: status)
-        paginate("/projects.json", params: params)
+        wrap_paginated(service: "projects", operation: "list", is_mutation: false) do
+          params = compact_params(status: status)
+          paginate("/projects.json", params: params)
+        end
       end
 
       # Create a new project
@@ -20,14 +22,18 @@ module Basecamp
       # @param description [String, nil] description
       # @return [Hash] response data
       def create(name:, description: nil)
-        http_post("/projects.json", body: compact_params(name: name, description: description)).json
+        with_operation(service: "projects", operation: "create", is_mutation: true) do
+          http_post("/projects.json", body: compact_params(name: name, description: description)).json
+        end
       end
 
       # Get a single project by id
       # @param project_id [Integer] project id ID
       # @return [Hash] response data
       def get(project_id:)
-        http_get("/projects/#{project_id}").json
+        with_operation(service: "projects", operation: "get", is_mutation: false, project_id: project_id) do
+          http_get("/projects/#{project_id}").json
+        end
       end
 
       # Update an existing project
@@ -38,15 +44,19 @@ module Basecamp
       # @param schedule_attributes [String, nil] schedule attributes
       # @return [Hash] response data
       def update(project_id:, name:, description: nil, admissions: nil, schedule_attributes: nil)
-        http_put("/projects/#{project_id}", body: compact_params(name: name, description: description, admissions: admissions, schedule_attributes: schedule_attributes)).json
+        with_operation(service: "projects", operation: "update", is_mutation: true, project_id: project_id) do
+          http_put("/projects/#{project_id}", body: compact_params(name: name, description: description, admissions: admissions, schedule_attributes: schedule_attributes)).json
+        end
       end
 
       # Trash a project (returns 204 No Content)
       # @param project_id [Integer] project id ID
       # @return [void]
       def trash(project_id:)
-        http_delete("/projects/#{project_id}")
-        nil
+        with_operation(service: "projects", operation: "trash", is_mutation: true, project_id: project_id) do
+          http_delete("/projects/#{project_id}")
+          nil
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/recordings_service.rb
+++ b/ruby/lib/basecamp/generated/services/recordings_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param recording_id [Integer] recording id ID
       # @return [Hash] response data
       def get(project_id:, recording_id:)
-        http_get(bucket_path(project_id, "/recordings/#{recording_id}")).json
+        with_operation(service: "recordings", operation: "get", is_mutation: false, project_id: project_id, resource_id: recording_id) do
+          http_get(bucket_path(project_id, "/recordings/#{recording_id}")).json
+        end
       end
 
       # Unarchive a recording (restore to active status)
@@ -20,8 +22,10 @@ module Basecamp
       # @param recording_id [Integer] recording id ID
       # @return [void]
       def unarchive(project_id:, recording_id:)
-        http_put(bucket_path(project_id, "/recordings/#{recording_id}/status/active.json"))
-        nil
+        with_operation(service: "recordings", operation: "unarchive", is_mutation: true, project_id: project_id, resource_id: recording_id) do
+          http_put(bucket_path(project_id, "/recordings/#{recording_id}/status/active.json"))
+          nil
+        end
       end
 
       # Archive a recording
@@ -29,8 +33,10 @@ module Basecamp
       # @param recording_id [Integer] recording id ID
       # @return [void]
       def archive(project_id:, recording_id:)
-        http_put(bucket_path(project_id, "/recordings/#{recording_id}/status/archived.json"))
-        nil
+        with_operation(service: "recordings", operation: "archive", is_mutation: true, project_id: project_id, resource_id: recording_id) do
+          http_put(bucket_path(project_id, "/recordings/#{recording_id}/status/archived.json"))
+          nil
+        end
       end
 
       # Trash a recording
@@ -38,8 +44,10 @@ module Basecamp
       # @param recording_id [Integer] recording id ID
       # @return [void]
       def trash(project_id:, recording_id:)
-        http_put(bucket_path(project_id, "/recordings/#{recording_id}/status/trashed.json"))
-        nil
+        with_operation(service: "recordings", operation: "trash", is_mutation: true, project_id: project_id, resource_id: recording_id) do
+          http_put(bucket_path(project_id, "/recordings/#{recording_id}/status/trashed.json"))
+          nil
+        end
       end
 
       # List recordings of a given type across projects
@@ -50,8 +58,10 @@ module Basecamp
       # @param direction [String, nil] asc|desc
       # @return [Enumerator<Hash>] paginated results
       def list(type:, bucket: nil, status: nil, sort: nil, direction: nil)
-        params = compact_params(type: type, bucket: bucket, status: status, sort: sort, direction: direction)
-        paginate("/projects/recordings.json", params: params)
+        wrap_paginated(service: "recordings", operation: "list", is_mutation: false) do
+          params = compact_params(type: type, bucket: bucket, status: status, sort: sort, direction: direction)
+          paginate("/projects/recordings.json", params: params)
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/reports_service.rb
+++ b/ruby/lib/basecamp/generated/services/reports_service.rb
@@ -10,7 +10,9 @@ module Basecamp
       # Get account-wide activity feed (progress report)
       # @return [Enumerator<Hash>] paginated results
       def progress()
-        paginate("/reports/progress.json")
+        wrap_paginated(service: "reports", operation: "progress", is_mutation: false) do
+          paginate("/reports/progress.json")
+        end
       end
 
       # Get upcoming schedule entries within a date window
@@ -18,7 +20,9 @@ module Basecamp
       # @param window_ends_on [String, nil] window ends on
       # @return [Hash] response data
       def upcoming(window_starts_on: nil, window_ends_on: nil)
-        http_get("/reports/schedules/upcoming.json", params: compact_params(window_starts_on: window_starts_on, window_ends_on: window_ends_on)).json
+        with_operation(service: "reports", operation: "upcoming", is_mutation: false) do
+          http_get("/reports/schedules/upcoming.json", params: compact_params(window_starts_on: window_starts_on, window_ends_on: window_ends_on)).json
+        end
       end
 
       # Get todos assigned to a specific person
@@ -26,20 +30,26 @@ module Basecamp
       # @param group_by [String, nil] Group by "bucket" or "date"
       # @return [Hash] response data
       def assigned(person_id:, group_by: nil)
-        http_get("/reports/todos/assigned/#{person_id}", params: compact_params(group_by: group_by)).json
+        with_operation(service: "reports", operation: "assigned", is_mutation: false, resource_id: person_id) do
+          http_get("/reports/todos/assigned/#{person_id}", params: compact_params(group_by: group_by)).json
+        end
       end
 
       # Get overdue todos grouped by lateness
       # @return [Hash] response data
       def overdue()
-        http_get("/reports/todos/overdue.json").json
+        with_operation(service: "reports", operation: "overdue", is_mutation: false) do
+          http_get("/reports/todos/overdue.json").json
+        end
       end
 
       # Get a person's activity timeline
       # @param person_id [Integer] person id ID
       # @return [Hash] response data
       def person_progress(person_id:)
-        http_get("/reports/users/progress/#{person_id}").json
+        with_operation(service: "reports", operation: "person_progress", is_mutation: false, resource_id: person_id) do
+          http_get("/reports/users/progress/#{person_id}").json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/schedules_service.rb
+++ b/ruby/lib/basecamp/generated/services/schedules_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param entry_id [Integer] entry id ID
       # @return [Hash] response data
       def get_entry(project_id:, entry_id:)
-        http_get(bucket_path(project_id, "/schedule_entries/#{entry_id}")).json
+        with_operation(service: "schedules", operation: "get_entry", is_mutation: false, project_id: project_id, resource_id: entry_id) do
+          http_get(bucket_path(project_id, "/schedule_entries/#{entry_id}")).json
+        end
       end
 
       # Update an existing schedule entry
@@ -27,7 +29,9 @@ module Basecamp
       # @param notify [Boolean, nil] notify
       # @return [Hash] response data
       def update_entry(project_id:, entry_id:, summary: nil, starts_at: nil, ends_at: nil, description: nil, participant_ids: nil, all_day: nil, notify: nil)
-        http_put(bucket_path(project_id, "/schedule_entries/#{entry_id}"), body: compact_params(summary: summary, starts_at: starts_at, ends_at: ends_at, description: description, participant_ids: participant_ids, all_day: all_day, notify: notify)).json
+        with_operation(service: "schedules", operation: "update_entry", is_mutation: true, project_id: project_id, resource_id: entry_id) do
+          http_put(bucket_path(project_id, "/schedule_entries/#{entry_id}"), body: compact_params(summary: summary, starts_at: starts_at, ends_at: ends_at, description: description, participant_ids: participant_ids, all_day: all_day, notify: notify)).json
+        end
       end
 
       # Get a specific occurrence of a recurring schedule entry
@@ -36,7 +40,9 @@ module Basecamp
       # @param date [String] date ID
       # @return [Hash] response data
       def get_entry_occurrence(project_id:, entry_id:, date:)
-        http_get(bucket_path(project_id, "/schedule_entries/#{entry_id}/occurrences/#{date}")).json
+        with_operation(service: "schedules", operation: "get_entry_occurrence", is_mutation: false, project_id: project_id, resource_id: date) do
+          http_get(bucket_path(project_id, "/schedule_entries/#{entry_id}/occurrences/#{date}")).json
+        end
       end
 
       # Get a schedule
@@ -44,7 +50,9 @@ module Basecamp
       # @param schedule_id [Integer] schedule id ID
       # @return [Hash] response data
       def get(project_id:, schedule_id:)
-        http_get(bucket_path(project_id, "/schedules/#{schedule_id}")).json
+        with_operation(service: "schedules", operation: "get", is_mutation: false, project_id: project_id, resource_id: schedule_id) do
+          http_get(bucket_path(project_id, "/schedules/#{schedule_id}")).json
+        end
       end
 
       # Update schedule settings
@@ -53,7 +61,9 @@ module Basecamp
       # @param include_due_assignments [Boolean] include due assignments
       # @return [Hash] response data
       def update_settings(project_id:, schedule_id:, include_due_assignments:)
-        http_put(bucket_path(project_id, "/schedules/#{schedule_id}"), body: compact_params(include_due_assignments: include_due_assignments)).json
+        with_operation(service: "schedules", operation: "update_settings", is_mutation: true, project_id: project_id, resource_id: schedule_id) do
+          http_put(bucket_path(project_id, "/schedules/#{schedule_id}"), body: compact_params(include_due_assignments: include_due_assignments)).json
+        end
       end
 
       # List entries on a schedule
@@ -62,8 +72,10 @@ module Basecamp
       # @param status [String, nil] active|archived|trashed
       # @return [Enumerator<Hash>] paginated results
       def list_entries(project_id:, schedule_id:, status: nil)
-        params = compact_params(status: status)
-        paginate(bucket_path(project_id, "/schedules/#{schedule_id}/entries.json"), params: params)
+        wrap_paginated(service: "schedules", operation: "list_entries", is_mutation: false, project_id: project_id, resource_id: schedule_id) do
+          params = compact_params(status: status)
+          paginate(bucket_path(project_id, "/schedules/#{schedule_id}/entries.json"), params: params)
+        end
       end
 
       # Create a new schedule entry
@@ -78,7 +90,9 @@ module Basecamp
       # @param notify [Boolean, nil] notify
       # @return [Hash] response data
       def create_entry(project_id:, schedule_id:, summary:, starts_at:, ends_at:, description: nil, participant_ids: nil, all_day: nil, notify: nil)
-        http_post(bucket_path(project_id, "/schedules/#{schedule_id}/entries.json"), body: compact_params(summary: summary, starts_at: starts_at, ends_at: ends_at, description: description, participant_ids: participant_ids, all_day: all_day, notify: notify)).json
+        with_operation(service: "schedules", operation: "create_entry", is_mutation: true, project_id: project_id, resource_id: schedule_id) do
+          http_post(bucket_path(project_id, "/schedules/#{schedule_id}/entries.json"), body: compact_params(summary: summary, starts_at: starts_at, ends_at: ends_at, description: description, participant_ids: participant_ids, all_day: all_day, notify: notify)).json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/search_service.rb
+++ b/ruby/lib/basecamp/generated/services/search_service.rb
@@ -13,14 +13,18 @@ module Basecamp
       # @param page [Integer, nil] page
       # @return [Enumerator<Hash>] paginated results
       def search(query:, sort: nil, page: nil)
-        params = compact_params(query: query, sort: sort, page: page)
-        paginate("/search.json", params: params)
+        wrap_paginated(service: "search", operation: "search", is_mutation: false) do
+          params = compact_params(query: query, sort: sort, page: page)
+          paginate("/search.json", params: params)
+        end
       end
 
       # Get search metadata (available filter options)
       # @return [Hash] response data
       def metadata()
-        http_get("/searches/metadata.json").json
+        with_operation(service: "search", operation: "metadata", is_mutation: false) do
+          http_get("/searches/metadata.json").json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/subscriptions_service.rb
+++ b/ruby/lib/basecamp/generated/services/subscriptions_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param recording_id [Integer] recording id ID
       # @return [Hash] response data
       def get(project_id:, recording_id:)
-        http_get(bucket_path(project_id, "/recordings/#{recording_id}/subscription.json")).json
+        with_operation(service: "subscriptions", operation: "get", is_mutation: false, project_id: project_id, resource_id: recording_id) do
+          http_get(bucket_path(project_id, "/recordings/#{recording_id}/subscription.json")).json
+        end
       end
 
       # Subscribe the current user to a recording
@@ -20,7 +22,9 @@ module Basecamp
       # @param recording_id [Integer] recording id ID
       # @return [Hash] response data
       def subscribe(project_id:, recording_id:)
-        http_post(bucket_path(project_id, "/recordings/#{recording_id}/subscription.json")).json
+        with_operation(service: "subscriptions", operation: "subscribe", is_mutation: true, project_id: project_id, resource_id: recording_id) do
+          http_post(bucket_path(project_id, "/recordings/#{recording_id}/subscription.json")).json
+        end
       end
 
       # Update subscriptions by adding or removing specific users
@@ -30,7 +34,9 @@ module Basecamp
       # @param unsubscriptions [Array, nil] unsubscriptions
       # @return [Hash] response data
       def update(project_id:, recording_id:, subscriptions: nil, unsubscriptions: nil)
-        http_put(bucket_path(project_id, "/recordings/#{recording_id}/subscription.json"), body: compact_params(subscriptions: subscriptions, unsubscriptions: unsubscriptions)).json
+        with_operation(service: "subscriptions", operation: "update", is_mutation: true, project_id: project_id, resource_id: recording_id) do
+          http_put(bucket_path(project_id, "/recordings/#{recording_id}/subscription.json"), body: compact_params(subscriptions: subscriptions, unsubscriptions: unsubscriptions)).json
+        end
       end
 
       # Unsubscribe the current user from a recording
@@ -38,8 +44,10 @@ module Basecamp
       # @param recording_id [Integer] recording id ID
       # @return [void]
       def unsubscribe(project_id:, recording_id:)
-        http_delete(bucket_path(project_id, "/recordings/#{recording_id}/subscription.json"))
-        nil
+        with_operation(service: "subscriptions", operation: "unsubscribe", is_mutation: true, project_id: project_id, resource_id: recording_id) do
+          http_delete(bucket_path(project_id, "/recordings/#{recording_id}/subscription.json"))
+          nil
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/templates_service.rb
+++ b/ruby/lib/basecamp/generated/services/templates_service.rb
@@ -11,8 +11,10 @@ module Basecamp
       # @param status [String, nil] active|archived|trashed
       # @return [Enumerator<Hash>] paginated results
       def list(status: nil)
-        params = compact_params(status: status)
-        paginate("/templates.json", params: params)
+        wrap_paginated(service: "templates", operation: "list", is_mutation: false) do
+          params = compact_params(status: status)
+          paginate("/templates.json", params: params)
+        end
       end
 
       # Create a new template
@@ -20,14 +22,18 @@ module Basecamp
       # @param description [String, nil] description
       # @return [Hash] response data
       def create(name:, description: nil)
-        http_post("/templates.json", body: compact_params(name: name, description: description)).json
+        with_operation(service: "templates", operation: "create", is_mutation: true) do
+          http_post("/templates.json", body: compact_params(name: name, description: description)).json
+        end
       end
 
       # Get a single template by id
       # @param template_id [Integer] template id ID
       # @return [Hash] response data
       def get(template_id:)
-        http_get("/templates/#{template_id}").json
+        with_operation(service: "templates", operation: "get", is_mutation: false, resource_id: template_id) do
+          http_get("/templates/#{template_id}").json
+        end
       end
 
       # Update an existing template
@@ -36,15 +42,19 @@ module Basecamp
       # @param description [String, nil] description
       # @return [Hash] response data
       def update(template_id:, name: nil, description: nil)
-        http_put("/templates/#{template_id}", body: compact_params(name: name, description: description)).json
+        with_operation(service: "templates", operation: "update", is_mutation: true, resource_id: template_id) do
+          http_put("/templates/#{template_id}", body: compact_params(name: name, description: description)).json
+        end
       end
 
       # Delete a template (trash it)
       # @param template_id [Integer] template id ID
       # @return [void]
       def delete(template_id:)
-        http_delete("/templates/#{template_id}")
-        nil
+        with_operation(service: "templates", operation: "delete", is_mutation: true, resource_id: template_id) do
+          http_delete("/templates/#{template_id}")
+          nil
+        end
       end
 
       # Create a project from a template (asynchronous)
@@ -53,7 +63,9 @@ module Basecamp
       # @param description [String, nil] description
       # @return [Hash] response data
       def create_project(template_id:, name:, description: nil)
-        http_post("/templates/#{template_id}/project_constructions.json", body: compact_params(name: name, description: description)).json
+        with_operation(service: "templates", operation: "create_project", is_mutation: true, resource_id: template_id) do
+          http_post("/templates/#{template_id}/project_constructions.json", body: compact_params(name: name, description: description)).json
+        end
       end
 
       # Get the status of a project construction
@@ -61,7 +73,9 @@ module Basecamp
       # @param construction_id [Integer] construction id ID
       # @return [Hash] response data
       def get_construction(template_id:, construction_id:)
-        http_get("/templates/#{template_id}/project_constructions/#{construction_id}").json
+        with_operation(service: "templates", operation: "get_construction", is_mutation: false, resource_id: construction_id) do
+          http_get("/templates/#{template_id}/project_constructions/#{construction_id}").json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/timeline_service.rb
+++ b/ruby/lib/basecamp/generated/services/timeline_service.rb
@@ -11,7 +11,9 @@ module Basecamp
       # @param project_id [Integer] project id ID
       # @return [Enumerator<Hash>] paginated results
       def get_project_timeline(project_id:)
-        paginate("/projects/#{project_id}/timeline.json")
+        wrap_paginated(service: "timeline", operation: "get_project_timeline", is_mutation: false, project_id: project_id) do
+          paginate("/projects/#{project_id}/timeline.json")
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/timesheets_service.rb
+++ b/ruby/lib/basecamp/generated/services/timesheets_service.rb
@@ -16,7 +16,9 @@ module Basecamp
       # @param person_id [Integer, nil] person id
       # @return [Hash] response data
       def create(project_id:, recording_id:, date:, hours:, description: nil, person_id: nil)
-        http_post(bucket_path(project_id, "/recordings/#{recording_id}/timesheet/entries.json"), body: compact_params(date: date, hours: hours, description: description, person_id: person_id)).json
+        with_operation(service: "timesheets", operation: "create", is_mutation: true, project_id: project_id, resource_id: recording_id) do
+          http_post(bucket_path(project_id, "/recordings/#{recording_id}/timesheet/entries.json"), body: compact_params(date: date, hours: hours, description: description, person_id: person_id)).json
+        end
       end
 
       # Get timesheet for a specific recording
@@ -27,7 +29,9 @@ module Basecamp
       # @param person_id [Integer, nil] person id
       # @return [Hash] response data
       def for_recording(project_id:, recording_id:, from: nil, to: nil, person_id: nil)
-        http_get("/projects/#{project_id}/recordings/#{recording_id}/timesheet.json", params: compact_params(from: from, to: to, person_id: person_id)).json
+        with_operation(service: "timesheets", operation: "for_recording", is_mutation: false, project_id: project_id, resource_id: recording_id) do
+          http_get("/projects/#{project_id}/recordings/#{recording_id}/timesheet.json", params: compact_params(from: from, to: to, person_id: person_id)).json
+        end
       end
 
       # Get timesheet for a specific project
@@ -37,7 +41,9 @@ module Basecamp
       # @param person_id [Integer, nil] person id
       # @return [Hash] response data
       def for_project(project_id:, from: nil, to: nil, person_id: nil)
-        http_get("/projects/#{project_id}/timesheet.json", params: compact_params(from: from, to: to, person_id: person_id)).json
+        with_operation(service: "timesheets", operation: "for_project", is_mutation: false, project_id: project_id) do
+          http_get("/projects/#{project_id}/timesheet.json", params: compact_params(from: from, to: to, person_id: person_id)).json
+        end
       end
 
       # Get a single timesheet entry
@@ -45,7 +51,9 @@ module Basecamp
       # @param entry_id [Integer] entry id ID
       # @return [Hash] response data
       def get(project_id:, entry_id:)
-        http_get("/projects/#{project_id}/timesheet/entries/#{entry_id}").json
+        with_operation(service: "timesheets", operation: "get", is_mutation: false, project_id: project_id, resource_id: entry_id) do
+          http_get("/projects/#{project_id}/timesheet/entries/#{entry_id}").json
+        end
       end
 
       # Update a timesheet entry
@@ -57,7 +65,9 @@ module Basecamp
       # @param person_id [Integer, nil] person id
       # @return [Hash] response data
       def update(project_id:, entry_id:, date: nil, hours: nil, description: nil, person_id: nil)
-        http_put("/projects/#{project_id}/timesheet/entries/#{entry_id}", body: compact_params(date: date, hours: hours, description: description, person_id: person_id)).json
+        with_operation(service: "timesheets", operation: "update", is_mutation: true, project_id: project_id, resource_id: entry_id) do
+          http_put("/projects/#{project_id}/timesheet/entries/#{entry_id}", body: compact_params(date: date, hours: hours, description: description, person_id: person_id)).json
+        end
       end
 
       # Get account-wide timesheet report
@@ -66,7 +76,9 @@ module Basecamp
       # @param person_id [Integer, nil] person id
       # @return [Hash] response data
       def report(from: nil, to: nil, person_id: nil)
-        http_get("/reports/timesheet.json", params: compact_params(from: from, to: to, person_id: person_id)).json
+        with_operation(service: "timesheets", operation: "report", is_mutation: false) do
+          http_get("/reports/timesheet.json", params: compact_params(from: from, to: to, person_id: person_id)).json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/todolist_groups_service.rb
+++ b/ruby/lib/basecamp/generated/services/todolist_groups_service.rb
@@ -13,8 +13,10 @@ module Basecamp
       # @param position [Integer] position
       # @return [void]
       def reposition(project_id:, group_id:, position:)
-        http_put(bucket_path(project_id, "/todolists/#{group_id}/position.json"), body: compact_params(position: position))
-        nil
+        with_operation(service: "todolistgroups", operation: "reposition", is_mutation: true, project_id: project_id, resource_id: group_id) do
+          http_put(bucket_path(project_id, "/todolists/#{group_id}/position.json"), body: compact_params(position: position))
+          nil
+        end
       end
 
       # List groups in a todolist
@@ -22,7 +24,9 @@ module Basecamp
       # @param todolist_id [Integer] todolist id ID
       # @return [Enumerator<Hash>] paginated results
       def list(project_id:, todolist_id:)
-        paginate(bucket_path(project_id, "/todolists/#{todolist_id}/groups.json"))
+        wrap_paginated(service: "todolistgroups", operation: "list", is_mutation: false, project_id: project_id, resource_id: todolist_id) do
+          paginate(bucket_path(project_id, "/todolists/#{todolist_id}/groups.json"))
+        end
       end
 
       # Create a new group in a todolist
@@ -31,7 +35,9 @@ module Basecamp
       # @param name [String] name
       # @return [Hash] response data
       def create(project_id:, todolist_id:, name:)
-        http_post(bucket_path(project_id, "/todolists/#{todolist_id}/groups.json"), body: compact_params(name: name)).json
+        with_operation(service: "todolistgroups", operation: "create", is_mutation: true, project_id: project_id, resource_id: todolist_id) do
+          http_post(bucket_path(project_id, "/todolists/#{todolist_id}/groups.json"), body: compact_params(name: name)).json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/todolists_service.rb
+++ b/ruby/lib/basecamp/generated/services/todolists_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param id [Integer] id ID
       # @return [Hash] response data
       def get(project_id:, id:)
-        http_get(bucket_path(project_id, "/todolists/#{id}")).json
+        with_operation(service: "todolists", operation: "get", is_mutation: false, project_id: project_id, resource_id: id) do
+          http_get(bucket_path(project_id, "/todolists/#{id}")).json
+        end
       end
 
       # Update an existing todolist or todolist group
@@ -22,7 +24,9 @@ module Basecamp
       # @param description [String, nil] Description (Todolist only, ignored for groups)
       # @return [Hash] response data
       def update(project_id:, id:, name: nil, description: nil)
-        http_put(bucket_path(project_id, "/todolists/#{id}"), body: compact_params(name: name, description: description)).json
+        with_operation(service: "todolists", operation: "update", is_mutation: true, project_id: project_id, resource_id: id) do
+          http_put(bucket_path(project_id, "/todolists/#{id}"), body: compact_params(name: name, description: description)).json
+        end
       end
 
       # List todolists in a todoset
@@ -31,8 +35,10 @@ module Basecamp
       # @param status [String, nil] active|archived|trashed
       # @return [Enumerator<Hash>] paginated results
       def list(project_id:, todoset_id:, status: nil)
-        params = compact_params(status: status)
-        paginate(bucket_path(project_id, "/todosets/#{todoset_id}/todolists.json"), params: params)
+        wrap_paginated(service: "todolists", operation: "list", is_mutation: false, project_id: project_id, resource_id: todoset_id) do
+          params = compact_params(status: status)
+          paginate(bucket_path(project_id, "/todosets/#{todoset_id}/todolists.json"), params: params)
+        end
       end
 
       # Create a new todolist in a todoset
@@ -42,7 +48,9 @@ module Basecamp
       # @param description [String, nil] description
       # @return [Hash] response data
       def create(project_id:, todoset_id:, name:, description: nil)
-        http_post(bucket_path(project_id, "/todosets/#{todoset_id}/todolists.json"), body: compact_params(name: name, description: description)).json
+        with_operation(service: "todolists", operation: "create", is_mutation: true, project_id: project_id, resource_id: todoset_id) do
+          http_post(bucket_path(project_id, "/todosets/#{todoset_id}/todolists.json"), body: compact_params(name: name, description: description)).json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/todos_service.rb
+++ b/ruby/lib/basecamp/generated/services/todos_service.rb
@@ -14,8 +14,10 @@ module Basecamp
       # @param completed [Boolean, nil] completed
       # @return [Enumerator<Hash>] paginated results
       def list(project_id:, todolist_id:, status: nil, completed: nil)
-        params = compact_params(status: status, completed: completed)
-        paginate(bucket_path(project_id, "/todolists/#{todolist_id}/todos.json"), params: params)
+        wrap_paginated(service: "todos", operation: "list", is_mutation: false, project_id: project_id, resource_id: todolist_id) do
+          params = compact_params(status: status, completed: completed)
+          paginate(bucket_path(project_id, "/todolists/#{todolist_id}/todos.json"), params: params)
+        end
       end
 
       # Create a new todo in a todolist
@@ -30,7 +32,9 @@ module Basecamp
       # @param starts_on [String, nil] starts on (YYYY-MM-DD)
       # @return [Hash] response data
       def create(project_id:, todolist_id:, content:, description: nil, assignee_ids: nil, completion_subscriber_ids: nil, notify: nil, due_on: nil, starts_on: nil)
-        http_post(bucket_path(project_id, "/todolists/#{todolist_id}/todos.json"), body: compact_params(content: content, description: description, assignee_ids: assignee_ids, completion_subscriber_ids: completion_subscriber_ids, notify: notify, due_on: due_on, starts_on: starts_on)).json
+        with_operation(service: "todos", operation: "create", is_mutation: true, project_id: project_id, resource_id: todolist_id) do
+          http_post(bucket_path(project_id, "/todolists/#{todolist_id}/todos.json"), body: compact_params(content: content, description: description, assignee_ids: assignee_ids, completion_subscriber_ids: completion_subscriber_ids, notify: notify, due_on: due_on, starts_on: starts_on)).json
+        end
       end
 
       # Get a single todo by id
@@ -38,7 +42,9 @@ module Basecamp
       # @param todo_id [Integer] todo id ID
       # @return [Hash] response data
       def get(project_id:, todo_id:)
-        http_get(bucket_path(project_id, "/todos/#{todo_id}")).json
+        with_operation(service: "todos", operation: "get", is_mutation: false, project_id: project_id, resource_id: todo_id) do
+          http_get(bucket_path(project_id, "/todos/#{todo_id}")).json
+        end
       end
 
       # Update an existing todo
@@ -53,7 +59,9 @@ module Basecamp
       # @param starts_on [String, nil] starts on (YYYY-MM-DD)
       # @return [Hash] response data
       def update(project_id:, todo_id:, content: nil, description: nil, assignee_ids: nil, completion_subscriber_ids: nil, notify: nil, due_on: nil, starts_on: nil)
-        http_put(bucket_path(project_id, "/todos/#{todo_id}"), body: compact_params(content: content, description: description, assignee_ids: assignee_ids, completion_subscriber_ids: completion_subscriber_ids, notify: notify, due_on: due_on, starts_on: starts_on)).json
+        with_operation(service: "todos", operation: "update", is_mutation: true, project_id: project_id, resource_id: todo_id) do
+          http_put(bucket_path(project_id, "/todos/#{todo_id}"), body: compact_params(content: content, description: description, assignee_ids: assignee_ids, completion_subscriber_ids: completion_subscriber_ids, notify: notify, due_on: due_on, starts_on: starts_on)).json
+        end
       end
 
       # Trash a todo (returns 204 No Content)
@@ -61,8 +69,10 @@ module Basecamp
       # @param todo_id [Integer] todo id ID
       # @return [void]
       def trash(project_id:, todo_id:)
-        http_delete(bucket_path(project_id, "/todos/#{todo_id}"))
-        nil
+        with_operation(service: "todos", operation: "trash", is_mutation: true, project_id: project_id, resource_id: todo_id) do
+          http_delete(bucket_path(project_id, "/todos/#{todo_id}"))
+          nil
+        end
       end
 
       # Mark a todo as complete
@@ -70,8 +80,10 @@ module Basecamp
       # @param todo_id [Integer] todo id ID
       # @return [void]
       def complete(project_id:, todo_id:)
-        http_post(bucket_path(project_id, "/todos/#{todo_id}/completion.json"))
-        nil
+        with_operation(service: "todos", operation: "complete", is_mutation: true, project_id: project_id, resource_id: todo_id) do
+          http_post(bucket_path(project_id, "/todos/#{todo_id}/completion.json"))
+          nil
+        end
       end
 
       # Mark a todo as incomplete
@@ -79,8 +91,10 @@ module Basecamp
       # @param todo_id [Integer] todo id ID
       # @return [void]
       def uncomplete(project_id:, todo_id:)
-        http_delete(bucket_path(project_id, "/todos/#{todo_id}/completion.json"))
-        nil
+        with_operation(service: "todos", operation: "uncomplete", is_mutation: true, project_id: project_id, resource_id: todo_id) do
+          http_delete(bucket_path(project_id, "/todos/#{todo_id}/completion.json"))
+          nil
+        end
       end
 
       # Reposition a todo within its todolist
@@ -90,8 +104,10 @@ module Basecamp
       # @param parent_id [Integer, nil] Optional todolist ID to move the todo to a different parent
       # @return [void]
       def reposition(project_id:, todo_id:, position:, parent_id: nil)
-        http_put(bucket_path(project_id, "/todos/#{todo_id}/position.json"), body: compact_params(position: position, parent_id: parent_id))
-        nil
+        with_operation(service: "todos", operation: "reposition", is_mutation: true, project_id: project_id, resource_id: todo_id) do
+          http_put(bucket_path(project_id, "/todos/#{todo_id}/position.json"), body: compact_params(position: position, parent_id: parent_id))
+          nil
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/todosets_service.rb
+++ b/ruby/lib/basecamp/generated/services/todosets_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param todoset_id [Integer] todoset id ID
       # @return [Hash] response data
       def get(project_id:, todoset_id:)
-        http_get(bucket_path(project_id, "/todosets/#{todoset_id}")).json
+        with_operation(service: "todosets", operation: "get", is_mutation: false, project_id: project_id, resource_id: todoset_id) do
+          http_get(bucket_path(project_id, "/todosets/#{todoset_id}")).json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/tools_service.rb
+++ b/ruby/lib/basecamp/generated/services/tools_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param source_recording_id [Integer] source recording id
       # @return [Hash] response data
       def clone(project_id:, source_recording_id:)
-        http_post(bucket_path(project_id, "/dock/tools.json"), body: compact_params(source_recording_id: source_recording_id)).json
+        with_operation(service: "tools", operation: "clone", is_mutation: true, project_id: project_id) do
+          http_post(bucket_path(project_id, "/dock/tools.json"), body: compact_params(source_recording_id: source_recording_id)).json
+        end
       end
 
       # Get a dock tool by id
@@ -20,7 +22,9 @@ module Basecamp
       # @param tool_id [Integer] tool id ID
       # @return [Hash] response data
       def get(project_id:, tool_id:)
-        http_get(bucket_path(project_id, "/dock/tools/#{tool_id}")).json
+        with_operation(service: "tools", operation: "get", is_mutation: false, project_id: project_id, resource_id: tool_id) do
+          http_get(bucket_path(project_id, "/dock/tools/#{tool_id}")).json
+        end
       end
 
       # Update (rename) an existing tool
@@ -29,7 +33,9 @@ module Basecamp
       # @param title [String] title
       # @return [Hash] response data
       def update(project_id:, tool_id:, title:)
-        http_put(bucket_path(project_id, "/dock/tools/#{tool_id}"), body: compact_params(title: title)).json
+        with_operation(service: "tools", operation: "update", is_mutation: true, project_id: project_id, resource_id: tool_id) do
+          http_put(bucket_path(project_id, "/dock/tools/#{tool_id}"), body: compact_params(title: title)).json
+        end
       end
 
       # Delete a tool (trash it)
@@ -37,8 +43,10 @@ module Basecamp
       # @param tool_id [Integer] tool id ID
       # @return [void]
       def delete(project_id:, tool_id:)
-        http_delete(bucket_path(project_id, "/dock/tools/#{tool_id}"))
-        nil
+        with_operation(service: "tools", operation: "delete", is_mutation: true, project_id: project_id, resource_id: tool_id) do
+          http_delete(bucket_path(project_id, "/dock/tools/#{tool_id}"))
+          nil
+        end
       end
 
       # Enable a tool (show it on the project dock)
@@ -46,8 +54,10 @@ module Basecamp
       # @param tool_id [Integer] tool id ID
       # @return [void]
       def enable(project_id:, tool_id:)
-        http_post(bucket_path(project_id, "/recordings/#{tool_id}/position.json"))
-        nil
+        with_operation(service: "tools", operation: "enable", is_mutation: true, project_id: project_id, resource_id: tool_id) do
+          http_post(bucket_path(project_id, "/recordings/#{tool_id}/position.json"))
+          nil
+        end
       end
 
       # Reposition a tool on the project dock
@@ -56,8 +66,10 @@ module Basecamp
       # @param position [Integer] position
       # @return [void]
       def reposition(project_id:, tool_id:, position:)
-        http_put(bucket_path(project_id, "/recordings/#{tool_id}/position.json"), body: compact_params(position: position))
-        nil
+        with_operation(service: "tools", operation: "reposition", is_mutation: true, project_id: project_id, resource_id: tool_id) do
+          http_put(bucket_path(project_id, "/recordings/#{tool_id}/position.json"), body: compact_params(position: position))
+          nil
+        end
       end
 
       # Disable a tool (hide it from the project dock)
@@ -65,8 +77,10 @@ module Basecamp
       # @param tool_id [Integer] tool id ID
       # @return [void]
       def disable(project_id:, tool_id:)
-        http_delete(bucket_path(project_id, "/recordings/#{tool_id}/position.json"))
-        nil
+        with_operation(service: "tools", operation: "disable", is_mutation: true, project_id: project_id, resource_id: tool_id) do
+          http_delete(bucket_path(project_id, "/recordings/#{tool_id}/position.json"))
+          nil
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/uploads_service.rb
+++ b/ruby/lib/basecamp/generated/services/uploads_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param upload_id [Integer] upload id ID
       # @return [Hash] response data
       def get(project_id:, upload_id:)
-        http_get(bucket_path(project_id, "/uploads/#{upload_id}")).json
+        with_operation(service: "uploads", operation: "get", is_mutation: false, project_id: project_id, resource_id: upload_id) do
+          http_get(bucket_path(project_id, "/uploads/#{upload_id}")).json
+        end
       end
 
       # Update an existing upload
@@ -22,7 +24,9 @@ module Basecamp
       # @param base_name [String, nil] base name
       # @return [Hash] response data
       def update(project_id:, upload_id:, description: nil, base_name: nil)
-        http_put(bucket_path(project_id, "/uploads/#{upload_id}"), body: compact_params(description: description, base_name: base_name)).json
+        with_operation(service: "uploads", operation: "update", is_mutation: true, project_id: project_id, resource_id: upload_id) do
+          http_put(bucket_path(project_id, "/uploads/#{upload_id}"), body: compact_params(description: description, base_name: base_name)).json
+        end
       end
 
       # List versions of an upload
@@ -30,7 +34,9 @@ module Basecamp
       # @param upload_id [Integer] upload id ID
       # @return [Enumerator<Hash>] paginated results
       def list_versions(project_id:, upload_id:)
-        paginate(bucket_path(project_id, "/uploads/#{upload_id}/versions.json"))
+        wrap_paginated(service: "uploads", operation: "list_versions", is_mutation: false, project_id: project_id, resource_id: upload_id) do
+          paginate(bucket_path(project_id, "/uploads/#{upload_id}/versions.json"))
+        end
       end
 
       # List uploads in a vault
@@ -38,7 +44,9 @@ module Basecamp
       # @param vault_id [Integer] vault id ID
       # @return [Enumerator<Hash>] paginated results
       def list(project_id:, vault_id:)
-        paginate(bucket_path(project_id, "/vaults/#{vault_id}/uploads.json"))
+        wrap_paginated(service: "uploads", operation: "list", is_mutation: false, project_id: project_id, resource_id: vault_id) do
+          paginate(bucket_path(project_id, "/vaults/#{vault_id}/uploads.json"))
+        end
       end
 
       # Create a new upload in a vault
@@ -49,7 +57,9 @@ module Basecamp
       # @param base_name [String, nil] base name
       # @return [Hash] response data
       def create(project_id:, vault_id:, attachable_sgid:, description: nil, base_name: nil)
-        http_post(bucket_path(project_id, "/vaults/#{vault_id}/uploads.json"), body: compact_params(attachable_sgid: attachable_sgid, description: description, base_name: base_name)).json
+        with_operation(service: "uploads", operation: "create", is_mutation: true, project_id: project_id, resource_id: vault_id) do
+          http_post(bucket_path(project_id, "/vaults/#{vault_id}/uploads.json"), body: compact_params(attachable_sgid: attachable_sgid, description: description, base_name: base_name)).json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/vaults_service.rb
+++ b/ruby/lib/basecamp/generated/services/vaults_service.rb
@@ -12,7 +12,9 @@ module Basecamp
       # @param vault_id [Integer] vault id ID
       # @return [Hash] response data
       def get(project_id:, vault_id:)
-        http_get(bucket_path(project_id, "/vaults/#{vault_id}")).json
+        with_operation(service: "vaults", operation: "get", is_mutation: false, project_id: project_id, resource_id: vault_id) do
+          http_get(bucket_path(project_id, "/vaults/#{vault_id}")).json
+        end
       end
 
       # Update an existing vault
@@ -21,7 +23,9 @@ module Basecamp
       # @param title [String, nil] title
       # @return [Hash] response data
       def update(project_id:, vault_id:, title: nil)
-        http_put(bucket_path(project_id, "/vaults/#{vault_id}"), body: compact_params(title: title)).json
+        with_operation(service: "vaults", operation: "update", is_mutation: true, project_id: project_id, resource_id: vault_id) do
+          http_put(bucket_path(project_id, "/vaults/#{vault_id}"), body: compact_params(title: title)).json
+        end
       end
 
       # List vaults (subfolders) in a vault
@@ -29,7 +33,9 @@ module Basecamp
       # @param vault_id [Integer] vault id ID
       # @return [Enumerator<Hash>] paginated results
       def list(project_id:, vault_id:)
-        paginate(bucket_path(project_id, "/vaults/#{vault_id}/vaults.json"))
+        wrap_paginated(service: "vaults", operation: "list", is_mutation: false, project_id: project_id, resource_id: vault_id) do
+          paginate(bucket_path(project_id, "/vaults/#{vault_id}/vaults.json"))
+        end
       end
 
       # Create a new vault (subfolder) in a vault
@@ -38,7 +44,9 @@ module Basecamp
       # @param title [String] title
       # @return [Hash] response data
       def create(project_id:, vault_id:, title:)
-        http_post(bucket_path(project_id, "/vaults/#{vault_id}/vaults.json"), body: compact_params(title: title)).json
+        with_operation(service: "vaults", operation: "create", is_mutation: true, project_id: project_id, resource_id: vault_id) do
+          http_post(bucket_path(project_id, "/vaults/#{vault_id}/vaults.json"), body: compact_params(title: title)).json
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/generated/services/webhooks_service.rb
+++ b/ruby/lib/basecamp/generated/services/webhooks_service.rb
@@ -11,7 +11,9 @@ module Basecamp
       # @param project_id [Integer] project id ID
       # @return [Enumerator<Hash>] paginated results
       def list(project_id:)
-        paginate(bucket_path(project_id, "/webhooks.json"))
+        wrap_paginated(service: "webhooks", operation: "list", is_mutation: false, project_id: project_id) do
+          paginate(bucket_path(project_id, "/webhooks.json"))
+        end
       end
 
       # Create a new webhook for a project
@@ -21,7 +23,9 @@ module Basecamp
       # @param active [Boolean, nil] active
       # @return [Hash] response data
       def create(project_id:, payload_url:, types:, active: nil)
-        http_post(bucket_path(project_id, "/webhooks.json"), body: compact_params(payload_url: payload_url, types: types, active: active)).json
+        with_operation(service: "webhooks", operation: "create", is_mutation: true, project_id: project_id) do
+          http_post(bucket_path(project_id, "/webhooks.json"), body: compact_params(payload_url: payload_url, types: types, active: active)).json
+        end
       end
 
       # Get a single webhook by id
@@ -29,7 +33,9 @@ module Basecamp
       # @param webhook_id [Integer] webhook id ID
       # @return [Hash] response data
       def get(project_id:, webhook_id:)
-        http_get(bucket_path(project_id, "/webhooks/#{webhook_id}")).json
+        with_operation(service: "webhooks", operation: "get", is_mutation: false, project_id: project_id, resource_id: webhook_id) do
+          http_get(bucket_path(project_id, "/webhooks/#{webhook_id}")).json
+        end
       end
 
       # Update an existing webhook
@@ -40,7 +46,9 @@ module Basecamp
       # @param active [Boolean, nil] active
       # @return [Hash] response data
       def update(project_id:, webhook_id:, payload_url: nil, types: nil, active: nil)
-        http_put(bucket_path(project_id, "/webhooks/#{webhook_id}"), body: compact_params(payload_url: payload_url, types: types, active: active)).json
+        with_operation(service: "webhooks", operation: "update", is_mutation: true, project_id: project_id, resource_id: webhook_id) do
+          http_put(bucket_path(project_id, "/webhooks/#{webhook_id}"), body: compact_params(payload_url: payload_url, types: types, active: active)).json
+        end
       end
 
       # Delete a webhook
@@ -48,8 +56,10 @@ module Basecamp
       # @param webhook_id [Integer] webhook id ID
       # @return [void]
       def delete(project_id:, webhook_id:)
-        http_delete(bucket_path(project_id, "/webhooks/#{webhook_id}"))
-        nil
+        with_operation(service: "webhooks", operation: "delete", is_mutation: true, project_id: project_id, resource_id: webhook_id) do
+          http_delete(bucket_path(project_id, "/webhooks/#{webhook_id}"))
+          nil
+        end
       end
     end
   end

--- a/ruby/lib/basecamp/hooks.rb
+++ b/ruby/lib/basecamp/hooks.rb
@@ -19,6 +19,21 @@ module Basecamp
   #
   #   client = Basecamp::Client.new(config: config, token_provider: provider, hooks: LoggingHooks.new)
   module Hooks
+    # Called when a service operation starts (e.g., projects.list, todos.create).
+    # @param info [OperationInfo] operation information
+    # @return [void]
+    def on_operation_start(info)
+      # Override in implementation
+    end
+
+    # Called when a service operation completes (success or failure).
+    # @param info [OperationInfo] operation information
+    # @param result [OperationResult] result information
+    # @return [void]
+    def on_operation_end(info, result)
+      # Override in implementation
+    end
+
     # Called when an HTTP request starts.
     # @param info [RequestInfo] request information
     # @return [void]

--- a/ruby/lib/basecamp/operation_info.rb
+++ b/ruby/lib/basecamp/operation_info.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Basecamp
+  # Information about a service operation for observability hooks.
+  OperationInfo = Data.define(:service, :operation, :resource_type, :is_mutation, :project_id, :resource_id) do
+    def initialize(service:, operation:, resource_type: nil, is_mutation: false, project_id: nil, resource_id: nil)
+      super
+    end
+  end
+
+  # Result information for completed service operations.
+  OperationResult = Data.define(:duration_ms, :error) do
+    def initialize(duration_ms: 0, error: nil)
+      super
+    end
+  end
+end

--- a/ruby/test/basecamp/chain_hooks_test.rb
+++ b/ruby/test/basecamp/chain_hooks_test.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ChainHooksTest < Minitest::Test
+  def test_calls_start_hooks_in_order
+    calls = []
+    hook_a = RecordingHooks.new("A", calls)
+    hook_b = RecordingHooks.new("B", calls)
+    chain = Basecamp::ChainHooks.new(hook_a, hook_b)
+
+    info = Basecamp::RequestInfo.new(method: "GET", url: "/test")
+    chain.on_request_start(info)
+
+    assert_equal [ [ "A", :on_request_start ], [ "B", :on_request_start ] ], calls
+  end
+
+  def test_calls_end_hooks_in_reverse_order
+    calls = []
+    hook_a = RecordingHooks.new("A", calls)
+    hook_b = RecordingHooks.new("B", calls)
+    chain = Basecamp::ChainHooks.new(hook_a, hook_b)
+
+    info = Basecamp::RequestInfo.new(method: "GET", url: "/test")
+    result = Basecamp::RequestResult.new(status_code: 200)
+    chain.on_request_end(info, result)
+
+    assert_equal [ [ "B", :on_request_end ], [ "A", :on_request_end ] ], calls
+  end
+
+  def test_calls_operation_start_in_order
+    calls = []
+    hook_a = RecordingHooks.new("A", calls)
+    hook_b = RecordingHooks.new("B", calls)
+    chain = Basecamp::ChainHooks.new(hook_a, hook_b)
+
+    info = Basecamp::OperationInfo.new(service: "projects", operation: "list")
+    chain.on_operation_start(info)
+
+    assert_equal [ [ "A", :on_operation_start ], [ "B", :on_operation_start ] ], calls
+  end
+
+  def test_calls_operation_end_in_reverse_order
+    calls = []
+    hook_a = RecordingHooks.new("A", calls)
+    hook_b = RecordingHooks.new("B", calls)
+    chain = Basecamp::ChainHooks.new(hook_a, hook_b)
+
+    info = Basecamp::OperationInfo.new(service: "projects", operation: "list")
+    result = Basecamp::OperationResult.new(duration_ms: 100)
+    chain.on_operation_end(info, result)
+
+    assert_equal [ [ "B", :on_operation_end ], [ "A", :on_operation_end ] ], calls
+  end
+
+  def test_calls_retry_hooks_in_order
+    calls = []
+    hook_a = RecordingHooks.new("A", calls)
+    hook_b = RecordingHooks.new("B", calls)
+    chain = Basecamp::ChainHooks.new(hook_a, hook_b)
+
+    info = Basecamp::RequestInfo.new(method: "GET", url: "/test")
+    chain.on_retry(info, 2, StandardError.new, 1.0)
+
+    assert_equal [ [ "A", :on_retry ], [ "B", :on_retry ] ], calls
+  end
+
+  def test_calls_paginate_hooks_in_order
+    calls = []
+    hook_a = RecordingHooks.new("A", calls)
+    hook_b = RecordingHooks.new("B", calls)
+    chain = Basecamp::ChainHooks.new(hook_a, hook_b)
+
+    chain.on_paginate("/url", 1)
+
+    assert_equal [ [ "A", :on_paginate ], [ "B", :on_paginate ] ], calls
+  end
+
+  def test_swallows_exceptions_from_hooks
+    bad_hook = ExplodingHooks.new
+    calls = []
+    good_hook = RecordingHooks.new("good", calls)
+    chain = Basecamp::ChainHooks.new(bad_hook, good_hook)
+
+    info = Basecamp::RequestInfo.new(method: "GET", url: "/test")
+    chain.on_request_start(info)
+
+    # The good hook was still called despite the bad hook raising
+    assert_equal [ [ "good", :on_request_start ] ], calls
+  end
+
+  def test_swallows_exceptions_on_end_hooks
+    calls = []
+    good_hook = RecordingHooks.new("good", calls)
+    bad_hook = ExplodingHooks.new
+    chain = Basecamp::ChainHooks.new(good_hook, bad_hook)
+
+    info = Basecamp::RequestInfo.new(method: "GET", url: "/test")
+    result = Basecamp::RequestResult.new(status_code: 200)
+    # on_request_end calls in reverse: bad_hook first (raises), then good_hook
+    chain.on_request_end(info, result)
+
+    assert_equal [ [ "good", :on_request_end ] ], calls
+  end
+
+  private
+
+  class RecordingHooks
+    include Basecamp::Hooks
+
+    def initialize(name, calls)
+      @name = name
+      @calls = calls
+    end
+
+    def on_operation_start(_info)
+      @calls << [ @name, :on_operation_start ]
+    end
+
+    def on_operation_end(_info, _result)
+      @calls << [ @name, :on_operation_end ]
+    end
+
+    def on_request_start(_info)
+      @calls << [ @name, :on_request_start ]
+    end
+
+    def on_request_end(_info, _result)
+      @calls << [ @name, :on_request_end ]
+    end
+
+    def on_retry(_info, _attempt, _error, _delay)
+      @calls << [ @name, :on_retry ]
+    end
+
+    def on_paginate(_url, _page)
+      @calls << [ @name, :on_paginate ]
+    end
+  end
+
+  class ExplodingHooks
+    include Basecamp::Hooks
+
+    def on_request_start(_info)
+      raise "boom"
+    end
+
+    def on_request_end(_info, _result)
+      raise "boom"
+    end
+
+    def on_operation_start(_info)
+      raise "boom"
+    end
+
+    def on_operation_end(_info, _result)
+      raise "boom"
+    end
+  end
+end

--- a/ruby/test/basecamp/operation_hooks_test.rb
+++ b/ruby/test/basecamp/operation_hooks_test.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class OperationHooksTest < Minitest::Test
+  include TestHelper
+
+  # -- Eager operations (with_operation) --
+
+  def test_eager_operation_fires_hooks_immediately
+    events = []
+    hooks = TrackingHooks.new(events)
+    account = create_account_client(hooks: hooks)
+
+    stub_get("/12345/projects/123", response_body: { "id" => 123, "name" => "Test" })
+
+    account.projects.get(project_id: 123)
+
+    op_events = events.select { |e| e[:event].to_s.start_with?("on_operation") }
+    assert_equal [ :on_operation_start, :on_operation_end ], op_events.map { |e| e[:event] }
+    assert_equal "projects", op_events[0][:info].service
+    assert_equal "get", op_events[0][:info].operation
+    assert_not_nil op_events[1][:result].duration_ms
+    assert_nil op_events[1][:result].error
+  end
+
+  def test_eager_operation_reports_error_on_failure
+    events = []
+    hooks = TrackingHooks.new(events)
+    account = create_account_client(hooks: hooks)
+
+    stub_request(:get, "https://3.basecampapi.com/12345/projects/999")
+      .to_return(status: 404, body: { "error" => "not found" }.to_json)
+
+    assert_raises(Basecamp::NotFoundError) { account.projects.get(project_id: 999) }
+
+    end_event = events.find { |e| e[:event] == :on_operation_end }
+    assert_not_nil end_event
+    assert_kind_of Basecamp::NotFoundError, end_event[:result].error
+  end
+
+  # -- Paginated operations (wrap_paginated) --
+
+  def test_paginated_hooks_do_not_fire_until_iteration
+    events = []
+    hooks = TrackingHooks.new(events)
+    account = create_account_client(hooks: hooks)
+
+    stub_get("/12345/projects.json", response_body: [ { "id" => 1 } ])
+
+    enum = account.projects.list
+    assert_empty events, "hooks should not fire before iteration starts"
+
+    enum.to_a
+    op_events = events.select { |e| e[:event].to_s.start_with?("on_operation") }
+    assert_equal [ :on_operation_start, :on_operation_end ], op_events.map { |e| e[:event] }
+  end
+
+  def test_paginated_hooks_fire_on_iteration
+    events = []
+    hooks = TrackingHooks.new(events)
+    account = create_account_client(hooks: hooks)
+
+    stub_get("/12345/projects.json", response_body: [ { "id" => 1 }, { "id" => 2 } ])
+
+    account.projects.list.to_a
+
+    start_event = events.find { |e| e[:event] == :on_operation_start }
+    end_event = events.find { |e| e[:event] == :on_operation_end }
+
+    assert_not_nil start_event
+    assert_equal "projects", start_event[:info].service
+    assert_equal "list", start_event[:info].operation
+
+    assert_not_nil end_event
+    assert_nil end_event[:result].error
+    assert end_event[:result].duration_ms >= 0
+  end
+
+  def test_paginated_hooks_fire_on_partial_consumption
+    events = []
+    hooks = TrackingHooks.new(events)
+    account = create_account_client(hooks: hooks)
+
+    stub_get("/12345/projects.json", response_body: [ { "id" => 1 }, { "id" => 2 }, { "id" => 3 } ])
+
+    account.projects.list.first(1)
+
+    end_event = events.find { |e| e[:event] == :on_operation_end }
+    assert_not_nil end_event, "on_operation_end should fire even on partial consumption"
+    assert_nil end_event[:result].error
+  end
+
+  def test_paginated_hooks_report_error_during_iteration
+    events = []
+    hooks = TrackingHooks.new(events)
+    account = create_account_client(hooks: hooks)
+
+    stub_request(:get, "https://3.basecampapi.com/12345/projects.json")
+      .to_return(status: 404, body: { "error" => "not found" }.to_json)
+
+    assert_raises(Basecamp::NotFoundError) { account.projects.list.to_a }
+
+    end_event = events.find { |e| e[:event] == :on_operation_end }
+    assert_not_nil end_event
+    assert_kind_of Basecamp::NotFoundError, end_event[:result].error
+  end
+
+  def test_paginated_request_hooks_fire_per_page
+    events = []
+    hooks = TrackingHooks.new(events)
+    account = create_account_client(hooks: hooks)
+
+    page2_url = "https://3.basecampapi.com/12345/projects.json?page=2"
+
+    stub_request(:get, "https://3.basecampapi.com/12345/projects.json")
+      .to_return(
+        status: 200,
+        body: [ { "id" => 1 } ].to_json,
+        headers: { "Content-Type" => "application/json", "Link" => "<#{page2_url}>; rel=\"next\"" }
+      )
+    stub_request(:get, page2_url)
+      .to_return(
+        status: 200,
+        body: [ { "id" => 2 } ].to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    account.projects.list.to_a
+
+    # Operation hooks: exactly one start, one end
+    op_events = events.select { |e| e[:event].to_s.start_with?("on_operation") }
+    assert_equal [ :on_operation_start, :on_operation_end ], op_events.map { |e| e[:event] }
+
+    # Request hooks: one per page (2 pages = 2 start + 2 end)
+    req_starts = events.count { |e| e[:event] == :on_request_start }
+    req_ends = events.count { |e| e[:event] == :on_request_end }
+    assert_equal 2, req_starts, "should fire on_request_start for each page"
+    assert_equal 2, req_ends, "should fire on_request_end for each page"
+  end
+
+  def test_paginated_start_hook_exception_does_not_break_iteration
+    events = []
+    hooks = ExplodingStartHooks.new(events)
+    account = create_account_client(hooks: hooks)
+
+    stub_get("/12345/projects.json", response_body: [ { "id" => 1 } ])
+
+    # Hook exception is swallowed — iteration proceeds normally
+    results = account.projects.list.to_a
+    assert_equal 1, results.length
+
+    assert_equal [ :on_operation_start, :on_operation_end ], events.map { |e| e[:event] }
+    end_event = events.find { |e| e[:event] == :on_operation_end }
+    assert_nil end_event[:error]
+  end
+
+  def test_paginated_duration_reflects_iteration_time
+    events = []
+    hooks = TrackingHooks.new(events)
+    account = create_account_client(hooks: hooks)
+
+    stub_get("/12345/projects.json", response_body: [ { "id" => 1 } ])
+
+    enum = account.projects.list
+    sleep 0.01 # time passes before iteration — should NOT count
+    enum.to_a
+
+    end_event = events.find { |e| e[:event] == :on_operation_end }
+    # Duration should reflect iteration time, not time since .list was called
+    assert end_event[:result].duration_ms < 1000, "duration should reflect iteration, not creation"
+  end
+
+  private
+
+  class TrackingHooks
+    include Basecamp::Hooks
+
+    def initialize(events)
+      @events = events
+    end
+
+    def on_operation_start(info)
+      @events << { event: :on_operation_start, info: info }
+    end
+
+    def on_operation_end(info, result)
+      @events << { event: :on_operation_end, info: info, result: result }
+    end
+
+    def on_request_start(info)
+      @events << { event: :on_request_start, info: info }
+    end
+
+    def on_request_end(info, result)
+      @events << { event: :on_request_end, info: info, result: result }
+    end
+  end
+
+  class ExplodingStartHooks
+    include Basecamp::Hooks
+
+    def initialize(events)
+      @events = events
+    end
+
+    def on_operation_start(_info)
+      @events << { event: :on_operation_start }
+      raise "start hook exploded"
+    end
+
+    def on_operation_end(_info, result)
+      @events << { event: :on_operation_end, error: result.error }
+    end
+  end
+end

--- a/swift/Tests/BasecampTests/ChainHooksTests.swift
+++ b/swift/Tests/BasecampTests/ChainHooksTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import Basecamp
+
+final class ChainHooksTests: XCTestCase {
+
+    func testStartEventsCalledInOrder() {
+        let recorder = OrderRecorder()
+        let hookA = RecordingHooks(id: "A", recorder: recorder)
+        let hookB = RecordingHooks(id: "B", recorder: recorder)
+        let chain = ChainHooks(hookA, hookB)
+
+        let info = RequestInfo(method: "GET", url: "https://example.com", attempt: 1)
+        chain.onRequestStart(info)
+
+        XCTAssertEqual(recorder.events, ["A:requestStart", "B:requestStart"])
+    }
+
+    func testEndEventsCalledInReverseOrder() {
+        let recorder = OrderRecorder()
+        let hookA = RecordingHooks(id: "A", recorder: recorder)
+        let hookB = RecordingHooks(id: "B", recorder: recorder)
+        let chain = ChainHooks(hookA, hookB)
+
+        let info = RequestInfo(method: "GET", url: "https://example.com", attempt: 1)
+        let result = RequestResult(statusCode: 200, durationMs: 10)
+        chain.onRequestEnd(info, result: result)
+
+        XCTAssertEqual(recorder.events, ["B:requestEnd", "A:requestEnd"])
+    }
+
+    func testOperationStartInOrderEndReversed() {
+        let recorder = OrderRecorder()
+        let hookA = RecordingHooks(id: "A", recorder: recorder)
+        let hookB = RecordingHooks(id: "B", recorder: recorder)
+        let hookC = RecordingHooks(id: "C", recorder: recorder)
+        let chain = ChainHooks(hookA, hookB, hookC)
+
+        let info = OperationInfo(
+            service: "Test", operation: "Get",
+            resourceType: "test", isMutation: false
+        )
+
+        chain.onOperationStart(info)
+        chain.onOperationEnd(info, result: OperationResult(durationMs: 5))
+
+        XCTAssertEqual(recorder.events, [
+            "A:operationStart", "B:operationStart", "C:operationStart",
+            "C:operationEnd", "B:operationEnd", "A:operationEnd",
+        ])
+    }
+
+    func testRetryCalledInOrder() {
+        let recorder = OrderRecorder()
+        let hookA = RecordingHooks(id: "A", recorder: recorder)
+        let hookB = RecordingHooks(id: "B", recorder: recorder)
+        let chain = ChainHooks(hookA, hookB)
+
+        let info = RequestInfo(method: "GET", url: "https://example.com", attempt: 1)
+        let error = BasecampError.network(message: "timeout", cause: nil)
+        chain.onRetry(info, attempt: 1, error: error, delaySeconds: 1.0)
+
+        XCTAssertEqual(recorder.events, ["A:retry", "B:retry"])
+    }
+
+    func testEmptyChainDoesNotCrash() {
+        let chain = ChainHooks([])
+
+        let info = RequestInfo(method: "GET", url: "https://example.com", attempt: 1)
+        chain.onRequestStart(info)
+        chain.onRequestEnd(info, result: RequestResult(statusCode: 200, durationMs: 0))
+    }
+
+    func testArrayInitializer() {
+        let recorder = OrderRecorder()
+        let hooks: [any BasecampHooks] = [
+            RecordingHooks(id: "X", recorder: recorder),
+            RecordingHooks(id: "Y", recorder: recorder),
+        ]
+        let chain = ChainHooks(hooks)
+
+        let info = RequestInfo(method: "GET", url: "https://example.com", attempt: 1)
+        chain.onRequestStart(info)
+
+        XCTAssertEqual(recorder.events, ["X:requestStart", "Y:requestStart"])
+    }
+}
+
+// MARK: - Test helpers
+
+private final class OrderRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _events: [String] = []
+
+    var events: [String] {
+        lock.withLock { _events }
+    }
+
+    func record(_ event: String) {
+        lock.withLock { _events.append(event) }
+    }
+}
+
+private struct RecordingHooks: BasecampHooks {
+    let id: String
+    let recorder: OrderRecorder
+
+    func onOperationStart(_ info: OperationInfo) {
+        recorder.record("\(id):operationStart")
+    }
+
+    func onOperationEnd(_ info: OperationInfo, result: OperationResult) {
+        recorder.record("\(id):operationEnd")
+    }
+
+    func onRequestStart(_ info: RequestInfo) {
+        recorder.record("\(id):requestStart")
+    }
+
+    func onRequestEnd(_ info: RequestInfo, result: RequestResult) {
+        recorder.record("\(id):requestEnd")
+    }
+
+    func onRetry(_ info: RequestInfo, attempt: Int, error: any Error, delaySeconds: TimeInterval) {
+        recorder.record("\(id):retry")
+    }
+}


### PR DESCRIPTION
## Summary

- **ChainHooks** (Ruby + Swift): Composes multiple hook implementations into one — start events fire in order, end events in reverse. Exception-safe so a failing hook never crashes the SDK.
- **Operation-level hooks** (Ruby): Every generated service method now fires `on_operation_start`/`on_operation_end` callbacks reporting service name, operation, timing, and errors.
- **Lazy pagination hooks**: Paginated methods use `wrap_paginated` so hooks fire during actual iteration (not at Enumerator definition time), with `ensure`-based cleanup that handles complete, error, and `break`/`take`.
- Regenerates all 38 Ruby service files (175 operations) with hook wrappers.

## Test plan

- [x] Ruby: 521 tests, 759 assertions, 0 failures (includes 12 new operation hook tests + 8 ChainHooks tests)
- [x] Swift: 90 tests, 0 failures (includes 6 new ChainHooks tests)
- [x] Go, TypeScript, Kotlin: unchanged, all passing