### PR TITLE
Fix stale MAX_PAGES reference in comment

### DIFF
--- a/typescript/src/services/base.ts
+++ b/typescript/src/services/base.ts
@@ -271,7 +271,7 @@ export abstract class BaseService {
       }
     }
 
-    // If we exited the loop because page >= MAX_PAGES and there's still a next link,
+    // If we exited the loop because page >= maxPages and there's still a next link,
     // the results are truncated by the safety cap
     const hasMore = parseNextLink(response.headers.get("Link")) !== null;
     return { items: allItems, truncated: hasMore };


### PR DESCRIPTION
Addresses unresolved review thread from #149.

The pagination loop comment still referenced the old `MAX_PAGES` constant after it was renamed to `DEFAULT_MAX_PAGES` and replaced by `this.maxPages`. Updates the comment to match.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the pagination loop comment to reference maxPages instead of MAX_PAGES, matching the current implementation. Keeps the comment accurate and avoids confusion when reading truncation logic.

<sup>Written for commit 342c8fcdc0864234a19d8e891fa6bf7519f99fb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

