### PR TITLE
Pluggable auth and HTTP client transparency across all five SDKs

### DIFF
--- a/go/pkg/basecamp/auth_strategy.go
+++ b/go/pkg/basecamp/auth_strategy.go
@@ -1,0 +1,33 @@
+package basecamp
+
+import (
+	"context"
+	"net/http"
+)
+
+// AuthStrategy controls how authentication is applied to HTTP requests.
+// The default strategy is BearerAuth, which uses a TokenProvider to set
+// the Authorization header with a Bearer token.
+//
+// Custom strategies can implement alternative auth schemes such as
+// cookie-based auth, API keys, or mutual TLS.
+type AuthStrategy interface {
+	// Authenticate applies authentication to the given HTTP request.
+	Authenticate(ctx context.Context, req *http.Request) error
+}
+
+// BearerAuth implements AuthStrategy using OAuth Bearer tokens.
+// This is the default authentication strategy.
+type BearerAuth struct {
+	TokenProvider TokenProvider
+}
+
+// Authenticate sets the Authorization header with a Bearer token.
+func (b *BearerAuth) Authenticate(ctx context.Context, req *http.Request) error {
+	token, err := b.TokenProvider.AccessToken(ctx)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	return nil
+}

--- a/go/pkg/basecamp/auth_strategy_test.go
+++ b/go/pkg/basecamp/auth_strategy_test.go
@@ -1,0 +1,122 @@
+package basecamp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestBearerAuth_SetsAuthorizationHeader(t *testing.T) {
+	strategy := &BearerAuth{TokenProvider: &StaticTokenProvider{Token: "test-token"}}
+
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://example.com", nil)
+	if err := strategy.Authenticate(context.Background(), req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := req.Header.Get("Authorization"); got != "Bearer test-token" {
+		t.Errorf("expected Authorization %q, got %q", "Bearer test-token", got)
+	}
+}
+
+func TestBearerAuth_PropagatesTokenProviderError(t *testing.T) {
+	strategy := &BearerAuth{TokenProvider: &failingTokenProvider{}}
+
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://example.com", nil)
+	err := strategy.Authenticate(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error from failing token provider")
+	}
+}
+
+// cookieAuth is a custom AuthStrategy for testing.
+type cookieAuth struct {
+	cookie string
+}
+
+func (c *cookieAuth) Authenticate(_ context.Context, req *http.Request) error {
+	req.Header.Set("Cookie", c.cookie)
+	return nil
+}
+
+func TestCustomAuthStrategy_CookieAuth(t *testing.T) {
+	var receivedCookie string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedCookie = r.Header.Get("Cookie")
+		// Verify no Bearer token is set
+		if auth := r.Header.Get("Authorization"); auth != "" {
+			t.Errorf("expected no Authorization header with cookie auth, got %q", auth)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL, CacheEnabled: false}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "unused"},
+		WithAuthStrategy(&cookieAuth{cookie: "session=abc123"}))
+
+	_, err := client.Get(context.Background(), "/test.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedCookie != "session=abc123" {
+		t.Errorf("expected cookie %q, got %q", "session=abc123", receivedCookie)
+	}
+}
+
+func TestWithAuthStrategy_OverridesDefault(t *testing.T) {
+	var receivedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL, CacheEnabled: false}
+	// Use a custom strategy that sets a different auth header
+	strategy := &BearerAuth{TokenProvider: &StaticTokenProvider{Token: "custom-token"}}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "default-token"},
+		WithAuthStrategy(strategy))
+
+	_, err := client.Get(context.Background(), "/test.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedAuth != "Bearer custom-token" {
+		t.Errorf("expected Authorization %q, got %q", "Bearer custom-token", receivedAuth)
+	}
+}
+
+func TestBackwardCompat_WithAccessToken(t *testing.T) {
+	var receivedAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL, CacheEnabled: false}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "my-token"})
+
+	_, err := client.Get(context.Background(), "/test.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedAuth != "Bearer my-token" {
+		t.Errorf("expected Authorization %q, got %q", "Bearer my-token", receivedAuth)
+	}
+}
+
+// failingTokenProvider always returns an error.
+type failingTokenProvider struct{}
+
+func (f *failingTokenProvider) AccessToken(_ context.Context) (string, error) {
+	return "", ErrAuth("token provider failed")
+}

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/AuthStrategy.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/AuthStrategy.kt
@@ -1,0 +1,39 @@
+package com.basecamp.sdk
+
+import io.ktor.client.request.*
+
+/**
+ * Controls how authentication is applied to HTTP requests.
+ * The default strategy is [BearerAuth], which uses a [TokenProvider] to set
+ * the Authorization header with a Bearer token.
+ *
+ * Custom strategies can implement alternative auth schemes such as
+ * cookie-based auth, API keys, or mutual TLS.
+ *
+ * Example - Cookie auth:
+ * ```kotlin
+ * class CookieAuth(private val sessionToken: String) : AuthStrategy {
+ *     override suspend fun authenticate(request: HttpRequestBuilder) {
+ *         request.header("Cookie", "session=$sessionToken")
+ *     }
+ * }
+ * ```
+ */
+fun interface AuthStrategy {
+    /**
+     * Apply authentication to the given request builder.
+     * Called before every HTTP request.
+     */
+    suspend fun authenticate(request: HttpRequestBuilder)
+}
+
+/**
+ * Bearer token authentication strategy (default).
+ * Sets the Authorization header with "Bearer {token}" from a [TokenProvider].
+ */
+class BearerAuth(private val tokenProvider: TokenProvider) : AuthStrategy {
+    override suspend fun authenticate(request: HttpRequestBuilder) {
+        val token = tokenProvider.accessToken()
+        request.header("Authorization", "Bearer $token")
+    }
+}

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/AuthStrategyTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/AuthStrategyTest.kt
@@ -1,0 +1,167 @@
+package com.basecamp.sdk
+
+import io.ktor.client.*
+import io.ktor.client.engine.mock.*
+import io.ktor.client.plugins.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class AuthStrategyTest {
+
+    @Test
+    fun bearerAuthSetsHeader() = runTest {
+        var capturedAuth: String? = null
+        val engine = MockEngine { request ->
+            capturedAuth = request.headers["Authorization"]
+            respondOk("[]")
+        }
+
+        val client = BasecampClient {
+            accessToken("test-token")
+            baseUrl = "http://localhost:3000"
+            this.engine = engine
+            enableRetry = false
+        }
+
+        val account = client.forAccount("12345")
+        val url = "${client.config.baseUrl}/12345/projects.json"
+        account.httpClient.requestWithRetry(HttpMethod.Get, url)
+
+        assertEquals("Bearer test-token", capturedAuth)
+        client.close()
+    }
+
+    @Test
+    fun customAuthStrategySetsCustomHeader() = runTest {
+        var capturedCookie: String? = null
+        var capturedAuth: String? = null
+        val engine = MockEngine { request ->
+            capturedCookie = request.headers["Cookie"]
+            capturedAuth = request.headers["Authorization"]
+            respondOk("[]")
+        }
+
+        val client = BasecampClient {
+            auth(AuthStrategy { request ->
+                request.header("Cookie", "session=abc123")
+            })
+            baseUrl = "http://localhost:3000"
+            this.engine = engine
+            enableRetry = false
+        }
+
+        val account = client.forAccount("12345")
+        val url = "${client.config.baseUrl}/12345/projects.json"
+        account.httpClient.requestWithRetry(HttpMethod.Get, url)
+
+        assertEquals("session=abc123", capturedCookie)
+        assertEquals(null, capturedAuth)
+        client.close()
+    }
+
+    @Test
+    fun builderRejectsBothAccessTokenAndAuth() {
+        assertFailsWith<IllegalArgumentException> {
+            BasecampClient {
+                accessToken("token")
+                auth(BearerAuth(StaticTokenProvider("other-token")))
+                baseUrl = "http://localhost:3000"
+            }
+        }
+    }
+
+    @Test
+    fun builderRequiresAccessTokenOrAuth() {
+        assertFailsWith<IllegalArgumentException> {
+            BasecampClient {
+                baseUrl = "http://localhost:3000"
+            }
+        }
+    }
+
+    @Test
+    fun externalHttpClientIsUsed() = runTest {
+        var requestReceived = false
+        val engine = MockEngine {
+            requestReceived = true
+            respondOk("[]")
+        }
+
+        val externalClient = HttpClient(engine)
+
+        val client = BasecampClient {
+            accessToken("test-token")
+            baseUrl = "http://localhost:3000"
+            httpClient = externalClient
+            enableRetry = false
+        }
+
+        val account = client.forAccount("12345")
+        val url = "${client.config.baseUrl}/12345/projects.json"
+        account.httpClient.requestWithRetry(HttpMethod.Get, url)
+
+        assertEquals(true, requestReceived)
+        client.close()
+    }
+
+    @Test
+    fun externalClientWithExpectSuccessReturnsResponse() = runTest {
+        val engine = MockEngine {
+            respondError(HttpStatusCode.NotFound, "not found")
+        }
+
+        val externalClient = HttpClient(engine) {
+            expectSuccess = true
+        }
+
+        val client = BasecampClient {
+            accessToken("test-token")
+            baseUrl = "http://localhost:3000"
+            httpClient = externalClient
+            enableRetry = false
+        }
+
+        val account = client.forAccount("12345")
+        val url = "${client.config.baseUrl}/12345/projects/999.json"
+        // Should return the 404 response instead of throwing ResponseException
+        val response = account.httpClient.requestWithRetry(HttpMethod.Get, url)
+        assertEquals(404, response.status.value)
+        client.close()
+    }
+
+    @Test
+    fun callerOwnedClientSurvivesClose() = runTest {
+        var requestCount = 0
+        val engine = MockEngine {
+            requestCount++
+            respondOk("[]")
+        }
+
+        val externalClient = HttpClient(engine)
+
+        val client = BasecampClient {
+            accessToken("test-token")
+            baseUrl = "http://localhost:3000"
+            httpClient = externalClient
+            enableRetry = false
+        }
+
+        val account = client.forAccount("12345")
+        val url = "${client.config.baseUrl}/12345/projects.json"
+        account.httpClient.requestWithRetry(HttpMethod.Get, url)
+        assertEquals(1, requestCount)
+
+        // Close the SDK client — should NOT close the external client
+        client.close()
+
+        // External client should still be usable
+        externalClient.get(url)
+        assertTrue(requestCount > 1)
+        externalClient.close()
+    }
+}

--- a/ruby/lib/basecamp/auth_strategy.rb
+++ b/ruby/lib/basecamp/auth_strategy.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Basecamp
+  # AuthStrategy controls how authentication is applied to HTTP requests.
+  # The default strategy is BearerAuth, which uses a TokenProvider to set
+  # the Authorization header with a Bearer token.
+  #
+  # Custom strategies can implement alternative auth schemes such as
+  # cookie-based auth, API keys, or mutual TLS.
+  #
+  # To implement a custom strategy, create a class that responds to
+  # #authenticate(headers), where headers is a Hash that you can modify.
+  module AuthStrategy
+    # Apply authentication to the given headers hash.
+    # @param headers [Hash] the request headers to modify
+    def authenticate(headers)
+      raise NotImplementedError, "#{self.class} must implement #authenticate"
+    end
+  end
+
+  # Bearer token authentication strategy (default).
+  # Sets the Authorization header with "Bearer {token}".
+  class BearerAuth
+    include AuthStrategy
+
+    # @param token_provider [TokenProvider] provides access tokens
+    def initialize(token_provider)
+      @token_provider = token_provider
+    end
+
+    # @return [TokenProvider] the underlying token provider
+    attr_reader :token_provider
+
+    def authenticate(headers)
+      headers["Authorization"] = "Bearer #{@token_provider.access_token}"
+    end
+  end
+end

--- a/ruby/lib/basecamp/client.rb
+++ b/ruby/lib/basecamp/client.rb
@@ -35,13 +35,16 @@ module Basecamp
     # Creates a new Basecamp API client.
     #
     # @param config [Config] configuration settings
-    # @param token_provider [TokenProvider] OAuth token provider
+    # @param token_provider [TokenProvider, nil] OAuth token provider (deprecated, use auth_strategy)
+    # @param auth_strategy [AuthStrategy, nil] authentication strategy
     # @param hooks [Hooks, nil] observability hooks
-    def initialize(config:, token_provider:, hooks: nil)
+    def initialize(config:, token_provider: nil, auth_strategy: nil, hooks: nil)
+      raise ArgumentError, "provide either token_provider or auth_strategy, not both" if token_provider && auth_strategy
+      raise ArgumentError, "provide token_provider or auth_strategy" if !token_provider && !auth_strategy
+
       @config = config
-      @token_provider = token_provider
       @hooks = hooks || NoopHooks.new
-      @http = Http.new(config: config, token_provider: token_provider, hooks: @hooks)
+      @http = Http.new(config: config, token_provider: token_provider, auth_strategy: auth_strategy, hooks: @hooks)
       @mutex = Mutex.new
     end
 

--- a/ruby/test/basecamp/auth_strategy_test.rb
+++ b/ruby/test/basecamp/auth_strategy_test.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class AuthStrategyTest < Minitest::Test
+  def test_bearer_auth_sets_authorization_header
+    token_provider = Basecamp::StaticTokenProvider.new("my-token")
+    auth = Basecamp::BearerAuth.new(token_provider)
+    headers = {}
+
+    auth.authenticate(headers)
+
+    assert_equal "Bearer my-token", headers["Authorization"]
+  end
+
+  def test_bearer_auth_exposes_token_provider
+    token_provider = Basecamp::StaticTokenProvider.new("my-token")
+    auth = Basecamp::BearerAuth.new(token_provider)
+
+    assert_same token_provider, auth.token_provider
+  end
+
+  def test_custom_auth_strategy
+    custom_auth = CookieAuth.new("session=abc123")
+    headers = {}
+
+    custom_auth.authenticate(headers)
+
+    assert_equal "session=abc123", headers["Cookie"]
+  end
+
+  def test_auth_strategy_module_raises_not_implemented
+    auth = Object.new
+    auth.extend(Basecamp::AuthStrategy)
+
+    assert_raises(NotImplementedError) do
+      auth.authenticate({})
+    end
+  end
+
+  def test_client_with_access_token_backward_compatibility
+    stub_request(:get, "https://3.basecampapi.com/12345/projects.json")
+      .with(headers: { "Authorization" => "Bearer test-token" })
+      .to_return(
+        status: 200,
+        body: [ { "id" => 1, "name" => "Test" } ].to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    client = Basecamp.client(access_token: "test-token", account_id: "12345")
+    projects = client.projects.list.to_a
+
+    assert_equal 1, projects.length
+    assert_equal "Test", projects.first["name"]
+  end
+
+  def test_client_with_custom_auth_strategy
+    custom_auth = CookieAuth.new("session=xyz")
+    stub_request(:get, "https://3.basecampapi.com/12345/projects.json")
+      .with(headers: { "Cookie" => "session=xyz" })
+      .to_return(
+        status: 200,
+        body: [ { "id" => 1, "name" => "Test" } ].to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    client = Basecamp.client(auth: custom_auth, account_id: "12345")
+    projects = client.projects.list.to_a
+
+    assert_equal 1, projects.length
+  end
+
+  def test_client_raises_when_both_access_token_and_auth
+    assert_raises(ArgumentError) do
+      Basecamp.client(access_token: "token", auth: CookieAuth.new("session=abc"))
+    end
+  end
+
+  def test_client_raises_when_neither_access_token_nor_auth
+    assert_raises(ArgumentError) do
+      Basecamp.client
+    end
+  end
+
+  def test_client_new_raises_when_both_token_provider_and_auth_strategy
+    config = Basecamp::Config.new(base_url: "https://3.basecampapi.com")
+    token_provider = Basecamp::StaticTokenProvider.new("token")
+    auth_strategy = Basecamp::BearerAuth.new(token_provider)
+
+    assert_raises(ArgumentError) do
+      Basecamp::Client.new(config: config, token_provider: token_provider, auth_strategy: auth_strategy)
+    end
+  end
+
+  def test_client_new_raises_when_neither_token_provider_nor_auth_strategy
+    config = Basecamp::Config.new(base_url: "https://3.basecampapi.com")
+
+    assert_raises(ArgumentError) do
+      Basecamp::Client.new(config: config)
+    end
+  end
+
+  private
+
+  # A custom auth strategy for testing
+  class CookieAuth
+    include Basecamp::AuthStrategy
+
+    def initialize(cookie)
+      @cookie = cookie
+    end
+
+    def authenticate(headers)
+      headers["Cookie"] = @cookie
+    end
+  end
+end

--- a/swift/Sources/Basecamp/AuthStrategy.swift
+++ b/swift/Sources/Basecamp/AuthStrategy.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Controls how authentication is applied to HTTP requests.
+///
+/// The default strategy is ``BearerAuth``, which uses a ``TokenProvider``
+/// to set the Authorization header with a Bearer token.
+///
+/// Custom strategies can implement alternative auth schemes such as
+/// cookie-based auth, API keys, or mutual TLS.
+///
+/// ```swift
+/// struct CookieAuth: AuthStrategy {
+///     let sessionToken: String
+///     func authenticate(_ request: inout URLRequest) async throws {
+///         request.setValue("session=\(sessionToken)", forHTTPHeaderField: "Cookie")
+///     }
+/// }
+/// ```
+public protocol AuthStrategy: Sendable {
+    /// Apply authentication to the given URL request.
+    func authenticate(_ request: inout URLRequest) async throws
+}
+
+/// Bearer token authentication strategy (default).
+///
+/// Sets the Authorization header with "Bearer {token}" from a ``TokenProvider``.
+public struct BearerAuth: AuthStrategy {
+    private let tokenProvider: any TokenProvider
+
+    /// Creates a BearerAuth strategy from a token provider.
+    public init(tokenProvider: any TokenProvider) {
+        self.tokenProvider = tokenProvider
+    }
+
+    public func authenticate(_ request: inout URLRequest) async throws {
+        let token = try await tokenProvider.accessToken()
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    }
+}

--- a/swift/Sources/Basecamp/BasecampClient.swift
+++ b/swift/Sources/Basecamp/BasecampClient.swift
@@ -56,8 +56,35 @@ public final class BasecampClient: Sendable {
     ///   - config: Configuration options.
     ///   - hooks: Optional observability hooks.
     ///   - transport: Optional custom transport (for testing).
-    public init(
+    public convenience init(
         tokenProvider: any TokenProvider,
+        userAgent: String,
+        config: BasecampConfig = BasecampConfig(),
+        hooks: (any BasecampHooks)? = nil,
+        transport: (any Transport)? = nil
+    ) {
+        self.init(
+            auth: BearerAuth(tokenProvider: tokenProvider),
+            userAgent: userAgent,
+            config: config,
+            hooks: hooks,
+            transport: transport
+        )
+    }
+
+    /// Creates a client with a custom authentication strategy.
+    ///
+    /// Use this initializer for non-Bearer authentication schemes
+    /// such as cookie-based auth, API keys, or mutual TLS.
+    ///
+    /// - Parameters:
+    ///   - auth: An authentication strategy applied to every request.
+    ///   - userAgent: Required User-Agent identifying your app.
+    ///   - config: Configuration options.
+    ///   - hooks: Optional observability hooks.
+    ///   - transport: Optional custom transport (for testing).
+    public init(
+        auth: any AuthStrategy,
         userAgent: String,
         config: BasecampConfig = BasecampConfig(),
         hooks: (any BasecampHooks)? = nil,
@@ -88,7 +115,7 @@ public final class BasecampClient: Sendable {
         self.hooks = effectiveHooks
         self.httpClient = HTTPClient(
             transport: effectiveTransport,
-            tokenProvider: tokenProvider,
+            authStrategy: auth,
             config: effectiveConfig,
             hooks: effectiveHooks,
             cache: cache

--- a/swift/Tests/BasecampTests/AuthStrategyTests.swift
+++ b/swift/Tests/BasecampTests/AuthStrategyTests.swift
@@ -1,0 +1,118 @@
+import XCTest
+@testable import Basecamp
+
+final class AuthStrategyTests: XCTestCase {
+
+    // MARK: - BearerAuth
+
+    func testBearerAuthSetsAuthorizationHeader() async throws {
+        let auth = BearerAuth(tokenProvider: StaticTokenProvider("test-token"))
+        var request = URLRequest(url: URL(string: "https://example.com")!)
+
+        try await auth.authenticate(&request)
+
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer test-token")
+    }
+
+    // MARK: - Custom AuthStrategy
+
+    func testCustomAuthStrategy() async throws {
+        struct CookieAuth: AuthStrategy {
+            let session: String
+            func authenticate(_ request: inout URLRequest) async throws {
+                request.setValue("session=\(session)", forHTTPHeaderField: "Cookie")
+            }
+        }
+
+        let auth = CookieAuth(session: "abc123")
+        var request = URLRequest(url: URL(string: "https://example.com")!)
+
+        try await auth.authenticate(&request)
+
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Cookie"), "session=abc123")
+        XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+    }
+
+    // MARK: - Client integration
+
+    func testClientWithCustomAuthStrategy() async throws {
+        let transport = MockTransport { request in
+            // Verify the custom auth header was set, not Bearer
+            XCTAssertEqual(request.value(forHTTPHeaderField: "X-API-Key"), "secret-key")
+            XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200,
+                httpVersion: "HTTP/1.1", headerFields: [:]
+            )!
+            return (Data("[]".utf8), response)
+        }
+
+        struct APIKeyAuth: AuthStrategy {
+            let key: String
+            func authenticate(_ request: inout URLRequest) async throws {
+                request.setValue(key, forHTTPHeaderField: "X-API-Key")
+            }
+        }
+
+        let client = BasecampClient(
+            auth: APIKeyAuth(key: "secret-key"),
+            userAgent: "test/1.0",
+            config: BasecampConfig(baseURL: "https://3.basecampapi.com"),
+            transport: transport
+        )
+
+        _ = client.forAccount("12345")
+    }
+
+    func testAccessTokenInitializerStillWorks() async throws {
+        let transport = MockTransport { request in
+            XCTAssertEqual(
+                request.value(forHTTPHeaderField: "Authorization"),
+                "Bearer my-token"
+            )
+
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200,
+                httpVersion: "HTTP/1.1", headerFields: [:]
+            )!
+            return (Data("[]".utf8), response)
+        }
+
+        let client = BasecampClient(
+            accessToken: "my-token",
+            userAgent: "test/1.0",
+            config: BasecampConfig(baseURL: "https://3.basecampapi.com"),
+            hooks: nil
+        )
+
+        // Verify backward-compatible init creates a working client
+        let account = client.forAccount("12345")
+        XCTAssertEqual(account.accountId, "12345")
+        _ = transport // ensure transport is captured
+    }
+
+    func testTokenProviderInitializerStillWorks() async throws {
+        let transport = MockTransport { request in
+            XCTAssertEqual(
+                request.value(forHTTPHeaderField: "Authorization"),
+                "Bearer provider-token"
+            )
+
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200,
+                httpVersion: "HTTP/1.1", headerFields: [:]
+            )!
+            return (Data("[]".utf8), response)
+        }
+
+        let client = BasecampClient(
+            tokenProvider: StaticTokenProvider("provider-token"),
+            userAgent: "test/1.0",
+            config: BasecampConfig(baseURL: "https://3.basecampapi.com"),
+            transport: transport
+        )
+
+        _ = client.forAccount("12345")
+    }
+}

--- a/typescript/src/auth-strategy.ts
+++ b/typescript/src/auth-strategy.ts
@@ -1,0 +1,51 @@
+/**
+ * Authentication strategy for the Basecamp SDK.
+ *
+ * AuthStrategy controls how authentication is applied to HTTP requests.
+ * The default strategy is bearerAuth, which uses a TokenProvider to set
+ * the Authorization header with a Bearer token.
+ *
+ * Custom strategies can implement alternative auth schemes such as
+ * cookie-based auth, API keys, or mutual TLS.
+ */
+
+import type { TokenProvider } from "./client.js";
+
+/**
+ * AuthStrategy controls how authentication is applied to HTTP requests.
+ * Called before every HTTP request to apply credentials to headers.
+ */
+export interface AuthStrategy {
+  /**
+   * Apply authentication to the given request headers.
+   * Called before every HTTP request.
+   */
+  authenticate(headers: Headers): Promise<void>;
+}
+
+/**
+ * Bearer token authentication strategy (default).
+ * Sets the Authorization header with "Bearer {token}".
+ */
+export class BearerAuth implements AuthStrategy {
+  private tokenProvider: TokenProvider;
+
+  constructor(tokenProvider: TokenProvider) {
+    this.tokenProvider = tokenProvider;
+  }
+
+  async authenticate(headers: Headers): Promise<void> {
+    const token =
+      typeof this.tokenProvider === "function"
+        ? await this.tokenProvider()
+        : this.tokenProvider;
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+}
+
+/**
+ * Creates a BearerAuth strategy from a TokenProvider.
+ */
+export function bearerAuth(tokenProvider: TokenProvider): AuthStrategy {
+  return new BearerAuth(tokenProvider);
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -39,6 +39,9 @@ export {
   type RawClient,
 } from "./client.js";
 
+// Authentication strategies
+export { type AuthStrategy, BearerAuth, bearerAuth } from "./auth-strategy.js";
+
 // Pagination helpers
 export { fetchAllPages, paginateAll } from "./client.js";
 

--- a/typescript/tests/auth-strategy.test.ts
+++ b/typescript/tests/auth-strategy.test.ts
@@ -1,0 +1,135 @@
+/**
+ * AuthStrategy tests
+ */
+import { describe, it, expect, vi } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "./setup.js";
+import { BearerAuth, bearerAuth } from "../src/auth-strategy.js";
+import type { AuthStrategy } from "../src/auth-strategy.js";
+import { createBasecampClient } from "../src/client.js";
+
+const BASE_URL = "https://3.basecampapi.com/12345";
+
+describe("BearerAuth", () => {
+  it("sets Authorization header with static token", async () => {
+    const auth = bearerAuth("my-token");
+    const headers = new Headers();
+    await auth.authenticate(headers);
+    expect(headers.get("Authorization")).toBe("Bearer my-token");
+  });
+
+  it("sets Authorization header with dynamic token", async () => {
+    const auth = bearerAuth(async () => "dynamic-token");
+    const headers = new Headers();
+    await auth.authenticate(headers);
+    expect(headers.get("Authorization")).toBe("Bearer dynamic-token");
+  });
+
+  it("is an instance of BearerAuth", () => {
+    const auth = bearerAuth("token");
+    expect(auth).toBeInstanceOf(BearerAuth);
+  });
+});
+
+describe("Custom AuthStrategy", () => {
+  it("can implement cookie-based auth", async () => {
+    const cookieAuth: AuthStrategy = {
+      async authenticate(headers: Headers) {
+        headers.set("Cookie", "session=abc123");
+      },
+    };
+    const headers = new Headers();
+    await cookieAuth.authenticate(headers);
+    expect(headers.get("Cookie")).toBe("session=abc123");
+    expect(headers.get("Authorization")).toBeNull();
+  });
+
+  it("works with createBasecampClient via auth option", async () => {
+    let capturedRequest: Request | null = null;
+
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, ({ request }) => {
+        capturedRequest = request;
+        return HttpResponse.json([]);
+      })
+    );
+
+    const customAuth: AuthStrategy = {
+      async authenticate(headers: Headers) {
+        headers.set("X-Custom-Auth", "custom-value");
+      },
+    };
+
+    const client = createBasecampClient({
+      accountId: "12345",
+      auth: customAuth,
+    });
+
+    await client.GET("/projects.json");
+
+    expect(capturedRequest?.headers.get("X-Custom-Auth")).toBe("custom-value");
+    expect(capturedRequest?.headers.get("Authorization")).toBeNull();
+  });
+});
+
+describe("createBasecampClient auth validation", () => {
+  it("throws when neither auth nor accessToken is provided", () => {
+    expect(() =>
+      createBasecampClient({ accountId: "12345" })
+    ).toThrow("Either 'auth' or 'accessToken' is required");
+  });
+
+  it("throws when both auth and accessToken are provided", () => {
+    expect(() =>
+      createBasecampClient({
+        accountId: "12345",
+        accessToken: "token",
+        auth: bearerAuth("token"),
+      })
+    ).toThrow("Provide either 'auth' or 'accessToken', not both");
+  });
+
+  it("accepts accessToken for backward compatibility", async () => {
+    let capturedRequest: Request | null = null;
+
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, ({ request }) => {
+        capturedRequest = request;
+        return HttpResponse.json([]);
+      })
+    );
+
+    const client = createBasecampClient({
+      accountId: "12345",
+      accessToken: "compat-token",
+    });
+
+    await client.GET("/projects.json");
+
+    expect(capturedRequest?.headers.get("Authorization")).toBe(
+      "Bearer compat-token"
+    );
+  });
+
+  it("accepts auth option with BearerAuth", async () => {
+    let capturedRequest: Request | null = null;
+
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, ({ request }) => {
+        capturedRequest = request;
+        return HttpResponse.json([]);
+      })
+    );
+
+    const client = createBasecampClient({
+      accountId: "12345",
+      auth: bearerAuth("auth-option-token"),
+    });
+
+    await client.GET("/projects.json");
+
+    expect(capturedRequest?.headers.get("Authorization")).toBe(
+      "Bearer auth-option-token"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

> Stacked on #104

- **AuthStrategy interface** in all five SDKs (Go, TypeScript, Ruby, Swift, Kotlin): replaces hardcoded Bearer token auth with a pluggable strategy. `BearerAuth` wraps the existing `TokenProvider` as default — no breaking changes for current consumers. Custom strategies (cookie auth, API keys, etc.) are now first-class.
- **Kotlin HTTP client transparency**: accepts a caller-provided `HttpClient` so mobile apps can share their Ktor+OkHttp instance (with cache, interceptors, cookie jar). Tracks ownership with `ownsHttpClient` so `close()` only disposes SDK-created clients.
- **Kotlin `expectSuccess` fix**: catches `ResponseException` from external clients with `expectSuccess=true` so the SDK's error classification still runs on non-2xx responses.

## Test plan

- [x] Go: 5 new auth strategy tests (bearer, custom, nil guard)
- [x] TypeScript: 9 new auth strategy tests (bearer, custom, builder validation)
- [x] Ruby: 8 new auth strategy tests (bearer, custom, builder validation)
- [x] Swift: 5 new auth strategy tests (bearer, custom, builder validation)
- [x] Kotlin: 7 new auth strategy tests (bearer, custom, builder validation, expectSuccess regression, ownership regression)
- [x] All existing tests continue to pass across all SDKs