### PR TITLE
Fix govulncheck Go 1.26 compatibility in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -301,15 +301,9 @@ jobs:
         with:
           go-version-file: 'go/go.mod'
 
-      - name: Cache Go tools
-        uses: actions/cache@v5
-        with:
-          path: ~/go/bin
-          key: go-tools-${{ runner.os }}-govulncheck-v1.1.4
-
       - name: Run govulncheck
         run: |
-          command -v govulncheck || go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+          go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
 
   race:


### PR DESCRIPTION
## Summary

- The `security` job in `test.yml` cached `govulncheck@v1.1.4` (built with Go 1.25), which can't parse Go 1.26 source files after #102
- Install `@latest` with the active toolchain instead, matching what `security.yml` already does

## Test plan

- [x] CI should pass — govulncheck will be built with Go 1.26, matching `go.mod`