### PR TITLE
Fix Go todo list status filters for completed and lifecycle states

### DIFF
--- a/go/pkg/basecamp/doc.go
+++ b/go/pkg/basecamp/doc.go
@@ -88,6 +88,8 @@
 //
 // # Working with Todos
 //
+// Todo APIs take todolistID or todoID directly; projectID is not required.
+//
 // List todos in a todolist:
 //
 //	todos, err := account.Todos().List(ctx, todolistID, nil)

--- a/go/pkg/basecamp/doc.go
+++ b/go/pkg/basecamp/doc.go
@@ -90,18 +90,22 @@
 //
 // List todos in a todolist:
 //
-//	todos, err := account.Todos().List(ctx, projectID, todolistID, nil)
+//	todos, err := account.Todos().List(ctx, todolistID, nil)
+//
+// List completed todos in a todolist:
+//
+//	completed, err := account.Todos().List(ctx, todolistID, &basecamp.TodoListOptions{Status: "completed"})
 //
 // Create a todo:
 //
-//	todo, err := account.Todos().Create(ctx, projectID, todolistID, &basecamp.CreateTodoRequest{
+//	todo, err := account.Todos().Create(ctx, todolistID, &basecamp.CreateTodoRequest{
 //	    Content: "Ship the feature",
 //	    DueOn:   "2024-12-31",
 //	})
 //
 // Complete a todo:
 //
-//	err := account.Todos().Complete(ctx, projectID, todoID)
+//	err := account.Todos().Complete(ctx, todoID)
 //
 // # Searching
 //
@@ -176,6 +180,6 @@
 //	acme := client.ForAccount("12345")
 //	initech := client.ForAccount("67890")
 //
-//	go func() { acme.Todos().List(ctx, projectID, todolistID, nil) }()
+//	go func() { acme.Todos().List(ctx, todolistID, nil) }()
 //	go func() { initech.Projects().List(ctx, nil) }()
 package basecamp

--- a/go/pkg/basecamp/example_test.go
+++ b/go/pkg/basecamp/example_test.go
@@ -134,8 +134,8 @@ func ExampleTodosService_List() {
 
 	todolistID := int64(789012)
 
-	// List completed todos in a todolist
-	todosResult, err := client.ForAccount("12345").Todos().List(ctx, todolistID, &basecamp.TodoListOptions{Status: "completed"})
+	// List todos in a todolist
+	todosResult, err := client.ForAccount("12345").Todos().List(ctx, todolistID, nil)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -146,6 +146,26 @@ func ExampleTodosService_List() {
 			status = "[x]"
 		}
 		fmt.Printf("%s %s\n", status, t.Content)
+	}
+}
+
+func ExampleTodosService_List_completed() {
+	cfg := basecamp.DefaultConfig()
+	token := &basecamp.StaticTokenProvider{Token: os.Getenv("BASECAMP_TOKEN")}
+	client := basecamp.NewClient(cfg, token)
+
+	ctx := context.Background()
+
+	todolistID := int64(789012)
+
+	// List completed todos in a todolist
+	todosResult, err := client.ForAccount("12345").Todos().List(ctx, todolistID, &basecamp.TodoListOptions{Status: "completed"})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, t := range todosResult.Todos {
+		fmt.Printf("[x] %s\n", t.Content)
 	}
 }
 

--- a/go/pkg/basecamp/example_test.go
+++ b/go/pkg/basecamp/example_test.go
@@ -134,8 +134,8 @@ func ExampleTodosService_List() {
 
 	todolistID := int64(789012)
 
-	// List all todos in a todolist
-	todosResult, err := client.ForAccount("12345").Todos().List(ctx, todolistID, nil)
+	// List completed todos in a todolist
+	todosResult, err := client.ForAccount("12345").Todos().List(ctx, todolistID, &basecamp.TodoListOptions{Status: "completed"})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go/pkg/basecamp/todos.go
+++ b/go/pkg/basecamp/todos.go
@@ -95,9 +95,10 @@ type Bucket struct {
 
 // TodoListOptions specifies options for listing todos.
 type TodoListOptions struct {
-	// Status filters by completion status.
-	// "completed" returns completed todos, "pending" returns pending todos.
-	// Empty returns all todos.
+	// Status filters todos by lifecycle or completion status.
+	// Lifecycle statuses: "active", "archived", "trashed".
+	// Backwards-compatible completion shorthands: "completed", "pending", "incomplete".
+	// Empty returns the API default (pending/incomplete todos).
 	Status string
 
 	// Limit is the maximum number of todos to return.
@@ -188,10 +189,26 @@ func (s *TodosService) List(ctx context.Context, todolistID int64, opts *TodoLis
 	ctx = s.client.parent.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.parent.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	// Build params for generated client
+	// Build params for generated client.
+	// The BC3 todos endpoint uses two different query shapes:
+	//   - status=active|archived|trashed for lifecycle state
+	//   - completed=true for completed todos
+	// Historically this wrapper exposed completion filtering via Status, so we
+	// keep mapping "completed"/"pending"/"incomplete" here for compatibility.
 	var params *generated.ListTodosParams
 	if opts != nil && opts.Status != "" {
-		params = &generated.ListTodosParams{Status: opts.Status}
+		built := &generated.ListTodosParams{}
+		switch opts.Status {
+		case "completed":
+			built.Completed = true
+		case "pending", "incomplete":
+			// Omit both params: the API returns pending/incomplete todos by default.
+		default:
+			built.Status = opts.Status
+		}
+		if built.Status != "" || built.Completed {
+			params = built
+		}
 	}
 
 	// Call generated client for first page (spec-conformant - no manual path construction)

--- a/go/pkg/basecamp/todos_test.go
+++ b/go/pkg/basecamp/todos_test.go
@@ -495,8 +495,12 @@ func TestTodoListOptions_StatusFilter(t *testing.T) {
 		name   string
 		status string
 	}{
+		{"active", "active"},
+		{"archived", "archived"},
+		{"trashed", "trashed"},
 		{"completed", "completed"},
 		{"pending", "pending"},
+		{"incomplete", "incomplete"},
 		{"empty", ""},
 	}
 
@@ -949,6 +953,84 @@ func testTodosServer(t *testing.T, handler http.HandlerFunc) *TodosService {
 	client := NewClient(cfg, token)
 	account := client.ForAccount("99999")
 	return account.Todos()
+}
+
+func TestTodosService_ListCompletedFilter(t *testing.T) {
+	fixture := loadTodosFixture(t, "list.json")
+	var gotStatus string
+	var gotCompleted string
+
+	svc := testTodosServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotStatus = r.URL.Query().Get("status")
+		gotCompleted = r.URL.Query().Get("completed")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write(fixture)
+	})
+
+	result, err := svc.List(context.Background(), 1069479519, &TodoListOptions{Status: "completed"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Todos) != 2 {
+		t.Fatalf("expected 2 todos, got %d", len(result.Todos))
+	}
+	if gotStatus != "" {
+		t.Errorf("expected status query to be omitted, got %q", gotStatus)
+	}
+	if gotCompleted != "true" {
+		t.Errorf("expected completed=true, got %q", gotCompleted)
+	}
+}
+
+func TestTodosService_ListPendingFilterOmitsQueryParams(t *testing.T) {
+	fixture := loadTodosFixture(t, "list.json")
+	var gotStatus string
+	var gotCompleted string
+
+	svc := testTodosServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotStatus = r.URL.Query().Get("status")
+		gotCompleted = r.URL.Query().Get("completed")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write(fixture)
+	})
+
+	_, err := svc.List(context.Background(), 1069479519, &TodoListOptions{Status: "pending"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotStatus != "" {
+		t.Errorf("expected status query to be omitted, got %q", gotStatus)
+	}
+	if gotCompleted != "" {
+		t.Errorf("expected completed query to be omitted, got %q", gotCompleted)
+	}
+}
+
+func TestTodosService_ListLifecycleStatusFilter(t *testing.T) {
+	fixture := loadTodosFixture(t, "list.json")
+	var gotStatus string
+	var gotCompleted string
+
+	svc := testTodosServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotStatus = r.URL.Query().Get("status")
+		gotCompleted = r.URL.Query().Get("completed")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write(fixture)
+	})
+
+	_, err := svc.List(context.Background(), 1069479519, &TodoListOptions{Status: "archived"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotStatus != "archived" {
+		t.Errorf("expected status=archived, got %q", gotStatus)
+	}
+	if gotCompleted != "" {
+		t.Errorf("expected completed query to be omitted, got %q", gotCompleted)
+	}
 }
 
 func TestTodosService_Update(t *testing.T) {

--- a/go/pkg/basecamp/todos_test.go
+++ b/go/pkg/basecamp/todos_test.go
@@ -1008,6 +1008,31 @@ func TestTodosService_ListPendingFilterOmitsQueryParams(t *testing.T) {
 	}
 }
 
+func TestTodosService_ListIncompleteFilterOmitsQueryParams(t *testing.T) {
+	fixture := loadTodosFixture(t, "list.json")
+	var gotStatus string
+	var gotCompleted string
+
+	svc := testTodosServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotStatus = r.URL.Query().Get("status")
+		gotCompleted = r.URL.Query().Get("completed")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write(fixture)
+	})
+
+	_, err := svc.List(context.Background(), 1069479519, &TodoListOptions{Status: "incomplete"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotStatus != "" {
+		t.Errorf("expected status query to be omitted, got %q", gotStatus)
+	}
+	if gotCompleted != "" {
+		t.Errorf("expected completed query to be omitted, got %q", gotCompleted)
+	}
+}
+
 func TestTodosService_ListLifecycleStatusFilter(t *testing.T) {
 	fixture := loadTodosFixture(t, "list.json")
 	var gotStatus string

--- a/go/pkg/basecamp/todos_test.go
+++ b/go/pkg/basecamp/todos_test.go
@@ -959,10 +959,15 @@ func TestTodosService_ListCompletedFilter(t *testing.T) {
 	fixture := loadTodosFixture(t, "list.json")
 	var gotStatus string
 	var gotCompleted string
+	var hasStatus bool
+	var hasCompleted bool
 
 	svc := testTodosServer(t, func(w http.ResponseWriter, r *http.Request) {
-		gotStatus = r.URL.Query().Get("status")
-		gotCompleted = r.URL.Query().Get("completed")
+		query := r.URL.Query()
+		hasStatus = query.Has("status")
+		hasCompleted = query.Has("completed")
+		gotStatus = query.Get("status")
+		gotCompleted = query.Get("completed")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
 		w.Write(fixture)
@@ -975,11 +980,11 @@ func TestTodosService_ListCompletedFilter(t *testing.T) {
 	if len(result.Todos) != 2 {
 		t.Fatalf("expected 2 todos, got %d", len(result.Todos))
 	}
-	if gotStatus != "" {
+	if hasStatus {
 		t.Errorf("expected status query to be omitted, got %q", gotStatus)
 	}
-	if gotCompleted != "true" {
-		t.Errorf("expected completed=true, got %q", gotCompleted)
+	if !hasCompleted || gotCompleted != "true" {
+		t.Errorf("expected completed=true, got present=%t value=%q", hasCompleted, gotCompleted)
 	}
 }
 
@@ -987,10 +992,15 @@ func TestTodosService_ListPendingFilterOmitsQueryParams(t *testing.T) {
 	fixture := loadTodosFixture(t, "list.json")
 	var gotStatus string
 	var gotCompleted string
+	var hasStatus bool
+	var hasCompleted bool
 
 	svc := testTodosServer(t, func(w http.ResponseWriter, r *http.Request) {
-		gotStatus = r.URL.Query().Get("status")
-		gotCompleted = r.URL.Query().Get("completed")
+		query := r.URL.Query()
+		hasStatus = query.Has("status")
+		hasCompleted = query.Has("completed")
+		gotStatus = query.Get("status")
+		gotCompleted = query.Get("completed")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
 		w.Write(fixture)
@@ -1000,10 +1010,10 @@ func TestTodosService_ListPendingFilterOmitsQueryParams(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if gotStatus != "" {
+	if hasStatus {
 		t.Errorf("expected status query to be omitted, got %q", gotStatus)
 	}
-	if gotCompleted != "" {
+	if hasCompleted {
 		t.Errorf("expected completed query to be omitted, got %q", gotCompleted)
 	}
 }
@@ -1012,10 +1022,15 @@ func TestTodosService_ListIncompleteFilterOmitsQueryParams(t *testing.T) {
 	fixture := loadTodosFixture(t, "list.json")
 	var gotStatus string
 	var gotCompleted string
+	var hasStatus bool
+	var hasCompleted bool
 
 	svc := testTodosServer(t, func(w http.ResponseWriter, r *http.Request) {
-		gotStatus = r.URL.Query().Get("status")
-		gotCompleted = r.URL.Query().Get("completed")
+		query := r.URL.Query()
+		hasStatus = query.Has("status")
+		hasCompleted = query.Has("completed")
+		gotStatus = query.Get("status")
+		gotCompleted = query.Get("completed")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
 		w.Write(fixture)
@@ -1025,10 +1040,10 @@ func TestTodosService_ListIncompleteFilterOmitsQueryParams(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if gotStatus != "" {
+	if hasStatus {
 		t.Errorf("expected status query to be omitted, got %q", gotStatus)
 	}
-	if gotCompleted != "" {
+	if hasCompleted {
 		t.Errorf("expected completed query to be omitted, got %q", gotCompleted)
 	}
 }
@@ -1037,10 +1052,13 @@ func TestTodosService_ListLifecycleStatusFilter(t *testing.T) {
 	fixture := loadTodosFixture(t, "list.json")
 	var gotStatus string
 	var gotCompleted string
+	var hasCompleted bool
 
 	svc := testTodosServer(t, func(w http.ResponseWriter, r *http.Request) {
-		gotStatus = r.URL.Query().Get("status")
-		gotCompleted = r.URL.Query().Get("completed")
+		query := r.URL.Query()
+		gotStatus = query.Get("status")
+		hasCompleted = query.Has("completed")
+		gotCompleted = query.Get("completed")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
 		w.Write(fixture)
@@ -1053,7 +1071,7 @@ func TestTodosService_ListLifecycleStatusFilter(t *testing.T) {
 	if gotStatus != "archived" {
 		t.Errorf("expected status=archived, got %q", gotStatus)
 	}
-	if gotCompleted != "" {
+	if hasCompleted {
 		t.Errorf("expected completed query to be omitted, got %q", gotCompleted)
 	}
 }


### PR DESCRIPTION
## Summary
The Go todos wrapper exposed completion filtering through `TodoListOptions.Status`, but the Basecamp todos endpoint uses `completed=true` for completed items and `status=active|archived|trashed` for lifecycle state. This PR keeps the existing Go API intact while translating those filters into the query parameters the API actually expects, so todo listing returns the correct results for completed and lifecycle-filtered requests.

Refs basecamp/basecamp-cli#403

## Changes
- map `Status: "completed"` to `completed=true`
- treat `pending` and `incomplete` as the default API behavior by omitting both query params
- continue passing lifecycle statuses like `active`, `archived`, and `trashed` through `status`
- update Go docs and examples to show the supported filtering behavior
- add Go test coverage for completed, pending/incomplete, and lifecycle filter handling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes todo list filtering in the Go client so completed and lifecycle states return correct results. `TodoListOptions.Status` now maps to the API’s `completed` and `status` query params, and docs/examples clarify that todo APIs take `todolistID`/`todoID` without `projectID`.

- **Bug Fixes**
  - Map `Status: "completed"` to `completed=true`; omit both params for `pending`/`incomplete` (API default).
  - Pass lifecycle states (`"active"`, `"archived"`, `"trashed"`) via `status`.
  - Harden tests to assert correct query param presence/omission, and update docs/examples (drop `projectID`, add completed list example).

<sup>Written for commit d8b20af1cc5db0074c161da241a359297c8370e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

