### PR TITLE
Fix codegen: omit zero-value optional bool params

### DIFF
--- a/go/pkg/basecamp/zero_value_params_test.go
+++ b/go/pkg/basecamp/zero_value_params_test.go
@@ -25,7 +25,7 @@ func TestZeroValueOptionalQueryParams_Omitted(t *testing.T) {
 		}
 	})
 
-	t.Run("todos: string zero value omitted, bool false still serialized", func(t *testing.T) {
+	t.Run("todos: string and bool zero values omitted", func(t *testing.T) {
 		req, err := generated.NewListTodosRequest("https://3.basecampapi.com", "12345", 999, &generated.ListTodosParams{})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -36,10 +36,11 @@ func TestZeroValueOptionalQueryParams_Omitted(t *testing.T) {
 		if q.Has("status") {
 			t.Errorf("expected status to be absent, got %q", q.Get("status"))
 		}
-		// Bool params serialize unconditionally — false is a meaningful value
-		// (e.g., completed=false means "show incomplete todos")
-		if got := q.Get("completed"); got != "false" {
-			t.Errorf("expected completed=false, got %q", got)
+		// BC3 API returns pending (incomplete) todos by default when completed
+		// is omitted; only completed=true changes behavior. Zero-value false
+		// is treated as "unset," same as "" for strings and 0 for numerics.
+		if q.Has("completed") {
+			t.Errorf("expected completed to be absent, got %q", q.Get("completed"))
 		}
 	})
 

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -13296,16 +13296,20 @@ func NewListTodosRequest(server string, accountId string, todolistId int64, para
 
 		}
 
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "completed", runtime.ParamLocationQuery, params.Completed); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
+		if params.Completed {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "completed", runtime.ParamLocationQuery, params.Completed); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
 				}
 			}
+
 		}
 
 		queryURL.RawQuery = queryValues.Encode()

--- a/go/templates/client.tmpl
+++ b/go/templates/client.tmpl
@@ -384,6 +384,7 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
             {{if and (not .Required) (not .HasOptionalPointer)}}
             {{if eq .Schema.GoType "string"}}if params.{{.GoName}} != "" {
             {{else if or (eq .Schema.GoType "int") (eq .Schema.GoType "int32") (eq .Schema.GoType "int64") (eq .Schema.GoType "float32") (eq .Schema.GoType "float64")}}if params.{{.GoName}} != 0 {
+            {{else if eq .Schema.GoType "bool"}}if params.{{.GoName}} {
             {{end}}
             {{end}}
             {{if .IsPassThrough}}
@@ -411,7 +412,7 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
             }
             {{end}}
             {{if and (not .Required) (not .HasOptionalPointer)}}
-            {{if or (eq .Schema.GoType "string") (eq .Schema.GoType "int") (eq .Schema.GoType "int32") (eq .Schema.GoType "int64") (eq .Schema.GoType "float32") (eq .Schema.GoType "float64")}} }
+            {{if or (eq .Schema.GoType "string") (eq .Schema.GoType "int") (eq .Schema.GoType "int32") (eq .Schema.GoType "int64") (eq .Schema.GoType "float32") (eq .Schema.GoType "float64") (eq .Schema.GoType "bool")}} }
             {{end}}
             {{end}}
             {{if .HasOptionalPointer}}}{{end}}
@@ -432,6 +433,7 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
         {{if and (not .Required) (not .HasOptionalPointer)}}
         {{if eq .Schema.GoType "string"}}if params.{{.GoName}} != "" {
         {{else if or (eq .Schema.GoType "int") (eq .Schema.GoType "int32") (eq .Schema.GoType "int64") (eq .Schema.GoType "float32") (eq .Schema.GoType "float64")}}if params.{{.GoName}} != 0 {
+        {{else if eq .Schema.GoType "bool"}}if params.{{.GoName}} {
         {{end}}
         {{end}}
         var headerParam{{$paramIdx}} string
@@ -454,7 +456,7 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
         {{end}}
         req.Header.Set("{{.ParamName}}", headerParam{{$paramIdx}})
         {{if and (not .Required) (not .HasOptionalPointer)}}
-        {{if or (eq .Schema.GoType "string") (eq .Schema.GoType "int") (eq .Schema.GoType "int32") (eq .Schema.GoType "int64") (eq .Schema.GoType "float32") (eq .Schema.GoType "float64")}} }
+        {{if or (eq .Schema.GoType "string") (eq .Schema.GoType "int") (eq .Schema.GoType "int32") (eq .Schema.GoType "int64") (eq .Schema.GoType "float32") (eq .Schema.GoType "float64") (eq .Schema.GoType "bool")}} }
         {{end}}
         {{end}}
         {{if .HasOptionalPointer}}}{{end}}
@@ -469,6 +471,7 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
         {{if and (not .Required) (not .HasOptionalPointer)}}
         {{if eq .Schema.GoType "string"}}if params.{{.GoName}} != "" {
         {{else if or (eq .Schema.GoType "int") (eq .Schema.GoType "int32") (eq .Schema.GoType "int64") (eq .Schema.GoType "float32") (eq .Schema.GoType "float64")}}if params.{{.GoName}} != 0 {
+        {{else if eq .Schema.GoType "bool"}}if params.{{.GoName}} {
         {{end}}
         {{end}}
         var cookieParam{{$paramIdx}} string
@@ -495,7 +498,7 @@ func New{{$opid}}Request{{if .HasBody}}WithBody{{end}}(server string{{genParamAr
         }
         req.AddCookie(cookie{{$paramIdx}})
         {{if and (not .Required) (not .HasOptionalPointer)}}
-        {{if or (eq .Schema.GoType "string") (eq .Schema.GoType "int") (eq .Schema.GoType "int32") (eq .Schema.GoType "int64") (eq .Schema.GoType "float32") (eq .Schema.GoType "float64")}} }
+        {{if or (eq .Schema.GoType "string") (eq .Schema.GoType "int") (eq .Schema.GoType "int32") (eq .Schema.GoType "int64") (eq .Schema.GoType "float32") (eq .Schema.GoType "float64") (eq .Schema.GoType "bool")}} }
         {{end}}
         {{end}}
         {{if .HasOptionalPointer}}}{{end}}


### PR DESCRIPTION
## Summary

- Add `bool` to the zero-value guard pattern in `client.tmpl` for query, header, and cookie params — matching the existing `string`/numeric treatment
- Regenerate `client.gen.go`: `NewListTodosRequest` now wraps `completed` in `if params.Completed {`, so `false` (zero value) is omitted
- Update regression test to assert `completed` is absent when unset, with a comment citing the BC3 API default behavior

Only `ListTodosParams.Completed` is affected in the current spec. The high-level `TodosService.List` wrapper doesn't forward `Completed` at all (it only forwards `Status`), so this only impacts direct consumers of the generated client.

Card: https://3.basecamp.com/2914079/buckets/46292715/card_tables/cards/9660339476

## Test plan

- [x] `go test ./pkg/basecamp -run ZeroValueOptionalQueryParams` — targeted test passes
- [x] `go test ./...` — full Go suite passes
- [x] `make` — all checks passed (smithy, go, ts, rb, kt, swift, conformance)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop serializing zero-value optional bools in generated requests. This prevents sending `false` by default (e.g., `completed=false`) so requests follow API defaults.

- **Bug Fixes**
  - Added bool zero-value guards in `client.tmpl` for query, header, and cookie params.
  - Regenerated `client.gen.go`: `NewListTodosRequest` only includes `completed` when true.
  - Updated test to expect `completed` omitted when unset, matching BC3 default behavior.
  - Scope: affects direct generated client calls only; `TodosService.List` does not forward `Completed`.

<sup>Written for commit 005adc35f17e47c00bcbdc47ed7e3d05f6c14253. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

