### PR TITLE
fix(todos): use completed=true for completed filters

### DIFF
--- a/go/pkg/basecamp/todos.go
+++ b/go/pkg/basecamp/todos.go
@@ -98,10 +98,6 @@ type TodoListOptions struct {
 	// Status filters by recording lifecycle: "archived" or "trashed".
 	// Omit for the API default — incomplete todos with status inherited
 	// from the parent list.
-	//
-	// For backward compatibility, "completed" and "pending" are also
-	// accepted as shortcuts: "completed" is translated to Completed=true,
-	// "pending" is translated to the API default.
 	Status string
 
 	// Completed, when true, returns only completed todos.
@@ -201,17 +197,8 @@ func (s *TodosService) List(ctx context.Context, todolistID int64, opts *TodoLis
 	// upstream: Status filters by recording lifecycle (archived/trashed),
 	// Completed=true narrows to completed todos, and they may be combined.
 	var params *generated.ListTodosParams
-	if opts != nil {
-		status, completed := opts.Status, opts.Completed
-		switch status {
-		case "completed":
-			status, completed = "", true
-		case "pending":
-			status = ""
-		}
-		if status != "" || completed {
-			params = &generated.ListTodosParams{Status: status, Completed: completed}
-		}
+	if opts != nil && (opts.Status != "" || opts.Completed) {
+		params = &generated.ListTodosParams{Status: opts.Status, Completed: opts.Completed}
 	}
 
 	// Call generated client for first page (spec-conformant - no manual path construction)

--- a/go/pkg/basecamp/todos.go
+++ b/go/pkg/basecamp/todos.go
@@ -95,14 +95,19 @@ type Bucket struct {
 
 // TodoListOptions specifies options for listing todos.
 type TodoListOptions struct {
-	// Status filters todos by lifecycle status or by legacy completion shortcuts.
+	// Status filters by recording lifecycle: "archived" or "trashed".
+	// Omit for the API default — incomplete todos with status inherited
+	// from the parent list.
 	//
-	// Supported values:
-	//   - "completed": completed todos (sent as completed=true)
-	//   - "pending": active, incomplete todos (default API behavior)
-	//   - "active", "archived", "trashed": recording status filters
-	//   - "": default API behavior (active, incomplete todos)
+	// For backward compatibility, "completed" and "pending" are also
+	// accepted as shortcuts: "completed" is translated to Completed=true,
+	// "pending" is translated to the API default.
 	Status string
+
+	// Completed, when true, returns only completed todos.
+	// May be combined with Status (e.g. Status="archived", Completed=true
+	// to list archived completed todos).
+	Completed bool
 
 	// Limit is the maximum number of todos to return.
 	// If 0, uses DefaultTodoLimit (100). Use -1 for unlimited.
@@ -192,19 +197,20 @@ func (s *TodosService) List(ctx context.Context, todolistID int64, opts *TodoLis
 	ctx = s.client.parent.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.parent.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	// Build params for generated client.
-	// The API uses completed=true for completion filtering and reserves status
-	// for recording lifecycle state (active/archived/trashed).
+	// Build params for generated client. Status and Completed are orthogonal
+	// upstream: Status filters by recording lifecycle (archived/trashed),
+	// Completed=true narrows to completed todos, and they may be combined.
 	var params *generated.ListTodosParams
-	if opts != nil && opts.Status != "" {
-		switch opts.Status {
+	if opts != nil {
+		status, completed := opts.Status, opts.Completed
+		switch status {
 		case "completed":
-			params = &generated.ListTodosParams{Completed: true}
+			status, completed = "", true
 		case "pending":
-			// Default API behavior already returns active, incomplete todos.
-			params = nil
-		default:
-			params = &generated.ListTodosParams{Status: opts.Status}
+			status = ""
+		}
+		if status != "" || completed {
+			params = &generated.ListTodosParams{Status: status, Completed: completed}
 		}
 	}
 

--- a/go/pkg/basecamp/todos.go
+++ b/go/pkg/basecamp/todos.go
@@ -95,9 +95,13 @@ type Bucket struct {
 
 // TodoListOptions specifies options for listing todos.
 type TodoListOptions struct {
-	// Status filters by completion status.
-	// "completed" returns completed todos, "pending" returns pending todos.
-	// Empty returns all todos.
+	// Status filters todos by lifecycle status or by legacy completion shortcuts.
+	//
+	// Supported values:
+	//   - "completed": completed todos (sent as completed=true)
+	//   - "pending": active, incomplete todos (default API behavior)
+	//   - "active", "archived", "trashed": recording status filters
+	//   - "": default API behavior (active, incomplete todos)
 	Status string
 
 	// Limit is the maximum number of todos to return.
@@ -188,10 +192,20 @@ func (s *TodosService) List(ctx context.Context, todolistID int64, opts *TodoLis
 	ctx = s.client.parent.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.parent.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	// Build params for generated client
+	// Build params for generated client.
+	// The API uses completed=true for completion filtering and reserves status
+	// for recording lifecycle state (active/archived/trashed).
 	var params *generated.ListTodosParams
 	if opts != nil && opts.Status != "" {
-		params = &generated.ListTodosParams{Status: opts.Status}
+		switch opts.Status {
+		case "completed":
+			params = &generated.ListTodosParams{Completed: true}
+		case "pending":
+			// Default API behavior already returns active, incomplete todos.
+			params = nil
+		default:
+			params = &generated.ListTodosParams{Status: opts.Status}
+		}
 	}
 
 	// Call generated client for first page (spec-conformant - no manual path construction)

--- a/go/pkg/basecamp/todos.go
+++ b/go/pkg/basecamp/todos.go
@@ -97,7 +97,10 @@ type Bucket struct {
 type TodoListOptions struct {
 	// Status filters by recording lifecycle: "archived" or "trashed".
 	// Omit for the API default — incomplete todos with status inherited
-	// from the parent list.
+	// from the parent list. Unsupported values are rejected at the wrapper
+	// boundary (the BC3 server silently coerces them to nil, so we fail
+	// fast to surface bugs instead of returning unexpectedly-default
+	// results).
 	Status string
 
 	// Completed, when true, returns only completed todos.
@@ -192,6 +195,11 @@ func (s *TodosService) List(ctx context.Context, todolistID int64, opts *TodoLis
 	start := time.Now()
 	ctx = s.client.parent.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.parent.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
+
+	if opts != nil && opts.Status != "" && opts.Status != "archived" && opts.Status != "trashed" {
+		err = ErrUsage(fmt.Sprintf("todo list status must be empty, %q, or %q (got %q)", "archived", "trashed", opts.Status))
+		return nil, err
+	}
 
 	// Build params for generated client. Status and Completed are orthogonal
 	// upstream: Status filters by recording lifecycle (archived/trashed),

--- a/go/pkg/basecamp/todos_test.go
+++ b/go/pkg/basecamp/todos_test.go
@@ -493,19 +493,27 @@ func TestTodoListOptions_Defaults(t *testing.T) {
 
 func TestTodoListOptions_StatusFilter(t *testing.T) {
 	tests := []struct {
-		name   string
-		status string
+		name      string
+		status    string
+		completed bool
 	}{
-		{"completed", "completed"},
-		{"pending", "pending"},
-		{"empty", ""},
+		{name: "completed shortcut", status: "completed"},
+		{name: "pending shortcut", status: "pending"},
+		{name: "archived", status: "archived"},
+		{name: "trashed", status: "trashed"},
+		{name: "completed bool", completed: true},
+		{name: "archived + completed", status: "archived", completed: true},
+		{name: "empty", status: ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			opts := &TodoListOptions{Status: tt.status}
+			opts := &TodoListOptions{Status: tt.status, Completed: tt.completed}
 			if opts.Status != tt.status {
 				t.Errorf("expected status %q, got %q", tt.status, opts.Status)
+			}
+			if opts.Completed != tt.completed {
+				t.Errorf("expected completed %t, got %t", tt.completed, opts.Completed)
 			}
 		})
 	}
@@ -962,11 +970,13 @@ func TestTodosService_List_QueryParameters(t *testing.T) {
 		wantCompleted string
 	}{
 		{name: "nil options", opts: nil},
-		{name: "completed shortcut", opts: &TodoListOptions{Status: "completed"}, wantCompleted: "true"},
-		{name: "pending shortcut", opts: &TodoListOptions{Status: "pending"}},
+		{name: "completed bool", opts: &TodoListOptions{Completed: true}, wantCompleted: "true"},
 		{name: "archived status", opts: &TodoListOptions{Status: "archived"}, wantStatus: "archived"},
 		{name: "trashed status", opts: &TodoListOptions{Status: "trashed"}, wantStatus: "trashed"},
-		{name: "active status", opts: &TodoListOptions{Status: "active"}, wantStatus: "active"},
+		{name: "archived + completed", opts: &TodoListOptions{Status: "archived", Completed: true}, wantStatus: "archived", wantCompleted: "true"},
+		{name: "trashed + completed", opts: &TodoListOptions{Status: "trashed", Completed: true}, wantStatus: "trashed", wantCompleted: "true"},
+		{name: "completed shortcut", opts: &TodoListOptions{Status: "completed"}, wantCompleted: "true"},
+		{name: "pending shortcut", opts: &TodoListOptions{Status: "pending"}},
 	}
 
 	for _, tt := range tests {

--- a/go/pkg/basecamp/todos_test.go
+++ b/go/pkg/basecamp/todos_test.go
@@ -3,6 +3,7 @@ package basecamp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -1009,6 +1010,26 @@ func TestTodosService_List_QueryParameters(t *testing.T) {
 				}
 			} else if got := gotQuery.Get("completed"); got != tt.wantCompleted {
 				t.Fatalf("completed query = %q, want %q", got, tt.wantCompleted)
+			}
+		})
+	}
+}
+
+func TestTodosService_List_RejectsInvalidStatus(t *testing.T) {
+	// Server must never be reached — validation happens before the request.
+	svc := testTodosServer(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("handler should not be called for invalid status; got %s %s", r.Method, r.URL.Path)
+	})
+
+	for _, status := range []string{"completed", "pending", "active", "something-else"} {
+		t.Run(status, func(t *testing.T) {
+			_, err := svc.List(context.Background(), 1069479519, &TodoListOptions{Status: status})
+			if err == nil {
+				t.Fatalf("expected usage error for Status=%q, got nil", status)
+			}
+			apiErr, ok := errors.AsType[*Error](err)
+			if !ok || apiErr.Code != CodeUsage {
+				t.Fatalf("expected CodeUsage for Status=%q, got %T %v", status, err, err)
 			}
 		})
 	}

--- a/go/pkg/basecamp/todos_test.go
+++ b/go/pkg/basecamp/todos_test.go
@@ -990,10 +990,18 @@ func TestTodosService_List_QueryParameters(t *testing.T) {
 			if len(result.Todos) != 2 {
 				t.Fatalf("expected 2 todos, got %d", len(result.Todos))
 			}
-			if got := gotQuery.Get("status"); got != tt.wantStatus {
+			if tt.wantStatus == "" {
+				if gotQuery.Has("status") {
+					t.Fatalf("expected status to be absent, got %q", gotQuery.Get("status"))
+				}
+			} else if got := gotQuery.Get("status"); got != tt.wantStatus {
 				t.Fatalf("status query = %q, want %q", got, tt.wantStatus)
 			}
-			if got := gotQuery.Get("completed"); got != tt.wantCompleted {
+			if tt.wantCompleted == "" {
+				if gotQuery.Has("completed") {
+					t.Fatalf("expected completed to be absent, got %q", gotQuery.Get("completed"))
+				}
+			} else if got := gotQuery.Get("completed"); got != tt.wantCompleted {
 				t.Fatalf("completed query = %q, want %q", got, tt.wantCompleted)
 			}
 		})

--- a/go/pkg/basecamp/todos_test.go
+++ b/go/pkg/basecamp/todos_test.go
@@ -497,8 +497,6 @@ func TestTodoListOptions_StatusFilter(t *testing.T) {
 		status    string
 		completed bool
 	}{
-		{name: "completed shortcut", status: "completed"},
-		{name: "pending shortcut", status: "pending"},
 		{name: "archived", status: "archived"},
 		{name: "trashed", status: "trashed"},
 		{name: "completed bool", completed: true},
@@ -975,8 +973,6 @@ func TestTodosService_List_QueryParameters(t *testing.T) {
 		{name: "trashed status", opts: &TodoListOptions{Status: "trashed"}, wantStatus: "trashed"},
 		{name: "archived + completed", opts: &TodoListOptions{Status: "archived", Completed: true}, wantStatus: "archived", wantCompleted: "true"},
 		{name: "trashed + completed", opts: &TodoListOptions{Status: "trashed", Completed: true}, wantStatus: "trashed", wantCompleted: "true"},
-		{name: "completed shortcut", opts: &TodoListOptions{Status: "completed"}, wantCompleted: "true"},
-		{name: "pending shortcut", opts: &TodoListOptions{Status: "pending"}},
 	}
 
 	for _, tt := range tests {

--- a/go/pkg/basecamp/todos_test.go
+++ b/go/pkg/basecamp/todos_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -949,6 +950,54 @@ func testTodosServer(t *testing.T, handler http.HandlerFunc) *TodosService {
 	client := NewClient(cfg, token)
 	account := client.ForAccount("99999")
 	return account.Todos()
+}
+
+func TestTodosService_List_QueryParameters(t *testing.T) {
+	fixture := loadTodosFixture(t, "list.json")
+
+	tests := []struct {
+		name          string
+		opts          *TodoListOptions
+		wantStatus    string
+		wantCompleted string
+	}{
+		{name: "nil options", opts: nil},
+		{name: "completed shortcut", opts: &TodoListOptions{Status: "completed"}, wantCompleted: "true"},
+		{name: "pending shortcut", opts: &TodoListOptions{Status: "pending"}},
+		{name: "archived status", opts: &TodoListOptions{Status: "archived"}, wantStatus: "archived"},
+		{name: "trashed status", opts: &TodoListOptions{Status: "trashed"}, wantStatus: "trashed"},
+		{name: "active status", opts: &TodoListOptions{Status: "active"}, wantStatus: "active"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotQuery url.Values
+			svc := testTodosServer(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != "GET" {
+					t.Errorf("expected GET, got %s", r.Method)
+				}
+				gotQuery = r.URL.Query()
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-Total-Count", "2")
+				w.WriteHeader(200)
+				_, _ = w.Write(fixture)
+			})
+
+			result, err := svc.List(context.Background(), 1069479519, tt.opts)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(result.Todos) != 2 {
+				t.Fatalf("expected 2 todos, got %d", len(result.Todos))
+			}
+			if got := gotQuery.Get("status"); got != tt.wantStatus {
+				t.Fatalf("status query = %q, want %q", got, tt.wantStatus)
+			}
+			if got := gotQuery.Get("completed"); got != tt.wantCompleted {
+				t.Fatalf("completed query = %q, want %q", got, tt.wantCompleted)
+			}
+		})
+	}
 }
 
 func TestTodosService_Update(t *testing.T) {


### PR DESCRIPTION
## Summary
- fix the Go `TodosService.List` wrapper so `Status: "completed"` sends `completed=true`
- preserve `Status: "pending"` as the API default instead of sending `status=pending`
- add a red/green request-level test that locks the query mapping down

## Problem
`basecamp-cli` issue [#445](https://github.com/basecamp/basecamp-cli/issues/445) reported that completed to-do filtering returned zero results.

The API behavior is correct:
- `completed=true` filters to completed to-dos
- `status` is for recording lifecycle (`active|archived|trashed`)

The generated Go client already models those as separate query params. The bug lived in the handwritten Go SDK wrapper, which treated `TodoListOptions.Status` as a completion filter and forwarded values like `completed` and `pending` through `status=...`.

That produced requests like `?status=completed`, which the API ignores.

## Why this PR is focused
This only fixes the Go SDK wrapper/query mapping that caused the bad request shape.

It does **not** broaden the SDK surface area or change CLI behavior directly. That keeps the review scoped to the bug reported in #445 and leaves any follow-up API/CLI ergonomics changes for separate PRs.

## Testing
- added a failing-then-passing wrapper test for todo list query params
- `make check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose a Completed filter for todos and send completed=true when set; restrict Status to lifecycle (archived|trashed) and reject unsupported values so both filters can be combined reliably. Fixes completed filtering returning 0 results.

- **Bug Fixes**
  - Send completed=true when Completed is true; pass through Status="archived"|"trashed" and allow combinations.
  - Omit status for defaults (incomplete todos with inherited status); stop sending status=pending.
  - Reject unsupported Status values (e.g., "completed", "pending", "active") with a usage error; add request-level tests for query params and invalid statuses; fixes `basecamp-cli` issue #445.

- **Migration**
  - Breaking (pre-1.0): `TodoListOptions.Status` now only accepts "archived" or "trashed" (no "completed", "pending", or "active").
  - Migrate: `Status: "completed"` → `Completed: true`; `Status: "pending"` → omit `Status`.

<sup>Written for commit 4c4286acf66a6824eca9804f3568c824d98b1af6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

