### PR TITLE
Fix: make ts-typecheck fails without prior npm install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,22 @@ go-check-drift:
 # TypeScript SDK targets
 #------------------------------------------------------------------------------
 
-.PHONY: ts-generate ts-generate-services ts-build ts-test ts-typecheck ts-check ts-clean
+.PHONY: ts-install ts-generate ts-generate-services ts-build ts-test ts-typecheck ts-check ts-clean
+
+TS_NODE_STAMP := typescript/node_modules/.install-stamp
+
+$(TS_NODE_STAMP): typescript/package-lock.json typescript/package.json
+	@echo "==> Installing TypeScript dependencies..."
+	cd typescript && npm ci
+	@touch $(TS_NODE_STAMP)
+
+ts-install: $(TS_NODE_STAMP)
+
+ts-generate: ts-install
+ts-generate-services: ts-install
+ts-build: ts-install
+ts-test: ts-install
+ts-typecheck: ts-install
 
 # Generate TypeScript types and metadata from OpenAPI
 ts-generate:


### PR DESCRIPTION
## Summary

- `make ts-typecheck` (and all TS targets) fails on fresh clones, new worktrees, and after `make ts-clean` because `node_modules` doesn't exist. CI works because `test.yml` runs `npm ci` first.
- Add a stamp-file target (`ts-install`) that runs `npm ci` when `package.json` or `package-lock.json` changes, and wire all TS targets through it.
- No-op on subsequent runs when deps are current. `make ts-clean` already removes the stamp by deleting `node_modules/`.

## Test plan

- [x] `rm -rf typescript/node_modules && make ts-typecheck` — installs deps, typecheck passes
- [x] `make ts-typecheck` again — no reinstall (stamp is current)
- [x] `make ts-check` — both typecheck and test pass (544 tests green)
- [x] `rm -rf typescript/node_modules && make ts-generate-services` — generation targets auto-install