### PR TITLE
Preserve request IDs on raw client errors

### DIFF
--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -705,6 +705,8 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 
 	c.logger.Debug("http response", "status", resp.StatusCode)
 
+	requestID := resp.Header.Get("X-Request-Id")
+
 	// Handle response based on status code
 	switch resp.StatusCode {
 	case http.StatusNotModified: // 304
@@ -720,7 +722,7 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 				}, nil
 			}
 		}
-		return nil, ErrAPI(304, "304 received but no cached response available")
+		return nil, ErrAPI(304, "304 received but no cached response available").withRequestID(requestID)
 
 	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
 		respBody, err := limitedReadAll(resp.Body, MaxResponseBodyBytes)
@@ -755,7 +757,7 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 
 	case http.StatusTooManyRequests: // 429
 		retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
-		return nil, ErrRateLimit(retryAfter)
+		return nil, ErrRateLimit(retryAfter).withRequestID(requestID)
 
 	case http.StatusUnauthorized: // 401
 		// Try token refresh on first 401
@@ -771,28 +773,28 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 				}
 			}
 		}
-		return nil, ErrAuth("Authentication failed")
+		return nil, ErrAuth("Authentication failed").withRequestID(requestID)
 
 	case http.StatusForbidden: // 403
 		// Check if this might be a scope issue
 		if method != "GET" {
-			return nil, ErrForbiddenScope()
+			return nil, ErrForbiddenScope().withRequestID(requestID)
 		}
-		return nil, ErrForbidden("Access denied")
+		return nil, ErrForbidden("Access denied").withRequestID(requestID)
 
 	case http.StatusNotFound: // 404
-		return nil, ErrNotFound("Resource", url)
+		return nil, ErrNotFound("Resource", url).withRequestID(requestID)
 
 	case http.StatusInternalServerError: // 500
-		return nil, ErrAPI(500, "Server error (500)")
+		return nil, ErrAPI(500, "Server error (500)").withRequestID(requestID)
 
 	case http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout: // 502, 503, 504
-		return nil, &Error{
+		return nil, (&Error{
 			Code:       CodeAPI,
 			Message:    fmt.Sprintf("Gateway error (%d)", resp.StatusCode),
 			HTTPStatus: resp.StatusCode,
 			Retryable:  true,
-		}
+		}).withRequestID(requestID)
 
 	default:
 		respBody, _ := limitedReadAll(resp.Body, MaxErrorBodyBytes)
@@ -807,10 +809,10 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 			}
 			if msg != "" {
 				// Truncate error messages to prevent information leakage and unbounded memory growth
-				return nil, ErrAPI(resp.StatusCode, truncateString(msg, MaxErrorMessageBytes))
+				return nil, ErrAPI(resp.StatusCode, truncateString(msg, MaxErrorMessageBytes)).withRequestID(requestID)
 			}
 		}
-		return nil, ErrAPI(resp.StatusCode, fmt.Sprintf("Request failed (HTTP %d)", resp.StatusCode))
+		return nil, ErrAPI(resp.StatusCode, fmt.Sprintf("Request failed (HTTP %d)", resp.StatusCode)).withRequestID(requestID)
 	}
 }
 

--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -705,7 +705,7 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 
 	c.logger.Debug("http response", "status", resp.StatusCode)
 
-	requestID := resp.Header.Get("X-Request-Id")
+	requestID := resp.Header.Get(requestIDHeader)
 
 	// Handle response based on status code
 	switch resp.StatusCode {

--- a/go/pkg/basecamp/client_test.go
+++ b/go/pkg/basecamp/client_test.go
@@ -268,3 +268,106 @@ func TestSingleRequest_201EmptyBodyNotNormalized(t *testing.T) {
 		t.Error("expected UnmarshalData error for empty 201 body, got nil")
 	}
 }
+
+func TestSingleRequest_ErrorIncludesRequestID(t *testing.T) {
+	tests := []struct {
+		name          string
+		method        string
+		status        int
+		body          string
+		wantCode      string
+		wantMessage   string
+		wantHint      string
+		wantRetryable bool
+	}{
+		{
+			name:        "not found get",
+			method:      http.MethodGet,
+			status:      http.StatusNotFound,
+			wantCode:    CodeNotFound,
+			wantMessage: "Resource not found: ",
+		},
+		{
+			name:          "rate limit post",
+			method:        http.MethodPost,
+			status:        http.StatusTooManyRequests,
+			wantCode:      CodeRateLimit,
+			wantMessage:   "Rate limited",
+			wantHint:      "Try again later",
+			wantRetryable: true,
+		},
+		{
+			name:        "forbidden scope put",
+			method:      http.MethodPut,
+			status:      http.StatusForbidden,
+			wantCode:    CodeForbidden,
+			wantMessage: "Access denied: insufficient scope",
+			wantHint:    "Re-authenticate with full scope",
+		},
+		{
+			name:        "generic api message",
+			method:      http.MethodDelete,
+			status:      http.StatusTeapot,
+			body:        `{"error":"brew stopped"}`,
+			wantCode:    CodeAPI,
+			wantMessage: "brew stopped",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("X-Request-Id", "req-raw-123")
+				if tt.body != "" {
+					w.Header().Set("Content-Type", "application/json")
+				}
+				w.WriteHeader(tt.status)
+				if tt.body != "" {
+					_, _ = w.Write([]byte(tt.body))
+				}
+			}))
+			defer server.Close()
+
+			cfg := &Config{BaseURL: server.URL, CacheEnabled: false}
+			client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+			client.httpOpts.MaxRetries = 1
+
+			var err error
+			switch tt.method {
+			case http.MethodGet:
+				_, err = client.Get(context.Background(), "/test.json")
+			case http.MethodPost:
+				_, err = client.Post(context.Background(), "/test.json", map[string]any{"ok": true})
+			case http.MethodPut:
+				_, err = client.Put(context.Background(), "/test.json", map[string]any{"ok": true})
+			case http.MethodDelete:
+				_, err = client.Delete(context.Background(), "/test.json")
+			default:
+				t.Fatalf("unsupported method %s", tt.method)
+			}
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			apiErr, ok := err.(*Error)
+			if !ok {
+				t.Fatalf("expected *Error, got %T", err)
+			}
+			if apiErr.RequestID != "req-raw-123" {
+				t.Fatalf("RequestID = %q, want %q", apiErr.RequestID, "req-raw-123")
+			}
+			if apiErr.Code != tt.wantCode {
+				t.Fatalf("Code = %q, want %q", apiErr.Code, tt.wantCode)
+			}
+			if apiErr.Message != tt.wantMessage && !(tt.wantCode == CodeNotFound && len(apiErr.Message) >= len(tt.wantMessage) && apiErr.Message[:len(tt.wantMessage)] == tt.wantMessage) {
+				t.Fatalf("Message = %q, want %q", apiErr.Message, tt.wantMessage)
+			}
+			if apiErr.Hint != tt.wantHint {
+				t.Fatalf("Hint = %q, want %q", apiErr.Hint, tt.wantHint)
+			}
+			if apiErr.Retryable != tt.wantRetryable {
+				t.Fatalf("Retryable = %v, want %v", apiErr.Retryable, tt.wantRetryable)
+			}
+		})
+	}
+}

--- a/go/pkg/basecamp/client_test.go
+++ b/go/pkg/basecamp/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -359,7 +360,11 @@ func TestSingleRequest_ErrorIncludesRequestID(t *testing.T) {
 			if apiErr.Code != tt.wantCode {
 				t.Fatalf("Code = %q, want %q", apiErr.Code, tt.wantCode)
 			}
-			if apiErr.Message != tt.wantMessage && !(tt.wantCode == CodeNotFound && len(apiErr.Message) >= len(tt.wantMessage) && apiErr.Message[:len(tt.wantMessage)] == tt.wantMessage) {
+			messageMatches := apiErr.Message == tt.wantMessage
+			if tt.wantCode == CodeNotFound {
+				messageMatches = strings.HasPrefix(apiErr.Message, tt.wantMessage)
+			}
+			if !messageMatches {
 				t.Fatalf("Message = %q, want %q", apiErr.Message, tt.wantMessage)
 			}
 			if apiErr.Hint != tt.wantHint {

--- a/go/pkg/basecamp/errors.go
+++ b/go/pkg/basecamp/errors.go
@@ -67,6 +67,17 @@ func (e *Error) Unwrap() error {
 	return e.Cause
 }
 
+// withRequestID returns a shallow copy of the error with RequestID set.
+// If requestID is empty, it returns the original error unchanged.
+func (e *Error) withRequestID(requestID string) *Error {
+	if e == nil || requestID == "" {
+		return e
+	}
+	copy := *e
+	copy.RequestID = requestID
+	return &copy
+}
+
 // ExitCode returns the appropriate exit code for this error.
 func (e *Error) ExitCode() int {
 	return ExitCodeFor(e.Code)

--- a/go/pkg/basecamp/errors.go
+++ b/go/pkg/basecamp/errors.go
@@ -43,6 +43,9 @@ const (
 	ExitValidation = 9 // Validation error (422)
 )
 
+// requestIDHeader is the response header carrying the server-issued request ID.
+const requestIDHeader = "X-Request-Id"
+
 // Error is a structured error with code, message, and optional hint.
 type Error struct {
 	Code       string
@@ -68,7 +71,7 @@ func (e *Error) Unwrap() error {
 }
 
 // withRequestID returns a shallow copy of the error with RequestID set.
-// If requestID is empty, it returns the original error unchanged.
+// Returns the receiver unchanged when it is nil or when requestID is empty.
 func (e *Error) withRequestID(requestID string) *Error {
 	if e == nil || requestID == "" {
 		return e

--- a/go/pkg/basecamp/errors.go
+++ b/go/pkg/basecamp/errors.go
@@ -73,9 +73,9 @@ func (e *Error) withRequestID(requestID string) *Error {
 	if e == nil || requestID == "" {
 		return e
 	}
-	copy := *e
-	copy.RequestID = requestID
-	return &copy
+	errCopy := *e
+	errCopy.RequestID = requestID
+	return &errCopy
 }
 
 // ExitCode returns the appropriate exit code for this error.

--- a/go/pkg/basecamp/helpers.go
+++ b/go/pkg/basecamp/helpers.go
@@ -78,7 +78,7 @@ func checkResponse(resp *http.Response, body []byte) error {
 		return nil
 	}
 
-	requestID := resp.Header.Get("X-Request-Id")
+	requestID := resp.Header.Get(requestIDHeader)
 	serverMsg, serverHint := parseErrorBody(body)
 
 	switch resp.StatusCode {

--- a/go/pkg/basecamp/helpers_test.go
+++ b/go/pkg/basecamp/helpers_test.go
@@ -90,6 +90,20 @@ func TestCheckResponse_JSONErrorWithDescription(t *testing.T) {
 	}
 }
 
+func TestCheckResponse_RequestID(t *testing.T) {
+	resp := &http.Response{StatusCode: 500, Header: http.Header{}}
+	resp.Header.Set("X-Request-Id", "req-sdk-123")
+
+	err := checkResponse(resp, nil)
+	e, ok := err.(*Error)
+	if !ok {
+		t.Fatalf("expected *Error, got %T", err)
+	}
+	if e.RequestID != "req-sdk-123" {
+		t.Fatalf("RequestID = %q, want %q", e.RequestID, "req-sdk-123")
+	}
+}
+
 func TestCheckResponse_EmptyBody(t *testing.T) {
 	resp := &http.Response{StatusCode: 403, Header: http.Header{}}
 	err := checkResponse(resp, nil)


### PR DESCRIPTION
## Summary
- preserve `X-Request-Id` on raw Go client HTTP failures in `Client.singleRequest`
- reuse the existing `basecamp.Error.RequestID` field for raw `Get`/`Post`/`Put`/`Delete` paths
- add tests covering both `checkResponse()` and raw client failures

## Problem
The Go SDK already had a `RequestID` field on `basecamp.Error`, and generated-service paths populated it via `checkResponse()`.

But the raw HTTP client path used by `AccountClient.Get/Post/Put/Delete` built fresh SDK errors in `singleRequest()` without copying the response request id. That made request-id handling inconsistent across the SDK and meant downstream consumers like the CLI could not reliably surface failing request ids for raw API calls.

## What changed
- added a small `withRequestID()` helper on `basecamp.Error`
- captured `X-Request-Id` in `singleRequest()`
- attached the request id to all raw-client non-2xx SDK errors, including:
  - 304 cache-miss errors
  - 401/403/404/429/500
  - 502/503/504 gateway errors
  - generic non-2xx API errors
- added tests to verify:
  - `checkResponse()` still records request ids
  - raw client request failures now include `RequestID`

## Why this belongs in the SDK
By the time the CLI receives an `error`, it no longer has access to the original HTTP response headers. If we want all SDK consumers to be able to surface request ids consistently, the SDK has to preserve the header on its structured error type.

## Testing
```bash
cd go && go test ./pkg/basecamp/...
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves `X-Request-Id` on errors from raw client requests so request IDs are consistent across the SDK and visible to tools like the CLI. Centralizes the header name and adds tests for both `checkResponse()` and raw paths.

- **Bug Fixes**
  - Capture `X-Request-Id` in `Client.singleRequest` and attach it to all non-2xx errors from raw `Get`/`Post`/`Put`/`Delete` (including 304, auth, rate limit, gateway, and not found).
  - Keep `checkResponse()` behavior; add tests confirming IDs are preserved on both paths.

- **Refactors**
  - Add `basecamp.Error.withRequestID()` and centralize the header via a `requestIDHeader` constant used in the client and helpers.
  - Fix minor SDK lint issues in touched files.

<sup>Written for commit 3cba4f86229b7de10a3808e84a6f338531680c5a. Summary will update on new commits. <a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/277?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

