### PR TITLE
Ensure breaking label exists before applying it

### DIFF
--- a/.github/workflows/ai-labeler.yml
+++ b/.github/workflows/ai-labeler.yml
@@ -157,6 +157,7 @@ jobs:
 
           if [ "$BREAKING" = "true" ]; then
             ITEMS=$(echo "$RESPONSE" | jq -r '.items[]' | sed 's/^/- /')
+            gh label create breaking --color "B60205" 2>/dev/null || true
             gh pr edit "$PR" --add-label "breaking"
             # Post/update comment
             COMMENT_BODY=$(cat <<'COMMENT_EOF'


### PR DESCRIPTION
The breaking change detector calls `gh pr edit --add-label "breaking"` which
fails if the label doesn't exist in the repo. Auto-create it first.

The label was just created manually, but this guards against deletion.