### PR TITLE
Fix 401 on file downloads

### DIFF
--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -64,6 +64,34 @@ type Assertion struct {
 	Min      float64     `json:"min"`
 	Max      float64     `json:"max"`
 	Path     string      `json:"path"`
+	// Index selects which captured request to inspect for header assertions.
+	// Defaults to 0 (first request); negative values index from the end.
+	Index *int `json:"index,omitempty"`
+}
+
+// requestHeadersAt returns the headers captured for the given request index.
+// Negative indexes count from the end (-1 = last). Returns (nil, false) when
+// the index is out of range.
+func requestHeadersAt(requestHeaders []http.Header, index int) (http.Header, bool) {
+	n := len(requestHeaders)
+	if n == 0 {
+		return nil, false
+	}
+	if index < 0 {
+		index += n
+	}
+	if index < 0 || index >= n {
+		return nil, false
+	}
+	return requestHeaders[index], true
+}
+
+// assertionIndex returns the Index value, defaulting to 0 if unset.
+func assertionIndex(a Assertion) int {
+	if a.Index == nil {
+		return 0
+	}
+	return *a.Index
 }
 
 // TestResult captures the outcome of a test case.
@@ -672,22 +700,36 @@ func checkAssertion(
 	case "headerInjected":
 		headerName := assertion.Path
 		expected := expectedString(assertion.Expected)
-		if len(requestHeaders) == 0 {
-			return fail(tc, fmt.Sprintf("Expected header %s=%q, but no requests were recorded", headerName, expected))
+		idx := assertionIndex(assertion)
+		headers, ok := requestHeadersAt(requestHeaders, idx)
+		if !ok {
+			return fail(tc, fmt.Sprintf("Expected header %s=%q on request index %d, but only %d requests were recorded", headerName, expected, idx, len(requestHeaders)))
 		}
-		actual := requestHeaders[0].Get(headerName)
+		actual := headers.Get(headerName)
 		if actual != expected {
-			return fail(tc, fmt.Sprintf("Expected header %s=%q, got %q", headerName, expected, actual))
+			return fail(tc, fmt.Sprintf("Expected header %s=%q on request index %d, got %q", headerName, expected, idx, actual))
 		}
 
 	case "headerPresent":
 		headerName := assertion.Path
-		if len(requestHeaders) == 0 {
-			return fail(tc, fmt.Sprintf("Expected header %s to be present, but no requests were recorded", headerName))
+		idx := assertionIndex(assertion)
+		headers, ok := requestHeadersAt(requestHeaders, idx)
+		if !ok {
+			return fail(tc, fmt.Sprintf("Expected header %s on request index %d, but only %d requests were recorded", headerName, idx, len(requestHeaders)))
 		}
-		actual := requestHeaders[0].Get(headerName)
-		if actual == "" {
-			return fail(tc, fmt.Sprintf("Expected header %s to be present, but it was empty or missing", headerName))
+		if headers.Get(headerName) == "" {
+			return fail(tc, fmt.Sprintf("Expected header %s on request index %d, but it was empty or missing", headerName, idx))
+		}
+
+	case "headerAbsent":
+		headerName := assertion.Path
+		idx := assertionIndex(assertion)
+		headers, ok := requestHeadersAt(requestHeaders, idx)
+		if !ok {
+			return fail(tc, fmt.Sprintf("Expected header %s absent on request index %d, but only %d requests were recorded", headerName, idx, len(requestHeaders)))
+		}
+		if v := headers.Get(headerName); v != "" {
+			return fail(tc, fmt.Sprintf("Expected header %s absent on request index %d, got %q", headerName, idx, v))
 		}
 
 	case "headerValue":

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -282,7 +282,7 @@ func runTest(tc TestCase) TestResult {
 				msg := fmt.Sprintf("%v", r)
 				if strings.HasPrefix(msg, "basecamp: base URL must use HTTPS") ||
 					strings.HasPrefix(msg, "basecamp: timeout must be positive") ||
-					strings.HasPrefix(msg, "basecamp: max retries must be non-negative") ||
+					strings.HasPrefix(msg, "basecamp: max retries must be at least 1") ||
 					strings.HasPrefix(msg, "basecamp: max pages must be positive") {
 					opResult.err = basecamp.ErrUsage(msg)
 				} else {
@@ -728,8 +728,11 @@ func checkAssertion(
 		if !ok {
 			return fail(tc, fmt.Sprintf("Expected header %s absent on request index %d, but only %d requests were recorded", headerName, idx, len(requestHeaders)))
 		}
-		if v := headers.Get(headerName); v != "" {
-			return fail(tc, fmt.Sprintf("Expected header %s absent on request index %d, got %q", headerName, idx, v))
+		// Use Values (not Get): Get returns "" for both "not present" and
+		// "present with empty value"; for an absence assertion, a present-
+		// but-empty header must fail.
+		if values := headers.Values(headerName); len(values) > 0 {
+			return fail(tc, fmt.Sprintf("Expected header %s absent on request index %d, got %q", headerName, idx, values))
 		}
 
 	case "headerValue":

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -490,7 +490,9 @@ func executeOperation(ctx context.Context, account *basecamp.AccountClient, tc T
 			return operationResult{err: err}
 		}
 		defer result.Body.Close()
-		_, _ = io.Copy(io.Discard, result.Body)
+		if _, copyErr := io.Copy(io.Discard, result.Body); copyErr != nil {
+			return operationResult{err: copyErr}
+		}
 		return operationResult{err: nil}
 
 	default:

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -478,6 +479,19 @@ func executeOperation(ctx context.Context, account *basecamp.AccountClient, tc T
 		toolID := getInt64Param(tc.PathParams, "toolId")
 		err := account.Tools().Enable(ctx, toolID)
 		return operationResult{err: err}
+
+	case "DownloadURL":
+		// Construct an absolute URL the SDK will accept. The SDK rewrites the
+		// scheme+host to the configured BaseURL, so the synthetic host here
+		// is never actually hit — only tc.Path matters for mock-server routing.
+		rawURL := "https://storage.3.basecamp.com" + tc.Path
+		result, err := account.DownloadURL(ctx, rawURL)
+		if err != nil {
+			return operationResult{err: err}
+		}
+		defer result.Body.Close()
+		_, _ = io.Copy(io.Discard, result.Body)
+		return operationResult{err: nil}
 
 	default:
 		return operationResult{

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -370,11 +370,22 @@ def _get_error_field(error: Exception, field_path: str) -> Any:
 
 
 class ConformanceRunner:
+    _DOWNLOAD_SKIP = "Python runner does not yet dispatch DownloadURL (tracked as follow-up)"
     SKIPS: set[str] = {
         "maxItems caps results across pages",
+        "DownloadURL auth'd first hop 302s to signed URL",
+        "DownloadURL direct 2xx body",
+        "DownloadURL retries on 503 at the auth'd first hop",
+        "DownloadURL honors Retry-After on 429 at the auth'd first hop",
+        "DownloadURL surfaces redirect with no Location",
     }
     SKIP_REASONS: dict[str, str] = {
         "maxItems caps results across pages": "Python SDK list methods don't expose a public max_items parameter",
+        "DownloadURL auth'd first hop 302s to signed URL": _DOWNLOAD_SKIP,
+        "DownloadURL direct 2xx body": _DOWNLOAD_SKIP,
+        "DownloadURL retries on 503 at the auth'd first hop": _DOWNLOAD_SKIP,
+        "DownloadURL honors Retry-After on 429 at the auth'd first hop": _DOWNLOAD_SKIP,
+        "DownloadURL surfaces redirect with no Location": _DOWNLOAD_SKIP,
     }
 
     def __init__(self, tests_dir: str):

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -168,8 +168,14 @@ RUBY_SKIPS = Set.new([
   "Missing X-Total-Count returns zero",
   "Pagination stops at maxPages safety cap",
   "maxItems caps results across pages",
+  "DownloadURL auth'd first hop 302s to signed URL",
+  "DownloadURL direct 2xx body",
+  "DownloadURL retries on 503 at the auth'd first hop",
+  "DownloadURL honors Retry-After on 429 at the auth'd first hop",
+  "DownloadURL surfaces redirect with no Location",
 ].freeze)
 
+DOWNLOAD_SKIP = "Ruby runner does not yet dispatch DownloadURL (tracked as follow-up)".freeze
 RUBY_SKIP_REASONS = {
   "PUT operation is naturally idempotent" => "Ruby SDK only retries GET",
   "DELETE operation is naturally idempotent" => "Ruby SDK only retries GET",
@@ -177,6 +183,11 @@ RUBY_SKIP_REASONS = {
   "Missing X-Total-Count returns zero" => "Ruby SDK paginate doesn't expose X-Total-Count metadata",
   "Pagination stops at maxPages safety cap" => "Ruby SDK paginate doesn't expose truncation metadata",
   "maxItems caps results across pages" => "Ruby SDK paginate doesn't support maxItems",
+  "DownloadURL auth'd first hop 302s to signed URL" => DOWNLOAD_SKIP,
+  "DownloadURL direct 2xx body" => DOWNLOAD_SKIP,
+  "DownloadURL retries on 503 at the auth'd first hop" => DOWNLOAD_SKIP,
+  "DownloadURL honors Retry-After on 429 at the auth'd first hop" => DOWNLOAD_SKIP,
+  "DownloadURL surfaces redirect with no Location" => DOWNLOAD_SKIP,
 }.freeze
 
 # Single test case

--- a/conformance/runner/typescript/runner.test.ts
+++ b/conformance/runner/typescript/runner.test.ts
@@ -71,6 +71,16 @@ const TS_SDK_SKIPS: Record<string, string> = {
     "TS SDK retry middleware yields at most 1 retry per middleware pass",
   "Large integer IDs preserved without precision loss":
     "JavaScript loses precision on integers > Number.MAX_SAFE_INTEGER (2^53)",
+  "DownloadURL auth'd first hop 302s to signed URL":
+    "TS runner does not yet dispatch DownloadURL (tracked as follow-up)",
+  "DownloadURL direct 2xx body":
+    "TS runner does not yet dispatch DownloadURL (tracked as follow-up)",
+  "DownloadURL retries on 503 at the auth'd first hop":
+    "TS runner does not yet dispatch DownloadURL (tracked as follow-up)",
+  "DownloadURL honors Retry-After on 429 at the auth'd first hop":
+    "TS runner does not yet dispatch DownloadURL (tracked as follow-up)",
+  "DownloadURL surfaces redirect with no Location":
+    "TS runner does not yet dispatch DownloadURL (tracked as follow-up)",
 };
 
 // =============================================================================

--- a/conformance/schema.json
+++ b/conformance/schema.json
@@ -87,6 +87,7 @@
               "responseStatus",
               "responseBody",
               "headerPresent",
+              "headerAbsent",
               "headerValue",
               "errorType",
               "noError",
@@ -114,6 +115,10 @@
           "path": {
             "type": "string",
             "description": "JSONPath or dot-notation path for nested value assertions"
+          },
+          "index": {
+            "type": "integer",
+            "description": "Request index for headerPresent / headerAbsent / headerInjected (0-based; negative values index from the end, e.g. -1 = last request). Default 0."
           }
         }
       }

--- a/conformance/tests/downloads.json
+++ b/conformance/tests/downloads.json
@@ -47,7 +47,8 @@
     "assertions": [
       {"type": "requestCount", "expected": 4},
       {"type": "delayBetweenRequests", "min": 1000},
-      {"type": "noError"}
+      {"type": "noError"},
+      {"type": "headerPresent", "path": "Authorization"}
     ],
     "tags": ["download", "retry", "503"]
   },
@@ -65,7 +66,8 @@
     "assertions": [
       {"type": "requestCount", "expected": 3},
       {"type": "delayBetweenRequests", "min": 1000},
-      {"type": "noError"}
+      {"type": "noError"},
+      {"type": "headerPresent", "path": "Authorization"}
     ],
     "tags": ["download", "retry", "429", "retry-after"]
   },

--- a/conformance/tests/downloads.json
+++ b/conformance/tests/downloads.json
@@ -1,0 +1,87 @@
+[
+  {
+    "name": "DownloadURL auth'd first hop 302s to signed URL",
+    "description": "Two-hop download: authenticated request to API host returns 302 with Location; SDK follows Location (unauthenticated) to fetch the body. Location is relative so hop 2 hits the same mock server.",
+    "operation": "DownloadURL",
+    "method": "GET",
+    "path": "/999999999/blobs/abcd1234/download/logo.png",
+    "mockResponses": [
+      {"status": 302, "headers": {"Location": "/signed/logo.png"}},
+      {"status": 200, "headers": {"Content-Type": "image/png"}, "body": "pixels"}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 2},
+      {"type": "noError"},
+      {"type": "headerPresent", "path": "Authorization"}
+    ],
+    "tags": ["download", "redirect"]
+  },
+  {
+    "name": "DownloadURL direct 2xx body",
+    "description": "Authenticated first hop returns 200 with body directly (no redirect).",
+    "operation": "DownloadURL",
+    "method": "GET",
+    "path": "/999999999/blobs/abcd1234/download/doc.pdf",
+    "mockResponses": [
+      {"status": 200, "headers": {"Content-Type": "application/pdf"}, "body": "pdf-data"}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 1},
+      {"type": "noError"},
+      {"type": "headerPresent", "path": "Authorization"}
+    ],
+    "tags": ["download", "direct-body"]
+  },
+  {
+    "name": "DownloadURL retries on 503 at the auth'd first hop",
+    "description": "The first hop is a GET and must follow SDK-wide GET retry semantics (spec 2A.2): retry on 5xx with exponential backoff. After two 503s, the third attempt returns 302 and hop 2 completes.",
+    "operation": "DownloadURL",
+    "method": "GET",
+    "path": "/999999999/blobs/abcd1234/download/logo.png",
+    "mockResponses": [
+      {"status": 503},
+      {"status": 503},
+      {"status": 302, "headers": {"Location": "/signed/logo.png"}},
+      {"status": 200, "headers": {"Content-Type": "image/png"}, "body": "pixels"}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 4},
+      {"type": "delayBetweenRequests", "min": 1000},
+      {"type": "noError"}
+    ],
+    "tags": ["download", "retry", "503"]
+  },
+  {
+    "name": "DownloadURL honors Retry-After on 429 at the auth'd first hop",
+    "description": "429 Too Many Requests with Retry-After: 1 pauses for at least one second before retry. Retry succeeds with 302 → 200 body.",
+    "operation": "DownloadURL",
+    "method": "GET",
+    "path": "/999999999/blobs/abcd1234/download/logo.png",
+    "mockResponses": [
+      {"status": 429, "headers": {"Retry-After": "1"}},
+      {"status": 302, "headers": {"Location": "/signed/logo.png"}},
+      {"status": 200, "headers": {"Content-Type": "image/png"}, "body": "pixels"}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 3},
+      {"type": "delayBetweenRequests", "min": 1000},
+      {"type": "noError"}
+    ],
+    "tags": ["download", "retry", "429", "retry-after"]
+  },
+  {
+    "name": "DownloadURL surfaces redirect with no Location",
+    "description": "A 3xx response without a Location header is a protocol error, not a retryable failure. SDK surfaces an error after one request.",
+    "operation": "DownloadURL",
+    "method": "GET",
+    "path": "/999999999/blobs/abcd1234/download/logo.png",
+    "mockResponses": [
+      {"status": 302}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 1},
+      {"type": "errorMessage", "expected": "no Location"}
+    ],
+    "tags": ["download", "redirect", "error"]
+  }
+]

--- a/conformance/tests/downloads.json
+++ b/conformance/tests/downloads.json
@@ -12,7 +12,8 @@
     "assertions": [
       {"type": "requestCount", "expected": 2},
       {"type": "noError"},
-      {"type": "headerPresent", "path": "Authorization"}
+      {"type": "headerPresent", "path": "Authorization", "index": 0},
+      {"type": "headerAbsent", "path": "Authorization", "index": -1}
     ],
     "tags": ["download", "redirect"]
   },
@@ -48,7 +49,8 @@
       {"type": "requestCount", "expected": 4},
       {"type": "delayBetweenRequests", "min": 1000},
       {"type": "noError"},
-      {"type": "headerPresent", "path": "Authorization"}
+      {"type": "headerPresent", "path": "Authorization", "index": 0},
+      {"type": "headerAbsent", "path": "Authorization", "index": -1}
     ],
     "tags": ["download", "retry", "503"]
   },
@@ -67,7 +69,8 @@
       {"type": "requestCount", "expected": 3},
       {"type": "delayBetweenRequests", "min": 1000},
       {"type": "noError"},
-      {"type": "headerPresent", "path": "Authorization"}
+      {"type": "headerPresent", "path": "Authorization", "index": 0},
+      {"type": "headerAbsent", "path": "Authorization", "index": -1}
     ],
     "tags": ["download", "retry", "429", "retry-after"]
   },

--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -180,7 +180,7 @@ func WithAuthStrategy(strategy AuthStrategy) ClientOption {
 //
 // Configuration options:
 //   - WithTimeout(d)      - Request timeout (default: 30s)
-//   - WithMaxRetries(n)   - Max retry attempts for GET (default: 3)
+//   - WithMaxRetries(n)   - Total attempt count for GET (default: 3, minimum 1)
 //   - WithCache(c)        - Enable ETag-based caching
 //   - WithTransport(t)    - Custom http.RoundTripper
 //   - WithLogger(l)       - slog.Logger for debug output

--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -242,8 +242,11 @@ func NewClient(cfg *Config, tokenProvider TokenProvider, opts ...ClientOption) *
 	if c.httpOpts.Timeout <= 0 {
 		panic("basecamp: timeout must be positive")
 	}
-	if c.httpOpts.MaxRetries < 0 {
-		panic("basecamp: max retries must be non-negative")
+	if c.httpOpts.MaxRetries < 1 {
+		// MaxRetries names the total attempt count used by the retry loops in
+		// doRequestURL and fetchAPIDownload. Zero attempts is always a
+		// misconfiguration; reject it here so both loops can assume >= 1.
+		panic("basecamp: max retries must be at least 1")
 	}
 	if c.httpOpts.MaxPages <= 0 {
 		panic("basecamp: max pages must be positive")

--- a/go/pkg/basecamp/download.go
+++ b/go/pkg/basecamp/download.go
@@ -130,9 +130,14 @@ func (c *Client) fetchAPIDownload(ctx context.Context, rawURL string) (*Download
 		},
 	}
 
-	// Iteration semantics mirror Client.doRequestURL: MaxRetries is the total
-	// attempt count, and a misconfigured MaxRetries<=0 yields zero attempts and
-	// an error (same "failed after N attempts" shape as the main GET loop).
+	// MaxRetries is the total attempt count for this loop, matching
+	// Client.doRequestURL's iteration. MaxRetries<=0 skips the loop entirely
+	// and is surfaced as ErrUsage by the fallback after the loop. On
+	// exhaustion, the last per-attempt error is returned directly. Retry-
+	// eligible statuses are aligned with the main GET loop's @retryable set:
+	// 429 (rate limit) and 502/503/504 (gateway errors), plus transport
+	// errors. 500 and other non-@retryable 5xx fall through to the dispatch
+	// switch and surface as errors without retry.
 	maxAttempts := c.httpOpts.MaxRetries
 
 	var resp *http.Response
@@ -155,10 +160,20 @@ func (c *Client) fetchAPIDownload(ctx context.Context, rawURL string) (*Download
 		switch {
 		case doErr != nil:
 			lastErr = ErrNetwork(doErr)
-		case r.StatusCode == http.StatusTooManyRequests || (r.StatusCode >= 500 && r.StatusCode < 600):
-			body, _ := io.ReadAll(io.LimitReader(r.Body, maxErrorMessageLen*2))
+		case r.StatusCode == http.StatusTooManyRequests ||
+			r.StatusCode == http.StatusBadGateway ||
+			r.StatusCode == http.StatusServiceUnavailable ||
+			r.StatusCode == http.StatusGatewayTimeout:
+			// Drain up to MaxErrorBodyBytes so the connection can return to
+			// the keep-alive pool before the next retry. checkResponse only
+			// uses the first maxErrorMessageLen*2 bytes for the error message.
+			drained, _ := io.ReadAll(io.LimitReader(r.Body, MaxErrorBodyBytes))
 			_ = r.Body.Close()
-			lastErr = checkResponse(r, body)
+			bodyForErr := drained
+			if len(bodyForErr) > maxErrorMessageLen*2 {
+				bodyForErr = bodyForErr[:maxErrorMessageLen*2]
+			}
+			lastErr = checkResponse(r, bodyForErr)
 			if r.StatusCode == http.StatusTooManyRequests {
 				retryAfter = parseRetryAfter(r.Header.Get("Retry-After"))
 			}

--- a/go/pkg/basecamp/download.go
+++ b/go/pkg/basecamp/download.go
@@ -86,11 +86,13 @@ func (ac *AccountClient) DownloadURL(ctx context.Context, rawURL string) (result
 // hop, and either returns the 2xx body directly or follows a 3xx Location
 // through an unauthenticated second hop to a signed URL.
 //
-// The authenticated hop is wrapped in the SDK-standard GET retry loop:
-// network errors and 429/502/503/504 responses are retried up to MaxRetries
-// with exponential backoff, honoring Retry-After on 429. Other 5xx statuses
-// (500 and up) are surfaced without retry, matching Client.singleRequest's
-// @retryable markings. Retries stop once the response enters 2xx/3xx
+// The authenticated hop is wrapped in the SDK-standard GET retry loop.
+// Retry scope matches Client.singleRequest's @retryable set: network errors
+// and 429/502/503/504 responses are retried up to MaxRetries with exponential
+// backoff, honoring Retry-After on 429. Non-retried statuses (including 500)
+// are surfaced via the dispatch switch — 500 is mapped to a non-retryable
+// Error that mirrors singleRequest's ErrAPI(500, ...); other statuses go
+// through checkResponse. Retries stop once the response enters 2xx/3xx
 // dispatch — the body then belongs to the caller (2xx direct) or has
 // already been discarded in favor of the Location hop (3xx). Not sharing
 // doWithRetry because that path is tightly coupled to the JSON-response
@@ -207,9 +209,10 @@ func (c *Client) fetchAPIDownload(ctx context.Context, rawURL string) (*Download
 	}
 
 	if resp == nil {
-		// Exhaustion after real attempts is handled inside the loop (`return
-		// nil, lastErr`). The only path that reaches this fallback is a
-		// misconfigured MaxRetries<=0 that skips the loop entirely.
+		// Defense in depth: NewClient panics on MaxRetries<1, so this path
+		// is unreachable from normal construction. Direct-struct-built
+		// Clients with a zero MaxRetries would skip the loop entirely and
+		// land here.
 		return nil, ErrUsage(fmt.Sprintf("download aborted: MaxRetries (%d) must be >= 1", maxAttempts))
 	}
 
@@ -248,6 +251,14 @@ func (c *Client) fetchAPIDownload(ctx context.Context, rawURL string) (*Download
 	default:
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorMessageLen*2))
 		_ = resp.Body.Close()
+		// Align the Retryable flag with Client.singleRequest's classification
+		// for statuses outside the retry loop's set: 500 surfaces as non-
+		// retryable, mirroring ErrAPI(500, "Server error (500)"). checkResponse
+		// would otherwise mark all 5xx as Retryable=true, which contradicts
+		// the fact that this loop intentionally did not retry 500.
+		if resp.StatusCode == http.StatusInternalServerError {
+			return nil, ErrAPI(500, "Server error (500)")
+		}
 		return nil, checkResponse(resp, body)
 	}
 }

--- a/go/pkg/basecamp/download.go
+++ b/go/pkg/basecamp/download.go
@@ -123,10 +123,10 @@ func (c *Client) fetchAPIDownload(ctx context.Context, rawURL string) (*Download
 		},
 	}
 
+	// Iteration semantics mirror Client.doRequestURL: MaxRetries is the total
+	// attempt count, and a misconfigured MaxRetries<=0 yields zero attempts and
+	// an error (same "failed after N attempts" shape as the main GET loop).
 	maxAttempts := c.httpOpts.MaxRetries
-	if maxAttempts < 1 {
-		maxAttempts = 1
-	}
 
 	var resp *http.Response
 	var lastErr error
@@ -182,10 +182,17 @@ func (c *Client) fetchAPIDownload(ctx context.Context, rawURL string) (*Download
 		}
 	}
 
+	if resp == nil {
+		return nil, fmt.Errorf("download failed after %d attempts: %w", maxAttempts, lastErr)
+	}
+
 	switch {
 	case resp.StatusCode == 301 || resp.StatusCode == 302 || resp.StatusCode == 303 ||
 		resp.StatusCode == 307 || resp.StatusCode == 308:
 		location := resp.Header.Get("Location")
+		// Drain a bounded prefix of the body before close so the underlying
+		// connection can be returned to the keep-alive pool for hop 2.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
 		_ = resp.Body.Close()
 		if location == "" {
 			return nil, ErrAPI(resp.StatusCode, fmt.Sprintf("redirect %d with no Location header", resp.StatusCode))

--- a/go/pkg/basecamp/download.go
+++ b/go/pkg/basecamp/download.go
@@ -87,12 +87,14 @@ func (ac *AccountClient) DownloadURL(ctx context.Context, rawURL string) (result
 // through an unauthenticated second hop to a signed URL.
 //
 // The authenticated hop is wrapped in the SDK-standard GET retry loop:
-// network errors and 429/5xx responses are retried up to MaxRetries with
-// exponential backoff, honoring Retry-After on 429. Retries stop once the
-// response enters 2xx/3xx dispatch — the body then belongs to the caller
-// (2xx direct) or has already been discarded in favor of the Location hop
-// (3xx). Not sharing doWithRetry because that path is tightly coupled to
-// the JSON-response generated client; this loop owns raw *http.Response.
+// network errors and 429/502/503/504 responses are retried up to MaxRetries
+// with exponential backoff, honoring Retry-After on 429. Other 5xx statuses
+// (500 and up) are surfaced without retry, matching Client.singleRequest's
+// @retryable markings. Retries stop once the response enters 2xx/3xx
+// dispatch — the body then belongs to the caller (2xx direct) or has
+// already been discarded in favor of the Location hop (3xx). Not sharing
+// doWithRetry because that path is tightly coupled to the JSON-response
+// generated client; this loop owns raw *http.Response.
 //
 // Callers own operation-hook lifecycle and are responsible for closing the
 // returned Body. Filename is derived from rawURL; callers may override.
@@ -205,12 +207,10 @@ func (c *Client) fetchAPIDownload(ctx context.Context, rawURL string) (*Download
 	}
 
 	if resp == nil {
-		// maxAttempts <= 0 skips the loop entirely and leaves lastErr nil;
-		// surface that as a usage error rather than wrapping nil with %w.
-		if lastErr == nil {
-			return nil, ErrUsage(fmt.Sprintf("download aborted: MaxRetries (%d) must be >= 1", maxAttempts))
-		}
-		return nil, fmt.Errorf("download failed after %d attempts: %w", maxAttempts, lastErr)
+		// Exhaustion after real attempts is handled inside the loop (`return
+		// nil, lastErr`). The only path that reaches this fallback is a
+		// misconfigured MaxRetries<=0 that skips the loop entirely.
+		return nil, ErrUsage(fmt.Sprintf("download aborted: MaxRetries (%d) must be >= 1", maxAttempts))
 	}
 
 	switch {

--- a/go/pkg/basecamp/download.go
+++ b/go/pkg/basecamp/download.go
@@ -190,6 +190,11 @@ func (c *Client) fetchAPIDownload(ctx context.Context, rawURL string) (*Download
 	}
 
 	if resp == nil {
+		// maxAttempts <= 0 skips the loop entirely and leaves lastErr nil;
+		// surface that as a usage error rather than wrapping nil with %w.
+		if lastErr == nil {
+			return nil, ErrUsage(fmt.Sprintf("download aborted: MaxRetries (%d) must be >= 1", maxAttempts))
+		}
 		return nil, fmt.Errorf("download failed after %d attempts: %w", maxAttempts, lastErr)
 	}
 

--- a/go/pkg/basecamp/download.go
+++ b/go/pkg/basecamp/download.go
@@ -101,6 +101,13 @@ func (c *Client) fetchAPIDownload(ctx context.Context, rawURL string) (*Download
 	if err != nil {
 		return nil, ErrUsage("download URL must be a valid URL")
 	}
+	// Defense-in-depth: AccountClient.DownloadURL already validates user input,
+	// but UploadsService.Download passes upload.download_url straight from the
+	// API response. Reject relative or non-http(s) URLs here so a malformed
+	// field can't silently collapse to requesting the API base root.
+	if !parsed.IsAbs() || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return nil, ErrUsage("download URL must be an absolute http or https URL")
+	}
 
 	baseURL, baseErr := url.Parse(c.cfg.BaseURL)
 	if baseErr != nil {

--- a/go/pkg/basecamp/download.go
+++ b/go/pkg/basecamp/download.go
@@ -86,6 +86,14 @@ func (ac *AccountClient) DownloadURL(ctx context.Context, rawURL string) (result
 // hop, and either returns the 2xx body directly or follows a 3xx Location
 // through an unauthenticated second hop to a signed URL.
 //
+// The authenticated hop is wrapped in the SDK-standard GET retry loop:
+// network errors and 429/5xx responses are retried up to MaxRetries with
+// exponential backoff, honoring Retry-After on 429. Retries stop once the
+// response enters 2xx/3xx dispatch — the body then belongs to the caller
+// (2xx direct) or has already been discarded in favor of the Location hop
+// (3xx). Not sharing doWithRetry because that path is tightly coupled to
+// the JSON-response generated client; this loop owns raw *http.Response.
+//
 // Callers own operation-hook lifecycle and are responsible for closing the
 // returned Body. Filename is derived from rawURL; callers may override.
 func (c *Client) fetchAPIDownload(ctx context.Context, rawURL string) (*DownloadResult, error) {
@@ -107,16 +115,6 @@ func (c *Client) fetchAPIDownload(ctx context.Context, rawURL string) (*Download
 	}
 	rewrittenURL := rewritten.String()
 
-	// Hop 1: Authenticated API request (capture redirect)
-	req, err := http.NewRequestWithContext(ctx, "GET", rewrittenURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	if authErr := c.authStrategy.Authenticate(ctx, req); authErr != nil {
-		return nil, authErr
-	}
-	req.Header.Set("User-Agent", c.userAgent)
-
 	apiClient := &http.Client{
 		Transport: c.httpClient.Transport, // loggingTransport — fires hooks
 		Timeout:   0,                      // no client-level timeout — body may be streamed on direct 2xx
@@ -125,12 +123,63 @@ func (c *Client) fetchAPIDownload(ctx context.Context, rawURL string) (*Download
 		},
 	}
 
-	ctx = contextWithAttempt(ctx, 1)
-	req = req.WithContext(ctx)
+	maxAttempts := c.httpOpts.MaxRetries
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
 
-	resp, err := apiClient.Do(req) // #nosec G704 -- SDK HTTP client: URL is caller-configured
-	if err != nil {
-		return nil, ErrNetwork(err)
+	var resp *http.Response
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		attemptCtx := contextWithAttempt(ctx, attempt)
+
+		req, reqErr := http.NewRequestWithContext(attemptCtx, "GET", rewrittenURL, nil)
+		if reqErr != nil {
+			return nil, fmt.Errorf("failed to create request: %w", reqErr)
+		}
+		if authErr := c.authStrategy.Authenticate(attemptCtx, req); authErr != nil {
+			return nil, authErr
+		}
+		req.Header.Set("User-Agent", c.userAgent)
+
+		r, doErr := apiClient.Do(req) // #nosec G704 -- SDK HTTP client: URL is caller-configured
+
+		var retryAfter int
+		switch {
+		case doErr != nil:
+			lastErr = ErrNetwork(doErr)
+		case r.StatusCode == http.StatusTooManyRequests || (r.StatusCode >= 500 && r.StatusCode < 600):
+			body, _ := io.ReadAll(io.LimitReader(r.Body, maxErrorMessageLen*2))
+			_ = r.Body.Close()
+			lastErr = checkResponse(r, body)
+			if r.StatusCode == http.StatusTooManyRequests {
+				retryAfter = parseRetryAfter(r.Header.Get("Retry-After"))
+			}
+		default:
+			resp = r
+		}
+
+		if resp != nil {
+			break
+		}
+
+		if attempt >= maxAttempts {
+			return nil, lastErr
+		}
+
+		delay := c.backoffDelay(attempt)
+		if retryAfter > 0 {
+			delay = time.Duration(retryAfter) * time.Second
+		}
+		info := RequestInfo{Method: "GET", URL: rewrittenURL, Attempt: attempt}
+		c.hooks.OnRetry(ctx, info, attempt+1, lastErr)
+		c.logger.Debug("retrying download request", "attempt", attempt, "maxRetries", maxAttempts, "delay", delay, "error", lastErr)
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(delay):
+		}
 	}
 
 	switch {

--- a/go/pkg/basecamp/download.go
+++ b/go/pkg/basecamp/download.go
@@ -77,8 +77,24 @@ func (ac *AccountClient) DownloadURL(ctx context.Context, rawURL string) (result
 	ctx = ac.parent.hooks.OnOperationStart(ctx, op)
 	defer func() { ac.parent.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	// URL rewriting: replace scheme+host with cfg.BaseURL origin, preserve path+query
-	baseURL, baseErr := url.Parse(ac.parent.cfg.BaseURL)
+	return ac.parent.fetchAPIDownload(ctx, rawURL)
+}
+
+// fetchAPIDownload executes the authenticated-hop + optional 302-follow flow
+// used by both AccountClient.DownloadURL and UploadsService.Download. It
+// rewrites the URL's host to the configured API base, authenticates the first
+// hop, and either returns the 2xx body directly or follows a 3xx Location
+// through an unauthenticated second hop to a signed URL.
+//
+// Callers own operation-hook lifecycle and are responsible for closing the
+// returned Body. Filename is derived from rawURL; callers may override.
+func (c *Client) fetchAPIDownload(ctx context.Context, rawURL string) (*DownloadResult, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, ErrUsage("download URL must be a valid URL")
+	}
+
+	baseURL, baseErr := url.Parse(c.cfg.BaseURL)
 	if baseErr != nil {
 		return nil, fmt.Errorf("invalid base URL: %w", baseErr)
 	}
@@ -96,14 +112,14 @@ func (ac *AccountClient) DownloadURL(ctx context.Context, rawURL string) (result
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-	if authErr := ac.parent.authStrategy.Authenticate(ctx, req); authErr != nil {
+	if authErr := c.authStrategy.Authenticate(ctx, req); authErr != nil {
 		return nil, authErr
 	}
-	req.Header.Set("User-Agent", ac.parent.userAgent)
+	req.Header.Set("User-Agent", c.userAgent)
 
 	apiClient := &http.Client{
-		Transport: ac.parent.httpClient.Transport, // loggingTransport — fires hooks
-		Timeout:   0,                              // no client-level timeout — body may be streamed on direct 2xx
+		Transport: c.httpClient.Transport, // loggingTransport — fires hooks
+		Timeout:   0,                      // no client-level timeout — body may be streamed on direct 2xx
 		CheckRedirect: func(*http.Request, []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
@@ -117,21 +133,17 @@ func (ac *AccountClient) DownloadURL(ctx context.Context, rawURL string) (result
 		return nil, ErrNetwork(err)
 	}
 
-	// Dispatch on response status
 	switch {
 	case resp.StatusCode == 301 || resp.StatusCode == 302 || resp.StatusCode == 303 ||
 		resp.StatusCode == 307 || resp.StatusCode == 308:
-		// Redirect — extract Location, close body, proceed to hop 2
 		location := resp.Header.Get("Location")
 		_ = resp.Body.Close()
 		if location == "" {
 			return nil, ErrAPI(resp.StatusCode, fmt.Sprintf("redirect %d with no Location header", resp.StatusCode))
 		}
-		// Resolve relative Location against the rewritten API URL
 		resolvedLocation := resolveURL(rewrittenURL, location)
 
-		// Hop 2: fetch from signed URL
-		signedResp, signedErr := ac.parent.fetchSignedDownload(ctx, resolvedLocation) //nolint:bodyclose // body ownership transfers to caller via DownloadResult
+		signedResp, signedErr := c.fetchSignedDownload(ctx, resolvedLocation) //nolint:bodyclose // body ownership transfers to caller via DownloadResult
 		if signedErr != nil {
 			return nil, signedErr
 		}
@@ -143,7 +155,6 @@ func (ac *AccountClient) DownloadURL(ctx context.Context, rawURL string) (result
 		}, nil
 
 	case resp.StatusCode >= 200 && resp.StatusCode < 300:
-		// Direct download — no second hop
 		return &DownloadResult{
 			Body:          resp.Body,
 			ContentType:   resp.Header.Get("Content-Type"),

--- a/go/pkg/basecamp/download.go
+++ b/go/pkg/basecamp/download.go
@@ -168,15 +168,14 @@ func (c *Client) fetchAPIDownload(ctx context.Context, rawURL string) (*Download
 			r.StatusCode == http.StatusBadGateway ||
 			r.StatusCode == http.StatusServiceUnavailable ||
 			r.StatusCode == http.StatusGatewayTimeout:
-			// Drain up to MaxErrorBodyBytes so the connection can return to
-			// the keep-alive pool before the next retry. checkResponse only
-			// uses the first maxErrorMessageLen*2 bytes for the error message.
-			drained, _ := io.ReadAll(io.LimitReader(r.Body, MaxErrorBodyBytes))
+			// Read only the prefix checkResponse needs for the error message,
+			// then drain the remainder up to MaxErrorBodyBytes so the
+			// connection can return to the keep-alive pool before the next
+			// retry. Reading everything up front would allocate up to 1 MB
+			// per retry even though we only consume ~1 KB of it.
+			bodyForErr, _ := io.ReadAll(io.LimitReader(r.Body, int64(maxErrorMessageLen*2)))
+			_, _ = io.Copy(io.Discard, io.LimitReader(r.Body, MaxErrorBodyBytes))
 			_ = r.Body.Close()
-			bodyForErr := drained
-			if len(bodyForErr) > maxErrorMessageLen*2 {
-				bodyForErr = bodyForErr[:maxErrorMessageLen*2]
-			}
 			lastErr = checkResponse(r, bodyForErr)
 			if r.StatusCode == http.StatusTooManyRequests {
 				retryAfter = parseRetryAfter(r.Header.Get("Retry-After"))
@@ -220,9 +219,11 @@ func (c *Client) fetchAPIDownload(ctx context.Context, rawURL string) (*Download
 	case resp.StatusCode == 301 || resp.StatusCode == 302 || resp.StatusCode == 303 ||
 		resp.StatusCode == 307 || resp.StatusCode == 308:
 		location := resp.Header.Get("Location")
-		// Drain a bounded prefix of the body before close so the underlying
-		// connection can be returned to the keep-alive pool for hop 2.
-		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
+		// Drain the redirect body up to MaxErrorBodyBytes before close so the
+		// underlying connection can return to the keep-alive pool for hop 2.
+		// net/http requires reading to EOF for connection reuse; the cap
+		// guards against an adversarial server sending unbounded bytes.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, MaxErrorBodyBytes))
 		_ = resp.Body.Close()
 		if location == "" {
 			return nil, ErrAPI(resp.StatusCode, fmt.Sprintf("redirect %d with no Location header", resp.StatusCode))

--- a/go/pkg/basecamp/download_test.go
+++ b/go/pkg/basecamp/download_test.go
@@ -568,12 +568,13 @@ func TestDownloadURL_GateRejection(t *testing.T) {
 // --- UploadsService.Download regression: second leg assertions ---
 
 func TestDownload_SecondLegNoAuth(t *testing.T) {
-	var secondLegHit bool
-	var s3AuthHeader string
+	var secondLegHit atomic.Bool
+	var s3AuthHeader atomic.Value
+	s3AuthHeader.Store("")
 
 	s3Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		secondLegHit = true
-		s3AuthHeader = r.Header.Get("Authorization")
+		secondLegHit.Store(true)
+		s3AuthHeader.Store(r.Header.Get("Authorization"))
 		w.Header().Set("Content-Type", "image/png")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("pixels"))
@@ -614,21 +615,21 @@ func TestDownload_SecondLegNoAuth(t *testing.T) {
 	defer result.Body.Close()
 	io.Copy(io.Discard, result.Body)
 
-	if !secondLegHit {
+	if !secondLegHit.Load() {
 		t.Fatal("second leg (signed URL fetch) was never reached")
 	}
-	if s3AuthHeader != "" {
-		t.Errorf("expected no Authorization header on S3 request, got %q", s3AuthHeader)
+	if auth := s3AuthHeader.Load().(string); auth != "" {
+		t.Errorf("expected no Authorization header on S3 request, got %q", auth)
 	}
 }
 
 func TestDownload_SecondLegNoTimeout(t *testing.T) {
 	// Verify the bare client used for signed downloads has no client-level timeout.
 	// Use a fresh context.Background() so no preexisting deadline can confuse the check.
-	var secondLegHit bool
+	var secondLegHit atomic.Bool
 
 	s3Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		secondLegHit = true
+		secondLegHit.Store(true)
 		// Assert no deadline on the request context — proves Timeout: 0 on the bare client
 		if _, hasDeadline := r.Context().Deadline(); hasDeadline {
 			t.Error("expected no deadline on S3 request context (bare client should have Timeout: 0)")
@@ -674,7 +675,7 @@ func TestDownload_SecondLegNoTimeout(t *testing.T) {
 	defer result.Body.Close()
 	io.Copy(io.Discard, result.Body)
 
-	if !secondLegHit {
+	if !secondLegHit.Load() {
 		t.Fatal("second leg (signed URL fetch) was never reached — no-deadline assertion did not run")
 	}
 }

--- a/go/pkg/basecamp/download_test.go
+++ b/go/pkg/basecamp/download_test.go
@@ -568,9 +568,11 @@ func TestDownloadURL_GateRejection(t *testing.T) {
 // --- UploadsService.Download regression: second leg assertions ---
 
 func TestDownload_SecondLegNoAuth(t *testing.T) {
+	var secondLegHit bool
 	var s3AuthHeader string
 
 	s3Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		secondLegHit = true
 		s3AuthHeader = r.Header.Get("Authorization")
 		w.Header().Set("Content-Type", "image/png")
 		w.WriteHeader(http.StatusOK)
@@ -578,16 +580,29 @@ func TestDownload_SecondLegNoAuth(t *testing.T) {
 	}))
 	defer s3Server.Close()
 
-	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"id":           1069479400,
-			"title":        "logo.png",
-			"filename":     "logo.png",
-			"download_url": s3Server.URL + "/bucket/file.png",
+	mux := http.NewServeMux()
+	mux.HandleFunc("/12345/uploads/1069479400",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			apiHost := "http://" + r.Host
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":           1069479400,
+				"title":        "logo.png",
+				"filename":     "logo.png",
+				"download_url": apiHost + "/12345/buckets/137/uploads/1069479400/download/logo.png",
+			})
 		})
-	}))
+	mux.HandleFunc("/12345/buckets/137/uploads/1069479400/download/logo.png",
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") == "" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			w.Header().Set("Location", s3Server.URL+"/bucket/file.png")
+			w.WriteHeader(http.StatusFound)
+		})
+	apiServer := httptest.NewServer(mux)
 	defer apiServer.Close()
 
 	cfg := DefaultConfig()
@@ -603,6 +618,9 @@ func TestDownload_SecondLegNoAuth(t *testing.T) {
 	defer result.Body.Close()
 	io.Copy(io.Discard, result.Body)
 
+	if !secondLegHit {
+		t.Fatal("second leg (signed URL fetch) was never reached")
+	}
 	if s3AuthHeader != "" {
 		t.Errorf("expected no Authorization header on S3 request, got %q", s3AuthHeader)
 	}
@@ -611,7 +629,10 @@ func TestDownload_SecondLegNoAuth(t *testing.T) {
 func TestDownload_SecondLegNoTimeout(t *testing.T) {
 	// Verify the bare client used for signed downloads has no client-level timeout.
 	// Use a fresh context.Background() so no preexisting deadline can confuse the check.
+	var secondLegHit bool
+
 	s3Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		secondLegHit = true
 		// Assert no deadline on the request context — proves Timeout: 0 on the bare client
 		if _, hasDeadline := r.Context().Deadline(); hasDeadline {
 			t.Error("expected no deadline on S3 request context (bare client should have Timeout: 0)")
@@ -622,16 +643,29 @@ func TestDownload_SecondLegNoTimeout(t *testing.T) {
 	}))
 	defer s3Server.Close()
 
-	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"id":           1069479400,
-			"title":        "logo.png",
-			"filename":     "logo.png",
-			"download_url": s3Server.URL + "/bucket/file.png",
+	mux := http.NewServeMux()
+	mux.HandleFunc("/12345/uploads/1069479400",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			apiHost := "http://" + r.Host
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":           1069479400,
+				"title":        "logo.png",
+				"filename":     "logo.png",
+				"download_url": apiHost + "/12345/buckets/137/uploads/1069479400/download/logo.png",
+			})
 		})
-	}))
+	mux.HandleFunc("/12345/buckets/137/uploads/1069479400/download/logo.png",
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") == "" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			w.Header().Set("Location", s3Server.URL+"/bucket/file.png")
+			w.WriteHeader(http.StatusFound)
+		})
+	apiServer := httptest.NewServer(mux)
 	defer apiServer.Close()
 
 	cfg := DefaultConfig()
@@ -647,6 +681,10 @@ func TestDownload_SecondLegNoTimeout(t *testing.T) {
 	}
 	defer result.Body.Close()
 	io.Copy(io.Discard, result.Body)
+
+	if !secondLegHit {
+		t.Fatal("second leg (signed URL fetch) was never reached — no-deadline assertion did not run")
+	}
 }
 
 // --- test helpers ---

--- a/go/pkg/basecamp/download_test.go
+++ b/go/pkg/basecamp/download_test.go
@@ -721,9 +721,10 @@ func TestDownloadURL_AuthHopRetriesOn503(t *testing.T) {
 	if got := attempts.Load(); got != 3 {
 		t.Errorf("expected 3 attempts, got %d", got)
 	}
-	// Backoff between attempts: baseDelay then 2*baseDelay. Require at least 2*baseDelay total.
-	if elapsed < 2*baseDelay {
-		t.Errorf("expected elapsed >= %v, got %v", 2*baseDelay, elapsed)
+	// Backoff between attempts: baseDelay then 2*baseDelay. Require at least 3*baseDelay
+	// total so a regression that flattened the second delay back to baseDelay fails.
+	if elapsed < 3*baseDelay {
+		t.Errorf("expected elapsed >= %v, got %v", 3*baseDelay, elapsed)
 	}
 	body, _ := io.ReadAll(result.Body)
 	if string(body) != fileContent {

--- a/go/pkg/basecamp/download_test.go
+++ b/go/pkg/basecamp/download_test.go
@@ -319,8 +319,10 @@ func TestDownloadURL_RedirectNoLocation(t *testing.T) {
 // --- Error handling ---
 
 func TestDownloadURL_APIError(t *testing.T) {
-	// 5xx status codes exercise the retry loop (see TestDownloadURL_AuthHopRetriesOn503);
-	// this table covers the non-retryable error-mapping paths.
+	// 502/503/504 exercise the retry loop (see TestDownloadURL_AuthHopRetriesOn503);
+	// this table covers non-retryable error-mapping paths, including 500 which
+	// fetchAPIDownload intentionally does not retry (matches the @retryable set
+	// in Client.singleRequest).
 	tests := []struct {
 		name     string
 		status   int
@@ -328,11 +330,14 @@ func TestDownloadURL_APIError(t *testing.T) {
 	}{
 		{"not found", http.StatusNotFound, CodeNotFound},
 		{"forbidden", http.StatusForbidden, CodeForbidden},
+		{"server error", http.StatusInternalServerError, CodeAPI},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var requests atomic.Int32
 			apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requests.Add(1)
 				w.WriteHeader(tt.status)
 			}))
 			defer apiServer.Close()
@@ -354,6 +359,9 @@ func TestDownloadURL_APIError(t *testing.T) {
 			}
 			if sdkErr.Code != tt.wantCode {
 				t.Errorf("expected code %q, got %q", tt.wantCode, sdkErr.Code)
+			}
+			if got := requests.Load(); got != 1 {
+				t.Errorf("expected 1 request (non-retryable), got %d", got)
 			}
 		})
 	}

--- a/go/pkg/basecamp/download_test.go
+++ b/go/pkg/basecamp/download_test.go
@@ -2,7 +2,6 @@ package basecamp
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -320,6 +319,8 @@ func TestDownloadURL_RedirectNoLocation(t *testing.T) {
 // --- Error handling ---
 
 func TestDownloadURL_APIError(t *testing.T) {
+	// 5xx status codes exercise the retry loop (see TestDownloadURL_AuthHopRetriesOn503);
+	// this table covers the non-retryable error-mapping paths.
 	tests := []struct {
 		name     string
 		status   int
@@ -327,7 +328,6 @@ func TestDownloadURL_APIError(t *testing.T) {
 	}{
 		{"not found", http.StatusNotFound, CodeNotFound},
 		{"forbidden", http.StatusForbidden, CodeForbidden},
-		{"server error", http.StatusInternalServerError, CodeAPI},
 	}
 
 	for _, tt := range tests {
@@ -581,19 +581,17 @@ func TestDownload_SecondLegNoAuth(t *testing.T) {
 	defer s3Server.Close()
 
 	mux := http.NewServeMux()
+	apiServer := httptest.NewServer(mux)
+	defer apiServer.Close()
+
+	metadataBody, downloadPath := loadUploadFixture(t, apiServer.URL)
 	mux.HandleFunc("/12345/uploads/1069479400",
 		func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			apiHost := "http://" + r.Host
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"id":           1069479400,
-				"title":        "logo.png",
-				"filename":     "logo.png",
-				"download_url": apiHost + "/12345/buckets/137/uploads/1069479400/download/logo.png",
-			})
+			_, _ = w.Write(metadataBody)
 		})
-	mux.HandleFunc("/12345/buckets/137/uploads/1069479400/download/logo.png",
+	mux.HandleFunc(downloadPath,
 		func(w http.ResponseWriter, r *http.Request) {
 			if r.Header.Get("Authorization") == "" {
 				w.WriteHeader(http.StatusUnauthorized)
@@ -602,8 +600,6 @@ func TestDownload_SecondLegNoAuth(t *testing.T) {
 			w.Header().Set("Location", s3Server.URL+"/bucket/file.png")
 			w.WriteHeader(http.StatusFound)
 		})
-	apiServer := httptest.NewServer(mux)
-	defer apiServer.Close()
 
 	cfg := DefaultConfig()
 	cfg.BaseURL = apiServer.URL
@@ -644,19 +640,17 @@ func TestDownload_SecondLegNoTimeout(t *testing.T) {
 	defer s3Server.Close()
 
 	mux := http.NewServeMux()
+	apiServer := httptest.NewServer(mux)
+	defer apiServer.Close()
+
+	metadataBody, downloadPath := loadUploadFixture(t, apiServer.URL)
 	mux.HandleFunc("/12345/uploads/1069479400",
 		func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			apiHost := "http://" + r.Host
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"id":           1069479400,
-				"title":        "logo.png",
-				"filename":     "logo.png",
-				"download_url": apiHost + "/12345/buckets/137/uploads/1069479400/download/logo.png",
-			})
+			_, _ = w.Write(metadataBody)
 		})
-	mux.HandleFunc("/12345/buckets/137/uploads/1069479400/download/logo.png",
+	mux.HandleFunc(downloadPath,
 		func(w http.ResponseWriter, r *http.Request) {
 			if r.Header.Get("Authorization") == "" {
 				w.WriteHeader(http.StatusUnauthorized)
@@ -665,8 +659,6 @@ func TestDownload_SecondLegNoTimeout(t *testing.T) {
 			w.Header().Set("Location", s3Server.URL+"/bucket/file.png")
 			w.WriteHeader(http.StatusFound)
 		})
-	apiServer := httptest.NewServer(mux)
-	defer apiServer.Close()
 
 	cfg := DefaultConfig()
 	cfg.BaseURL = apiServer.URL
@@ -684,6 +676,208 @@ func TestDownload_SecondLegNoTimeout(t *testing.T) {
 
 	if !secondLegHit {
 		t.Fatal("second leg (signed URL fetch) was never reached — no-deadline assertion did not run")
+	}
+}
+
+// --- Auth-hop retry behavior ---
+
+func TestDownloadURL_AuthHopRetriesOn503(t *testing.T) {
+	fileContent := "retried-ok"
+	var attempts atomic.Int32
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if attempts.Add(1) < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte(`{"error":"try again"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/pdf")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(fileContent))
+	}))
+	defer apiServer.Close()
+
+	baseDelay := 30 * time.Millisecond
+	cfg := DefaultConfig()
+	cfg.BaseURL = apiServer.URL
+	token := &StaticTokenProvider{Token: "test-token"}
+	client := NewClient(cfg, token,
+		WithMaxRetries(3),
+		WithBaseDelay(baseDelay),
+		WithMaxJitter(time.Millisecond),
+	)
+	ac := client.ForAccount("12345")
+
+	start := time.Now()
+	result, err := ac.DownloadURL(context.Background(),
+		"https://storage.3.basecamp.com/999/blobs/abc/download/doc.pdf")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer result.Body.Close()
+
+	if got := attempts.Load(); got != 3 {
+		t.Errorf("expected 3 attempts, got %d", got)
+	}
+	// Backoff between attempts: baseDelay then 2*baseDelay. Require at least 2*baseDelay total.
+	if elapsed < 2*baseDelay {
+		t.Errorf("expected elapsed >= %v, got %v", 2*baseDelay, elapsed)
+	}
+	body, _ := io.ReadAll(result.Body)
+	if string(body) != fileContent {
+		t.Errorf("expected body %q, got %q", fileContent, string(body))
+	}
+}
+
+func TestDownloadURL_AuthHopRetriesOn429WithRetryAfter(t *testing.T) {
+	fileContent := "rate-limit-ok"
+	var attempts atomic.Int32
+
+	s3Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/pdf")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(fileContent))
+	}))
+	defer s3Server.Close()
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if attempts.Add(1) == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Location", s3Server.URL+"/bucket/file.pdf")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer apiServer.Close()
+
+	// Use a tiny BaseDelay so, if Retry-After is ignored, the test would finish
+	// well under 1s and surface the regression.
+	cfg := DefaultConfig()
+	cfg.BaseURL = apiServer.URL
+	token := &StaticTokenProvider{Token: "test-token"}
+	client := NewClient(cfg, token,
+		WithMaxRetries(3),
+		WithBaseDelay(10*time.Millisecond),
+		WithMaxJitter(time.Millisecond),
+		WithTransport(http.DefaultTransport),
+	)
+	ac := client.ForAccount("12345")
+
+	start := time.Now()
+	result, err := ac.DownloadURL(context.Background(),
+		"https://storage.3.basecamp.com/999/blobs/abc/download/doc.pdf")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer result.Body.Close()
+
+	if got := attempts.Load(); got != 2 {
+		t.Errorf("expected 2 attempts, got %d", got)
+	}
+	if elapsed < time.Second {
+		t.Errorf("expected elapsed >= 1s (Retry-After), got %v", elapsed)
+	}
+	body, _ := io.ReadAll(result.Body)
+	if string(body) != fileContent {
+		t.Errorf("expected body %q, got %q", fileContent, string(body))
+	}
+}
+
+// flakyRoundTripper fails the first N RoundTrips with a synthetic network error,
+// then delegates to inner. Used to prove network-error retry without relying on
+// OS-level connection-reset semantics (which Go's transport sometimes retries
+// on its own for idempotent requests).
+type flakyRoundTripper struct {
+	inner    http.RoundTripper
+	failures atomic.Int32
+	limit    int32
+}
+
+func (t *flakyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.failures.Add(1) <= t.limit {
+		return nil, errors.New("synthetic network failure")
+	}
+	return t.inner.RoundTrip(req)
+}
+
+func TestDownloadURL_AuthHopRetriesOnNetworkError(t *testing.T) {
+	fileContent := "net-ok"
+	var serverHits atomic.Int32
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serverHits.Add(1)
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(fileContent))
+	}))
+	defer apiServer.Close()
+
+	flaky := &flakyRoundTripper{inner: apiServer.Client().Transport, limit: 1}
+
+	cfg := DefaultConfig()
+	cfg.BaseURL = apiServer.URL
+	token := &StaticTokenProvider{Token: "test-token"}
+	client := NewClient(cfg, token,
+		WithTransport(flaky),
+		WithMaxRetries(3),
+		WithBaseDelay(10*time.Millisecond),
+		WithMaxJitter(time.Millisecond),
+	)
+	ac := client.ForAccount("12345")
+
+	result, err := ac.DownloadURL(context.Background(),
+		"https://storage.3.basecamp.com/999/blobs/abc/download/file.txt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer result.Body.Close()
+
+	if got := flaky.failures.Load(); got != 2 {
+		t.Errorf("expected 2 RoundTrip calls, got %d", got)
+	}
+	if got := serverHits.Load(); got != 1 {
+		t.Errorf("expected 1 successful request to reach the server, got %d", got)
+	}
+	body, _ := io.ReadAll(result.Body)
+	if string(body) != fileContent {
+		t.Errorf("expected body %q, got %q", fileContent, string(body))
+	}
+}
+
+func TestDownloadURL_AuthHopNoRetryOn404(t *testing.T) {
+	var attempts atomic.Int32
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer apiServer.Close()
+
+	cfg := DefaultConfig()
+	cfg.BaseURL = apiServer.URL
+	token := &StaticTokenProvider{Token: "test-token"}
+	client := NewClient(cfg, token,
+		WithMaxRetries(3),
+		WithBaseDelay(time.Millisecond),
+	)
+	ac := client.ForAccount("12345")
+
+	_, err := ac.DownloadURL(context.Background(),
+		"https://storage.3.basecamp.com/999/blobs/abc/download/file.txt")
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	var sdkErr *Error
+	if !isSDKError(err, &sdkErr) || sdkErr.Code != CodeNotFound {
+		t.Errorf("expected not_found error, got: %v", err)
+	}
+	if got := attempts.Load(); got != 1 {
+		t.Errorf("expected 1 attempt on 404, got %d", got)
 	}
 }
 

--- a/go/pkg/basecamp/http.go
+++ b/go/pkg/basecamp/http.go
@@ -21,8 +21,9 @@ type HTTPOptions struct {
 	// Timeout is the request timeout (default: 30s).
 	Timeout time.Duration
 
-	// MaxRetries is the maximum retry attempts for GET requests (default: 3).
-	// POST/PUT/DELETE requests only get 1 retry after successful token refresh.
+	// MaxRetries is the total attempt count for GET requests (default: 3,
+	// minimum 1 — NewClient panics on lower values). POST/PUT/DELETE requests
+	// make one attempt plus one retry after a successful token refresh.
 	MaxRetries int
 
 	// BaseDelay is the initial backoff delay (default: 1s).
@@ -57,7 +58,8 @@ func WithTimeout(d time.Duration) ClientOption {
 	}
 }
 
-// WithMaxRetries sets the maximum number of retry attempts for GET requests.
+// WithMaxRetries sets the total attempt count for GET requests.
+// Must be at least 1 (NewClient panics otherwise).
 func WithMaxRetries(n int) ClientOption {
 	return func(c *Client) {
 		c.httpOpts.MaxRetries = n

--- a/go/pkg/basecamp/test_helpers_test.go
+++ b/go/pkg/basecamp/test_helpers_test.go
@@ -5,8 +5,53 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
 )
+
+// loadUploadFixture parses spec/fixtures/uploads/get.json, substitutes the
+// scheme+host of its download_url with testHost, and returns the rewritten
+// metadata JSON body plus the path portion of the substituted download_url
+// (e.g. "/999999999/blobs/abcd1234/download/logo.png").
+//
+// Hand-rolled Download tests use this to stay aligned with the canonical
+// API response shape rather than inventing their own shape — the original
+// UploadsService.Download bug survived CI because its tests invented a
+// shape the server never returns.
+func loadUploadFixture(t *testing.T, testHost string) (metadataBody []byte, downloadPath string) {
+	t.Helper()
+	fixturePath := filepath.Join("..", "..", "..", "spec", "fixtures", "uploads", "get.json")
+	data, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("loadUploadFixture: read %s: %v", fixturePath, err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(data, &obj); err != nil {
+		t.Fatalf("loadUploadFixture: parse: %v", err)
+	}
+	rawURL, ok := obj["download_url"].(string)
+	if !ok {
+		t.Fatalf("loadUploadFixture: download_url missing or not a string")
+	}
+	orig, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("loadUploadFixture: parse download_url %q: %v", rawURL, err)
+	}
+	host, err := url.Parse(testHost)
+	if err != nil {
+		t.Fatalf("loadUploadFixture: parse testHost %q: %v", testHost, err)
+	}
+	orig.Scheme = host.Scheme
+	orig.Host = host.Host
+	obj["download_url"] = orig.String()
+	out, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("loadUploadFixture: marshal: %v", err)
+	}
+	return out, orig.Path
+}
 
 // unmarshalWithNumbers decodes JSON into a map preserving numbers as json.Number
 // which can be cleanly converted to int64 without float64 precision loss.

--- a/go/pkg/basecamp/vaults.go
+++ b/go/pkg/basecamp/vaults.go
@@ -1007,9 +1007,11 @@ type DownloadResult struct {
 // Download fetches the file content from an upload's download URL.
 // The caller is responsible for closing the returned Body.
 //
-// This method first fetches the upload metadata to get the download URL,
-// then fetches the file content from that URL. The download URL is a
-// signed S3 URL that doesn't require authentication headers.
+// This method first fetches the upload metadata to retrieve the download URL,
+// then fetches the file content. The API returns download_url as an
+// API-host URL that requires Bearer auth and 302-redirects to a signed
+// S3 URL, so the first hop is authenticated and the second hop fetches
+// the signed URL without auth.
 func (s *UploadsService) Download(ctx context.Context, uploadID int64) (result *DownloadResult, err error) {
 	op := OperationInfo{
 		Service: "Uploads", Operation: "Download",
@@ -1025,7 +1027,6 @@ func (s *UploadsService) Download(ctx context.Context, uploadID int64) (result *
 	ctx = s.client.parent.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.parent.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	// First, get the upload metadata to retrieve the download URL
 	upload, err := s.Get(ctx, uploadID)
 	if err != nil {
 		return nil, err
@@ -1036,18 +1037,15 @@ func (s *UploadsService) Download(ctx context.Context, uploadID int64) (result *
 		return nil, err
 	}
 
-	// Fetch the file content from the signed download URL (no auth headers, no timeout).
-	resp, err := s.client.parent.fetchSignedDownload(ctx, upload.DownloadURL) //nolint:bodyclose // body ownership transfers to caller via DownloadResult
+	result, err = s.client.parent.fetchAPIDownload(ctx, upload.DownloadURL)
 	if err != nil {
 		return nil, err
 	}
-
-	return &DownloadResult{
-		Body:          resp.Body,
-		ContentType:   resp.Header.Get("Content-Type"),
-		ContentLength: resp.ContentLength,
-		Filename:      upload.Filename,
-	}, nil
+	// Prefer the filename from upload metadata over URL-derived filename.
+	if upload.Filename != "" {
+		result.Filename = upload.Filename
+	}
+	return result, nil
 }
 
 // vaultFromGenerated converts a generated Vault to our clean Vault type.

--- a/go/pkg/basecamp/vaults_test.go
+++ b/go/pkg/basecamp/vaults_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -846,7 +847,7 @@ func TestUploadsService_Download_DirectBody(t *testing.T) {
 	// assertion proves the metadata-filename override is in effect on the
 	// direct-2xx branch.
 	fileContent := "png bytes"
-	var downloadHit bool
+	var downloadHit atomic.Bool
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/12345/uploads/1069479400",
@@ -867,7 +868,7 @@ func TestUploadsService_Download_DirectBody(t *testing.T) {
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}
-			downloadHit = true
+			downloadHit.Store(true)
 			w.Header().Set("Content-Type", "image/png")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(fileContent))
@@ -887,7 +888,7 @@ func TestUploadsService_Download_DirectBody(t *testing.T) {
 	}
 	defer result.Body.Close()
 
-	if !downloadHit {
+	if !downloadHit.Load() {
 		t.Fatal("download endpoint was never reached")
 	}
 	if result.ContentType != "image/png" {

--- a/go/pkg/basecamp/vaults_test.go
+++ b/go/pkg/basecamp/vaults_test.go
@@ -848,3 +848,68 @@ func TestUploadsService_Download_Success(t *testing.T) {
 		t.Errorf("expected body %q, got %q", fileContent, string(body))
 	}
 }
+
+func TestUploadsService_Download_DirectBody(t *testing.T) {
+	// URL path filename deliberately differs from metadata filename so the
+	// assertion proves the metadata-filename override is in effect on the
+	// direct-2xx branch.
+	fileContent := "png bytes"
+	var downloadHit bool
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/12345/uploads/1069479400",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			apiHost := "http://" + r.Host
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":           1069479400,
+				"title":        "logo.png",
+				"filename":     "logo.png",
+				"download_url": apiHost + "/12345/buckets/137/uploads/1069479400/download/logo.bin",
+			})
+		})
+	mux.HandleFunc("/12345/buckets/137/uploads/1069479400/download/logo.bin",
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") == "" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			downloadHit = true
+			w.Header().Set("Content-Type", "image/png")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(fileContent))
+		})
+	apiServer := httptest.NewServer(mux)
+	defer apiServer.Close()
+
+	cfg := DefaultConfig()
+	cfg.BaseURL = apiServer.URL
+	token := &StaticTokenProvider{Token: "test-token"}
+	client := NewClient(cfg, token, WithTransport(apiServer.Client().Transport))
+
+	ac := client.ForAccount("12345")
+	result, err := ac.Uploads().Download(context.Background(), 1069479400)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer result.Body.Close()
+
+	if !downloadHit {
+		t.Fatal("download endpoint was never reached")
+	}
+	if result.ContentType != "image/png" {
+		t.Errorf("expected Content-Type 'image/png', got %q", result.ContentType)
+	}
+	if result.Filename != "logo.png" {
+		t.Errorf("expected Filename 'logo.png' (from metadata), got %q", result.Filename)
+	}
+
+	body, err := io.ReadAll(result.Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+	if string(body) != fileContent {
+		t.Errorf("expected body %q, got %q", fileContent, string(body))
+	}
+}

--- a/go/pkg/basecamp/vaults_test.go
+++ b/go/pkg/basecamp/vaults_test.go
@@ -740,19 +740,17 @@ func TestUploadsService_Download_S3Error(t *testing.T) {
 	defer s3Server.Close()
 
 	mux := http.NewServeMux()
+	apiServer := httptest.NewServer(mux)
+	defer apiServer.Close()
+
+	metadataBody, downloadPath := loadUploadFixture(t, apiServer.URL)
 	mux.HandleFunc("/12345/uploads/1069479400",
 		func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			apiHost := "http://" + r.Host
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"id":           1069479400,
-				"title":        "logo.png",
-				"filename":     "logo.png",
-				"download_url": apiHost + "/12345/buckets/137/uploads/1069479400/download/logo.png",
-			})
+			_, _ = w.Write(metadataBody)
 		})
-	mux.HandleFunc("/12345/buckets/137/uploads/1069479400/download/logo.png",
+	mux.HandleFunc(downloadPath,
 		func(w http.ResponseWriter, r *http.Request) {
 			if r.Header.Get("Authorization") == "" {
 				w.WriteHeader(http.StatusUnauthorized)
@@ -761,8 +759,6 @@ func TestUploadsService_Download_S3Error(t *testing.T) {
 			w.Header().Set("Location", s3Server.URL+"/bucket/file.png")
 			w.WriteHeader(http.StatusFound)
 		})
-	apiServer := httptest.NewServer(mux)
-	defer apiServer.Close()
 
 	cfg := DefaultConfig()
 	cfg.BaseURL = apiServer.URL
@@ -796,19 +792,17 @@ func TestUploadsService_Download_Success(t *testing.T) {
 	defer s3Server.Close()
 
 	mux := http.NewServeMux()
+	apiServer := httptest.NewServer(mux)
+	defer apiServer.Close()
+
+	metadataBody, downloadPath := loadUploadFixture(t, apiServer.URL)
 	mux.HandleFunc("/12345/uploads/1069479400",
 		func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			apiHost := "http://" + r.Host
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"id":           1069479400,
-				"title":        "logo.png",
-				"filename":     "logo.png",
-				"download_url": apiHost + "/12345/buckets/137/uploads/1069479400/download/logo.png",
-			})
+			_, _ = w.Write(metadataBody)
 		})
-	mux.HandleFunc("/12345/buckets/137/uploads/1069479400/download/logo.png",
+	mux.HandleFunc(downloadPath,
 		func(w http.ResponseWriter, r *http.Request) {
 			if r.Header.Get("Authorization") == "" {
 				w.WriteHeader(http.StatusUnauthorized)
@@ -817,8 +811,6 @@ func TestUploadsService_Download_Success(t *testing.T) {
 			w.Header().Set("Location", s3Server.URL+"/bucket/file.png")
 			w.WriteHeader(http.StatusFound)
 		})
-	apiServer := httptest.NewServer(mux)
-	defer apiServer.Close()
 
 	cfg := DefaultConfig()
 	cfg.BaseURL = apiServer.URL

--- a/go/pkg/basecamp/vaults_test.go
+++ b/go/pkg/basecamp/vaults_test.go
@@ -733,22 +733,35 @@ func TestUploadsService_Download_MissingDownloadURL(t *testing.T) {
 }
 
 func TestUploadsService_Download_S3Error(t *testing.T) {
-	// Test that Download handles non-200 responses from S3
+	// Test that Download surfaces non-2xx responses from the signed S3 hop.
 	s3Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 	}))
 	defer s3Server.Close()
 
-	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"id":           1069479400,
-			"title":        "logo.png",
-			"filename":     "logo.png",
-			"download_url": s3Server.URL + "/bucket/file.png",
+	mux := http.NewServeMux()
+	mux.HandleFunc("/12345/uploads/1069479400",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			apiHost := "http://" + r.Host
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":           1069479400,
+				"title":        "logo.png",
+				"filename":     "logo.png",
+				"download_url": apiHost + "/12345/buckets/137/uploads/1069479400/download/logo.png",
+			})
 		})
-	}))
+	mux.HandleFunc("/12345/buckets/137/uploads/1069479400/download/logo.png",
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") == "" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			w.Header().Set("Location", s3Server.URL+"/bucket/file.png")
+			w.WriteHeader(http.StatusFound)
+		})
+	apiServer := httptest.NewServer(mux)
 	defer apiServer.Close()
 
 	cfg := DefaultConfig()
@@ -769,7 +782,9 @@ func TestUploadsService_Download_S3Error(t *testing.T) {
 }
 
 func TestUploadsService_Download_Success(t *testing.T) {
-	// Test successful download with proper header extraction
+	// Test successful download with proper header extraction.
+	// Matches real API shape: download_url is an API-host URL that 302s
+	// to a signed S3 URL.
 	fileContent := "test file content"
 
 	s3Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -780,16 +795,29 @@ func TestUploadsService_Download_Success(t *testing.T) {
 	}))
 	defer s3Server.Close()
 
-	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"id":           1069479400,
-			"title":        "logo.png",
-			"filename":     "logo.png",
-			"download_url": s3Server.URL + "/bucket/file.png",
+	mux := http.NewServeMux()
+	mux.HandleFunc("/12345/uploads/1069479400",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			apiHost := "http://" + r.Host
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":           1069479400,
+				"title":        "logo.png",
+				"filename":     "logo.png",
+				"download_url": apiHost + "/12345/buckets/137/uploads/1069479400/download/logo.png",
+			})
 		})
-	}))
+	mux.HandleFunc("/12345/buckets/137/uploads/1069479400/download/logo.png",
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") == "" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			w.Header().Set("Location", s3Server.URL+"/bucket/file.png")
+			w.WriteHeader(http.StatusFound)
+		})
+	apiServer := httptest.NewServer(mux)
 	defer apiServer.Close()
 
 	cfg := DefaultConfig()

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
@@ -15,6 +15,15 @@ import java.util.concurrent.atomic.AtomicInteger
 /** Default account ID for conformance tests. */
 private const val TEST_ACCOUNT_ID = "999"
 
+/** Tests where the Kotlin runner's operation dispatcher has no implementation yet. */
+private val KOTLIN_SKIPS: Map<String, String> = mapOf(
+    "DownloadURL auth'd first hop 302s to signed URL" to "Kotlin runner does not yet dispatch DownloadURL (tracked as follow-up)",
+    "DownloadURL direct 2xx body" to "Kotlin runner does not yet dispatch DownloadURL (tracked as follow-up)",
+    "DownloadURL retries on 503 at the auth'd first hop" to "Kotlin runner does not yet dispatch DownloadURL (tracked as follow-up)",
+    "DownloadURL honors Retry-After on 429 at the auth'd first hop" to "Kotlin runner does not yet dispatch DownloadURL (tracked as follow-up)",
+    "DownloadURL surfaces redirect with no Location" to "Kotlin runner does not yet dispatch DownloadURL (tracked as follow-up)",
+)
+
 fun main() {
     val testsDir = File("../conformance/tests")
 
@@ -42,6 +51,13 @@ fun main() {
                 skipped++
                 println("  SKIP: ${tc.name}")
                 println("        Kotlin SDK auto-paginates (follows Link headers by design)")
+                continue
+            }
+            val skipReason = KOTLIN_SKIPS[tc.name]
+            if (skipReason != null) {
+                skipped++
+                println("  SKIP: ${tc.name}")
+                println("        $skipReason")
                 continue
             }
             // Note: MissingFieldException from kotlinx.serialization (when mock


### PR DESCRIPTION
## Problem

Every call to `UploadsService.Download` returned 401. SDK users couldn't
download any uploaded file.

ref: https://app.basecamp.com/2914079/buckets/27/card_tables/cards/9812641548

## Solution

Authenticate the download URL. `upload.download_url` is an authenticated
endpoint (requires Bearer auth, 302-redirects to a signed URL), not a
pre-signed URL as the old code assumed.

## Why this fix

`AccountClient.DownloadURL` already implemented the correct flow for
authenticated storage URLs and continued to work in production. Extracting
that logic into a shared `Client.fetchAPIDownload` helper and routing
`UploadsService.Download` through it reuses proven code and keeps the two
methods in sync.

## In-PR scope additions (review cycle)

- **Retry the auth'd hop.** `fetchAPIDownload` now retries on network
  errors and 429/502/503/504 (matching `Client.singleRequest`'s
  `@retryable` set), with exponential backoff and `Retry-After` on 429.
  500 is surfaced non-retryable, mirroring `singleRequest`.
- **Keep-alive drains.** Redirect and retry paths drain bodies up to
  `MaxErrorBodyBytes` before `Close()` so connections can return to the
  keep-alive pool.
- **URL validation inside the helper.** `fetchAPIDownload` now rejects
  non-absolute / non-http(s) URLs itself, so `UploadsService.Download`
  is guarded against malformed `download_url` values from API responses
  in addition to the existing `AccountClient.DownloadURL` check.
- **Fixture-driven download tests.** `loadUploadFixture` seeds
  hand-rolled tests from `spec/fixtures/uploads/get.json` so the API
  response shape can't silently drift from what the server actually
  returns — the failure mode that let the original bug ship.
- **Download conformance suite.** New `conformance/tests/downloads.json`
  codifies the 2-hop invariant (auth'd first hop, unauthenticated signed
  hop, retry shape) cross-SDK. Go runner is wired; Ruby/Python/TS/Kotlin
  runners skip these cases with a follow-up note. The suite asserts
  `Authorization` present on hop 1 **and absent on hop 2** — catches the
  exact regression pattern this PR fixes.

## Potentially breaking

- **`NewClient` now panics on `MaxRetries < 1`** (previously `< 0`). Zero
  was already broken before this PR: `doRequestURL` ran zero iterations
  and returned a malformed `%!w(<nil>)` error; `fetchAPIDownload` hit
  its `ErrUsage` fallback. The panic surfaces the misconfiguration at
  construction instead of hiding it. No known caller sets 0.

## Additional info

Manually verified against live Basecamp:

- SaaS production: byte-identical 1 MB PDF download across three CLI modes.
- Local bc3 dev: direct-2xx branch works end-to-end (bc3 `send_file`
  returns 200 in one hop).
