### PR TITLE
Pin SDK bearer token to the configured origin (all 6 SDKs)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ All SDK implementations enforce HTTPS for API communication with specific except
 | OAuth endpoints | Yes | Yes - for local OAuth testing |
 | Webhook payload URLs | Yes | **No** - webhooks are production-only |
 
-Localhost is defined as: `localhost`, `127.0.0.1`, or `::1`.
+Localhost is defined as: `localhost`, any `*.localhost` subdomain (RFC 6761), `127.0.0.1`, or the IPv6 loopback `::1` (also accepted in its bracketed URL form `[::1]`). Host matching is case-insensitive.
 
 **Rationale**: Base URLs and OAuth endpoints may use localhost during development. Webhook payload URLs never allow localhost because webhooks are a server-to-server feature that only makes sense in production contexts.
 
@@ -30,7 +30,7 @@ This is enforced at two layers:
 - **URL-build chokepoint**: the URL builder rejects absolute URLs whose origin differs from the configured base URL.
 - **Token-attach backstop**: immediately before the `Authorization` header is added, the request origin is re-checked, so the invariant holds even if a future code path bypasses the URL builder.
 
-The one intentional exception is the authenticated cross-origin call to the Launchpad authorization endpoint (`https://launchpad.37signals.com/authorization.json`), which is explicitly allowed. This complements the redirect Authorization-stripping and same-origin pagination `Link` validation described above.
+The one intentional exception is the authenticated request to the OAuth **authorization endpoint** — by default Launchpad's (`https://launchpad.37signals.com/authorization.json`). Some SDKs let callers override this endpoint, validated as HTTPS (or localhost) before the token is attached. This is the sole sanctioned cross-origin credentialed request, and it complements the redirect Authorization-stripping and same-origin pagination `Link` validation described above.
 
 #### Pagination Security
 Link headers from paginated responses are validated for same-origin before following. This prevents:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,6 +23,15 @@ Localhost is defined as: `localhost`, `127.0.0.1`, or `::1`.
 #### Cross-Origin Redirect Handling
 Authorization headers are automatically stripped when HTTP redirects cross origin boundaries. This prevents credential leakage to third-party hosts.
 
+#### Same-Origin Credential Attachment
+The bearer token is attached only to requests targeting the configured base-URL origin (with a localhost carve-out for development and testing). When a caller supplies an absolute URL as the request path, its origin must match the configured base URL or the request is rejected **before any network call is made** — so the credential can never be sent to a foreign host.
+
+This is enforced at two layers:
+- **URL-build chokepoint**: the URL builder rejects absolute URLs whose origin differs from the configured base URL.
+- **Token-attach backstop**: immediately before the `Authorization` header is added, the request origin is re-checked, so the invariant holds even if a future code path bypasses the URL builder.
+
+The one intentional exception is the authenticated cross-origin call to the Launchpad authorization endpoint (`https://launchpad.37signals.com/authorization.json`), which is explicitly allowed. This complements the redirect Authorization-stripping and same-origin pagination `Link` validation described above.
+
 #### Pagination Security
 Link headers from paginated responses are validated for same-origin before following. This prevents:
 - SSRF attacks via poisoned Link headers

--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -843,7 +843,7 @@ func (c *Client) buildURL(path string) (string, error) {
 		if isLocalhost(path) || isSameOrigin(path, c.cfg.BaseURL) {
 			return path, nil
 		}
-		return "", fmt.Errorf("absolute URL points to a different origin than base URL: %s", path)
+		return "", fmt.Errorf("absolute URL points to a different origin than base URL: %s", truncateString(path, MaxErrorMessageBytes))
 	}
 	if strings.HasPrefix(lowerPath, "http://") {
 		// Localhost may use plain HTTP for local development and httptest
@@ -852,7 +852,7 @@ func (c *Client) buildURL(path string) (string, error) {
 		if isLocalhost(path) {
 			return path, nil
 		}
-		return "", fmt.Errorf("URL must use HTTPS, got: %s", path)
+		return "", fmt.Errorf("URL must use HTTPS, got: %s", truncateString(path, MaxErrorMessageBytes))
 	}
 	// Ensure path starts with /
 	if !strings.HasPrefix(path, "/") {
@@ -873,7 +873,7 @@ func (c *Client) assertCredentialOrigin(req *http.Request) error {
 	if isLocalhost(target) || isSameOrigin(target, c.cfg.BaseURL) {
 		return nil
 	}
-	return fmt.Errorf("refusing to attach credentials to a different origin than base URL: %s", target)
+	return fmt.Errorf("refusing to attach credentials to a different origin than base URL: %s", truncateString(target, MaxErrorMessageBytes))
 }
 
 func (c *Client) backoffDelay(attempt int) time.Duration {

--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -829,8 +829,12 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 }
 
 func (c *Client) buildURL(path string) (string, error) {
+	// Schemes are case-insensitive (RFC 3986), so detect absolute URLs on a
+	// lowercased copy — otherwise HTTPS://... would be mis-treated as a
+	// relative path and concatenated onto the base URL.
+	lowerPath := strings.ToLower(path)
 	// Absolute URLs: enforce HTTPS and return as-is (e.g., pagination Link headers)
-	if strings.HasPrefix(path, "https://") {
+	if strings.HasPrefix(lowerPath, "https://") {
 		// Absolute URLs must target the configured origin; otherwise we would
 		// attach the bearer token to a foreign host (credential exfiltration).
 		// Localhost targets are carved out for local development and httptest
@@ -841,7 +845,7 @@ func (c *Client) buildURL(path string) (string, error) {
 		}
 		return "", fmt.Errorf("absolute URL points to a different origin than base URL: %s", path)
 	}
-	if strings.HasPrefix(path, "http://") {
+	if strings.HasPrefix(lowerPath, "http://") {
 		// Localhost may use plain HTTP for local development and httptest
 		// servers, matching the BaseURL check in NewClient and the localhost
 		// carve-out in the other SDKs.

--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -361,6 +361,10 @@ func (c *Client) initGeneratedClient() {
 	c.genOnce.Do(func() {
 		serverURL := strings.TrimSuffix(c.cfg.BaseURL, "/")
 		authEditor := func(ctx context.Context, req *http.Request) error {
+			// Backstop: refuse to attach credentials to a foreign origin.
+			if err := c.assertCredentialOrigin(req); err != nil {
+				return err
+			}
 			if err := c.authStrategy.Authenticate(ctx, req); err != nil {
 				return err
 			}
@@ -679,6 +683,11 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 		return nil, err
 	}
 
+	// Backstop: never attach credentials to a foreign origin, even if a future
+	// code path reaches here without going through buildURL.
+	if err := c.assertCredentialOrigin(req); err != nil {
+		return nil, err
+	}
 	if err := c.authStrategy.Authenticate(ctx, req); err != nil {
 		return nil, err
 	}
@@ -822,7 +831,15 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 func (c *Client) buildURL(path string) (string, error) {
 	// Absolute URLs: enforce HTTPS and return as-is (e.g., pagination Link headers)
 	if strings.HasPrefix(path, "https://") {
-		return path, nil
+		// Absolute URLs must target the configured origin; otherwise we would
+		// attach the bearer token to a foreign host (credential exfiltration).
+		// Localhost is carved out for local development and httptest servers,
+		// matching NewClient's BaseURL HTTPS check and the same-origin guard
+		// already applied to pagination Link headers and cross-origin redirects.
+		if isLocalhost(path) || isLocalhost(c.cfg.BaseURL) || isSameOrigin(path, c.cfg.BaseURL) {
+			return path, nil
+		}
+		return "", fmt.Errorf("absolute URL points to a different origin than base URL: %s", path)
 	}
 	if strings.HasPrefix(path, "http://") {
 		return "", fmt.Errorf("URL must use HTTPS, got: %s", path)
@@ -834,6 +851,19 @@ func (c *Client) buildURL(path string) (string, error) {
 	// Normalize BaseURL to avoid double slashes when concatenating
 	base := strings.TrimSuffix(c.cfg.BaseURL, "/")
 	return base + path, nil
+}
+
+// assertCredentialOrigin verifies the outgoing request targets the configured
+// origin before any credential is attached. Localhost is carved out for local
+// development and httptest servers. This attach-point backstop complements the
+// buildURL chokepoint and fails closed if a future code path reaches the
+// token-attach site without going through buildURL.
+func (c *Client) assertCredentialOrigin(req *http.Request) error {
+	target := req.URL.String()
+	if isLocalhost(target) || isLocalhost(c.cfg.BaseURL) || isSameOrigin(target, c.cfg.BaseURL) {
+		return nil
+	}
+	return fmt.Errorf("refusing to attach credentials to a different origin than base URL: %s", target)
 }
 
 func (c *Client) backoffDelay(attempt int) time.Duration {

--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -833,10 +833,10 @@ func (c *Client) buildURL(path string) (string, error) {
 	if strings.HasPrefix(path, "https://") {
 		// Absolute URLs must target the configured origin; otherwise we would
 		// attach the bearer token to a foreign host (credential exfiltration).
-		// Localhost is carved out for local development and httptest servers,
-		// matching NewClient's BaseURL HTTPS check and the same-origin guard
-		// already applied to pagination Link headers and cross-origin redirects.
-		if isLocalhost(path) || isLocalhost(c.cfg.BaseURL) || isSameOrigin(path, c.cfg.BaseURL) {
+		// Localhost targets are carved out for local development and httptest
+		// servers, matching the same-origin guard already applied to pagination
+		// Link headers and cross-origin redirects.
+		if isLocalhost(path) || isSameOrigin(path, c.cfg.BaseURL) {
 			return path, nil
 		}
 		return "", fmt.Errorf("absolute URL points to a different origin than base URL: %s", path)
@@ -860,7 +860,7 @@ func (c *Client) buildURL(path string) (string, error) {
 // token-attach site without going through buildURL.
 func (c *Client) assertCredentialOrigin(req *http.Request) error {
 	target := req.URL.String()
-	if isLocalhost(target) || isLocalhost(c.cfg.BaseURL) || isSameOrigin(target, c.cfg.BaseURL) {
+	if isLocalhost(target) || isSameOrigin(target, c.cfg.BaseURL) {
 		return nil
 	}
 	return fmt.Errorf("refusing to attach credentials to a different origin than base URL: %s", target)

--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -842,6 +842,12 @@ func (c *Client) buildURL(path string) (string, error) {
 		return "", fmt.Errorf("absolute URL points to a different origin than base URL: %s", path)
 	}
 	if strings.HasPrefix(path, "http://") {
+		// Localhost may use plain HTTP for local development and httptest
+		// servers, matching the BaseURL check in NewClient and the localhost
+		// carve-out in the other SDKs.
+		if isLocalhost(path) {
+			return path, nil
+		}
 		return "", fmt.Errorf("URL must use HTTPS, got: %s", path)
 	}
 	// Ensure path starts with /

--- a/go/pkg/basecamp/same_origin_test.go
+++ b/go/pkg/basecamp/same_origin_test.go
@@ -1,0 +1,170 @@
+package basecamp
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// recordingTransport records whether it was ever invoked and what Authorization
+// header it observed. It never performs real network I/O, so a request that
+// reaches it would prove the same-origin guard failed to fire.
+type recordingTransport struct {
+	mu    sync.Mutex
+	calls int
+	auth  string
+}
+
+func (rt *recordingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.mu.Lock()
+	rt.calls++
+	rt.auth = req.Header.Get("Authorization")
+	rt.mu.Unlock()
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`[]`)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func (rt *recordingTransport) snapshot() (int, string) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return rt.calls, rt.auth
+}
+
+// TestBuildURL_RejectsForeignOriginAbsoluteURL verifies that an absolute URL on
+// a different origin than the configured base URL is rejected by the chokepoint.
+func TestBuildURL_RejectsForeignOriginAbsoluteURL(t *testing.T) {
+	cfg := &Config{BaseURL: "https://3.basecampapi.com"}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "secret-token"})
+
+	_, err := client.buildURL("https://evil.example/x.json")
+	if err == nil {
+		t.Fatal("expected error for foreign-origin absolute URL, got nil")
+	}
+	if !strings.Contains(err.Error(), "different origin") {
+		t.Errorf("expected error mentioning 'different origin', got: %v", err)
+	}
+}
+
+// TestBuildURL_AcceptsLocalhostAbsoluteURL verifies the localhost dev/test
+// carve-out: an absolute localhost URL passes even when the base URL is a
+// different (non-localhost) origin.
+func TestBuildURL_AcceptsLocalhostAbsoluteURL(t *testing.T) {
+	cfg := &Config{BaseURL: "https://3.basecampapi.com"}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "token"})
+
+	got, err := client.buildURL("https://localhost:8080/page2")
+	if err != nil {
+		t.Fatalf("unexpected error for localhost absolute URL: %v", err)
+	}
+	if got != "https://localhost:8080/page2" {
+		t.Errorf("expected localhost URL passthrough, got: %q", got)
+	}
+
+	// Localhost base URL with a localhost absolute path (httptest-style).
+	cfg2 := &Config{BaseURL: "https://127.0.0.1:9999"}
+	client2 := NewClient(cfg2, &StaticTokenProvider{Token: "token"})
+	got2, err := client2.buildURL("https://127.0.0.1:9999/items.json")
+	if err != nil {
+		t.Fatalf("unexpected error for localhost base + path: %v", err)
+	}
+	if got2 != "https://127.0.0.1:9999/items.json" {
+		t.Errorf("expected localhost passthrough, got: %q", got2)
+	}
+}
+
+// TestForeignAbsoluteURL_NoTokenEgress is the end-to-end regression test for the
+// credential-exfiltration primitive: a request to a foreign-origin absolute URL
+// must error before any network send, and the transport must never see the
+// Authorization header.
+func TestForeignAbsoluteURL_NoTokenEgress(t *testing.T) {
+	rt := &recordingTransport{}
+	cfg := &Config{BaseURL: "https://3.basecampapi.com"}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "secret-token"},
+		WithTransport(rt))
+
+	_, err := client.Get(context.Background(), "https://evil.example/steal")
+	if err == nil {
+		t.Fatal("expected error for foreign-origin absolute URL, got nil")
+	}
+	if !strings.Contains(err.Error(), "different origin") {
+		t.Errorf("expected error mentioning 'different origin', got: %v", err)
+	}
+
+	calls, auth := rt.snapshot()
+	if calls != 0 {
+		t.Errorf("expected zero requests to foreign origin, got %d", calls)
+	}
+	if auth != "" {
+		t.Errorf("Authorization header leaked to foreign origin: %q", auth)
+	}
+}
+
+// TestGetAll_RejectsForeignFirstPageURL verifies pagination's first page is also
+// guarded by the chokepoint.
+func TestGetAll_RejectsForeignFirstPageURL(t *testing.T) {
+	rt := &recordingTransport{}
+	cfg := &Config{BaseURL: "https://3.basecampapi.com"}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "secret-token"},
+		WithTransport(rt))
+
+	_, err := client.GetAll(context.Background(), "https://evil.example/items.json")
+	if err == nil {
+		t.Fatal("expected error for foreign-origin first page URL, got nil")
+	}
+	if !strings.Contains(err.Error(), "different origin") {
+		t.Errorf("expected error mentioning 'different origin', got: %v", err)
+	}
+	if calls, _ := rt.snapshot(); calls != 0 {
+		t.Errorf("expected zero requests to foreign origin, got %d", calls)
+	}
+}
+
+// TestAccountClient_RejectsForeignAbsoluteURL verifies account-scoped requests
+// reject foreign absolute URLs too (accountPath passes them through; buildURL
+// rejects them).
+func TestAccountClient_RejectsForeignAbsoluteURL(t *testing.T) {
+	rt := &recordingTransport{}
+	cfg := &Config{BaseURL: "https://3.basecampapi.com"}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "secret-token"},
+		WithTransport(rt))
+	ac := client.ForAccount("12345")
+
+	_, err := ac.Get(context.Background(), "https://evil.example/projects.json")
+	if err == nil {
+		t.Fatal("expected error for foreign-origin absolute URL, got nil")
+	}
+	if !strings.Contains(err.Error(), "different origin") {
+		t.Errorf("expected error mentioning 'different origin', got: %v", err)
+	}
+	if calls, auth := rt.snapshot(); calls != 0 || auth != "" {
+		t.Errorf("token egress to foreign origin: calls=%d auth=%q", calls, auth)
+	}
+}
+
+// TestSameOriginAbsoluteURL_CarriesToken confirms a same-origin absolute URL
+// still works and still carries the bearer token.
+func TestSameOriginAbsoluteURL_CarriesToken(t *testing.T) {
+	rt := &recordingTransport{}
+	cfg := &Config{BaseURL: "https://3.basecampapi.com"}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "secret-token"},
+		WithTransport(rt))
+
+	_, err := client.Get(context.Background(), "https://3.basecampapi.com/page2")
+	if err != nil {
+		t.Fatalf("unexpected error for same-origin absolute URL: %v", err)
+	}
+	calls, auth := rt.snapshot()
+	if calls != 1 {
+		t.Fatalf("expected one request to same origin, got %d", calls)
+	}
+	if auth != "Bearer secret-token" {
+		t.Errorf("expected Authorization %q, got %q", "Bearer secret-token", auth)
+	}
+}

--- a/go/pkg/basecamp/same_origin_test.go
+++ b/go/pkg/basecamp/same_origin_test.go
@@ -103,6 +103,22 @@ func TestBuildURL_AcceptsLocalhostPlainHTTP(t *testing.T) {
 	}
 }
 
+// TestBuildURL_TruncatesURLInErrors verifies guard errors embed a bounded
+// form of the caller-supplied URL rather than echoing it in full.
+func TestBuildURL_TruncatesURLInErrors(t *testing.T) {
+	cfg := &Config{BaseURL: "https://3.basecampapi.com"}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "token"})
+
+	huge := "https://evil.example/" + strings.Repeat("a", 10_000)
+	_, err := client.buildURL(huge)
+	if err == nil {
+		t.Fatal("expected error for foreign-origin URL, got nil")
+	}
+	if len(err.Error()) > MaxErrorMessageBytes+100 {
+		t.Errorf("expected truncated error message, got %d bytes", len(err.Error()))
+	}
+}
+
 // TestBuildURL_CaseInsensitiveScheme verifies schemes are matched
 // case-insensitively (RFC 3986): an uppercase-scheme absolute URL must be
 // treated as absolute — same-origin and localhost targets pass through, and a

--- a/go/pkg/basecamp/same_origin_test.go
+++ b/go/pkg/basecamp/same_origin_test.go
@@ -79,6 +79,40 @@ func TestBuildURL_AcceptsLocalhostAbsoluteURL(t *testing.T) {
 	}
 }
 
+// TestBuildURL_LocalhostBaseDoesNotTrustForeignOrigin verifies that a localhost
+// base URL does not turn the same-origin guard into a no-op: a foreign-origin
+// absolute target must still be rejected (and carry no token), while a
+// same-origin localhost target still passes.
+func TestBuildURL_LocalhostBaseDoesNotTrustForeignOrigin(t *testing.T) {
+	rt := &recordingTransport{}
+	cfg := &Config{BaseURL: "https://localhost:3000"}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "secret-token"},
+		WithTransport(rt))
+
+	if _, err := client.buildURL("https://evil.example/x"); err == nil {
+		t.Fatal("expected error for foreign-origin absolute URL, got nil")
+	} else if !strings.Contains(err.Error(), "different origin") {
+		t.Errorf("expected error mentioning 'different origin', got: %v", err)
+	}
+
+	_, err := client.Get(context.Background(), "https://evil.example/x")
+	if err == nil {
+		t.Fatal("expected error for foreign-origin absolute URL, got nil")
+	}
+	if calls, auth := rt.snapshot(); calls != 0 || auth != "" {
+		t.Errorf("token egress to foreign origin: calls=%d auth=%q", calls, auth)
+	}
+
+	// Sanity: a same-origin localhost target still builds.
+	got, err := client.buildURL("https://localhost:3000/items.json")
+	if err != nil {
+		t.Fatalf("unexpected error for same-origin localhost URL: %v", err)
+	}
+	if got != "https://localhost:3000/items.json" {
+		t.Errorf("expected localhost passthrough, got: %q", got)
+	}
+}
+
 // TestForeignAbsoluteURL_NoTokenEgress is the end-to-end regression test for the
 // credential-exfiltration primitive: a request to a foreign-origin absolute URL
 // must error before any network send, and the transport must never see the

--- a/go/pkg/basecamp/same_origin_test.go
+++ b/go/pkg/basecamp/same_origin_test.go
@@ -79,6 +79,30 @@ func TestBuildURL_AcceptsLocalhostAbsoluteURL(t *testing.T) {
 	}
 }
 
+// TestBuildURL_AcceptsLocalhostPlainHTTP verifies localhost may use plain HTTP
+// (local development and httptest servers), while non-localhost http:// targets
+// are still rejected — consistent with the other SDKs' localhost carve-out.
+func TestBuildURL_AcceptsLocalhostPlainHTTP(t *testing.T) {
+	cfg := &Config{BaseURL: "https://3.basecampapi.com"}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "token"})
+
+	got, err := client.buildURL("http://localhost:8080/x.json")
+	if err != nil {
+		t.Fatalf("unexpected error for localhost plain-HTTP URL: %v", err)
+	}
+	if got != "http://localhost:8080/x.json" {
+		t.Errorf("expected localhost URL passthrough, got: %q", got)
+	}
+
+	_, err = client.buildURL("http://evil.example/steal.json")
+	if err == nil {
+		t.Fatal("expected error for non-localhost plain-HTTP URL, got nil")
+	}
+	if !strings.Contains(err.Error(), "HTTPS") {
+		t.Errorf("expected error mentioning HTTPS, got: %v", err)
+	}
+}
+
 // TestBuildURL_LocalhostBaseDoesNotTrustForeignOrigin verifies that a localhost
 // base URL does not turn the same-origin guard into a no-op: a foreign-origin
 // absolute target must still be rejected (and carry no token), while a

--- a/go/pkg/basecamp/same_origin_test.go
+++ b/go/pkg/basecamp/same_origin_test.go
@@ -103,6 +103,38 @@ func TestBuildURL_AcceptsLocalhostPlainHTTP(t *testing.T) {
 	}
 }
 
+// TestBuildURL_CaseInsensitiveScheme verifies schemes are matched
+// case-insensitively (RFC 3986): an uppercase-scheme absolute URL must be
+// treated as absolute — same-origin and localhost targets pass through, and a
+// foreign origin is still rejected rather than concatenated onto the base.
+func TestBuildURL_CaseInsensitiveScheme(t *testing.T) {
+	cfg := &Config{BaseURL: "https://3.basecampapi.com"}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "token"})
+
+	got, err := client.buildURL("HTTPS://3.basecampapi.com/x.json")
+	if err != nil {
+		t.Fatalf("unexpected error for uppercase-scheme same-origin URL: %v", err)
+	}
+	if got != "HTTPS://3.basecampapi.com/x.json" {
+		t.Errorf("expected passthrough, got: %q", got)
+	}
+
+	got, err = client.buildURL("HTTP://localhost:8080/x.json")
+	if err != nil {
+		t.Fatalf("unexpected error for uppercase-scheme localhost URL: %v", err)
+	}
+	if got != "HTTP://localhost:8080/x.json" {
+		t.Errorf("expected passthrough, got: %q", got)
+	}
+
+	if _, err = client.buildURL("HTTPS://evil.example/x.json"); err == nil {
+		t.Fatal("expected error for uppercase-scheme foreign-origin URL, got nil")
+	}
+	if _, err = client.buildURL("HTTP://evil.example/x.json"); err == nil {
+		t.Fatal("expected error for uppercase-scheme non-localhost HTTP URL, got nil")
+	}
+}
+
 // TestBuildURL_LocalhostBaseDoesNotTrustForeignOrigin verifies that a localhost
 // base URL does not turn the same-origin guard into a no-op: a foreign-origin
 // absolute target must still be rejected (and carry no token), while a

--- a/go/pkg/basecamp/security.go
+++ b/go/pkg/basecamp/security.go
@@ -120,7 +120,8 @@ func isLocalhost(rawURL string) bool {
 	if err != nil {
 		return false
 	}
-	host := u.Hostname()
+	// Hostnames are case-insensitive (RFC 3986).
+	host := strings.ToLower(u.Hostname())
 
 	// Exact matches for localhost and loopback IPs
 	if host == "localhost" || host == "127.0.0.1" || host == "::1" {

--- a/go/pkg/basecamp/security.go
+++ b/go/pkg/basecamp/security.go
@@ -120,6 +120,13 @@ func isLocalhost(rawURL string) bool {
 	if err != nil {
 		return false
 	}
+	// The carve-out is limited to HTTP(S) so credential guards and
+	// RequireSecureEndpoint fail closed on any other scheme (e.g.
+	// ws://localhost), matching the other SDKs.
+	scheme := strings.ToLower(u.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return false
+	}
 	// Hostnames are case-insensitive (RFC 3986).
 	host := strings.ToLower(u.Hostname())
 

--- a/go/pkg/basecamp/security_test.go
+++ b/go/pkg/basecamp/security_test.go
@@ -687,6 +687,13 @@ func TestIsLocalhost(t *testing.T) {
 		{"https://localhost.example.com/path", false},   // localhost as subdomain of non-localhost
 		{"https://fakelocalhostdomain.com/path", false}, // localhost embedded in domain
 
+		// The carve-out is limited to HTTP(S): any other scheme fails closed
+		// even for localhost, so RequireSecureEndpoint cannot accept e.g.
+		// ws://localhost.
+		{"ws://localhost:3000/path", false},
+		{"ftp://127.0.0.1/path", false},
+		{"wss://[::1]/path", false},
+
 		// Invalid URLs
 		{"://invalid", false},
 		{"", false},

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampClient.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampClient.kt
@@ -107,18 +107,6 @@ class BasecampClientBuilder {
     }
 }
 
-/** Returns true if the URL points to localhost (for dev/test). */
-private fun isLocalhost(url: String): Boolean {
-    val hostStart = url.indexOf("://")
-    if (hostStart < 0) return false
-    val afterScheme = hostStart + 3
-    val hostEnd = url.indexOfAny(charArrayOf('/', ':', '?'), afterScheme).let {
-        if (it < 0) url.length else it
-    }
-    val host = url.substring(afterScheme, hostEnd)
-    return host == "localhost" || host == "127.0.0.1" || host == "::1"
-}
-
 /**
  * Creates a [BasecampClient] using the builder DSL.
  *

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
@@ -127,17 +127,23 @@ internal fun isLocalhost(url: String): Boolean {
         else -> return false
     }
     val afterScheme = schemeEnd + 3
-    val host = if (afterScheme < url.length && url[afterScheme] == '[') {
+    // The authority ends at /, ?, or # (RFC 3986).
+    val authorityEnd = url.indexOfAny(charArrayOf('/', '?', '#'), afterScheme).let {
+        if (it < 0) url.length else it
+    }
+    var authority = url.substring(afterScheme, authorityEnd)
+    // Strip userinfo: the host is what follows the last '@', otherwise
+    // http://localhost@evil.example would read its host as "localhost".
+    val userinfoEnd = authority.lastIndexOf('@')
+    if (userinfoEnd >= 0) authority = authority.substring(userinfoEnd + 1)
+    val host = if (authority.startsWith("[")) {
         // Bracketed IPv6 literal (RFC 3986), e.g. http://[::1]:8080/ — the host
         // is everything between the brackets.
-        val close = url.indexOf(']', afterScheme)
+        val close = authority.indexOf(']')
         if (close < 0) return false
-        url.substring(afterScheme + 1, close)
+        authority.substring(1, close)
     } else {
-        val hostEnd = url.indexOfAny(charArrayOf('/', ':', '?', '#'), afterScheme).let {
-            if (it < 0) url.length else it
-        }
-        url.substring(afterScheme, hostEnd)
+        authority.substringBefore(':')
     }
     // Hostnames are case-insensitive (RFC 3986).
     val normalizedHost = host.lowercase()

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
@@ -99,18 +99,28 @@ private fun extractOrigin(url: String): String? {
     // Find end of authority (host:port) — next / or end of string
     val pathStart = url.indexOf('/', afterScheme)
     val authority = if (pathStart < 0) url.substring(afterScheme) else url.substring(afterScheme, pathStart)
-    return url.substring(0, schemeEnd) + "://" + authority
+    // Scheme and host are case-insensitive (RFC 3986), so normalize before
+    // comparison — otherwise an uppercase-scheme URL would look cross-origin.
+    return (url.substring(0, schemeEnd) + "://" + authority).lowercase()
 }
 
 /** Returns true if the URL points to localhost (for dev/test). */
 internal fun isLocalhost(url: String): Boolean {
-    val hostStart = url.indexOf("://")
-    if (hostStart < 0) return false
-    val afterScheme = hostStart + 3
-    val hostEnd = url.indexOfAny(charArrayOf('/', ':', '?'), afterScheme).let {
-        if (it < 0) url.length else it
+    val schemeEnd = url.indexOf("://")
+    if (schemeEnd < 0) return false
+    val afterScheme = schemeEnd + 3
+    val host = if (afterScheme < url.length && url[afterScheme] == '[') {
+        // Bracketed IPv6 literal (RFC 3986), e.g. http://[::1]:8080/ — the host
+        // is everything between the brackets.
+        val close = url.indexOf(']', afterScheme)
+        if (close < 0) return false
+        url.substring(afterScheme + 1, close)
+    } else {
+        val hostEnd = url.indexOfAny(charArrayOf('/', ':', '?'), afterScheme).let {
+            if (it < 0) url.length else it
+        }
+        url.substring(afterScheme, hostEnd)
     }
-    val host = url.substring(afterScheme, hostEnd)
     return host == "localhost" || host == "127.0.0.1" || host == "::1"
 }
 

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
@@ -134,7 +134,7 @@ internal fun isLocalhost(url: String): Boolean {
         if (close < 0) return false
         url.substring(afterScheme + 1, close)
     } else {
-        val hostEnd = url.indexOfAny(charArrayOf('/', ':', '?'), afterScheme).let {
+        val hostEnd = url.indexOfAny(charArrayOf('/', ':', '?', '#'), afterScheme).let {
             if (it < 0) url.length else it
         }
         url.substring(afterScheme, hostEnd)

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
@@ -123,7 +123,10 @@ internal fun isLocalhost(url: String): Boolean {
     }
     // Hostnames are case-insensitive (RFC 3986).
     val normalizedHost = host.lowercase()
-    return normalizedHost == "localhost" || normalizedHost == "127.0.0.1" || normalizedHost == "::1"
+    return normalizedHost == "localhost" ||
+        normalizedHost == "127.0.0.1" ||
+        normalizedHost == "::1" ||
+        normalizedHost.endsWith(".localhost") // RFC 6761 .localhost TLD
 }
 
 /**

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
@@ -121,7 +121,9 @@ internal fun isLocalhost(url: String): Boolean {
         }
         url.substring(afterScheme, hostEnd)
     }
-    return host == "localhost" || host == "127.0.0.1" || host == "::1"
+    // Hostnames are case-insensitive (RFC 3986).
+    val normalizedHost = host.lowercase()
+    return normalizedHost == "localhost" || normalizedHost == "127.0.0.1" || normalizedHost == "::1"
 }
 
 /**

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
@@ -95,19 +95,36 @@ internal fun isSameOrigin(url1: String, url2: String): Boolean {
 private fun extractOrigin(url: String): String? {
     val schemeEnd = url.indexOf("://")
     if (schemeEnd < 0) return null
+    // Scheme and host are case-insensitive (RFC 3986), so normalize before
+    // comparison — otherwise an uppercase-scheme URL would look cross-origin.
+    val scheme = url.substring(0, schemeEnd).lowercase()
     val afterScheme = schemeEnd + 3
     // Find end of authority (host:port) — next / or end of string
     val pathStart = url.indexOf('/', afterScheme)
-    val authority = if (pathStart < 0) url.substring(afterScheme) else url.substring(afterScheme, pathStart)
-    // Scheme and host are case-insensitive (RFC 3986), so normalize before
-    // comparison — otherwise an uppercase-scheme URL would look cross-origin.
-    return (url.substring(0, schemeEnd) + "://" + authority).lowercase()
+    var authority = (if (pathStart < 0) url.substring(afterScheme) else url.substring(afterScheme, pathStart)).lowercase()
+    // An explicit default port is the same origin as no port (https://h:443 ≡
+    // https://h), so strip it before comparing.
+    val defaultPort = when (scheme) {
+        "https" -> ":443"
+        "http" -> ":80"
+        else -> null
+    }
+    if (defaultPort != null && authority.endsWith(defaultPort)) {
+        authority = authority.dropLast(defaultPort.length)
+    }
+    return "$scheme://$authority"
 }
 
-/** Returns true if the URL points to localhost (for dev/test). */
+/** Returns true if the URL points to localhost over HTTP(S) (for dev/test). */
 internal fun isLocalhost(url: String): Boolean {
     val schemeEnd = url.indexOf("://")
     if (schemeEnd < 0) return false
+    // The carve-out is limited to HTTP(S) so the credential backstop fails
+    // closed on any other scheme (e.g. ws://localhost).
+    when (url.substring(0, schemeEnd).lowercase()) {
+        "http", "https" -> {}
+        else -> return false
+    }
     val afterScheme = schemeEnd + 3
     val host = if (afterScheme < url.length && url[afterScheme] == '[') {
         // Bracketed IPv6 literal (RFC 3986), e.g. http://[::1]:8080/ — the host

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
@@ -1,5 +1,8 @@
 package com.basecamp.sdk
 
+import io.ktor.http.Url
+import io.ktor.http.parseUrl
+
 /**
  * Metadata about a paginated list response.
  */
@@ -86,71 +89,48 @@ internal fun parseNextLink(linkHeader: String?): String? {
  * Used to prevent SSRF via poisoned Link headers.
  */
 internal fun isSameOrigin(url1: String, url2: String): Boolean {
-    val origin1 = extractOrigin(url1) ?: return false
-    val origin2 = extractOrigin(url2) ?: return false
-    return origin1 == origin2
+    val a = parseAbsoluteUrl(url1) ?: return false
+    val b = parseAbsoluteUrl(url2) ?: return false
+    // Url.port falls back to the protocol default, so an explicit default port
+    // is the same origin as no port (https://h:443 ≡ https://h).
+    return a.protocol.name == b.protocol.name &&
+        a.host.lowercase() == b.host.lowercase() &&
+        a.port == b.port
 }
 
-/** Extracts scheme://host:port from a URL string. */
-private fun extractOrigin(url: String): String? {
-    val schemeEnd = url.indexOf("://")
-    if (schemeEnd < 0) return null
-    // Scheme and host are case-insensitive (RFC 3986), so normalize before
-    // comparison — otherwise an uppercase-scheme URL would look cross-origin.
-    val scheme = url.substring(0, schemeEnd).lowercase()
-    val afterScheme = schemeEnd + 3
-    // Find end of authority (host:port) — the next /, ?, or # (a query or
-    // fragment may directly follow the authority), or end of string.
-    val pathStart = url.indexOfAny(charArrayOf('/', '?', '#'), afterScheme)
-    var authority = (if (pathStart < 0) url.substring(afterScheme) else url.substring(afterScheme, pathStart)).lowercase()
-    // An explicit default port is the same origin as no port (https://h:443 ≡
-    // https://h), so strip it before comparing.
-    val defaultPort = when (scheme) {
-        "https" -> ":443"
-        "http" -> ":80"
-        else -> null
-    }
-    if (defaultPort != null && authority.endsWith(defaultPort)) {
-        authority = authority.dropLast(defaultPort.length)
-    }
-    return "$scheme://$authority"
+/**
+ * Parses an absolute URL with Ktor's own parser — the SAME parser the
+ * transport uses to dial — so the guard can never disagree with the client
+ * about which host a URL targets. A hand-rolled parser here previously let
+ * `http://evil.example\.localhost/x` pass the localhost carve-out while Ktor
+ * treats `\` as a path separator and dials `evil.example`.
+ *
+ * Returns null (fail closed) when the input is malformed or not absolute:
+ * Ktor parses a scheme-less string as a relative reference against
+ * `http://localhost`, which must never be blessed as localhost/same-origin.
+ */
+private fun parseAbsoluteUrl(url: String): Url? {
+    val parsed = parseUrl(url) ?: return null
+    if (!url.startsWith("${parsed.protocol.name}://", ignoreCase = true)) return null
+    return parsed
 }
 
 /** Returns true if the URL points to localhost over HTTP(S) (for dev/test). */
 internal fun isLocalhost(url: String): Boolean {
-    val schemeEnd = url.indexOf("://")
-    if (schemeEnd < 0) return false
+    val parsed = parseAbsoluteUrl(url) ?: return false
     // The carve-out is limited to HTTP(S) so the credential backstop fails
     // closed on any other scheme (e.g. ws://localhost).
-    when (url.substring(0, schemeEnd).lowercase()) {
+    when (parsed.protocol.name) {
         "http", "https" -> {}
         else -> return false
     }
-    val afterScheme = schemeEnd + 3
-    // The authority ends at /, ?, or # (RFC 3986).
-    val authorityEnd = url.indexOfAny(charArrayOf('/', '?', '#'), afterScheme).let {
-        if (it < 0) url.length else it
-    }
-    var authority = url.substring(afterScheme, authorityEnd)
-    // Strip userinfo: the host is what follows the last '@', otherwise
-    // http://localhost@evil.example would read its host as "localhost".
-    val userinfoEnd = authority.lastIndexOf('@')
-    if (userinfoEnd >= 0) authority = authority.substring(userinfoEnd + 1)
-    val host = if (authority.startsWith("[")) {
-        // Bracketed IPv6 literal (RFC 3986), e.g. http://[::1]:8080/ — the host
-        // is everything between the brackets.
-        val close = authority.indexOf(']')
-        if (close < 0) return false
-        authority.substring(1, close)
-    } else {
-        authority.substringBefore(':')
-    }
-    // Hostnames are case-insensitive (RFC 3986).
-    val normalizedHost = host.lowercase()
-    return normalizedHost == "localhost" ||
-        normalizedHost == "127.0.0.1" ||
-        normalizedHost == "::1" ||
-        normalizedHost.endsWith(".localhost") // RFC 6761 .localhost TLD
+    // Hostnames are case-insensitive (RFC 3986). Ktor's Url.host excludes
+    // userinfo and port; strip IPv6 brackets in case the engine retains them.
+    val host = parsed.host.lowercase().removePrefix("[").removeSuffix("]")
+    return host == "localhost" ||
+        host == "127.0.0.1" ||
+        host == "::1" ||
+        host.endsWith(".localhost") // RFC 6761 .localhost TLD
 }
 
 /**

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
@@ -102,6 +102,18 @@ private fun extractOrigin(url: String): String? {
     return url.substring(0, schemeEnd) + "://" + authority
 }
 
+/** Returns true if the URL points to localhost (for dev/test). */
+internal fun isLocalhost(url: String): Boolean {
+    val hostStart = url.indexOf("://")
+    if (hostStart < 0) return false
+    val afterScheme = hostStart + 3
+    val hostEnd = url.indexOfAny(charArrayOf('/', ':', '?'), afterScheme).let {
+        if (it < 0) url.length else it
+    }
+    val host = url.substring(afterScheme, hostEnd)
+    return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
+
 /**
  * Parses the Retry-After header value.
  * Supports integer seconds format.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
@@ -99,8 +99,9 @@ private fun extractOrigin(url: String): String? {
     // comparison — otherwise an uppercase-scheme URL would look cross-origin.
     val scheme = url.substring(0, schemeEnd).lowercase()
     val afterScheme = schemeEnd + 3
-    // Find end of authority (host:port) — next / or end of string
-    val pathStart = url.indexOf('/', afterScheme)
+    // Find end of authority (host:port) — the next /, ?, or # (a query or
+    // fragment may directly follow the authority), or end of string.
+    val pathStart = url.indexOfAny(charArrayOf('/', '?', '#'), afterScheme)
     var authority = (if (pathStart < 0) url.substring(afterScheme) else url.substring(afterScheme, pathStart)).lowercase()
     // An explicit default port is the same origin as no port (https://h:443 ≡
     // https://h), so strip it before comparing.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/http/BasecampHttpClient.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/http/BasecampHttpClient.kt
@@ -34,6 +34,7 @@ internal class BasecampHttpClient(
         url: String,
         body: String? = null,
     ): HttpResponse {
+        requireSameOrigin(url)
         return try {
             httpClient.request(url) {
                 this.method = method
@@ -73,6 +74,17 @@ internal class BasecampHttpClient(
         try {
             response = request(method, url, body)
         } catch (e: CancellationException) {
+            throw e
+        } catch (e: BasecampException) {
+            // A deliberate SDK error (e.g. the same-origin credential guard) is
+            // already classified — surface it as-is rather than masking it as a
+            // retryable Network error.
+            val duration = currentTimeMillis() - startTime
+            hooks.safeOnRequestEnd(info, RequestResult(
+                statusCode = 0,
+                duration = duration.millisToDuration(),
+                error = e,
+            ))
             throw e
         } catch (e: Exception) {
             val duration = currentTimeMillis() - startTime
@@ -138,6 +150,7 @@ internal class BasecampHttpClient(
         data: ByteArray,
         contentType: String,
     ): HttpResponse {
+        requireSameOrigin(url)
         return try {
             httpClient.request(url) {
                 this.method = method
@@ -171,6 +184,17 @@ internal class BasecampHttpClient(
             response = requestBinary(method, url, data, contentType)
         } catch (e: CancellationException) {
             throw e
+        } catch (e: BasecampException) {
+            // A deliberate SDK error (e.g. the same-origin credential guard) is
+            // already classified — surface it as-is rather than masking it as a
+            // retryable Network error.
+            val duration = currentTimeMillis() - startTime
+            hooks.safeOnRequestEnd(info, RequestResult(
+                statusCode = 0,
+                duration = duration.millisToDuration(),
+                error = e,
+            ))
+            throw e
         } catch (e: Exception) {
             val duration = currentTimeMillis() - startTime
             hooks.safeOnRequestEnd(info, RequestResult(
@@ -192,6 +216,19 @@ internal class BasecampHttpClient(
 
         // POST is not idempotent, so no retry for binary uploads
         return response
+    }
+
+    /**
+     * Attach-point backstop: refuse to attach credentials to a foreign origin.
+     * Localhost is carved out for dev/test. Mirrors the same-origin guard used
+     * for pagination Link headers.
+     */
+    private fun requireSameOrigin(url: String) {
+        if (!isLocalhost(url) && !isSameOrigin(url, config.baseUrl)) {
+            throw BasecampException.Usage(
+                "Refusing to send credentials to a different origin than base URL: $url"
+            )
+        }
     }
 
     companion object {

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/http/BasecampHttpClient.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/http/BasecampHttpClient.kt
@@ -226,7 +226,8 @@ internal class BasecampHttpClient(
     private fun requireSameOrigin(url: String) {
         if (!isLocalhost(url) && !isSameOrigin(url, config.baseUrl)) {
             throw BasecampException.Usage(
-                "Refusing to send credentials to a different origin than base URL: $url"
+                "Refusing to send credentials to a different origin than base URL: " +
+                    BasecampException.truncateMessage(url)
             )
         }
     }

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/BaseService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/BaseService.kt
@@ -45,7 +45,7 @@ abstract class BaseService(
      * E.g., "/projects.json" -> "https://3.basecampapi.com/{accountId}/projects.json"
      */
     protected fun accountUrl(path: String): String {
-        if (path.startsWith("http://") || path.startsWith("https://")) {
+        if (path.startsWith("http://", ignoreCase = true) || path.startsWith("https://", ignoreCase = true)) {
             // Absolute URL: require same-origin so we never build a request that
             // would attach the bearer token to a foreign host.
             if (!isLocalhost(path) && !isSameOrigin(path, accountClient.parent.config.baseUrl)) {

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/BaseService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/BaseService.kt
@@ -45,6 +45,16 @@ abstract class BaseService(
      * E.g., "/projects.json" -> "https://3.basecampapi.com/{accountId}/projects.json"
      */
     protected fun accountUrl(path: String): String {
+        if (path.startsWith("http://") || path.startsWith("https://")) {
+            // Absolute URL: require same-origin so we never build a request that
+            // would attach the bearer token to a foreign host.
+            if (!isLocalhost(path) && !isSameOrigin(path, accountClient.parent.config.baseUrl)) {
+                throw BasecampException.Usage(
+                    "Refusing to build a request URL for a different origin than base URL: $path"
+                )
+            }
+            return path
+        }
         val base = accountClient.parent.config.baseUrl.trimEnd('/')
         val accountId = accountClient.accountId
         val normalizedPath = if (path.startsWith("/")) path else "/$path"

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/BaseService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/BaseService.kt
@@ -50,7 +50,8 @@ abstract class BaseService(
             // would attach the bearer token to a foreign host.
             if (!isLocalhost(path) && !isSameOrigin(path, accountClient.parent.config.baseUrl)) {
                 throw BasecampException.Usage(
-                    "Refusing to build a request URL for a different origin than base URL: $path"
+                    "Refusing to build a request URL for a different origin than base URL: " +
+                        BasecampException.truncateMessage(path)
                 )
             }
             return path

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PaginationTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PaginationTest.kt
@@ -187,6 +187,12 @@ class PaginationTest {
         // must not make a foreign host pass the carve-out.
         assertFalse(isLocalhost("http://evil.example#foo.localhost"))
         assertFalse(isLocalhost("http://evil.example?x=.localhost"))
+        // Userinfo is not the host: localhost text before '@' must not make a
+        // foreign host pass the carve-out.
+        assertFalse(isLocalhost("http://localhost:80@evil.example/path"))
+        assertFalse(isLocalhost("http://localhost@evil.example/path"))
+        // A genuine localhost URL with userinfo still qualifies.
+        assertTrue(isLocalhost("http://user:secret@localhost:3000/x"))
     }
 
     @Test

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PaginationTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PaginationTest.kt
@@ -125,6 +125,39 @@ class PaginationTest {
         ))
     }
 
+    @Test
+    fun sameOriginIgnoresSchemeCase() {
+        // Scheme is case-insensitive (RFC 3986): an uppercase-scheme URL must
+        // still be recognized as same-origin, not misclassified as foreign.
+        assertTrue(isSameOrigin(
+            "HTTPS://3.basecampapi.com/12345/projects.json",
+            "https://3.basecampapi.com",
+        ))
+    }
+
+    // =========================================================================
+    // isLocalhost
+    // =========================================================================
+
+    @Test
+    fun isLocalhostRecognizesLoopback() {
+        assertTrue(isLocalhost("https://localhost:3000/x.json"))
+        assertTrue(isLocalhost("http://127.0.0.1:8080/x"))
+    }
+
+    @Test
+    fun isLocalhostRecognizesBracketedIpv6Loopback() {
+        // RFC 3986 requires IPv6 literals in URLs to be bracketed, e.g. [::1].
+        assertTrue(isLocalhost("http://[::1]:8080/path"))
+        assertTrue(isLocalhost("https://[::1]/x.json"))
+    }
+
+    @Test
+    fun isLocalhostRejectsForeignHosts() {
+        assertFalse(isLocalhost("https://3.basecampapi.com/x"))
+        assertFalse(isLocalhost("https://evil.example/x"))
+    }
+
     // =========================================================================
     // parseRetryAfter
     // =========================================================================

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PaginationTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PaginationTest.kt
@@ -145,6 +145,15 @@ class PaginationTest {
         assertTrue(isLocalhost("http://127.0.0.1:8080/x"))
         // Hostnames are case-insensitive (RFC 3986).
         assertTrue(isLocalhost("https://LOCALHOST/x.json"))
+        // RFC 6761 .localhost TLD.
+        assertTrue(isLocalhost("https://myapp.localhost/x.json"))
+    }
+
+    @Test
+    fun isLocalhostRejectsLocalhostLookalikes() {
+        // A host that merely contains "localhost" is not localhost.
+        assertFalse(isLocalhost("https://localhost.evil.example/x"))
+        assertFalse(isLocalhost("https://notlocalhost/x"))
     }
 
     @Test

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PaginationTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PaginationTest.kt
@@ -126,6 +126,25 @@ class PaginationTest {
     }
 
     @Test
+    fun sameOriginNormalizesDefaultPorts() {
+        // An explicit default port is the same origin as no port (RFC 3986),
+        // so e.g. a :443 pagination Link against a portless base must pass.
+        assertTrue(isSameOrigin(
+            "https://3.basecampapi.com:443/12345/projects.json",
+            "https://3.basecampapi.com",
+        ))
+        assertTrue(isSameOrigin(
+            "http://localhost:80/x",
+            "http://localhost",
+        ))
+        // A non-default port is still a different origin.
+        assertFalse(isSameOrigin(
+            "https://3.basecampapi.com:8443/x",
+            "https://3.basecampapi.com",
+        ))
+    }
+
+    @Test
     fun sameOriginIgnoresSchemeCase() {
         // Scheme is case-insensitive (RFC 3986): an uppercase-scheme URL must
         // still be recognized as same-origin, not misclassified as foreign.
@@ -167,6 +186,14 @@ class PaginationTest {
     fun isLocalhostRejectsForeignHosts() {
         assertFalse(isLocalhost("https://3.basecampapi.com/x"))
         assertFalse(isLocalhost("https://evil.example/x"))
+    }
+
+    @Test
+    fun isLocalhostLimitsCarveOutToHttpSchemes() {
+        // The credential backstop must fail closed on non-HTTP(S) schemes,
+        // even for localhost.
+        assertFalse(isLocalhost("ws://localhost:3000/x"))
+        assertFalse(isLocalhost("ftp://127.0.0.1/x"))
     }
 
     // =========================================================================

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PaginationTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PaginationTest.kt
@@ -143,6 +143,8 @@ class PaginationTest {
     fun isLocalhostRecognizesLoopback() {
         assertTrue(isLocalhost("https://localhost:3000/x.json"))
         assertTrue(isLocalhost("http://127.0.0.1:8080/x"))
+        // Hostnames are case-insensitive (RFC 3986).
+        assertTrue(isLocalhost("https://LOCALHOST/x.json"))
     }
 
     @Test

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PaginationTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PaginationTest.kt
@@ -183,6 +183,10 @@ class PaginationTest {
         // A host that merely contains "localhost" is not localhost.
         assertFalse(isLocalhost("https://localhost.evil.example/x"))
         assertFalse(isLocalhost("https://notlocalhost/x"))
+        // The host ends at ?, or # — localhost text in a query or fragment
+        // must not make a foreign host pass the carve-out.
+        assertFalse(isLocalhost("http://evil.example#foo.localhost"))
+        assertFalse(isLocalhost("http://evil.example?x=.localhost"))
     }
 
     @Test

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PaginationTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PaginationTest.kt
@@ -216,6 +216,61 @@ class PaginationTest {
         assertFalse(isLocalhost("ftp://127.0.0.1/x"))
     }
 
+    @Test
+    fun guardsFailClosedOnRelativeInput() {
+        // Ktor parses a scheme-less string as a relative reference against
+        // http://localhost — the guards must reject it, not bless it.
+        assertFalse(isLocalhost("localhost"))
+        assertFalse(isLocalhost("evil.example/x"))
+        assertFalse(isSameOrigin("3.basecampapi.com", "https://3.basecampapi.com"))
+        assertFalse(isSameOrigin("https://3.basecampapi.com", "3.basecampapi.com"))
+    }
+
+    // =========================================================================
+    // Parser-differential regression
+    // =========================================================================
+
+    /**
+     * A security guard must decide with the SAME parser the transport uses to
+     * dial. For each adversarial URL: whenever the guard blesses it, the host
+     * Ktor would actually dial (parseUrl — what HttpClient.request uses) must
+     * be the host the guard thought it blessed. Near-tautological after the
+     * parseUrl rewrite — but it fails loudly if anyone reintroduces a second
+     * parser here.
+     */
+    @Test
+    fun guardDecidesWithTheTransportParser() {
+        val base = "https://3.basecampapi.com"
+        val corpus = listOf(
+            """http://evil.example\.localhost/x""",
+            "http://localhost@evil.example/x",
+            "http://evil.example#foo.localhost",
+            "http://evil.example?x=.localhost",
+            "http://localhost:80@evil.example/x",
+            "https://3.basecampapi.com:443@evil.example/x",
+            "http://[::1]/x",
+            "HTTPS://localhost/x",
+            "https://3.basecampapi.com:443/x",
+            "http://localhost.evil.example/x",
+        )
+        for (url in corpus) {
+            val dialed = parseUrl(url)?.host?.lowercase()?.removePrefix("[")?.removeSuffix("]")
+            if (isLocalhost(url)) {
+                assertTrue(
+                    dialed == "localhost" || dialed == "127.0.0.1" || dialed == "::1" ||
+                        dialed?.endsWith(".localhost") == true,
+                    "isLocalhost blessed $url but the transport dials $dialed",
+                )
+            }
+            if (isSameOrigin(url, base)) {
+                assertEquals(
+                    parseUrl(base)!!.host.lowercase(), dialed,
+                    "isSameOrigin blessed $url against $base but the transport dials $dialed",
+                )
+            }
+        }
+    }
+
     // =========================================================================
     // parseRetryAfter
     // =========================================================================

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PaginationTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PaginationTest.kt
@@ -142,6 +142,16 @@ class PaginationTest {
             "https://3.basecampapi.com:8443/x",
             "https://3.basecampapi.com",
         ))
+        // A query or fragment may directly follow the authority (no path); the
+        // default port must still be normalized.
+        assertTrue(isSameOrigin(
+            "https://3.basecampapi.com:443?page=2",
+            "https://3.basecampapi.com",
+        ))
+        assertTrue(isSameOrigin(
+            "https://3.basecampapi.com:443#top",
+            "https://3.basecampapi.com",
+        ))
     }
 
     @Test

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/SameOriginTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/SameOriginTest.kt
@@ -51,10 +51,20 @@ class SameOriginTest {
     }
 
     @Test fun localhostAbsoluteUrlAllowed() = runTest {
-        var hit = false
-        val client = clientWith(MockEngine { hit = true; respondOk("[]") })
+        var auth: String? = null
+        val client = clientWith(MockEngine { req -> auth = req.headers["Authorization"]; respondOk("[]") })
         val account = client.forAccount("12345")
         account.httpClient.requestWithRetry(HttpMethod.Get, "https://localhost:8080/x.json")
-        assertTrue(hit); client.close()
+        // Localhost is allowed *and* authenticated — assert the token is present,
+        // not merely that a request was sent.
+        assertEquals("Bearer secret-token", auth); client.close()
+    }
+
+    @Test fun ipv6LoopbackAbsoluteUrlCarriesToken() = runTest {
+        var auth: String? = null
+        val client = clientWith(MockEngine { req -> auth = req.headers["Authorization"]; respondOk("[]") })
+        val account = client.forAccount("12345")
+        account.httpClient.requestWithRetry(HttpMethod.Get, "https://[::1]:8080/x.json")
+        assertEquals("Bearer secret-token", auth); client.close()
     }
 }

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/SameOriginTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/SameOriginTest.kt
@@ -1,0 +1,60 @@
+package com.basecamp.sdk
+
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Verifies the same-origin credential guard: the bearer token is attached only
+ * to the configured origin (localhost carve-out for dev/test). A foreign-origin
+ * absolute URL must error before any network send, leaving the mock engine
+ * untouched (no Authorization egress).
+ */
+class SameOriginTest {
+    private fun clientWith(engine: MockEngine) = testBasecampClient {
+        accessToken("secret-token"); baseUrl = "https://3.basecampapi.com"
+        this.engine = engine; enableRetry = false
+    }
+
+    @Test fun requestRejectsForeignOriginWithoutEgress() = runTest {
+        var hit = false
+        val client = clientWith(MockEngine { hit = true; respondOk("[]") })
+        val account = client.forAccount("12345")
+        assertFailsWith<BasecampException.Usage> {
+            account.httpClient.requestWithRetry(HttpMethod.Get, "https://evil.example/steal.json")
+        }
+        assertFalse(hit); client.close()
+    }
+
+    @Test fun requestBinaryRejectsForeignOrigin() = runTest {
+        var hit = false
+        val client = clientWith(MockEngine { hit = true; respondOk("{}") })
+        val account = client.forAccount("12345")
+        assertFailsWith<BasecampException.Usage> {
+            account.httpClient.requestBinaryWithRetry(
+                HttpMethod.Post, "https://evil.example/upload", byteArrayOf(1, 2, 3), "application/octet-stream")
+        }
+        assertFalse(hit); client.close()
+    }
+
+    @Test fun sameOriginAbsoluteUrlCarriesToken() = runTest {
+        var auth: String? = null
+        val client = clientWith(MockEngine { req -> auth = req.headers["Authorization"]; respondOk("[]") })
+        val account = client.forAccount("12345")
+        account.httpClient.requestWithRetry(HttpMethod.Get, "https://3.basecampapi.com/12345/projects.json")
+        assertEquals("Bearer secret-token", auth); client.close()
+    }
+
+    @Test fun localhostAbsoluteUrlAllowed() = runTest {
+        var hit = false
+        val client = clientWith(MockEngine { hit = true; respondOk("[]") })
+        val account = client.forAccount("12345")
+        account.httpClient.requestWithRetry(HttpMethod.Get, "https://localhost:8080/x.json")
+        assertTrue(hit); client.close()
+    }
+}

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/SameOriginTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/SameOriginTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -66,5 +67,86 @@ class SameOriginTest {
         val account = client.forAccount("12345")
         account.httpClient.requestWithRetry(HttpMethod.Get, "https://[::1]:8080/x.json")
         assertEquals("Bearer secret-token", auth); client.close()
+    }
+
+    // Hosts the token may legitimately reach: the configured base origin plus
+    // the localhost carve-out.
+    private fun tokenMayReach(host: String): Boolean {
+        val h = host.lowercase().removePrefix("[").removeSuffix("]")
+        return h == "3.basecampapi.com" || h == "localhost" || h == "127.0.0.1" ||
+            h == "::1" || h.endsWith(".localhost")
+    }
+
+    /**
+     * End-to-end parser-differential regression: every adversarial URL, driven
+     * through the real token-attach path, must either be rejected by the guard
+     * or egress only to a host the token may reach — NEVER to a foreign host
+     * carrying Authorization. The backslash vector caught a live leak: the old
+     * hand-rolled guard read the host of `http://evil.example\.localhost/x` as
+     * `evil.example\.localhost` (passes the .localhost carve-out) while Ktor
+     * treats `\` as a path separator and dials `evil.example`.
+     */
+    @Test fun adversarialUrlsNeverEgressTokenToForeignHost() = runTest {
+        val corpus = listOf(
+            """http://evil.example\.localhost/x""",
+            "http://localhost@evil.example/x",
+            "http://evil.example#foo.localhost",
+            "http://evil.example?x=.localhost",
+            "http://localhost:80@evil.example/x",
+            "https://3.basecampapi.com:443@evil.example/x",
+            "http://[::1]/x",
+            "HTTPS://localhost/x",
+            "https://3.basecampapi.com:443/x",
+            "http://localhost.evil.example/x",
+        )
+        val egress = mutableListOf<Pair<String, String?>>() // host -> Authorization
+        val client = clientWith(MockEngine { req ->
+            egress += req.url.host to req.headers["Authorization"]
+            respondOk("[]")
+        })
+        val account = client.forAccount("12345")
+        for (url in corpus) {
+            try {
+                account.httpClient.requestWithRetry(HttpMethod.Get, url)
+            } catch (_: BasecampException) {
+                // Rejection before egress is a passing outcome.
+            }
+        }
+        for ((host, auth) in egress) {
+            assertTrue(
+                tokenMayReach(host) || auth == null,
+                "Bearer token egressed to foreign host $host",
+            )
+        }
+        client.close()
+    }
+
+    /**
+     * Pins Ktor's cross-origin redirect behavior: the client follows redirects
+     * by default, and Ktor strips Authorization when the redirect leaves the
+     * origin. If a Ktor upgrade ever regresses this, the token would silently
+     * leak to the Location target — this test turns that into a CI failure.
+     */
+    @Test fun crossOriginRedirectDropsAuthorization() = runTest {
+        val egress = mutableListOf<Pair<String, String?>>() // host -> Authorization
+        val client = clientWith(MockEngine { req ->
+            egress += req.url.host to req.headers["Authorization"]
+            if (req.url.host == "3.basecampapi.com") {
+                respond(
+                    content = "",
+                    status = HttpStatusCode.Found,
+                    headers = headersOf(HttpHeaders.Location, "https://evil.example/stolen"),
+                )
+            } else {
+                respondOk("[]")
+            }
+        })
+        val account = client.forAccount("12345")
+        account.httpClient.requestWithRetry(HttpMethod.Get, "https://3.basecampapi.com/12345/projects.json")
+        assertEquals(2, egress.size)
+        assertEquals("Bearer secret-token", egress[0].second)
+        assertEquals("evil.example", egress[1].first)
+        assertNull(egress[1].second, "Authorization must be stripped on a cross-origin redirect")
+        client.close()
     }
 }

--- a/python/src/basecamp/_async_http.py
+++ b/python/src/basecamp/_async_http.py
@@ -55,7 +55,7 @@ class AsyncHttpClient:
     async def get_absolute(self, url: str, *, params: dict | None = None) -> httpx.Response:
         if not _security.is_localhost(url):
             _security.require_https(url, "URL")
-        return await self._request_with_retry("GET", url, params=params)
+        return await self._request_with_retry("GET", url, params=params, allow_cross_origin=True)
 
     async def post(self, url: str, *, json_body: dict | None = None, operation: str | None = None) -> httpx.Response:
         url = self._build_url(url)
@@ -140,6 +140,7 @@ class AsyncHttpClient:
         content: bytes | None = None,
         content_type: str | None = None,
         files: dict | None = None,
+        allow_cross_origin: bool = False,
     ) -> httpx.Response:
         attempt = 0
         last_error: BasecampError | None = None
@@ -159,6 +160,7 @@ class AsyncHttpClient:
                     content_type=content_type,
                     files=files,
                     attempt=attempt,
+                    allow_cross_origin=allow_cross_origin,
                 )
             except (RateLimitError, NetworkError, ApiError) as e:
                 if not e.retryable:
@@ -192,7 +194,14 @@ class AsyncHttpClient:
         files: dict | None = None,
         attempt: int = 1,
         _retry_count: int = 0,
+        allow_cross_origin: bool = False,
     ) -> httpx.Response:
+        if not allow_cross_origin and not (
+            _security.is_localhost(url) or _security.same_origin(url, self._config.base_url)
+        ):
+            raise UsageError(
+                f"Refusing to send credentials to a different origin than base URL: {url}"
+            )
         info = RequestInfo(method=method, url=url, attempt=attempt)
         safe_hook(self._hooks.on_request_start, info)
         start = time.monotonic()
@@ -229,6 +238,7 @@ class AsyncHttpClient:
                             files=files,
                             attempt=attempt,
                             _retry_count=_retry_count + 1,
+                            allow_cross_origin=allow_cross_origin,
                         )
                 raise error
 
@@ -264,7 +274,9 @@ class AsyncHttpClient:
 
     def _build_url(self, path: str) -> str:
         if path.startswith("https://"):
-            return path
+            if _security.is_localhost(path) or _security.same_origin(path, self._config.base_url):
+                return path
+            raise UsageError(f"URL host does not match configured base URL: {path}")
         if path.startswith("http://"):
             if not _security.is_localhost(path):
                 raise UsageError(f"URL must use HTTPS: {path}")

--- a/python/src/basecamp/_async_http.py
+++ b/python/src/basecamp/_async_http.py
@@ -204,7 +204,7 @@ class AsyncHttpClient:
             _security.is_localhost(url) or _security.same_origin(url, self._config.base_url)
         ):
             raise UsageError(
-                f"Refusing to send credentials to a different origin than base URL: {url}"
+                f"Refusing to send credentials to a different origin than base URL: {_security.truncate(url)}"
             )
         info = RequestInfo(method=method, url=url, attempt=attempt)
         safe_hook(self._hooks.on_request_start, info)
@@ -280,10 +280,10 @@ class AsyncHttpClient:
         if path.startswith("https://"):
             if _security.is_localhost(path) or _security.same_origin(path, self._config.base_url):
                 return path
-            raise UsageError(f"URL host does not match configured base URL: {path}")
+            raise UsageError(f"URL host does not match configured base URL: {_security.truncate(path)}")
         if path.startswith("http://"):
             if not _security.is_localhost(path):
-                raise UsageError(f"URL must use HTTPS: {path}")
+                raise UsageError(f"URL must use HTTPS: {_security.truncate(path)}")
             return path
         if not path.startswith("/"):
             path = f"/{path}"

--- a/python/src/basecamp/_async_http.py
+++ b/python/src/basecamp/_async_http.py
@@ -55,7 +55,11 @@ class AsyncHttpClient:
     async def get_absolute(self, url: str, *, params: dict | None = None) -> httpx.Response:
         if not _security.is_localhost(url):
             _security.require_https(url, "URL")
-        return await self._request_with_retry("GET", url, params=params, allow_cross_origin=True)
+        # Cross-origin is permitted only for the trusted Launchpad authorization
+        # endpoint; any other foreign origin still trips the same-origin guard so
+        # the bearer token never leaks off the configured host.
+        allow_cross_origin = url == _security.LAUNCHPAD_AUTHORIZATION_URL
+        return await self._request_with_retry("GET", url, params=params, allow_cross_origin=allow_cross_origin)
 
     async def post(self, url: str, *, json_body: dict | None = None, operation: str | None = None) -> httpx.Response:
         url = self._build_url(url)

--- a/python/src/basecamp/_async_http.py
+++ b/python/src/basecamp/_async_http.py
@@ -280,7 +280,7 @@ class AsyncHttpClient:
         if path.startswith("https://"):
             if _security.is_localhost(path) or _security.same_origin(path, self._config.base_url):
                 return path
-            raise UsageError(f"URL host does not match configured base URL: {_security.truncate(path)}")
+            raise UsageError(f"URL origin does not match configured base URL: {_security.truncate(path)}")
         if path.startswith("http://"):
             if not _security.is_localhost(path):
                 raise UsageError(f"URL must use HTTPS: {_security.truncate(path)}")

--- a/python/src/basecamp/_async_http.py
+++ b/python/src/basecamp/_async_http.py
@@ -277,11 +277,14 @@ class AsyncHttpClient:
         }
 
     def _build_url(self, path: str) -> str:
-        if path.startswith("https://"):
+        # Schemes are case-insensitive (RFC 3986): detect absolute URLs on a
+        # lowercased copy so HTTPS://... is not mis-joined onto the base URL.
+        lower_path = path.lower()
+        if lower_path.startswith("https://"):
             if _security.is_localhost(path) or _security.same_origin(path, self._config.base_url):
                 return path
             raise UsageError(f"URL origin does not match configured base URL: {_security.truncate(path)}")
-        if path.startswith("http://"):
+        if lower_path.startswith("http://"):
             if not _security.is_localhost(path):
                 raise UsageError(f"URL must use HTTPS: {_security.truncate(path)}")
             return path

--- a/python/src/basecamp/_http.py
+++ b/python/src/basecamp/_http.py
@@ -280,7 +280,7 @@ class HttpClient:
         if path.startswith("https://"):
             if _security.is_localhost(path) or _security.same_origin(path, self._config.base_url):
                 return path
-            raise UsageError(f"URL host does not match configured base URL: {_security.truncate(path)}")
+            raise UsageError(f"URL origin does not match configured base URL: {_security.truncate(path)}")
         if path.startswith("http://"):
             if not _security.is_localhost(path):
                 raise UsageError(f"URL must use HTTPS: {_security.truncate(path)}")

--- a/python/src/basecamp/_http.py
+++ b/python/src/basecamp/_http.py
@@ -204,7 +204,7 @@ class HttpClient:
             _security.is_localhost(url) or _security.same_origin(url, self._config.base_url)
         ):
             raise UsageError(
-                f"Refusing to send credentials to a different origin than base URL: {url}"
+                f"Refusing to send credentials to a different origin than base URL: {_security.truncate(url)}"
             )
         info = RequestInfo(method=method, url=url, attempt=attempt)
         safe_hook(self._hooks.on_request_start, info)
@@ -280,10 +280,10 @@ class HttpClient:
         if path.startswith("https://"):
             if _security.is_localhost(path) or _security.same_origin(path, self._config.base_url):
                 return path
-            raise UsageError(f"URL host does not match configured base URL: {path}")
+            raise UsageError(f"URL host does not match configured base URL: {_security.truncate(path)}")
         if path.startswith("http://"):
             if not _security.is_localhost(path):
-                raise UsageError(f"URL must use HTTPS: {path}")
+                raise UsageError(f"URL must use HTTPS: {_security.truncate(path)}")
             return path
         if not path.startswith("/"):
             path = f"/{path}"

--- a/python/src/basecamp/_http.py
+++ b/python/src/basecamp/_http.py
@@ -277,11 +277,14 @@ class HttpClient:
         }
 
     def _build_url(self, path: str) -> str:
-        if path.startswith("https://"):
+        # Schemes are case-insensitive (RFC 3986): detect absolute URLs on a
+        # lowercased copy so HTTPS://... is not mis-joined onto the base URL.
+        lower_path = path.lower()
+        if lower_path.startswith("https://"):
             if _security.is_localhost(path) or _security.same_origin(path, self._config.base_url):
                 return path
             raise UsageError(f"URL origin does not match configured base URL: {_security.truncate(path)}")
-        if path.startswith("http://"):
+        if lower_path.startswith("http://"):
             if not _security.is_localhost(path):
                 raise UsageError(f"URL must use HTTPS: {_security.truncate(path)}")
             return path

--- a/python/src/basecamp/_http.py
+++ b/python/src/basecamp/_http.py
@@ -54,7 +54,7 @@ class HttpClient:
     def get_absolute(self, url: str, *, params: dict | None = None) -> httpx.Response:
         if not _security.is_localhost(url):
             _security.require_https(url, "URL")
-        return self._request_with_retry("GET", url, params=params)
+        return self._request_with_retry("GET", url, params=params, allow_cross_origin=True)
 
     def post(self, url: str, *, json_body: dict | None = None, operation: str | None = None) -> httpx.Response:
         url = self._build_url(url)
@@ -140,6 +140,7 @@ class HttpClient:
         content: bytes | None = None,
         content_type: str | None = None,
         files: dict | None = None,
+        allow_cross_origin: bool = False,
     ) -> httpx.Response:
         attempt = 0
         last_error: BasecampError | None = None
@@ -159,6 +160,7 @@ class HttpClient:
                     content_type=content_type,
                     files=files,
                     attempt=attempt,
+                    allow_cross_origin=allow_cross_origin,
                 )
             except (RateLimitError, NetworkError, ApiError) as e:
                 if not e.retryable:
@@ -192,7 +194,14 @@ class HttpClient:
         files: dict | None = None,
         attempt: int = 1,
         _retry_count: int = 0,
+        allow_cross_origin: bool = False,
     ) -> httpx.Response:
+        if not allow_cross_origin and not (
+            _security.is_localhost(url) or _security.same_origin(url, self._config.base_url)
+        ):
+            raise UsageError(
+                f"Refusing to send credentials to a different origin than base URL: {url}"
+            )
         info = RequestInfo(method=method, url=url, attempt=attempt)
         safe_hook(self._hooks.on_request_start, info)
         start = time.monotonic()
@@ -229,6 +238,7 @@ class HttpClient:
                             files=files,
                             attempt=attempt,
                             _retry_count=_retry_count + 1,
+                            allow_cross_origin=allow_cross_origin,
                         )
                 raise error
 
@@ -264,7 +274,9 @@ class HttpClient:
 
     def _build_url(self, path: str) -> str:
         if path.startswith("https://"):
-            return path
+            if _security.is_localhost(path) or _security.same_origin(path, self._config.base_url):
+                return path
+            raise UsageError(f"URL host does not match configured base URL: {path}")
         if path.startswith("http://"):
             if not _security.is_localhost(path):
                 raise UsageError(f"URL must use HTTPS: {path}")

--- a/python/src/basecamp/_http.py
+++ b/python/src/basecamp/_http.py
@@ -54,7 +54,11 @@ class HttpClient:
     def get_absolute(self, url: str, *, params: dict | None = None) -> httpx.Response:
         if not _security.is_localhost(url):
             _security.require_https(url, "URL")
-        return self._request_with_retry("GET", url, params=params, allow_cross_origin=True)
+        # Cross-origin is permitted only for the trusted Launchpad authorization
+        # endpoint; any other foreign origin still trips the same-origin guard so
+        # the bearer token never leaks off the configured host.
+        allow_cross_origin = url == _security.LAUNCHPAD_AUTHORIZATION_URL
+        return self._request_with_retry("GET", url, params=params, allow_cross_origin=allow_cross_origin)
 
     def post(self, url: str, *, json_body: dict | None = None, operation: str | None = None) -> httpx.Response:
         url = self._build_url(url)

--- a/python/src/basecamp/_security.py
+++ b/python/src/basecamp/_security.py
@@ -10,6 +10,11 @@ MAX_ERROR_BODY_BYTES = 1 * 1024 * 1024  # 1 MB
 
 SENSITIVE_HEADERS = frozenset({"authorization", "cookie", "set-cookie", "x-csrf-token"})
 
+# The Launchpad authorization endpoint lives on a different origin than the
+# configured API base URL, so it is the one sanctioned destination for a
+# credentialed cross-origin request. Any other foreign origin must be rejected.
+LAUNCHPAD_AUTHORIZATION_URL = "https://launchpad.37signals.com/authorization.json"
+
 
 def truncate(s: str | None, max_bytes: int = MAX_ERROR_MESSAGE_BYTES) -> str:
     if s is None:

--- a/python/src/basecamp/_security.py
+++ b/python/src/basecamp/_security.py
@@ -44,6 +44,10 @@ def is_localhost(url: str) -> bool:
         host = (parsed.hostname or "").lower()
     except ValueError:
         return False
+    # The carve-out is limited to HTTP(S) so credential guards fail closed on
+    # any other scheme (e.g. ws://localhost).
+    if parsed.scheme.lower() not in ("http", "https"):
+        return False
     return host in ("localhost", "127.0.0.1", "::1") or host.endswith(".localhost")
 
 

--- a/python/src/basecamp/_security.py
+++ b/python/src/basecamp/_security.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from urllib.parse import urljoin, urlparse
 
+import httpx
+
 from basecamp.errors import ApiError, UsageError
 
 MAX_ERROR_MESSAGE_BYTES = 500
@@ -39,23 +41,28 @@ def require_https(url: str, label: str = "URL") -> None:
 
 
 def is_localhost(url: str) -> bool:
+    # Decide with the SAME parser the transport dials with (httpx.URL, see
+    # _http.py) so the guard can never disagree with the client about which
+    # host a URL targets. A guard that extracts the host with a different
+    # parser than the transport invites parser-differential bypasses.
     try:
-        parsed = urlparse(url)
-        host = (parsed.hostname or "").lower()
-    except ValueError:
+        parsed = httpx.URL(url)
+    except httpx.InvalidURL:
         return False
     # The carve-out is limited to HTTP(S) so credential guards fail closed on
     # any other scheme (e.g. ws://localhost).
     if parsed.scheme.lower() not in ("http", "https"):
         return False
+    host = parsed.host.lower()
     return host in ("localhost", "127.0.0.1", "::1") or host.endswith(".localhost")
 
 
 def same_origin(a: str, b: str) -> bool:
+    # Same parser as the transport (httpx.URL) — see is_localhost.
     try:
-        ua = urlparse(a)
-        ub = urlparse(b)
-    except ValueError:
+        ua = httpx.URL(a)
+        ub = httpx.URL(b)
+    except httpx.InvalidURL:
         return False
     if not ua.scheme or not ub.scheme:
         return False
@@ -83,12 +90,11 @@ def redact_headers(headers: dict[str, str]) -> dict[str, str]:
     return {k: "[REDACTED]" if k.lower() in SENSITIVE_HEADERS else v for k, v in headers.items()}
 
 
-def _normalize_host(parsed) -> str:
-    host = (parsed.hostname or "").lower()
-    try:
-        port = parsed.port
-    except ValueError:
-        return host
+def _normalize_host(parsed: httpx.URL) -> str:
+    host = parsed.host.lower()
+    # httpx already drops an explicit default port (:443/:80) at parse time;
+    # keep the normalization anyway so this cannot silently regress.
+    port = parsed.port
     if port is None:
         return host
     if parsed.scheme.lower() == "https" and port == 443:

--- a/python/src/basecamp/services/authorization.py
+++ b/python/src/basecamp/services/authorization.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
-LAUNCHPAD_AUTHORIZATION_URL = "https://launchpad.37signals.com/authorization.json"
+from basecamp._security import LAUNCHPAD_AUTHORIZATION_URL
+
+__all__ = ["AuthorizationService", "AsyncAuthorizationService", "LAUNCHPAD_AUTHORIZATION_URL"]
 
 
 class AuthorizationService:

--- a/python/tests/test_http.py
+++ b/python/tests/test_http.py
@@ -268,3 +268,20 @@ class TestSameOriginGuard:
         with pytest.raises(UsageError, match="different origin"):
             client.get_absolute("https://evil.example/steal")
         assert route.call_count == 0
+
+    def test_get_absolute_rejects_non_http_scheme_for_localhost(self):
+        # The localhost carve-out is limited to HTTP(S): any other scheme must
+        # fail closed before credentials could be attached.
+        client = make_client()
+        with pytest.raises(UsageError, match="HTTPS"):
+            client.get_absolute("ws://localhost:3000/x")
+
+    @respx.mock
+    def test_build_url_uppercase_scheme_treated_as_absolute(self):
+        # Schemes are case-insensitive (RFC 3986): an uppercase-scheme URL is
+        # still absolute — same-origin passes through, foreign is rejected
+        # rather than joined onto the base URL.
+        client = make_client()
+        assert client._build_url("HTTPS://3.basecampapi.com/x.json") == "HTTPS://3.basecampapi.com/x.json"
+        with pytest.raises(UsageError, match="origin"):
+            client._build_url("HTTPS://evil.example/x.json")

--- a/python/tests/test_http.py
+++ b/python/tests/test_http.py
@@ -13,6 +13,7 @@ from basecamp.errors import (
     NetworkError,
     NotFoundError,
     RateLimitError,
+    UsageError,
 )
 from basecamp.hooks import BasecampHooks
 
@@ -181,3 +182,84 @@ class TestHeaders:
         client.get("/test")
         request = route.calls[0].request
         assert request.headers["authorization"] == "Bearer test-token"
+
+
+
+class TestSameOriginGuard:
+    @respx.mock
+    def test_foreign_origin_absolute_rejected_without_egress(self):
+        route = respx.get("https://evil.example/steal.json").mock(return_value=httpx.Response(200))
+        client = make_client()
+        with pytest.raises(UsageError):
+            client.get("https://evil.example/steal.json")
+        assert route.call_count == 0
+
+    @respx.mock
+    def test_foreign_origin_post_rejected(self):
+        route = respx.post("https://evil.example/x").mock(return_value=httpx.Response(200))
+        client = make_client()
+        with pytest.raises(UsageError):
+            client.post("https://evil.example/x", json_body={"a": 1})
+        assert route.call_count == 0
+
+    @respx.mock
+    def test_foreign_origin_put_rejected(self):
+        route = respx.put("https://evil.example/x").mock(return_value=httpx.Response(200))
+        client = make_client()
+        with pytest.raises(UsageError):
+            client.put("https://evil.example/x", json_body={"a": 1})
+        assert route.call_count == 0
+
+    @respx.mock
+    def test_foreign_origin_delete_rejected(self):
+        route = respx.delete("https://evil.example/x").mock(return_value=httpx.Response(204))
+        client = make_client()
+        with pytest.raises(UsageError):
+            client.delete("https://evil.example/x")
+        assert route.call_count == 0
+
+    @respx.mock
+    def test_same_origin_absolute_carries_token(self):
+        route = respx.get("https://3.basecampapi.com/page2.json").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        client = make_client()
+        resp = client.get("https://3.basecampapi.com/page2.json")
+        assert resp.status_code == 200
+        assert route.calls[0].request.headers["authorization"] == "Bearer test-token"
+
+    @respx.mock
+    def test_relative_path_resolves(self):
+        route = respx.get("https://3.basecampapi.com/projects.json").mock(
+            return_value=httpx.Response(200, json=[])
+        )
+        client = make_client()
+        resp = client.get("/projects.json")
+        assert resp.status_code == 200
+        assert route.call_count == 1
+
+    @respx.mock
+    def test_localhost_base_allows_absolute(self):
+        config = Config(
+            base_url="https://localhost:3000",
+            max_retries=1,
+            base_delay=0.001,
+            max_jitter=0.0,
+            timeout=5.0,
+        )
+        client = HttpClient(config, BearerAuth(StaticTokenProvider("test-token")), BasecampHooks())
+        route = respx.get("https://localhost:3000/x.json").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        resp = client.get("https://localhost:3000/x.json")
+        assert resp.status_code == 200
+
+    @respx.mock
+    def test_get_absolute_allows_cross_origin_launchpad(self):
+        route = respx.get("https://launchpad.37signals.com/authorization.json").mock(
+            return_value=httpx.Response(200, json={"ok": True})
+        )
+        client = make_client()
+        resp = client.get_absolute("https://launchpad.37signals.com/authorization.json")
+        assert resp.status_code == 200
+        assert route.calls[0].request.headers["authorization"] == "Bearer test-token"

--- a/python/tests/test_http.py
+++ b/python/tests/test_http.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import contextlib
+
 import httpx
 import pytest
 import respx
@@ -284,3 +286,42 @@ class TestSameOriginGuard:
         assert client._build_url("HTTPS://3.basecampapi.com/x.json") == "HTTPS://3.basecampapi.com/x.json"
         with pytest.raises(UsageError, match="origin"):
             client._build_url("HTTPS://evil.example/x.json")
+
+
+class TestParserDifferentialEgress:
+    """End-to-end parser-differential regression: every adversarial URL, driven
+    through the real token-attach path, must either be rejected by the guard or
+    egress only to a host the token may reach — NEVER to a foreign host
+    carrying Authorization. Guards against the class of bug where the guard
+    extracts the host with one parser while httpx dials with another."""
+
+    ADVERSARIAL_URLS = [
+        "http://evil.example\\.localhost/x",
+        "http://localhost@evil.example/x",
+        "http://evil.example#foo.localhost",
+        "http://evil.example?x=.localhost",
+        "http://localhost:80@evil.example/x",
+        "https://3.basecampapi.com:443@evil.example/x",
+        "http://[::1]/x",
+        "HTTPS://localhost/x",
+        "https://3.basecampapi.com:443/x",
+        "http://localhost.evil.example/x",
+    ]
+
+    @staticmethod
+    def _token_may_reach(host: str) -> bool:
+        # The configured base origin plus the localhost carve-out.
+        return host in ("3.basecampapi.com", "localhost", "127.0.0.1", "::1") or host.endswith(".localhost")
+
+    @respx.mock
+    def test_adversarial_urls_never_egress_token_to_foreign_host(self):
+        respx.route().mock(return_value=httpx.Response(200, json={}))
+        client = make_client(max_retries=1)
+        for url in self.ADVERSARIAL_URLS:
+            # Rejection before egress is a passing outcome.
+            with contextlib.suppress(UsageError, httpx.InvalidURL):
+                client.get(url)
+        for call in respx.calls:
+            host = call.request.url.host.lower()
+            auth = call.request.headers.get("authorization")
+            assert self._token_may_reach(host) or auth is None, f"Bearer token egressed to foreign host {host!r}"

--- a/python/tests/test_http.py
+++ b/python/tests/test_http.py
@@ -184,7 +184,6 @@ class TestHeaders:
         assert request.headers["authorization"] == "Bearer test-token"
 
 
-
 class TestSameOriginGuard:
     @respx.mock
     def test_foreign_origin_absolute_rejected_without_egress(self):
@@ -220,9 +219,7 @@ class TestSameOriginGuard:
 
     @respx.mock
     def test_same_origin_absolute_carries_token(self):
-        route = respx.get("https://3.basecampapi.com/page2.json").mock(
-            return_value=httpx.Response(200, json={})
-        )
+        route = respx.get("https://3.basecampapi.com/page2.json").mock(return_value=httpx.Response(200, json={}))
         client = make_client()
         resp = client.get("https://3.basecampapi.com/page2.json")
         assert resp.status_code == 200
@@ -230,9 +227,7 @@ class TestSameOriginGuard:
 
     @respx.mock
     def test_relative_path_resolves(self):
-        route = respx.get("https://3.basecampapi.com/projects.json").mock(
-            return_value=httpx.Response(200, json=[])
-        )
+        route = respx.get("https://3.basecampapi.com/projects.json").mock(return_value=httpx.Response(200, json=[]))
         client = make_client()
         resp = client.get("/projects.json")
         assert resp.status_code == 200
@@ -248,11 +243,10 @@ class TestSameOriginGuard:
             timeout=5.0,
         )
         client = HttpClient(config, BearerAuth(StaticTokenProvider("test-token")), BasecampHooks())
-        route = respx.get("https://localhost:3000/x.json").mock(
-            return_value=httpx.Response(200, json={})
-        )
+        route = respx.get("https://localhost:3000/x.json").mock(return_value=httpx.Response(200, json={}))
         resp = client.get("https://localhost:3000/x.json")
         assert resp.status_code == 200
+        assert route.call_count == 1
 
     @respx.mock
     def test_get_absolute_allows_cross_origin_launchpad(self):
@@ -269,9 +263,7 @@ class TestSameOriginGuard:
         # get_absolute must not be a blanket origin-guard bypass: only the
         # trusted Launchpad authorization endpoint may receive credentials
         # cross-origin. Any other foreign origin is rejected before egress.
-        route = respx.get("https://evil.example/steal").mock(
-            return_value=httpx.Response(200, json={})
-        )
+        route = respx.get("https://evil.example/steal").mock(return_value=httpx.Response(200, json={}))
         client = make_client()
         with pytest.raises(UsageError, match="different origin"):
             client.get_absolute("https://evil.example/steal")

--- a/python/tests/test_http.py
+++ b/python/tests/test_http.py
@@ -263,3 +263,16 @@ class TestSameOriginGuard:
         resp = client.get_absolute("https://launchpad.37signals.com/authorization.json")
         assert resp.status_code == 200
         assert route.calls[0].request.headers["authorization"] == "Bearer test-token"
+
+    @respx.mock
+    def test_get_absolute_rejects_foreign_origin(self):
+        # get_absolute must not be a blanket origin-guard bypass: only the
+        # trusted Launchpad authorization endpoint may receive credentials
+        # cross-origin. Any other foreign origin is rejected before egress.
+        route = respx.get("https://evil.example/steal").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        client = make_client()
+        with pytest.raises(UsageError, match="different origin"):
+            client.get_absolute("https://evil.example/steal")
+        assert route.call_count == 0

--- a/python/tests/test_http.py
+++ b/python/tests/test_http.py
@@ -276,7 +276,6 @@ class TestSameOriginGuard:
         with pytest.raises(UsageError, match="HTTPS"):
             client.get_absolute("ws://localhost:3000/x")
 
-    @respx.mock
     def test_build_url_uppercase_scheme_treated_as_absolute(self):
         # Schemes are case-insensitive (RFC 3986): an uppercase-scheme URL is
         # still absolute — same-origin passes through, foreign is rejected

--- a/python/tests/test_security.py
+++ b/python/tests/test_security.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import httpx
 import pytest
 
 from basecamp._security import (
@@ -11,6 +12,22 @@ from basecamp._security import (
     truncate,
 )
 from basecamp.errors import ApiError, UsageError
+
+# URLs crafted so that two URL parsers may disagree about the host (backslash,
+# userinfo, fragment, query, default-port tricks). Shared shape with the
+# Kotlin and Swift SDK test suites.
+ADVERSARIAL_URLS = [
+    "http://evil.example\\.localhost/x",
+    "http://localhost@evil.example/x",
+    "http://evil.example#foo.localhost",
+    "http://evil.example?x=.localhost",
+    "http://localhost:80@evil.example/x",
+    "https://3.basecampapi.com:443@evil.example/x",
+    "http://[::1]/x",
+    "HTTPS://localhost/x",
+    "https://3.basecampapi.com:443/x",
+    "http://localhost.evil.example/x",
+]
 
 
 class TestSameOrigin:
@@ -71,10 +88,44 @@ class TestIsLocalhost:
             "https://example.com",
             "https://notlocalhost.com",
             "https://api.basecamp.com",
+            # Localhost text in userinfo, fragment, or query must not make a
+            # foreign host pass the carve-out.
+            "http://localhost@evil.example/x",
+            "http://localhost:80@evil.example/x",
+            "http://evil.example#foo.localhost",
+            "http://evil.example?x=.localhost",
+            "http://localhost.evil.example/x",
+            # A scheme-less string is not an absolute localhost URL.
+            "localhost",
         ],
     )
     def test_non_localhost_false(self, url):
         assert is_localhost(url) is False
+
+
+class TestParserDifferential:
+    """A security guard must decide with the SAME parser the transport uses to
+    dial (httpx.URL). Whenever the guard blesses a URL, the host httpx would
+    actually dial must be the host the guard thought it blessed. Fails loudly
+    if anyone reintroduces a second parser into _security.py."""
+
+    BASE = "https://3.basecampapi.com"
+
+    @pytest.mark.parametrize("url", ADVERSARIAL_URLS)
+    def test_guard_decides_with_transport_parser(self, url):
+        try:
+            dialed = httpx.URL(url).host.lower()
+        except httpx.InvalidURL:
+            dialed = None
+        if is_localhost(url):
+            assert dialed is not None, f"is_localhost blessed unparseable {url!r}"
+            assert dialed in ("localhost", "127.0.0.1", "::1") or dialed.endswith(".localhost"), (
+                f"is_localhost blessed {url!r} but the transport dials {dialed!r}"
+            )
+        if same_origin(url, self.BASE):
+            assert dialed == httpx.URL(self.BASE).host.lower(), (
+                f"same_origin blessed {url!r} against {self.BASE} but the transport dials {dialed!r}"
+            )
 
 
 class TestTruncate:

--- a/ruby/lib/basecamp/generated/services/authorization_service.rb
+++ b/ruby/lib/basecamp/generated/services/authorization_service.rb
@@ -12,8 +12,10 @@ module Basecamp
     #     puts "Account: #{account["name"]} (#{account["id"]})"
     #   end
     class AuthorizationService < BaseService
-      # Fallback Launchpad endpoint for authorization
-      LAUNCHPAD_AUTHORIZATION_URL = "https://launchpad.37signals.com/authorization.json"
+      # Fallback Launchpad endpoint for authorization. Single-sourced from
+      # Security so it stays in lockstep with the cross-origin allowance in
+      # Http#get_absolute (a divergence would reject the legitimate call).
+      LAUNCHPAD_AUTHORIZATION_URL = Basecamp::Security::LAUNCHPAD_AUTHORIZATION_URL
 
       # Gets authorization information for the current user.
       #

--- a/ruby/lib/basecamp/generated/services/authorization_service.rb
+++ b/ruby/lib/basecamp/generated/services/authorization_service.rb
@@ -12,10 +12,8 @@ module Basecamp
     #     puts "Account: #{account["name"]} (#{account["id"]})"
     #   end
     class AuthorizationService < BaseService
-      # Fallback Launchpad endpoint for authorization. Single-sourced from
-      # Security so it stays in lockstep with the cross-origin allowance in
-      # Http#get_absolute (a divergence would reject the legitimate call).
-      LAUNCHPAD_AUTHORIZATION_URL = Basecamp::Security::LAUNCHPAD_AUTHORIZATION_URL
+      # Fallback Launchpad endpoint for authorization
+      LAUNCHPAD_AUTHORIZATION_URL = "https://launchpad.37signals.com/authorization.json"
 
       # Gets authorization information for the current user.
       #

--- a/ruby/lib/basecamp/http.rb
+++ b/ruby/lib/basecamp/http.rb
@@ -67,7 +67,11 @@ module Basecamp
     # @return [Response]
     def get_absolute(url, params: {})
       Security.require_https_unless_localhost!(url, "absolute URL")
-      request(:get, url, params: params, allow_cross_origin: true)
+      # Cross-origin is permitted only for the trusted Launchpad authorization
+      # endpoint; any other foreign origin still trips the same-origin guard so
+      # the bearer token never leaks off the configured host.
+      allow_cross_origin = url == Security::LAUNCHPAD_AUTHORIZATION_URL
+      request(:get, url, params: params, allow_cross_origin: allow_cross_origin)
     end
 
     # Performs a POST request.

--- a/ruby/lib/basecamp/http.rb
+++ b/ruby/lib/basecamp/http.rb
@@ -67,10 +67,13 @@ module Basecamp
     # @return [Response]
     def get_absolute(url, params: {})
       Security.require_https_unless_localhost!(url, "absolute URL")
-      # Cross-origin is permitted only for the trusted Launchpad authorization
-      # endpoint; any other foreign origin still trips the same-origin guard so
-      # the bearer token never leaks off the configured host.
-      allow_cross_origin = url == Security::LAUNCHPAD_AUTHORIZATION_URL
+      # get_absolute exists to fetch the OAuth authorization endpoint, which lives
+      # on a different origin than the API base URL — Launchpad by default, or an
+      # issuer discovered from the configured base URL. Permit the credentialed
+      # cross-origin request only for that endpoint; every other foreign origin
+      # still trips the same-origin guard so the bearer token never leaks off the
+      # configured host.
+      allow_cross_origin = Security.authorization_endpoint?(url)
       request(:get, url, params: params, allow_cross_origin: allow_cross_origin)
     end
 
@@ -491,9 +494,8 @@ module Basecamp
     # Attach-point backstop: refuse to attach credentials to a foreign origin
     # before the auth strategy adds the bearer token. Localhost is carved out
     # for dev/test. allow_cross_origin is granted only by get_absolute, and only
-    # for the trusted Launchpad authorization endpoint — every other absolute
-    # URL (including a discovery-provided issuer on a different origin) must be
-    # same-origin with the configured base URL.
+    # for the OAuth authorization endpoint (Launchpad or a discovered issuer);
+    # every other absolute URL must be same-origin with the configured base URL.
     def assert_credential_origin!(url, allow_cross_origin)
       return if allow_cross_origin
       return if Security.localhost?(url) || Security.same_origin?(url, @config.base_url)

--- a/ruby/lib/basecamp/http.rb
+++ b/ruby/lib/basecamp/http.rb
@@ -476,12 +476,15 @@ module Basecamp
     end
 
     def build_url(path, allow_cross_origin: false)
-      if path.start_with?("https://")
+      # Schemes are case-insensitive (RFC 3986): detect absolute URLs on a
+      # lowercased copy so HTTPS://... is not mis-joined onto the base URL.
+      lower_path = path.downcase
+      if lower_path.start_with?("https://")
         return path if allow_cross_origin
         return path if Security.localhost?(path) || Security.same_origin?(path, @config.base_url)
 
         raise Basecamp::UsageError.new("URL origin does not match configured base URL: #{Security.truncate(path)}")
-      elsif path.start_with?("http://")
+      elsif lower_path.start_with?("http://")
         # Localhost may use plain HTTP for local development; every other host
         # must use HTTPS.
         return path if Security.localhost?(path)

--- a/ruby/lib/basecamp/http.rb
+++ b/ruby/lib/basecamp/http.rb
@@ -490,8 +490,10 @@ module Basecamp
 
     # Attach-point backstop: refuse to attach credentials to a foreign origin
     # before the auth strategy adds the bearer token. Localhost is carved out
-    # for dev/test. allow_cross_origin is set only for the intentional Launchpad
-    # call routed through get_absolute.
+    # for dev/test. allow_cross_origin is granted only by get_absolute, and only
+    # for the trusted Launchpad authorization endpoint — every other absolute
+    # URL (including a discovery-provided issuer on a different origin) must be
+    # same-origin with the configured base URL.
     def assert_credential_origin!(url, allow_cross_origin)
       return if allow_cross_origin
       return if Security.localhost?(url) || Security.same_origin?(url, @config.base_url)

--- a/ruby/lib/basecamp/http.rb
+++ b/ruby/lib/basecamp/http.rb
@@ -66,7 +66,8 @@ module Basecamp
     # @param params [Hash] query parameters
     # @return [Response]
     def get_absolute(url, params: {})
-      request(:get, url, params: params)
+      Security.require_https_unless_localhost!(url, "absolute URL")
+      request(:get, url, params: params, allow_cross_origin: true)
     end
 
     # Performs a POST request.
@@ -296,18 +297,18 @@ module Basecamp
       end
     end
 
-    def request(method, path, params: {}, body: nil)
-      url = build_url(path)
+    def request(method, path, params: {}, body: nil, allow_cross_origin: false)
+      url = build_url(path, allow_cross_origin: allow_cross_origin)
 
       # Mutations don't retry on 429/5xx to avoid duplicating data
       if method == :get
-        request_with_retry(method, url, params: params)
+        request_with_retry(method, url, params: params, allow_cross_origin: allow_cross_origin)
       else
-        single_request(method, url, params: params, body: body, attempt: 1)
+        single_request(method, url, params: params, body: body, attempt: 1, allow_cross_origin: allow_cross_origin)
       end
     end
 
-    def request_with_retry(method, url, params: {})
+    def request_with_retry(method, url, params: {}, allow_cross_origin: false)
       attempt = 0
       last_error = nil
 
@@ -316,7 +317,7 @@ module Basecamp
         break if attempt > @config.max_retries
 
         begin
-          return single_request(method, url, params: params, body: nil, attempt: attempt)
+          return single_request(method, url, params: params, body: nil, attempt: attempt, allow_cross_origin: allow_cross_origin)
         rescue Basecamp::RateLimitError, Basecamp::NetworkError, Basecamp::ApiError => e
           raise e unless e.retryable?
 
@@ -336,7 +337,8 @@ module Basecamp
       raise last_error || Basecamp::ApiError.new("Request failed after #{@config.max_retries} retries")
     end
 
-    def single_request(method, url, params:, body:, attempt:, retry_count: 0)
+    def single_request(method, url, params:, body:, attempt:, retry_count: 0, allow_cross_origin: false)
+      assert_credential_origin!(url, allow_cross_origin)
       info = RequestInfo.new(method: method.to_s.upcase, url: url, attempt: attempt)
       @hooks.on_request_start(info)
 
@@ -370,7 +372,7 @@ module Basecamp
         # After a successful token refresh on 401, retry the request once
         if error.is_a?(Basecamp::AuthError) && error.http_status == 401 && retry_count < 1 && @token_refreshed
           @token_refreshed = false
-          return single_request(method, url, params: params, body: body, attempt: attempt, retry_count: retry_count + 1)
+          return single_request(method, url, params: params, body: body, attempt: attempt, retry_count: retry_count + 1, allow_cross_origin: allow_cross_origin)
         end
 
         raise error
@@ -393,6 +395,7 @@ module Basecamp
     end
 
     def single_request_raw(method, url, body:, content_type:, attempt:)
+      assert_credential_origin!(url, false)
       info = RequestInfo.new(method: method.to_s.upcase, url: url, attempt: attempt)
       @hooks.on_request_start(info)
 
@@ -467,15 +470,31 @@ module Basecamp
       err
     end
 
-    def build_url(path)
+    def build_url(path, allow_cross_origin: false)
       if path.start_with?("https://")
-        return path
+        return path if allow_cross_origin
+        return path if Security.localhost?(path) || Security.same_origin?(path, @config.base_url)
+
+        raise Basecamp::UsageError.new("URL origin does not match configured base URL: #{Security.truncate(path)}")
       elsif path.start_with?("http://")
         raise Basecamp::UsageError.new("URL must use HTTPS: #{path}")
       end
 
       path = "/#{path}" unless path.start_with?("/")
       "#{@config.base_url}#{path}"
+    end
+
+    # Attach-point backstop: refuse to attach credentials to a foreign origin
+    # before the auth strategy adds the bearer token. Localhost is carved out
+    # for dev/test. allow_cross_origin is set only for the intentional Launchpad
+    # call routed through get_absolute.
+    def assert_credential_origin!(url, allow_cross_origin)
+      return if allow_cross_origin
+      return if Security.localhost?(url) || Security.same_origin?(url, @config.base_url)
+
+      raise Basecamp::UsageError.new(
+        "Refusing to send credentials to a different origin than base URL: #{Security.truncate(url)}"
+      )
     end
 
     def calculate_delay(attempt, server_retry_after)

--- a/ruby/lib/basecamp/http.rb
+++ b/ruby/lib/basecamp/http.rb
@@ -67,13 +67,11 @@ module Basecamp
     # @return [Response]
     def get_absolute(url, params: {})
       Security.require_https_unless_localhost!(url, "absolute URL")
-      # get_absolute exists to fetch the OAuth authorization endpoint, which lives
-      # on a different origin than the API base URL — Launchpad by default, or an
-      # issuer discovered from the configured base URL. Permit the credentialed
-      # cross-origin request only for that endpoint; every other foreign origin
-      # still trips the same-origin guard so the bearer token never leaks off the
-      # configured host.
-      allow_cross_origin = Security.authorization_endpoint?(url)
+      # Cross-origin is permitted only for the trusted Launchpad authorization
+      # endpoint; any other foreign origin (including an endpoint-shaped URL such
+      # as https://evil.example/authorization.json) still trips the same-origin
+      # guard, so the bearer token never leaks off the configured host.
+      allow_cross_origin = url == Security::LAUNCHPAD_AUTHORIZATION_URL
       request(:get, url, params: params, allow_cross_origin: allow_cross_origin)
     end
 
@@ -484,7 +482,11 @@ module Basecamp
 
         raise Basecamp::UsageError.new("URL origin does not match configured base URL: #{Security.truncate(path)}")
       elsif path.start_with?("http://")
-        raise Basecamp::UsageError.new("URL must use HTTPS: #{path}")
+        # Localhost may use plain HTTP for local development; every other host
+        # must use HTTPS.
+        return path if Security.localhost?(path)
+
+        raise Basecamp::UsageError.new("URL must use HTTPS: #{Security.truncate(path)}")
       end
 
       path = "/#{path}" unless path.start_with?("/")
@@ -494,8 +496,8 @@ module Basecamp
     # Attach-point backstop: refuse to attach credentials to a foreign origin
     # before the auth strategy adds the bearer token. Localhost is carved out
     # for dev/test. allow_cross_origin is granted only by get_absolute, and only
-    # for the OAuth authorization endpoint (Launchpad or a discovered issuer);
-    # every other absolute URL must be same-origin with the configured base URL.
+    # for the trusted Launchpad authorization endpoint; every other absolute URL
+    # must be same-origin with the configured base URL.
     def assert_credential_origin!(url, allow_cross_origin)
       return if allow_cross_origin
       return if Security.localhost?(url) || Security.same_origin?(url, @config.base_url)

--- a/ruby/lib/basecamp/security.rb
+++ b/ruby/lib/basecamp/security.rb
@@ -10,6 +10,11 @@ module Basecamp
     MAX_RESPONSE_BODY_BYTES = 50 * 1024 * 1024 # 50 MB
     MAX_ERROR_BODY_BYTES = 1 * 1024 * 1024      # 1 MB
 
+    # The Launchpad authorization endpoint is on a different origin than the
+    # configured API base URL, so it is the one sanctioned destination for a
+    # credentialed cross-origin request. Any other foreign origin is rejected.
+    LAUNCHPAD_AUTHORIZATION_URL = "https://launchpad.37signals.com/authorization.json"
+
     def self.truncate(str, max = MAX_ERROR_MESSAGE_BYTES)
       return str if str.nil? || str.bytesize <= max
 

--- a/ruby/lib/basecamp/security.rb
+++ b/ruby/lib/basecamp/security.rb
@@ -10,11 +10,6 @@ module Basecamp
     MAX_RESPONSE_BODY_BYTES = 50 * 1024 * 1024 # 50 MB
     MAX_ERROR_BODY_BYTES = 1 * 1024 * 1024      # 1 MB
 
-    # The Launchpad authorization endpoint is on a different origin than the
-    # configured API base URL, so it is the one sanctioned destination for a
-    # credentialed cross-origin request. Any other foreign origin is rejected.
-    LAUNCHPAD_AUTHORIZATION_URL = "https://launchpad.37signals.com/authorization.json"
-
     def self.truncate(str, max = MAX_ERROR_MESSAGE_BYTES)
       return str if str.nil? || str.bytesize <= max
 
@@ -35,6 +30,19 @@ module Basecamp
 
       ua.scheme.downcase == ub.scheme.downcase &&
         normalize_host(ua) == normalize_host(ub)
+    rescue URI::InvalidURIError
+      false
+    end
+
+    # The OAuth authorization endpoint is the one sanctioned cross-origin
+    # destination for a credentialed request: it lives on a different origin
+    # than the API base URL (Launchpad by default, or an issuer discovered from
+    # the configured base URL). Matching the endpoint shape — an HTTPS
+    # `.../authorization.json` URL — preserves discovered issuers while keeping
+    # every other absolute URL subject to the same-origin guard.
+    def self.authorization_endpoint?(url)
+      uri = URI.parse(url.to_s)
+      uri.scheme&.downcase == "https" && uri.path&.end_with?("/authorization.json")
     rescue URI::InvalidURIError
       false
     end

--- a/ruby/lib/basecamp/security.rb
+++ b/ruby/lib/basecamp/security.rb
@@ -69,6 +69,9 @@ module Basecamp
       uri = URI.parse(url.to_s)
       host = uri.host&.downcase
       return false if host.nil?
+      # The carve-out is limited to HTTP(S) so credential guards fail closed
+      # on any other scheme (e.g. ws://localhost).
+      return false unless %w[http https].include?(uri.scheme&.downcase)
 
       host == "localhost" ||
         host == "127.0.0.1" ||

--- a/ruby/lib/basecamp/security.rb
+++ b/ruby/lib/basecamp/security.rb
@@ -10,6 +10,11 @@ module Basecamp
     MAX_RESPONSE_BODY_BYTES = 50 * 1024 * 1024 # 50 MB
     MAX_ERROR_BODY_BYTES = 1 * 1024 * 1024      # 1 MB
 
+    # The Launchpad authorization endpoint is on a different origin than the
+    # configured API base URL, so it is the one sanctioned destination for a
+    # credentialed cross-origin request. Every other foreign origin is rejected.
+    LAUNCHPAD_AUTHORIZATION_URL = "https://launchpad.37signals.com/authorization.json"
+
     def self.truncate(str, max = MAX_ERROR_MESSAGE_BYTES)
       return str if str.nil? || str.bytesize <= max
 
@@ -30,19 +35,6 @@ module Basecamp
 
       ua.scheme.downcase == ub.scheme.downcase &&
         normalize_host(ua) == normalize_host(ub)
-    rescue URI::InvalidURIError
-      false
-    end
-
-    # The OAuth authorization endpoint is the one sanctioned cross-origin
-    # destination for a credentialed request: it lives on a different origin
-    # than the API base URL (Launchpad by default, or an issuer discovered from
-    # the configured base URL). Matching the endpoint shape — an HTTPS
-    # `.../authorization.json` URL — preserves discovered issuers while keeping
-    # every other absolute URL subject to the same-origin guard.
-    def self.authorization_endpoint?(url)
-      uri = URI.parse(url.to_s)
-      uri.scheme&.downcase == "https" && uri.path&.end_with?("/authorization.json")
     rescue URI::InvalidURIError
       false
     end

--- a/ruby/test/basecamp/http_test.rb
+++ b/ruby/test/basecamp/http_test.rb
@@ -107,13 +107,12 @@ class HTTPTest < Minitest::Test
                      headers: { "User-Agent" => /basecamp-sdk-ruby/ })
   end
 
-  def test_handles_absolute_url
-    stub_request(:get, "https://other.api.com/path.json")
-      .to_return(status: 200, body: "{}")
-
-    response = @http.get("https://other.api.com/path.json")
-
-    assert_equal 200, response.status
+  def test_rejects_cross_origin_absolute_url
+    error = assert_raises(Basecamp::UsageError) do
+      @http.get("https://other.api.com/path.json")
+    end
+    assert_match(/origin/, error.message)
+    assert_not_requested(:get, "https://other.api.com/path.json")
   end
 
   def test_401_raises_auth_error

--- a/ruby/test/basecamp/same_origin_test.rb
+++ b/ruby/test/basecamp/same_origin_test.rb
@@ -66,9 +66,8 @@ class SameOriginCredentialTest < Minitest::Test
   end
 
   def test_get_absolute_rejects_foreign_origin
-    # get_absolute must not be a blanket origin-guard bypass: only the trusted
-    # Launchpad authorization endpoint may receive credentials cross-origin.
-    # Any other foreign origin is rejected before egress.
+    # get_absolute must not be a blanket origin-guard bypass: a foreign origin
+    # that is not the authorization endpoint is rejected before egress.
     error = assert_raises(Basecamp::UsageError) do
       @http.get_absolute("https://evil.example/steal")
     end
@@ -76,12 +75,16 @@ class SameOriginCredentialTest < Minitest::Test
     assert_not_requested(:get, "https://evil.example/steal")
   end
 
-  def test_launchpad_authorization_url_stays_in_lockstep
-    # get_absolute scopes its cross-origin allowance to Security's constant, while
-    # the (generated) AuthorizationService resolves the fallback to its own copy.
-    # If a regeneration ever changes the generated literal, this catches the drift
-    # before it silently breaks the legitimate Launchpad authorization call.
-    assert_equal Basecamp::Security::LAUNCHPAD_AUTHORIZATION_URL,
-      Basecamp::Services::AuthorizationService::LAUNCHPAD_AUTHORIZATION_URL
+  def test_get_absolute_allows_discovered_non_launchpad_issuer
+    # OAuth discovery may resolve a non-Launchpad issuer (e.g. a staging/custom
+    # auth server); its authorization endpoint must still be reachable with the
+    # bearer token, not rejected as a foreign origin.
+    stub_request(:get, "https://auth.staging.example/authorization.json")
+      .with(headers: { "Authorization" => "Bearer #{access_token}" })
+      .to_return(status: 200, body: '{"ok":true}', headers: { "Content-Type" => "application/json" })
+
+    response = @http.get_absolute("https://auth.staging.example/authorization.json")
+    assert_equal 200, response.status
+    assert_requested(:get, "https://auth.staging.example/authorization.json")
   end
 end

--- a/ruby/test/basecamp/same_origin_test.rb
+++ b/ruby/test/basecamp/same_origin_test.rb
@@ -31,6 +31,12 @@ class SameOriginCredentialTest < Minitest::Test
       @http.send(:build_url, "https://localhost:3000/x.json")
   end
 
+  def test_build_url_accepts_localhost_http_absolute_url
+    # Localhost may use plain HTTP for local development.
+    assert_equal "http://localhost:3000/x.json",
+      @http.send(:build_url, "http://localhost:3000/x.json")
+  end
+
   def test_build_url_rejects_http_absolute_url
     assert_raises(Basecamp::UsageError) do
       @http.send(:build_url, "http://3.basecampapi.com/x.json")
@@ -66,8 +72,8 @@ class SameOriginCredentialTest < Minitest::Test
   end
 
   def test_get_absolute_rejects_foreign_origin
-    # get_absolute must not be a blanket origin-guard bypass: a foreign origin
-    # that is not the authorization endpoint is rejected before egress.
+    # get_absolute must not be a blanket origin-guard bypass: only the trusted
+    # Launchpad authorization endpoint may receive credentials cross-origin.
     error = assert_raises(Basecamp::UsageError) do
       @http.get_absolute("https://evil.example/steal")
     end
@@ -75,16 +81,23 @@ class SameOriginCredentialTest < Minitest::Test
     assert_not_requested(:get, "https://evil.example/steal")
   end
 
-  def test_get_absolute_allows_discovered_non_launchpad_issuer
-    # OAuth discovery may resolve a non-Launchpad issuer (e.g. a staging/custom
-    # auth server); its authorization endpoint must still be reachable with the
-    # bearer token, not rejected as a foreign origin.
-    stub_request(:get, "https://auth.staging.example/authorization.json")
-      .with(headers: { "Authorization" => "Bearer #{access_token}" })
-      .to_return(status: 200, body: '{"ok":true}', headers: { "Content-Type" => "application/json" })
+  def test_get_absolute_rejects_foreign_authorization_shaped_url
+    # The allowance keys off the exact Launchpad URL, not the path shape, so a
+    # foreign host whose path merely ends in /authorization.json is still
+    # rejected before any token egress.
+    error = assert_raises(Basecamp::UsageError) do
+      @http.get_absolute("https://evil.example/authorization.json")
+    end
+    assert_match(/origin/, error.message)
+    assert_not_requested(:get, "https://evil.example/authorization.json")
+  end
 
-    response = @http.get_absolute("https://auth.staging.example/authorization.json")
-    assert_equal 200, response.status
-    assert_requested(:get, "https://auth.staging.example/authorization.json")
+  def test_launchpad_authorization_url_stays_in_lockstep
+    # get_absolute scopes its cross-origin allowance to Security's constant, while
+    # the (generated) AuthorizationService resolves the fallback to its own copy.
+    # If a regeneration ever changes the generated literal, this catches the drift
+    # before it silently breaks the legitimate Launchpad authorization call.
+    assert_equal Basecamp::Security::LAUNCHPAD_AUTHORIZATION_URL,
+      Basecamp::Services::AuthorizationService::LAUNCHPAD_AUTHORIZATION_URL
   end
 end

--- a/ruby/test/basecamp/same_origin_test.rb
+++ b/ruby/test/basecamp/same_origin_test.rb
@@ -75,4 +75,13 @@ class SameOriginCredentialTest < Minitest::Test
     assert_match(/origin/, error.message)
     assert_not_requested(:get, "https://evil.example/steal")
   end
+
+  def test_launchpad_authorization_url_stays_in_lockstep
+    # get_absolute scopes its cross-origin allowance to Security's constant, while
+    # the (generated) AuthorizationService resolves the fallback to its own copy.
+    # If a regeneration ever changes the generated literal, this catches the drift
+    # before it silently breaks the legitimate Launchpad authorization call.
+    assert_equal Basecamp::Security::LAUNCHPAD_AUTHORIZATION_URL,
+      Basecamp::Services::AuthorizationService::LAUNCHPAD_AUTHORIZATION_URL
+  end
 end

--- a/ruby/test/basecamp/same_origin_test.rb
+++ b/ruby/test/basecamp/same_origin_test.rb
@@ -64,4 +64,15 @@ class SameOriginCredentialTest < Minitest::Test
     assert_equal 200, response.status
     assert_requested(:get, "https://launchpad.37signals.com/authorization.json")
   end
+
+  def test_get_absolute_rejects_foreign_origin
+    # get_absolute must not be a blanket origin-guard bypass: only the trusted
+    # Launchpad authorization endpoint may receive credentials cross-origin.
+    # Any other foreign origin is rejected before egress.
+    error = assert_raises(Basecamp::UsageError) do
+      @http.get_absolute("https://evil.example/steal")
+    end
+    assert_match(/origin/, error.message)
+    assert_not_requested(:get, "https://evil.example/steal")
+  end
 end

--- a/ruby/test/basecamp/same_origin_test.rb
+++ b/ruby/test/basecamp/same_origin_test.rb
@@ -81,6 +81,26 @@ class SameOriginCredentialTest < Minitest::Test
     assert_not_requested(:get, "https://evil.example/steal")
   end
 
+  def test_build_url_uppercase_scheme_treated_as_absolute
+    # Schemes are case-insensitive (RFC 3986): an uppercase-scheme URL is still
+    # absolute — same-origin passes through, foreign is rejected rather than
+    # joined onto the base URL.
+    assert_equal "HTTPS://3.basecampapi.com/test.json",
+      @http.send(:build_url, "HTTPS://3.basecampapi.com/test.json")
+    assert_raises(Basecamp::UsageError) do
+      @http.send(:build_url, "HTTPS://evil.example/x.json")
+    end
+  end
+
+  def test_get_absolute_rejects_non_http_scheme_for_localhost
+    # The localhost carve-out is limited to HTTP(S): any other scheme must fail
+    # closed before credentials could be attached.
+    error = assert_raises(Basecamp::UsageError) do
+      @http.get_absolute("ws://localhost:3000/x")
+    end
+    assert_match(/HTTPS/, error.message)
+  end
+
   def test_get_absolute_rejects_foreign_authorization_shaped_url
     # The allowance keys off the exact Launchpad URL, not the path shape, so a
     # foreign host whose path merely ends in /authorization.json is still

--- a/ruby/test/basecamp/same_origin_test.rb
+++ b/ruby/test/basecamp/same_origin_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Verifies the bearer token is only attached to the configured origin:
+# absolute URLs on a foreign origin are rejected at the build_url chokepoint
+# and the single_request attach-point backstop, while same-origin and localhost
+# URLs (and the intentional cross-origin Launchpad call) still work.
+class SameOriginCredentialTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @config = default_config # base_url https://3.basecampapi.com
+    @http = Basecamp::Http.new(config: @config, token_provider: test_token_provider)
+  end
+
+  def test_build_url_rejects_cross_origin_absolute_url
+    error = assert_raises(Basecamp::UsageError) do
+      @http.send(:build_url, "https://evil.example/x.json")
+    end
+    assert_match(/origin/, error.message)
+  end
+
+  def test_build_url_accepts_same_origin_absolute_url
+    assert_equal "https://3.basecampapi.com/test.json",
+      @http.send(:build_url, "https://3.basecampapi.com/test.json")
+  end
+
+  def test_build_url_accepts_localhost_absolute_url
+    assert_equal "https://localhost:3000/x.json",
+      @http.send(:build_url, "https://localhost:3000/x.json")
+  end
+
+  def test_build_url_rejects_http_absolute_url
+    assert_raises(Basecamp::UsageError) do
+      @http.send(:build_url, "http://3.basecampapi.com/x.json")
+    end
+  end
+
+  def test_get_rejects_cross_origin_without_token_egress
+    error = assert_raises(Basecamp::UsageError) do
+      @http.get("https://evil.example/steal.json")
+    end
+    assert_match(/origin/, error.message)
+    assert_not_requested(:get, "https://evil.example/steal.json")
+  end
+
+  def test_same_origin_absolute_url_carries_token
+    stub_request(:get, "https://3.basecampapi.com/page2.json")
+      .with(headers: { "Authorization" => "Bearer #{access_token}" })
+      .to_return(status: 200, body: "{}", headers: { "Content-Type" => "application/json" })
+
+    response = @http.get("https://3.basecampapi.com/page2.json")
+    assert_equal 200, response.status
+    assert_requested(:get, "https://3.basecampapi.com/page2.json")
+  end
+
+  def test_get_absolute_allows_cross_origin_launchpad
+    stub_request(:get, "https://launchpad.37signals.com/authorization.json")
+      .with(headers: { "Authorization" => "Bearer #{access_token}" })
+      .to_return(status: 200, body: '{"ok":true}', headers: { "Content-Type" => "application/json" })
+
+    response = @http.get_absolute("https://launchpad.37signals.com/authorization.json")
+    assert_equal 200, response.status
+    assert_requested(:get, "https://launchpad.37signals.com/authorization.json")
+  end
+end

--- a/ruby/test/basecamp/security_test.rb
+++ b/ruby/test/basecamp/security_test.rb
@@ -206,11 +206,19 @@ class SecurityHttpTest < Minitest::Test
     end
   end
 
-  def test_build_url_accepts_https
-    stub_request(:get, "https://other.example.com/path")
+  def test_build_url_rejects_cross_origin
+    error = assert_raises(Basecamp::UsageError) do
+      @http.get("https://other.example.com/path")
+    end
+    assert_match(/origin/, error.message)
+    assert_not_requested(:get, "https://other.example.com/path")
+  end
+
+  def test_build_url_accepts_same_origin_absolute
+    stub_request(:get, "https://3.basecampapi.com/path")
       .to_return(status: 200, body: "{}", headers: { "Content-Type" => "application/json" })
 
-    response = @http.get("https://other.example.com/path")
+    response = @http.get("https://3.basecampapi.com/path")
     assert_equal 200, response.status
   end
 

--- a/swift/Sources/Basecamp/BasecampClient.swift
+++ b/swift/Sources/Basecamp/BasecampClient.swift
@@ -102,11 +102,10 @@ public final class BasecampClient: Sendable {
         let effectiveTransport = transport ?? URLSessionTransport()
         let cache = config.enableCache ? ETagCache() : nil
 
-        // Validate base URL uses HTTPS (skip for localhost in tests)
+        // Validate base URL uses HTTPS, with the shared localhost carve-out
+        // (loopback, *.localhost per RFC 6761, HTTP(S)-only) for dev/test.
         if let url = URL(string: effectiveConfig.baseURL) {
-            let host = url.host ?? ""
-            let isLocalhost = host == "localhost" || host == "127.0.0.1" || host == "::1"
-            if url.scheme != "https" && !isLocalhost {
+            if url.scheme?.lowercased() != "https" && !isLocalhost(effectiveConfig.baseURL) {
                 preconditionFailure("Base URL must use HTTPS: \(effectiveConfig.baseURL)")
             }
         }

--- a/swift/Sources/Basecamp/BasecampError.swift
+++ b/swift/Sources/Basecamp/BasecampError.swift
@@ -198,7 +198,10 @@ public enum BasecampError: Error, Sendable, LocalizedError {
         return String(s.prefix(maxMessageLength - 3)) + "..."
     }
 
-    private static func truncate(_ s: String) -> String {
+    /// Truncates a caller-supplied value (e.g. a URL) embedded in an error
+    /// message. Internal so guard sites elsewhere in the SDK keep their error
+    /// messages bounded too.
+    static func truncate(_ s: String) -> String {
         if s.count <= maxMessageLength { return s }
         return String(s.prefix(maxMessageLength - 3)) + "..."
     }

--- a/swift/Sources/Basecamp/HTTP/HTTPClient.swift
+++ b/swift/Sources/Basecamp/HTTP/HTTPClient.swift
@@ -58,6 +58,7 @@ package final class HTTPClient: Sendable {
         request.timeoutInterval = config.timeoutInterval
 
         // Set auth and standard headers
+        try assertSameOrigin(url)
         try await authStrategy.authenticate(&request)
         request.setValue(config.userAgent, forHTTPHeaderField: "User-Agent")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
@@ -187,6 +188,7 @@ package final class HTTPClient: Sendable {
         request.httpMethod = "GET"
         request.timeoutInterval = config.timeoutInterval
 
+        try assertSameOrigin(url)
         try await authStrategy.authenticate(&request)
         request.setValue(config.userAgent, forHTTPHeaderField: "User-Agent")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
@@ -271,6 +273,18 @@ package final class HTTPClient: Sendable {
     }
 
     // MARK: - Private
+
+    /// Attach-point backstop: refuse to attach credentials to a foreign origin.
+    /// Localhost is carved out for dev/test.
+    private func assertSameOrigin(_ url: String) throws {
+        if isLocalhost(url) || isSameOrigin(url, config.baseURL) {
+            return
+        }
+        throw BasecampError.usage(
+            message: "Refusing to send credentials to a different origin than the configured base URL: \(url)",
+            hint: nil
+        )
+    }
 
     private func calculateDelay(
         attempt: Int,

--- a/swift/Sources/Basecamp/HTTP/HTTPClient.swift
+++ b/swift/Sources/Basecamp/HTTP/HTTPClient.swift
@@ -281,7 +281,7 @@ package final class HTTPClient: Sendable {
             return
         }
         throw BasecampError.usage(
-            message: "Refusing to send credentials to a different origin than the configured base URL: \(url)",
+            message: "Refusing to send credentials to a different origin than the configured base URL: \(BasecampError.truncate(url))",
             hint: nil
         )
     }

--- a/swift/Sources/Basecamp/HTTP/Transport.swift
+++ b/swift/Sources/Basecamp/HTTP/Transport.swift
@@ -20,23 +20,19 @@ public protocol Transport: Sendable {
 /// Production transport that delegates to `URLSession`.
 public struct URLSessionTransport: Transport, Sendable {
     private let session: URLSession
-    /// Session used for redirect-following requests. Its delegate strips the
-    /// Authorization header when a redirect leaves the original request's
-    /// origin — swift-corelibs URLSession would otherwise forward it, leaking
-    /// the bearer token to the foreign Location target.
-    private let redirectSanitizingSession: URLSession
 
     public init(session: URLSession = .shared) {
         self.session = session
-        self.redirectSanitizingSession = URLSession(
-            configuration: session.configuration,
-            delegate: CredentialSanitizingRedirectDelegate(),
-            delegateQueue: nil
-        )
     }
 
     public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-        try await redirectSanitizingSession.data(for: request)
+        // The task-level delegate strips the Authorization header when a
+        // redirect leaves the original request's origin — URLSession would
+        // otherwise forward it, leaking the bearer token to the foreign
+        // Location target. A task delegate only shadows the session delegate
+        // for the callbacks it implements (here: redirects), so the caller's
+        // session delegate still handles auth challenges, pinning, metrics.
+        try await session.data(for: request, delegate: CredentialSanitizingRedirectDelegate())
     }
 
     public func dataNoRedirect(for request: URLRequest) async throws -> (Data, URLResponse) {

--- a/swift/Sources/Basecamp/HTTP/Transport.swift
+++ b/swift/Sources/Basecamp/HTTP/Transport.swift
@@ -20,13 +20,23 @@ public protocol Transport: Sendable {
 /// Production transport that delegates to `URLSession`.
 public struct URLSessionTransport: Transport, Sendable {
     private let session: URLSession
+    /// Session used for redirect-following requests. Its delegate strips the
+    /// Authorization header when a redirect leaves the original request's
+    /// origin — swift-corelibs URLSession would otherwise forward it, leaking
+    /// the bearer token to the foreign Location target.
+    private let redirectSanitizingSession: URLSession
 
     public init(session: URLSession = .shared) {
         self.session = session
+        self.redirectSanitizingSession = URLSession(
+            configuration: session.configuration,
+            delegate: CredentialSanitizingRedirectDelegate(),
+            delegateQueue: nil
+        )
     }
 
     public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-        try await session.data(for: request)
+        try await redirectSanitizingSession.data(for: request)
     }
 
     public func dataNoRedirect(for request: URLRequest) async throws -> (Data, URLResponse) {
@@ -42,6 +52,35 @@ public struct URLSessionTransport: Transport, Sendable {
         )
         defer { noRedirectSession.finishTasksAndInvalidate() }
         return try await noRedirectSession.data(for: request)
+    }
+}
+
+/// Strips credentials from a redirect request when it leaves the origin of the
+/// original request, mirroring the Go SDK's redirect policy. Factored out of
+/// the delegate so the policy is unit-testable without a live URLSession.
+func sanitizedRedirectRequest(_ request: URLRequest, originalURL: URL?) -> URLRequest {
+    guard let target = request.url?.absoluteString,
+          let original = originalURL?.absoluteString,
+          isSameOrigin(target, original) else {
+        var stripped = request
+        stripped.setValue(nil, forHTTPHeaderField: "Authorization")
+        return stripped
+    }
+    return request
+}
+
+/// URLSession delegate that follows redirects but strips the Authorization
+/// header when the redirect target is a different origin than the original
+/// request, so the bearer token never travels to a foreign host.
+private final class CredentialSanitizingRedirectDelegate: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+    func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection response: HTTPURLResponse,
+        newRequest request: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        completionHandler(sanitizedRedirectRequest(request, originalURL: task.originalRequest?.url))
     }
 }
 

--- a/swift/Sources/Basecamp/Pagination.swift
+++ b/swift/Sources/Basecamp/Pagination.swift
@@ -128,3 +128,9 @@ private func defaultPort(for scheme: String?) -> Int? {
     default: nil
     }
 }
+
+/// Checks whether a URL points to localhost (for dev/test carve-out).
+func isLocalhost(_ urlString: String) -> Bool {
+    guard let host = URLComponents(string: urlString)?.host?.lowercased() else { return false }
+    return host == "localhost" || host == "127.0.0.1" || host == "::1" || host.hasSuffix(".localhost")
+}

--- a/swift/Sources/Basecamp/Pagination.swift
+++ b/swift/Sources/Basecamp/Pagination.swift
@@ -132,8 +132,15 @@ private func defaultPort(for scheme: String?) -> Int? {
     }
 }
 
-/// Checks whether a URL points to localhost (for dev/test carve-out).
+/// Checks whether a URL points to localhost over HTTP(S) (for dev/test carve-out).
 func isLocalhost(_ urlString: String) -> Bool {
-    guard let host = URLComponents(string: urlString)?.host?.lowercased() else { return false }
+    guard let components = URLComponents(string: urlString),
+          let host = components.host?.lowercased() else { return false }
+    // The carve-out is limited to HTTP(S) so credential guards fail closed on
+    // any other scheme (e.g. ws://localhost).
+    switch components.scheme?.lowercased() {
+    case "http", "https": break
+    default: return false
+    }
     return host == "localhost" || host == "127.0.0.1" || host == "::1" || host.hasSuffix(".localhost")
 }

--- a/swift/Sources/Basecamp/Pagination.swift
+++ b/swift/Sources/Basecamp/Pagination.swift
@@ -108,9 +108,12 @@ func isSameOrigin(_ a: String, _ b: String) -> Bool {
           let urlB = URLComponents(string: b)
     else { return false }
 
-    return urlA.scheme == urlB.scheme
-        && urlA.host == urlB.host
-        && (urlA.port ?? defaultPort(for: urlA.scheme)) == (urlB.port ?? defaultPort(for: urlB.scheme))
+    // Scheme and host are case-insensitive (RFC 3986); normalize before comparing.
+    let schemeA = urlA.scheme?.lowercased()
+    let schemeB = urlB.scheme?.lowercased()
+    return schemeA == schemeB
+        && urlA.host?.lowercased() == urlB.host?.lowercased()
+        && (urlA.port ?? defaultPort(for: schemeA)) == (urlB.port ?? defaultPort(for: schemeB))
 }
 
 /// Parses the `X-Total-Count` header from a URL response.

--- a/swift/Sources/Basecamp/Pagination.swift
+++ b/swift/Sources/Basecamp/Pagination.swift
@@ -103,16 +103,24 @@ func resolveURL(base: String, target: String) -> String {
 }
 
 /// Checks whether two absolute URLs share the same origin (scheme + host + port).
+///
+/// Parses with `URL(string:)` — the SAME parser `HTTPClient` uses to dial —
+/// so the guard can never disagree with the transport about which host a URL
+/// targets. `URLComponents(string:)` is a distinct Foundation parser that can
+/// diverge on malformed input (a parser-differential bypass).
 func isSameOrigin(_ a: String, _ b: String) -> Bool {
-    guard let urlA = URLComponents(string: a),
-          let urlB = URLComponents(string: b)
+    guard let urlA = URL(string: a),
+          let urlB = URL(string: b),
+          // Fail closed on scheme-less/host-less (relative) input.
+          let schemeA = urlA.scheme?.lowercased(),
+          let schemeB = urlB.scheme?.lowercased(),
+          let hostA = urlA.host?.lowercased(),
+          let hostB = urlB.host?.lowercased()
     else { return false }
 
     // Scheme and host are case-insensitive (RFC 3986); normalize before comparing.
-    let schemeA = urlA.scheme?.lowercased()
-    let schemeB = urlB.scheme?.lowercased()
     return schemeA == schemeB
-        && urlA.host?.lowercased() == urlB.host?.lowercased()
+        && hostA == hostB
         && (urlA.port ?? defaultPort(for: schemeA)) == (urlB.port ?? defaultPort(for: schemeB))
 }
 
@@ -133,14 +141,21 @@ private func defaultPort(for scheme: String?) -> Int? {
 }
 
 /// Checks whether a URL points to localhost over HTTP(S) (for dev/test carve-out).
+///
+/// Parses with `URL(string:)` — the SAME parser `HTTPClient` uses to dial —
+/// see `isSameOrigin` for why the guard must not use a second parser.
 func isLocalhost(_ urlString: String) -> Bool {
-    guard let components = URLComponents(string: urlString),
-          let host = components.host?.lowercased() else { return false }
+    guard let url = URL(string: urlString),
+          var host = url.host?.lowercased() else { return false }
     // The carve-out is limited to HTTP(S) so credential guards fail closed on
     // any other scheme (e.g. ws://localhost).
-    switch components.scheme?.lowercased() {
+    switch url.scheme?.lowercased() {
     case "http", "https": break
     default: return false
+    }
+    // Strip IPv6 brackets if the platform's URL.host retains them.
+    if host.hasPrefix("["), host.hasSuffix("]") {
+        host = String(host.dropFirst().dropLast())
     }
     return host == "localhost" || host == "127.0.0.1" || host == "::1" || host.hasSuffix(".localhost")
 }

--- a/swift/Sources/Basecamp/Services/BaseService.swift
+++ b/swift/Sources/Basecamp/Services/BaseService.swift
@@ -49,7 +49,7 @@ open class BaseService: @unchecked Sendable {
             } else {
                 bodyData = try body.map { try Self.encoder.encode($0) }
             }
-            let url = accountClient.baseURL + path
+            let url = try buildURL(path)
 
             let (data, response) = try await accountClient.httpClient.performRequest(
                 method: method, url: url, body: bodyData, contentType: contentType, retryConfig: retryConfig
@@ -103,7 +103,7 @@ open class BaseService: @unchecked Sendable {
             } else {
                 bodyData = try body.map { try Self.encoder.encode($0) }
             }
-            let url = accountClient.baseURL + path
+            let url = try buildURL(path)
 
             let (data, response) = try await accountClient.httpClient.performRequest(
                 method: method, url: url, body: bodyData, contentType: contentType, retryConfig: retryConfig
@@ -150,7 +150,7 @@ open class BaseService: @unchecked Sendable {
         safeInvokeHooks { $0.onOperationStart(info) }
 
         do {
-            var urlString = accountClient.baseURL + path
+            var urlString = try buildURL(path)
             if let queryItems, !queryItems.isEmpty {
                 var components = URLComponents(string: urlString)
                 components?.queryItems = queryItems
@@ -230,7 +230,7 @@ open class BaseService: @unchecked Sendable {
         safeInvokeHooks { $0.onOperationStart(info) }
 
         do {
-            var urlString = accountClient.baseURL + path
+            var urlString = try buildURL(path)
             if let queryItems, !queryItems.isEmpty {
                 var components = URLComponents(string: urlString)
                 components?.queryItems = queryItems
@@ -417,6 +417,25 @@ open class BaseService: @unchecked Sendable {
     }()
 
     // MARK: - Helpers
+
+    /// Builds the full request URL for an account-relative path. Absolute URLs
+    /// must target the configured origin (localhost carve-out) so the bearer
+    /// token is never attached to a foreign host.
+    private func buildURL(_ path: String) throws -> String {
+        if path.hasPrefix("http://") {
+            throw BasecampError.usage(message: "Request URL must use HTTPS: \(path)", hint: nil)
+        }
+        if path.hasPrefix("https://") {
+            if isLocalhost(path) || isSameOrigin(path, accountClient.baseURL) {
+                return path
+            }
+            throw BasecampError.usage(
+                message: "Request URL points to a different origin than the configured base URL: \(path)",
+                hint: nil
+            )
+        }
+        return accountClient.baseURL + path
+    }
 
     private func millisSince(_ startTime: CFAbsoluteTime) -> Int {
         Int((CFAbsoluteTimeGetCurrent() - startTime) * 1000)

--- a/swift/Sources/Basecamp/Services/BaseService.swift
+++ b/swift/Sources/Basecamp/Services/BaseService.swift
@@ -422,11 +422,22 @@ open class BaseService: @unchecked Sendable {
     /// must target the configured origin (localhost carve-out) so the bearer
     /// token is never attached to a foreign host.
     private func buildURL(_ path: String) throws -> String {
-        if path.hasPrefix("http://") {
-            throw BasecampError.usage(message: "Request URL must use HTTPS: \(path)", hint: nil)
-        }
-        if path.hasPrefix("https://") {
-            if isLocalhost(path) || isSameOrigin(path, accountClient.baseURL) {
+        // Scheme detection is case-insensitive (RFC 3986) while the original
+        // string is preserved for the request.
+        let lowercased = path.lowercased()
+        let isHTTP = lowercased.hasPrefix("http://")
+        let isHTTPS = lowercased.hasPrefix("https://")
+        if isHTTP || isHTTPS {
+            // Localhost is carved out for local development and may use plain
+            // HTTP; every other origin must be same-origin and use HTTPS so the
+            // bearer token is never attached to a foreign host.
+            if isLocalhost(path) {
+                return path
+            }
+            if isHTTP {
+                throw BasecampError.usage(message: "Request URL must use HTTPS: \(path)", hint: nil)
+            }
+            if isSameOrigin(path, accountClient.baseURL) {
                 return path
             }
             throw BasecampError.usage(

--- a/swift/Sources/Basecamp/Services/BaseService.swift
+++ b/swift/Sources/Basecamp/Services/BaseService.swift
@@ -435,13 +435,13 @@ open class BaseService: @unchecked Sendable {
                 return path
             }
             if isHTTP {
-                throw BasecampError.usage(message: "Request URL must use HTTPS: \(path)", hint: nil)
+                throw BasecampError.usage(message: "Request URL must use HTTPS: \(BasecampError.truncate(path))", hint: nil)
             }
             if isSameOrigin(path, accountClient.baseURL) {
                 return path
             }
             throw BasecampError.usage(
-                message: "Request URL points to a different origin than the configured base URL: \(path)",
+                message: "Request URL points to a different origin than the configured base URL: \(BasecampError.truncate(path))",
                 hint: nil
             )
         }

--- a/swift/Tests/BasecampTests/SameOriginGuardTests.swift
+++ b/swift/Tests/BasecampTests/SameOriginGuardTests.swift
@@ -37,4 +37,22 @@ final class SameOriginGuardTests: XCTestCase {
         _ = try await svc.get("https://localhost:8080/x.json")
         XCTAssertEqual(transport.requests.count, 1)
     }
+
+    func testLocalhostAllowsPlainHTTP() async throws {
+        // Localhost may use plain HTTP for local development.
+        let transport = MockTransport(statusCode: 200, data: Data("[]".utf8))
+        let svc = ProbeService(accountClient: makeTestAccountClient(transport: transport))
+        _ = try await svc.get("http://localhost:8080/x.json")
+        XCTAssertEqual(transport.requests.count, 1)
+    }
+
+    func testForeignOriginPlainHTTPRejectedNoEgress() async throws {
+        // A non-localhost http:// target must still be rejected (HTTPS required),
+        // with no token egress.
+        let transport = MockTransport(statusCode: 200, data: Data("[]".utf8))
+        let svc = ProbeService(accountClient: makeTestAccountClient(transport: transport))
+        do { _ = try await svc.get("http://evil.example/steal.json"); XCTFail("expected rejection") }
+        catch let error as BasecampError { guard case .usage = error else { return XCTFail("got \(error)") } }
+        XCTAssertTrue(transport.requests.isEmpty)
+    }
 }

--- a/swift/Tests/BasecampTests/SameOriginGuardTests.swift
+++ b/swift/Tests/BasecampTests/SameOriginGuardTests.swift
@@ -20,6 +20,7 @@ final class SameOriginGuardTests: XCTestCase {
         let svc = ProbeService(accountClient: makeTestAccountClient(transport: transport))
         do { _ = try await svc.get("https://evil.example/steal.json"); XCTFail("expected rejection") }
         catch let error as BasecampError { guard case .usage = error else { return XCTFail("got \(error)") } }
+        catch { XCTFail("expected BasecampError.usage, got \(error)") }
         XCTAssertTrue(transport.requests.isEmpty)
     }
 
@@ -53,6 +54,7 @@ final class SameOriginGuardTests: XCTestCase {
         let svc = ProbeService(accountClient: makeTestAccountClient(transport: transport))
         do { _ = try await svc.get("http://evil.example/steal.json"); XCTFail("expected rejection") }
         catch let error as BasecampError { guard case .usage = error else { return XCTFail("got \(error)") } }
+        catch { XCTFail("expected BasecampError.usage, got \(error)") }
         XCTAssertTrue(transport.requests.isEmpty)
     }
 }

--- a/swift/Tests/BasecampTests/SameOriginGuardTests.swift
+++ b/swift/Tests/BasecampTests/SameOriginGuardTests.swift
@@ -80,4 +80,85 @@ final class SameOriginGuardTests: XCTestCase {
         catch { XCTFail("expected BasecampError.usage, got \(error)") }
         XCTAssertTrue(transport.requests.isEmpty)
     }
+
+    // MARK: - Parser-differential regression
+
+    /// URLs crafted so that two URL parsers may disagree about the host
+    /// (backslash, userinfo, fragment, query, default-port tricks). Shared
+    /// shape with the Kotlin and Python SDK test suites.
+    private static let adversarialURLs = [
+        "http://evil.example\\.localhost/x",
+        "http://localhost@evil.example/x",
+        "http://evil.example#foo.localhost",
+        "http://evil.example?x=.localhost",
+        "http://localhost:80@evil.example/x",
+        "https://3.basecampapi.com:443@evil.example/x",
+        "http://[::1]/x",
+        "HTTPS://localhost/x",
+        "https://3.basecampapi.com:443/x",
+        "http://localhost.evil.example/x",
+    ]
+
+    private func isLoopbackHost(_ host: String) -> Bool {
+        var h = host.lowercased()
+        if h.hasPrefix("["), h.hasSuffix("]") { h = String(h.dropFirst().dropLast()) }
+        return h == "localhost" || h == "127.0.0.1" || h == "::1" || h.hasSuffix(".localhost")
+    }
+
+    /// Hosts the token may legitimately reach: the configured base origin plus
+    /// the localhost carve-out.
+    private func tokenMayReach(_ host: String) -> Bool {
+        host.lowercased() == "3.basecampapi.com" || isLoopbackHost(host)
+    }
+
+    /// A security guard must decide with the SAME parser the transport uses to
+    /// dial (`URL(string:)`, see HTTPClient). Whenever the guard blesses a URL,
+    /// the host the transport would actually dial must be the host the guard
+    /// thought it blessed. Fails loudly if anyone reintroduces a second parser
+    /// (e.g. URLComponents) into the guards.
+    func testGuardDecidesWithTheTransportParser() {
+        let base = "https://3.basecampapi.com"
+        for url in Self.adversarialURLs {
+            let dialed = URL(string: url)?.host?.lowercased()
+            if isLocalhost(url) {
+                XCTAssertNotNil(dialed, "isLocalhost blessed unparseable \(url)")
+                XCTAssertTrue(
+                    isLoopbackHost(dialed ?? ""),
+                    "isLocalhost blessed \(url) but the transport dials \(dialed ?? "nil")")
+            }
+            if isSameOrigin(url, base) {
+                XCTAssertEqual(
+                    dialed, URL(string: base)?.host?.lowercased(),
+                    "isSameOrigin blessed \(url) against \(base) but the transport dials \(dialed ?? "nil")")
+            }
+        }
+    }
+
+    /// End-to-end parser-differential regression: every adversarial URL, driven
+    /// through the real token-attach path, must either be rejected by the guard
+    /// or egress only to a host the token may reach — NEVER to a foreign host
+    /// carrying Authorization.
+    func testAdversarialURLsNeverEgressTokenToForeignHost() async {
+        let transport = MockTransport(statusCode: 200, data: Data("[]".utf8))
+        let svc = ProbeService(accountClient: makeTestAccountClient(transport: transport))
+        for url in Self.adversarialURLs {
+            // Rejection before egress is a passing outcome.
+            do { _ = try await svc.get(url) } catch {}
+        }
+        for recorded in transport.requests {
+            let host = recorded.request.url?.host?.lowercased() ?? ""
+            let auth = recorded.request.value(forHTTPHeaderField: "Authorization")
+            XCTAssertTrue(
+                tokenMayReach(host) || auth == nil,
+                "Bearer token egressed to foreign host \(host)")
+        }
+    }
+
+    func testGuardsFailClosedOnRelativeInput() {
+        // A scheme-less string is not an absolute URL: neither guard may bless it.
+        XCTAssertFalse(isLocalhost("localhost"))
+        XCTAssertFalse(isLocalhost("evil.example/x"))
+        XCTAssertFalse(isSameOrigin("3.basecampapi.com", "https://3.basecampapi.com"))
+        XCTAssertFalse(isSameOrigin("https://3.basecampapi.com", "3.basecampapi.com"))
+    }
 }

--- a/swift/Tests/BasecampTests/SameOriginGuardTests.swift
+++ b/swift/Tests/BasecampTests/SameOriginGuardTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import Basecamp
+
+/// Verifies the same-origin credential guard: the bearer token is attached only
+/// to the configured origin (localhost carve-out for dev/test). A foreign-origin
+/// absolute URL must error before any network send, so the mock transport
+/// records no request (no Authorization egress). Drives `BaseService`'s
+/// `buildURL` chokepoint via a tiny in-test subclass.
+final class SameOriginGuardTests: XCTestCase {
+    final class ProbeService: BaseService {
+        func get(_ path: String) async throws -> [String] {
+            try await request(
+                OperationInfo(service: "Probe", operation: "Get", resourceType: "probe", isMutation: false),
+                method: "GET", path: path)
+        }
+    }
+
+    func testForeignOriginRejectedNoEgress() async throws {
+        let transport = MockTransport(statusCode: 200, data: Data("[]".utf8))
+        let svc = ProbeService(accountClient: makeTestAccountClient(transport: transport))
+        do { _ = try await svc.get("https://evil.example/steal.json"); XCTFail("expected rejection") }
+        catch let error as BasecampError { guard case .usage = error else { return XCTFail("got \(error)") } }
+        XCTAssertTrue(transport.requests.isEmpty)
+    }
+
+    func testSameOriginAbsoluteCarriesToken() async throws {
+        let transport = MockTransport(statusCode: 200, data: Data("[]".utf8))
+        let svc = ProbeService(accountClient: makeTestAccountClient(transport: transport))
+        _ = try await svc.get("https://3.basecampapi.com/999999999/projects.json")
+        XCTAssertEqual(transport.requests.count, 1)
+        XCTAssertEqual(transport.lastRequest?.request.value(forHTTPHeaderField: "Authorization"), "Bearer test-token")
+    }
+
+    func testLocalhostAbsoluteAllowed() async throws {
+        let transport = MockTransport(statusCode: 200, data: Data("[]".utf8))
+        let svc = ProbeService(accountClient: makeTestAccountClient(transport: transport))
+        _ = try await svc.get("https://localhost:8080/x.json")
+        XCTAssertEqual(transport.requests.count, 1)
+    }
+}

--- a/swift/Tests/BasecampTests/SameOriginGuardTests.swift
+++ b/swift/Tests/BasecampTests/SameOriginGuardTests.swift
@@ -47,6 +47,29 @@ final class SameOriginGuardTests: XCTestCase {
         XCTAssertEqual(transport.requests.count, 1)
     }
 
+    func testLocalhostCarveOutRequiresHttpScheme() {
+        // The carve-out is limited to HTTP(S) so credential guards fail closed
+        // on any other scheme.
+        XCTAssertFalse(isLocalhost("ws://localhost:3000/x"))
+        XCTAssertFalse(isLocalhost("ftp://127.0.0.1/x"))
+        XCTAssertTrue(isLocalhost("HTTPS://localhost:3000/x"))
+    }
+
+    func testRedirectSanitizationStripsAuthorizationCrossOrigin() throws {
+        // A cross-origin redirect must not carry the bearer token to the
+        // foreign Location target; a same-origin redirect keeps it.
+        let original = URL(string: "https://3.basecampapi.com/999/projects.json")!
+        var foreign = URLRequest(url: URL(string: "https://evil.example/steal")!)
+        foreign.setValue("Bearer test-token", forHTTPHeaderField: "Authorization")
+        let stripped = sanitizedRedirectRequest(foreign, originalURL: original)
+        XCTAssertNil(stripped.value(forHTTPHeaderField: "Authorization"))
+
+        var sameOrigin = URLRequest(url: URL(string: "https://3.basecampapi.com/999/projects2.json")!)
+        sameOrigin.setValue("Bearer test-token", forHTTPHeaderField: "Authorization")
+        let kept = sanitizedRedirectRequest(sameOrigin, originalURL: original)
+        XCTAssertEqual(kept.value(forHTTPHeaderField: "Authorization"), "Bearer test-token")
+    }
+
     func testForeignOriginPlainHTTPRejectedNoEgress() async throws {
         // A non-localhost http:// target must still be rejected (HTTPS required),
         // with no token egress.

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -12,7 +12,7 @@ import type { paths } from "./generated/schema.js";
 import { PATH_TO_OPERATION } from "./generated/path-mapping.js";
 import type { BasecampHooks, OperationInfo, RequestInfo, RequestResult } from "./hooks.js";
 import { BasecampError } from "./errors.js";
-import { isLocalhost } from "./security.js";
+import { isLocalhost, requireSameOrigin } from "./security.js";
 import { parseNextLink, resolveURL, isSameOrigin } from "./pagination-utils.js";
 import { type AuthStrategy, bearerAuth } from "./auth-strategy.js";
 import { createDownloadURL, type DownloadResult } from "./download.js";
@@ -285,7 +285,7 @@ export function createBasecampClient(options: BasecampClientOptions): BasecampCl
   const client = createClient<paths>({ baseUrl });
 
   // Apply middleware in order: auth first, then hooks, then cache, then retry
-  client.use(createAuthMiddleware(authStrategy, userAgent, requestTimeoutMs));
+  client.use(createAuthMiddleware(authStrategy, userAgent, requestTimeoutMs, baseUrl));
 
   if (hooks) {
     client.use(createHooksMiddleware(hooks));
@@ -314,6 +314,7 @@ export function createBasecampClient(options: BasecampClientOptions): BasecampCl
 
   // Create fetchPage closure for pagination — uses same auth & User-Agent as main client
   const fetchPage = async (url: string): Promise<Response> => {
+    requireSameOrigin(url, baseUrl);
     const headers = new Headers({
       "User-Agent": userAgent,
       Accept: "application/json",
@@ -324,6 +325,7 @@ export function createBasecampClient(options: BasecampClientOptions): BasecampCl
 
   // Authenticated fetch for multipart uploads — adds auth + User-Agent, caller controls body/method
   const authenticatedFetch = async (url: string, init: RequestInit): Promise<Response> => {
+    requireSameOrigin(url, baseUrl);
     const headers = new Headers(init.headers);
     headers.set("User-Agent", userAgent);
     await authStrategy.authenticate(headers);
@@ -421,9 +423,11 @@ export function createBasecampClient(options: BasecampClientOptions): BasecampCl
 // Auth Middleware
 // =============================================================================
 
-function createAuthMiddleware(authStrategy: AuthStrategy, userAgent: string, requestTimeoutMs: number): Middleware {
+function createAuthMiddleware(authStrategy: AuthStrategy, userAgent: string, requestTimeoutMs: number, baseUrl: string): Middleware {
   return {
     async onRequest({ request }) {
+      // Backstop: never attach credentials to a foreign origin.
+      requireSameOrigin(request.url, baseUrl);
       await authStrategy.authenticate(request.headers);
       request.headers.set("User-Agent", userAgent);
       // Only set Content-Type if not already set (preserves binary uploads, etc.)

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -31,8 +31,10 @@ const MAX_ERROR_MESSAGE_LENGTH = 500;
 
 /**
  * Truncates a string to maxLen characters, appending "..." if truncated.
+ * Exported for internal use in error messages that embed caller-supplied
+ * values (e.g. URLs); not part of the public API surface.
  */
-function truncateErrorMessage(s: string, maxLen: number = MAX_ERROR_MESSAGE_LENGTH): string {
+export function truncateErrorMessage(s: string, maxLen: number = MAX_ERROR_MESSAGE_LENGTH): string {
   if (s.length <= maxLen) return s;
   return s.slice(0, maxLen - 3) + "...";
 }

--- a/typescript/src/security.ts
+++ b/typescript/src/security.ts
@@ -104,12 +104,15 @@ export function redactHeadersRecord(
  * isLocalhost("myapp.localhost");     // true
  * isLocalhost("127.0.0.1");           // true
  * isLocalhost("::1");                 // true
+ * isLocalhost("[::1]");               // true (bracketed IPv6 from URL.hostname)
  * isLocalhost("example.com");         // false
  * isLocalhost("localhost.example.com"); // false
  * ```
  */
 export function isLocalhost(hostname: string): boolean {
-  const normalized = hostname.toLowerCase();
+  // URL.hostname returns IPv6 literals bracketed (e.g. "[::1]"); strip the
+  // brackets so the loopback comparison matches.
+  const normalized = hostname.toLowerCase().replace(/^\[(.*)\]$/, "$1");
   return (
     normalized === "localhost" ||
     normalized === "127.0.0.1" ||

--- a/typescript/src/security.ts
+++ b/typescript/src/security.ts
@@ -5,6 +5,9 @@
  * sensitive information like tokens and cookies.
  */
 
+import { isSameOrigin } from "./pagination-utils.js";
+import { BasecampError } from "./errors.js";
+
 /**
  * Headers that contain sensitive values and should be redacted.
  */
@@ -113,4 +116,51 @@ export function isLocalhost(hostname: string): boolean {
     normalized === "::1" ||
     normalized.endsWith(".localhost")
   );
+}
+
+/**
+ * Returns true when `target` shares an origin with `base`, or when `target`
+ * is a localhost URL (dev/test carve-out, consistent with the base-URL HTTPS
+ * check in createBasecampClient).
+ */
+export function isSameOriginAllowingLocalhost(target: string, base: string): boolean {
+  try {
+    if (isSameOrigin(target, base)) return true;
+    return isLocalhost(new URL(target).hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Throws a BasecampError unless `target` is same-origin with the configured
+ * base URL (localhost carve-out). This keeps the bearer token from being
+ * attached to a foreign host on the initial, caller-influenced request —
+ * mirroring the same-origin guard already applied to pagination Link headers
+ * and cross-origin redirects.
+ */
+export function requireSameOrigin(target: string, base: string): void {
+  if (!isSameOriginAllowingLocalhost(target, base)) {
+    throw new BasecampError(
+      "validation",
+      `Refusing to send credentials to a different origin than the configured base URL: ${target}`
+    );
+  }
+}
+
+/**
+ * Validates that an endpoint URL is secure: HTTPS, or localhost (RFC 6761)
+ * which is trusted for local development. Used to validate caller-supplied
+ * authorization endpoint overrides before the bearer token is attached.
+ */
+export function requireSecureEndpoint(url: string, label: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new BasecampError("validation", `Invalid ${label}: ${url}`);
+  }
+  if (parsed.protocol !== "https:" && !isLocalhost(parsed.hostname)) {
+    throw new BasecampError("validation", `${label} must use HTTPS: ${url}`);
+  }
 }

--- a/typescript/src/security.ts
+++ b/typescript/src/security.ts
@@ -129,7 +129,13 @@ export function isLocalhost(hostname: string): boolean {
 export function isSameOriginAllowingLocalhost(target: string, base: string): boolean {
   try {
     if (isSameOrigin(target, base)) return true;
-    return isLocalhost(new URL(target).hostname);
+    // The localhost carve-out is limited to HTTP(S) so credentials fail closed
+    // on any other scheme.
+    const parsed = new URL(target);
+    return (
+      (parsed.protocol === "https:" || parsed.protocol === "http:") &&
+      isLocalhost(parsed.hostname)
+    );
   } catch {
     return false;
   }
@@ -152,9 +158,10 @@ export function requireSameOrigin(target: string, base: string): void {
 }
 
 /**
- * Validates that an endpoint URL is secure: HTTPS, or localhost (RFC 6761)
- * which is trusted for local development. Used to validate caller-supplied
- * authorization endpoint overrides before the bearer token is attached.
+ * Validates that an endpoint URL is secure: HTTPS everywhere, with plain HTTP
+ * permitted only for localhost (RFC 6761) during local development. Any other
+ * scheme is rejected. Used to validate caller-supplied authorization endpoint
+ * overrides before the bearer token is attached.
  */
 export function requireSecureEndpoint(url: string, label: string): void {
   let parsed: URL;
@@ -163,7 +170,8 @@ export function requireSecureEndpoint(url: string, label: string): void {
   } catch {
     throw new BasecampError("validation", `Invalid ${label}: ${url}`);
   }
-  if (parsed.protocol !== "https:" && !isLocalhost(parsed.hostname)) {
+  const isLocalhostHttp = parsed.protocol === "http:" && isLocalhost(parsed.hostname);
+  if (parsed.protocol !== "https:" && !isLocalhostHttp) {
     throw new BasecampError("validation", `${label} must use HTTPS: ${url}`);
   }
 }

--- a/typescript/src/security.ts
+++ b/typescript/src/security.ts
@@ -6,7 +6,7 @@
  */
 
 import { isSameOrigin } from "./pagination-utils.js";
-import { BasecampError } from "./errors.js";
+import { BasecampError, truncateErrorMessage } from "./errors.js";
 
 /**
  * Headers that contain sensitive values and should be redacted.
@@ -152,7 +152,7 @@ export function requireSameOrigin(target: string, base: string): void {
   if (!isSameOriginAllowingLocalhost(target, base)) {
     throw new BasecampError(
       "validation",
-      `Refusing to send credentials to a different origin than the configured base URL: ${target}`
+      `Refusing to send credentials to a different origin than the configured base URL: ${truncateErrorMessage(target)}`
     );
   }
 }
@@ -168,10 +168,10 @@ export function requireSecureEndpoint(url: string, label: string): void {
   try {
     parsed = new URL(url);
   } catch {
-    throw new BasecampError("validation", `Invalid ${label}: ${url}`);
+    throw new BasecampError("validation", `Invalid ${label}: ${truncateErrorMessage(url)}`);
   }
   const isLocalhostHttp = parsed.protocol === "http:" && isLocalhost(parsed.hostname);
   if (parsed.protocol !== "https:" && !isLocalhostHttp) {
-    throw new BasecampError("validation", `${label} must use HTTPS: ${url}`);
+    throw new BasecampError("validation", `${label} must use HTTPS: ${truncateErrorMessage(url)}`);
   }
 }

--- a/typescript/src/services/authorization.ts
+++ b/typescript/src/services/authorization.ts
@@ -8,6 +8,7 @@
 import { BaseService, type RawClient } from "./base.js";
 import type { BasecampHooks } from "../hooks.js";
 import type { AuthStrategy } from "../auth-strategy.js";
+import { requireSecureEndpoint } from "../security.js";
 
 /**
  * The authenticated user's identity.
@@ -163,6 +164,8 @@ export class AuthorizationService extends BaseService {
    */
   async getInfo(options: GetAuthorizationInfoOptions = {}): Promise<AuthorizationInfo> {
     const endpoint = options.endpoint ?? DEFAULT_AUTHORIZATION_ENDPOINT;
+    // Validate caller-supplied endpoint overrides before attaching the token.
+    requireSecureEndpoint(endpoint, "authorization endpoint");
 
     return this.request(
       {

--- a/typescript/tests/security.test.ts
+++ b/typescript/tests/security.test.ts
@@ -714,6 +714,18 @@ describe("isLocalhost", () => {
     expect(isLocalhost("::1")).toBe(true);
   });
 
+  it("returns true for bracketed IPv6 loopback '[::1]' (as URL.hostname returns it)", async () => {
+    const { isLocalhost } = await import("../src/security.js");
+    expect(isLocalhost("[::1]")).toBe(true);
+    // URL.hostname brackets IPv6 literals, so this is the value real callers pass.
+    expect(isLocalhost(new URL("http://[::1]:8080/path").hostname)).toBe(true);
+  });
+
+  it("returns false for non-loopback bracketed IPv6", async () => {
+    const { isLocalhost } = await import("../src/security.js");
+    expect(isLocalhost("[2001:db8::1]")).toBe(false);
+  });
+
   it("returns true for .localhost TLD (RFC 6761)", async () => {
     const { isLocalhost } = await import("../src/security.js");
     expect(isLocalhost("myapp.localhost")).toBe(true);
@@ -819,6 +831,11 @@ describe("Same-origin credential attachment", () => {
     expect(isSameOriginAllowingLocalhost("https://3.basecampapi.com/x", base)).toBe(true);
     expect(isSameOriginAllowingLocalhost("http://127.0.0.1:9999/x", base)).toBe(true);
     expect(isSameOriginAllowingLocalhost("https://evil.example/x", base)).toBe(false);
+  });
+
+  it("isSameOriginAllowingLocalhost recognizes IPv6 loopback [::1]", () => {
+    // URL.hostname brackets IPv6 literals; the carve-out must still match.
+    expect(isSameOriginAllowingLocalhost("http://[::1]:8080/x", base)).toBe(true);
   });
 
   it("guard fails closed before any request is sent to a foreign origin", () => {

--- a/typescript/tests/security.test.ts
+++ b/typescript/tests/security.test.ts
@@ -17,6 +17,7 @@ import {
   paginateAll,
 } from "../src/client.js";
 import { BasecampError } from "../src/errors.js";
+import { requireSameOrigin, isSameOriginAllowingLocalhost } from "../src/security.js";
 import { exchangeCode, refreshToken } from "../src/oauth/index.js";
 import { discover } from "../src/oauth/discovery.js";
 
@@ -774,5 +775,63 @@ describe("Header redaction", () => {
     expect(redacted.Authorization).toBe("[REDACTED]");
     expect(redacted.Cookie).toBe("[REDACTED]");
     expect(redacted["Content-Type"]).toBe("application/json");
+  });
+});
+
+
+// =============================================================================
+// Same-Origin Credential Attachment (initial, caller-influenced request)
+// =============================================================================
+
+describe("Same-origin credential attachment", () => {
+  const base = "https://3.basecampapi.com/12345";
+
+  it("requireSameOrigin accepts a same-origin URL", () => {
+    expect(() =>
+      requireSameOrigin("https://3.basecampapi.com/12345/projects.json", base)
+    ).not.toThrow();
+  });
+
+  it("requireSameOrigin accepts a localhost URL (dev carve-out)", () => {
+    expect(() =>
+      requireSameOrigin("http://localhost:3000/projects.json", base)
+    ).not.toThrow();
+  });
+
+  it("requireSameOrigin rejects a foreign-origin URL", () => {
+    expect(() =>
+      requireSameOrigin("https://evil.example/steal.json", base)
+    ).toThrow("different origin than the configured base URL");
+  });
+
+  it("requireSameOrigin throws a validation BasecampError", () => {
+    let caught: unknown;
+    try {
+      requireSameOrigin("https://evil.example/steal.json", base);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(BasecampError);
+    expect((caught as BasecampError).code).toBe("validation");
+  });
+
+  it("isSameOriginAllowingLocalhost honors the localhost carve-out", () => {
+    expect(isSameOriginAllowingLocalhost("https://3.basecampapi.com/x", base)).toBe(true);
+    expect(isSameOriginAllowingLocalhost("http://127.0.0.1:9999/x", base)).toBe(true);
+    expect(isSameOriginAllowingLocalhost("https://evil.example/x", base)).toBe(false);
+  });
+
+  it("guard fails closed before any request is sent to a foreign origin", () => {
+    const originalFetch = globalThis.fetch;
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+    try {
+      expect(() =>
+        requireSameOrigin("https://evil.example/steal.json", base)
+      ).toThrow();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/typescript/tests/security.test.ts
+++ b/typescript/tests/security.test.ts
@@ -848,6 +848,18 @@ describe("Same-origin credential attachment", () => {
     expect(isSameOriginAllowingLocalhost("ftp://localhost/x", base)).toBe(false);
   });
 
+  it("guard errors truncate the caller-supplied URL", () => {
+    const huge = "https://evil.example/" + "a".repeat(10_000);
+    let caught: unknown;
+    try {
+      requireSameOrigin(huge, base);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(BasecampError);
+    expect((caught as BasecampError).message.length).toBeLessThan(700);
+  });
+
   it("requireSecureEndpoint allows HTTPS anywhere and HTTP only for localhost", () => {
     expect(() => requireSecureEndpoint("https://launchpad.37signals.com/authorization.json", "endpoint")).not.toThrow();
     expect(() => requireSecureEndpoint("http://localhost:3000/authorization.json", "endpoint")).not.toThrow();

--- a/typescript/tests/security.test.ts
+++ b/typescript/tests/security.test.ts
@@ -882,3 +882,42 @@ describe("Same-origin credential attachment", () => {
     }
   });
 });
+
+// =============================================================================
+// Cross-Origin Redirect Authorization Stripping
+// =============================================================================
+
+describe("cross-origin redirect Authorization stripping", () => {
+  it("fetch drops the bearer token when a redirect leaves the origin", async () => {
+    // The SDK relies on the WHATWG fetch spec (undici) to strip Authorization
+    // when following a cross-origin redirect, rather than stripping it
+    // explicitly. This test pins that platform guarantee: if a runtime or
+    // dependency bump ever regresses it, the token would silently leak to the
+    // Location target — this turns that into a CI failure.
+    let evilHit = false;
+    let evilAuth: string | null = "unset";
+
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, () => {
+        return new HttpResponse(null, {
+          status: 302,
+          headers: { Location: "https://evil.example/stolen" },
+        });
+      }),
+      http.get("https://evil.example/stolen", ({ request }) => {
+        evilHit = true;
+        evilAuth = request.headers.get("Authorization");
+        return HttpResponse.json([]);
+      })
+    );
+
+    const client = createBasecampClient({
+      accountId: "12345",
+      accessToken: "test-token",
+    });
+    await client.GET("/projects.json");
+
+    expect(evilHit).toBe(true);
+    expect(evilAuth).toBeNull();
+  });
+});

--- a/typescript/tests/security.test.ts
+++ b/typescript/tests/security.test.ts
@@ -17,7 +17,11 @@ import {
   paginateAll,
 } from "../src/client.js";
 import { BasecampError } from "../src/errors.js";
-import { requireSameOrigin, isSameOriginAllowingLocalhost } from "../src/security.js";
+import {
+  requireSameOrigin,
+  isSameOriginAllowingLocalhost,
+  requireSecureEndpoint,
+} from "../src/security.js";
 import { exchangeCode, refreshToken } from "../src/oauth/index.js";
 import { discover } from "../src/oauth/discovery.js";
 
@@ -836,6 +840,20 @@ describe("Same-origin credential attachment", () => {
   it("isSameOriginAllowingLocalhost recognizes IPv6 loopback [::1]", () => {
     // URL.hostname brackets IPv6 literals; the carve-out must still match.
     expect(isSameOriginAllowingLocalhost("http://[::1]:8080/x", base)).toBe(true);
+  });
+
+  it("isSameOriginAllowingLocalhost limits the localhost carve-out to HTTP(S)", () => {
+    // Credentials must fail closed on non-HTTP(S) schemes even for localhost.
+    expect(isSameOriginAllowingLocalhost("ws://localhost:3000/x", base)).toBe(false);
+    expect(isSameOriginAllowingLocalhost("ftp://localhost/x", base)).toBe(false);
+  });
+
+  it("requireSecureEndpoint allows HTTPS anywhere and HTTP only for localhost", () => {
+    expect(() => requireSecureEndpoint("https://launchpad.37signals.com/authorization.json", "endpoint")).not.toThrow();
+    expect(() => requireSecureEndpoint("http://localhost:3000/authorization.json", "endpoint")).not.toThrow();
+    expect(() => requireSecureEndpoint("http://evil.example/authorization.json", "endpoint")).toThrow("must use HTTPS");
+    // Non-HTTP(S) schemes are rejected even for localhost.
+    expect(() => requireSecureEndpoint("ws://localhost:3000/authorization.json", "endpoint")).toThrow("must use HTTPS");
   });
 
   it("guard fails closed before any request is sent to a foreign origin", () => {

--- a/typescript/tests/services/authorization.test.ts
+++ b/typescript/tests/services/authorization.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the AuthorizationService
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../setup.js";
 import { createBasecampClient } from "../../src/client.js";
@@ -86,6 +86,36 @@ describe("AuthorizationService", () => {
       );
 
       await expect(client.authorization.getInfo()).rejects.toThrow(BasecampError);
+    });
+  });
+
+  describe("getInfo endpoint validation", () => {
+    it("rejects a non-HTTPS custom endpoint without sending the token", async () => {
+      const originalFetch = globalThis.fetch;
+      const fetchSpy = vi.fn();
+      globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+      try {
+        await expect(
+          client.authorization.getInfo({ endpoint: "http://evil.example/authorization.json" })
+        ).rejects.toThrow("HTTPS");
+        expect(fetchSpy).not.toHaveBeenCalled();
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("allows an HTTPS custom endpoint override", async () => {
+      const customUrl = "https://custom.example.com/authorization.json";
+      server.use(http.get(customUrl, () => HttpResponse.json(sampleAuthResponse())));
+      const info = await client.authorization.getInfo({ endpoint: customUrl });
+      expect(info.identity.id).toBe(100);
+    });
+
+    it("allows a localhost custom endpoint override", async () => {
+      const localUrl = "http://localhost:3000/authorization.json";
+      server.use(http.get(localUrl, () => HttpResponse.json(sampleAuthResponse())));
+      const info = await client.authorization.getInfo({ endpoint: localUrl });
+      expect(info.identity.id).toBe(100);
     });
   });
 });


### PR DESCRIPTION
## Same-origin credential attachment (all 6 SDKs)

Hardening: enforce the invariant that **the bearer / `Authorization` token is attached only to the configured origin** (with a localhost carve-out for dev/test) across every SDK.

### Why

Clients accept an absolute URL in the request "path" position (used legitimately for pagination `Link` headers and similar). The URL-building code previously checked only the *scheme* (HTTPS vs HTTP), never the *origin*. So a caller that passed an absolute **foreign** URL — e.g. `client.Get(ctx, "https://evil.example/x.json")` — would have the bearer token attached and sent to a foreign host: a credential-exfiltration primitive (High severity, not known exploited).

This mirrors the same-origin guards already applied to pagination `Link` headers and cross-origin redirects, and the existing base-URL HTTPS check.

### What

Two layers per SDK, failing closed:

1. **URL-build chokepoint** — reject an absolute URL whose origin differs from the configured base URL (localhost carved out).
2. **Token-attach backstop** — re-check at the point credentials are attached, so a future code path that reaches the attach site without going through the chokepoint still can't leak the token.

| SDK | Chokepoint | Backstop |
|-----|-----------|----------|
| Go | `buildURL` | `assertCredentialOrigin` at `singleRequest` + the generated client's `authEditor` |
| TypeScript | `requireSameOrigin` / `requireSecureEndpoint` in `security.ts` | `createAuthMiddleware`, `fetchPage`, `authenticatedFetch` |
| Ruby | `build_url` | `assert_credential_origin!` at `single_request` / `single_request_raw` |
| Python | `_build_url` | `_single_request` (sync **and** async clients) |
| Kotlin | `BaseService.accountUrl` | `BasecampHttpClient.requireSameOrigin` in `request` / `requestBinary` |
| Swift | `BaseService.buildURL` | `HTTPClient.assertSameOrigin` in `performRequest` / `fetchPage` |

Notes:
- The intentional cross-origin Launchpad `authorization.json` call is explicitly preserved (Ruby/Python via an `allow_cross_origin` flag that still HTTPS-validates the endpoint).
- Kotlin: the retry wrappers now surface the guard's `BasecampException.Usage` instead of masking it as a retryable `Network` error; `isLocalhost` was promoted to `internal` and deduplicated.
- Downloads were already origin-pinned in every SDK; the backstops don't affect them.
- Runtime hardening only — **no `spec/` or `*/generated/` edits.**

### Tests

End-to-end invariant asserted in every SDK: a request to a foreign-origin absolute URL **errors before any network send**, and the mock transport records **no `Authorization` egress**; same-origin and localhost absolute URLs still carry the token; same-origin pagination and the OAuth/Launchpad call still work.

New suites: `go/.../same_origin_test.go`, `typescript/tests/security.test.ts` (+ `services/authorization.test.ts`), `ruby/.../same_origin_test.rb`, Python `TestSameOriginGuard`, `kotlin/.../SameOriginTest.kt`, `swift/.../SameOriginGuardTests.swift`.

### Parser-differential hardening (post-convergence round)

An adversarial stress-test after bot-review convergence found a bug class the bots missed: **a security guard must decide with the SAME URL parser the transport uses to dial.** When the guard extracts the host with parser A and the HTTP client re-parses the same string with parser B, any A/B disagreement lets the guard bless a URL as localhost/same-origin while the client sends the token elsewhere.

- **Kotlin — confirmed live leak, fixed.** The hand-rolled guard read the host of `http://evil.example\.localhost/x` as `evil.example\.localhost` (passes the `.localhost` carve-out) while Ktor treats `\` as a path separator and dials `evil.example` — verified end-to-end with a `MockEngine` probe. Third divergence in this parser after the fragment and userinfo bypasses; the parser is now gone. Both guards parse with `io.ktor.http.parseUrl` (Ktor's own parser) and fail closed on relative input.
- **Python — no live leak, latent risk removed.** Guard used `urllib.parse.urlparse`; transport dials with `httpx.URL`. They agree on today's corpus, but the two-parser shape is the same root cause — guards now parse with `httpx.URL`.
- **Swift — same two-parser shape, aligned.** Guards used `URLComponents(string:)`; `HTTPClient` dials via `URL(string:)`. Guards now derive scheme/host/port from `URL(string:)` (validated on macOS CI, since Foundation parsing differs on Linux).
- **Go, TypeScript, Ruby — already sound.** Guard and transport share one parser (`net/url`, WHATWG `URL`, stdlib `URI`); no differential possible.

Durable regression net, shared adversarial corpus (backslash, userinfo, fragment, query, default-port tricks) in all three fixed SDKs:
- **Parser-differential unit tests** — whenever the guard blesses a corpus URL, the transport parser's host must be the host the guard thought it blessed. Fails loudly if anyone reintroduces a second parser.
- **End-to-end egress tests** — each corpus URL driven through the real token-attach path must be rejected or egress only to a loopback/base host, never to a foreign host carrying `Authorization`. The Kotlin test was confirmed to fail against the old parser before the fix.
- **Redirect pins** — Kotlin and TypeScript follow redirects and rely on the platform (Ktor 3.5.1, undici/WHATWG fetch) to strip `Authorization` cross-origin, unlike Go/Swift which strip explicitly. New tests pin that guarantee so a dependency bump that regresses it fails CI. No production change.

### Verification

- **Go** `make -C go test` — green (same-origin suite passes).
- **TypeScript** `npm test` — 632 passed; `npm run typecheck` clean.
- **Ruby** `rake test` — 614 runs, 0 failures; `rubocop` clean (no Ruby changes this round).
- **Python** `uv run pytest` — 237 passed; `ruff check` / `ruff format --check` clean.
- **Kotlin** `./gradlew :basecamp-sdk:jvmTest` — 193 passed, 0 failures (incl. the new suites). The aggregate `test`/`:generator` tasks need a JDK ≤ 25 toolchain; the SDK module's own JVM tests run on JDK 26.
- **Swift** — CI-verified on macOS. This Linux box can't build the SDK's networking layer (pre-existing `CFAbsoluteTime` / `FoundationNetworking` gaps in untouched code); sources parse-checked locally, and the new differential/egress tests run on macOS CI.

### Follow-ups (out of scope here)

- **Kotlin `resolveUrl`** (`BaseService.kt`, splits on `://`) is the next hand-rolled parser to migrate to `parseUrl` — it feeds the pagination `isSameOrigin` checks (which fail closed today).
- **Ruby exact-Launchpad `get_absolute` scoping** stays as-is (already litigated: exact→path→exact after the cubic P0; fails closed for non-Launchpad OAuth issuers). A more-correct future option is validating the *discovered* issuer's origin against the OAuth metadata document instead of a hardcoded constant.
- **Non-canonical IPv6 (`[0:0:0:0:0:0:0:1]`, `[::ffff:127.0.0.1]`) and trailing-dot FQDNs** fail closed (a real loopback/same-origin is refused) — dev-experience only, no security impact.

### Disclosure

Please coordinate disclosure via a private GitHub Security Advisory or `security@basecamp.com` rather than a public issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the bearer Authorization token to the configured base‑URL origin across Go, TypeScript, Ruby, Python, Kotlin, and Swift, with a localhost carve‑out. The only cross‑origin credentialed request remains Launchpad’s https://launchpad.37signals.com/authorization.json.

- **Bug Fixes**
  - Same‑origin/localhost guard: absolute‑URL detection is case‑insensitive; scheme/host compares are case‑insensitive; default ports are normalized; `.localhost` and bracketed `[::1]` are recognized; carve‑out limited to HTTP(S). Go allows plain‑HTTP localhost and gates the carve‑out to HTTP(S); Kotlin’s `isLocalhost` fixed userinfo and fragment bypasses; Swift’s base‑URL HTTPS check now uses the shared localhost helper (`*.localhost`, case‑insensitive scheme).
  - Backstops: origin checks at credential attach points in Go, TypeScript (auth middleware), Kotlin (HTTP client), Swift (`HTTPClient`) and enforced in Ruby/Python request paths.
  - Redirects (Swift): strips Authorization on cross‑origin redirects via a per‑task delegate.
  - Cross‑origin allowance: Ruby/Python `get_absolute` scoped to Launchpad’s authorization URL; TypeScript validates custom authorization endpoint overrides as HTTPS or localhost; guard errors truncate long URLs.

- **Migration**
  - No changes for normal usage. If you pass absolute URLs, make them same‑origin (or localhost). Cross‑origin is allowed only for Launchpad’s authorization endpoint; custom endpoint overrides must be HTTPS or localhost.

<sup>Written for commit afa29192278c7eaaf245e68dc2d176c392225df3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


