### PR TITLE
Add ListAnswersByPerson to CheckinsService

### DIFF
--- a/go/pkg/basecamp/checkins.go
+++ b/go/pkg/basecamp/checkins.go
@@ -507,6 +507,74 @@ func (s *CheckinsService) ListAnswers(ctx context.Context, questionID int64, opt
 	return &AnswerListResult{Answers: answers, Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 }
 
+// ListAnswersByUser returns all answers for a question posted by a specific person.
+//
+// Pagination options:
+//   - Limit: maximum number of answers to return (0 = all)
+//   - Page: if non-zero, disables pagination and returns first page only.
+//     NOTE: The page number itself is not yet honored due to OpenAPI client
+//     limitations. Use 0 to paginate through all results up to Limit.
+func (s *CheckinsService) ListAnswersByUser(ctx context.Context, questionID, personID int64, opts *AnswerListOptions) (result *AnswerListResult, err error) {
+	op := OperationInfo{
+		Service: "Checkins", Operation: "ListAnswersByUser",
+		ResourceType: "answer", IsMutation: false,
+		ResourceID: questionID,
+	}
+	if gater, ok := s.client.parent.hooks.(GatingHooks); ok {
+		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
+			return
+		}
+	}
+	start := time.Now()
+	ctx = s.client.parent.hooks.OnOperationStart(ctx, op)
+	defer func() { s.client.parent.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
+
+	resp, err := s.client.parent.gen.GetAnswersByPersonWithResponse(ctx, s.client.accountID, questionID, personID)
+	if err != nil {
+		return nil, err
+	}
+	if err = checkResponse(resp.HTTPResponse, resp.Body); err != nil {
+		return nil, err
+	}
+
+	totalCount := parseTotalCount(resp.HTTPResponse)
+
+	var answers []QuestionAnswer
+	if resp.JSON200 != nil {
+		for _, ga := range *resp.JSON200 {
+			answers = append(answers, questionAnswerFromGenerated(ga))
+		}
+	}
+
+	if opts != nil && opts.Page > 0 {
+		return &AnswerListResult{Answers: answers, Meta: ListMeta{TotalCount: totalCount}}, nil
+	}
+
+	limit := 0
+	if opts != nil && opts.Limit > 0 {
+		limit = opts.Limit
+	}
+
+	if limit > 0 && len(answers) >= limit {
+		return &AnswerListResult{Answers: answers[:limit], Meta: ListMeta{TotalCount: totalCount, Truncated: isFirstPageTruncated(resp.HTTPResponse, len(answers), limit)}}, nil
+	}
+
+	rawMore, truncated, err := s.client.parent.followPagination(ctx, resp.HTTPResponse, len(answers), limit)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, raw := range rawMore {
+		var ga generated.QuestionAnswer
+		if err := json.Unmarshal(raw, &ga); err != nil {
+			return nil, fmt.Errorf("failed to parse answer: %w", err)
+		}
+		answers = append(answers, questionAnswerFromGenerated(ga))
+	}
+
+	return &AnswerListResult{Answers: answers, Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
+}
+
 // GetAnswer returns a question answer by ID.
 func (s *CheckinsService) GetAnswer(ctx context.Context, answerID int64) (result *QuestionAnswer, err error) {
 	op := OperationInfo{

--- a/go/pkg/basecamp/checkins.go
+++ b/go/pkg/basecamp/checkins.go
@@ -434,7 +434,9 @@ func (s *CheckinsService) UpdateQuestion(ctx context.Context, questionID int64, 
 //
 // Pagination options:
 //   - Limit: maximum number of answers to return (0 = all)
-//   - Page: if non-zero, disables pagination and returns first page only
+//   - Page: if non-zero, disables pagination and returns first page only.
+//     NOTE: The page number itself is not yet honored due to OpenAPI client
+//     limitations. Use 0 to paginate through all results up to Limit.
 //
 // The returned AnswerListResult includes pagination metadata (TotalCount from
 // X-Total-Count header) when available.
@@ -507,16 +509,18 @@ func (s *CheckinsService) ListAnswers(ctx context.Context, questionID int64, opt
 	return &AnswerListResult{Answers: answers, Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 }
 
-// ListAnswersByUser returns all answers for a question posted by a specific person.
+// ListAnswersByPerson returns all answers for a question posted by a specific person.
+//
+// By default, returns all answers (no limit). Use Limit to cap results.
 //
 // Pagination options:
 //   - Limit: maximum number of answers to return (0 = all)
 //   - Page: if non-zero, disables pagination and returns first page only.
 //     NOTE: The page number itself is not yet honored due to OpenAPI client
 //     limitations. Use 0 to paginate through all results up to Limit.
-func (s *CheckinsService) ListAnswersByUser(ctx context.Context, questionID, personID int64, opts *AnswerListOptions) (result *AnswerListResult, err error) {
+func (s *CheckinsService) ListAnswersByPerson(ctx context.Context, questionID, personID int64, opts *AnswerListOptions) (result *AnswerListResult, err error) {
 	op := OperationInfo{
-		Service: "Checkins", Operation: "ListAnswersByUser",
+		Service: "Checkins", Operation: "ListAnswersByPerson",
 		ResourceType: "answer", IsMutation: false,
 		ResourceID: questionID,
 	}

--- a/go/pkg/basecamp/checkins_test.go
+++ b/go/pkg/basecamp/checkins_test.go
@@ -3,6 +3,7 @@ package basecamp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -950,5 +951,86 @@ func TestCheckinsService_ListAnswersByPerson(t *testing.T) {
 	}
 	if a.Creator.Name != "Victor Cooper" {
 		t.Errorf("expected Creator.Name 'Victor Cooper', got %q", a.Creator.Name)
+	}
+}
+
+func TestCheckinsService_ListAnswersByPerson_Pagination(t *testing.T) {
+	page1Body := `[{"id":1,"creator":{"id":1049715914,"name":"A"}},{"id":2,"creator":{"id":1049715914,"name":"B"}}]`
+	page2Body := `[{"id":3,"creator":{"id":1049715914,"name":"C"}},{"id":4,"creator":{"id":1049715914,"name":"D"}}]`
+
+	cases := []struct {
+		name          string
+		emitNextLink  bool
+		opts          *AnswerListOptions
+		wantAnswers   int
+		wantRequests  int
+		wantTruncated bool
+	}{
+		{
+			name:          "collects across pages when no limit",
+			emitNextLink:  true,
+			opts:          nil,
+			wantAnswers:   4,
+			wantRequests:  2,
+			wantTruncated: false,
+		},
+		{
+			name:          "Page option returns first page and skips Link follow",
+			emitNextLink:  true,
+			opts:          &AnswerListOptions{Page: 1},
+			wantAnswers:   2,
+			wantRequests:  1,
+			wantTruncated: false,
+		},
+		{
+			name:          "Limit smaller than first page truncates without follow",
+			emitNextLink:  true,
+			opts:          &AnswerListOptions{Limit: 1},
+			wantAnswers:   1,
+			wantRequests:  1,
+			wantTruncated: true,
+		},
+		{
+			name:          "Limit straddling page boundary trims second page",
+			emitNextLink:  true,
+			opts:          &AnswerListOptions{Limit: 3},
+			wantAnswers:   3,
+			wantRequests:  2,
+			wantTruncated: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var requestCount int
+			svc := testCheckinsServer(t, func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+				w.Header().Set("Content-Type", "application/json")
+				if requestCount == 1 {
+					if tc.emitNextLink {
+						w.Header().Set("Link", fmt.Sprintf(`<http://%s/99999/questions/1069479410/answers/by/1049715914?page=2>; rel="next"`, r.Host))
+					}
+					w.WriteHeader(200)
+					w.Write([]byte(page1Body))
+					return
+				}
+				w.WriteHeader(200)
+				w.Write([]byte(page2Body))
+			})
+
+			result, err := svc.ListAnswersByPerson(context.Background(), 1069479410, 1049715914, tc.opts)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(result.Answers) != tc.wantAnswers {
+				t.Errorf("expected %d answers, got %d", tc.wantAnswers, len(result.Answers))
+			}
+			if requestCount != tc.wantRequests {
+				t.Errorf("expected %d HTTP requests, got %d", tc.wantRequests, requestCount)
+			}
+			if result.Meta.Truncated != tc.wantTruncated {
+				t.Errorf("expected Truncated=%v, got %v", tc.wantTruncated, result.Meta.Truncated)
+			}
+		})
 	}
 }

--- a/go/pkg/basecamp/checkins_test.go
+++ b/go/pkg/basecamp/checkins_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -914,24 +913,28 @@ func TestCheckinsService_UpdateAnswerRejectsMissingResolvedGroupOn(t *testing.T)
 	}
 }
 
-func TestCheckinsService_ListAnswersByUser(t *testing.T) {
+func TestCheckinsService_ListAnswersByPerson(t *testing.T) {
 	fixture := loadCheckinsFixture(t, "answers_by_person.json")
 
-	var requestedPath string
+	var requestedMethod, requestedPath string
 	svc := testCheckinsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestedMethod = r.Method
 		requestedPath = r.URL.Path
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
 		w.Write(fixture)
 	})
 
-	result, err := svc.ListAnswersByUser(context.Background(), 1069479410, 1049715914, nil)
+	result, err := svc.ListAnswersByPerson(context.Background(), 1069479410, 1049715914, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if !strings.Contains(requestedPath, "/questions/1069479410/answers/by/1049715914") {
-		t.Errorf("expected path to contain /questions/1069479410/answers/by/1049715914, got %q", requestedPath)
+	if requestedMethod != http.MethodGet {
+		t.Errorf("expected GET, got %s", requestedMethod)
+	}
+	if requestedPath != "/99999/questions/1069479410/answers/by/1049715914" {
+		t.Errorf("expected path /99999/questions/1069479410/answers/by/1049715914, got %q", requestedPath)
 	}
 
 	if len(result.Answers) != 1 {

--- a/go/pkg/basecamp/checkins_test.go
+++ b/go/pkg/basecamp/checkins_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -910,5 +911,41 @@ func TestCheckinsService_UpdateAnswerRejectsMissingResolvedGroupOn(t *testing.T)
 	}
 	if apiErr.Message != "group_on is required" {
 		t.Fatalf("unexpected error message: %q", apiErr.Message)
+	}
+}
+
+func TestCheckinsService_ListAnswersByUser(t *testing.T) {
+	fixture := loadCheckinsFixture(t, "answers_by_person.json")
+
+	var requestedPath string
+	svc := testCheckinsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write(fixture)
+	})
+
+	result, err := svc.ListAnswersByUser(context.Background(), 1069479410, 1049715914, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(requestedPath, "/questions/1069479410/answers/by/1049715914") {
+		t.Errorf("expected path to contain /questions/1069479410/answers/by/1049715914, got %q", requestedPath)
+	}
+
+	if len(result.Answers) != 1 {
+		t.Fatalf("expected 1 answer, got %d", len(result.Answers))
+	}
+
+	a := result.Answers[0]
+	if a.ID != 1069479450 {
+		t.Errorf("expected ID 1069479450, got %d", a.ID)
+	}
+	if a.Creator == nil || a.Creator.ID != 1049715914 {
+		t.Errorf("expected Creator.ID 1049715914, got %v", a.Creator)
+	}
+	if a.Creator.Name != "Victor Cooper" {
+		t.Errorf("expected Creator.Name 'Victor Cooper', got %q", a.Creator.Name)
 	}
 }

--- a/scripts/check-service-drift.sh
+++ b/scripts/check-service-drift.sh
@@ -19,7 +19,6 @@ SERVICE_DIR="$SDK_DIR/pkg/basecamp"
 
 # Operations intentionally not yet wrapped (tracked for Go service generator work)
 EXCLUDED_OPS=(
-  GetAnswersByPerson
   GetQuestionReminders
   ListQuestionAnswerers
   PauseQuestion

--- a/spec/fixtures/checkins/answers_by_person.json
+++ b/spec/fixtures/checkins/answers_by_person.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": 1069479450,
+    "status": "active",
+    "visible_to_clients": false,
+    "created_at": "2022-10-28T17:30:00.000Z",
+    "updated_at": "2022-10-28T17:30:00.000Z",
+    "title": "What did you work on today?",
+    "inherits_status": true,
+    "type": "Question::Answer",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/question_answers/1069479450.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/question_answers/1069479450",
+    "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5NDUwP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--aabbccdd.json",
+    "subscription_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479450/subscription.json",
+    "comments_count": 2,
+    "comments_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479450/comments.json",
+    "content": "<div>Worked on the new landing page design and reviewed PRs.</div>",
+    "group_on": "2022-10-28",
+    "parent": {
+      "id": 1069479410,
+      "title": "What did you work on today?",
+      "type": "Question",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/questions/1069479410.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/questions/1069479410"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715914,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+      "name": "Victor Cooper",
+      "email_address": "victor@honchodesign.com",
+      "personable_type": "User",
+      "title": "Chief Strategist",
+      "bio": "Don't let your dreams be dreams",
+      "location": "Chicago, IL",
+      "created_at": "2022-11-22T08:23:21.732Z",
+      "updated_at": "2022-11-22T08:23:21.732Z",
+      "admin": true,
+      "owner": true,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+      "can_manage_projects": true,
+      "can_manage_people": true
+    }
+  }
+]


### PR DESCRIPTION
## Summary

The BC3 API supports `GET /questions/{id}/answers/by/{personId}.json` to fetch a specific person's answers to a check-in question, and the generated Go client already exposes `GetAnswersByPersonWithResponse`. However, the `CheckinsService` had no service-layer wrapper for it.

This PR adds `ListAnswersByPerson(ctx, questionID, personID int64, opts *AnswerListOptions) (*AnswerListResult, error)` to `CheckinsService`, following the same pagination pattern as the existing `ListAnswers` method.

## Changes

- `go/pkg/basecamp/checkins.go` — new `ListAnswersByPerson` method on `CheckinsService`
- `go/pkg/basecamp/checkins_test.go` — `TestCheckinsService_ListAnswersByPerson` verifies path/method, plus a table-driven `_Pagination` test exercising multi-page collect, `Page` short-circuit, and limit truncation on both first page and mid-second-page (also retroactively covers `ListAnswers`'s shared pagination path)
- `spec/fixtures/checkins/answers_by_person.json` — fixture for the answers-by-person list response
- `scripts/check-service-drift.sh` — drop the now-stale `GetAnswersByPerson` entry from `EXCLUDED_OPS` (this PR wraps it)

## Naming

The method is `ListAnswersByPerson` rather than `ListAnswersByUser` to match upstream conventions: the Smithy spec defines `GetAnswersByPerson`, the Go generated client exposes `GetAnswersByPersonWithResponse`, the URL path is `/by/{personId}`, the parameter type is `PersonId`, and Ruby, Python, TypeScript, Kotlin, and Swift all use `by_person`/`byPerson`. "Person" is also the correct Basecamp domain term — it covers users, clients, employees, and vendors, all of whom can submit check-in answers.

## Other languages

Ruby, Python, TypeScript, Kotlin, and Swift all already expose this endpoint — their SDKs are fully generated from the OpenAPI spec so `byPerson`/`by_person` was included from the start. The Go SDK is unique in having a hand-written service layer on top of the generated client, which is why only Go needed this change.

## Context

This unblocks [basecamp/basecamp-cli#443](https://github.com/basecamp/basecamp-cli/issues/443), which requests a `--by` filter on `basecamp checkins answers`. The CLI PR depends on this SDK method being available.