### PR TITLE
Use bc3 as the sole API provenance source

### DIFF
--- a/.claude/skills/api-sync/SKILL.md
+++ b/.claude/skills/api-sync/SKILL.md
@@ -2,7 +2,7 @@
 name: api-sync
 description: >
   Check upstream Basecamp API changes and sync the Smithy spec.
-  Compares bc3-api docs and bc3 app code against tracked revisions
+  Compares bc3 API docs and app code against the tracked bc3 revision
   in spec/api-provenance.json, identifies what changed, and optionally
   updates the Smithy spec and regenerates SDKs.
 disable-model-invocation: true
@@ -17,29 +17,32 @@ You are synchronizing the Basecamp SDK's Smithy spec against upstream API change
 
 - **mode**: `{{ arguments.mode | default: "check" }}`
 
-## Upstream repos
+## Upstream repo
 
-- **bc3-api** (API reference docs): `basecamp/bc3-api` — watch `sections/`
-- **bc3** (Rails app): `basecamp/bc3` — watch `app/controllers/`
+- **bc3** (canonical source): `basecamp/bc3`
+  - API reference docs: watch `doc/api/`
+  - Rails app/API implementation: watch `app/controllers/`
+
+The public `basecamp/bc3-api` repo is a mirror for documentation consumption, not a provenance input.
 
 ## Phase 1: Load State
 
-1. Read `spec/api-provenance.json` to get the last-synced revisions for `bc3_api` and `bc3`.
+1. Read `spec/api-provenance.json` to get the last-synced revision for `bc3`.
 
 ## Phase 2: Check Upstream
 
 List files changed in the watched paths since the last sync.
 
-For **bc3-api** (API reference docs — `sections/` only):
+For **bc3 API docs** (`doc/api/`):
 ```bash
-gh api repos/basecamp/bc3-api/compare/<bc3_api.revision>...HEAD \
-  --jq '[.files[] | select(.filename | startswith("sections/"))] |
-    if length == 0 then "  (no changes in sections/)"
+gh api repos/basecamp/bc3/compare/<bc3.revision>...HEAD \
+  --jq '[.files[] | select(.filename | startswith("doc/api/"))] |
+    if length == 0 then "  (no changes in doc/api/)"
     else .[] | .status[:1] + " " + .filename
     end'
 ```
 
-For **bc3** (Rails app — `app/controllers/` only):
+For **bc3 API implementation** (`app/controllers/`):
 ```bash
 gh api repos/basecamp/bc3/compare/<bc3.revision>...HEAD \
   --jq '[.files[] | select(.filename | startswith("app/controllers/"))] |
@@ -48,23 +51,23 @@ gh api repos/basecamp/bc3/compare/<bc3.revision>...HEAD \
     end'
 ```
 
-Summarize the changed files by API domain (todos, messages, people, etc.). If there are no changes in either repo, report "up to date" and stop.
+Summarize the changed files by API domain (todos, messages, people, etc.). If there are no changes in either watched path, report "up to date" and stop.
 
 If mode is `check`, stop here after reporting what changed.
 
 ## Phase 3: Sync Spec (mode=sync only)
 
-For each changed section file in bc3-api:
+For each changed doc file in `bc3`:
 
-1. Fetch the upstream doc:
+1. Fetch the upstream doc from `basecamp/bc3`:
    ```bash
-   gh api repos/basecamp/bc3-api/contents/sections/<file>.md --jq '.content' | base64 -d
+   gh api repos/basecamp/bc3/contents/doc/api/<path> --jq '.content' | base64 -d
    ```
 2. Read the corresponding Smithy operations in `spec/basecamp.smithy` and `spec/overlays/`
 3. Identify gaps: missing operations, changed fields, new parameters
 4. Propose specific Smithy changes and apply after confirmation
 
-For controller changes in bc3, cross-reference with the API docs to identify behavioral changes that affect the spec.
+For controller changes in `bc3`, cross-reference them with `doc/api/` to identify behavioral changes that affect the spec.
 
 ## Phase 4: Regenerate (mode=sync only)
 
@@ -82,21 +85,16 @@ make check
 
 Fix any issues that arise during generation or checks.
 
-## Phase 5: Update Revisions (mode=sync or update-rev)
+## Phase 5: Update Revision (mode=sync or update-rev)
 
-Get the current HEAD of each upstream repo:
+Get the current `bc3` HEAD:
 ```bash
-gh api repos/basecamp/bc3-api/commits/HEAD --jq '.sha'
 gh api repos/basecamp/bc3/commits/HEAD --jq '.sha'
 ```
 
-Write the new revisions and today's date to `spec/api-provenance.json`:
+Write the new revision and today's date to `spec/api-provenance.json`:
 ```json
 {
-  "bc3_api": {
-    "revision": "<new-sha>",
-    "date": "<today>"
-  },
   "bc3": {
     "revision": "<new-sha>",
     "date": "<today>"
@@ -111,5 +109,5 @@ Then run `make provenance-sync` to update the Go embedded copy.
 Report a summary of:
 - What changed upstream (by domain)
 - What spec changes were made (if sync mode)
-- New revision SHAs stamped
+- New revision SHA stamped
 - Any warnings or issues encountered

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,7 +187,7 @@ Reuse these common shapes: `ProjectId`, `PersonId`, `ISO8601Timestamp`, `ISO8601
 
 ### Reference Sources
 
-- **BC3 API docs** (`~/Work/basecamp/bc3-api/sections/*.md`) — authoritative HTTP endpoint documentation
+- **BC3 API docs** (`~/Work/basecamp/bc3/doc/api/sections/*.md`) — authoritative HTTP endpoint documentation. The public `bc3-api` repo is a synced mirror, not the source of truth.
 - **Go SDK** (`go/pkg/basecamp/*.go`) — existing operation signatures
 - **Existing Smithy** (`spec/basecamp.smithy`) — established patterns and reusable types
 
@@ -257,17 +257,16 @@ gh run list --repo basecamp/basecamp-sdk --limit 7 --json name,status,conclusion
 
 ## Upstream API Sync Workflow
 
-When syncing the SDK spec to match upstream API changes (bc3-api docs + bc3 Rails app):
+When syncing the SDK spec to match upstream API changes in `basecamp/bc3` (`doc/api/` docs + Rails app):
 
 ### Provenance is Mandatory
 
-Every sync MUST update `spec/api-provenance.json` with the upstream HEADs:
+Every sync MUST update `spec/api-provenance.json` with the upstream `bc3` HEAD:
 ```bash
-gh api repos/basecamp/bc3-api/commits/HEAD --jq '.sha'
 gh api repos/basecamp/bc3/commits/HEAD --jq '.sha'
 ```
 
-Update both `revision` and `date` fields, then `make provenance-sync`. This is not optional — provenance tracks what the SDK is conformant to.
+Update the `revision` and `date` fields, then `make provenance-sync`. This is not optional — provenance tracks what the SDK is conformant to.
 
 The Smithy service version is derived from the shared provenance date. Run `make sync-spec-version` (or `make smithy-build`, which does this automatically) after updating provenance.
 

--- a/Makefile
+++ b/Makefile
@@ -99,26 +99,23 @@ provenance-check:
 	@echo "api-provenance.json is up to date"
 
 # Show upstream changes since last spec sync (queries GitHub via gh CLI).
-BC3_API_REPO ?= basecamp/bc3-api
-BC3_REPO     ?= basecamp/bc3
+BC3_REPO ?= basecamp/bc3
 
 sync-status:
 	@command -v gh > /dev/null 2>&1 || { echo "ERROR: gh CLI not found. Install: https://cli.github.com"; exit 1; }
 	@gh auth status > /dev/null 2>&1 || { echo "ERROR: gh not authenticated. Run: gh auth login"; exit 1; }
-	@REV=$$(jq -r '.bc3_api.revision // empty' spec/api-provenance.json); \
-	if [ -z "$$REV" ]; then \
-		echo "==> bc3-api: no baseline revision set"; \
-	else \
-		echo "==> bc3-api changes since last sync ($$(echo $$REV | cut -c1-7)):"; \
-		gh api "repos/$(BC3_API_REPO)/compare/$$REV...HEAD" \
-			--jq '[.files[] | select(.filename | startswith("sections/"))] | if length == 0 then "  (no changes in sections/)" else .[] | "  " + .status[:1] + " " + .filename end'; \
-	fi
-	@echo ""
 	@REV=$$(jq -r '.bc3.revision // empty' spec/api-provenance.json); \
 	if [ -z "$$REV" ]; then \
-		echo "==> bc3: no baseline revision set"; \
+		echo "==> bc3 API docs: no baseline revision set"; \
+		echo ""; \
+		echo "==> bc3 API implementation: no baseline revision set"; \
 	else \
-		echo "==> bc3 API changes since last sync ($$(echo $$REV | cut -c1-7)):"; \
+		SHORT_REV=$$(echo $$REV | cut -c1-7); \
+		echo "==> bc3 API docs changes since last sync ($$SHORT_REV):"; \
+		gh api "repos/$(BC3_REPO)/compare/$$REV...HEAD" \
+			--jq '[.files[] | select(.filename | startswith("doc/api/"))] | if length == 0 then "  (no changes in doc/api/)" else .[] | "  " + .status[:1] + " " + .filename end'; \
+		echo ""; \
+		echo "==> bc3 API implementation changes since last sync ($$SHORT_REV):"; \
 		gh api "repos/$(BC3_REPO)/compare/$$REV...HEAD" \
 			--jq '[.files[] | select(.filename | startswith("app/controllers/"))] | if length == 0 then "  (no changes in app/controllers/)" else .[] | "  " + .status[:1] + " " + .filename end'; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -173,13 +173,10 @@ sync-spec-version:
 sync-spec-version-check:
 	@echo "==> Checking Smithy service version freshness..."
 	@command -v jq > /dev/null 2>&1 || { echo "ERROR: jq not found. Install jq to run sync-spec-version-check (used by 'make check')."; exit 1; }
-	@PROVENANCE_DATE=$$(jq -r '.bc3_api.date' spec/api-provenance.json); \
-		BC3_DATE=$$(jq -r '.bc3.date' spec/api-provenance.json); \
+	@BC3_DATE=$$(jq -r '.bc3.date' spec/api-provenance.json); \
 		SMITHY_VER=$$(sed -n 's/^  version: "\(.*\)"/\1/p' spec/basecamp.smithy | head -1); \
-		if [ -z "$$PROVENANCE_DATE" ] || [ "$$PROVENANCE_DATE" = "null" ]; then echo "ERROR: Could not read bc3_api.date from spec/api-provenance.json"; exit 1; fi; \
 		if [ -z "$$BC3_DATE" ] || [ "$$BC3_DATE" = "null" ]; then echo "ERROR: Could not read bc3.date from spec/api-provenance.json"; exit 1; fi; \
-		if [ "$$PROVENANCE_DATE" != "$$BC3_DATE" ]; then echo "ERROR: Provenance dates differ: bc3_api.date=$$PROVENANCE_DATE bc3.date=$$BC3_DATE"; exit 1; fi; \
-		if [ "$$SMITHY_VER" != "$$PROVENANCE_DATE" ]; then echo "ERROR: Smithy service version is out of date. Run 'make sync-spec-version'"; exit 1; fi
+		if [ "$$SMITHY_VER" != "$$BC3_DATE" ]; then echo "ERROR: Smithy service version is out of date. Run 'make sync-spec-version'"; exit 1; fi
 	@echo "Smithy service version is up to date"
 
 # Sync API_VERSION constants from openapi.json info.version

--- a/go/pkg/basecamp/api-provenance.json
+++ b/go/pkg/basecamp/api-provenance.json
@@ -1,8 +1,4 @@
 {
-  "bc3_api": {
-    "revision": "89ca8f9b5ee2cd197c2f536f01d838df6ee53dc7",
-    "date": "2026-03-23"
-  },
   "bc3": {
     "revision": "056a356ee0d3b018362adbc8b44703df0567adbf",
     "date": "2026-03-23"

--- a/go/pkg/basecamp/provenance.go
+++ b/go/pkg/basecamp/provenance.go
@@ -9,10 +9,9 @@ import (
 //go:embed api-provenance.json
 var provenanceJSON []byte
 
-// APIProvenance describes which upstream API revisions the SDK was built against.
+// APIProvenance describes which upstream Basecamp revision the SDK was built against.
 type APIProvenance struct {
-	BC3    UpstreamRef `json:"bc3"`
-	BC3API UpstreamRef `json:"bc3_api"`
+	BC3 UpstreamRef `json:"bc3"`
 }
 
 // UpstreamRef is a git revision and the date it was synced.
@@ -26,7 +25,7 @@ var (
 	provenanceOnce sync.Once
 )
 
-// Provenance returns the upstream API revisions this SDK was built against.
+// Provenance returns the upstream Basecamp revision this SDK was built against.
 func Provenance() APIProvenance {
 	provenanceOnce.Do(func() {
 		if err := json.Unmarshal(provenanceJSON, &provenance); err != nil {

--- a/go/pkg/basecamp/provenance_test.go
+++ b/go/pkg/basecamp/provenance_test.go
@@ -16,13 +16,3 @@ func TestProvenanceBC3(t *testing.T) {
 		t.Error("BC3.Date is empty")
 	}
 }
-
-func TestProvenanceBC3API(t *testing.T) {
-	p := Provenance()
-	if !reSHA.MatchString(p.BC3API.Revision) {
-		t.Errorf("BC3API.Revision = %q, want 40-hex SHA", p.BC3API.Revision)
-	}
-	if p.BC3API.Date == "" {
-		t.Error("BC3API.Date is empty")
-	}
-}

--- a/scripts/sync-spec-version.sh
+++ b/scripts/sync-spec-version.sh
@@ -11,26 +11,15 @@ if ! command -v jq &>/dev/null; then
   exit 1
 fi
 
-BC3_API_DATE=$(jq -r '.bc3_api.date' "$PROVENANCE_FILE")
 BC3_DATE=$(jq -r '.bc3.date' "$PROVENANCE_FILE")
-
-if [ -z "$BC3_API_DATE" ] || [ "$BC3_API_DATE" = "null" ]; then
-  echo "ERROR: Could not read bc3_api.date from $PROVENANCE_FILE" >&2
-  exit 1
-fi
 
 if [ -z "$BC3_DATE" ] || [ "$BC3_DATE" = "null" ]; then
   echo "ERROR: Could not read bc3.date from $PROVENANCE_FILE" >&2
   exit 1
 fi
 
-if [ "$BC3_API_DATE" != "$BC3_DATE" ]; then
-  echo "ERROR: Provenance dates differ: bc3_api.date=$BC3_API_DATE bc3.date=$BC3_DATE" >&2
-  exit 1
-fi
-
-if ! printf '%s' "$BC3_API_DATE" | grep -Eq '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
-  echo "ERROR: Invalid provenance date format: $BC3_API_DATE" >&2
+if ! printf '%s' "$BC3_DATE" | grep -Eq '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+  echo "ERROR: Invalid provenance date format: $BC3_DATE" >&2
   exit 1
 fi
 
@@ -42,11 +31,11 @@ sedi() {
   sed "$expr" "$file" > "$tmp" && cat "$tmp" > "$file" && rm "$tmp"
 }
 
-echo "Syncing Smithy service version: $BC3_API_DATE"
+echo "Syncing Smithy service version: $BC3_DATE"
 
-sedi "s/^  version: \".*\"/  version: \"$BC3_API_DATE\"/" "$SMITHY_FILE"
+sedi "s/^  version: \".*\"/  version: \"$BC3_DATE\"/" "$SMITHY_FILE"
 
-if ! grep -q "  version: \"$BC3_API_DATE\"" "$SMITHY_FILE"; then
+if ! grep -q "  version: \"$BC3_DATE\"" "$SMITHY_FILE"; then
   echo "ERROR: Failed to update version line in $SMITHY_FILE" >&2
   exit 1
 fi

--- a/spec/README.md
+++ b/spec/README.md
@@ -7,10 +7,10 @@ ergonomics.
 ## Files
 - `basecamp.smithy` — canonical model (types + operations)
 - `overlays/` — semantic overlays (pagination, retries, idempotency)
-- `api-provenance.json` — upstream revision tracking (bc3-api + bc3 SHAs)
+- `api-provenance.json` — upstream revision tracking (`basecamp/bc3` SHA)
 
 ## Grounding
-- API reference: `basecamp/bc3-api` → `sections/`
+- API reference: `basecamp/bc3` → `doc/api/`
 - App code: `basecamp/bc3` → `app/controllers/`
 
 ## Conventions

--- a/spec/api-provenance.json
+++ b/spec/api-provenance.json
@@ -1,8 +1,4 @@
 {
-  "bc3_api": {
-    "revision": "89ca8f9b5ee2cd197c2f536f01d838df6ee53dc7",
-    "date": "2026-03-23"
-  },
   "bc3": {
     "revision": "056a356ee0d3b018362adbc8b44703df0567adbf",
     "date": "2026-03-23"

--- a/spec/fixtures/projects/README.md
+++ b/spec/fixtures/projects/README.md
@@ -1,6 +1,6 @@
 # Projects Fixtures
 
-JSON fixtures extracted from bc3-api/sections/projects.md for golden tests.
+JSON fixtures extracted from the canonical projects docs in `basecamp/bc3/doc/api/sections/projects.md` for golden tests.
 
 ## Fixture to Operation Mapping
 


### PR DESCRIPTION
## Summary

This PR removes `bc3-api` from the SDK repo’s provenance model and sync workflow so we track only `basecamp/bc3`, which is now the canonical source of truth for both API docs and implementation behavior. `bc3-api` remains a public mirrored docs destination, but it should no longer be treated as an independent upstream input when determining what the SDK is conformant to.

## What changed

- reduces `spec/api-provenance.json` to a single tracked upstream: `bc3`
- updates the embedded Go provenance model to expose only `BC3`
- simplifies `make sync-status` to compare one repo (`basecamp/bc3`) across two watched areas:
  - `doc/api/`
  - `app/controllers/`
- updates contributor guidance and sync instructions to point at `bc3/doc/api/` as the canonical docs source
- updates the API sync skill to use the bc3-only workflow
- adjusts fixture/source wording so it reflects canonical docs coming from `bc3`

## Notes

- Public README links to `bc3-api` are intentionally unchanged, since that repo still serves as the public mirrored documentation surface.
- This removes `basecamp.Provenance().BC3API` from the Go API surface. Any external caller using that field will need to read `basecamp.Provenance().BC3` instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `basecamp/bc3` the only upstream for API provenance and sync. Drops `bc3-api` as an input and updates tooling and docs.

- **Refactors**
  - Collapse provenance to `BC3` only in `spec/api-provenance.json` and embedded Go model; remove `BC3API` and its test.
  - Update `make sync-status` to show diffs for `doc/api/` and `app/controllers/` in `basecamp/bc3`.
  - Simplify version syncing: `scripts/sync-spec-version.sh` and `sync-spec-version-check` now use `bc3.date` only.
  - Refresh docs/tools: point AGENTS, spec README, fixtures, and `api-sync` skill to `bc3/doc/api/`; clarify `bc3-api` is a mirror only and fix lingering references.

- **Migration**
  - Replace `basecamp.Provenance().BC3API` with `basecamp.Provenance().BC3`.

<sup>Written for commit d4b1fc51b34fb2fea86b176f895fe1aed2536d13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

