### PR TITLE
Expose timeout on Kotlin client builder; disable in tests

### DIFF
--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampClient.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampClient.kt
@@ -5,6 +5,7 @@ import io.ktor.client.*
 import io.ktor.client.engine.*
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.http.*
+import kotlin.time.Duration
 import kotlinx.serialization.json.Json
 
 /**
@@ -41,6 +42,9 @@ class BasecampClientBuilder {
     /** Maximum pages to follow during pagination (safety cap). */
     var maxPages: Int = BasecampConfig.DEFAULT_MAX_PAGES
 
+    /** Request timeout. Use [Duration.INFINITE] to disable. */
+    var timeout: Duration = BasecampConfig.DEFAULT_TIMEOUT
+
     /** Observability hooks. */
     var hooks: BasecampHooks = NoopHooks
 
@@ -72,6 +76,9 @@ class BasecampClientBuilder {
         require(httpClient == null || engine == null) {
             "Cannot set both httpClient and engine. Use one or the other."
         }
+        require(timeout == Duration.INFINITE || timeout.isPositive()) {
+            "timeout must be positive or Duration.INFINITE, got: $timeout"
+        }
 
         val resolvedAuth = authStrategy
             ?: tokenProvider?.let { BearerAuth(it) }
@@ -84,6 +91,7 @@ class BasecampClientBuilder {
             userAgent = userAgent,
             enableCache = enableCache,
             enableRetry = enableRetry,
+            timeout = timeout,
             maxPages = maxPages,
         )
 
@@ -165,10 +173,12 @@ class BasecampClient internal constructor(
 
     private fun HttpClientConfig<*>.configureClient() {
         expectSuccess = false
-        install(HttpTimeout) {
-            requestTimeoutMillis = config.timeout.inWholeMilliseconds
-            connectTimeoutMillis = config.timeout.inWholeMilliseconds
-            socketTimeoutMillis = config.timeout.inWholeMilliseconds
+        if (config.timeout.isFinite()) {
+            install(HttpTimeout) {
+                requestTimeoutMillis = config.timeout.inWholeMilliseconds
+                connectTimeoutMillis = config.timeout.inWholeMilliseconds
+                socketTimeoutMillis = config.timeout.inWholeMilliseconds
+            }
         }
     }
 

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampConfig.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampConfig.kt
@@ -19,7 +19,7 @@ data class BasecampConfig(
     /** Enable automatic retry on 429/503 with exponential backoff. */
     val enableRetry: Boolean = true,
     /** Request timeout. */
-    val timeout: Duration = 30.seconds,
+    val timeout: Duration = DEFAULT_TIMEOUT,
     /** Maximum retry attempts for GET requests. */
     val maxRetries: Int = DEFAULT_MAX_RETRIES,
     /** Maximum pages to follow for pagination (safety cap). */
@@ -34,5 +34,6 @@ data class BasecampConfig(
         const val DEFAULT_USER_AGENT = "basecamp-sdk-kotlin/$VERSION (api:$API_VERSION)"
         const val DEFAULT_MAX_RETRIES = 3
         const val DEFAULT_MAX_PAGES = 10_000
+        val DEFAULT_TIMEOUT: Duration = 30.seconds
     }
 }

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/AuthStrategyTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/AuthStrategyTest.kt
@@ -21,7 +21,7 @@ class AuthStrategyTest {
             respondOk("[]")
         }
 
-        val client = BasecampClient {
+        val client = testBasecampClient {
             accessToken("test-token")
             baseUrl = "http://localhost:3000"
             this.engine = engine
@@ -46,7 +46,7 @@ class AuthStrategyTest {
             respondOk("[]")
         }
 
-        val client = BasecampClient {
+        val client = testBasecampClient {
             auth(AuthStrategy { request ->
                 request.header("Cookie", "session=abc123")
             })
@@ -67,7 +67,7 @@ class AuthStrategyTest {
     @Test
     fun builderRejectsBothAccessTokenAndAuth() {
         assertFailsWith<IllegalArgumentException> {
-            BasecampClient {
+            testBasecampClient {
                 accessToken("token")
                 auth(BearerAuth(StaticTokenProvider("other-token")))
                 baseUrl = "http://localhost:3000"
@@ -78,7 +78,7 @@ class AuthStrategyTest {
     @Test
     fun builderRequiresAccessTokenOrAuth() {
         assertFailsWith<IllegalArgumentException> {
-            BasecampClient {
+            testBasecampClient {
                 baseUrl = "http://localhost:3000"
             }
         }
@@ -94,7 +94,7 @@ class AuthStrategyTest {
 
         val externalClient = HttpClient(engine)
 
-        val client = BasecampClient {
+        val client = testBasecampClient {
             accessToken("test-token")
             baseUrl = "http://localhost:3000"
             httpClient = externalClient
@@ -119,7 +119,7 @@ class AuthStrategyTest {
             expectSuccess = true
         }
 
-        val client = BasecampClient {
+        val client = testBasecampClient {
             accessToken("test-token")
             baseUrl = "http://localhost:3000"
             httpClient = externalClient
@@ -144,7 +144,7 @@ class AuthStrategyTest {
 
         val externalClient = HttpClient(engine)
 
-        val client = BasecampClient {
+        val client = testBasecampClient {
             accessToken("test-token")
             baseUrl = "http://localhost:3000"
             httpClient = externalClient

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/ClientTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/ClientTest.kt
@@ -3,6 +3,8 @@ package com.basecamp.sdk
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import io.ktor.utils.io.*
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -15,7 +17,7 @@ class ClientTest {
         handler: MockRequestHandler,
     ): BasecampClient {
         val engine = MockEngine(handler)
-        return BasecampClient {
+        return testBasecampClient {
             accessToken("test-token")
             baseUrl = "http://localhost:3000"
             this.engine = engine
@@ -89,7 +91,7 @@ class ClientTest {
     @Test
     fun builderRequiresAccessToken() {
         assertFailsWith<IllegalArgumentException> {
-            BasecampClient {
+            testBasecampClient {
                 baseUrl = "http://localhost:3000"
             }
         }
@@ -98,7 +100,7 @@ class ClientTest {
     @Test
     fun builderRejectsNonHttpsUrl() {
         assertFailsWith<IllegalArgumentException> {
-            BasecampClient {
+            testBasecampClient {
                 accessToken("token")
                 baseUrl = "http://not-localhost.com"
             }
@@ -107,11 +109,60 @@ class ClientTest {
 
     @Test
     fun builderAllowsLocalhost() {
-        val client = BasecampClient {
+        val client = testBasecampClient {
             accessToken("token")
             baseUrl = "http://localhost:3000"
         }
         assertEquals("http://localhost:3000", client.config.baseUrl)
+        client.close()
+    }
+
+    @Test
+    fun builderPropagatesTimeoutToConfig() {
+        val client = testBasecampClient {
+            accessToken("token")
+            baseUrl = "http://localhost:3000"
+            timeout = 5.seconds
+        }
+        assertEquals(5.seconds, client.config.timeout)
+        client.close()
+    }
+
+    @Test
+    fun builderRejectsNonPositiveTimeout() {
+        assertFailsWith<IllegalArgumentException> {
+            BasecampClient {
+                accessToken("token")
+                baseUrl = "http://localhost:3000"
+                timeout = Duration.ZERO
+            }
+        }
+        assertFailsWith<IllegalArgumentException> {
+            BasecampClient {
+                accessToken("token")
+                baseUrl = "http://localhost:3000"
+                timeout = (-1).seconds
+            }
+        }
+    }
+
+    @Test
+    fun infiniteTimeoutAllowsRequestUnderRunTest() = runTest {
+        // Regression guard: HttpTimeout is skipped when timeout is INFINITE,
+        // sidestepping the KTOR-8271 virtual-clock race in MockEngine + runTest.
+        val engine = MockEngine { respondOk("[]") }
+        val client = BasecampClient {
+            accessToken("token")
+            baseUrl = "http://localhost:3000"
+            this.engine = engine
+            timeout = Duration.INFINITE
+            enableRetry = false
+        }
+        val account = client.forAccount("12345")
+        val response = account.httpClient.requestWithRetry(
+            HttpMethod.Get, "${client.config.baseUrl}/12345/projects.json"
+        )
+        assertEquals(200, response.status.value)
         client.close()
     }
 
@@ -148,7 +199,7 @@ class ClientTest {
         }
 
         val engine = MockEngine { respondOk("[]") }
-        val client = BasecampClient {
+        val client = testBasecampClient {
             accessToken("test-token")
             baseUrl = "http://localhost:3000"
             this.engine = engine

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/CommentsServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/CommentsServiceTest.kt
@@ -19,7 +19,7 @@ class CommentsServiceTest {
 
     private fun mockClient(handler: MockRequestHandler): BasecampClient {
         val engine = MockEngine(handler)
-        return BasecampClient {
+        return testBasecampClient {
             accessToken("test-token")
             this.engine = engine
         }

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/DownloadTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/DownloadTest.kt
@@ -14,7 +14,7 @@ class DownloadTest {
         enableRetry: Boolean = false,
     ): BasecampClient {
         val mockEngine = MockEngine(handler)
-        return BasecampClient {
+        return testBasecampClient {
             accessToken("test-token")
             baseUrl = "http://localhost:3000"
             engine = mockEngine

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PaginationTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PaginationTest.kt
@@ -179,7 +179,7 @@ class PaginationTest {
 
     private fun mockClient(handler: MockRequestHandler): BasecampClient {
         val engine = MockEngine(handler)
-        return BasecampClient {
+        return testBasecampClient {
             accessToken("test-token")
             this.engine = engine
         }

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PeopleServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PeopleServiceTest.kt
@@ -12,7 +12,7 @@ class PeopleServiceTest {
 
     private fun mockClient(handler: MockRequestHandler): BasecampClient {
         val engine = MockEngine(handler)
-        return BasecampClient {
+        return testBasecampClient {
             accessToken("test-token")
             this.engine = engine
         }

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/ProjectsServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/ProjectsServiceTest.kt
@@ -20,7 +20,7 @@ class ProjectsServiceTest {
 
     private fun mockClient(handler: MockRequestHandler): BasecampClient {
         val engine = MockEngine(handler)
-        return BasecampClient {
+        return testBasecampClient {
             accessToken("test-token")
             this.engine = engine
         }

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/RetryTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/RetryTest.kt
@@ -48,7 +48,7 @@ class RetryTest {
             }
         }
 
-        val client = BasecampClient {
+        val client = testBasecampClient {
             accessToken("test-token")
             baseUrl = "http://localhost:3000"
             this.engine = engine
@@ -75,7 +75,7 @@ class RetryTest {
             )
         }
 
-        val client = BasecampClient {
+        val client = testBasecampClient {
             accessToken("test-token")
             baseUrl = "http://localhost:3000"
             this.engine = engine
@@ -110,7 +110,7 @@ class RetryTest {
             }
         }
 
-        val client = BasecampClient {
+        val client = testBasecampClient {
             accessToken("test-token")
             baseUrl = "http://localhost:3000"
             this.engine = engine
@@ -143,7 +143,7 @@ class RetryTest {
             }
         }
 
-        val client = BasecampClient {
+        val client = testBasecampClient {
             accessToken("test-token")
             baseUrl = "http://localhost:3000"
             this.engine = engine
@@ -169,7 +169,7 @@ class RetryTest {
             )
         }
 
-        val client = BasecampClient {
+        val client = testBasecampClient {
             accessToken("test-token")
             baseUrl = "http://localhost:3000"
             this.engine = engine
@@ -205,7 +205,7 @@ class RetryTest {
             }
         }
 
-        val client = BasecampClient {
+        val client = testBasecampClient {
             accessToken("test-token")
             baseUrl = "http://localhost:3000"
             this.engine = engine
@@ -237,7 +237,7 @@ class RetryTest {
             )
         }
 
-        val client = BasecampClient {
+        val client = testBasecampClient {
             accessToken("test-token")
             baseUrl = "http://localhost:3000"
             this.engine = engine
@@ -271,7 +271,7 @@ class RetryTest {
             }
         }
 
-        val client = BasecampClient {
+        val client = testBasecampClient {
             accessToken("test-token")
             baseUrl = "http://localhost:3000"
             this.engine = engine
@@ -301,7 +301,7 @@ class RetryTest {
             )
         }
 
-        val client = BasecampClient {
+        val client = testBasecampClient {
             accessToken("test-token")
             baseUrl = "http://localhost:3000"
             enableRetry = false
@@ -329,7 +329,7 @@ class RetryTest {
             }
         }
 
-        val client = BasecampClient {
+        val client = testBasecampClient {
             accessToken("test-token")
             baseUrl = "http://localhost:3000"
             this.engine = engine
@@ -376,7 +376,7 @@ class RetryTest {
             }
         }
 
-        val client = BasecampClient {
+        val client = testBasecampClient {
             accessToken("test-token")
             baseUrl = "http://localhost:3000"
             this.engine = engine

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TestBasecampClient.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TestBasecampClient.kt
@@ -1,0 +1,14 @@
+package com.basecamp.sdk
+
+import kotlin.time.Duration
+
+// Disables HttpTimeout by default. Ktor 3.5.0 (KTOR-8271) made HttpTimeout
+// honor the kotlinx-coroutines test scheduler's virtual clock; runTest then
+// auto-advances past the timeout while MockEngine's IO-dispatched response is
+// in flight, firing HttpRequestTimeoutException before the mock can respond.
+// Override `timeout` inside the block to test timeout behavior explicitly.
+internal fun testBasecampClient(block: BasecampClientBuilder.() -> Unit): BasecampClient =
+    BasecampClient {
+        timeout = Duration.INFINITE
+        block()
+    }

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TodosServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TodosServiceTest.kt
@@ -19,7 +19,7 @@ class TodosServiceTest {
 
     private fun mockClient(handler: MockRequestHandler): BasecampClient {
         val engine = MockEngine(handler)
-        return BasecampClient {
+        return testBasecampClient {
             accessToken("test-token")
             this.engine = engine
         }

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/WebhooksServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/WebhooksServiceTest.kt
@@ -20,7 +20,7 @@ class WebhooksServiceTest {
 
     private fun mockClient(handler: MockRequestHandler): BasecampClient {
         val engine = MockEngine(handler)
-        return BasecampClient {
+        return testBasecampClient {
             accessToken("test-token")
             this.engine = engine
         }


### PR DESCRIPTION
## Summary

- `BasecampClientBuilder` didn't surface a `timeout` knob, so callers were stuck on the 30-second default baked into `BasecampConfig`. Wired it through.
- `configureClient()` skips installing Ktor's `HttpTimeout` plugin when `timeout` is `Duration.INFINITE`.
- Test client construction now flows through a new `testBasecampClient { … }` helper that defaults `timeout` to `Duration.INFINITE`. Tests that want to exercise timeout behavior can override inside the block.

## Why

Ktor 3.5.0 ([KTOR-8271](https://youtrack.jetbrains.com/issue/KTOR-8271), bumped in #311) made `HttpTimeout` honor the kotlinx-coroutines test scheduler's virtual clock. Under `runTest`, the dispatcher idles while `MockEngine` posts its response back from `Dispatchers.IO`; virtual time auto-advances past 30s; the timeout coroutine fires and every request fails with `HttpRequestTimeoutException`. 66 tests broke from a single dependency bump.

Rather than pinning ktor or sniffing for `MockEngine` in production code, this surfaces `timeout` as a real public builder field and uses the existing API (set it to `INFINITE`) to opt out in tests. Production code path is unchanged.

## Test plan

- [x] `make kt-test` green (was 66 failures before this change).
- [ ] Future timeout-behavior tests can set `timeout = 100.milliseconds` inside `testBasecampClient { … }` and assert `HttpRequestTimeoutException` — a capability KTOR-8271 unlocked.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose a request timeout on the Kotlin `BasecampClientBuilder` and disable it by default in tests to prevent false timeouts after the Ktor 3.5.0 update. Centralizes the 30s default, validates the value, and installs `HttpTimeout` only when the timeout is finite.

- New Features
  - Added `timeout: Duration` to `BasecampClientBuilder` (defaults to `BasecampConfig.DEFAULT_TIMEOUT` = 30s). Set `Duration.INFINITE` to disable.
  - Validate timeout at build: must be positive or `Duration.INFINITE`.
  - `configureClient()` installs `HttpTimeout` only when the timeout is finite; default moved to `BasecampConfig.DEFAULT_TIMEOUT` shared by builder and config.

- Bug Fixes
  - Tests now build clients via `testBasecampClient { ... }` with `timeout = Duration.INFINITE` to avoid `HttpRequestTimeoutException` under `runTest` with Ktor 3.5.0’s virtual clock. Override the timeout in tests when needed.

<sup>Written for commit b777b8e24fd91a3e49d9ff2a160cac89436c5de6. Summary will update on new commits. <a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/317?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



