### PR TITLE
Fix stale Todos signatures in Go SDK doc comments

### DIFF
--- a/go/pkg/basecamp/doc.go
+++ b/go/pkg/basecamp/doc.go
@@ -90,18 +90,18 @@
 //
 // List todos in a todolist:
 //
-//	todos, err := account.Todos().List(ctx, projectID, todolistID, nil)
+//	todos, err := account.Todos().List(ctx, todolistID, nil)
 //
 // Create a todo:
 //
-//	todo, err := account.Todos().Create(ctx, projectID, todolistID, &basecamp.CreateTodoRequest{
+//	todo, err := account.Todos().Create(ctx, todolistID, &basecamp.CreateTodoRequest{
 //	    Content: "Ship the feature",
 //	    DueOn:   "2024-12-31",
 //	})
 //
 // Complete a todo:
 //
-//	err := account.Todos().Complete(ctx, projectID, todoID)
+//	err := account.Todos().Complete(ctx, todoID)
 //
 // # Searching
 //
@@ -176,6 +176,6 @@
 //	acme := client.ForAccount("12345")
 //	initech := client.ForAccount("67890")
 //
-//	go func() { acme.Todos().List(ctx, projectID, todolistID, nil) }()
+//	go func() { acme.Todos().List(ctx, todolistID, nil) }()
 //	go func() { initech.Projects().List(ctx, nil) }()
 package basecamp

--- a/go/pkg/basecamp/example_test.go
+++ b/go/pkg/basecamp/example_test.go
@@ -149,6 +149,28 @@ func ExampleTodosService_List() {
 	}
 }
 
+func ExampleTodosService_List_completed() {
+	cfg := basecamp.DefaultConfig()
+	token := &basecamp.StaticTokenProvider{Token: os.Getenv("BASECAMP_TOKEN")}
+	client := basecamp.NewClient(cfg, token)
+
+	ctx := context.Background()
+
+	todolistID := int64(789012)
+
+	// List only completed todos in a todolist.
+	todosResult, err := client.ForAccount("12345").Todos().List(ctx, todolistID, &basecamp.TodoListOptions{
+		Completed: true,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, t := range todosResult.Todos {
+		fmt.Printf("[x] %s\n", t.Content)
+	}
+}
+
 func ExampleTodosService_Create() {
 	cfg := basecamp.DefaultConfig()
 	token := &basecamp.StaticTokenProvider{Token: os.Getenv("BASECAMP_TOKEN")}


### PR DESCRIPTION
## Summary

- Update four `Todos` examples in the package doc comment (`go/pkg/basecamp/doc.go`) that still showed the pre-#279 leading `projectID` argument. Brings `List`, `Create`, and `Complete` examples back in sync with the canonical signatures in `go/pkg/basecamp/todos.go`.
- Add `ExampleTodosService_List_completed` to demonstrate the first-class `Completed` field on `TodoListOptions` introduced in #279.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/basecamp/...` (compiles `example_test.go`, validating the new example's signature)
- [x] `go vet ./...`
- [x] `gofmt -l pkg/basecamp/doc.go pkg/basecamp/example_test.go` (empty output)
- [x] `go doc github.com/basecamp/basecamp-sdk/go/pkg/basecamp` — confirmed the four updated examples render with the corrected signatures

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale Todos examples in the Go SDK docs by removing the old `projectID` argument to match current `List`, `Create`, and `Complete` signatures. Adds an example showing the `TodoListOptions.Completed` filter from #279 to illustrate listing completed todos.

- **Bug Fixes**
  - Updated four examples in `go/pkg/basecamp/doc.go` to the current signatures (no leading `projectID`).

- **New Features**
  - Added `ExampleTodosService_List_completed` in `go/pkg/basecamp/example_test.go` demonstrating `TodoListOptions.Completed`.

<sup>Written for commit d9b0459ab240a909a779d3d00315d76206e5ed51. Summary will update on new commits. <a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/290?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

