### PR TITLE
Fix breaking detector: remove unsafe sed, add issues:write

### DIFF
--- a/.github/workflows/ai-labeler.yml
+++ b/.github/workflows/ai-labeler.yml
@@ -10,6 +10,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
   models: read
   pull-requests: write
 
@@ -153,8 +154,6 @@ jobs:
         run: |
           # Read response from file to avoid backtick/quote issues in shell
           RESPONSE_FILE="${{ steps.detect.outputs.response-file }}"
-          # Strip markdown code fences if the model wrapped its JSON output
-          sed -i '/^```/d' "$RESPONSE_FILE"
           BREAKING=$(jq -r '.breaking' "$RESPONSE_FILE")
           PR=${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
## Summary

Addresses review feedback from #125:

- **Remove `sed -i '/^```/d'`** — The prompt uses `responseFormat: json_schema` with `strict: true`, so the response is always valid JSON without code fences. The sed was also unsafe: a breaking change description containing a line starting with backticks would have that line deleted, producing malformed JSON.
- **Add `issues: write` permission** — `gh label create breaking` requires `issues: write` to create labels. Without it, the create silently fails and the subsequent `--add-label "breaking"` also fails because the label doesn't exist.

## Test plan

- [ ] Trigger the breaking detector on a PR with API surface changes and verify the label is created and applied