### PR TITLE
Bump minimatch to fix npm audit vulnerability

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1992,9 +1992,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Bumps minimatch past 10.2.2 to resolve two high-severity ReDoS advisories (GHSA-7r86-cg39-jmmj, GHSA-23c5-xmqv-rm74)

## Test plan
- [ ] npm audit passes with 0 vulnerabilities
- [ ] TypeScript SDK tests pass