### PR TITLE
Add ./oauth subpath to root package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     ".": {
       "import": "./typescript/dist/index.js",
       "types": "./typescript/dist/index.d.ts"
+    },
+    "./oauth": {
+      "import": "./typescript/dist/oauth/index.js",
+      "types": "./typescript/dist/oauth/index.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
## Summary

- The root `package.json` (used for `npm install github:basecamp/basecamp-sdk#main`) was missing the `./oauth` subpath export added in #113
- `typescript/package.json` had it, but npm resolves from the root — so `@basecamp/sdk/oauth` failed with `Cannot find module`

One-line fix: adds the `./oauth` entry to the root exports map.