### PR TITLE
Prepare workflows for the zizmor bump in #360

### DIFF
--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -85,7 +85,7 @@ jobs:
           cache-dependency-path: typescript/package-lock.json
 
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@latest # zizmor: ignore[adhoc-packages] -- OIDC trusted publishing requires a newer npm than the runner ships; it publishes the release rather than building it
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -76,16 +76,16 @@ jobs:
           git fetch origin main
           git merge-base --is-ancestor "$GITHUB_SHA" origin/main
 
+      # Node 24 bundles npm 11.16, past the 11.5.1 that OIDC trusted publishing
+      # requires. Publishing therefore uses the npm shipped in the verified Node
+      # tarball rather than installing one from the registry at release time.
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
           cache-dependency-path: typescript/package-lock.json
-
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest # zizmor: ignore[adhoc-packages] -- OIDC trusted publishing requires a newer npm than the runner ships; it publishes the release rather than building it
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: './go'
@@ -56,7 +56,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: './typescript'
@@ -175,7 +175,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: './ruby'
@@ -215,7 +215,7 @@ jobs:
           working-directory: ruby
 
       - name: Install bundler-audit
-        run: gem install bundler-audit
+        run: gem install bundler-audit # zizmor: ignore[adhoc-packages] -- bundler-audit is the auditing tool itself; adding it to the SDK's Gemfile would make the gem under audit depend on its own auditor
 
       - name: Update vulnerability database
         run: bundle-audit update


### PR DESCRIPTION
#360 bumps `zizmor-action` v0.5.3 → v0.5.7, which ships a newer zizmor (1.26.x). That version reports five findings the currently pinned zizmor does not, so #360 fails `GitHub Actions audit` for reasons unrelated to the twenty actions it bumps. zizmor exits non-zero on any finding, so all five must be resolved.

Four of the five are not #360's doing. This clears them on `main` first, so #360 can go green on a plain rebase without anyone hand-editing a dependabot branch. Of the four, three are fixed, one is removed at the source, and exactly one is suppressed.

## `adhoc-packages` in the publish job — removed, not suppressed

`release-typescript.yml` ran `npm install -g npm@latest`: an unpinned install from the registry, inside the `publish` job that holds `id-token: write` and the `release-npm` environment, three steps before `npm publish` of `@37signals/basecamp`.

The blast radius is not "a linter is unhappy." A compromised `npm@latest` there executes against a live OIDC publishing identity and can push a malicious release of this SDK. Pinning the version would narrow that, but zizmor still flags it — the rule is about installing outside a lockfile at all — so a pin buys a suppression, not a fix.

Node 24 bundles npm 11.16, past the 11.5.1 that OIDC trusted publishing requires. The step is simply unnecessary. The publish job now uses Node 24 and takes npm from the Node tarball, which `setup-node` verifies by checksum. **The ad-hoc install is gone rather than accepted.**

Verified locally under Node 24 (npm 11.16.0): `npm ci`, `npm run build` (what `prepublishOnly` runs, including `postbuild`), and the full suite — 616 tests across 64 files, all passing.

## `adhoc-packages` in the bundler-audit job — suppressed, with reason

`gem install bundler-audit` remains. That job has `contents: read`, no `id-token`, no secrets, and does not publish; a compromised install reads a public repository. bundler-audit is also the auditing tool itself, so adding it to the SDK's `Gemfile` would make the gem under audit depend on its own auditor.

This is the one accepted risk, suppressed inline with a justification, matching the fifteen `# zizmor: ignore[...]` suppressions already in these workflows.

## `ref-version-mismatch` — 3 medium, latent

The `trivy-action` pin is commented `# 0.35.0`. That tag exists, so it is valid today and `main` is not currently flagged.

Upstream stopped publishing unprefixed tags after it: `ed142fd` is reachable only as `v0.36.0`, with no `0.36.0`. Dependabot mirrors the existing comment style, so when it bumped trivy in #360 it wrote `# 0.36.0` — an unknown ref — and the newer zizmor flagged it three times.

Correcting the comment to `# v0.35.0` means the next bump inherits the `v` prefix and resolves on its own. This improves auditability rather than reducing it: the comment exists so a reviewer can check the hash against a real tag.

## Verification

Three of the five findings come from zizmor's *online* audits, which silently do not run without a GitHub token — a plain local run reports clean and looks like a false alarm. All runs below had `GH_TOKEN` set.

| | low | medium |
|---|---|---|
| `main` today | 2 | 0 |
| #360's head | 2 | 3 |
| this branch | 0 | 0 |

The 2/3 split on #360's head matches its CI run exactly. The pinned zizmor 1.25.2 that `main` runs today also still passes here, so the unknown audit name in the ignore comment does not break current CI.

The remaining fifth finding is #360's own trivy comment, which its rebase will regenerate as `# v0.36.0` once this lands.