### PR TITLE
test: validate sensitive-change gate

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -37,3 +37,4 @@ jobs:
         continue-on-error: true
         with:
           sarif_file: results.sarif
+


### PR DESCRIPTION
Trivial whitespace change to a workflow file to verify the shadow gate comments. Delete after validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a no-op whitespace change in .github/workflows/scorecard.yml to trigger and validate the sensitive-change gate’s shadow comments. No functional changes to the Scorecard workflow.

<sup>Written for commit 3db78673b45a9a28311e0eb85f695a779a974258. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

