### PR TITLE
Fix TypeScript metadata bundling for serverless tracing

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -20,7 +20,7 @@
     "src/generated"
   ],
   "scripts": {
-    "generate": "tsx scripts/strip-account-id.ts ../openapi.json src/generated/openapi-stripped.json && openapi-typescript src/generated/openapi-stripped.json -o src/generated/schema.d.ts && tsx scripts/patch-flexible-ids.ts && tsx scripts/extract-metadata.ts src/generated/openapi-stripped.json > src/generated/metadata.json && tsx scripts/generate-path-mapping.ts",
+    "generate": "tsx scripts/strip-account-id.ts ../openapi.json src/generated/openapi-stripped.json && openapi-typescript src/generated/openapi-stripped.json -o src/generated/schema.d.ts && tsx scripts/patch-flexible-ids.ts && tsx scripts/extract-metadata.ts src/generated/openapi-stripped.json > src/generated/metadata.ts && tsx scripts/generate-path-mapping.ts",
     "build": "tsc",
     "postbuild": "node -e \"fs=require('fs');fs.cpSync('src/generated','dist/generated',{recursive:true});\"",
     "prepublishOnly": "npm run build",

--- a/typescript/scripts/extract-metadata.ts
+++ b/typescript/scripts/extract-metadata.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 /**
- * Extracts x-basecamp-* extensions from OpenAPI spec into a runtime-accessible metadata file.
- * This allows the TypeScript SDK to read operation metadata at runtime for retry, pagination, etc.
+ * Extracts x-basecamp-* extensions from OpenAPI spec into a runtime-accessible metadata module.
+ * The generated ESM module keeps operation metadata in the static import graph for bundlers and serverless file tracing.
  *
- * Usage: npx tsx extract-metadata.ts ../openapi.json > src/generated/metadata.json
+ * Usage: npx tsx extract-metadata.ts ../openapi.json > src/generated/metadata.ts
  */
 
 import * as fs from "fs";
@@ -21,6 +21,7 @@ interface PaginationConfig {
   pageParam?: string;
   totalCountHeader?: string;
   maxPageSize?: number;
+  key?: string;
 }
 
 interface IdempotentConfig {
@@ -108,4 +109,52 @@ if (!fs.existsSync(resolvedPath)) {
 }
 
 const metadata = extractMetadata(resolvedPath);
-console.log(JSON.stringify(metadata, null, 2));
+
+const json = JSON.stringify(metadata, null, 2);
+console.log(`// Generated from OpenAPI x-basecamp-* extensions. Do not edit by hand.
+
+export interface RetryConfig {
+  maxAttempts: number;
+  baseDelayMs: number;
+  backoff: "exponential" | "linear" | "constant";
+  retryOn: number[];
+}
+
+export interface PaginationConfig {
+  style: "link" | "cursor" | "page";
+  pageParam?: string;
+  totalCountHeader?: string;
+  maxPageSize?: number;
+  key?: string;
+}
+
+export interface IdempotentConfig {
+  keySupported?: boolean;
+  keyHeader?: string;
+  natural?: boolean;
+}
+
+export interface SensitiveField {
+  field: string;
+  category: string;
+  redact: boolean;
+}
+
+export interface OperationMetadata {
+  retry?: RetryConfig;
+  pagination?: PaginationConfig;
+  idempotent?: IdempotentConfig;
+  sensitive?: SensitiveField[];
+}
+
+export interface MetadataOutput {
+  $schema: string;
+  version: string;
+  generated: string;
+  operations: Record<string, OperationMetadata>;
+}
+
+const metadata: MetadataOutput = ${json};
+
+export default metadata;
+`);

--- a/typescript/scripts/extract-metadata.ts
+++ b/typescript/scripts/extract-metadata.ts
@@ -30,17 +30,10 @@ interface IdempotentConfig {
   natural?: boolean;
 }
 
-interface SensitiveField {
-  field: string;
-  category: string;
-  redact: boolean;
-}
-
 interface OperationMetadata {
   retry?: RetryConfig;
   pagination?: PaginationConfig;
   idempotent?: IdempotentConfig;
-  sensitive?: SensitiveField[];
 }
 
 interface MetadataOutput {
@@ -134,17 +127,10 @@ export interface IdempotentConfig {
   natural?: boolean;
 }
 
-export interface SensitiveField {
-  field: string;
-  category: string;
-  redact: boolean;
-}
-
 export interface OperationMetadata {
   retry?: RetryConfig;
   pagination?: PaginationConfig;
   idempotent?: IdempotentConfig;
-  sensitive?: SensitiveField[];
 }
 
 export interface MetadataOutput {

--- a/typescript/scripts/generate-path-mapping.ts
+++ b/typescript/scripts/generate-path-mapping.ts
@@ -5,7 +5,7 @@
  * Usage: npx tsx scripts/generate-path-mapping.ts
  *
  * IMPORTANT: This reads from openapi-stripped.json (same source as extract-metadata.ts)
- * to ensure operation IDs match those in metadata.json. The stripped spec has the
+ * to ensure operation IDs match those in the metadata module. The stripped spec has the
  * {accountId} prefix removed, so we add it back when generating the mapping.
  */
 
@@ -16,7 +16,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Use openapi-stripped.json - same source as extract-metadata.ts
-// This ensures operation IDs match those in metadata.json
+// This ensures operation IDs match those in the metadata module
 const OPENAPI_STRIPPED = resolve(__dirname, "../src/generated/openapi-stripped.json");
 const OUTPUT_PATH = resolve(__dirname, "../src/generated/path-mapping.ts");
 

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -7,19 +7,15 @@
  */
 
 import createClient, { type Middleware } from "openapi-fetch";
-import { createRequire } from "node:module";
 import type { paths } from "./generated/schema.js";
+import metadata from "./generated/metadata.js";
 import { PATH_TO_OPERATION } from "./generated/path-mapping.js";
-import type { BasecampHooks, OperationInfo, RequestInfo, RequestResult } from "./hooks.js";
+import type { BasecampHooks, RequestInfo, RequestResult } from "./hooks.js";
 import { BasecampError } from "./errors.js";
 import { isLocalhost } from "./security.js";
 import { parseNextLink, resolveURL, isSameOrigin } from "./pagination-utils.js";
 import { type AuthStrategy, bearerAuth } from "./auth-strategy.js";
 import { createDownloadURL, type DownloadResult } from "./download.js";
-
-// Use createRequire for JSON import (Node 18+ compatible)
-const require = createRequire(import.meta.url);
-const metadata = require("./generated/metadata.json") as OperationMetadata;
 
 // ============================================================================
 // Services - Generated from OpenAPI spec (spec-driven, not hand-written)
@@ -671,16 +667,6 @@ function getCacheKey(url: string, tokenHash: string): string {
 // =============================================================================
 // Retry Middleware
 // =============================================================================
-
-/**
- * Type for the metadata.json file structure.
- */
-interface OperationMetadata {
-  operations: Record<string, {
-    retry?: RetryConfig;
-    idempotent?: { natural: boolean };
-  }>;
-}
 
 /**
  * Retry configuration matching x-basecamp-retry extension schema.

--- a/typescript/src/download.ts
+++ b/typescript/src/download.ts
@@ -1,5 +1,5 @@
 import type { AuthStrategy } from "./auth-strategy.js";
-import type { BasecampHooks, OperationInfo, RequestInfo, RequestResult } from "./hooks.js";
+import type { BasecampHooks, OperationInfo, RequestInfo } from "./hooks.js";
 import { BasecampError, Errors, errorFromResponse } from "./errors.js";
 import { safeInvoke } from "./hooks.js";
 

--- a/typescript/src/generated/metadata.ts
+++ b/typescript/src/generated/metadata.ts
@@ -1,7 +1,50 @@
-{
+// Generated from OpenAPI x-basecamp-* extensions. Do not edit by hand.
+
+export interface RetryConfig {
+  maxAttempts: number;
+  baseDelayMs: number;
+  backoff: "exponential" | "linear" | "constant";
+  retryOn: number[];
+}
+
+export interface PaginationConfig {
+  style: "link" | "cursor" | "page";
+  pageParam?: string;
+  totalCountHeader?: string;
+  maxPageSize?: number;
+  key?: string;
+}
+
+export interface IdempotentConfig {
+  keySupported?: boolean;
+  keyHeader?: string;
+  natural?: boolean;
+}
+
+export interface SensitiveField {
+  field: string;
+  category: string;
+  redact: boolean;
+}
+
+export interface OperationMetadata {
+  retry?: RetryConfig;
+  pagination?: PaginationConfig;
+  idempotent?: IdempotentConfig;
+  sensitive?: SensitiveField[];
+}
+
+export interface MetadataOutput {
+  $schema: string;
+  version: string;
+  generated: string;
+  operations: Record<string, OperationMetadata>;
+}
+
+const metadata: MetadataOutput = {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-04-29T18:03:48.821Z",
+  "generated": "2026-07-08T12:00:56.602Z",
   "operations": {
     "GetAccount": {
       "retry": {
@@ -2650,4 +2693,7 @@
       }
     }
   }
-}
+};
+
+export default metadata;
+

--- a/typescript/src/generated/metadata.ts
+++ b/typescript/src/generated/metadata.ts
@@ -21,17 +21,10 @@ export interface IdempotentConfig {
   natural?: boolean;
 }
 
-export interface SensitiveField {
-  field: string;
-  category: string;
-  redact: boolean;
-}
-
 export interface OperationMetadata {
   retry?: RetryConfig;
   pagination?: PaginationConfig;
   idempotent?: IdempotentConfig;
-  sensitive?: SensitiveField[];
 }
 
 export interface MetadataOutput {
@@ -44,7 +37,7 @@ export interface MetadataOutput {
 const metadata: MetadataOutput = {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-07-08T12:00:56.602Z",
+  "generated": "2026-07-08T12:24:57.272Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/typescript/src/services/base.ts
+++ b/typescript/src/services/base.ts
@@ -24,9 +24,7 @@
 
 import type { BasecampHooks, OperationInfo, OperationResult } from "../hooks.js";
 import { BasecampError, errorFromResponse } from "../errors.js";
-import { createRequire } from "node:module";
-const require = createRequire(import.meta.url);
-const metadata = require("../generated/metadata.json") as { operations: Record<string, { retry?: { maxAttempts?: number; baseDelayMs?: number; backoff?: string; retryOn?: number[] } }> };
+import metadata from "../generated/metadata.js";
 import { ListResult, parseTotalCount, type PaginationOptions } from "../pagination.js";
 import { parseNextLink, resolveURL, isSameOrigin } from "../pagination-utils.js";
 import type { paths } from "../generated/schema.js";


### PR DESCRIPTION
## Summary

Fixes the TypeScript SDK metadata packaging issue reported in #361 by making runtime operation metadata part of the static ESM import graph.

The SDK previously loaded `generated/metadata.json` at runtime with `createRequire` from both `dist/client.js` and `dist/services/base.js`. Some serverless file tracers can miss that JSON file, leaving it out of the deployed artifact and causing cold starts to fail with `MODULE_NOT_FOUND`.

This change:

- generates metadata as `src/generated/metadata.ts`
- imports metadata statically from `client.ts` and `services/base.ts`
- removes the runtime `createRequire` JSON loading path
- emits `dist/generated/metadata.js`, which bundlers and file tracers can follow normally

Basecamp card: https://app.basecamp.com/2914079/buckets/46292715/card_tables/cards/10074337245

Fixes #361.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm test` — 616 passing
- `npm run build`
- `npm pack` + `@vercel/nft@0.30.4` smoke test confirmed:
  - `dist/generated/metadata.js` is traced
  - `dist/generated/metadata.json` is no longer required
  - the pruned artifact starts successfully (`client constructed`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the SDK’s runtime metadata from a JSON file to a generated, typed ESM module that’s statically imported, so serverless file tracers include it and cold starts no longer fail with MODULE_NOT_FOUND. Narrows metadata types for stronger compile-time checks. Fixes #361.

- **Bug Fixes**
  - Generate a typed ESM module at `src/generated/metadata.ts` (unions for backoff, etc.) and emit `dist/generated/metadata.js` as a default export.
  - Import the module in `client.ts` and `services/base.ts`; remove `createRequire` and local metadata type definitions.
  - Update `generate`/build to write and copy the module; the JSON file is no longer needed.

<sup>Written for commit 834356859baff5adfaa402b29cb12bc7c109d0d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

