### PR TITLE
Fix Go SDK Content-Type on GET requests

### DIFF
--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -365,8 +365,8 @@ func (c *Client) initGeneratedClient() {
 				return err
 			}
 			req.Header.Set("User-Agent", c.userAgent)
-			// Only set Content-Type when a request body is present. GET requests
-			// carry parameters in the URL, and Content-Type describes a request body.
+			// Content-Type describes a request body, so set the JSON default only
+			// when a body is present and the caller has not already set one.
 			if requestHasBody(req) && req.Header.Get("Content-Type") == "" {
 				req.Header.Set("Content-Type", "application/json")
 			}

--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -688,7 +688,7 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 		return nil, err
 	}
 	req.Header.Set("User-Agent", c.userAgent)
-	if requestHasBody(req) {
+	if requestHasBody(req) && req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", "application/json")
 	}
 	req.Header.Set("Accept", "application/json")

--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -365,8 +365,9 @@ func (c *Client) initGeneratedClient() {
 				return err
 			}
 			req.Header.Set("User-Agent", c.userAgent)
-			// Only set Content-Type if not already set (preserves binary upload content types)
-			if req.Header.Get("Content-Type") == "" {
+			// Only set Content-Type when a request body is present. GET requests
+			// carry parameters in the URL, and Content-Type describes a request body.
+			if requestHasBody(req) && req.Header.Get("Content-Type") == "" {
 				req.Header.Set("Content-Type", "application/json")
 			}
 			req.Header.Set("Accept", "application/json")
@@ -380,6 +381,10 @@ func (c *Client) initGeneratedClient() {
 		}
 		c.gen = gen
 	})
+}
+
+func requestHasBody(req *http.Request) bool {
+	return req != nil && req.Body != nil && req.Body != http.NoBody
 }
 
 // discardHandler is a slog.Handler that discards all log records.
@@ -683,7 +688,9 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 		return nil, err
 	}
 	req.Header.Set("User-Agent", c.userAgent)
-	req.Header.Set("Content-Type", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 	req.Header.Set("Accept", "application/json")
 
 	// Add ETag for cached GET requests. Derive cache key from the Authorization

--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -688,7 +688,7 @@ func (c *Client) singleRequest(ctx context.Context, method, url string, body any
 		return nil, err
 	}
 	req.Header.Set("User-Agent", c.userAgent)
-	if body != nil {
+	if requestHasBody(req) {
 		req.Header.Set("Content-Type", "application/json")
 	}
 	req.Header.Set("Accept", "application/json")

--- a/go/pkg/basecamp/client_test.go
+++ b/go/pkg/basecamp/client_test.go
@@ -9,6 +9,15 @@ import (
 	"testing"
 )
 
+type contentTypeAuthStrategy struct {
+	contentType string
+}
+
+func (s contentTypeAuthStrategy) Authenticate(_ context.Context, req *http.Request) error {
+	req.Header.Set("Content-Type", s.contentType)
+	return nil
+}
+
 func TestSingleRequest_204ReturnsValidJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
@@ -128,7 +137,9 @@ func TestSingleRequest_200WithBody(t *testing.T) {
 func TestSingleRequest_GETDoesNotSetContentType(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
-			t.Fatalf("expected GET, got %s", r.Method)
+			t.Errorf("expected GET, got %s", r.Method)
+			http.Error(w, "wrong method", http.StatusBadRequest)
+			return
 		}
 		if got := r.Header.Get("Content-Type"); got != "" {
 			t.Errorf("expected no Content-Type for bodyless GET, got %q", got)
@@ -153,7 +164,9 @@ func TestSingleRequest_GETDoesNotSetContentType(t *testing.T) {
 func TestSingleRequest_POSTSetsContentTypeForJSONBody(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
-			t.Fatalf("expected POST, got %s", r.Method)
+			t.Errorf("expected POST, got %s", r.Method)
+			http.Error(w, "wrong method", http.StatusBadRequest)
+			return
 		}
 		if got := r.Header.Get("Content-Type"); got != "application/json" {
 			t.Errorf("expected Content-Type application/json, got %q", got)
@@ -166,6 +179,36 @@ func TestSingleRequest_POSTSetsContentTypeForJSONBody(t *testing.T) {
 
 	cfg := &Config{BaseURL: server.URL, CacheEnabled: false}
 	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	if _, err := client.Post(context.Background(), "/test.json", map[string]any{"ok": true}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSingleRequest_POSTPreservesExistingContentType(t *testing.T) {
+	const customContentType = "application/merge-patch+json"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+			http.Error(w, "wrong method", http.StatusBadRequest)
+			return
+		}
+		if got := r.Header.Get("Content-Type"); got != customContentType {
+			t.Errorf("expected Content-Type %q, got %q", customContentType, got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL, CacheEnabled: false}
+	client := NewClient(
+		cfg,
+		&StaticTokenProvider{Token: "test-token"},
+		WithAuthStrategy(contentTypeAuthStrategy{contentType: customContentType}),
+	)
 
 	if _, err := client.Post(context.Background(), "/test.json", map[string]any{"ok": true}); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/go/pkg/basecamp/client_test.go
+++ b/go/pkg/basecamp/client_test.go
@@ -3,6 +3,7 @@ package basecamp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -14,6 +15,9 @@ type contentTypeAuthStrategy struct {
 }
 
 func (s contentTypeAuthStrategy) Authenticate(_ context.Context, req *http.Request) error {
+	if req.Header.Get("Content-Type") != "" {
+		return errors.New("expected Content-Type to be empty before auth strategy sets it")
+	}
 	req.Header.Set("Content-Type", s.contentType)
 	return nil
 }

--- a/go/pkg/basecamp/client_test.go
+++ b/go/pkg/basecamp/client_test.go
@@ -125,6 +125,47 @@ func TestSingleRequest_200WithBody(t *testing.T) {
 	}
 }
 
+func TestSingleRequest_GETDoesNotSetContentType(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Content-Type"); got != "" {
+			t.Errorf("expected no Content-Type for bodyless GET, got %q", got)
+		}
+		if got := r.Header.Get("Accept"); got != "application/json" {
+			t.Errorf("expected Accept application/json, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL, CacheEnabled: false}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	if _, err := client.Get(context.Background(), "/test.json"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSingleRequest_POSTSetsContentTypeForJSONBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL, CacheEnabled: false}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+	if _, err := client.Post(context.Background(), "/test.json", map[string]any{"ok": true}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestSingleRequest_204Delete(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodDelete {

--- a/go/pkg/basecamp/client_test.go
+++ b/go/pkg/basecamp/client_test.go
@@ -127,6 +127,9 @@ func TestSingleRequest_200WithBody(t *testing.T) {
 
 func TestSingleRequest_GETDoesNotSetContentType(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
 		if got := r.Header.Get("Content-Type"); got != "" {
 			t.Errorf("expected no Content-Type for bodyless GET, got %q", got)
 		}
@@ -149,6 +152,9 @@ func TestSingleRequest_GETDoesNotSetContentType(t *testing.T) {
 
 func TestSingleRequest_POSTSetsContentTypeForJSONBody(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
 		if got := r.Header.Get("Content-Type"); got != "application/json" {
 			t.Errorf("expected Content-Type application/json, got %q", got)
 		}

--- a/go/pkg/basecamp/search_test.go
+++ b/go/pkg/basecamp/search_test.go
@@ -290,6 +290,9 @@ func TestSearchService_Search_NoSort(t *testing.T) {
 func TestSearchService_Search_DoesNotSetContentTypeOnGet(t *testing.T) {
 	fixture := loadSearchFixture(t, "results.json")
 	svc := testSearchServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("expected GET, got %s", r.Method)
+		}
 		if got := r.Header.Get("Content-Type"); got != "" {
 			t.Errorf("expected no Content-Type for bodyless GET, got %q", got)
 		}
@@ -300,7 +303,7 @@ func TestSearchService_Search_DoesNotSetContentTypeOnGet(t *testing.T) {
 			t.Errorf("expected q=leto, got %q", got)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
+		w.WriteHeader(http.StatusOK)
 		w.Write(fixture)
 	})
 

--- a/go/pkg/basecamp/search_test.go
+++ b/go/pkg/basecamp/search_test.go
@@ -306,7 +306,7 @@ func TestSearchService_Search_DoesNotSetContentTypeOnGet(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write(fixture)
+		_, _ = w.Write(fixture)
 	})
 
 	_, err := svc.Search(context.Background(), "leto", nil)

--- a/go/pkg/basecamp/search_test.go
+++ b/go/pkg/basecamp/search_test.go
@@ -286,3 +286,26 @@ func TestSearchService_Search_NoSort(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestSearchService_Search_DoesNotSetContentTypeOnGet(t *testing.T) {
+	fixture := loadSearchFixture(t, "results.json")
+	svc := testSearchServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Content-Type"); got != "" {
+			t.Errorf("expected no Content-Type for bodyless GET, got %q", got)
+		}
+		if got := r.Header.Get("Accept"); got != "application/json" {
+			t.Errorf("expected Accept application/json, got %q", got)
+		}
+		if got := r.URL.Query().Get("q"); got != "leto" {
+			t.Errorf("expected q=leto, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write(fixture)
+	})
+
+	_, err := svc.Search(context.Background(), "leto", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/go/pkg/basecamp/search_test.go
+++ b/go/pkg/basecamp/search_test.go
@@ -291,7 +291,9 @@ func TestSearchService_Search_DoesNotSetContentTypeOnGet(t *testing.T) {
 	fixture := loadSearchFixture(t, "results.json")
 	svc := testSearchServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
-			t.Fatalf("expected GET, got %s", r.Method)
+			t.Errorf("expected GET, got %s", r.Method)
+			http.Error(w, "wrong method", http.StatusBadRequest)
+			return
 		}
 		if got := r.Header.Get("Content-Type"); got != "" {
 			t.Errorf("expected no Content-Type for bodyless GET, got %q", got)


### PR DESCRIPTION
## Summary
- stop setting `Content-Type: application/json` on bodyless Go SDK requests
- keep `Accept: application/json` on requests and keep `Content-Type` for JSON bodies
- add regression coverage for raw GETs and generated Search GETs

## Why
`Content-Type` describes the request body. Bodyless GET requests use URL query parameters, and sending `Content-Type: application/json` causes `/search.json?q=...` to return unfiltered results.

Fixes #324.

## Tests
- `go test ./go/pkg/basecamp`
- `go test ./go/...`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop sending `Content-Type: application/json` on bodyless GET requests in the Go SDK (`go/pkg/basecamp`) to fix unfiltered `/search.json` results (Fixes #324). `Accept: application/json` stays; `Content-Type` is only set when a JSON body exists and isn’t already set.

- **Bug Fixes**
  - Add `requestHasBody` and use it in the generated client and `singleRequest` so `Content-Type` is only set with a body; always set `Accept: application/json`.
  - Tests cover: GET without `Content-Type`, POST sets JSON `Content-Type`, POST preserves an existing `Content-Type` via an auth strategy and asserts it was empty before auth runs, and Search GET checks headers and `q` param.

<sup>Written for commit 767a8ff0fd0b38e6c484ece8c2a09e3fbf2a5cd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

