### PR TITLE
uploads.download(id) — parity across Ruby/Python/TypeScript/Swift

### DIFF
--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -523,6 +523,18 @@ func executeOperation(ctx context.Context, account *basecamp.AccountClient, tc T
 		}
 		return operationResult{err: nil}
 
+	case "UploadsDownload":
+		uploadID := getInt64Param(tc.PathParams, "uploadId")
+		result, err := account.Uploads().Download(ctx, uploadID)
+		if err != nil {
+			return operationResult{err: err}
+		}
+		defer result.Body.Close()
+		if _, copyErr := io.Copy(io.Discard, result.Body); copyErr != nil {
+			return operationResult{err: copyErr}
+		}
+		return operationResult{err: nil}
+
 	default:
 		return operationResult{
 			err: fmt.Errorf("unknown operation: %s", tc.Operation),

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -113,6 +113,8 @@ class OperationMapper:
                 return self._account.tools.clone(source_recording_id=body["source_recording_id"], title=body["title"])
             case "EnableTool":
                 return self._account.tools.enable(tool_id=path_params["toolId"])
+            case "UploadsDownload":
+                return self._account.uploads.download(upload_id=path_params["uploadId"])
             case _:
                 raise ValueError(f"Unknown operation: {operation}")
 
@@ -371,6 +373,7 @@ def _get_error_field(error: Exception, field_path: str) -> Any:
 
 class ConformanceRunner:
     _DOWNLOAD_SKIP = "Python runner does not yet dispatch DownloadURL (tracked as follow-up)"
+    _MULTIHOP_SKIP = "Python runner's respx stub matches a single path; multi-hop download fixtures need per-hop stub wiring (tracked as follow-up with DownloadURL)"
     SKIPS: set[str] = {
         "maxItems caps results across pages",
         "DownloadURL auth'd first hop 302s to signed URL",
@@ -378,6 +381,7 @@ class ConformanceRunner:
         "DownloadURL retries on 503 at the auth'd first hop",
         "DownloadURL honors Retry-After on 429 at the auth'd first hop",
         "DownloadURL surfaces redirect with no Location",
+        "UploadsDownload delegates through DownloadURL primitive",
     }
     SKIP_REASONS: dict[str, str] = {
         "maxItems caps results across pages": "Python SDK list methods don't expose a public max_items parameter",
@@ -386,6 +390,7 @@ class ConformanceRunner:
         "DownloadURL retries on 503 at the auth'd first hop": _DOWNLOAD_SKIP,
         "DownloadURL honors Retry-After on 429 at the auth'd first hop": _DOWNLOAD_SKIP,
         "DownloadURL surfaces redirect with no Location": _DOWNLOAD_SKIP,
+        "UploadsDownload delegates through DownloadURL primitive": _MULTIHOP_SKIP,
     }
 
     def __init__(self, tests_dir: str):

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -144,6 +144,8 @@ class OperationMapper
       @account.tools.enable(
         tool_id: path_params["toolId"]
       )
+    when "UploadsDownload"
+      @account.uploads.download(upload_id: path_params["uploadId"])
     else
       raise "Unknown operation: #{operation}"
     end
@@ -173,9 +175,11 @@ RUBY_SKIPS = Set.new([
   "DownloadURL retries on 503 at the auth'd first hop",
   "DownloadURL honors Retry-After on 429 at the auth'd first hop",
   "DownloadURL surfaces redirect with no Location",
+  "UploadsDownload delegates through DownloadURL primitive",
 ].freeze)
 
 DOWNLOAD_SKIP = "Ruby runner does not yet dispatch DownloadURL (tracked as follow-up)".freeze
+MULTIHOP_SKIP = "Ruby runner's WebMock stub matches a single path; multi-hop download fixtures need per-hop stub wiring (tracked as follow-up with DownloadURL)".freeze
 RUBY_SKIP_REASONS = {
   "PUT operation is naturally idempotent" => "Ruby SDK only retries GET",
   "DELETE operation is naturally idempotent" => "Ruby SDK only retries GET",
@@ -188,6 +192,7 @@ RUBY_SKIP_REASONS = {
   "DownloadURL retries on 503 at the auth'd first hop" => DOWNLOAD_SKIP,
   "DownloadURL honors Retry-After on 429 at the auth'd first hop" => DOWNLOAD_SKIP,
   "DownloadURL surfaces redirect with no Location" => DOWNLOAD_SKIP,
+  "UploadsDownload delegates through DownloadURL primitive" => MULTIHOP_SKIP,
 }.freeze
 
 # Single test case

--- a/conformance/runner/typescript/runner.test.ts
+++ b/conformance/runner/typescript/runner.test.ts
@@ -81,6 +81,8 @@ const TS_SDK_SKIPS: Record<string, string> = {
     "TS runner does not yet dispatch DownloadURL (tracked as follow-up)",
   "DownloadURL surfaces redirect with no Location":
     "TS runner does not yet dispatch DownloadURL (tracked as follow-up)",
+  "UploadsDownload delegates through DownloadURL primitive":
+    "TS runner's MSW stub matches a single path; multi-hop download fixtures need per-hop stub wiring (tracked as follow-up with DownloadURL)",
 };
 
 // =============================================================================
@@ -222,6 +224,13 @@ async function executeOperation(
       case "EnableTool":
         await client.tools.enable(Number(params.toolId));
         break;
+
+      case "UploadsDownload": {
+        const result = await client.uploads.download(Number(params.uploadId));
+        // Drain the stream so the socket can be reused and we don't leak.
+        await new Response(result.body).arrayBuffer();
+        break;
+      }
 
       default:
         throw new Error(`Unknown operation: ${tc.operation}`);

--- a/conformance/tests/uploads_download.json
+++ b/conformance/tests/uploads_download.json
@@ -1,0 +1,39 @@
+[
+  {
+    "name": "UploadsDownload delegates through DownloadURL primitive",
+    "description": "Convenience method fetches upload metadata, extracts download_url, then delegates to the authenticated download primitive. Expect three requests: the metadata fetch (auth'd), hop 1 of the download (auth'd, 302s), and hop 2 (signed, unauthenticated). The Location is relative so hop 2 hits the same mock server.",
+    "operation": "UploadsDownload",
+    "method": "GET",
+    "path": "/uploads/1069479400",
+    "pathParams": {"uploadId": 1069479400},
+    "mockResponses": [
+      {"status": 200, "headers": {"Content-Type": "application/json"}, "body": {"id": 1069479400, "filename": "logo.png", "download_url": "https://storage.3.basecamp.com/999999999/blobs/abcd1234/download/logo.png"}},
+      {"status": 302, "headers": {"Location": "/signed/logo.png"}},
+      {"status": 200, "headers": {"Content-Type": "image/png"}, "body": "pixels"}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 3},
+      {"type": "noError"},
+      {"type": "headerPresent", "path": "Authorization", "index": 0},
+      {"type": "headerPresent", "path": "Authorization", "index": 1},
+      {"type": "headerAbsent", "path": "Authorization", "index": -1}
+    ],
+    "tags": ["upload", "download", "redirect"]
+  },
+  {
+    "name": "UploadsDownload errors when upload has no download_url",
+    "description": "If the API returns upload metadata with no download_url, the SDK raises a usage error after the metadata fetch. No download hop should fire.",
+    "operation": "UploadsDownload",
+    "method": "GET",
+    "path": "/uploads/1069479400",
+    "pathParams": {"uploadId": 1069479400},
+    "mockResponses": [
+      {"status": 200, "headers": {"Content-Type": "application/json"}, "body": {"id": 1069479400, "filename": "logo.png", "download_url": null}}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 1},
+      {"type": "errorMessage", "expected": "has no download"}
+    ],
+    "tags": ["upload", "download", "error"]
+  }
+]

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
@@ -22,6 +22,8 @@ private val KOTLIN_SKIPS: Map<String, String> = mapOf(
     "DownloadURL retries on 503 at the auth'd first hop" to "Kotlin runner does not yet dispatch DownloadURL (tracked as follow-up)",
     "DownloadURL honors Retry-After on 429 at the auth'd first hop" to "Kotlin runner does not yet dispatch DownloadURL (tracked as follow-up)",
     "DownloadURL surfaces redirect with no Location" to "Kotlin runner does not yet dispatch DownloadURL (tracked as follow-up)",
+    "UploadsDownload delegates through DownloadURL primitive" to "Kotlin SDK does not yet expose uploads.download(id) (parity tracked as follow-up)",
+    "UploadsDownload errors when upload has no download_url" to "Kotlin SDK does not yet expose uploads.download(id) (parity tracked as follow-up)",
 )
 
 fun main() {

--- a/python/README.md
+++ b/python/README.md
@@ -310,7 +310,8 @@ result = await account.uploads.download(upload_id=1069479400)
 ```
 
 For any authenticated download URL (e.g. a `download_url` you already
-have in hand), use `Client.download_url` / `AsyncClient.download_url`:
+have in hand), use `AccountClient.download_url` /
+`AsyncAccountClient.download_url`:
 
 ```python
 result = account.download_url(url)          # sync

--- a/python/README.md
+++ b/python/README.md
@@ -293,6 +293,30 @@ project = account.projects.create(name="My Project", description="A new project"
 todos = account.todos.list(todolist_id=456, status="active")
 ```
 
+## Downloading Files
+
+Fetch an upload's file content in one call. The SDK fetches the upload
+metadata, then follows the authenticated-hop + 302 flow against the signed
+storage URL.
+
+```python
+# Sync
+result = account.uploads.download(upload_id=1069479400)
+with open("uploaded.bin", "wb") as f:
+    f.write(result.body)
+
+# Async
+result = await account.uploads.download(upload_id=1069479400)
+```
+
+For any authenticated download URL (e.g. a `download_url` you already
+have in hand), use `Client.download_url` / `AsyncClient.download_url`:
+
+```python
+result = account.download_url(url)          # sync
+result = await account.download_url(url)    # async
+```
+
 ## Pagination
 
 Paginated methods return a `ListResult`, which is a `list` subclass with a `.meta` attribute:

--- a/python/src/basecamp/async_client.py
+++ b/python/src/basecamp/async_client.py
@@ -261,7 +261,7 @@ class AsyncAccountClient:
 
     @property
     def uploads(self):
-        from basecamp.generated.services.uploads import AsyncUploadsService
+        from basecamp.services.uploads import AsyncUploadsService
 
         return self._service("uploads", lambda: AsyncUploadsService(self))
 

--- a/python/src/basecamp/client.py
+++ b/python/src/basecamp/client.py
@@ -262,7 +262,7 @@ class AccountClient:
 
     @property
     def uploads(self):
-        from basecamp.generated.services.uploads import UploadsService
+        from basecamp.services.uploads import UploadsService
 
         return self._service("uploads", lambda: UploadsService(self))
 

--- a/python/src/basecamp/services/__init__.py
+++ b/python/src/basecamp/services/__init__.py
@@ -1,3 +1,9 @@
 from basecamp.services.authorization import AsyncAuthorizationService, AuthorizationService
+from basecamp.services.uploads import AsyncUploadsService, UploadsService
 
-__all__ = ["AuthorizationService", "AsyncAuthorizationService"]
+__all__ = [
+    "AuthorizationService",
+    "AsyncAuthorizationService",
+    "UploadsService",
+    "AsyncUploadsService",
+]

--- a/python/src/basecamp/services/uploads.py
+++ b/python/src/basecamp/services/uploads.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+from basecamp.download import DownloadResult
+from basecamp.errors import UsageError
+from basecamp.generated.services.uploads import AsyncUploadsService as _GeneratedAsyncUploadsService
+from basecamp.generated.services.uploads import UploadsService as _GeneratedUploadsService
+
+
+class UploadsService(_GeneratedUploadsService):
+    """Sync uploads service with hand-written download() convenience."""
+
+    def download(self, *, upload_id: int) -> DownloadResult:
+        """Download an upload's file content in one call.
+
+        Fetches the upload metadata, then delegates to
+        :meth:`Client.download_url` so the authenticated-hop + 302-follow flow
+        lives in one place.
+
+        :param upload_id: The upload's numeric id.
+        :return: A :class:`DownloadResult` whose ``filename`` prefers
+            ``upload["filename"]`` from metadata, falling back to URL-derived.
+        :raises UsageError: If the upload has no ``download_url``.
+        """
+        upload = self.get(upload_id=upload_id)
+        url = upload.get("download_url")
+        if not url:
+            raise UsageError(f"upload {upload_id} has no download_url")
+        result = self._client.download_url(url)
+        filename = upload.get("filename")
+        return replace(result, filename=filename) if filename else result
+
+
+class AsyncUploadsService(_GeneratedAsyncUploadsService):
+    """Async uploads service with hand-written download() convenience."""
+
+    async def download(self, *, upload_id: int) -> DownloadResult:
+        upload = await self.get(upload_id=upload_id)
+        url = upload.get("download_url")
+        if not url:
+            raise UsageError(f"upload {upload_id} has no download_url")
+        result = await self._client.download_url(url)
+        filename = upload.get("filename")
+        return replace(result, filename=filename) if filename else result

--- a/python/tests/services/test_uploads.py
+++ b/python/tests/services/test_uploads.py
@@ -1,0 +1,142 @@
+"""Tests for the uploads.download(upload_id) convenience (sync + async)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from basecamp import AsyncClient, Client
+from basecamp.errors import UsageError
+
+
+def _metadata(upload_id: int = 1069479400, *, download_url, filename="report.pdf") -> dict:
+    """Minimal upload metadata payload; callers override download_url/filename."""
+    return {
+        "id": upload_id,
+        "filename": filename,
+        "download_url": download_url,
+    }
+
+
+class TestSyncDownload:
+    @respx.mock
+    def test_delegates_through_download_url(self):
+        metadata_route = respx.get("https://3.basecampapi.com/12345/uploads/1069479400").mock(
+            return_value=httpx.Response(
+                200,
+                json=_metadata(
+                    download_url="https://storage.example/12345/blobs/abc/download/report.pdf",
+                    filename="report.pdf",
+                ),
+            )
+        )
+        # Hop 1: auth'd, origin-rewritten to base_url. Responds 302.
+        hop1_route = respx.get("https://3.basecampapi.com/12345/blobs/abc/download/report.pdf").mock(
+            return_value=httpx.Response(
+                302,
+                headers={"Location": "https://signed.example/bucket/xyz?sig=abc"},
+            )
+        )
+        # Hop 2: signed URL, no auth.
+        hop2_route = respx.get("https://signed.example/bucket/xyz?sig=abc").mock(
+            return_value=httpx.Response(
+                200,
+                content=b"pdf-bytes",
+                headers={"content-type": "application/pdf", "content-length": "9"},
+            )
+        )
+
+        c = Client(access_token="test-token")
+        account = c.for_account("12345")
+        result = account.uploads.download(upload_id=1069479400)
+
+        assert metadata_route.called
+        assert hop1_route.called
+        assert hop2_route.called
+        assert result.body == b"pdf-bytes"
+        assert result.content_type == "application/pdf"
+        # Filename from metadata wins over URL-derived
+        assert result.filename == "report.pdf"
+        # First-hop (metadata) must be authenticated
+        assert metadata_route.calls[0].request.headers.get("authorization") == "Bearer test-token"
+        # Auth'd download hop also carries the bearer
+        assert hop1_route.calls[0].request.headers.get("authorization") == "Bearer test-token"
+        # Signed S3 hop must not carry auth
+        assert hop2_route.calls[0].request.headers.get("authorization") is None
+
+    def test_raises_when_metadata_missing_download_url(self):
+        with respx.mock() as router:
+            metadata_route = router.get("https://3.basecampapi.com/12345/uploads/1069479400").mock(
+                return_value=httpx.Response(200, json=_metadata(download_url=None, filename="report.pdf"))
+            )
+
+            c = Client(access_token="test-token")
+            account = c.for_account("12345")
+            with pytest.raises(UsageError) as exc_info:
+                account.uploads.download(upload_id=1069479400)
+
+            assert "1069479400" in str(exc_info.value)
+            assert "download_url" in str(exc_info.value)
+            # Only the metadata request fires — no download hop should be attempted.
+            assert metadata_route.call_count == 1
+            assert len(router.calls) == 1
+
+
+class TestAsyncDownload:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_delegates_through_download_url(self):
+        metadata_route = respx.get("https://3.basecampapi.com/12345/uploads/1069479400").mock(
+            return_value=httpx.Response(
+                200,
+                json=_metadata(
+                    download_url="https://storage.example/12345/blobs/abc/download/report.pdf",
+                    filename="report.pdf",
+                ),
+            )
+        )
+        hop1_route = respx.get("https://3.basecampapi.com/12345/blobs/abc/download/report.pdf").mock(
+            return_value=httpx.Response(
+                302,
+                headers={"Location": "https://signed.example/bucket/xyz?sig=abc"},
+            )
+        )
+        hop2_route = respx.get("https://signed.example/bucket/xyz?sig=abc").mock(
+            return_value=httpx.Response(
+                200,
+                content=b"pdf-bytes",
+                headers={"content-type": "application/pdf", "content-length": "9"},
+            )
+        )
+
+        c = AsyncClient(access_token="test-token")
+        account = c.for_account("12345")
+        result = await account.uploads.download(upload_id=1069479400)
+
+        assert metadata_route.called
+        assert hop1_route.called
+        assert hop2_route.called
+        assert result.body == b"pdf-bytes"
+        assert result.content_type == "application/pdf"
+        assert result.filename == "report.pdf"
+        assert metadata_route.calls[0].request.headers.get("authorization") == "Bearer test-token"
+        assert hop1_route.calls[0].request.headers.get("authorization") == "Bearer test-token"
+        assert hop2_route.calls[0].request.headers.get("authorization") is None
+
+    @pytest.mark.asyncio
+    async def test_raises_when_metadata_missing_download_url(self):
+        with respx.mock() as router:
+            metadata_route = router.get("https://3.basecampapi.com/12345/uploads/1069479400").mock(
+                return_value=httpx.Response(200, json=_metadata(download_url=None, filename="report.pdf"))
+            )
+
+            c = AsyncClient(access_token="test-token")
+            account = c.for_account("12345")
+            with pytest.raises(UsageError) as exc_info:
+                await account.uploads.download(upload_id=1069479400)
+
+            assert "1069479400" in str(exc_info.value)
+            assert "download_url" in str(exc_info.value)
+            assert metadata_route.call_count == 1
+            assert len(router.calls) == 1

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -194,6 +194,25 @@ first_10 = account.todos.list(todolist_id: 456).take(10)
 all_projects = account.projects.list.to_a
 ```
 
+## Downloading Files
+
+Fetch an upload's file content in one call. The SDK fetches the upload
+metadata, then follows the authenticated-hop + 302 flow against the
+signed storage URL.
+
+```ruby
+result = account.uploads.download(upload_id: 1069479400)
+File.binwrite("uploaded.bin", result.body)
+# result.content_type, result.content_length, result.filename are also available
+```
+
+For any authenticated download URL (e.g. a `download_url` you already
+have in hand), use `AccountClient#download_url`:
+
+```ruby
+result = account.download_url(url)
+```
+
 ## Retry Behavior
 
 GET requests automatically retry on transient failures with exponential backoff:

--- a/ruby/lib/basecamp/generated/services/uploads_service.rb
+++ b/ruby/lib/basecamp/generated/services/uploads_service.rb
@@ -57,6 +57,23 @@ module Basecamp
           http_post("/vaults/#{vault_id}/uploads.json", body: compact_params(attachable_sgid: attachable_sgid, description: description, base_name: base_name, subscriptions: subscriptions)).json
         end
       end
+
+      # Download an upload's file content in one call.
+      # Fetches upload metadata, then delegates to the AccountClient download
+      # primitive so the auth'd-hop + 302-follow flow lives in one place.
+      # @param upload_id [Integer] upload id ID
+      # @return [Basecamp::DownloadResult]
+      def download(upload_id:)
+        with_operation(service: "uploads", operation: "download", is_mutation: false, resource_id: upload_id) do
+          upload = get(upload_id: upload_id)
+          url = upload["download_url"]
+          raise UsageError.new("upload #{upload_id} has no download_url") if url.nil? || url.empty?
+
+          result = @client.download_url(url)
+          filename = upload["filename"]
+          filename.to_s.empty? ? result : result.with(filename: filename)
+        end
+      end
     end
   end
 end

--- a/ruby/scripts/generate-services.rb
+++ b/ruby/scripts/generate-services.rb
@@ -263,6 +263,31 @@ class ServiceGenerator
     { prefix: 'Search', method: 'search' }
   ].freeze
 
+  # Hand-written methods appended to specific generated services.
+  # Keyed by service name; value is an array of method code strings indented to match generated output.
+  HAND_WRITTEN_METHODS = {
+    'Uploads' => [
+      <<~RUBY.chomp
+        # Download an upload's file content in one call.
+        # Fetches upload metadata, then delegates to the AccountClient download
+        # primitive so the auth'd-hop + 302-follow flow lives in one place.
+        # @param upload_id [Integer] upload id ID
+        # @return [Basecamp::DownloadResult]
+        def download(upload_id:)
+          with_operation(service: "uploads", operation: "download", is_mutation: false, resource_id: upload_id) do
+            upload = get(upload_id: upload_id)
+            url = upload["download_url"]
+            raise UsageError.new("upload \#{upload_id} has no download_url") if url.nil? || url.empty?
+
+            result = @client.download_url(url)
+            filename = upload["filename"]
+            filename.to_s.empty? ? result : result.with(filename: filename)
+          end
+        end
+      RUBY
+    ]
+  }.freeze
+
   SIMPLE_RESOURCES = %w[
     todo todos todolist todolists todoset message messages comment comments
     card cards cardtable cardcolumn cardstep column step project projects
@@ -540,6 +565,13 @@ class ServiceGenerator
     service[:operations].each do |op|
       lines << ''
       lines.concat(generate_method(op, service_name: service[:name]))
+    end
+
+    (HAND_WRITTEN_METHODS[service[:name]] || []).each do |method_code|
+      lines << ''
+      method_code.each_line do |l|
+        lines << (l.chomp.empty? ? '' : "      #{l.chomp}")
+      end
     end
 
     lines << '    end'

--- a/ruby/test/basecamp/services/uploads_service_test.rb
+++ b/ruby/test/basecamp/services/uploads_service_test.rb
@@ -78,4 +78,47 @@ class UploadsServiceTest < Minitest::Test
     result = @account.uploads.list_versions(upload_id: 2).to_a
     assert_equal 2, result.length
   end
+
+  def test_download_delegates_through_download_url
+    metadata = {
+      "id" => 1069479400,
+      "filename" => "report.pdf",
+      "download_url" => "https://storage.example/12345/blobs/abc/download/report.pdf"
+    }
+    stub_request(:get, "#{base_url}/12345/uploads/1069479400")
+      .with(headers: { "Authorization" => "Bearer #{access_token}" })
+      .to_return(status: 200, body: metadata.to_json, headers: { "Content-Type" => "application/json" })
+
+    # Hop 1: auth'd, origin-rewritten; returns 302
+    stub_request(:get, "#{base_url}/12345/blobs/abc/download/report.pdf")
+      .with(headers: { "Authorization" => "Bearer #{access_token}" })
+      .to_return(status: 302, headers: { "Location" => "https://signed.example/bucket/xyz" })
+
+    # Hop 2: signed URL, no auth
+    stub_request(:get, "https://signed.example/bucket/xyz")
+      .to_return(
+        status: 200,
+        body: "pdf-bytes",
+        headers: { "Content-Type" => "application/pdf", "Content-Length" => "9" }
+      )
+
+    result = @account.uploads.download(upload_id: 1069479400)
+
+    assert_equal "pdf-bytes", result.body
+    assert_equal "application/pdf", result.content_type
+    # filename from upload metadata wins over URL-derived filename
+    assert_equal "report.pdf", result.filename
+  end
+
+  def test_download_raises_when_metadata_has_no_download_url
+    metadata = { "id" => 1069479400, "filename" => "report.pdf", "download_url" => nil }
+    stub_request(:get, "#{base_url}/12345/uploads/1069479400")
+      .to_return(status: 200, body: metadata.to_json, headers: { "Content-Type" => "application/json" })
+
+    error = assert_raises(Basecamp::UsageError) do
+      @account.uploads.download(upload_id: 1069479400)
+    end
+    assert_match(/1069479400/, error.message)
+    assert_match(/download_url/, error.message)
+  end
 end

--- a/swift/README.md
+++ b/swift/README.md
@@ -204,6 +204,26 @@ let client = BasecampClient(
 | `clientReplies` | Client replies |
 | `clientVisibility` | Client visibility settings |
 
+## Downloading Files
+
+Fetch an upload's file content in one call. The SDK fetches the upload
+metadata, then follows the authenticated-hop + 302 flow against the signed
+storage URL.
+
+```swift
+let account = client.forAccount("999999999")
+let result = try await account.uploads.download(uploadId: 1069479400)
+try result.body.write(to: URL(fileURLWithPath: "uploaded.bin"))
+// result.contentType, result.contentLength, result.filename are also available
+```
+
+For any authenticated download URL (e.g. a `downloadUrl` you already have
+in hand), use `AccountClient.downloadURL(_:)`:
+
+```swift
+let result = try await account.downloadURL(url)
+```
+
 ## Pagination
 
 List methods automatically follow Link headers and return all pages:

--- a/swift/Sources/Basecamp/UploadsServiceExtensions.swift
+++ b/swift/Sources/Basecamp/UploadsServiceExtensions.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+extension UploadsService {
+    /// Downloads an upload's file content in one call.
+    ///
+    /// Fetches the upload metadata to retrieve `download_url`, then delegates to
+    /// ``AccountClient/downloadURL(_:)`` so the authenticated-hop + 302-follow
+    /// flow lives in one place.
+    ///
+    /// - Parameter uploadId: The upload's numeric id.
+    /// - Returns: A ``DownloadResult`` with body, content type, content length,
+    ///   and filename. The filename prefers `upload.filename` from the metadata
+    ///   response and falls back to the URL-derived filename.
+    /// - Throws: ``BasecampError/usage(message:hint:)`` if the upload has no
+    ///   `download_url`; other ``BasecampError`` cases for network/API errors.
+    public func download(uploadId: Int) async throws -> DownloadResult {
+        let upload = try await get(uploadId: uploadId)
+        guard let url = upload.downloadUrl, !url.isEmpty else {
+            throw BasecampError.usage(
+                message: "upload \(uploadId) has no download_url",
+                hint: nil
+            )
+        }
+        let result = try await accountClient.downloadURL(url)
+        guard let filename = upload.filename, !filename.isEmpty else {
+            return result
+        }
+        return DownloadResult(
+            body: result.body,
+            contentType: result.contentType,
+            contentLength: result.contentLength,
+            filename: filename
+        )
+    }
+}

--- a/swift/Tests/BasecampTests/UploadsServiceExtensionsTests.swift
+++ b/swift/Tests/BasecampTests/UploadsServiceExtensionsTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+@testable import Basecamp
+
+/// Thread-safe counter for use in @Sendable closures.
+private final class Counter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _value: Int = 0
+
+    var value: Int { lock.withLock { _value } }
+
+    @discardableResult
+    func increment() -> Int {
+        lock.withLock {
+            _value += 1
+            return _value
+        }
+    }
+}
+
+/// Returns a minimally-populated upload metadata JSON object keyed on wire
+/// (snake_case) field names. Callers pass overrides for `download_url` and
+/// `filename`; the rest are fixed fillers for Upload's required fields.
+private func uploadMetadataJSON(
+    id: Int = 1069479400,
+    downloadURL: String?,
+    filename: String?
+) -> [String: Any] {
+    var json: [String: Any] = [
+        "id": id,
+        "app_url": "https://3.basecamp.com/999999999/uploads/\(id)",
+        "url": "https://3.basecampapi.com/999999999/uploads/\(id).json",
+        "created_at": "2026-01-01T00:00:00Z",
+        "updated_at": "2026-01-01T00:00:00Z",
+        "status": "active",
+        "title": "report.pdf",
+        "type": "Upload",
+        "inherits_status": false,
+        "visible_to_clients": false,
+        "bucket": ["id": 1, "name": "Project", "type": "Project"] as [String: Any],
+        "creator": ["id": 1, "name": "Test User"] as [String: Any],
+        "parent": [
+            "id": 2, "title": "Docs", "type": "Vault",
+            "app_url": "https://3.basecamp.com/999999999/vaults/2",
+            "url": "https://3.basecampapi.com/999999999/vaults/2.json"
+        ] as [String: Any]
+    ]
+    if let downloadURL = downloadURL {
+        json["download_url"] = downloadURL
+    }
+    if let filename = filename {
+        json["filename"] = filename
+    }
+    return json
+}
+
+final class UploadsServiceExtensionsTests: XCTestCase {
+
+    // MARK: - Success path
+
+    /// The metadata fetch resolves `download_url` to an API-host URL; the
+    /// download primitive then runs the auth'd hop (which 302s) and the signed
+    /// hop (no auth). The returned filename comes from the upload metadata.
+    func testDownload_delegatesThroughDownloadURL() async throws {
+        let metadata = uploadMetadataJSON(
+            downloadURL: "https://storage.3.basecamp.com/999999999/blobs/abcd1234/download/logo.png",
+            filename: "logo.png"
+        )
+        let metadataData = try JSONSerialization.data(withJSONObject: metadata)
+
+        let counter = Counter()
+        let transport = MockTransport { request in
+            let count = counter.increment()
+            switch count {
+            case 1:
+                // Metadata GET /uploads/{id}
+                XCTAssertEqual(request.url?.path, "/999999999/uploads/1069479400")
+                XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer test-token")
+                return (
+                    metadataData,
+                    makeHTTPResponse(
+                        url: request.url!.absoluteString,
+                        statusCode: 200,
+                        headers: ["Content-Type": "application/json"]
+                    )
+                )
+            case 2:
+                // Hop 1: auth'd API request (origin-rewritten from storage host to base host)
+                XCTAssertEqual(request.url?.host, "3.basecampapi.com")
+                XCTAssertEqual(request.url?.path, "/999999999/blobs/abcd1234/download/logo.png")
+                XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer test-token")
+                return (
+                    Data(),
+                    makeHTTPResponse(
+                        url: request.url!.absoluteString,
+                        statusCode: 302,
+                        headers: ["Location": "https://signed.example/bucket/xyz?sig=abc"]
+                    )
+                )
+            case 3:
+                // Hop 2: signed download, no auth header
+                XCTAssertNil(request.value(forHTTPHeaderField: "Authorization"))
+                return (
+                    Data("pixels".utf8),
+                    makeHTTPResponse(
+                        url: request.url!.absoluteString,
+                        statusCode: 200,
+                        headers: ["Content-Type": "image/png", "Content-Length": "6"]
+                    )
+                )
+            default:
+                XCTFail("Unexpected request #\(count) to \(request.url?.absoluteString ?? "<nil>")")
+                return (Data(), makeHTTPResponse(url: request.url!.absoluteString, statusCode: 500))
+            }
+        }
+        let account = makeTestAccountClient(transport: transport)
+
+        let result = try await account.uploads.download(uploadId: 1069479400)
+
+        XCTAssertEqual(String(data: result.body, encoding: .utf8), "pixels")
+        XCTAssertEqual(result.contentType, "image/png")
+        XCTAssertEqual(result.contentLength, 6)
+        // filename from metadata wins over URL-derived filename
+        XCTAssertEqual(result.filename, "logo.png")
+        XCTAssertEqual(counter.value, 3)
+    }
+
+    // MARK: - Missing download_url
+
+    func testDownload_throwsUsageWhenDownloadURLMissing() async throws {
+        let metadata = uploadMetadataJSON(downloadURL: nil, filename: "logo.png")
+        let metadataData = try JSONSerialization.data(withJSONObject: metadata)
+
+        let counter = Counter()
+        let transport = MockTransport { request in
+            let count = counter.increment()
+            XCTAssertEqual(count, 1, "No second hop should fire when metadata has no download_url")
+            return (
+                metadataData,
+                makeHTTPResponse(
+                    url: request.url!.absoluteString,
+                    statusCode: 200,
+                    headers: ["Content-Type": "application/json"]
+                )
+            )
+        }
+        let account = makeTestAccountClient(transport: transport)
+
+        do {
+            _ = try await account.uploads.download(uploadId: 1069479400)
+            XCTFail("Expected BasecampError.usage")
+        } catch let BasecampError.usage(message, _) {
+            XCTAssertTrue(message.contains("1069479400"), "Message should include upload id, got: \(message)")
+            XCTAssertTrue(message.contains("download_url"), "Message should mention download_url, got: \(message)")
+        }
+        XCTAssertEqual(counter.value, 1)
+    }
+}

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -259,6 +259,26 @@ The SDK provides typed services for the complete Basecamp API:
 |---------|---------|
 | `forwards` | list, get, createReply |
 
+## Downloading Files
+
+Fetch an upload's file content in one call. The SDK fetches the upload
+metadata, then follows the authenticated-hop + 302 flow against the signed
+storage URL.
+
+```ts
+const result = await client.uploads.download(1069479400);
+// result.body is a ReadableStream<Uint8Array>
+const bytes = new Uint8Array(await new Response(result.body).arrayBuffer());
+// result.contentType, result.contentLength, result.filename are also available
+```
+
+For any authenticated download URL (e.g. a `download_url` you already have
+in hand), use `client.downloadURL`:
+
+```ts
+const result = await client.downloadURL(url);
+```
+
 ## Pagination
 
 List methods return a single page of results by default. Use the pagination helpers with low-level API calls to fetch all pages:

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -49,7 +49,7 @@ import { SubscriptionsService } from "./generated/services/subscriptions.js";
 import { AttachmentsService } from "./generated/services/attachments.js";
 import { VaultsService } from "./generated/services/vaults.js";
 import { DocumentsService } from "./generated/services/documents.js";
-import { UploadsService } from "./generated/services/uploads.js";
+import { UploadsService } from "./services/uploads-extensions.js";
 import { SchedulesService } from "./generated/services/schedules.js";
 import { EventsService } from "./generated/services/events.js";
 import { RecordingsService } from "./generated/services/recordings.js";
@@ -353,6 +353,17 @@ export function createBasecampClient(options: BasecampClientOptions): BasecampCl
     });
   };
 
+  // Wire downloadURL — raw fetch, not openapi-fetch (like fetchPage).
+  // Defined before service factories so UploadsService can inject it.
+  const downloadURLFn = createDownloadURL({
+    authStrategy, userAgent, baseUrl, hooks, requestTimeoutMs,
+  });
+  Object.defineProperty(enhancedClient, "downloadURL", {
+    value: downloadURLFn,
+    writable: false,
+    enumerable: false,
+  });
+
   defineService("projects", () => new ProjectsService(client, hooks, fetchPage, maxPages));
   defineService("todos", () => new TodosService(client, hooks, fetchPage, maxPages));
   defineService("todolists", () => new TodolistsService(client, hooks, fetchPage, maxPages));
@@ -379,7 +390,7 @@ export function createBasecampClient(options: BasecampClientOptions): BasecampCl
   defineService("attachments", () => new AttachmentsService(client, hooks, fetchPage, maxPages));
   defineService("vaults", () => new VaultsService(client, hooks, fetchPage, maxPages));
   defineService("documents", () => new DocumentsService(client, hooks, fetchPage, maxPages));
-  defineService("uploads", () => new UploadsService(client, hooks, fetchPage, maxPages));
+  defineService("uploads", () => new UploadsService(client, hooks, fetchPage, maxPages, downloadURLFn));
   defineService("schedules", () => new SchedulesService(client, hooks, fetchPage, maxPages));
   defineService("events", () => new EventsService(client, hooks, fetchPage, maxPages));
   defineService("recordings", () => new RecordingsService(client, hooks, fetchPage, maxPages));
@@ -398,16 +409,6 @@ export function createBasecampClient(options: BasecampClientOptions): BasecampCl
   defineService("gauges", () => new GaugesService(client, hooks, fetchPage, maxPages));
   defineService("myAssignments", () => new MyAssignmentsService(client, hooks, fetchPage, maxPages));
   defineService("myNotifications", () => new MyNotificationsService(client, hooks, fetchPage, maxPages));
-
-  // Wire downloadURL — raw fetch, not openapi-fetch (like fetchPage)
-  const downloadURLFn = createDownloadURL({
-    authStrategy, userAgent, baseUrl, hooks, requestTimeoutMs,
-  });
-  Object.defineProperty(enhancedClient, "downloadURL", {
-    value: downloadURLFn,
-    writable: false,
-    enumerable: false,
-  });
 
   return enhancedClient;
 }

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -390,7 +390,11 @@ export function createBasecampClient(options: BasecampClientOptions): BasecampCl
   defineService("attachments", () => new AttachmentsService(client, hooks, fetchPage, maxPages));
   defineService("vaults", () => new VaultsService(client, hooks, fetchPage, maxPages));
   defineService("documents", () => new DocumentsService(client, hooks, fetchPage, maxPages));
-  defineService("uploads", () => new UploadsService(client, hooks, fetchPage, maxPages, downloadURLFn));
+  defineService("uploads", () =>
+    // Positional args mirror BaseService (incl. authenticatedFetch/baseUrl slots the
+    // factory leaves unset), with downloadURLFn appended at the end.
+    new UploadsService(client, hooks, fetchPage, maxPages, undefined, undefined, downloadURLFn),
+  );
   defineService("schedules", () => new SchedulesService(client, hooks, fetchPage, maxPages));
   defineService("events", () => new EventsService(client, hooks, fetchPage, maxPages));
   defineService("recordings", () => new RecordingsService(client, hooks, fetchPage, maxPages));

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -247,6 +247,12 @@ export const Errors = {
     }),
 
   /**
+   * Creates a usage error — invalid arguments, missing configuration.
+   */
+  usage: (message: string, hint?: string): BasecampError =>
+    new BasecampError("usage", message, { hint }),
+
+  /**
    * Creates a generic API error.
    */
   apiError: (

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -306,8 +306,8 @@ export {
   type UpdateDocumentRequest,
 } from "./generated/services/documents.js";
 
+export { UploadsService } from "./services/uploads-extensions.js";
 export {
-  UploadsService,
   type Upload,
   type CreateUploadRequest,
   type UpdateUploadRequest,

--- a/typescript/src/services/uploads-extensions.ts
+++ b/typescript/src/services/uploads-extensions.ts
@@ -15,14 +15,17 @@ type DownloadURLFn = (rawURL: string) => Promise<DownloadResult>;
  * flow stays in one place (`createDownloadURL` in `download.ts`).
  */
 export class UploadsService extends GeneratedUploadsService {
-  private readonly downloadURLFn: DownloadURLFn;
+  private readonly downloadURLFn?: DownloadURLFn;
 
+  // downloadURLFn is optional so direct `new UploadsService(client, hooks, fetchPage, maxPages)`
+  // construction stays backwards-compatible. `download()` throws a clear usage error if the
+  // primitive wasn't injected (i.e. the service was constructed outside createBasecampClient).
   constructor(
     client: RawClient,
-    hooks: BasecampHooks | undefined,
-    fetchPage: ((url: string) => Promise<Response>) | undefined,
-    maxPages: number | undefined,
-    downloadURLFn: DownloadURLFn,
+    hooks?: BasecampHooks,
+    fetchPage?: (url: string) => Promise<Response>,
+    maxPages?: number,
+    downloadURLFn?: DownloadURLFn,
   ) {
     super(client, hooks, fetchPage, maxPages);
     this.downloadURLFn = downloadURLFn;
@@ -37,9 +40,16 @@ export class UploadsService extends GeneratedUploadsService {
    * @param uploadId - The upload's numeric id.
    * @returns A `DownloadResult` whose `filename` prefers `upload.filename`
    *   from metadata, falling back to the URL-derived filename.
-   * @throws {BasecampError} `usage` if the upload has no `download_url`.
+   * @throws {BasecampError} `usage` if the upload has no `download_url`,
+   *   or if the service was constructed without the injected download
+   *   primitive (obtain the service through `createBasecampClient().uploads`).
    */
   async download(uploadId: number): Promise<DownloadResult> {
+    if (!this.downloadURLFn) {
+      throw Errors.usage(
+        "uploads.download requires the download primitive — obtain UploadsService via createBasecampClient(...).uploads rather than instantiating it directly",
+      );
+    }
     const upload = await this.get(uploadId);
     const url = upload.download_url;
     if (!url) {

--- a/typescript/src/services/uploads-extensions.ts
+++ b/typescript/src/services/uploads-extensions.ts
@@ -1,0 +1,51 @@
+import type { BasecampHooks } from "../hooks.js";
+import type { DownloadResult } from "../download.js";
+import { Errors } from "../errors.js";
+import { UploadsService as GeneratedUploadsService } from "../generated/services/uploads.js";
+import type { RawClient } from "./base.js";
+
+/** Function signature for the client-level `downloadURL` primitive. */
+type DownloadURLFn = (rawURL: string) => Promise<DownloadResult>;
+
+/**
+ * UploadsService with a hand-written `download(uploadId)` convenience.
+ *
+ * The subclass injects the client-level `downloadURL` function so the
+ * convenience method can delegate to it — the authenticated-hop + 302-follow
+ * flow stays in one place (`createDownloadURL` in `download.ts`).
+ */
+export class UploadsService extends GeneratedUploadsService {
+  private readonly downloadURLFn: DownloadURLFn;
+
+  constructor(
+    client: RawClient,
+    hooks: BasecampHooks | undefined,
+    fetchPage: ((url: string) => Promise<Response>) | undefined,
+    maxPages: number | undefined,
+    downloadURLFn: DownloadURLFn,
+  ) {
+    super(client, hooks, fetchPage, maxPages);
+    this.downloadURLFn = downloadURLFn;
+  }
+
+  /**
+   * Downloads an upload's file content in one call.
+   *
+   * Fetches the upload metadata to retrieve `download_url`, then delegates to
+   * the client-level `downloadURL` primitive (authenticated-hop + 302-follow).
+   *
+   * @param uploadId - The upload's numeric id.
+   * @returns A `DownloadResult` whose `filename` prefers `upload.filename`
+   *   from metadata, falling back to the URL-derived filename.
+   * @throws {BasecampError} `usage` if the upload has no `download_url`.
+   */
+  async download(uploadId: number): Promise<DownloadResult> {
+    const upload = await this.get(uploadId);
+    const url = upload.download_url;
+    if (!url) {
+      throw Errors.usage(`upload ${uploadId} has no download_url`);
+    }
+    const result = await this.downloadURLFn(url);
+    return upload.filename ? { ...result, filename: upload.filename } : result;
+  }
+}

--- a/typescript/src/services/uploads-extensions.ts
+++ b/typescript/src/services/uploads-extensions.ts
@@ -17,17 +17,22 @@ type DownloadURLFn = (rawURL: string) => Promise<DownloadResult>;
 export class UploadsService extends GeneratedUploadsService {
   private readonly downloadURLFn?: DownloadURLFn;
 
-  // downloadURLFn is optional so direct `new UploadsService(client, hooks, fetchPage, maxPages)`
-  // construction stays backwards-compatible. `download()` throws a clear usage error if the
-  // primitive wasn't injected (i.e. the service was constructed outside createBasecampClient).
+  // Preserve BaseService's full positional signature (authenticatedFetch, baseUrl),
+  // then append downloadURLFn — otherwise existing `new UploadsService(client, hooks,
+  // fetchPage, maxPages, authenticatedFetch, baseUrl)` callers would silently miswire
+  // authenticatedFetch into the 5th slot. All params optional for direct-construction
+  // back-compat; `download()` throws a clear usage error if the primitive wasn't
+  // injected (i.e. the service was constructed outside createBasecampClient).
   constructor(
     client: RawClient,
     hooks?: BasecampHooks,
     fetchPage?: (url: string) => Promise<Response>,
     maxPages?: number,
+    authenticatedFetch?: (url: string, init: RequestInit) => Promise<Response>,
+    baseUrl?: string,
     downloadURLFn?: DownloadURLFn,
   ) {
-    super(client, hooks, fetchPage, maxPages);
+    super(client, hooks, fetchPage, maxPages, authenticatedFetch, baseUrl);
     this.downloadURLFn = downloadURLFn;
   }
 

--- a/typescript/tests/services/uploads.test.ts
+++ b/typescript/tests/services/uploads.test.ts
@@ -8,14 +8,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../setup.js";
-import type { UploadsService } from "../../src/generated/services/uploads.js";
 import { BasecampError } from "../../src/errors.js";
 import { createBasecampClient } from "../../src/client.js";
 
 const BASE_URL = "https://3.basecampapi.com/12345";
 
+// Infer the service type from client.uploads so download() is visible on the
+// type (the subclass lives in src/services/uploads-extensions.ts).
+type UploadsServiceT = ReturnType<typeof createBasecampClient>["uploads"];
+
 describe("UploadsService", () => {
-  let service: UploadsService;
+  let service: UploadsServiceT;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/typescript/tests/services/uploads.test.ts
+++ b/typescript/tests/services/uploads.test.ts
@@ -317,15 +317,13 @@ describe("UploadsService", () => {
         }),
       );
 
-      await expect(service.download(1069479400)).rejects.toThrow(BasecampError);
-      try {
-        await service.download(1069479400);
-      } catch (err) {
-        const e = err as BasecampError;
-        expect(e.code).toBe("usage");
-        expect(e.message).toContain("1069479400");
-        expect(e.message).toContain("download_url");
-      }
+      const error = await service.download(1069479400).catch((err) => err);
+
+      expect(error).toBeInstanceOf(BasecampError);
+      const e = error as BasecampError;
+      expect(e.code).toBe("usage");
+      expect(e.message).toContain("1069479400");
+      expect(e.message).toContain("download_url");
       expect(downloadHopCalled).toBe(false);
     });
   });

--- a/typescript/tests/services/uploads.test.ts
+++ b/typescript/tests/services/uploads.test.ts
@@ -243,5 +243,88 @@ describe("UploadsService", () => {
 
   // Note: trash() is on RecordingsService, not UploadsService (spec-conformant)
   // Use client.recordings.trash(uploadId) instead
+
+  describe("download", () => {
+    const API_ORIGIN = "https://3.basecampapi.com";
+    const SIGNED_URL = "https://signed.example/bucket/xyz?sig=abc";
+
+    it("delegates through the downloadURL primitive", async () => {
+      const authorizationHeaders: Array<string | null> = [];
+
+      server.use(
+        // Metadata fetch
+        http.get(`${BASE_URL}/uploads/1069479400`, ({ request }) => {
+          authorizationHeaders.push(request.headers.get("authorization"));
+          return HttpResponse.json({
+            id: 1069479400,
+            filename: "logo.png",
+            download_url: "https://storage.3.basecamp.com/12345/blobs/abc/download/logo.png",
+          });
+        }),
+        // Hop 1: origin-rewritten to API_ORIGIN
+        http.get(`${API_ORIGIN}/12345/blobs/abc/download/logo.png`, ({ request }) => {
+          authorizationHeaders.push(request.headers.get("authorization"));
+          return new HttpResponse(null, {
+            status: 302,
+            headers: { Location: SIGNED_URL },
+          });
+        }),
+        // Hop 2: signed URL (no auth)
+        http.get(SIGNED_URL, ({ request }) => {
+          authorizationHeaders.push(request.headers.get("authorization"));
+          return new HttpResponse("pixels", {
+            status: 200,
+            headers: { "Content-Type": "image/png", "Content-Length": "6" },
+          });
+        }),
+      );
+
+      const result = await service.download(1069479400);
+
+      expect(result.contentType).toBe("image/png");
+      expect(result.contentLength).toBe(6);
+      // filename from upload metadata wins over URL-derived
+      expect(result.filename).toBe("logo.png");
+
+      const bodyText = await new Response(result.body).text();
+      expect(bodyText).toBe("pixels");
+
+      // Metadata request + auth'd download hop must carry bearer; signed hop must not
+      expect(authorizationHeaders).toHaveLength(3);
+      expect(authorizationHeaders[0]).toBe("Bearer test-token");
+      expect(authorizationHeaders[1]).toBe("Bearer test-token");
+      expect(authorizationHeaders[2]).toBeNull();
+    });
+
+    it("throws usage error when upload has no download_url", async () => {
+      let downloadHopCalled = false;
+
+      server.use(
+        http.get(`${BASE_URL}/uploads/1069479400`, () => {
+          return HttpResponse.json({
+            id: 1069479400,
+            filename: "logo.png",
+            download_url: null,
+          });
+        }),
+        // No download hop should fire — this handler would record it if so
+        http.get(`${API_ORIGIN}/12345/blobs/*`, () => {
+          downloadHopCalled = true;
+          return new HttpResponse(null, { status: 500 });
+        }),
+      );
+
+      await expect(service.download(1069479400)).rejects.toThrow(BasecampError);
+      try {
+        await service.download(1069479400);
+      } catch (err) {
+        const e = err as BasecampError;
+        expect(e.code).toBe("usage");
+        expect(e.message).toContain("1069479400");
+        expect(e.message).toContain("download_url");
+      }
+      expect(downloadHopCalled).toBe(false);
+    });
+  });
 });
 


### PR DESCRIPTION
## What this PR does

Adds `uploads.download(id)` to the Ruby, Python, TypeScript, and Swift SDKs, matching Go's `UploadsService.Download`. One call returns the upload's file content; the method fetches upload metadata and passes `upload.download_url` through the SDK's existing `download_url` primitive.

Also adds `conformance/tests/uploads_download.json` (2 cases) and wires `UploadsDownload` dispatch in the Go, Ruby, Python, and TypeScript conformance runners. Kotlin gets skip entries (parity for Kotlin is deferred). Swift has no conformance runner harness in this repo, so the convenience is covered by Swift unit tests only.

## Why

These SDKs ship for external developers. The one-call ergonomic belongs in the languages where it's worth supporting; this PR addresses Ruby, Python, TypeScript, and Swift in one diff so the four implementations stay shape-aligned. This closes the loop on the parity question explicitly deferred in commit `148e1278`.

## Why not Kotlin

Kotlin is intentionally out of scope for this PR. The Kotlin SDK has `AccountClient.downloadURL` and the generated `UploadsService.get`, but no `uploads.download(id)` convenience. Adding it would mean another language implementation, another conformance runner change, and a dispatcher path Kotlin's runner doesn't currently have. We're tracking Kotlin parity as a follow-up; this PR adds Kotlin skip entries for `UploadsDownload` to keep CI green (mirroring the existing `DownloadURL` skip pattern from commit `dda8482f`).

## Hard rule (enforced in every implementation)

Each SDK's `uploads.download(id)` calls through its existing `download_url` primitive — `client.download_url(...)` in Ruby/Python, the injected `downloadURL` function in TypeScript, `accountClient.downloadURL(...)` in Swift. **No second copy of the auth'd-hop + 302-follow flow.** This is what PR #278 codifies in Go via the shared `fetchAPIDownload` helper. Stacking on #278's branch puts that helper in ancestor history.

## API shape

```ruby
result = account.uploads.download(upload_id: 1069479400)  # Ruby
```
```python
result = account.uploads.download(upload_id=1069479400)         # Python sync
result = await account.uploads.download(upload_id=1069479400)   # Python async
```
```ts
const result = await client.uploads.download(1069479400);  // TypeScript
```
```swift
let result = try await account.uploads.download(uploadId: 1069479400)  // Swift
```

All four raise/throw a usage error if `upload.download_url` is missing or empty.

## Commits

1. Ruby — generator-template addition + unit tests + README + Ruby runner dispatch.
2. Swift — `extension UploadsService` + unit tests + README.
3. Python — `services/uploads.py` subclasses + property rewires + unit tests + README + Python runner dispatch.
4. TypeScript — subclass in `services/uploads-extensions.ts` + `client.ts` + `index.ts` rewires + unit tests + README + TS runner dispatch.
5. Conformance — `uploads_download.json` (2 cases) + Go runner dispatch + Kotlin skip entries.

## Conformance scope

The two new cases test the convenience-specific contract:
1. Metadata fetch + delegation chain. The happy-path fixture uses the indexed `headerPresent`/`headerAbsent` support from commit `b2df40fb` to assert `Authorization` is present on the metadata fetch (request 0) and the auth'd download hop (request 1) and absent on the signed hop (request -1). Three requests total.
2. SDK-level guard fires when `download_url` is missing — request count = 1, error message contains "has no download".

Retry, 302-handling, and Retry-After on the download legs are the primitive's contract, covered by `downloads.json` for Go today. Non-Go runners skip those cases (existing) and also skip the new multi-hop `UploadsDownload` happy-path case because their mock setups (WebMock/respx/MSW) stub a single URL pattern and need per-hop wiring — tracked as the same follow-up as the `DownloadURL` skips. The single-hop missing-url case runs in every runner with an `UploadsDownload` dispatcher (Go, Ruby, Python, TS).

### Verified

| Runner | UploadsDownload (delegation) | UploadsDownload (missing url) |
|--------|------------------------------|-------------------------------|
| Go     | PASS                         | PASS                          |
| Ruby   | SKIP (multi-hop wiring)      | PASS                          |
| Python | SKIP (multi-hop wiring)      | PASS                          |
| TS     | SKIP (multi-hop wiring)      | PASS                          |
| Kotlin | SKIP (SDK parity follow-up)  | SKIP (SDK parity follow-up)   |

The auth/no-auth invariants on the download legs are also covered by per-SDK unit tests in Ruby/Python/TS/Swift where the mock frameworks allow per-request header assertions directly.

## Test plan

- [x] Ruby: `bundle exec rake test` — 599 tests pass, coverage met.
- [x] Python: `uv run pytest` — 209 tests pass.
- [x] TypeScript: `npm test` (616 tests) + `npm run typecheck` — both clean.
- [x] Swift: `swift test` — 166 tests pass.
- [x] Conformance: `make conformance-go` (68/68), `make conformance-ruby` (56/0/12), `make conformance-python` (61/0/7), `make conformance-typescript` (60/0/8), `make conformance-kotlin` (58/0/10).
- [x] Ruby generator regeneration is idempotent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `uploads.download(id)` to the Ruby, Python, TypeScript, and Swift SDKs. One call fetches upload metadata and streams the file via each SDK’s download primitive; includes conformance tests and docs, with Kotlin deferred.

- **New Features**
  - `uploads.download(id)` in Ruby/Python/TypeScript/Swift delegates to `download_url`/`downloadURL`; `filename` prefers metadata.
  - Conformance: added `conformance/tests/uploads_download.json` (delegation + missing-url); wired in Go/Ruby/Python/TypeScript; Swift via unit tests; Kotlin skipped.
  - Docs: added “Downloading Files” examples in Ruby/Python/TypeScript/Swift.

- **Bug Fixes**
  - TypeScript: preserved the full BaseService positional constructor signature for `UploadsService`; `download()` throws a clear usage error when the service lacks the injected `downloadURL` primitive.
  - Docs: corrected Python README to reference `AccountClient.download_url` / `AsyncAccountClient.download_url`.

<sup>Written for commit 08b89218654ee28998dbcdf8e206460146621e84. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

