### PR TITLE
Fix ai-labeler: splice prompts instead of yaml round-trip, guard jq parse

### DIFF
--- a/.github/workflows/ai-labeler.yml
+++ b/.github/workflows/ai-labeler.yml
@@ -190,6 +190,15 @@ assert doc['messages'][-1]['role'] == 'user', 'prompt splice failed: last messag
         run: |
           # Read response from file to avoid backtick/quote issues in shell
           RESPONSE_FILE="${{ steps.detect.outputs.response-file }}"
+          if ! jq empty "$RESPONSE_FILE" 2>/dev/null; then
+            echo "::warning::Model response is not valid JSON; skipping breaking label. See step summary for details."
+            echo "## Breaking change detection failed" >> "$GITHUB_STEP_SUMMARY"
+            echo "Model returned invalid JSON. Breaking label was **not** applied." >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            cat "$RESPONSE_FILE" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           BREAKING=$(jq -r '.breaking' "$RESPONSE_FILE")
           PR=${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
## Summary

- **Prompt building**: Replace `yaml.safe_load` → `yaml.dump` round-trip with line-level splice that inserts the user message into the `messages` array before the first top-level key. Preserves original prompt file byte-for-byte (key order, scalar styles like `|-` block scalars for `jsonSchema`). Each job validates post-splice that `messages[-1].role == 'user'`.
- **jq guard**: Validate model response is valid JSON before parsing in the breaking detector. On invalid JSON, writes raw response to step summary for debugging and exits cleanly instead of crashing. Raw content kept out of `::warning::` to avoid log command injection.

## Test plan

- [x] Local validation: all three prompt files (`classify-pr`, `detect-breaking`, `spec-impact`) produce valid YAML with correct message count, model, and config fields
- [x] `jsonSchema` preserved as `str` type through splice (verified with `yaml.safe_load` + `type()` check)
- [x] PR #129 workflows pass (`classify`, `breaking`, `spec-impact` jobs)