### PR TITLE
Fix TS build: remove redundant postbuild invocation

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -21,7 +21,7 @@
   ],
   "scripts": {
     "generate": "tsx scripts/strip-account-id.ts ../spec/build/smithy/openapi/openapi/Basecamp.openapi.json src/generated/openapi-stripped.json && openapi-typescript src/generated/openapi-stripped.json -o src/generated/schema.d.ts && tsx scripts/extract-metadata.ts src/generated/openapi-stripped.json > src/generated/metadata.json && tsx scripts/generate-path-mapping.ts",
-    "build": "tsc && npm run postbuild",
+    "build": "tsc",
     "postbuild": "node -e \"fs=require('fs');fs.cpSync('src/generated','dist/generated',{recursive:true});\"",
     "prepublishOnly": "npm run build",
     "test": "vitest run",


### PR DESCRIPTION
## Summary

- The `build` script was `tsc && npm run postbuild`, but npm lifecycle hooks already run `postbuild` automatically after `build` completes, causing it to execute twice on every build
- Changed to just `tsc`

## Test plan

- [x] `npm run build` — `postbuild` runs exactly once (verified via output)
- [x] `dist/generated/` directory is correctly populated
- [x] `make` passes