### PR TITLE
Build prompt YAML dynamically to fix multiline content parsing

### DIFF
--- a/.github/prompts/classify-pr.prompt.yml
+++ b/.github/prompts/classify-pr.prompt.yml
@@ -18,14 +18,6 @@ messages:
 
       When a PR mixes categories: bug > enhancement > documentation.
       Prefer diff evidence over the PR title.
-  - role: user
-    content: |
-      PR #{{number}}: {{title}}
-
-      {{body}}
-
-      Diff (truncated):
-      {{diff}}
 model: openai/gpt-4o-mini
 modelParameters:
   maxCompletionTokens: 10

--- a/.github/prompts/detect-breaking.prompt.yml
+++ b/.github/prompts/detect-breaking.prompt.yml
@@ -18,12 +18,6 @@ messages:
       }
 
       If no breaking changes, respond: {"breaking": false, "items": []}
-  - role: user
-    content: |
-      PR #{{number}}: {{title}}
-
-      Diff of public API surface files:
-      {{diff}}
 model: openai/gpt-4o-mini
 responseFormat: json_schema
 jsonSchema: |-

--- a/.github/prompts/spec-impact.prompt.yml
+++ b/.github/prompts/spec-impact.prompt.yml
@@ -19,12 +19,6 @@ messages:
         - [ ] Swift
 
       Keep it concise — this is a PR comment, not a document.
-  - role: user
-    content: |
-      PR #{{number}}: {{title}}
-
-      Spec diff:
-      {{diff}}
 model: openai/gpt-4o
 modelParameters:
   maxCompletionTokens: 800

--- a/.github/prompts/summarize-changelog.prompt.yml
+++ b/.github/prompts/summarize-changelog.prompt.yml
@@ -13,16 +13,6 @@ messages:
       - If the diff touches generated code only (service files, types), note
         what API coverage was added rather than listing file changes
       - Keep it under 30 lines
-  - role: user
-    content: |
-      SDK: {{sdk_name}}
-      Version: {{version}}
-
-      Commits since last release:
-      {{commits}}
-
-      Diff (truncated):
-      {{diff}}
 model: openai/gpt-4o
 modelParameters:
   maxCompletionTokens: 1000

--- a/.github/workflows/ai-labeler.yml
+++ b/.github/workflows/ai-labeler.yml
@@ -19,26 +19,43 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Fetch PR context
+      - name: Build prompt
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr diff ${{ github.event.pull_request.number }} > /tmp/pr.diff
-          head -c 100000 /tmp/pr.diff > /tmp/pr-truncated.diff
-          gh pr view ${{ github.event.pull_request.number }} --json title,body --jq .title > /tmp/pr-title.txt
-          gh pr view ${{ github.event.pull_request.number }} --json body --jq .body > /tmp/pr-body.txt
+          PR=${{ github.event.pull_request.number }}
+          gh pr diff "$PR" > /tmp/pr.diff
+          gh pr view "$PR" --json title --jq .title > /tmp/pr-title.txt
+          gh pr view "$PR" --json body --jq .body > /tmp/pr-body.txt
+
+          # Compose user message
+          {
+            echo "PR #${PR}: $(cat /tmp/pr-title.txt)"
+            echo ""
+            cat /tmp/pr-body.txt
+            echo ""
+            echo "Diff (truncated):"
+            head -c 100000 /tmp/pr.diff
+          } > /tmp/user-message.txt
+
+          # Build full prompt YAML: base prompt + indented user message
+          cp .github/prompts/classify-pr.prompt.yml /tmp/prompt.yml
+          python3 -c "
+          import yaml, sys
+          with open('/tmp/prompt.yml') as f:
+              prompt = yaml.safe_load(f)
+          with open('/tmp/user-message.txt') as f:
+              user_msg = f.read()
+          prompt['messages'].append({'role': 'user', 'content': user_msg})
+          with open('/tmp/prompt.yml', 'w') as f:
+              yaml.dump(prompt, f, default_flow_style=False, allow_unicode=True)
+          "
 
       - name: Classify
         id: classify
         uses: actions/ai-inference@v1
         with:
-          prompt-file: .github/prompts/classify-pr.prompt.yml
-          input: |
-            number: "${{ github.event.pull_request.number }}"
-          file_input: |
-            title: /tmp/pr-title.txt
-            body: /tmp/pr-body.txt
-            diff: /tmp/pr-truncated.diff
+          prompt-file: /tmp/prompt.yml
 
       - name: Apply label
         env:
@@ -59,11 +76,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Collect public API diff
+      - name: Build prompt
         id: api-diff
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          PR=${{ github.event.pull_request.number }}
+
           # Public API surface files per SDK
           PATTERNS=(
             "go/pkg/basecamp/*.go"
@@ -76,8 +95,7 @@ jobs:
             "kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/**/*.kt"
             "swift/Sources/Basecamp/*.swift" "swift/Sources/Basecamp/Services/*.swift" "swift/Sources/Basecamp/Generated/**/*.swift"
           )
-          gh pr diff ${{ github.event.pull_request.number }} > /tmp/full.diff
-          gh pr view ${{ github.event.pull_request.number }} --json title --jq .title > /tmp/pr-title.txt
+          gh pr diff "$PR" > /tmp/full.diff
 
           # Filter diff to only public API files
           python3 -c "
@@ -96,7 +114,28 @@ jobs:
           if [ ! -s /tmp/api.diff ]; then
             echo "skip=true" >> $GITHUB_OUTPUT
           else
-            head -c 100000 /tmp/api.diff > /tmp/api-truncated.diff
+            TITLE=$(gh pr view "$PR" --json title --jq .title)
+
+            # Compose user message
+            {
+              echo "PR #${PR}: ${TITLE}"
+              echo ""
+              echo "Diff of public API surface files:"
+              head -c 100000 /tmp/api.diff
+            } > /tmp/user-message.txt
+
+            # Build full prompt YAML
+            cp .github/prompts/detect-breaking.prompt.yml /tmp/prompt.yml
+            python3 -c "
+          import yaml
+          with open('/tmp/prompt.yml') as f:
+              prompt = yaml.safe_load(f)
+          with open('/tmp/user-message.txt') as f:
+              user_msg = f.read()
+          prompt['messages'].append({'role': 'user', 'content': user_msg})
+          with open('/tmp/prompt.yml', 'w') as f:
+              yaml.dump(prompt, f, default_flow_style=False, allow_unicode=True)
+          "
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
@@ -105,12 +144,7 @@ jobs:
         id: detect
         uses: actions/ai-inference@v1
         with:
-          prompt-file: .github/prompts/detect-breaking.prompt.yml
-          input: |
-            number: "${{ github.event.pull_request.number }}"
-          file_input: |
-            title: /tmp/pr-title.txt
-            diff: /tmp/api-truncated.diff
+          prompt-file: /tmp/prompt.yml
 
       - name: Apply breaking label
         if: steps.api-diff.outputs.skip != 'true'
@@ -150,18 +184,39 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check for spec changes
+      - name: Build prompt
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          CHANGED=$(gh pr diff ${{ github.event.pull_request.number }} --name-only | grep -cE '^(spec/|openapi\.json|behavior-model\.json)' || true)
+          PR=${{ github.event.pull_request.number }}
+          CHANGED=$(gh pr diff "$PR" --name-only | grep -cE '^(spec/|openapi\.json|behavior-model\.json)' || true)
           if [ "$CHANGED" -eq 0 ]; then
             echo "skip=true" >> $GITHUB_OUTPUT
           else
-            gh pr diff ${{ github.event.pull_request.number }} -- spec/ openapi.json behavior-model.json > /tmp/spec.diff 2>/dev/null || true
-            head -c 100000 /tmp/spec.diff > /tmp/spec-truncated.diff
-            gh pr view ${{ github.event.pull_request.number }} --json title --jq .title > /tmp/pr-title.txt
+            gh pr diff "$PR" -- spec/ openapi.json behavior-model.json > /tmp/spec.diff 2>/dev/null || true
+            TITLE=$(gh pr view "$PR" --json title --jq .title)
+
+            # Compose user message
+            {
+              echo "PR #${PR}: ${TITLE}"
+              echo ""
+              echo "Spec diff:"
+              head -c 100000 /tmp/spec.diff
+            } > /tmp/user-message.txt
+
+            # Build full prompt YAML
+            cp .github/prompts/spec-impact.prompt.yml /tmp/prompt.yml
+            python3 -c "
+          import yaml
+          with open('/tmp/prompt.yml') as f:
+              prompt = yaml.safe_load(f)
+          with open('/tmp/user-message.txt') as f:
+              user_msg = f.read()
+          prompt['messages'].append({'role': 'user', 'content': user_msg})
+          with open('/tmp/prompt.yml', 'w') as f:
+              yaml.dump(prompt, f, default_flow_style=False, allow_unicode=True)
+          "
             echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
@@ -170,12 +225,7 @@ jobs:
         id: analyze
         uses: actions/ai-inference@v1
         with:
-          prompt-file: .github/prompts/spec-impact.prompt.yml
-          input: |
-            number: "${{ github.event.pull_request.number }}"
-          file_input: |
-            title: /tmp/pr-title.txt
-            diff: /tmp/spec-truncated.diff
+          prompt-file: /tmp/prompt.yml
 
       - name: Post impact comment
         if: steps.check.outputs.skip != 'true'

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -141,7 +141,7 @@ jobs:
           echo "::notice::Dry run mode - not actually publishing"
           echo "Would publish: basecamp-sdk-${{ steps.version.outputs.version }}.gem"
 
-      - name: Collect changelog inputs
+      - name: Build changelog prompt
         if: github.event_name == 'push'
         id: changelog-inputs
         run: |
@@ -154,8 +154,30 @@ jobs:
             COMMITS=$(git log --pretty=format:"- %s (%h)" "${PREV_TAG}..HEAD" -- ruby/)
             git diff "${PREV_TAG}..HEAD" -- ruby/ > /tmp/sdk-diff.txt
           fi
-          head -c 100000 /tmp/sdk-diff.txt > /tmp/sdk-diff-truncated.txt
           echo "$COMMITS" > /tmp/commits.txt
+
+          {
+            echo "SDK: Ruby"
+            echo "Version: v${{ steps.version.outputs.version }}"
+            echo ""
+            echo "Commits since last release:"
+            cat /tmp/commits.txt
+            echo ""
+            echo "Diff (truncated):"
+            head -c 100000 /tmp/sdk-diff.txt
+          } > /tmp/user-message.txt
+
+          cp .github/prompts/summarize-changelog.prompt.yml /tmp/prompt.yml
+          python3 -c "
+          import yaml
+          with open('/tmp/prompt.yml') as f:
+              prompt = yaml.safe_load(f)
+          with open('/tmp/user-message.txt') as f:
+              user_msg = f.read()
+          prompt['messages'].append({'role': 'user', 'content': user_msg})
+          with open('/tmp/prompt.yml', 'w') as f:
+              yaml.dump(prompt, f, default_flow_style=False, allow_unicode=True)
+          "
 
       - name: Summarize changes
         if: github.event_name == 'push'
@@ -163,14 +185,7 @@ jobs:
         continue-on-error: true
         uses: actions/ai-inference@v1
         with:
-          prompt-file: .github/prompts/summarize-changelog.prompt.yml
-          input: |
-            sdk_name: "Ruby"
-            version: "v${{ steps.version.outputs.version }}"
-            commits: |
-              $(cat /tmp/commits.txt)
-          file_input: |
-            diff: /tmp/sdk-diff-truncated.txt
+          prompt-file: /tmp/prompt.yml
 
       - name: Write changelog
         if: github.event_name == 'push' && steps.summarize.outcome == 'success'

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -97,7 +97,7 @@ jobs:
             echo "Releasing version: $VERSION"
           fi
 
-      - name: Collect changelog inputs
+      - name: Build changelog prompt
         id: changelog-inputs
         run: |
           PREV_TAG=$(git describe --tags --match 'swift/v*' --abbrev=0 HEAD^ 2>/dev/null || true)
@@ -108,22 +108,37 @@ jobs:
             COMMITS=$(git log --pretty=format:"- %s (%h)" "${PREV_TAG}..HEAD" -- swift/ Package.swift)
             git diff "${PREV_TAG}..HEAD" -- swift/ Package.swift > /tmp/sdk-diff.txt
           fi
-          head -c 100000 /tmp/sdk-diff.txt > /tmp/sdk-diff-truncated.txt
           echo "$COMMITS" > /tmp/commits.txt
+
+          {
+            echo "SDK: Swift"
+            echo "Version: ${{ steps.version.outputs.version }}"
+            echo ""
+            echo "Commits since last release:"
+            cat /tmp/commits.txt
+            echo ""
+            echo "Diff (truncated):"
+            head -c 100000 /tmp/sdk-diff.txt
+          } > /tmp/user-message.txt
+
+          cp .github/prompts/summarize-changelog.prompt.yml /tmp/prompt.yml
+          python3 -c "
+          import yaml
+          with open('/tmp/prompt.yml') as f:
+              prompt = yaml.safe_load(f)
+          with open('/tmp/user-message.txt') as f:
+              user_msg = f.read()
+          prompt['messages'].append({'role': 'user', 'content': user_msg})
+          with open('/tmp/prompt.yml', 'w') as f:
+              yaml.dump(prompt, f, default_flow_style=False, allow_unicode=True)
+          "
 
       - name: Summarize changes
         id: summarize
         continue-on-error: true
         uses: actions/ai-inference@v1
         with:
-          prompt-file: .github/prompts/summarize-changelog.prompt.yml
-          input: |
-            sdk_name: "Swift"
-            version: "${{ steps.version.outputs.version }}"
-            commits: |
-              $(cat /tmp/commits.txt)
-          file_input: |
-            diff: /tmp/sdk-diff-truncated.txt
+          prompt-file: /tmp/prompt.yml
 
       - name: Write changelog
         if: steps.summarize.outcome == 'success'

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -175,7 +175,7 @@ jobs:
             npm publish --access public --tag ${{ steps.npm-tag.outputs.tag }} --dry-run
           fi
 
-      - name: Collect changelog inputs
+      - name: Build changelog prompt
         if: github.event_name == 'push'
         id: changelog-inputs
         run: |
@@ -188,8 +188,30 @@ jobs:
             COMMITS=$(git log --pretty=format:"- %s (%h)" "${PREV_TAG}..HEAD" -- typescript/)
             git diff "${PREV_TAG}..HEAD" -- typescript/ > /tmp/sdk-diff.txt
           fi
-          head -c 100000 /tmp/sdk-diff.txt > /tmp/sdk-diff-truncated.txt
           echo "$COMMITS" > /tmp/commits.txt
+
+          {
+            echo "SDK: TypeScript"
+            echo "Version: v${{ steps.version.outputs.version }}"
+            echo ""
+            echo "Commits since last release:"
+            cat /tmp/commits.txt
+            echo ""
+            echo "Diff (truncated):"
+            head -c 100000 /tmp/sdk-diff.txt
+          } > /tmp/user-message.txt
+
+          cp .github/prompts/summarize-changelog.prompt.yml /tmp/prompt.yml
+          python3 -c "
+          import yaml
+          with open('/tmp/prompt.yml') as f:
+              prompt = yaml.safe_load(f)
+          with open('/tmp/user-message.txt') as f:
+              user_msg = f.read()
+          prompt['messages'].append({'role': 'user', 'content': user_msg})
+          with open('/tmp/prompt.yml', 'w') as f:
+              yaml.dump(prompt, f, default_flow_style=False, allow_unicode=True)
+          "
 
       - name: Summarize changes
         if: github.event_name == 'push'
@@ -197,14 +219,7 @@ jobs:
         continue-on-error: true
         uses: actions/ai-inference@v1
         with:
-          prompt-file: .github/prompts/summarize-changelog.prompt.yml
-          input: |
-            sdk_name: "TypeScript"
-            version: "v${{ steps.version.outputs.version }}"
-            commits: |
-              $(cat /tmp/commits.txt)
-          file_input: |
-            diff: /tmp/sdk-diff-truncated.txt
+          prompt-file: /tmp/prompt.yml
 
       - name: Write changelog
         if: github.event_name == 'push' && steps.summarize.outcome == 'success'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
           fi
           echo "Module verification passed"
 
-      - name: Collect changelog inputs
+      - name: Build changelog prompt
         id: changelog-inputs
         run: |
           PREV_TAG=$(git describe --tags --match 'go/v*' --abbrev=0 HEAD^ 2>/dev/null || true)
@@ -144,22 +144,39 @@ jobs:
             COMMITS=$(git log --pretty=format:"- %s (%h)" "${PREV_TAG}..HEAD" -- go/)
             git diff "${PREV_TAG}..HEAD" -- go/ > /tmp/sdk-diff.txt
           fi
-          head -c 100000 /tmp/sdk-diff.txt > /tmp/sdk-diff-truncated.txt
           echo "$COMMITS" > /tmp/commits.txt
+
+          # Compose user message
+          {
+            echo "SDK: Go"
+            echo "Version: ${{ steps.version.outputs.version }}"
+            echo ""
+            echo "Commits since last release:"
+            cat /tmp/commits.txt
+            echo ""
+            echo "Diff (truncated):"
+            head -c 100000 /tmp/sdk-diff.txt
+          } > /tmp/user-message.txt
+
+          # Build full prompt YAML
+          cp .github/prompts/summarize-changelog.prompt.yml /tmp/prompt.yml
+          python3 -c "
+          import yaml
+          with open('/tmp/prompt.yml') as f:
+              prompt = yaml.safe_load(f)
+          with open('/tmp/user-message.txt') as f:
+              user_msg = f.read()
+          prompt['messages'].append({'role': 'user', 'content': user_msg})
+          with open('/tmp/prompt.yml', 'w') as f:
+              yaml.dump(prompt, f, default_flow_style=False, allow_unicode=True)
+          "
 
       - name: Summarize changes
         id: summarize
         continue-on-error: true
         uses: actions/ai-inference@v1
         with:
-          prompt-file: .github/prompts/summarize-changelog.prompt.yml
-          input: |
-            sdk_name: "Go"
-            version: "${{ steps.version.outputs.version }}"
-            commits: |
-              $(cat /tmp/commits.txt)
-          file_input: |
-            diff: /tmp/sdk-diff-truncated.txt
+          prompt-file: /tmp/prompt.yml
 
       - name: Write changelog
         if: steps.summarize.outcome == 'success'


### PR DESCRIPTION
## Summary

Supersedes the `file_input` approach from #121 — that moved variables out of `input:` but the action still substitutes `file_input` content into the prompt YAML template before parsing, so multiline PR bodies and diffs break YAML block scalars.

Fix: remove user message templates from all prompt YAML files entirely, compose the complete prompt YAML dynamically in shell steps using `yaml.dump` (proper escaping/indentation), and pass `/tmp/prompt.yml` to the action with no template variables.

- Prompt files now contain only the system message + model config
- Workflow shell steps build the user message as plain text, then use Python `yaml.safe_load` / `yaml.dump` to produce valid YAML
- Applies to ai-labeler (classify, breaking, spec-impact) and all four release workflows

## Test plan

- [x] Force-push PR 118 after merge to trigger `synchronize` → classify job succeeds on a PR body with markdown headings and colons