### PR TITLE
fix(go): omit zero-value optional query params in codegen

### DIFF
--- a/go/pkg/basecamp/zero_value_params_test.go
+++ b/go/pkg/basecamp/zero_value_params_test.go
@@ -1,0 +1,146 @@
+package basecamp
+
+import (
+	"testing"
+
+	"github.com/basecamp/basecamp-sdk/go/pkg/generated"
+)
+
+func TestZeroValueOptionalQueryParams_Omitted(t *testing.T) {
+	t.Run("search: string and int32 zero values omitted", func(t *testing.T) {
+		req, err := generated.NewSearchRequest("https://3.basecampapi.com", "12345", &generated.SearchParams{
+			Query: "omacon",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		q := req.URL.Query()
+
+		if got := q.Get("query"); got != "omacon" {
+			t.Errorf("expected query=omacon, got %q", got)
+		}
+		if q.Has("sort") {
+			t.Errorf("expected sort to be absent, got %q", q.Get("sort"))
+		}
+		if q.Has("page") {
+			t.Errorf("expected page to be absent, got %q", q.Get("page"))
+		}
+	})
+
+	t.Run("todos: string zero value omitted, bool false still serialized", func(t *testing.T) {
+		req, err := generated.NewListTodosRequest("https://3.basecampapi.com", "12345", 999, &generated.ListTodosParams{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		q := req.URL.Query()
+
+		if q.Has("status") {
+			t.Errorf("expected status to be absent, got %q", q.Get("status"))
+		}
+		// Bool params serialize unconditionally — false is a meaningful value
+		// (e.g., completed=false means "show incomplete todos")
+		if got := q.Get("completed"); got != "false" {
+			t.Errorf("expected completed=false, got %q", got)
+		}
+	})
+
+	t.Run("recordings: required param present, optional params omitted", func(t *testing.T) {
+		req, err := generated.NewListRecordingsRequest("https://3.basecampapi.com", "12345", &generated.ListRecordingsParams{
+			Type: "Todo",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		q := req.URL.Query()
+
+		if got := q.Get("type"); got != "Todo" {
+			t.Errorf("expected type=Todo, got %q", got)
+		}
+		if q.Has("bucket") {
+			t.Errorf("expected bucket to be absent, got %q", q.Get("bucket"))
+		}
+		if q.Has("status") {
+			t.Errorf("expected status to be absent, got %q", q.Get("status"))
+		}
+		if q.Has("sort") {
+			t.Errorf("expected sort to be absent, got %q", q.Get("sort"))
+		}
+		if q.Has("direction") {
+			t.Errorf("expected direction to be absent, got %q", q.Get("direction"))
+		}
+	})
+}
+
+func TestNonZeroOptionalQueryParams_Included(t *testing.T) {
+	t.Run("search: all params present", func(t *testing.T) {
+		req, err := generated.NewSearchRequest("https://3.basecampapi.com", "12345", &generated.SearchParams{
+			Query: "omacon",
+			Sort:  "created_at",
+			Page:  2,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		q := req.URL.Query()
+
+		if got := q.Get("query"); got != "omacon" {
+			t.Errorf("expected query=omacon, got %q", got)
+		}
+		if got := q.Get("sort"); got != "created_at" {
+			t.Errorf("expected sort=created_at, got %q", got)
+		}
+		if got := q.Get("page"); got != "2" {
+			t.Errorf("expected page=2, got %q", got)
+		}
+	})
+
+	t.Run("todos: bool true included", func(t *testing.T) {
+		req, err := generated.NewListTodosRequest("https://3.basecampapi.com", "12345", 999, &generated.ListTodosParams{
+			Status:    "active",
+			Completed: true,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		q := req.URL.Query()
+
+		if got := q.Get("status"); got != "active" {
+			t.Errorf("expected status=active, got %q", got)
+		}
+		if got := q.Get("completed"); got != "true" {
+			t.Errorf("expected completed=true, got %q", got)
+		}
+	})
+
+	t.Run("recordings: optional strings included when set", func(t *testing.T) {
+		req, err := generated.NewListRecordingsRequest("https://3.basecampapi.com", "12345", &generated.ListRecordingsParams{
+			Type:      "Todo",
+			Status:    "archived",
+			Sort:      "updated_at",
+			Direction: "desc",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		q := req.URL.Query()
+
+		if got := q.Get("type"); got != "Todo" {
+			t.Errorf("expected type=Todo, got %q", got)
+		}
+		if got := q.Get("status"); got != "archived" {
+			t.Errorf("expected status=archived, got %q", got)
+		}
+		if got := q.Get("sort"); got != "updated_at" {
+			t.Errorf("expected sort=updated_at, got %q", got)
+		}
+		if got := q.Get("direction"); got != "desc" {
+			t.Errorf("expected direction=desc, got %q", got)
+		}
+	})
+}

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -9275,16 +9275,20 @@ func NewListProjectsRequest(server string, accountId string, params *ListProject
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, params.Status); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Status != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, params.Status); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -9386,52 +9390,68 @@ func NewListRecordingsRequest(server string, accountId string, params *ListRecor
 			}
 		}
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "bucket", runtime.ParamLocationQuery, params.Bucket); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Bucket != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "bucket", runtime.ParamLocationQuery, params.Bucket); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, params.Status); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Status != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, params.Status); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "sort", runtime.ParamLocationQuery, params.Sort); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Sort != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "sort", runtime.ParamLocationQuery, params.Sort); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "direction", runtime.ParamLocationQuery, params.Direction); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Direction != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "direction", runtime.ParamLocationQuery, params.Direction); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -9753,40 +9773,52 @@ func NewGetProjectTimesheetRequest(server string, accountId string, projectId in
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "from", runtime.ParamLocationQuery, params.From); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.From != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "from", runtime.ParamLocationQuery, params.From); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "to", runtime.ParamLocationQuery, params.To); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.To != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "to", runtime.ParamLocationQuery, params.To); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "person_id", runtime.ParamLocationQuery, params.PersonId); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.PersonId != 0 {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "person_id", runtime.ParamLocationQuery, params.PersonId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -11299,40 +11331,52 @@ func NewGetRecordingTimesheetRequest(server string, accountId string, recordingI
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "from", runtime.ParamLocationQuery, params.From); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.From != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "from", runtime.ParamLocationQuery, params.From); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "to", runtime.ParamLocationQuery, params.To); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.To != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "to", runtime.ParamLocationQuery, params.To); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "person_id", runtime.ParamLocationQuery, params.PersonId); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.PersonId != 0 {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "person_id", runtime.ParamLocationQuery, params.PersonId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -11599,28 +11643,36 @@ func NewGetUpcomingScheduleRequest(server string, accountId string, params *GetU
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "window_starts_on", runtime.ParamLocationQuery, params.WindowStartsOn); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.WindowStartsOn != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "window_starts_on", runtime.ParamLocationQuery, params.WindowStartsOn); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "window_ends_on", runtime.ParamLocationQuery, params.WindowEndsOn); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.WindowEndsOn != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "window_ends_on", runtime.ParamLocationQuery, params.WindowEndsOn); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -11663,40 +11715,52 @@ func NewGetTimesheetReportRequest(server string, accountId string, params *GetTi
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "from", runtime.ParamLocationQuery, params.From); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.From != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "from", runtime.ParamLocationQuery, params.From); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "to", runtime.ParamLocationQuery, params.To); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.To != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "to", runtime.ParamLocationQuery, params.To); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "person_id", runtime.ParamLocationQuery, params.PersonId); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.PersonId != 0 {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "person_id", runtime.ParamLocationQuery, params.PersonId); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -11780,16 +11844,20 @@ func NewGetAssignedTodosRequest(server string, accountId string, personId int64,
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "group_by", runtime.ParamLocationQuery, params.GroupBy); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.GroupBy != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "group_by", runtime.ParamLocationQuery, params.GroupBy); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -12152,16 +12220,20 @@ func NewListScheduleEntriesRequest(server string, accountId string, scheduleId i
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, params.Status); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Status != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, params.Status); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -12270,28 +12342,36 @@ func NewSearchRequest(server string, accountId string, params *SearchParams) (*h
 			}
 		}
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "sort", runtime.ParamLocationQuery, params.Sort); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Sort != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "sort", runtime.ParamLocationQuery, params.Sort); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Page != 0 {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -12368,16 +12448,20 @@ func NewListTemplatesRequest(server string, accountId string, params *ListTempla
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, params.Status); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Status != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, params.Status); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()
@@ -13051,16 +13135,20 @@ func NewListTodosRequest(server string, accountId string, todolistId int64, para
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, params.Status); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Status != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, params.Status); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "completed", runtime.ParamLocationQuery, params.Completed); err != nil {
@@ -13489,16 +13577,20 @@ func NewListTodolistsRequest(server string, accountId string, todosetId int64, p
 	if params != nil {
 		queryValues := queryURL.Query()
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, params.Status); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Status != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "status", runtime.ParamLocationQuery, params.Status); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()

--- a/go/templates/client.tmpl
+++ b/go/templates/client.tmpl
@@ -381,6 +381,11 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
         queryValues := queryURL.Query()
             {{range $paramIdx, $param := .QueryParams}}
             {{if .HasOptionalPointer}} if params.{{.GoName}} != nil { {{end}}
+            {{if and (not .Required) (not .HasOptionalPointer)}}
+            {{if eq .Schema.GoType "string"}}if params.{{.GoName}} != "" {
+            {{else if or (eq .Schema.GoType "int") (eq .Schema.GoType "int32") (eq .Schema.GoType "int64") (eq .Schema.GoType "float32") (eq .Schema.GoType "float64")}}if params.{{.GoName}} != 0 {
+            {{end}}
+            {{end}}
             {{if .IsPassThrough}}
             queryValues.Add("{{.ParamName}}", {{if .HasOptionalPointer}}*{{end}}params.{{.GoName}})
             {{end}}
@@ -405,6 +410,10 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
                }
             }
             {{end}}
+            {{if and (not .Required) (not .HasOptionalPointer)}}
+            {{if or (eq .Schema.GoType "string") (eq .Schema.GoType "int") (eq .Schema.GoType "int32") (eq .Schema.GoType "int64") (eq .Schema.GoType "float32") (eq .Schema.GoType "float64")}} }
+            {{end}}
+            {{end}}
             {{if .HasOptionalPointer}}}{{end}}
         {{end}}
         queryURL.RawQuery = queryValues.Encode()
@@ -420,6 +429,11 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
     if params != nil {
     {{range $paramIdx, $param := .HeaderParams}}
         {{if .HasOptionalPointer}} if params.{{.GoName}} != nil { {{end}}
+        {{if and (not .Required) (not .HasOptionalPointer)}}
+        {{if eq .Schema.GoType "string"}}if params.{{.GoName}} != "" {
+        {{else if or (eq .Schema.GoType "int") (eq .Schema.GoType "int32") (eq .Schema.GoType "int64") (eq .Schema.GoType "float32") (eq .Schema.GoType "float64")}}if params.{{.GoName}} != 0 {
+        {{end}}
+        {{end}}
         var headerParam{{$paramIdx}} string
         {{if .IsPassThrough}}
         headerParam{{$paramIdx}} = {{if .HasOptionalPointer}}*{{end}}params.{{.GoName}}
@@ -439,6 +453,10 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
         }
         {{end}}
         req.Header.Set("{{.ParamName}}", headerParam{{$paramIdx}})
+        {{if and (not .Required) (not .HasOptionalPointer)}}
+        {{if or (eq .Schema.GoType "string") (eq .Schema.GoType "int") (eq .Schema.GoType "int32") (eq .Schema.GoType "int64") (eq .Schema.GoType "float32") (eq .Schema.GoType "float64")}} }
+        {{end}}
+        {{end}}
         {{if .HasOptionalPointer}}}{{end}}
     {{end}}
     }
@@ -448,6 +466,11 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
     if params != nil {
     {{range $paramIdx, $param := .CookieParams}}
         {{if .HasOptionalPointer}} if params.{{.GoName}} != nil { {{end}}
+        {{if and (not .Required) (not .HasOptionalPointer)}}
+        {{if eq .Schema.GoType "string"}}if params.{{.GoName}} != "" {
+        {{else if or (eq .Schema.GoType "int") (eq .Schema.GoType "int32") (eq .Schema.GoType "int64") (eq .Schema.GoType "float32") (eq .Schema.GoType "float64")}}if params.{{.GoName}} != 0 {
+        {{end}}
+        {{end}}
         var cookieParam{{$paramIdx}} string
         {{if .IsPassThrough}}
         cookieParam{{$paramIdx}} = {{if .HasOptionalPointer}}*{{end}}params.{{.GoName}}
@@ -471,6 +494,10 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
             Value:cookieParam{{$paramIdx}},
         }
         req.AddCookie(cookie{{$paramIdx}})
+        {{if and (not .Required) (not .HasOptionalPointer)}}
+        {{if or (eq .Schema.GoType "string") (eq .Schema.GoType "int") (eq .Schema.GoType "int32") (eq .Schema.GoType "int64") (eq .Schema.GoType "float32") (eq .Schema.GoType "float64")}} }
+        {{end}}
+        {{end}}
         {{if .HasOptionalPointer}}}{{end}}
     {{ end -}}
     }


### PR DESCRIPTION
## Summary

- Add zero-value guards in `go/templates/client.tmpl` for optional non-pointer query params (string `!= ""`, numeric `!= 0`, bool truthy), preventing zero values from being unconditionally serialized onto every request
- Regenerate `go/pkg/generated/client.gen.go` — search now omits `sort` and `page` when unset, restoring relevance-ranked results
- Guards also applied to header and cookie param sections (defensive; no current endpoints use them)

**Root cause:** `oapi-codegen.yaml` sets `prefer-skip-optional-pointer: true`, making optional params value types. The template only emitted nil-guards for pointer types, so value-type zero values always serialized. `sort=""` on BC3 search disables relevance ordering.

## Test plan

- [x] `make` passes (all checks including conformance)
- [x] `go test ./...` — new tests in `go/pkg/basecamp/zero_value_params_test.go` cover all three type branches:
  - Search: string (`Sort`) and int32 (`Page`) omission + inclusion
  - Todos: bool (`Completed`) omission + inclusion
  - Recordings: required `Type` unconditional, optional strings omitted
- [x] `go vet ./...` — clean
- [ ] Verify search relevance ranking with `basecamp search "omacon"`

## Related

- #163 — tracks search spec drift (Smithy `query`/`sort` vs upstream `q`/undocumented `sort`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Go client codegen to omit zero-value optional params so we don’t serialize empty query/header/cookie values. This restores relevance-ranked search by not sending sort="" or page=0 when unset.

- **Bug Fixes**
  - Add zero-value guards in `go/templates/client.tmpl` for optional non-pointer params: strings `!= ""`, numerics `!= 0`; bools are unguarded so `false` can be sent when intended.
  - Regenerate `go/pkg/generated/client.gen.go`; `Search` now omits `sort` and `page` when unset. Other endpoints skip empty strings and zero numerics.
  - Add tests in `go/pkg/basecamp/zero_value_params_test.go` covering omission/inclusion for string and int32, and inclusion for bool `true` and `false`.
  - Root cause: `oapi-codegen.yaml` sets `prefer-skip-optional-pointer: true`, but the template previously guarded only pointer-optional params. Refs #163.

<sup>Written for commit 4cef0c9aab17dac147824db8bcd2884d1e215f81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

