### PR TITLE
Fix three CI failures affecting every branch off main

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -93,6 +93,8 @@ jobs:
         with:
           go-version-file: 'go/go.mod'
           cache-dependency-path: 'go/go.sum'
+          # Scan against the newest 1.26.x, not whatever patch the runner has cached.
+          check-latest: true
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,9 +146,19 @@ jobs:
           persist-credentials: false
 
       - name: Set up Ruby
+        if: matrix.ruby != 'head'
         uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a # v1.302.0
         with:
           ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+          working-directory: ruby
+
+      - name: Set up Ruby head
+        if: matrix.ruby == 'head'
+        uses: ruby/setup-ruby@7372622e62b60b3cb750dcd2b9e32c247ffec26a # v1.302.0
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler: default
           bundler-cache: true
           working-directory: ruby
 

--- a/ruby/Gemfile.lock
+++ b/ruby/Gemfile.lock
@@ -136,7 +136,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.9.2)
     yard (0.9.44)
     zeitwerk (2.8.2)
 
@@ -153,7 +152,6 @@ DEPENDENCIES
   rubocop-37signals
   simplecov (~> 0.22)
   webmock (~> 3.24)
-  webrick (~> 1.9)
   yard (~> 0.9)
 
 CHECKSUMS
@@ -216,7 +214,6 @@ CHECKSUMS
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
-  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
   yard (0.9.44) sha256=eb087e9b631ccd887b049f303d489963945452d5e2a7eb49a5a74a7cf6887f28
   zeitwerk (2.8.2) sha256=7212a61311083c604184b1ea2574b9aa05cd14f855a0841c06985cabe9181d12
 

--- a/ruby/basecamp-sdk.gemspec
+++ b/ruby/basecamp-sdk.gemspec
@@ -41,6 +41,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock', '~> 3.24'
   spec.add_development_dependency 'irb', '~> 1.15'
   spec.add_development_dependency 'rdoc', '~> 7.1'
-  spec.add_development_dependency 'webrick', '~> 1.9'
   spec.add_development_dependency 'yard', '~> 0.9'
 end


### PR DESCRIPTION
Three independent CI checks are failing on `main`, and therefore on every open PR branched from it. Each has a different cause and a different fix. They are grouped here because none of them is a code change and all three must land before any PR can go green.

## 1. `Ruby head` — `bundler` incompatibility

`ruby/setup-ruby` installs a Bundler that Ruby head rejects, so the `head` matrix entry fails while every pinned version passes.

The setup step is now split: the `head` entry passes `bundler: default` and uses the Bundler that Ruby head ships with. Rubies 3.2 through 4.0 keep the existing step and existing behavior.

This is the check currently blocking #356, #358, and #360 — each fails `Ruby head` and nothing else.

## 2. `Go Vulnerability Check` — stale toolchain, not a real vulnerability

`GO-2026-5856` is a privacy leak in `crypto/tls`, present in `go1.26.4` and fixed in `go1.26.5`.

`actions/setup-go` defaults to `check-latest: false`. Given `go 1.26` in `go.mod`, it accepts any cached `1.26.x` and the runners have `go1.26.4` warm in the tool cache, so the scan never installs the patched release. The SDK code is unaffected; the scanner was simply pointed at an old stdlib.

Setting `check-latest: true` on the govulncheck job makes it resolve the newest `1.26.x`. Confirmed in CI: `Attempting to download 1.26.5` → `go version go1.26.5` → `No vulnerabilities found`.

Scoped to the govulncheck job so the change stays CI-only. Deliberately **not** fixed with a `toolchain` directive in `go.mod`, which would force a minimum toolchain onto everyone consuming the Go SDK and would need a manual bump after each future stdlib CVE.

## 3. `Bundler Audit` — unused gem with an unpatched CVE

`CVE-2026-38969` (WEBrick reparses trailer) affects `webrick 1.9.2`. There is no fixed release; `1.9.2` is the newest and bundler-audit's guidance is to remove the gem.

`webrick` has been declared in `basecamp-sdk.gemspec` since the Ruby SDK landed in #54 and has never been loaded. Nothing requires it, no rake task invokes it, and the tests stub HTTP through WebMock (205 `stub_request` sites) rather than starting a real server. The gemspec declaration is the only occurrence of the string in the repository.

Removing the declaration drops it from the lockfile entirely, rather than suppressing a live advisory via `.bundler-audit.yml`.

`yard` and `rdoc` can serve documentation over WEBrick. Neither has a rake task here, so nothing automated depends on it; anyone running a doc server ad hoc will get a clear missing-gem error.

---

Fixes 1 and 3 were extracted from the branch for #302, which had accumulated them while sitting open. #302 is now rebased to contain only its schedule-dates change.