### PR TITLE
Add direct-push alerting and sensitive-change gate

### DIFF
--- a/.github/workflows/direct-push-alert.yml
+++ b/.github/workflows/direct-push-alert.yml
@@ -1,0 +1,16 @@
+name: Direct Push Alert
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  alert:
+    uses: basecamp/.github/.github/workflows/direct-push-alert.yml@a667bfaac8b33b9c8a6c61019664463a98055995
+    permissions:
+      contents: read
+      issues: write

--- a/.github/workflows/sensitive-change-gate.yml
+++ b/.github/workflows/sensitive-change-gate.yml
@@ -1,0 +1,16 @@
+name: Sensitive Change Gate
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  gate:
+    uses: basecamp/.github/.github/workflows/sensitive-change-gate.yml@a667bfaac8b33b9c8a6c61019664463a98055995
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
## Summary
- **direct-push-alert**: Detects commits pushed directly to the default branch (bypassing PR flow) and creates/appends to a tracking issue.
- **sensitive-change-gate**: Detects PR changes to control-plane paths (workflows, CODEOWNERS, .goreleaser.yaml, release scripts). Runs in shadow mode — posts an informational comment but does not block.

Both are thin callers to reusable workflows in `basecamp/.github`, pinned to SHA `a667bfaa`.

## Test plan
- [ ] Open a PR touching `.github/workflows/` — verify shadow comment appears

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds alerts for direct pushes to the default branch and a shadow gate for sensitive PR changes to improve visibility without blocking merges.

- **New Features**
  - Direct Push Alert: triggers on pushes to `main` and creates/appends to a tracking issue.
  - Sensitive Change Gate: runs on `pull_request_target` and comments when control-plane files change (workflows, `CODEOWNERS`, `.goreleaser.yaml`, release scripts). Shadow mode only.

- **Dependencies**
  - Both jobs call reusable workflows from `basecamp/.github`, pinned to a specific SHA, with least-privileged permissions.

<sup>Written for commit 9d4d74b907e3760ebd52c3d3a6c36d21f785ca45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

