### PR TITLE
BC5 OAuth: device flow (RFC 8628, 5 SDKs)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1291,7 +1291,16 @@ FUNCTION pollDeviceToken(tokenEndpoint, clientId, deviceCode, interval, expiresI
               # would issue one POST for a code already known to be expired
        POST tokenEndpoint: grant_type=urn:ietf:params:oauth:grant-type:device_code,
                            device_code, client_id
+            # the per-request timeout is min(request timeout, remaining
+            # lifetime): near expiry a stalled POST must not hold the flow past
+            # the monotonic deadline for the full request budget
        CASE response:
+         # ONLY a 200 can produce a token, and OAuth protocol error codes
+         # (authorization_pending / slow_down / access_denied / expired_token)
+         # are recognized ONLY on a 4xx (RFC 8628 §3.5 error responses are
+         # 400-class). Any other status — a nonstandard 2xx like 201/202, or a
+         # 5xx — is terminal api_error (http_<status>) even if its body
+         # carries a protocol error code.
          200 with a non-empty access_token → validate optional fields, return Token
          200 that is not a JSON object, or lacks a non-empty access_token
               → raise api_error (a malformed success body is NOT a usable Token,

--- a/SPEC.md
+++ b/SPEC.md
@@ -1279,8 +1279,12 @@ FUNCTION pollDeviceToken(tokenEndpoint, clientId, deviceCode, interval, expiresI
      backoff = interval                    # transient timeout backoff, SEPARATE
                                            # from the server-driven interval
   3. LOOP (cancellation-aware):
-       wait = max(interval, backoff), clamped to the remaining lifetime
-       IF clock.now() ≥ deadline → raise DeviceFlowError(expired)
+       IF cancelled → raise DeviceFlowError(cancelled)
+       IF clock.now() ≥ deadline → raise DeviceFlowError(expired)   # check BEFORE waiting,
+              # so a long display hook, a stalled prior request, or a long backoff
+              # cannot carry the loop past expiry undetected
+       wait = max(interval, backoff), clamped to the remaining lifetime (> 0 here)
+       SLEEP wait   # abortable; a cancel mid-wait → DeviceFlowError(cancelled)
        POST tokenEndpoint: grant_type=urn:ietf:params:oauth:grant-type:device_code,
                            device_code, client_id
        CASE response:
@@ -1289,11 +1293,14 @@ FUNCTION pollDeviceToken(tokenEndpoint, clientId, deviceCode, interval, expiresI
               → raise api_error (a malformed success body is NOT a usable Token,
                 and is NOT a retryable transport error)
          200 whose optional token fields are malformed → raise api_error:
-              expires_in, when present, MUST be a finite positive number ≤
+              expires_in, when present, MUST be a finite positive WHOLE number ≤
               2147483647 s — a non-numeric value, a non-finite one (1e400 parses
-              to Infinity), a non-positive one, or one past the ceiling would make
-              expires_at arithmetic overflow/NaN so the token would appear to never
-              expire; refresh_token/token_type/scope, when present, MUST be strings.
+              to Infinity), a fractional one, a non-positive one, or one past the
+              ceiling would make expires_at arithmetic overflow/NaN so the token
+              would appear to never expire (an integer-valued float like 3600.0 is
+              accepted; whole seconds match the device-duration rule and Go/Kotlin,
+              whose int/Long typing already rejects a fractional lifetime);
+              refresh_token/token_type/scope, when present, MUST be strings.
               Absent expires_in is allowed (the token carries no expiry).
               The 2147483647 s (~68 year) token-lifetime ceiling is separate from
               the 2147483 s device-duration ceiling above: it bounds expires_at

--- a/SPEC.md
+++ b/SPEC.md
@@ -1305,9 +1305,13 @@ FUNCTION pollDeviceToken(tokenEndpoint, clientId, deviceCode, interval, expiresI
               accepted and coerced to whole seconds, matching the device-duration
               rule; every SDK decodes the numeric value and validates it
               explicitly to reject a fractional lifetime);
-              refresh_token/token_type/scope, when present, MUST be strings —
-              token_type additionally non-empty when present (absent defaults to
-              Bearer; an explicit "" is malformed).
+              refresh_token/token_type/scope, when present and non-null, MUST be
+              strings — a JSON null is treated as absent (like an omitted field),
+              consistent with the null-duration rule above. token_type is
+              additionally non-empty when present: absent or JSON null defaults to
+              Bearer, while an explicit "" is malformed (api_error). A non-object
+              or unparsable body, and every field/status error above, carries the
+              HTTP status on the raised api_error.
               Absent expires_in is allowed (the token carries no expiry).
               The 2147483647 s (~68 year) token-lifetime ceiling is separate from
               the 2147483 s device-duration ceiling above: it bounds expires_at

--- a/SPEC.md
+++ b/SPEC.md
@@ -1285,6 +1285,10 @@ FUNCTION pollDeviceToken(tokenEndpoint, clientId, deviceCode, interval, expiresI
               # cannot carry the loop past expiry undetected
        wait = max(interval, backoff), clamped to the remaining lifetime (> 0 here)
        SLEEP wait   # abortable; a cancel mid-wait → DeviceFlowError(cancelled)
+       IF clock.now() ≥ deadline → raise DeviceFlowError(expired)
+              # re-check AFTER the wait, before POSTing: the clamp above makes the
+              # final sleep land exactly on expiry, so without this check the loop
+              # would issue one POST for a code already known to be expired
        POST tokenEndpoint: grant_type=urn:ietf:params:oauth:grant-type:device_code,
                            device_code, client_id
        CASE response:
@@ -1298,9 +1302,12 @@ FUNCTION pollDeviceToken(tokenEndpoint, clientId, deviceCode, interval, expiresI
               to Infinity), a fractional one, a non-positive one, or one past the
               ceiling would make expires_at arithmetic overflow/NaN so the token
               would appear to never expire (an integer-valued float like 3600.0 is
-              accepted; whole seconds match the device-duration rule and Go/Kotlin,
-              whose int/Long typing already rejects a fractional lifetime);
-              refresh_token/token_type/scope, when present, MUST be strings.
+              accepted and coerced to whole seconds, matching the device-duration
+              rule; every SDK decodes the numeric value and validates it
+              explicitly to reject a fractional lifetime);
+              refresh_token/token_type/scope, when present, MUST be strings —
+              token_type additionally non-empty when present (absent defaults to
+              Bearer; an explicit "" is malformed).
               Absent expires_in is allowed (the token carries no expiry).
               The 2147483647 s (~68 year) token-lifetime ceiling is separate from
               the 2147483 s device-duration ceiling above: it bounds expires_at

--- a/SPEC.md
+++ b/SPEC.md
@@ -1284,10 +1284,22 @@ FUNCTION pollDeviceToken(tokenEndpoint, clientId, deviceCode, interval, expiresI
        POST tokenEndpoint: grant_type=urn:ietf:params:oauth:grant-type:device_code,
                            device_code, client_id
        CASE response:
-         200 with a non-empty access_token → return Token
+         200 with a non-empty access_token → validate optional fields, return Token
          200 that is not a JSON object, or lacks a non-empty access_token
               → raise api_error (a malformed success body is NOT a usable Token,
                 and is NOT a retryable transport error)
+         200 whose optional token fields are malformed → raise api_error:
+              expires_in, when present, MUST be a finite positive number ≤
+              2147483647 s — a non-numeric value, a non-finite one (1e400 parses
+              to Infinity), a non-positive one, or one past the ceiling would make
+              expires_at arithmetic overflow/NaN so the token would appear to never
+              expire; refresh_token/token_type/scope, when present, MUST be strings.
+              Absent expires_in is allowed (the token carries no expiry).
+              The 2147483647 s (~68 year) token-lifetime ceiling is separate from
+              the 2147483 s device-duration ceiling above: it bounds expires_at
+              arithmetic (a Date/instant), not a schedulable timer, so it is the
+              cross-runtime-safe int/Date maximum rather than the 32-bit-ms timer
+              bound. Shared across all five SDKs.
          3xx (redirects are never followed)
               → raise api_error BEFORE OAuth-error body parsing (a redirect
                 carrying an authorization_pending body must not keep polling)

--- a/SPEC.md
+++ b/SPEC.md
@@ -1258,7 +1258,11 @@ FUNCTION requestDeviceAuthorization(deviceAuthEndpoint, clientId, scope?) → De
   3. Parse → { device_code, user_code, verification_uri,
                verification_uri_complete?, expires_in, interval? }
   4. Validate: device_code, user_code, verification_uri non-empty;
-     0 < expires_in ≤ 2147483; 0 < interval ≤ 2147483 (default 5 when absent).
+     expires_in and interval are positive WHOLE seconds ≤ 2147483 — an
+     integer-valued float (900.0) is accepted, a fractional value (2.5) is
+     malformed (api_error). interval defaults to 5 when absent; a JSON null
+     duration is treated as absent (Go/Kotlin decoders cannot distinguish
+     null from omission).
      The 2147483 s (~24.8 day) ceiling is the largest whole-second duration
      whose millisecond form fits a 32-bit signed timer (2147483 × 1000 ≤ 2³¹−1):
      beyond it JS setTimeout silently clamps to 1 ms (hot poll loop) and Go's
@@ -1272,8 +1276,10 @@ END
 FUNCTION pollDeviceToken(tokenEndpoint, clientId, deviceCode, interval, expiresIn, clock) → Token
   1. requireSecureEndpoint(tokenEndpoint)
   2. deadline = clock.now() + expiresIn    # MONOTONIC clock, injectable
+     backoff = interval                    # transient timeout backoff, SEPARATE
+                                           # from the server-driven interval
   3. LOOP (cancellation-aware):
-       wait ≥ interval
+       wait = max(interval, backoff), clamped to the remaining lifetime
        IF clock.now() ≥ deadline → raise DeviceFlowError(expired)
        POST tokenEndpoint: grant_type=urn:ietf:params:oauth:grant-type:device_code,
                            device_code, client_id
@@ -1282,11 +1288,18 @@ FUNCTION pollDeviceToken(tokenEndpoint, clientId, deviceCode, interval, expiresI
          200 that is not a JSON object, or lacks a non-empty access_token
               → raise api_error (a malformed success body is NOT a usable Token,
                 and is NOT a retryable transport error)
+         3xx (redirects are never followed)
+              → raise api_error BEFORE OAuth-error body parsing (a redirect
+                carrying an authorization_pending body must not keep polling)
          error authorization_pending → keep polling
          error slow_down → interval += 5   (this AND all subsequent polls)
          error access_denied → raise DeviceFlowError(access_denied)
          error expired_token → raise DeviceFlowError(expired)
-         connection timeout → exponential backoff, keep polling
+         connection timeout → backoff = min(backoff × 2, 60), keep polling
+       ANY completed round-trip (2xx or OAuth error) → backoff = interval
+       # The two timers never contaminate each other: slow_down inflates
+       # interval permanently; timeouts inflate backoff transiently, and a
+       # completed round-trip resets backoff to the current interval.
 END
 ```
 
@@ -1296,26 +1309,34 @@ FUNCTION performDeviceLogin(config: OAuthConfig, clientId, scope?, display, cloc
      AND config.grantTypesSupported ∋ "urn:ietf:params:oauth:grant-type:device_code"
      ELSE raise DeviceFlowError(unavailable)      # accepts an ALREADY-SELECTED config
   2. auth = requestDeviceAuthorization(config.deviceAuthorizationEndpoint, clientId, scope)
-  3. display(auth)         # hook: show user_code + verification_uri
-  4. return pollDeviceToken(config.tokenEndpoint, clientId, auth.deviceCode,
-                            auth.interval, auth.expiresIn, clock)
+  3. deadline = clock.now() + auth.expiresIn   # anchor at ISSUANCE, before the hook
+     display(auth)         # hook: show user_code + verification_uri
+  4. remaining = deadline − clock.now()        # deduct display-hook time
+     IF remaining ≤ 0 → raise DeviceFlowError(expired)
+     return pollDeviceToken(config.tokenEndpoint, clientId, auth.deviceCode,
+                            auth.interval, remaining, clock)
+     # A slow display hook consumes code lifetime; polling gets only what is
+     # left of the server-issued expires_in, never a fresh full window.
 END
 ```
 
 **Terminal outcomes — `DeviceFlowError` carrying a `DeviceFlowReason`; the parent
 error category is DERIVED from the reason:**
 
-| reason | parent category |
+| reason | parent `code` |
 |---|---|
-| `access_denied` | auth |
-| `expired` | auth |
-| `transport` | network (retryable) |
-| `unavailable` | validation |
-| `cancelled` | native cancellation (Go `ctx.Err()`, Kotlin `CancellationException`) else usage |
+| `access_denied` | `auth_required` |
+| `expired` | `auth_required` |
+| `transport` | `network` (retryable) |
+| `unavailable` | `validation` |
+| `cancelled` | native cancellation (Go `ctx.Err()`, Kotlin `CancellationException`) else `usage` |
 
-Monotonic clocks are injectable for tests: Go `time.Now`; TS `performance.now`;
-Python `time.monotonic`; Ruby `CLOCK_MONOTONIC`; Kotlin a `TimeSource` (default
-`Monotonic`; tests pass a `TestTimeSource` locked to virtual time). The public
+Clocks are injectable for tests and SHOULD be monotonic: Go `time.Now`
+(monotonic reading); TS `performance.now` when available, falling back to
+`Date.now()` (wall-clock — a system clock adjustment can move the deadline;
+environments without `performance` accept this); Python `time.monotonic`;
+Ruby `CLOCK_MONOTONIC`; Kotlin a `TimeSource` (default `Monotonic`; tests
+pass a `TestTimeSource` locked to virtual time). The public
 `basecamp-cli` client sends no secret; Kotlin `refreshToken`'s `clientSecret`
 becomes nullable.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1241,6 +1241,84 @@ FUNCTION exchangeCode(token_endpoint, code, redirect_uri, client_id, client_secr
 END
 ```
 
+### RFC 8628 Device Authorization Grant `[conformance]`
+
+*BC5 go-live (communique §4). Public pre-registered client `basecamp-cli`:
+`token_endpoint_auth_method: none`, grants `device_code`+`refresh_token`, no
+redirect URIs, no secret. An omitted scope defaults to `read`.*
+
+Three functions per SDK. All device-auth + token requests are TLS-guarded (§9).
+
+```
+FUNCTION requestDeviceAuthorization(deviceAuthEndpoint, clientId, scope?) → DeviceAuthorization
+  1. requireSecureEndpoint(deviceAuthEndpoint)
+  2. POST deviceAuthEndpoint (application/x-www-form-urlencoded):
+       client_id={clientId}
+       scope={scope}          # OMITTED entirely when unset → server default `read`
+  3. Parse → { device_code, user_code, verification_uri,
+               verification_uri_complete?, expires_in, interval? }
+  4. Validate: device_code, user_code, verification_uri non-empty;
+     0 < expires_in ≤ 2147483; 0 < interval ≤ 2147483 (default 5 when absent).
+     The 2147483 s (~24.8 day) ceiling is the largest whole-second duration
+     whose millisecond form fits a 32-bit signed timer (2147483 × 1000 ≤ 2³¹−1):
+     beyond it JS setTimeout silently clamps to 1 ms (hot poll loop) and Go's
+     float→int conversion is implementation-defined. An absurd value such as
+     1e100 is a malformed response (api_error), not a schedulable deadline.
+     The bound is shared across all five SDKs.
+END
+```
+
+```
+FUNCTION pollDeviceToken(tokenEndpoint, clientId, deviceCode, interval, expiresIn, clock) → Token
+  1. requireSecureEndpoint(tokenEndpoint)
+  2. deadline = clock.now() + expiresIn    # MONOTONIC clock, injectable
+  3. LOOP (cancellation-aware):
+       wait ≥ interval
+       IF clock.now() ≥ deadline → raise DeviceFlowError(expired)
+       POST tokenEndpoint: grant_type=urn:ietf:params:oauth:grant-type:device_code,
+                           device_code, client_id
+       CASE response:
+         200 with a non-empty access_token → return Token
+         200 that is not a JSON object, or lacks a non-empty access_token
+              → raise api_error (a malformed success body is NOT a usable Token,
+                and is NOT a retryable transport error)
+         error authorization_pending → keep polling
+         error slow_down → interval += 5   (this AND all subsequent polls)
+         error access_denied → raise DeviceFlowError(access_denied)
+         error expired_token → raise DeviceFlowError(expired)
+         connection timeout → exponential backoff, keep polling
+END
+```
+
+```
+FUNCTION performDeviceLogin(config: OAuthConfig, clientId, scope?, display, clock?) → Token
+  1. Capability guard: REQUIRE config.deviceAuthorizationEndpoint present
+     AND config.grantTypesSupported ∋ "urn:ietf:params:oauth:grant-type:device_code"
+     ELSE raise DeviceFlowError(unavailable)      # accepts an ALREADY-SELECTED config
+  2. auth = requestDeviceAuthorization(config.deviceAuthorizationEndpoint, clientId, scope)
+  3. display(auth)         # hook: show user_code + verification_uri
+  4. return pollDeviceToken(config.tokenEndpoint, clientId, auth.deviceCode,
+                            auth.interval, auth.expiresIn, clock)
+END
+```
+
+**Terminal outcomes — `DeviceFlowError` carrying a `DeviceFlowReason`; the parent
+error category is DERIVED from the reason:**
+
+| reason | parent category |
+|---|---|
+| `access_denied` | auth |
+| `expired` | auth |
+| `transport` | network (retryable) |
+| `unavailable` | validation |
+| `cancelled` | native cancellation (Go `ctx.Err()`, Kotlin `CancellationException`) else usage |
+
+Monotonic clocks are injectable for tests: Go `time.Now`; TS `performance.now`;
+Python `time.monotonic`; Ruby `CLOCK_MONOTONIC`; Kotlin a `TimeSource` (default
+`Monotonic`; tests pass a `TestTimeSource` locked to virtual time). The public
+`basecamp-cli` client sends no secret; Kotlin `refreshToken`'s `clientSecret`
+becomes nullable.
+
 ---
 
 ## §17. ETag Caching

--- a/go/README.md
+++ b/go/README.md
@@ -169,6 +169,74 @@ Notes:
   timeouts are bounded, and bodies are read under a bounded cap. Non-2xx on
   either hop surfaces as an `api_error`.
 
+### OAuth device authorization grant (RFC 8628)
+
+For CLIs and other input-constrained clients, the `oauth` package implements the
+RFC 8628 device authorization grant. `PerformDeviceLogin` accepts an
+already-selected `*oauth.Config` (from discovery), guards the device capability,
+shows the user a code, and polls the token endpoint until they approve. Each
+configured endpoint is required to use HTTPS (localhost exempt) and redirects are
+suppressed.
+
+```go
+import "github.com/basecamp/basecamp-sdk/go/pkg/basecamp/oauth"
+
+// The device grant lives on BC5's authorization server, not Launchpad, so the
+// config must be the selected first-party result of resource-first discovery. A
+// Launchpad fallback advertises no device endpoint, and PerformDeviceLogin would
+// return DeviceFlowError{Reason: DeviceFlowUnavailable}.
+d := oauth.NewDiscoverer(http.DefaultClient)
+result, err := d.DiscoverFromResource(ctx, "https://3.basecampapi.com")
+if err != nil || result.IsFallback() {
+    return err // hard failure, or a Launchpad fallback with no device endpoint
+}
+
+token, err := oauth.PerformDeviceLogin(ctx, result.Config, "basecamp-cli",
+    func(auth oauth.DeviceAuthorization) {
+        fmt.Printf("Visit %s and enter code: %s\n", auth.VerificationURI, auth.UserCode)
+    },
+    // Optional: oauth.WithDeviceScope("read"), oauth.WithDeviceHTTPClient(hc).
+)
+if err != nil {
+    var dfe *oauth.DeviceFlowError
+    if errors.As(err, &dfe) {
+        switch dfe.Reason {
+        case oauth.DeviceFlowAccessDenied: // user declined  → auth_required
+        case oauth.DeviceFlowExpired:      // code expired    → auth_required
+        case oauth.DeviceFlowTransport:    // network failure → network (retryable)
+        case oauth.DeviceFlowUnavailable:  // AS lacks device flow → validation
+        case oauth.DeviceFlowCancelled:    // ctx cancelled   → wraps ctx.Err()
+        }
+    }
+    return err
+}
+use(token) // *oauth.Token
+```
+
+The capability guard requires BOTH `cfg.DeviceAuthorizationEndpoint != nil` AND
+`cfg.GrantTypesSupported` advertising `oauth.DeviceCodeGrantType`; otherwise it
+returns `DeviceFlowError{Reason: DeviceFlowUnavailable}` before any request.
+
+`DeviceFlowError` derives its parent error category from `Reason` (call `.Code()`
+for the `basecamp` taxonomy code, `.Retryable()` for retryability). A cancelled
+flow wraps the context error, so `errors.Is(err, context.Canceled)` matches.
+
+The two lower-level steps are exported for callers that drive the flow directly:
+
+```go
+auth, err := oauth.RequestDeviceAuthorization(ctx, deviceAuthEndpoint, "basecamp-cli")
+token, err := oauth.PollDeviceToken(ctx, tokenEndpoint, "basecamp-cli",
+    auth.DeviceCode, auth.Interval, auth.ExpiresIn)
+```
+
+`PollDeviceToken` runs the §3.5 loop: it waits at least `interval` seconds
+between polls, enforces a monotonic expiry deadline, sustains `slow_down` bumps
+(+5s), backs off exponentially on connection timeouts, and honors context
+cancellation. The clock (`oauth.WithDeviceClock`) and inter-poll wait
+(`oauth.WithDeviceSleep`) are injectable for deterministic tests; scope is
+omitted from the authorization request unless set with `oauth.WithDeviceScope`,
+so the server applies its default (`read`).
+
 ## Configuration
 
 ### Environment Variables

--- a/go/README.md
+++ b/go/README.md
@@ -187,8 +187,14 @@ import "github.com/basecamp/basecamp-sdk/go/pkg/basecamp/oauth"
 // return DeviceFlowError{Reason: DeviceFlowUnavailable}.
 d := oauth.NewDiscoverer(http.DefaultClient)
 result, err := d.DiscoverFromResource(ctx, "https://3.basecampapi.com")
-if err != nil || result.IsFallback() {
-    return err // hard failure, or a Launchpad fallback with no device endpoint
+if err != nil {
+    return err // hard failure
+}
+if result.IsFallback() {
+    // Launchpad fallback: no device endpoint. Surface it explicitly (or switch
+    // to the authorization-code flow) — never return nil here, or the caller
+    // treats the fallback as a successful device login with no token.
+    return fmt.Errorf("device flow unavailable: fell back to Launchpad (%s)", result.FallbackReason)
 }
 
 token, err := oauth.PerformDeviceLogin(ctx, result.Config, "basecamp-cli",
@@ -225,6 +231,9 @@ The two lower-level steps are exported for callers that drive the flow directly:
 
 ```go
 auth, err := oauth.RequestDeviceAuthorization(ctx, deviceAuthEndpoint, "basecamp-cli")
+if err != nil {
+    return err
+}
 token, err := oauth.PollDeviceToken(ctx, tokenEndpoint, "basecamp-cli",
     auth.DeviceCode, auth.Interval, auth.ExpiresIn)
 ```

--- a/go/README.md
+++ b/go/README.md
@@ -125,7 +125,6 @@ operations on `*oauth.Discoverer`:
 ```go
 import (
     "errors"
-    "fmt"
     "net/http"
 
     "github.com/basecamp/basecamp-sdk/go/pkg/basecamp/oauth"

--- a/go/README.md
+++ b/go/README.md
@@ -123,7 +123,13 @@ AS metadata discovery (RFC 8414). The `oauth` package exposes three composable
 operations on `*oauth.Discoverer`:
 
 ```go
-import "github.com/basecamp/basecamp-sdk/go/pkg/basecamp/oauth"
+import (
+    "errors"
+    "fmt"
+    "net/http"
+
+    "github.com/basecamp/basecamp-sdk/go/pkg/basecamp/oauth"
+)
 
 d := oauth.NewDiscoverer(http.DefaultClient)
 
@@ -179,7 +185,13 @@ configured endpoint is required to use HTTPS (localhost exempt) and redirects ar
 suppressed.
 
 ```go
-import "github.com/basecamp/basecamp-sdk/go/pkg/basecamp/oauth"
+import (
+    "errors"
+    "fmt"
+    "net/http"
+
+    "github.com/basecamp/basecamp-sdk/go/pkg/basecamp/oauth"
+)
 
 // The device grant lives on BC5's authorization server, not Launchpad, so the
 // config must be the selected first-party result of resource-first discovery. A

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -246,6 +246,15 @@ func RequestDeviceAuthorization(ctx context.Context, deviceAuthEndpoint, clientI
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	// A non-2xx is a hard failure whose body is unused — surface it by status
+	// BEFORE reading the body. Otherwise a slow/never-ending error body could hit
+	// the request timeout mid-read and be misclassified as a retryable transport
+	// failure instead of the api_error it is.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, basecamp.ErrAPI(resp.StatusCode,
+			fmt.Sprintf("device authorization failed with status %d", resp.StatusCode))
+	}
+
 	body, err := readBoundedBody(resp.Body, maxTokenResponseBytes)
 	if err != nil {
 		// An oversized body is a server/api fault (api_error, not retryable); any
@@ -260,11 +269,6 @@ func RequestDeviceAuthorization(ctx context.Context, deviceAuthEndpoint, clientI
 			return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: ctxErr}
 		}
 		return nil, &DeviceFlowError{Reason: DeviceFlowTransport, Err: fmt.Errorf("reading device authorization response: %w", err)}
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, basecamp.ErrAPI(resp.StatusCode,
-			fmt.Sprintf("device authorization failed with status %d: %s", resp.StatusCode, truncateBody(body)))
 	}
 
 	var raw rawDeviceAuthorization
@@ -476,6 +480,15 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	// A suppressed 3xx is an api fault whose body is unused — classify it by status
+	// BEFORE reading the body. Otherwise a redirect that slowly streams its body
+	// could time out mid-read (→ pollTimeout → the loop backs off and retries until
+	// the device code expires) instead of failing as api_error now.
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		return pollResult{kind: pollInvalidResponse, status: resp.StatusCode,
+			err: fmt.Errorf("device token endpoint returned redirect status %d", resp.StatusCode)}
+	}
+
 	body, err := readBoundedBody(resp.Body, maxTokenResponseBytes)
 	if err != nil {
 		switch {
@@ -548,11 +561,6 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 	// as-is. A redirect is never a valid token response — classify it as an api
 	// fault BEFORE the OAuth-error body parse so a crafted
 	// authorization_pending body on a 3xx cannot keep the loop polling.
-	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
-		return pollResult{kind: pollInvalidResponse, status: resp.StatusCode,
-			err: fmt.Errorf("device token endpoint returned redirect status %d", resp.StatusCode)}
-	}
-
 	var errResp struct {
 		Error string `json:"error"`
 	}

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -38,6 +38,13 @@ const (
 	// time.Duration multiplication downstream can never overflow (an unbounded
 	// value like 1e100 converts to int implementation-defined).
 	maxDeviceSeconds = 2_147_483
+	// maxTokenLifetimeSeconds caps an OAuth token's expires_in at 2147483647 s
+	// (~68 years) — cross-runtime safe and vastly beyond any realistic token
+	// lifetime. Unlike maxDeviceSeconds this bounds ExpiresAt arithmetic rather
+	// than a timer: a large finite value (e.g. math.MaxInt64) would overflow
+	// time.Duration(ExpiresIn) * time.Second and yield a garbage deadline, so a
+	// value past this ceiling is a malformed response. Shared across all five SDKs.
+	maxTokenLifetimeSeconds = 2_147_483_647
 )
 
 // DeviceAuthorization is an RFC 8628 §3.2 device authorization response.
@@ -459,6 +466,15 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 		}
 		if token.AccessToken == "" {
 			return pollResult{kind: pollInvalidResponse, status: resp.StatusCode, err: errors.New("device token response missing access_token")}
+		}
+		// A non-numeric/non-string field (a JSON string/bool for expires_in, or a
+		// number for token_type/refresh_token/scope) already fails json.Unmarshal
+		// above as pollInvalidResponse. What survives is a syntactically valid
+		// integer that is negative or so large that time.Duration(ExpiresIn) *
+		// time.Second overflows — bound it here so ExpiresAt can never wrap.
+		if token.ExpiresIn < 0 || token.ExpiresIn > maxTokenLifetimeSeconds {
+			return pollResult{kind: pollInvalidResponse, status: resp.StatusCode,
+				err: fmt.Errorf("device token response expires_in must be a positive integer no greater than %d seconds", maxTokenLifetimeSeconds)}
 		}
 		if token.TokenType == "" {
 			token.TokenType = "Bearer"

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -285,7 +285,8 @@ func validateDeviceAuthorization(raw rawDeviceAuthorization) (*DeviceAuthorizati
 // endpoint until the user approves, denies, or the code expires. It waits at
 // least interval seconds between polls, enforces a monotonic expiry deadline via
 // the injectable clock, sustains slow_down bumps (+5s), backs off exponentially
-// on connection timeouts, and honors context cancellation.
+// on connection timeouts (resetting once a round-trip completes), and honors
+// context cancellation.
 //
 // Terminal DeviceFlowError reasons: access_denied, expired, transport,
 // cancelled. Other server errors surface as a coded *basecamp.Error.
@@ -323,10 +324,11 @@ func PollDeviceToken(ctx context.Context, tokenEndpoint, clientID, deviceCode st
 		if remaining <= 0 {
 			return nil, &DeviceFlowError{Reason: DeviceFlowExpired}
 		}
-		// Clamp the wait (interval + any connection-timeout backoff) to the time
-		// left before the deadline so a long backoff never overshoots expiry;
-		// the deadline check below then terminates the flow promptly.
-		wait := time.Duration(intervalSeconds) * time.Second
+		// Each wait is the server-driven interval or the transient timeout
+		// backoff, whichever is larger, clamped to the time left before the
+		// deadline so a long backoff never overshoots expiry; the deadline
+		// check below then terminates the flow promptly.
+		wait := time.Duration(max(intervalSeconds, backoffSeconds)) * time.Second
 		if remaining < wait {
 			wait = remaining
 		}
@@ -348,8 +350,9 @@ func PollDeviceToken(ctx context.Context, tokenEndpoint, clientID, deviceCode st
 			return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: result.err}
 		case pollTimeout:
 			// Connection timeout — back off and keep polling (RFC 8628 §3.5).
+			// The server-driven interval is untouched so the backoff decays
+			// fully once a round-trip completes.
 			backoffSeconds = min(backoffSeconds*2, maxBackoffSeconds)
-			intervalSeconds = max(intervalSeconds, backoffSeconds)
 			continue
 		case pollTransport:
 			return nil, &DeviceFlowError{Reason: DeviceFlowTransport, Err: result.err}
@@ -357,7 +360,8 @@ func PollDeviceToken(ctx context.Context, tokenEndpoint, clientID, deviceCode st
 			// Malformed 2xx token response — api_error, not a retryable transport.
 			return nil, basecamp.ErrAPI(result.status, result.err.Error())
 		case pollOAuthError:
-			// A successful round-trip resets the timeout backoff.
+			// Any completed round-trip resets the timeout backoff to the
+			// server-driven interval.
 			backoffSeconds = intervalSeconds
 			switch result.oauthError {
 			case "authorization_pending":
@@ -389,8 +393,9 @@ const (
 	pollTransport
 	pollCancelled
 	// pollInvalidResponse is a server/api fault (api_error), NOT a retryable
-	// transport: a 2xx whose body is unparseable or missing the access token, or
-	// any response whose body exceeds the size cap.
+	// transport: a 2xx whose body is unparseable or missing the access token, a
+	// 3xx (redirects are suppressed, never a valid token response), or any
+	// response whose body exceeds the size cap.
 	pollInvalidResponse
 )
 
@@ -405,8 +410,8 @@ type pollResult struct {
 // postDeviceToken performs one token-endpoint poll and classifies the outcome.
 // A parent-context cancellation is pollCancelled; a per-request timeout (or any
 // net timeout) is pollTimeout (→ backoff); any other transport failure is
-// pollTransport. A 2xx yields a Token; a non-2xx with an OAuth error body yields
-// pollOAuthError.
+// pollTransport. A 2xx yields a Token; a 3xx is pollInvalidResponse; any other
+// non-2xx with an OAuth error body yields pollOAuthError.
 func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string, form url.Values) pollResult {
 	reqCtx, cancel := context.WithTimeout(ctx, cfg.timeout)
 	defer cancel()
@@ -462,6 +467,15 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 			token.ExpiresAt = cfg.clock().Add(time.Duration(token.ExpiresIn) * time.Second)
 		}
 		return pollResult{kind: pollToken, token: &token}
+	}
+
+	// Redirects are suppressed (http.ErrUseLastResponse), so a 3xx lands here
+	// as-is. A redirect is never a valid token response — classify it as an api
+	// fault BEFORE the OAuth-error body parse so a crafted
+	// authorization_pending body on a 3xx cannot keep the loop polling.
+	if resp.StatusCode >= 300 && resp.StatusCode < 400 {
+		return pollResult{kind: pollInvalidResponse, status: resp.StatusCode,
+			err: fmt.Errorf("device token endpoint returned redirect status %d", resp.StatusCode)}
 	}
 
 	var errResp struct {

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -403,6 +403,11 @@ func pollDeviceTokenUntil(ctx context.Context, cfg deviceConfig, tokenEndpoint, 
 				continue
 			case "slow_down":
 				intervalSeconds += slowDownIncrementSeconds
+				// Re-sync the backoff to the GROWN interval: the reset above used
+				// the pre-increment value, so a subsequent timeout must double from
+				// the new interval, not the stale one (else the client polls too
+				// aggressively under combined throttling + network timeouts).
+				backoffSeconds = intervalSeconds
 				continue
 			case "access_denied":
 				return nil, &DeviceFlowError{Reason: DeviceFlowAccessDenied}

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -1,0 +1,544 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
+)
+
+// DeviceCodeGrantType is the RFC 8628 URN grant type for the device
+// authorization grant.
+const DeviceCodeGrantType = "urn:ietf:params:oauth:grant-type:device_code"
+
+// Device-flow polling defaults (RFC 8628 §3.2/§3.5).
+const (
+	// defaultDeviceInterval is the polling interval used when the server omits
+	// interval (RFC 8628 §3.2).
+	defaultDeviceInterval = 5
+	// slowDownIncrementSeconds is the sustained interval bump applied on a
+	// slow_down response (RFC 8628 §3.5).
+	slowDownIncrementSeconds = 5
+	// maxBackoffSeconds caps exponential backoff after connection timeouts.
+	maxBackoffSeconds = 60
+	// defaultDeviceRequestTimeout bounds each individual HTTP round-trip.
+	defaultDeviceRequestTimeout = 30 * time.Second
+	// maxDeviceSeconds caps expires_in/interval at 2147483 s (~24.8 days) — the
+	// largest whole-second duration whose millisecond form fits a 32-bit signed
+	// timer, shared across all five SDKs (SPEC.md). Far above any legitimate
+	// device-code lifetime, and small enough that the float→int conversion and
+	// time.Duration multiplication downstream can never overflow (an unbounded
+	// value like 1e100 converts to int implementation-defined).
+	maxDeviceSeconds = 2_147_483
+)
+
+// DeviceAuthorization is an RFC 8628 §3.2 device authorization response.
+type DeviceAuthorization struct {
+	// DeviceCode is the device verification code (polled at the token endpoint).
+	DeviceCode string
+	// UserCode is the end-user code shown at the verification URI.
+	UserCode string
+	// VerificationURI is where the user enters the user code.
+	VerificationURI string
+	// VerificationURIComplete embeds the user code in the URI (optional).
+	VerificationURIComplete string
+	// ExpiresIn is the device/user code lifetime in seconds.
+	ExpiresIn int
+	// Interval is the minimum polling interval in seconds (default 5).
+	Interval int
+}
+
+// deviceConfig holds the resolved options for a device-flow operation.
+type deviceConfig struct {
+	httpClient *http.Client
+	scope      string
+	hasScope   bool
+	timeout    time.Duration
+	clock      func() time.Time
+	sleep      func(ctx context.Context, d time.Duration) error
+}
+
+// DeviceOption configures a device-flow operation.
+type DeviceOption func(*deviceConfig)
+
+// WithDeviceHTTPClient sets the HTTP client used for device-flow requests.
+// Nil leaves http.DefaultClient.
+func WithDeviceHTTPClient(c *http.Client) DeviceOption {
+	return func(cfg *deviceConfig) {
+		if c != nil {
+			cfg.httpClient = c
+		}
+	}
+}
+
+// WithDeviceScope sets the requested scope. When omitted, scope is left out of
+// the request entirely so the server applies its default (`read`).
+func WithDeviceScope(scope string) DeviceOption {
+	return func(cfg *deviceConfig) {
+		cfg.scope = scope
+		cfg.hasScope = true
+	}
+}
+
+// WithDeviceTimeout bounds each individual HTTP round-trip. Zero or negative
+// leaves the default (30s).
+func WithDeviceTimeout(d time.Duration) DeviceOption {
+	return func(cfg *deviceConfig) { cfg.timeout = d }
+}
+
+// WithDeviceClock injects a monotonic clock for the polling deadline. Defaults
+// to time.Now (monotonic in Go). Tests inject a clock to advance time.
+func WithDeviceClock(clock func() time.Time) DeviceOption {
+	return func(cfg *deviceConfig) {
+		if clock != nil {
+			cfg.clock = clock
+		}
+	}
+}
+
+// WithDeviceSleep injects the wait seam between polls. It receives the poll
+// context and the requested wait; returning a non-nil error (e.g. ctx.Err())
+// ends the wait. Tests inject a sleep that records the schedule and returns
+// immediately so there are no real delays.
+func WithDeviceSleep(sleep func(ctx context.Context, d time.Duration) error) DeviceOption {
+	return func(cfg *deviceConfig) {
+		if sleep != nil {
+			cfg.sleep = sleep
+		}
+	}
+}
+
+func newDeviceConfig(opts []DeviceOption) deviceConfig {
+	cfg := deviceConfig{
+		httpClient: http.DefaultClient,
+		timeout:    defaultDeviceRequestTimeout,
+		clock:      time.Now,
+		sleep:      defaultDeviceSleep,
+	}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	if cfg.timeout <= 0 {
+		cfg.timeout = defaultDeviceRequestTimeout
+	}
+	// Suppress redirects on every device-flow POST so a 3xx surfaces as a non-2xx
+	// api_error rather than the client chasing an attacker-influenced Location.
+	cfg.httpClient = suppressRedirects(cfg.httpClient)
+	return cfg
+}
+
+// suppressRedirects returns a shallow copy of c that never follows a redirect.
+// A 3xx response is returned as-is (via http.ErrUseLastResponse) so the caller
+// classifies it as a non-success instead of dialing the redirect target.
+func suppressRedirects(c *http.Client) *http.Client {
+	clone := *c
+	clone.CheckRedirect = func(*http.Request, []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	return &clone
+}
+
+// defaultDeviceSleep waits d, returning early with ctx.Err() when the context
+// is cancelled or its deadline passes.
+func defaultDeviceSleep(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return ctx.Err()
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// rawDeviceAuthorization mirrors an RFC 8628 §3.2 response. Numeric fields are
+// pointers so absent is distinguishable from a present zero, and *float64 (not
+// *int) so an integer-valued float like 900.0 decodes — encoding/json rejects a
+// fractional-looking number into an int, but the cross-SDK contract accepts
+// whole-second floats (900.0) and rejects fractional (2.5); whole-second
+// enforcement happens in validation.
+type rawDeviceAuthorization struct {
+	DeviceCode              string   `json:"device_code"`
+	UserCode                string   `json:"user_code"`
+	VerificationURI         string   `json:"verification_uri"`
+	VerificationURIComplete string   `json:"verification_uri_complete"`
+	ExpiresIn               *float64 `json:"expires_in"`
+	Interval                *float64 `json:"interval"`
+}
+
+// wholeSeconds coerces an RFC 8628 duration field to a positive integer number
+// of seconds no greater than maxDeviceSeconds. It accepts a positive
+// integer-valued float (900 or 900.0) and rejects absent, non-positive,
+// fractional (2.5), or oversized (1e100) values — matching TS, Ruby, Python,
+// and Kotlin.
+func wholeSeconds(v *float64) (int, bool) {
+	if v == nil || *v <= 0 || *v > maxDeviceSeconds || *v != math.Trunc(*v) {
+		return 0, false
+	}
+	return int(*v), true
+}
+
+// RequestDeviceAuthorization obtains a device/user code pair (RFC 8628
+// §3.1–3.2). The endpoint is TLS-guarded. scope is sent only when set via
+// WithDeviceScope; otherwise it is omitted so the server applies its default
+// (`read`). A network failure yields a DeviceFlowError(transport); a non-2xx,
+// unparsable, or invalid response yields a coded *basecamp.Error.
+func RequestDeviceAuthorization(ctx context.Context, deviceAuthEndpoint, clientID string, opts ...DeviceOption) (*DeviceAuthorization, error) {
+	cfg := newDeviceConfig(opts)
+
+	if err := basecamp.RequireSecureEndpoint(deviceAuthEndpoint); err != nil {
+		return nil, &basecamp.Error{
+			Code:    basecamp.CodeUsage,
+			Message: fmt.Sprintf("device authorization endpoint is not secure: %s", deviceAuthEndpoint),
+			Cause:   err,
+		}
+	}
+	if clientID == "" {
+		return nil, &basecamp.Error{Code: basecamp.CodeValidation, Message: "client ID is required for device authorization"}
+	}
+
+	form := url.Values{}
+	form.Set("client_id", clientID)
+	// Omit scope entirely when unset so the server applies its default (`read`).
+	if cfg.hasScope && cfg.scope != "" {
+		form.Set("scope", cfg.scope)
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, cfg.timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, deviceAuthEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, &basecamp.Error{Code: basecamp.CodeUsage, Message: fmt.Sprintf("creating device authorization request: %v", err), Cause: err}
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := cfg.httpClient.Do(req) // #nosec G704 -- SDK HTTP client: caller-supplied discovery endpoint
+	if err != nil {
+		return nil, &DeviceFlowError{Reason: DeviceFlowTransport, Err: fmt.Errorf("device authorization request failed: %w", err)}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := readBoundedBody(resp.Body, maxTokenResponseBytes)
+	if err != nil {
+		// An oversized body is a server/api fault (api_error, not retryable); any
+		// other read failure is a transport failure, matching the Do() error above.
+		if errors.Is(err, errBodyTooLarge) {
+			return nil, &basecamp.Error{Code: basecamp.CodeAPI, Message: fmt.Sprintf("device authorization response too large: %v", err), Cause: err}
+		}
+		return nil, &DeviceFlowError{Reason: DeviceFlowTransport, Err: fmt.Errorf("reading device authorization response: %w", err)}
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, basecamp.ErrAPI(resp.StatusCode,
+			fmt.Sprintf("device authorization failed with status %d: %s", resp.StatusCode, truncateBody(body)))
+	}
+
+	var raw rawDeviceAuthorization
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, &basecamp.Error{Code: basecamp.CodeAPI, Message: "failed to parse device authorization response", Cause: err}
+	}
+	return validateDeviceAuthorization(raw)
+}
+
+func validateDeviceAuthorization(raw rawDeviceAuthorization) (*DeviceAuthorization, error) {
+	apiErr := func(msg string) error { return &basecamp.Error{Code: basecamp.CodeAPI, Message: msg} }
+
+	if raw.DeviceCode == "" || raw.UserCode == "" || raw.VerificationURI == "" {
+		return nil, apiErr("invalid device authorization response: missing required fields")
+	}
+	expiresIn, ok := wholeSeconds(raw.ExpiresIn)
+	if !ok {
+		return nil, apiErr(fmt.Sprintf("invalid device authorization response: expires_in must be a positive integer no greater than %d", maxDeviceSeconds))
+	}
+	interval := defaultDeviceInterval
+	if raw.Interval != nil {
+		i, ok := wholeSeconds(raw.Interval)
+		if !ok {
+			return nil, apiErr(fmt.Sprintf("invalid device authorization response: interval must be a positive integer no greater than %d", maxDeviceSeconds))
+		}
+		interval = i
+	}
+	return &DeviceAuthorization{
+		DeviceCode:              raw.DeviceCode,
+		UserCode:                raw.UserCode,
+		VerificationURI:         raw.VerificationURI,
+		VerificationURIComplete: raw.VerificationURIComplete,
+		ExpiresIn:               expiresIn,
+		Interval:                interval,
+	}, nil
+}
+
+// PollDeviceToken runs the RFC 8628 §3.4–3.5 polling loop against the token
+// endpoint until the user approves, denies, or the code expires. It waits at
+// least interval seconds between polls, enforces a monotonic expiry deadline via
+// the injectable clock, sustains slow_down bumps (+5s), backs off exponentially
+// on connection timeouts, and honors context cancellation.
+//
+// Terminal DeviceFlowError reasons: access_denied, expired, transport,
+// cancelled. Other server errors surface as a coded *basecamp.Error.
+func PollDeviceToken(ctx context.Context, tokenEndpoint, clientID, deviceCode string, interval, expiresIn int, opts ...DeviceOption) (*Token, error) {
+	cfg := newDeviceConfig(opts)
+
+	if err := basecamp.RequireSecureEndpoint(tokenEndpoint); err != nil {
+		return nil, &basecamp.Error{
+			Code:    basecamp.CodeUsage,
+			Message: fmt.Sprintf("token endpoint is not secure: %s", tokenEndpoint),
+			Cause:   err,
+		}
+	}
+
+	intervalSeconds := interval
+	if intervalSeconds <= 0 {
+		intervalSeconds = defaultDeviceInterval
+	}
+	backoffSeconds := intervalSeconds
+	deadline := cfg.clock().Add(time.Duration(expiresIn) * time.Second)
+
+	form := url.Values{}
+	form.Set("grant_type", DeviceCodeGrantType)
+	form.Set("device_code", deviceCode)
+	form.Set("client_id", clientID)
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: err}
+		}
+		// Check-before-wait: if the monotonic deadline has already passed, the
+		// codes are expired — return now rather than sleeping a negative
+		// duration into the (possibly injected) sleep seam.
+		remaining := deadline.Sub(cfg.clock())
+		if remaining <= 0 {
+			return nil, &DeviceFlowError{Reason: DeviceFlowExpired}
+		}
+		// Clamp the wait (interval + any connection-timeout backoff) to the time
+		// left before the deadline so a long backoff never overshoots expiry;
+		// the deadline check below then terminates the flow promptly.
+		wait := time.Duration(intervalSeconds) * time.Second
+		if remaining < wait {
+			wait = remaining
+		}
+		if err := cfg.sleep(ctx, wait); err != nil {
+			return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: cancelCause(ctx, err)}
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: err}
+		}
+		if !cfg.clock().Before(deadline) {
+			return nil, &DeviceFlowError{Reason: DeviceFlowExpired}
+		}
+
+		result := postDeviceToken(ctx, cfg, tokenEndpoint, form)
+		switch result.kind {
+		case pollToken:
+			return result.token, nil
+		case pollCancelled:
+			return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: result.err}
+		case pollTimeout:
+			// Connection timeout — back off and keep polling (RFC 8628 §3.5).
+			backoffSeconds = min(backoffSeconds*2, maxBackoffSeconds)
+			intervalSeconds = max(intervalSeconds, backoffSeconds)
+			continue
+		case pollTransport:
+			return nil, &DeviceFlowError{Reason: DeviceFlowTransport, Err: result.err}
+		case pollInvalidResponse:
+			// Malformed 2xx token response — api_error, not a retryable transport.
+			return nil, basecamp.ErrAPI(result.status, result.err.Error())
+		case pollOAuthError:
+			// A successful round-trip resets the timeout backoff.
+			backoffSeconds = intervalSeconds
+			switch result.oauthError {
+			case "authorization_pending":
+				continue
+			case "slow_down":
+				intervalSeconds += slowDownIncrementSeconds
+				continue
+			case "access_denied":
+				return nil, &DeviceFlowError{Reason: DeviceFlowAccessDenied}
+			case "expired_token":
+				return nil, &DeviceFlowError{Reason: DeviceFlowExpired}
+			default:
+				return nil, basecamp.ErrAPI(result.status,
+					fmt.Sprintf("device token request failed: %s", result.oauthError))
+			}
+		default:
+			return nil, basecamp.ErrAPI(result.status, "device token request failed")
+		}
+	}
+}
+
+// pollResultKind classifies a single token-endpoint poll.
+type pollResultKind int
+
+const (
+	pollToken pollResultKind = iota
+	pollOAuthError
+	pollTimeout
+	pollTransport
+	pollCancelled
+	// pollInvalidResponse is a server/api fault (api_error), NOT a retryable
+	// transport: a 2xx whose body is unparseable or missing the access token, or
+	// any response whose body exceeds the size cap.
+	pollInvalidResponse
+)
+
+type pollResult struct {
+	kind       pollResultKind
+	token      *Token
+	oauthError string
+	status     int
+	err        error
+}
+
+// postDeviceToken performs one token-endpoint poll and classifies the outcome.
+// A parent-context cancellation is pollCancelled; a per-request timeout (or any
+// net timeout) is pollTimeout (→ backoff); any other transport failure is
+// pollTransport. A 2xx yields a Token; a non-2xx with an OAuth error body yields
+// pollOAuthError.
+func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string, form url.Values) pollResult {
+	reqCtx, cancel := context.WithTimeout(ctx, cfg.timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, tokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return pollResult{kind: pollTransport, err: fmt.Errorf("creating device token request: %w", err)}
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := cfg.httpClient.Do(req) // #nosec G704 -- SDK HTTP client: caller-supplied token endpoint
+	if err != nil {
+		// Parent cancellation ends the flow; a per-request timeout backs off.
+		if ctx.Err() != nil {
+			return pollResult{kind: pollCancelled, err: ctx.Err()}
+		}
+		if errors.Is(err, context.DeadlineExceeded) || isTimeout(err) {
+			return pollResult{kind: pollTimeout, err: err}
+		}
+		return pollResult{kind: pollTransport, err: fmt.Errorf("device token poll failed: %w", err)}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := readBoundedBody(resp.Body, maxTokenResponseBytes)
+	if err != nil {
+		switch {
+		case errors.Is(err, errBodyTooLarge):
+			// Oversized body — a server/api fault (api_error, not retryable), NOT a
+			// retryable transport failure.
+			return pollResult{kind: pollInvalidResponse, status: resp.StatusCode, err: fmt.Errorf("reading device token response: %w", err)}
+		case ctx.Err() != nil:
+			return pollResult{kind: pollCancelled, err: ctx.Err()}
+		case errors.Is(err, context.DeadlineExceeded) || isTimeout(err):
+			return pollResult{kind: pollTimeout, err: err}
+		default:
+			return pollResult{kind: pollTransport, err: fmt.Errorf("reading device token response: %w", err)}
+		}
+	}
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		var token Token
+		if err := json.Unmarshal(body, &token); err != nil {
+			return pollResult{kind: pollInvalidResponse, status: resp.StatusCode, err: fmt.Errorf("parsing device token response: %w", err)}
+		}
+		if token.AccessToken == "" {
+			return pollResult{kind: pollInvalidResponse, status: resp.StatusCode, err: errors.New("device token response missing access_token")}
+		}
+		if token.TokenType == "" {
+			token.TokenType = "Bearer"
+		}
+		if token.ExpiresIn > 0 {
+			token.ExpiresAt = cfg.clock().Add(time.Duration(token.ExpiresIn) * time.Second)
+		}
+		return pollResult{kind: pollToken, token: &token}
+	}
+
+	var errResp struct {
+		Error string `json:"error"`
+	}
+	oauthError := fmt.Sprintf("http_%d", resp.StatusCode)
+	if json.Unmarshal(body, &errResp) == nil && errResp.Error != "" {
+		oauthError = errResp.Error
+	}
+	return pollResult{kind: pollOAuthError, oauthError: oauthError, status: resp.StatusCode}
+}
+
+// PerformDeviceLogin runs the full RFC 8628 device authorization grant against
+// an ALREADY-SELECTED config. It first guards the device capability — requiring
+// BOTH a device authorization endpoint AND the device_code grant advertised —
+// then requests a device code, surfaces it through display, and polls for the
+// token.
+//
+// A config that cannot do device flow yields a DeviceFlowError(unavailable) and
+// no request is made.
+func PerformDeviceLogin(ctx context.Context, config *Config, clientID string, display func(DeviceAuthorization), opts ...DeviceOption) (*Token, error) {
+	if config == nil || config.DeviceAuthorizationEndpoint == nil || !supportsDeviceGrant(config.GrantTypesSupported) {
+		return nil, &DeviceFlowError{Reason: DeviceFlowUnavailable}
+	}
+
+	cfg := newDeviceConfig(opts)
+
+	auth, err := RequestDeviceAuthorization(ctx, *config.DeviceAuthorizationEndpoint, clientID, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Anchor the code's lifetime at issuance so a slow display hook cannot yield a
+	// fresh full polling window.
+	deadline := cfg.clock().Add(time.Duration(auth.ExpiresIn) * time.Second)
+
+	if display != nil {
+		display(*auth)
+	}
+
+	// Charge display time against the code's lifetime. If the hook consumed the
+	// whole window, the code has expired and no token request is warranted.
+	remaining := deadline.Sub(cfg.clock())
+	if remaining <= 0 {
+		return nil, &DeviceFlowError{Reason: DeviceFlowExpired}
+	}
+
+	// Pass the REMAINING lifetime (not the full expires_in) so PollDeviceToken's
+	// deadline keeps counting from issuance instead of re-anchoring a fresh full
+	// window after display. Round up so a sub-second remainder still allows one
+	// poll rather than truncating to an immediate expiry.
+	remainingSeconds := int((remaining + time.Second - 1) / time.Second)
+	return PollDeviceToken(ctx, config.TokenEndpoint, clientID, auth.DeviceCode, auth.Interval, remainingSeconds, opts...)
+}
+
+// supportsDeviceGrant reports whether the advertised grant types include the
+// device_code grant.
+func supportsDeviceGrant(grantTypes []string) bool {
+	for _, g := range grantTypes {
+		if g == DeviceCodeGrantType {
+			return true
+		}
+	}
+	return false
+}
+
+// cancelCause prefers the context's own error (native cancellation) over the
+// sleep seam's error, so a cancelled flow carries ctx.Err().
+func cancelCause(ctx context.Context, sleepErr error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return sleepErr
+}
+
+// isTimeout reports whether err is a network timeout.
+func isTimeout(err error) bool {
+	var ne net.Error
+	return errors.As(err, &ne) && ne.Timeout()
+}

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -55,8 +55,9 @@ type DeviceAuthorization struct {
 	UserCode string
 	// VerificationURI is where the user enters the user code.
 	VerificationURI string
-	// VerificationURIComplete embeds the user code in the URI (optional).
-	VerificationURIComplete string
+	// VerificationURIComplete embeds the user code in the URI (optional; nil when
+	// absent, matching the other SDKs' nullable/optional modeling of this field).
+	VerificationURIComplete *string
 	// ExpiresIn is the device/user code lifetime in seconds.
 	ExpiresIn int
 	// Interval is the minimum polling interval in seconds (default 5).
@@ -179,7 +180,7 @@ type rawDeviceAuthorization struct {
 	DeviceCode              string   `json:"device_code"`
 	UserCode                string   `json:"user_code"`
 	VerificationURI         string   `json:"verification_uri"`
-	VerificationURIComplete string   `json:"verification_uri_complete"`
+	VerificationURIComplete *string  `json:"verification_uri_complete"`
 	ExpiresIn               *float64 `json:"expires_in"`
 	Interval                *float64 `json:"interval"`
 }

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -252,6 +252,12 @@ func RequestDeviceAuthorization(ctx context.Context, deviceAuthEndpoint, clientI
 		if errors.Is(err, errBodyTooLarge) {
 			return nil, &basecamp.Error{Code: basecamp.CodeAPI, Message: fmt.Sprintf("device authorization response too large: %v", err), Cause: err}
 		}
+		// A caller abort while the body is still streaming must surface as
+		// cancellation too, not transport — same parent-ctx.Err() guard as the Do()
+		// error above and the token poll's body read.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: ctxErr}
+		}
 		return nil, &DeviceFlowError{Reason: DeviceFlowTransport, Err: fmt.Errorf("reading device authorization response: %w", err)}
 	}
 

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -321,8 +321,27 @@ func validateDeviceAuthorization(raw rawDeviceAuthorization, status int) (*Devic
 // context cancellation.
 //
 // Terminal DeviceFlowError reasons: access_denied, expired, transport,
-// cancelled. Other server errors surface as a coded *basecamp.Error.
+// cancelled. Other server errors surface as a coded *basecamp.Error; an
+// out-of-range interval/expiresIn is rejected up front as a usage error.
 func PollDeviceToken(ctx context.Context, tokenEndpoint, clientID, deviceCode string, interval, expiresIn int, opts ...DeviceOption) (*Token, error) {
+	// Caller-input sanity for this exported entry point (usage, not RFC response
+	// validation): a non-positive duration builds a deadline in the past, and an
+	// oversized one overflows the time.Duration(seconds) * time.Second math below
+	// into a garbage (possibly negative) deadline. Reject both, mirroring the TS
+	// pollDeviceToken guard so a direct caller gets the same rejection across SDKs.
+	// PerformDeviceLogin bypasses this via pollDeviceTokenUntil with already-
+	// validated, clamped values, so this only bounds direct callers.
+	for _, field := range []struct {
+		name  string
+		value int
+	}{{"expiresIn", expiresIn}, {"interval", interval}} {
+		if field.value <= 0 || field.value > maxDeviceSeconds {
+			return nil, &basecamp.Error{
+				Code:    basecamp.CodeUsage,
+				Message: fmt.Sprintf("PollDeviceToken: %s must be a positive number of seconds no greater than %d", field.name, maxDeviceSeconds),
+			}
+		}
+	}
 	cfg := newDeviceConfig(opts)
 	deadline := cfg.clock().Add(time.Duration(expiresIn) * time.Second)
 	return pollDeviceTokenUntil(ctx, cfg, tokenEndpoint, clientID, deviceCode, interval, deadline)

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -255,7 +255,9 @@ func RequestDeviceAuthorization(ctx context.Context, deviceAuthEndpoint, clientI
 
 	var raw rawDeviceAuthorization
 	if err := json.Unmarshal(body, &raw); err != nil {
-		return nil, &basecamp.Error{Code: basecamp.CodeAPI, Message: "failed to parse device authorization response", Cause: err}
+		// Carry the HTTP status like the sibling non-2xx raise above (and Python)
+		// so a failed 2xx-body parse still reports which response it came from.
+		return nil, &basecamp.Error{Code: basecamp.CodeAPI, Message: "failed to parse device authorization response", HTTPStatus: resp.StatusCode, Cause: err}
 	}
 	return validateDeviceAuthorization(raw)
 }

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -234,6 +234,13 @@ func RequestDeviceAuthorization(ctx context.Context, deviceAuthEndpoint, clientI
 
 	resp, err := cfg.httpClient.Do(req) // #nosec G704 -- SDK HTTP client: caller-supplied discovery endpoint
 	if err != nil {
+		// A caller cancelling (or its deadline expiring) during the POST must
+		// surface as DeviceFlowCancelled, not a retryable transport failure. The
+		// parent ctx.Err() is non-nil only for a caller abort — the SDK's own
+		// per-request timeout is the child reqCtx, whose expiry stays transport.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: ctxErr}
+		}
 		return nil, &DeviceFlowError{Reason: DeviceFlowTransport, Err: fmt.Errorf("device authorization request failed: %w", err)}
 	}
 	defer func() { _ = resp.Body.Close() }()

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -460,27 +460,47 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 	}
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		var token Token
-		if err := json.Unmarshal(body, &token); err != nil {
+		// expires_in decodes via *float64, not Token's plain int: a pointer keeps
+		// an explicit "expires_in":0 distinguishable from an omitted field (a
+		// plain int makes 0 look absent and skip validation), and float64 accepts
+		// an integer-valued 3600.0 per the cross-SDK contract. Whole-second
+		// enforcement happens below. Non-string token_type/refresh_token/scope
+		// still fail Unmarshal here as pollInvalidResponse.
+		var raw struct {
+			AccessToken  string   `json:"access_token"`
+			RefreshToken string   `json:"refresh_token"`
+			TokenType    string   `json:"token_type"`
+			ExpiresIn    *float64 `json:"expires_in"`
+			Scope        string   `json:"scope"`
+		}
+		if err := json.Unmarshal(body, &raw); err != nil {
 			return pollResult{kind: pollInvalidResponse, status: resp.StatusCode, err: fmt.Errorf("parsing device token response: %w", err)}
 		}
-		if token.AccessToken == "" {
+		if raw.AccessToken == "" {
 			return pollResult{kind: pollInvalidResponse, status: resp.StatusCode, err: errors.New("device token response missing access_token")}
 		}
-		// A non-numeric/non-string field (a JSON string/bool for expires_in, or a
-		// number for token_type/refresh_token/scope) already fails json.Unmarshal
-		// above as pollInvalidResponse. What survives is a syntactically valid
-		// integer that is negative or so large that time.Duration(ExpiresIn) *
-		// time.Second overflows — bound it here so ExpiresAt can never wrap.
-		if token.ExpiresIn < 0 || token.ExpiresIn > maxTokenLifetimeSeconds {
-			return pollResult{kind: pollInvalidResponse, status: resp.StatusCode,
-				err: fmt.Errorf("device token response expires_in must be a positive integer no greater than %d seconds", maxTokenLifetimeSeconds)}
+		token := Token{
+			AccessToken:  raw.AccessToken,
+			RefreshToken: raw.RefreshToken,
+			TokenType:    raw.TokenType,
+			Scope:        raw.Scope,
+		}
+		// When present, expires_in must be a positive WHOLE number of seconds no
+		// greater than maxTokenLifetimeSeconds — an explicit 0, a fractional
+		// 3600.5, or an oversized value is a malformed response (api_error),
+		// while an absent field yields a token with no expiry. The ceiling keeps
+		// the time.Duration multiplication below from wrapping ExpiresAt.
+		if raw.ExpiresIn != nil {
+			v := *raw.ExpiresIn
+			if v <= 0 || v > maxTokenLifetimeSeconds || v != math.Trunc(v) {
+				return pollResult{kind: pollInvalidResponse, status: resp.StatusCode,
+					err: fmt.Errorf("device token response expires_in must be a positive whole number of seconds no greater than %d", maxTokenLifetimeSeconds)}
+			}
+			token.ExpiresIn = int(v)
+			token.ExpiresAt = cfg.clock().Add(time.Duration(token.ExpiresIn) * time.Second)
 		}
 		if token.TokenType == "" {
 			token.TokenType = "Bearer"
-		}
-		if token.ExpiresIn > 0 {
-			token.ExpiresAt = cfg.clock().Add(time.Duration(token.ExpiresIn) * time.Second)
 		}
 		return pollResult{kind: pollToken, token: &token}
 	}

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -299,7 +299,15 @@ func validateDeviceAuthorization(raw rawDeviceAuthorization) (*DeviceAuthorizati
 // cancelled. Other server errors surface as a coded *basecamp.Error.
 func PollDeviceToken(ctx context.Context, tokenEndpoint, clientID, deviceCode string, interval, expiresIn int, opts ...DeviceOption) (*Token, error) {
 	cfg := newDeviceConfig(opts)
+	deadline := cfg.clock().Add(time.Duration(expiresIn) * time.Second)
+	return pollDeviceTokenUntil(ctx, cfg, tokenEndpoint, clientID, deviceCode, interval, deadline)
+}
 
+// pollDeviceTokenUntil is the polling loop against an ABSOLUTE monotonic
+// deadline. PerformDeviceLogin calls it with the exact issuance-anchored
+// deadline so no whole-second rounding or re-anchoring at a later clock read
+// can extend the code's lifetime.
+func pollDeviceTokenUntil(ctx context.Context, cfg deviceConfig, tokenEndpoint, clientID, deviceCode string, interval int, deadline time.Time) (*Token, error) {
 	if err := basecamp.RequireSecureEndpoint(tokenEndpoint); err != nil {
 		return nil, &basecamp.Error{
 			Code:    basecamp.CodeUsage,
@@ -313,7 +321,6 @@ func PollDeviceToken(ctx context.Context, tokenEndpoint, clientID, deviceCode st
 		intervalSeconds = defaultDeviceInterval
 	}
 	backoffSeconds := intervalSeconds
-	deadline := cfg.clock().Add(time.Duration(expiresIn) * time.Second)
 
 	form := url.Values{}
 	form.Set("grant_type", DeviceCodeGrantType)
@@ -464,12 +471,15 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 		// an explicit "expires_in":0 distinguishable from an omitted field (a
 		// plain int makes 0 look absent and skip validation), and float64 accepts
 		// an integer-valued 3600.0 per the cross-SDK contract. Whole-second
-		// enforcement happens below. Non-string token_type/refresh_token/scope
-		// still fail Unmarshal here as pollInvalidResponse.
+		// enforcement happens below. token_type is *string for the same
+		// absent-vs-explicit reason: an omitted field defaults to Bearer, but an
+		// explicit "token_type":"" is malformed metadata (api_error), uniform
+		// with the other SDKs. Non-string token_type/refresh_token/scope still
+		// fail Unmarshal here as pollInvalidResponse.
 		var raw struct {
 			AccessToken  string   `json:"access_token"`
 			RefreshToken string   `json:"refresh_token"`
-			TokenType    string   `json:"token_type"`
+			TokenType    *string  `json:"token_type"`
 			ExpiresIn    *float64 `json:"expires_in"`
 			Scope        string   `json:"scope"`
 		}
@@ -479,11 +489,17 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 		if raw.AccessToken == "" {
 			return pollResult{kind: pollInvalidResponse, status: resp.StatusCode, err: errors.New("device token response missing access_token")}
 		}
+		if raw.TokenType != nil && *raw.TokenType == "" {
+			return pollResult{kind: pollInvalidResponse, status: resp.StatusCode, err: errors.New("device token response token_type must be a non-empty string")}
+		}
 		token := Token{
 			AccessToken:  raw.AccessToken,
 			RefreshToken: raw.RefreshToken,
-			TokenType:    raw.TokenType,
+			TokenType:    "Bearer",
 			Scope:        raw.Scope,
+		}
+		if raw.TokenType != nil {
+			token.TokenType = *raw.TokenType
 		}
 		// When present, expires_in must be a positive WHOLE number of seconds no
 		// greater than maxTokenLifetimeSeconds — an explicit 0, a fractional
@@ -498,9 +514,6 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 			}
 			token.ExpiresIn = int(v)
 			token.ExpiresAt = cfg.clock().Add(time.Duration(token.ExpiresIn) * time.Second)
-		}
-		if token.TokenType == "" {
-			token.TokenType = "Bearer"
 		}
 		return pollResult{kind: pollToken, token: &token}
 	}
@@ -554,17 +567,14 @@ func PerformDeviceLogin(ctx context.Context, config *Config, clientID string, di
 
 	// Charge display time against the code's lifetime. If the hook consumed the
 	// whole window, the code has expired and no token request is warranted.
-	remaining := deadline.Sub(cfg.clock())
-	if remaining <= 0 {
+	if deadline.Sub(cfg.clock()) <= 0 {
 		return nil, &DeviceFlowError{Reason: DeviceFlowExpired}
 	}
 
-	// Pass the REMAINING lifetime (not the full expires_in) so PollDeviceToken's
-	// deadline keeps counting from issuance instead of re-anchoring a fresh full
-	// window after display. Round up so a sub-second remainder still allows one
-	// poll rather than truncating to an immediate expiry.
-	remainingSeconds := int((remaining + time.Second - 1) / time.Second)
-	return PollDeviceToken(ctx, config.TokenEndpoint, clientID, auth.DeviceCode, auth.Interval, remainingSeconds, opts...)
+	// Pass the EXACT issuance-anchored deadline — never a whole-second remaining
+	// count that a re-anchoring clock read could round upward — so the poll loop
+	// terminates precisely when the code expires.
+	return pollDeviceTokenUntil(ctx, cfg, config.TokenEndpoint, clientID, auth.DeviceCode, auth.Interval, deadline)
 }
 
 // supportsDeviceGrant reports whether the advertised grant types include the

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -259,11 +259,16 @@ func RequestDeviceAuthorization(ctx context.Context, deviceAuthEndpoint, clientI
 		// so a failed 2xx-body parse still reports which response it came from.
 		return nil, &basecamp.Error{Code: basecamp.CodeAPI, Message: "failed to parse device authorization response", HTTPStatus: resp.StatusCode, Cause: err}
 	}
-	return validateDeviceAuthorization(raw)
+	return validateDeviceAuthorization(raw, resp.StatusCode)
 }
 
-func validateDeviceAuthorization(raw rawDeviceAuthorization) (*DeviceAuthorization, error) {
-	apiErr := func(msg string) error { return &basecamp.Error{Code: basecamp.CodeAPI, Message: msg} }
+func validateDeviceAuthorization(raw rawDeviceAuthorization, status int) (*DeviceAuthorization, error) {
+	// Carry the (2xx) status on every validation error so a malformed success
+	// body is diagnosable as such, uniform with the token-poll raises and the
+	// other SDKs.
+	apiErr := func(msg string) error {
+		return &basecamp.Error{Code: basecamp.CodeAPI, Message: msg, HTTPStatus: status}
+	}
 
 	if raw.DeviceCode == "" || raw.UserCode == "" || raw.VerificationURI == "" {
 		return nil, apiErr("invalid device authorization response: missing required fields")

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -422,17 +422,17 @@ func pollDeviceTokenUntil(ctx context.Context, cfg deviceConfig, tokenEndpoint, 
 		// per-request timeout: near expiry, a stalled token POST must not hold
 		// the flow past the monotonic deadline for the full request budget.
 		result := postDeviceToken(ctx, cfg, tokenEndpoint, form, min(cfg.timeout, postRemaining))
+		// Re-check cancellation before classifying ANY completed round trip:
+		// an injected RoundTripper that ignores the request context can
+		// complete a 200, a terminal 4xx (access_denied, expired_token), or a
+		// malformed response after ctx is cancelled — the caller asked to
+		// stop, so cancelled wins over every completed outcome. Mirrors the
+		// post-authorization re-check and the Py/Rb post-round-trip probes.
+		if err := ctx.Err(); err != nil {
+			return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: err}
+		}
 		switch result.kind {
 		case pollToken:
-			// Re-check cancellation before returning the credential: an
-			// injected RoundTripper that ignores the request context can
-			// complete a 200 after ctx is cancelled — the caller asked to
-			// stop, so cancelled wins over the token. Mirrors the
-			// post-authorization re-check and the Py/Rb post-round-trip
-			// probes.
-			if err := ctx.Err(); err != nil {
-				return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: err}
-			}
 			return result.token, nil
 		case pollCancelled:
 			return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: result.err}

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -396,11 +396,15 @@ func pollDeviceTokenUntil(ctx context.Context, cfg deviceConfig, tokenEndpoint, 
 		if err := ctx.Err(); err != nil {
 			return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: err}
 		}
-		if !cfg.clock().Before(deadline) {
+		postRemaining := deadline.Sub(cfg.clock())
+		if postRemaining <= 0 {
 			return nil, &DeviceFlowError{Reason: DeviceFlowExpired}
 		}
 
-		result := postDeviceToken(ctx, cfg, tokenEndpoint, form)
+		// Bound the request by the REMAINING code lifetime as well as the
+		// per-request timeout: near expiry, a stalled token POST must not hold
+		// the flow past the monotonic deadline for the full request budget.
+		result := postDeviceToken(ctx, cfg, tokenEndpoint, form, min(cfg.timeout, postRemaining))
 		switch result.kind {
 		case pollToken:
 			return result.token, nil
@@ -475,8 +479,8 @@ type pollResult struct {
 // net timeout) is pollTimeout (→ backoff); any other transport failure is
 // pollTransport. A 2xx yields a Token; a 3xx is pollInvalidResponse; any other
 // non-2xx with an OAuth error body yields pollOAuthError.
-func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string, form url.Values) pollResult {
-	reqCtx, cancel := context.WithTimeout(ctx, cfg.timeout)
+func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string, form url.Values, timeout time.Duration) pollResult {
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, tokenEndpoint, strings.NewReader(form.Encode()))
@@ -584,16 +588,21 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 		return pollResult{kind: pollToken, token: &token}
 	}
 
-	// Redirects are suppressed (http.ErrUseLastResponse), so a 3xx lands here
-	// as-is. A redirect is never a valid token response — classify it as an api
-	// fault BEFORE the OAuth-error body parse so a crafted
-	// authorization_pending body on a 3xx cannot keep the loop polling.
-	var errResp struct {
-		Error string `json:"error"`
-	}
+	// Recognize OAuth protocol error codes ONLY on a 4xx (RFC 8628 §3.5 error
+	// responses are 400-class): a nonstandard 2xx (201/202) or a 5xx carrying a
+	// crafted {"error":"authorization_pending"} body must not keep the loop
+	// polling — only a 200 can produce a token and only a 4xx can produce a
+	// protocol state. Everything else is forced to http_<status>, which the
+	// loop terminates as api_error. (3xx never reaches here — classified above
+	// before the body read.)
 	oauthError := fmt.Sprintf("http_%d", resp.StatusCode)
-	if json.Unmarshal(body, &errResp) == nil && errResp.Error != "" {
-		oauthError = errResp.Error
+	if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+		var errResp struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(body, &errResp) == nil && errResp.Error != "" {
+			oauthError = errResp.Error
+		}
 	}
 	return pollResult{kind: pollOAuthError, oauthError: oauthError, status: resp.StatusCode}
 }

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -512,6 +512,16 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 			err: fmt.Errorf("device token endpoint returned redirect status %d", resp.StatusCode)}
 	}
 
+	// Every remaining status outside 200 and 4xx is terminal WITHOUT its body
+	// (only a 200 carries the token and only a 4xx the OAuth error code) —
+	// classify it before the read, like the 3xx above, so a 201/500 that
+	// stalls while streaming its body cannot time out mid-read and be retried
+	// as a transient failure until the code expires.
+	if resp.StatusCode != http.StatusOK && (resp.StatusCode < 400 || resp.StatusCode >= 500) {
+		return pollResult{kind: pollInvalidResponse, status: resp.StatusCode,
+			err: fmt.Errorf("device token request failed with status %d", resp.StatusCode)}
+	}
+
 	body, err := readBoundedBody(resp.Body, maxTokenResponseBytes)
 	if err != nil {
 		switch {

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -698,8 +698,13 @@ func PerformDeviceLogin(ctx context.Context, config *Config, clientID string, di
 	// fresh full polling window.
 	deadline := cfg.clock().Add(time.Duration(auth.ExpiresIn) * time.Second)
 
-	if display != nil {
-		display(*auth)
+	display(*auth)
+
+	// Cancellation raised INSIDE the display hook (a prompt closing in
+	// response to cancellation) wins over expiry: a hook that both cancels
+	// and consumes the lifetime must surface cancelled, not expired.
+	if err := ctx.Err(); err != nil {
+		return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: err}
 	}
 
 	// Charge display time against the code's lifetime. If the hook consumed the

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -255,6 +255,15 @@ func RequestDeviceAuthorization(ctx context.Context, deviceAuthEndpoint, clientI
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	// Re-check cancellation BEFORE classifying the completed response: a
+	// context-ignoring RoundTripper can cancel the parent and still complete a
+	// non-2xx or malformed response, and cancellation must win over every
+	// completed outcome — matching the token poll's pre-classification
+	// re-check.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: ctxErr}
+	}
+
 	// A non-2xx is a hard failure whose body is unused — surface it by status
 	// BEFORE reading the body. Otherwise a slow/never-ending error body could hit
 	// the request timeout mid-read and be misclassified as a retryable transport

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -635,7 +635,13 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 // A config that cannot do device flow yields a DeviceFlowError(unavailable) and
 // no request is made.
 func PerformDeviceLogin(ctx context.Context, config *Config, clientID string, display func(DeviceAuthorization), opts ...DeviceOption) (*Token, error) {
-	if config == nil || config.DeviceAuthorizationEndpoint == nil || !supportsDeviceGrant(config.GrantTypesSupported) {
+	// Present-but-empty is as unavailable as absent (the other SDK guards
+	// treat "" as no endpoint): without the dereference check an empty
+	// endpoint would fall through to RequestDeviceAuthorization and surface a
+	// usage/security error instead of the documented unavailable — after
+	// bypassing the make-no-request contract.
+	if config == nil || config.DeviceAuthorizationEndpoint == nil ||
+		*config.DeviceAuthorizationEndpoint == "" || !supportsDeviceGrant(config.GrantTypesSupported) {
 		return nil, &DeviceFlowError{Reason: DeviceFlowUnavailable}
 	}
 

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -416,6 +416,15 @@ func pollDeviceTokenUntil(ctx context.Context, cfg deviceConfig, tokenEndpoint, 
 		result := postDeviceToken(ctx, cfg, tokenEndpoint, form, min(cfg.timeout, postRemaining))
 		switch result.kind {
 		case pollToken:
+			// Re-check cancellation before returning the credential: an
+			// injected RoundTripper that ignores the request context can
+			// complete a 200 after ctx is cancelled — the caller asked to
+			// stop, so cancelled wins over the token. Mirrors the
+			// post-authorization re-check and the Py/Rb post-round-trip
+			// probes.
+			if err := ctx.Err(); err != nil {
+				return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: err}
+			}
 			return result.token, nil
 		case pollCancelled:
 			return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: result.err}

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -212,6 +212,14 @@ func wholeSeconds(v *float64) (int, bool) {
 // (`read`). A network failure yields a DeviceFlowError(transport); a non-2xx,
 // unparsable, or invalid response yields a coded *basecamp.Error.
 func RequestDeviceAuthorization(ctx context.Context, deviceAuthEndpoint, clientID string, opts ...DeviceOption) (*DeviceAuthorization, error) {
+	// An already-cancelled ctx makes no request at all — a context-ignoring
+	// injected RoundTripper would otherwise still send the POST (the standard
+	// transport rejects pre-cancelled contexts itself). Mirrors TS's entry
+	// throwIfAborted.
+	if err := ctx.Err(); err != nil {
+		return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: err}
+	}
+
 	cfg := newDeviceConfig(opts)
 
 	if err := basecamp.RequireSecureEndpoint(deviceAuthEndpoint); err != nil {
@@ -304,6 +312,11 @@ func RequestDeviceAuthorization(ctx context.Context, deviceAuthEndpoint, clientI
 		// Carry the HTTP status like the sibling non-2xx raise above (and Python)
 		// so a failed 2xx-body parse still reports which response it came from.
 		return nil, &basecamp.Error{Code: basecamp.CodeAPI, Message: "failed to parse device authorization response", HTTPStatus: resp.StatusCode, Cause: err}
+	}
+	// And once more AFTER decoding: a cancellation landing while Unmarshal
+	// chewed a large body must not hand back a usable device code.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: ctxErr}
 	}
 	return validateDeviceAuthorization(raw, resp.StatusCode)
 }

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -286,6 +286,14 @@ func RequestDeviceAuthorization(ctx context.Context, deviceAuthEndpoint, clientI
 		// so a failed 2xx-body parse still reports which response it came from.
 		return nil, &basecamp.Error{Code: basecamp.CodeAPI, Message: "failed to parse device authorization response", HTTPStatus: resp.StatusCode, Cause: err}
 	}
+	// A custom RoundTripper that ignores the request context can complete a
+	// valid response after the caller cancelled: re-check the parent context
+	// before handing back a usable device code, exactly as the token poll's
+	// success branch does. PerformDeviceLogin re-checks later, but that does
+	// not protect direct callers.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: ctxErr}
+	}
 	return validateDeviceAuthorization(raw, resp.StatusCode)
 }
 

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -587,12 +587,16 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 		// explicit "token_type":"" is malformed metadata (api_error), uniform
 		// with the other SDKs. Non-string token_type/refresh_token/scope still
 		// fail Unmarshal here as pollInvalidResponse.
+		// RefreshToken/Scope decode via *string to make null-tolerance
+		// EXPLICIT: encoding/json also no-ops JSON null into a plain string
+		// (leaving the zero value), but the pointer form documents the
+		// absent/null-are-absent contract instead of relying on that quirk.
 		var raw struct {
 			AccessToken  string   `json:"access_token"`
-			RefreshToken string   `json:"refresh_token"`
+			RefreshToken *string  `json:"refresh_token"`
 			TokenType    *string  `json:"token_type"`
 			ExpiresIn    *float64 `json:"expires_in"`
-			Scope        string   `json:"scope"`
+			Scope        *string  `json:"scope"`
 		}
 		if err := json.Unmarshal(body, &raw); err != nil {
 			return pollResult{kind: pollInvalidResponse, status: resp.StatusCode, err: fmt.Errorf("parsing device token response: %w", err)}
@@ -604,10 +608,14 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 			return pollResult{kind: pollInvalidResponse, status: resp.StatusCode, err: errors.New("device token response token_type must be a non-empty string")}
 		}
 		token := Token{
-			AccessToken:  raw.AccessToken,
-			RefreshToken: raw.RefreshToken,
-			TokenType:    "Bearer",
-			Scope:        raw.Scope,
+			AccessToken: raw.AccessToken,
+			TokenType:   "Bearer",
+		}
+		if raw.RefreshToken != nil {
+			token.RefreshToken = *raw.RefreshToken
+		}
+		if raw.Scope != nil {
+			token.Scope = *raw.Scope
 		}
 		if raw.TokenType != nil {
 			token.TokenType = *raw.TokenType

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -31,6 +31,13 @@ const (
 	maxBackoffSeconds = 60
 	// defaultDeviceRequestTimeout bounds each individual HTTP round-trip.
 	defaultDeviceRequestTimeout = 30 * time.Second
+
+	// maxDeviceRequestTimeout caps a caller-supplied per-request timeout (the
+	// shared 3600 s ceiling — Python's _MAX_DEVICE_REQUEST_TIMEOUT, TS's
+	// resolveDeviceTimeoutMs bound, Ruby's Fetcher::MAX_REQUEST_TIMEOUT). A
+	// huge value like math.MaxInt64 would hold a stalled request open
+	// effectively forever, defeating the flow's bounded-request guarantee.
+	maxDeviceRequestTimeout = time.Hour
 	// maxDeviceSeconds caps expires_in/interval at 2147483 s (~24.8 days) — the
 	// largest whole-second duration whose millisecond form fits a 32-bit signed
 	// timer, shared across all five SDKs (SPEC.md). Far above any legitimate
@@ -96,8 +103,8 @@ func WithDeviceScope(scope string) DeviceOption {
 	}
 }
 
-// WithDeviceTimeout bounds each individual HTTP round-trip. Zero or negative
-// leaves the default (30s).
+// WithDeviceTimeout bounds each individual HTTP round-trip. Zero, negative,
+// or beyond the shared 3600 s ceiling leaves the default (30s).
 func WithDeviceTimeout(d time.Duration) DeviceOption {
 	return func(cfg *deviceConfig) { cfg.timeout = d }
 }
@@ -134,7 +141,9 @@ func newDeviceConfig(opts []DeviceOption) deviceConfig {
 	for _, o := range opts {
 		o(&cfg)
 	}
-	if cfg.timeout <= 0 {
+	// Non-positive AND oversized values both fall back to the default: the
+	// same normalize-at-entry discipline as the other SDKs' timeout ceilings.
+	if cfg.timeout <= 0 || cfg.timeout > maxDeviceRequestTimeout {
 		cfg.timeout = defaultDeviceRequestTimeout
 	}
 	// Suppress redirects on every device-flow POST so a 3xx surfaces as a non-2xx
@@ -539,9 +548,9 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 	}
 
 	// Exactly HTTP 200, not any 2xx: RFC 8628/6749 token responses are 200, and
-	// SPEC §16 pins the contract. A nonstandard 201/202 carrying an access_token
-	// must not prematurely complete polling — it falls through to the OAuth-error
-	// parse below and terminates as api_error (http_<status>).
+	// SPEC §16 pins the contract. A nonstandard 201/202 never reaches here — the
+	// status-first gate above already terminated every non-200/non-4xx as
+	// api_error (http_<status>) without reading its body.
 	if resp.StatusCode == http.StatusOK {
 		// expires_in decodes via *float64, not Token's plain int: a pointer keeps
 		// an explicit "expires_in":0 distinguishable from an omitted field (a

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -659,6 +659,15 @@ func PerformDeviceLogin(ctx context.Context, config *Config, clientID string, di
 		return nil, err
 	}
 
+	// Re-check cancellation before surfacing the code: a ctx cancelled after
+	// the request completed (or under an injected RoundTripper that ignores
+	// request cancellation) must never reach the display hook — matching the
+	// Py/Rb/TS orchestrators' post-request re-check. The in-flight case is
+	// covered by the request's own context threading.
+	if err := ctx.Err(); err != nil {
+		return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: err}
+	}
+
 	// Anchor the code's lifetime at issuance so a slow display hook cannot yield a
 	// fresh full polling window.
 	deadline := cfg.clock().Add(time.Duration(auth.ExpiresIn) * time.Second)

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -524,7 +524,11 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 		}
 	}
 
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+	// Exactly HTTP 200, not any 2xx: RFC 8628/6749 token responses are 200, and
+	// SPEC §16 pins the contract. A nonstandard 201/202 carrying an access_token
+	// must not prematurely complete polling — it falls through to the OAuth-error
+	// parse below and terminates as api_error (http_<status>).
+	if resp.StatusCode == http.StatusOK {
 		// expires_in decodes via *float64, not Token's plain int: a pointer keeps
 		// an explicit "expires_in":0 distinguishable from an omitted field (a
 		// plain int makes 0 look absent and skip validation), and float64 accepts

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -716,6 +716,13 @@ func PerformDeviceLogin(ctx context.Context, config *Config, clientID string, di
 
 	cfg := newDeviceConfig(opts)
 
+	// The code's lifetime starts at SERVER issuance, which precedes the
+	// response: anchor conservatively BEFORE the request goes out, so a slow
+	// authorization response (or one delayed in transit) eats into the
+	// deadline instead of granting the code a fresh full lifetime. The anchor
+	// can only SHORTEN the usable window, never extend it.
+	issuedAt := cfg.clock()
+
 	auth, err := RequestDeviceAuthorization(ctx, *config.DeviceAuthorizationEndpoint, clientID, opts...)
 	if err != nil {
 		return nil, err
@@ -730,9 +737,10 @@ func PerformDeviceLogin(ctx context.Context, config *Config, clientID string, di
 		return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: err}
 	}
 
-	// Anchor the code's lifetime at issuance so a slow display hook cannot yield a
-	// fresh full polling window.
-	deadline := cfg.clock().Add(time.Duration(auth.ExpiresIn) * time.Second)
+	// Derive the deadline from the pre-request anchor so neither a slow
+	// authorization response nor a slow display hook can yield a fresh full
+	// polling window.
+	deadline := issuedAt.Add(time.Duration(auth.ExpiresIn) * time.Second)
 
 	display(*auth)
 

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -289,19 +289,21 @@ func RequestDeviceAuthorization(ctx context.Context, deviceAuthEndpoint, clientI
 		return nil, &DeviceFlowError{Reason: DeviceFlowTransport, Err: fmt.Errorf("reading device authorization response: %w", err)}
 	}
 
+	// Re-check cancellation the moment the body is in hand, BEFORE parsing:
+	// a context-ignoring RoundTripper whose Body.Read cancels the parent while
+	// yielding malformed JSON would otherwise classify as api_error first —
+	// cancellation wins over every completed outcome (same contract as the
+	// token poll). This also covers the valid-response-after-cancel case for
+	// direct callers.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: ctxErr}
+	}
+
 	var raw rawDeviceAuthorization
 	if err := json.Unmarshal(body, &raw); err != nil {
 		// Carry the HTTP status like the sibling non-2xx raise above (and Python)
 		// so a failed 2xx-body parse still reports which response it came from.
 		return nil, &basecamp.Error{Code: basecamp.CodeAPI, Message: "failed to parse device authorization response", HTTPStatus: resp.StatusCode, Cause: err}
-	}
-	// A custom RoundTripper that ignores the request context can complete a
-	// valid response after the caller cancelled: re-check the parent context
-	// before handing back a usable device code, exactly as the token poll's
-	// success branch does. PerformDeviceLogin re-checks later, but that does
-	// not protect direct callers.
-	if ctxErr := ctx.Err(); ctxErr != nil {
-		return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: ctxErr}
 	}
 	return validateDeviceAuthorization(raw, resp.StatusCode)
 }

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -571,7 +571,11 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 					err: fmt.Errorf("device token response expires_in must be a positive whole number of seconds no greater than %d", maxTokenLifetimeSeconds)}
 			}
 			token.ExpiresIn = int(v)
-			token.ExpiresAt = cfg.clock().Add(time.Duration(token.ExpiresIn) * time.Second)
+			// Wall time, NOT cfg.clock(): the injected clock is a monotonic
+			// polling-deadline seam (tests feed it artificial instants), while
+			// ExpiresAt is a public wall-clock field consumed outside the poll
+			// loop — matching exchange.go's time.Now() anchoring.
+			token.ExpiresAt = time.Now().Add(time.Duration(token.ExpiresIn) * time.Second)
 		}
 		return pollResult{kind: pollToken, token: &token}
 	}

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -716,13 +716,6 @@ func PerformDeviceLogin(ctx context.Context, config *Config, clientID string, di
 
 	cfg := newDeviceConfig(opts)
 
-	// The code's lifetime starts at SERVER issuance, which precedes the
-	// response: anchor conservatively BEFORE the request goes out, so a slow
-	// authorization response (or one delayed in transit) eats into the
-	// deadline instead of granting the code a fresh full lifetime. The anchor
-	// can only SHORTEN the usable window, never extend it.
-	issuedAt := cfg.clock()
-
 	auth, err := RequestDeviceAuthorization(ctx, *config.DeviceAuthorizationEndpoint, clientID, opts...)
 	if err != nil {
 		return nil, err
@@ -737,10 +730,11 @@ func PerformDeviceLogin(ctx context.Context, config *Config, clientID string, di
 		return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: err}
 	}
 
-	// Derive the deadline from the pre-request anchor so neither a slow
-	// authorization response nor a slow display hook can yield a fresh full
-	// polling window.
-	deadline := issuedAt.Add(time.Duration(auth.ExpiresIn) * time.Second)
+	// Anchor the code's lifetime at ISSUANCE — the response's arrival, per
+	// SPEC §16 — before the display hook, so a slow display eats into the
+	// deadline instead of resetting it. Expiry past this point is arbitrated
+	// by the server (expired_token), so receipt-anchoring fails safe.
+	deadline := cfg.clock().Add(time.Duration(auth.ExpiresIn) * time.Second)
 
 	display(*auth)
 

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -678,6 +678,14 @@ func PerformDeviceLogin(ctx context.Context, config *Config, clientID string, di
 		return nil, &DeviceFlowError{Reason: DeviceFlowUnavailable}
 	}
 
+	// A nil display is a usage error, not a skippable step: it is the ONLY
+	// mechanism that surfaces the verification URI and user code, so skipping
+	// it would mint a code nobody can approve and poll until it expires.
+	// Reject before any request is issued.
+	if display == nil {
+		return nil, &basecamp.Error{Code: basecamp.CodeUsage, Message: "PerformDeviceLogin: display callback is required"}
+	}
+
 	cfg := newDeviceConfig(opts)
 
 	auth, err := RequestDeviceAuthorization(ctx, *config.DeviceAuthorizationEndpoint, clientID, opts...)

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -620,7 +620,14 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 			Error string `json:"error"`
 		}
 		if json.Unmarshal(body, &errResp) == nil && errResp.Error != "" {
+			// Truncate at extraction (SPEC §9's 500-unit message cap): the
+			// server controls this string and an unrecognized value is
+			// interpolated into the api_error message. Real protocol codes are
+			// short, so classification is unaffected.
 			oauthError = errResp.Error
+			if len(oauthError) > maxErrorMessageLen {
+				oauthError = oauthError[:maxErrorMessageLen-3] + "..."
+			}
 		}
 	}
 	return pollResult{kind: pollOAuthError, oauthError: oauthError, status: resp.StatusCode}

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -309,6 +309,11 @@ func RequestDeviceAuthorization(ctx context.Context, deviceAuthEndpoint, clientI
 
 	var raw rawDeviceAuthorization
 	if err := json.Unmarshal(body, &raw); err != nil {
+		// Cancellation wins even over a malformed body: another goroutine can
+		// cancel while Unmarshal chews a large invalid payload.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: ctxErr}
+		}
 		// Carry the HTTP status like the sibling non-2xx raise above (and Python)
 		// so a failed 2xx-body parse still reports which response it came from.
 		return nil, &basecamp.Error{Code: basecamp.CodeAPI, Message: "failed to parse device authorization response", HTTPStatus: resp.StatusCode, Cause: err}

--- a/go/pkg/basecamp/oauth/device_errors.go
+++ b/go/pkg/basecamp/oauth/device_errors.go
@@ -1,0 +1,96 @@
+package oauth
+
+import (
+	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
+)
+
+// DeviceFlowReason identifies why a device flow terminated. The parent
+// basecamp.Error category is DERIVED from the reason (SPEC.md §16), so callers
+// can branch on the precise reason or on the coarse taxonomy code.
+type DeviceFlowReason string
+
+const (
+	// DeviceFlowAccessDenied — the user declined the authorization → auth.
+	DeviceFlowAccessDenied DeviceFlowReason = "access_denied"
+	// DeviceFlowExpired — the device/user code expired before approval → auth.
+	DeviceFlowExpired DeviceFlowReason = "expired"
+	// DeviceFlowTransport — a network failure ended the flow → network (retryable).
+	DeviceFlowTransport DeviceFlowReason = "transport"
+	// DeviceFlowUnavailable — the selected AS cannot do device flow → validation.
+	DeviceFlowUnavailable DeviceFlowReason = "unavailable"
+	// DeviceFlowCancelled — the caller cancelled the flow → native ctx.Err (usage
+	// taxonomy code).
+	DeviceFlowCancelled DeviceFlowReason = "cancelled"
+)
+
+// DeviceFlowError is a terminal device-flow error carrying a DeviceFlowReason.
+// Its parent taxonomy category is derived from the reason; for a cancelled flow
+// the underlying ctx error (Err) is exposed so errors.Is against
+// context.Canceled / context.DeadlineExceeded matches natively.
+type DeviceFlowError struct {
+	// Reason identifies the termination class.
+	Reason DeviceFlowReason
+	// Err is the underlying cause, if any (for cancelled: ctx.Err()).
+	Err error
+}
+
+// Error implements the error interface. The message is derived from the reason.
+func (e *DeviceFlowError) Error() string {
+	msg := messageForReason(e.Reason)
+	if e.Err != nil {
+		return msg + ": " + e.Err.Error()
+	}
+	return msg
+}
+
+// Unwrap exposes the derived taxonomy-coded *basecamp.Error (and, through it,
+// the underlying cause) for errors.Is / errors.As traversal. Matching a
+// *basecamp.Error yields the parent category; matching context.Canceled reaches
+// the cancellation cause.
+func (e *DeviceFlowError) Unwrap() error {
+	return e.category()
+}
+
+// Code returns the parent basecamp taxonomy code derived from the reason.
+func (e *DeviceFlowError) Code() string {
+	return e.category().Code
+}
+
+// Retryable reports whether the failure is retryable (transport only).
+func (e *DeviceFlowError) Retryable() bool {
+	return e.category().Retryable
+}
+
+// category maps the reason to its parent taxonomy-coded *basecamp.Error, carrying
+// the cause so downstream Unwrap traversal reaches it.
+func (e *DeviceFlowError) category() *basecamp.Error {
+	switch e.Reason {
+	case DeviceFlowAccessDenied, DeviceFlowExpired:
+		return &basecamp.Error{Code: basecamp.CodeAuth, Message: e.Error(), Cause: e.Err}
+	case DeviceFlowTransport:
+		return &basecamp.Error{Code: basecamp.CodeNetwork, Message: e.Error(), Retryable: true, Cause: e.Err}
+	case DeviceFlowUnavailable:
+		return &basecamp.Error{Code: basecamp.CodeValidation, Message: e.Error(), Cause: e.Err}
+	case DeviceFlowCancelled:
+		return &basecamp.Error{Code: basecamp.CodeUsage, Message: e.Error(), Cause: e.Err}
+	default:
+		return &basecamp.Error{Code: basecamp.CodeAPI, Message: e.Error(), Cause: e.Err}
+	}
+}
+
+func messageForReason(reason DeviceFlowReason) string {
+	switch reason {
+	case DeviceFlowAccessDenied:
+		return "the authorization request was denied"
+	case DeviceFlowExpired:
+		return "device code expired before authorization completed"
+	case DeviceFlowTransport:
+		return "device flow transport failure"
+	case DeviceFlowUnavailable:
+		return "the selected authorization server does not support the device authorization grant"
+	case DeviceFlowCancelled:
+		return "device flow cancelled"
+	default:
+		return "device flow failed"
+	}
+}

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -191,6 +191,26 @@ func TestRequestDeviceAuthorization_RejectsMissingField(t *testing.T) {
 	assertBasecampCode(t, err, basecamp.CodeAPI)
 }
 
+func TestRequestDeviceAuthorization_ParseFailureCarriesHTTPStatus(t *testing.T) {
+	// A 2xx body that is not valid JSON fails as api_error AND carries the HTTP
+	// status (like the non-2xx raise and Python), so callers keep the status.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	_, err := RequestDeviceAuthorization(context.Background(), srv.URL, "basecamp-cli",
+		WithDeviceHTTPClient(tlsClient(srv)))
+	var be *basecamp.Error
+	if !errors.As(err, &be) || be.Code != basecamp.CodeAPI {
+		t.Fatalf("want api_error, got %v (%T)", err, err)
+	}
+	if be.HTTPStatus != http.StatusOK {
+		t.Errorf("HTTPStatus = %d, want %d", be.HTTPStatus, http.StatusOK)
+	}
+}
+
 func TestRequestDeviceAuthorization_AcceptsIntegerValuedFloatDurations(t *testing.T) {
 	// A server sending 900.0 / 10.0 (integer-valued floats): *int decoding would
 	// reject these, but the cross-SDK contract accepts whole-second floats.

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -116,6 +116,29 @@ func TestRequestDeviceAuthorization_OmitsScopeAndValidates(t *testing.T) {
 	}
 }
 
+func TestRequestDeviceAuthorization_CallerCancellationIsCancelled(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(deviceAuthBody)
+	}))
+	defer srv.Close()
+
+	// A context already cancelled before the request: Do returns context.Canceled
+	// without contacting the server, so the outcome must be DeviceFlowCancelled —
+	// never a retryable transport failure (the SDK's own timeout stays transport).
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := RequestDeviceAuthorization(ctx, srv.URL, "basecamp-cli", WithDeviceHTTPClient(tlsClient(srv)))
+	var dfErr *DeviceFlowError
+	if !errors.As(err, &dfErr) {
+		t.Fatalf("expected *DeviceFlowError, got %T: %v", err, err)
+	}
+	if dfErr.Reason != DeviceFlowCancelled {
+		t.Errorf("Reason = %v, want DeviceFlowCancelled", dfErr.Reason)
+	}
+}
+
 func TestRequestDeviceAuthorization_SendsScopeWhenSet(t *testing.T) {
 	var sentScope string
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -1324,7 +1324,7 @@ func (t cancelOnReadTransport) RoundTrip(req *http.Request) (*http.Response, err
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": {"application/json"}},
-		Body:       cancelOnReadBody{cancel: t.cancel},
+		Body:       cancelOnReadBody(t),
 		Request:    req,
 	}, nil
 }

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -506,6 +506,71 @@ func TestPollDeviceToken_MalformedSuccessResponseIsAPIError(t *testing.T) {
 	}
 }
 
+// rawTokenServer serves a fixed raw 200 token-endpoint body, for cases a Go map
+// cannot express (a JSON literal like 1e400 that json.Marshal rejects).
+func rawTokenServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestPollDeviceToken_RejectsMalformedTokenExpiresIn(t *testing.T) {
+	// A 2xx whose expires_in cannot be a schedulable lifetime is a server/api
+	// fault, never a token: 1e400/string/bool fail json.Unmarshal into int;
+	// a negative or past-ceiling integer would overflow ExpiresAt arithmetic.
+	for _, body := range []string{
+		`{"access_token":"a","token_type":"Bearer","expires_in":1e400}`,
+		`{"access_token":"a","token_type":"Bearer","expires_in":"3600"}`,
+		`{"access_token":"a","token_type":"Bearer","expires_in":true}`,
+		`{"access_token":"a","token_type":"Bearer","expires_in":-1}`,
+		`{"access_token":"a","token_type":"Bearer","expires_in":2147483648}`,
+	} {
+		srv := rawTokenServer(t, body)
+		sleep := &recordingSleep{}
+		_, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+			WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+		assertBasecampCode(t, err, basecamp.CodeAPI)
+	}
+}
+
+func TestPollDeviceToken_AcceptsMaxTokenLifetime(t *testing.T) {
+	// The 2147483647 s ceiling itself is valid — the bound is inclusive.
+	srv := rawTokenServer(t, `{"access_token":"device_access_token","token_type":"Bearer","expires_in":2147483647}`)
+	sleep := &recordingSleep{}
+	token, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token.ExpiresIn != maxTokenLifetimeSeconds {
+		t.Errorf("ExpiresIn = %d, want %d", token.ExpiresIn, maxTokenLifetimeSeconds)
+	}
+	if token.ExpiresAt.IsZero() {
+		t.Error("ExpiresAt should be set for a positive expires_in")
+	}
+}
+
+func TestPollDeviceToken_AcceptsTokenWithoutExpiresIn(t *testing.T) {
+	// Absent expires_in (RFC 6749 §5.1) is allowed — the token carries no expiry.
+	srv := rawTokenServer(t, `{"access_token":"device_access_token","token_type":"Bearer"}`)
+	sleep := &recordingSleep{}
+	token, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token.ExpiresIn != 0 {
+		t.Errorf("ExpiresIn = %d, want 0 (absent)", token.ExpiresIn)
+	}
+	if !token.ExpiresAt.IsZero() {
+		t.Error("ExpiresAt should be zero when expires_in is absent")
+	}
+}
+
 func TestPollDeviceToken_CancelledViaContext(t *testing.T) {
 	srv, _ := queueTokenResponses(t, []struct {
 		status int

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -590,6 +590,32 @@ func TestPollDeviceToken_AcceptsIntegerValuedFloatExpiresIn(t *testing.T) {
 	}
 }
 
+func TestPollDeviceToken_RejectsExplicitEmptyTokenType(t *testing.T) {
+	// An explicit "token_type":"" is malformed token metadata (api_error),
+	// distinct from an absent field — the old plain-string decode coerced both
+	// to Bearer. Uniform with Python/Ruby/TS/Kotlin.
+	srv := rawTokenServer(t, `{"access_token":"device_access_token","token_type":"","expires_in":3600}`)
+	sleep := &recordingSleep{}
+	_, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+	assertBasecampCode(t, err, basecamp.CodeAPI)
+}
+
+func TestPollDeviceToken_DefaultsAbsentTokenTypeToBearer(t *testing.T) {
+	// Absent token_type defaults to Bearer — only an explicit empty string is
+	// rejected.
+	srv := rawTokenServer(t, `{"access_token":"device_access_token","expires_in":3600}`)
+	sleep := &recordingSleep{}
+	token, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token.TokenType != "Bearer" {
+		t.Errorf("TokenType = %q, want Bearer", token.TokenType)
+	}
+}
+
 func TestPollDeviceToken_AcceptsTokenWithoutExpiresIn(t *testing.T) {
 	// Absent expires_in (RFC 6749 §5.1) is allowed — the token carries no expiry.
 	srv := rawTokenServer(t, `{"access_token":"device_access_token","token_type":"Bearer"}`)
@@ -1037,9 +1063,10 @@ func TestPerformDeviceLogin_ChargesDisplayTimeAgainstPollDeadline(t *testing.T) 
 	}
 
 	// Clock reads, in order: (1) issuance anchor, (2) remaining after display,
-	// (3) poll deadline anchor, (4) wait clamp, (5) deadline check. The display
-	// burns 99 of the 100s window, then the final read crosses the deadline.
-	offsets := []int{0, 99, 99, 99, 100}
+	// (3) wait clamp, (4) post-sleep deadline check. The poll loop inherits the
+	// exact issuance-anchored deadline (no re-anchor read). The display burns 99
+	// of the 100s window, then the final read crosses the deadline.
+	offsets := []int{0, 99, 99, 100}
 	idx := 0
 	clock := func() time.Time {
 		s := offsets[min(idx, len(offsets)-1)]
@@ -1063,6 +1090,64 @@ func TestPerformDeviceLogin_ChargesDisplayTimeAgainstPollDeadline(t *testing.T) 
 	if polled {
 		t.Error("must not poll: display time should have exhausted the remaining lifetime")
 	}
+}
+
+func TestPerformDeviceLogin_ExactDeadlineNoWholeSecondRounding(t *testing.T) {
+	// A sub-second remainder after display must NOT round up to a whole extra
+	// second nor re-anchor at a later clock read: the poll loop inherits the
+	// EXACT issuance-anchored deadline, so the clamped 500ms wait lands on
+	// expiry and the endpoint is never polled. The pre-fix behavior (remaining
+	// rounded up to 1s, then a fresh deadline anchored inside PollDeviceToken)
+	// would have left a full-second window and polled once.
+	polled := false
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/device" {
+			body := map[string]any{}
+			for k, v := range deviceAuthBody {
+				body[k] = v
+			}
+			body["expires_in"] = 100
+			_ = json.NewEncoder(w).Encode(body)
+			return
+		}
+		polled = true
+		_ = json.NewEncoder(w).Encode(tokenBody)
+	}))
+	defer srv.Close()
+
+	endpoint := srv.URL + "/device"
+	config := &Config{
+		Issuer:                      srv.URL,
+		TokenEndpoint:               srv.URL + "/token",
+		DeviceAuthorizationEndpoint: &endpoint,
+		GrantTypesSupported:         []string{DeviceCodeGrantType, "refresh_token"},
+	}
+
+	// Clock reads: (1) issuance anchor (deadline = 100s), (2) remaining after a
+	// display that burned 99.5s, (3) wait clamp (500ms left), (4) post-sleep
+	// deadline check exactly at expiry.
+	offsetsMs := []int64{0, 99_500, 99_500, 100_000}
+	idx := 0
+	clock := func() time.Time {
+		ms := offsetsMs[min(idx, len(offsetsMs)-1)]
+		idx++
+		return time.UnixMilli(ms)
+	}
+	sleep := &recordingSleep{}
+
+	_, err := PerformDeviceLogin(context.Background(), config, "basecamp-cli",
+		func(DeviceAuthorization) {},
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceClock(clock), WithDeviceSleep(sleep.fn))
+
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) || dfe.Reason != DeviceFlowExpired {
+		t.Fatalf("want DeviceFlowError(expired) at the exact issuance deadline, got %v", err)
+	}
+	if polled {
+		t.Error("must not poll: the sub-second remainder ends at the exact deadline")
+	}
+	assertWaits(t, sleep.waits, []time.Duration{500 * time.Millisecond})
 }
 
 // --- helpers ---

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -1,0 +1,1007 @@
+package oauth
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
+)
+
+// recordingSleep is an injectable sleep seam that records requested waits and
+// returns immediately, so tests exercise the interval schedule without delay.
+type recordingSleep struct {
+	waits []time.Duration
+	// before, when set, runs before each recorded wait (e.g. to cancel a ctx).
+	before func()
+}
+
+func (r *recordingSleep) fn(_ context.Context, d time.Duration) error {
+	if r.before != nil {
+		r.before()
+	}
+	r.waits = append(r.waits, d)
+	return nil
+}
+
+// queueTokenResponses serves a fixed sequence of token-endpoint responses, one
+// per poll (the last response repeats). It returns a pointer to the call count.
+func queueTokenResponses(t *testing.T, responses []struct {
+	status int
+	body   map[string]any
+}) (*httptest.Server, *int) {
+	t.Helper()
+	calls := 0
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		i := calls
+		if i >= len(responses) {
+			i = len(responses) - 1
+		}
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(responses[i].status)
+		_ = json.NewEncoder(w).Encode(responses[i].body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &calls
+}
+
+// tlsClient returns an HTTP client that trusts the given test TLS server.
+func tlsClient(srv *httptest.Server) *http.Client {
+	return srv.Client()
+}
+
+const testDeviceCode = "dev-code-123"
+
+var deviceAuthBody = map[string]any{
+	"device_code":               testDeviceCode,
+	"user_code":                 "WDJB-MJHT",
+	"verification_uri":          "https://issuer.example/device",
+	"verification_uri_complete": "https://issuer.example/device?user_code=WDJB-MJHT",
+	"expires_in":                900,
+	"interval":                  5,
+}
+
+var tokenBody = map[string]any{
+	"access_token":  "device_access_token",
+	"refresh_token": "device_refresh_token",
+	"token_type":    "Bearer",
+	"expires_in":    3600,
+}
+
+func TestRequestDeviceAuthorization_OmitsScopeAndValidates(t *testing.T) {
+	var sentScope string
+	var scopePresent bool
+	var sentClientID string
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		sentScope = r.PostForm.Get("scope")
+		_, scopePresent = r.PostForm["scope"]
+		sentClientID = r.PostForm.Get("client_id")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(deviceAuthBody)
+	}))
+	defer srv.Close()
+
+	auth, err := RequestDeviceAuthorization(context.Background(), srv.URL, "basecamp-cli",
+		WithDeviceHTTPClient(tlsClient(srv)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if scopePresent {
+		t.Errorf("scope should be omitted when unset, got %q", sentScope)
+	}
+	if sentClientID != "basecamp-cli" {
+		t.Errorf("client_id = %q, want basecamp-cli", sentClientID)
+	}
+	if auth.DeviceCode != testDeviceCode {
+		t.Errorf("DeviceCode = %q", auth.DeviceCode)
+	}
+	if auth.UserCode != "WDJB-MJHT" {
+		t.Errorf("UserCode = %q", auth.UserCode)
+	}
+	if auth.Interval != 5 {
+		t.Errorf("Interval = %d, want 5", auth.Interval)
+	}
+}
+
+func TestRequestDeviceAuthorization_SendsScopeWhenSet(t *testing.T) {
+	var sentScope string
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		sentScope = r.PostForm.Get("scope")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(deviceAuthBody)
+	}))
+	defer srv.Close()
+
+	_, err := RequestDeviceAuthorization(context.Background(), srv.URL, "basecamp-cli",
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceScope("read write"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sentScope != "read write" {
+		t.Errorf("scope = %q, want %q", sentScope, "read write")
+	}
+}
+
+func TestRequestDeviceAuthorization_DefaultsIntervalTo5(t *testing.T) {
+	body := map[string]any{}
+	for k, v := range deviceAuthBody {
+		body[k] = v
+	}
+	delete(body, "interval")
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	defer srv.Close()
+
+	auth, err := RequestDeviceAuthorization(context.Background(), srv.URL, "basecamp-cli",
+		WithDeviceHTTPClient(tlsClient(srv)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if auth.Interval != 5 {
+		t.Errorf("Interval = %d, want 5 (default)", auth.Interval)
+	}
+}
+
+func TestRequestDeviceAuthorization_RejectsNonPositiveExpiresIn(t *testing.T) {
+	body := map[string]any{}
+	for k, v := range deviceAuthBody {
+		body[k] = v
+	}
+	body["expires_in"] = 0
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	defer srv.Close()
+
+	_, err := RequestDeviceAuthorization(context.Background(), srv.URL, "basecamp-cli",
+		WithDeviceHTTPClient(tlsClient(srv)))
+	assertBasecampCode(t, err, basecamp.CodeAPI)
+}
+
+func TestRequestDeviceAuthorization_RejectsMissingField(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"user_code":        "X",
+			"verification_uri": "https://issuer.example",
+			"expires_in":       900,
+		})
+	}))
+	defer srv.Close()
+
+	_, err := RequestDeviceAuthorization(context.Background(), srv.URL, "basecamp-cli",
+		WithDeviceHTTPClient(tlsClient(srv)))
+	assertBasecampCode(t, err, basecamp.CodeAPI)
+}
+
+func TestRequestDeviceAuthorization_AcceptsIntegerValuedFloatDurations(t *testing.T) {
+	// A server sending 900.0 / 10.0 (integer-valued floats): *int decoding would
+	// reject these, but the cross-SDK contract accepts whole-second floats.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"device_code":"d","user_code":"u","verification_uri":"https://issuer.example/device","expires_in":900.0,"interval":10.0}`))
+	}))
+	defer srv.Close()
+
+	auth, err := RequestDeviceAuthorization(context.Background(), srv.URL, "basecamp-cli",
+		WithDeviceHTTPClient(tlsClient(srv)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if auth.ExpiresIn != 900 || auth.Interval != 10 {
+		t.Errorf("ExpiresIn=%d Interval=%d, want 900/10", auth.ExpiresIn, auth.Interval)
+	}
+}
+
+func TestRequestDeviceAuthorization_RejectsFractionalDurations(t *testing.T) {
+	for _, body := range []string{
+		`{"device_code":"d","user_code":"u","verification_uri":"https://issuer.example/device","expires_in":0.5}`,
+		`{"device_code":"d","user_code":"u","verification_uri":"https://issuer.example/device","expires_in":900,"interval":2.5}`,
+	} {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(body))
+		}))
+		_, err := RequestDeviceAuthorization(context.Background(), srv.URL, "basecamp-cli",
+			WithDeviceHTTPClient(tlsClient(srv)))
+		assertBasecampCode(t, err, basecamp.CodeAPI)
+		srv.Close()
+	}
+}
+
+func TestRequestDeviceAuthorization_RejectsOversizedDurations(t *testing.T) {
+	// 1e100 is integer-valued, so whole-second checking alone would admit it —
+	// and its int conversion is implementation-defined. The shared cross-SDK
+	// ceiling (2147483 s) rejects it, and the first value past the boundary,
+	// as api_error before any deadline arithmetic.
+	for _, body := range []string{
+		`{"device_code":"d","user_code":"u","verification_uri":"https://issuer.example/device","expires_in":1e100}`,
+		`{"device_code":"d","user_code":"u","verification_uri":"https://issuer.example/device","expires_in":900,"interval":1e100}`,
+		`{"device_code":"d","user_code":"u","verification_uri":"https://issuer.example/device","expires_in":2147484}`,
+	} {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(body))
+		}))
+		_, err := RequestDeviceAuthorization(context.Background(), srv.URL, "basecamp-cli",
+			WithDeviceHTTPClient(tlsClient(srv)))
+		assertBasecampCode(t, err, basecamp.CodeAPI)
+		srv.Close()
+	}
+}
+
+func TestRequestDeviceAuthorization_AcceptsMaxDuration(t *testing.T) {
+	// The 2147483 s ceiling itself is valid — the bound is inclusive.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"device_code":"d","user_code":"u","verification_uri":"https://issuer.example/device","expires_in":2147483,"interval":2147483}`))
+	}))
+	defer srv.Close()
+
+	auth, err := RequestDeviceAuthorization(context.Background(), srv.URL, "basecamp-cli",
+		WithDeviceHTTPClient(tlsClient(srv)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if auth.ExpiresIn != maxDeviceSeconds || auth.Interval != maxDeviceSeconds {
+		t.Errorf("ExpiresIn=%d Interval=%d, want %d/%d", auth.ExpiresIn, auth.Interval, maxDeviceSeconds, maxDeviceSeconds)
+	}
+}
+
+func TestRequestDeviceAuthorization_RejectsInsecureEndpoint(t *testing.T) {
+	_, err := RequestDeviceAuthorization(context.Background(), "http://insecure.example/device", "basecamp-cli")
+	assertBasecampCode(t, err, basecamp.CodeUsage)
+}
+
+func TestRequestDeviceAuthorization_RequiresClientID(t *testing.T) {
+	_, err := RequestDeviceAuthorization(context.Background(), "https://issuer.example/device", "")
+	assertBasecampCode(t, err, basecamp.CodeValidation)
+}
+
+func TestPollDeviceToken_PendingSlowDownToken(t *testing.T) {
+	srv, _ := queueTokenResponses(t, []struct {
+		status int
+		body   map[string]any
+	}{
+		{http.StatusBadRequest, map[string]any{"error": "authorization_pending"}},
+		{http.StatusBadRequest, map[string]any{"error": "slow_down"}},
+		{http.StatusBadRequest, map[string]any{"error": "authorization_pending"}},
+		{http.StatusOK, tokenBody},
+	})
+	sleep := &recordingSleep{}
+
+	token, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token.AccessToken != "device_access_token" {
+		t.Errorf("AccessToken = %q", token.AccessToken)
+	}
+	// Waits: 5s (pending), 5s (before slow_down), then +5 sustained → 10s, 10s.
+	want := []time.Duration{5 * time.Second, 5 * time.Second, 10 * time.Second, 10 * time.Second}
+	assertWaits(t, sleep.waits, want)
+}
+
+func TestPollDeviceToken_DoublesIntervalAfterTimeout(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tokenBody)
+	}))
+	defer srv.Close()
+	sleep := &recordingSleep{}
+
+	// First attempt returns a network timeout; the rest hit the real server.
+	base := tlsClient(srv)
+	client := &http.Client{Transport: &timeoutOnceTransport{next: base.Transport}}
+
+	token, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(client), WithDeviceSleep(sleep.fn))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token.AccessToken != "device_access_token" {
+		t.Errorf("AccessToken = %q", token.AccessToken)
+	}
+	if len(sleep.waits) < 2 {
+		t.Fatalf("expected at least 2 waits, got %v", sleep.waits)
+	}
+	if sleep.waits[0] != 5*time.Second {
+		t.Errorf("waits[0] = %v, want 5s", sleep.waits[0])
+	}
+	if sleep.waits[1] != 10*time.Second {
+		t.Errorf("waits[1] = %v, want 10s (doubled after timeout)", sleep.waits[1])
+	}
+}
+
+func TestPollDeviceToken_ExpiresAgainstInjectedClock(t *testing.T) {
+	srv, calls := queueTokenResponses(t, []struct {
+		status int
+		body   map[string]any
+	}{
+		{http.StatusBadRequest, map[string]any{"error": "authorization_pending"}},
+	})
+	sleep := &recordingSleep{}
+
+	// Clock: base at t0, then jumps past the 900s deadline on the first check.
+	times := []time.Time{
+		time.Unix(0, 0),
+		time.Unix(1_000_000, 0),
+	}
+	idx := 0
+	clock := func() time.Time {
+		t := times[min(idx, len(times)-1)]
+		idx++
+		return t
+	}
+
+	_, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn), WithDeviceClock(clock))
+
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) {
+		t.Fatalf("want *DeviceFlowError, got %v", err)
+	}
+	if dfe.Reason != DeviceFlowExpired {
+		t.Errorf("Reason = %q, want expired", dfe.Reason)
+	}
+	if dfe.Code() != basecamp.CodeAuth {
+		t.Errorf("Code = %q, want auth_required", dfe.Code())
+	}
+	if *calls != 0 {
+		t.Errorf("expected no polls after expiry, got %d", *calls)
+	}
+}
+
+func TestPollDeviceToken_AccessDenied(t *testing.T) {
+	srv, _ := queueTokenResponses(t, []struct {
+		status int
+		body   map[string]any
+	}{
+		{http.StatusBadRequest, map[string]any{"error": "access_denied"}},
+	})
+	sleep := &recordingSleep{}
+
+	_, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) {
+		t.Fatalf("want *DeviceFlowError, got %v", err)
+	}
+	if dfe.Reason != DeviceFlowAccessDenied {
+		t.Errorf("Reason = %q, want access_denied", dfe.Reason)
+	}
+	if dfe.Code() != basecamp.CodeAuth {
+		t.Errorf("Code = %q, want auth_required", dfe.Code())
+	}
+}
+
+func TestPollDeviceToken_ExpiredTokenError(t *testing.T) {
+	srv, _ := queueTokenResponses(t, []struct {
+		status int
+		body   map[string]any
+	}{
+		{http.StatusBadRequest, map[string]any{"error": "expired_token"}},
+	})
+	sleep := &recordingSleep{}
+
+	_, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) || dfe.Reason != DeviceFlowExpired {
+		t.Fatalf("want DeviceFlowError(expired), got %v", err)
+	}
+}
+
+func TestPollDeviceToken_TransportRetryable(t *testing.T) {
+	// A server that resets the connection produces a non-timeout transport error.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err == nil {
+			_ = conn.Close()
+		}
+	}))
+	defer srv.Close()
+	sleep := &recordingSleep{}
+
+	_, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) {
+		t.Fatalf("want *DeviceFlowError, got %v", err)
+	}
+	if dfe.Reason != DeviceFlowTransport {
+		t.Errorf("Reason = %q, want transport", dfe.Reason)
+	}
+	if dfe.Code() != basecamp.CodeNetwork {
+		t.Errorf("Code = %q, want network", dfe.Code())
+	}
+	if !dfe.Retryable() {
+		t.Error("transport error should be retryable")
+	}
+}
+
+func TestPollDeviceToken_MalformedSuccessResponseIsAPIError(t *testing.T) {
+	// A 2xx whose body is missing access_token is a server/api fault (api_error),
+	// NOT a retryable transport error.
+	srv, _ := queueTokenResponses(t, []struct {
+		status int
+		body   map[string]any
+	}{
+		{http.StatusOK, map[string]any{"token_type": "Bearer"}}, // no access_token
+	})
+	sleep := &recordingSleep{}
+
+	_, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+
+	var dfe *DeviceFlowError
+	if errors.As(err, &dfe) {
+		t.Fatalf("want a plain api_error, got DeviceFlowError(%q)", dfe.Reason)
+	}
+	var be *basecamp.Error
+	if !errors.As(err, &be) || be.Code != basecamp.CodeAPI {
+		t.Fatalf("want api_error, got %v (%T)", err, err)
+	}
+	if be.Retryable {
+		t.Error("a malformed token response must not be retryable")
+	}
+}
+
+func TestPollDeviceToken_CancelledViaContext(t *testing.T) {
+	srv, _ := queueTokenResponses(t, []struct {
+		status int
+		body   map[string]any
+	}{
+		{http.StatusBadRequest, map[string]any{"error": "authorization_pending"}},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel on the first sleep, before any poll.
+	sleep := &recordingSleep{before: cancel}
+
+	_, err := PollDeviceToken(ctx, srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) {
+		t.Fatalf("want *DeviceFlowError, got %v", err)
+	}
+	if dfe.Reason != DeviceFlowCancelled {
+		t.Errorf("Reason = %q, want cancelled", dfe.Reason)
+	}
+	if dfe.Code() != basecamp.CodeUsage {
+		t.Errorf("Code = %q, want usage", dfe.Code())
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Error("cancelled error should wrap context.Canceled")
+	}
+}
+
+func TestPerformDeviceLogin_GuardsCapability(t *testing.T) {
+	polled := false
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		polled = true
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tokenBody)
+	}))
+	defer srv.Close()
+
+	endpoint := srv.URL + "/device"
+	config := &Config{
+		Issuer:                      srv.URL,
+		TokenEndpoint:               srv.URL,
+		DeviceAuthorizationEndpoint: &endpoint,
+		GrantTypesSupported:         []string{"refresh_token"}, // no device_code grant
+	}
+
+	_, err := PerformDeviceLogin(context.Background(), config, "basecamp-cli", func(DeviceAuthorization) {},
+		WithDeviceHTTPClient(tlsClient(srv)))
+
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) {
+		t.Fatalf("want *DeviceFlowError, got %v", err)
+	}
+	if dfe.Reason != DeviceFlowUnavailable {
+		t.Errorf("Reason = %q, want unavailable", dfe.Reason)
+	}
+	if dfe.Code() != basecamp.CodeValidation {
+		t.Errorf("Code = %q, want validation", dfe.Code())
+	}
+	if polled {
+		t.Error("must not poll when capability guard fails")
+	}
+}
+
+func TestPerformDeviceLogin_FiresDisplayThenCompletes(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/device" {
+			_ = json.NewEncoder(w).Encode(deviceAuthBody)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(tokenBody)
+	}))
+	defer srv.Close()
+
+	endpoint := srv.URL + "/device"
+	config := &Config{
+		Issuer:                      srv.URL,
+		TokenEndpoint:               srv.URL + "/token",
+		DeviceAuthorizationEndpoint: &endpoint,
+		GrantTypesSupported:         []string{DeviceCodeGrantType, "refresh_token"},
+	}
+
+	var displayed *DeviceAuthorization
+	sleep := &recordingSleep{}
+
+	token, err := PerformDeviceLogin(context.Background(), config, "basecamp-cli",
+		func(a DeviceAuthorization) { displayed = &a },
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if displayed == nil {
+		t.Fatal("display hook was not called")
+	}
+	if displayed.UserCode != "WDJB-MJHT" {
+		t.Errorf("displayed UserCode = %q", displayed.UserCode)
+	}
+	if token.AccessToken != "device_access_token" {
+		t.Errorf("AccessToken = %q", token.AccessToken)
+	}
+}
+
+func TestPerformDeviceLogin_NilConfigUnavailable(t *testing.T) {
+	_, err := PerformDeviceLogin(context.Background(), nil, "basecamp-cli", func(DeviceAuthorization) {})
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) || dfe.Reason != DeviceFlowUnavailable {
+		t.Fatalf("want DeviceFlowError(unavailable), got %v", err)
+	}
+}
+
+func TestPollDeviceToken_TokenEndpointDoesNotFollowRedirect(t *testing.T) {
+	attackerHit := false
+	attacker := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attackerHit = true
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tokenBody) // if chased, would masquerade as success
+	}))
+	defer attacker.Close()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", attacker.URL)
+		w.WriteHeader(http.StatusFound) // 302 → attacker
+	}))
+	defer srv.Close()
+	sleep := &recordingSleep{}
+
+	_, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(twoServerClient(srv, attacker)), WithDeviceSleep(sleep.fn))
+
+	if attackerHit {
+		t.Fatal("redirect was followed — attacker host was contacted")
+	}
+	var dfe *DeviceFlowError
+	if errors.As(err, &dfe) {
+		t.Fatalf("want a plain api_error, got DeviceFlowError(%q)", dfe.Reason)
+	}
+	var be *basecamp.Error
+	if !errors.As(err, &be) || be.Code != basecamp.CodeAPI {
+		t.Fatalf("want api_error for the unfollowed 302, got %v (%T)", err, err)
+	}
+}
+
+func TestRequestDeviceAuthorization_DoesNotFollowRedirect(t *testing.T) {
+	attackerHit := false
+	attacker := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attackerHit = true
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(deviceAuthBody)
+	}))
+	defer attacker.Close()
+
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", attacker.URL)
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer srv.Close()
+
+	_, err := RequestDeviceAuthorization(context.Background(), srv.URL, "basecamp-cli",
+		WithDeviceHTTPClient(twoServerClient(srv, attacker)))
+
+	if attackerHit {
+		t.Fatal("redirect was followed — attacker host was contacted")
+	}
+	assertBasecampCode(t, err, basecamp.CodeAPI)
+}
+
+func TestPollDeviceToken_ClampsBackoffToDeadline(t *testing.T) {
+	// Every poll times out, so the connection-timeout backoff escalates
+	// (5→10→20→40→60). A clock that jumps close to the deadline must clamp each
+	// subsequent wait to the remaining time rather than the escalating backoff,
+	// and the flow must expire promptly instead of overshooting.
+	client := &http.Client{Transport: timeoutAlwaysTransport{}}
+	sleep := &recordingSleep{}
+
+	base := time.Unix(0, 0)
+	// Per iteration the loop reads the clock twice (remaining, then deadline
+	// check); offsets in seconds, last value repeats.
+	offsets := []int{0, 0, 0, 0, 0, 95, 95, 98, 98, 100}
+	i := 0
+	clock := func() time.Time {
+		s := offsets[min(i, len(offsets)-1)]
+		i++
+		return base.Add(time.Duration(s) * time.Second)
+	}
+
+	_, err := PollDeviceToken(context.Background(), "https://issuer.example/token", "basecamp-cli",
+		testDeviceCode, 5, 100,
+		WithDeviceHTTPClient(client), WithDeviceSleep(sleep.fn), WithDeviceClock(clock))
+
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) || dfe.Reason != DeviceFlowExpired {
+		t.Fatalf("want DeviceFlowError(expired), got %v", err)
+	}
+	if len(sleep.waits) < 4 {
+		t.Fatalf("expected the backoff to escalate over several polls, got waits %v", sleep.waits)
+	}
+	// Absent clamping, the third and fourth waits would be 20s and 40s. Clamped to
+	// the remaining time they must stay at or below the largest full-interval wait
+	// (10s) and never exceed the remaining window.
+	for idx, w := range sleep.waits {
+		if w > 10*time.Second {
+			t.Errorf("waits[%d] = %v exceeds the deadline-clamped bound (10s): %v", idx, w, sleep.waits)
+		}
+	}
+}
+
+func TestPollDeviceToken_ExpiredBeforeFirstWaitDoesNotSleep(t *testing.T) {
+	// A slow caller between issuance and the first poll: the monotonic deadline is
+	// already in the past when the loop first checks it. The check-before-wait
+	// guard must return expired without sleeping a negative duration into the
+	// injected seam.
+	sleep := &recordingSleep{}
+	base := time.Unix(0, 0)
+	// clock call 0 anchors the deadline (t=0 → deadline 30s); call 1 (remaining)
+	// reads t=60s, already past the deadline.
+	offsets := []int{0, 60}
+	i := 0
+	clock := func() time.Time {
+		s := offsets[min(i, len(offsets)-1)]
+		i++
+		return base.Add(time.Duration(s) * time.Second)
+	}
+
+	_, err := PollDeviceToken(context.Background(), "https://issuer.example/token", "basecamp-cli",
+		testDeviceCode, 5, 30,
+		WithDeviceSleep(sleep.fn), WithDeviceClock(clock))
+
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) || dfe.Reason != DeviceFlowExpired {
+		t.Fatalf("want DeviceFlowError(expired), got %v", err)
+	}
+	if len(sleep.waits) != 0 {
+		t.Errorf("expected no sleep before expiry, got waits %v", sleep.waits)
+	}
+}
+
+func TestPerformDeviceLogin_RechecksDeadlineAfterDisplay(t *testing.T) {
+	polled := false
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/device" {
+			body := map[string]any{}
+			for k, v := range deviceAuthBody {
+				body[k] = v
+			}
+			body["expires_in"] = 10
+			_ = json.NewEncoder(w).Encode(body)
+			return
+		}
+		polled = true
+		_ = json.NewEncoder(w).Encode(tokenBody)
+	}))
+	defer srv.Close()
+
+	endpoint := srv.URL + "/device"
+	config := &Config{
+		Issuer:                      srv.URL,
+		TokenEndpoint:               srv.URL + "/token",
+		DeviceAuthorizationEndpoint: &endpoint,
+		GrantTypesSupported:         []string{DeviceCodeGrantType, "refresh_token"},
+	}
+
+	// Clock: t0 when the code is issued, then jumps past its 10s lifetime by the
+	// time the display hook returns.
+	times := []time.Time{time.Unix(0, 0), time.Unix(100, 0)}
+	idx := 0
+	clock := func() time.Time {
+		t := times[min(idx, len(times)-1)]
+		idx++
+		return t
+	}
+
+	displayed := false
+	_, err := PerformDeviceLogin(context.Background(), config, "basecamp-cli",
+		func(DeviceAuthorization) { displayed = true },
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceClock(clock))
+
+	if !displayed {
+		t.Fatal("display hook was not called")
+	}
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) || dfe.Reason != DeviceFlowExpired {
+		t.Fatalf("want DeviceFlowError(expired) after a slow display hook, got %v", err)
+	}
+	if polled {
+		t.Error("must not poll the token endpoint once the code has expired")
+	}
+}
+
+func TestRequestDeviceAuthorization_OversizedBodyIsAPIError(t *testing.T) {
+	// A body past the size cap is a server/api fault, not a retryable transport
+	// failure and not the "too large" mislabel applied to every read failure.
+	client := &http.Client{Transport: largeBodyTransport{n: maxTokenResponseBytes + 1}}
+
+	_, err := RequestDeviceAuthorization(context.Background(), "https://issuer.example/device", "basecamp-cli",
+		WithDeviceHTTPClient(client))
+
+	var dfe *DeviceFlowError
+	if errors.As(err, &dfe) {
+		t.Fatalf("want a plain api_error, got DeviceFlowError(%q)", dfe.Reason)
+	}
+	var be *basecamp.Error
+	if !errors.As(err, &be) || be.Code != basecamp.CodeAPI {
+		t.Fatalf("want api_error, got %v (%T)", err, err)
+	}
+	if be.Retryable {
+		t.Error("an oversized device authorization response must not be retryable")
+	}
+	if !errors.Is(err, errBodyTooLarge) {
+		t.Error("oversized body error should wrap errBodyTooLarge")
+	}
+}
+
+func TestRequestDeviceAuthorization_GenuineReadFailureIsTransport(t *testing.T) {
+	// A real read failure (not an overflow) must surface as a retryable transport
+	// error, NOT be mislabeled "too large".
+	client := &http.Client{Transport: errBodyTransport{err: io.ErrUnexpectedEOF}}
+
+	_, err := RequestDeviceAuthorization(context.Background(), "https://issuer.example/device", "basecamp-cli",
+		WithDeviceHTTPClient(client))
+
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) {
+		t.Fatalf("want *DeviceFlowError, got %v (%T)", err, err)
+	}
+	if dfe.Reason != DeviceFlowTransport {
+		t.Errorf("Reason = %q, want transport", dfe.Reason)
+	}
+	if dfe.Code() != basecamp.CodeNetwork {
+		t.Errorf("Code = %q, want network", dfe.Code())
+	}
+	if !dfe.Retryable() {
+		t.Error("a genuine read failure should be retryable")
+	}
+	if strings.Contains(err.Error(), "too large") {
+		t.Errorf("read failure must not be mislabeled 'too large': %v", err)
+	}
+	if errors.Is(err, errBodyTooLarge) {
+		t.Error("a genuine read failure must not wrap errBodyTooLarge")
+	}
+}
+
+func TestPollDeviceToken_OversizedBodyIsAPIErrorNotRetryable(t *testing.T) {
+	// A token-endpoint body past the size cap is a server/api fault (api_error,
+	// non-retryable), NOT a retryable transport failure.
+	client := &http.Client{Transport: largeBodyTransport{n: maxTokenResponseBytes + 1}}
+	sleep := &recordingSleep{}
+
+	_, err := PollDeviceToken(context.Background(), "https://issuer.example/token", "basecamp-cli",
+		testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(client), WithDeviceSleep(sleep.fn))
+
+	var dfe *DeviceFlowError
+	if errors.As(err, &dfe) {
+		t.Fatalf("want a plain api_error, got DeviceFlowError(%q)", dfe.Reason)
+	}
+	var be *basecamp.Error
+	if !errors.As(err, &be) || be.Code != basecamp.CodeAPI {
+		t.Fatalf("want api_error, got %v (%T)", err, err)
+	}
+	if be.Retryable {
+		t.Error("an oversized token response must not be retryable")
+	}
+	// The poll path converts to a coded api_error via ErrAPI (a string message,
+	// like the malformed-2xx path), so assert the size-cap classification shows
+	// through the message rather than via errors.Is.
+	if !strings.Contains(be.Message, "size cap") {
+		t.Errorf("api_error message should identify the size-cap overflow, got %q", be.Message)
+	}
+}
+
+func TestPerformDeviceLogin_ChargesDisplayTimeAgainstPollDeadline(t *testing.T) {
+	// The display hook consumes most (but not all) of the code's lifetime. The
+	// poll must inherit the REMAINING window, not a fresh full one — so with the
+	// remainder nearly gone it expires without ever polling. Under the pre-fix
+	// behavior (full expires_in re-anchored after display) the same clock would
+	// leave a large window and the token endpoint would be polled.
+	polled := false
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/device" {
+			body := map[string]any{}
+			for k, v := range deviceAuthBody {
+				body[k] = v
+			}
+			body["expires_in"] = 100
+			_ = json.NewEncoder(w).Encode(body)
+			return
+		}
+		polled = true
+		_ = json.NewEncoder(w).Encode(tokenBody)
+	}))
+	defer srv.Close()
+
+	endpoint := srv.URL + "/device"
+	config := &Config{
+		Issuer:                      srv.URL,
+		TokenEndpoint:               srv.URL + "/token",
+		DeviceAuthorizationEndpoint: &endpoint,
+		GrantTypesSupported:         []string{DeviceCodeGrantType, "refresh_token"},
+	}
+
+	// Clock reads, in order: (1) issuance anchor, (2) remaining after display,
+	// (3) poll deadline anchor, (4) wait clamp, (5) deadline check. The display
+	// burns 99 of the 100s window, then the final read crosses the deadline.
+	offsets := []int{0, 99, 99, 99, 100}
+	idx := 0
+	clock := func() time.Time {
+		s := offsets[min(idx, len(offsets)-1)]
+		idx++
+		return time.Unix(int64(s), 0)
+	}
+	sleep := &recordingSleep{}
+
+	displayed := false
+	_, err := PerformDeviceLogin(context.Background(), config, "basecamp-cli",
+		func(DeviceAuthorization) { displayed = true },
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceClock(clock), WithDeviceSleep(sleep.fn))
+
+	if !displayed {
+		t.Fatal("display hook was not called")
+	}
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) || dfe.Reason != DeviceFlowExpired {
+		t.Fatalf("want DeviceFlowError(expired) after display consumed the window, got %v", err)
+	}
+	if polled {
+		t.Error("must not poll: display time should have exhausted the remaining lifetime")
+	}
+}
+
+// --- helpers ---
+
+func assertWaits(t *testing.T, got, want []time.Duration) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("waits = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("waits = %v, want %v", got, want)
+		}
+	}
+}
+
+func assertBasecampCode(t *testing.T, err error, code string) {
+	t.Helper()
+	var be *basecamp.Error
+	if !errors.As(err, &be) {
+		t.Fatalf("want *basecamp.Error, got %v", err)
+	}
+	if be.Code != code {
+		t.Errorf("Code = %q, want %q", be.Code, code)
+	}
+}
+
+// twoServerClient returns an HTTP client that trusts both test servers, so a
+// followed redirect would actually reach the second (attacker) host — making
+// "attacker never contacted" a meaningful assertion.
+func twoServerClient(a, b *httptest.Server) *http.Client {
+	pool := x509.NewCertPool()
+	pool.AddCert(a.Certificate())
+	pool.AddCert(b.Certificate())
+	return &http.Client{Transport: &http.Transport{
+		TLSClientConfig: &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12},
+	}}
+}
+
+// timeoutAlwaysTransport returns a net timeout on every RoundTrip, driving the
+// connection-timeout backoff path deterministically without a live server.
+type timeoutAlwaysTransport struct{}
+
+func (timeoutAlwaysTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, &url.Error{Op: "Post", URL: req.URL.String(), Err: timeoutError{}}
+}
+
+// timeoutOnceTransport returns a net timeout on the first RoundTrip, then
+// delegates to next. It makes the connection-timeout backoff path deterministic.
+type timeoutOnceTransport struct {
+	next  http.RoundTripper
+	fired bool
+}
+
+func (t *timeoutOnceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if !t.fired {
+		t.fired = true
+		return nil, &url.Error{Op: "Post", URL: req.URL.String(), Err: timeoutError{}}
+	}
+	return t.next.RoundTrip(req)
+}
+
+// timeoutError is a net.Error reporting a timeout.
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "simulated connection timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }
+
+var _ net.Error = timeoutError{}
+
+// largeBodyTransport returns a 200 response whose body is n bytes, driving the
+// bounded-read overflow path without a live server.
+type largeBodyTransport struct{ n int64 }
+
+func (t largeBodyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": {"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader(make([]byte, t.n))),
+		Request:    req,
+	}, nil
+}
+
+// errBodyTransport returns a 200 response whose body read fails with err before
+// any cap is reached, driving the genuine-I/O-failure path.
+type errBodyTransport struct{ err error }
+
+func (t errBodyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": {"application/json"}},
+		Body:       errReadCloser(t),
+		Request:    req,
+	}, nil
+}
+
+// errReadCloser is a ReadCloser whose Read always fails with err.
+type errReadCloser struct{ err error }
+
+func (e errReadCloser) Read([]byte) (int, error) { return 0, e.err }
+func (e errReadCloser) Close() error             { return nil }

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -470,6 +470,26 @@ func TestPollDeviceToken_BackoffResetsAfterCompletedRoundTrip(t *testing.T) {
 	assertWaits(t, sleep.waits, want)
 }
 
+func TestPollDeviceToken_RedirectClassifiedByStatusWithoutDrainingBody(t *testing.T) {
+	// A 3xx must fail by STATUS before the body is read. An oversized 3xx body
+	// would trip the size cap if drained — the early status check surfaces it as a
+	// redirect api_error instead (and, for a slow body, avoids a timeout+retry).
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "https://attacker.example/token")
+		w.WriteHeader(http.StatusFound)
+		_, _ = w.Write(bytes.Repeat([]byte("x"), 2*1024*1024))
+	}))
+	defer srv.Close()
+
+	sleep := &recordingSleep{}
+	_, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+	assertBasecampCode(t, err, "api_error")
+	if !strings.Contains(err.Error(), "redirect") {
+		t.Errorf("want a redirect error, got %v", err)
+	}
+}
+
 func TestPollDeviceToken_BackoffTracksGrownIntervalAfterSlowDown(t *testing.T) {
 	// slow_down grows the interval 5→10; a following network timeout must double
 	// from the GROWN interval (10→20), not the stale pre-slow_down 5 (which would

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -139,6 +139,24 @@ func TestRequestDeviceAuthorization_CallerCancellationIsCancelled(t *testing.T) 
 	}
 }
 
+func TestRequestDeviceAuthorization_CancellationDuringBodyReadIsCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// The body cancels ctx on its first read then errors, so the abort lands during
+	// readBoundedBody (not at Do). The outcome must still be DeviceFlowCancelled.
+	client := &http.Client{Transport: cancelOnReadTransport{cancel: cancel}}
+	_, err := RequestDeviceAuthorization(ctx, "https://device.example.com/oauth/device", "basecamp-cli",
+		WithDeviceHTTPClient(client))
+	var dfErr *DeviceFlowError
+	if !errors.As(err, &dfErr) {
+		t.Fatalf("expected *DeviceFlowError, got %T: %v", err, err)
+	}
+	if dfErr.Reason != DeviceFlowCancelled {
+		t.Errorf("Reason = %v, want DeviceFlowCancelled", dfErr.Reason)
+	}
+}
+
 func TestRequestDeviceAuthorization_SendsScopeWhenSet(t *testing.T) {
 	var sentScope string
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1295,6 +1313,29 @@ func (t largeBodyTransport) RoundTrip(req *http.Request) (*http.Response, error)
 		Request:    req,
 	}, nil
 }
+
+// cancelOnReadTransport returns a 200 whose body cancels the caller's context on
+// its first read and then fails — simulating a caller abort landing after headers
+// arrive but while the body is still streaming. Do returns the response normally
+// (ctx is live at Do time); the abort surfaces only during readBoundedBody.
+type cancelOnReadTransport struct{ cancel context.CancelFunc }
+
+func (t cancelOnReadTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": {"application/json"}},
+		Body:       cancelOnReadBody{cancel: t.cancel},
+		Request:    req,
+	}, nil
+}
+
+type cancelOnReadBody struct{ cancel context.CancelFunc }
+
+func (b cancelOnReadBody) Read([]byte) (int, error) {
+	b.cancel()
+	return 0, errors.New("read aborted")
+}
+func (b cancelOnReadBody) Close() error { return nil }
 
 // errBodyTransport returns a 200 response whose body read fails with err before
 // any cap is reached, driving the genuine-I/O-failure path.

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -189,6 +189,12 @@ func TestRequestDeviceAuthorization_RejectsMissingField(t *testing.T) {
 	_, err := RequestDeviceAuthorization(context.Background(), srv.URL, "basecamp-cli",
 		WithDeviceHTTPClient(tlsClient(srv)))
 	assertBasecampCode(t, err, basecamp.CodeAPI)
+	// A malformed 2xx body's validation error carries the status, like the parse
+	// failure and the token-poll raises.
+	var be *basecamp.Error
+	if !errors.As(err, &be) || be.HTTPStatus != http.StatusOK {
+		t.Errorf("validation error should carry HTTPStatus=200, got %+v", err)
+	}
 }
 
 func TestRequestDeviceAuthorization_ParseFailureCarriesHTTPStatus(t *testing.T) {

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -526,6 +526,7 @@ func TestPollDeviceToken_RejectsMalformedTokenExpiresIn(t *testing.T) {
 		`{"access_token":"a","token_type":"Bearer","expires_in":1e400}`,
 		`{"access_token":"a","token_type":"Bearer","expires_in":"3600"}`,
 		`{"access_token":"a","token_type":"Bearer","expires_in":true}`,
+		`{"access_token":"a","token_type":"Bearer","expires_in":1.5}`, // fractional: whole-second contract
 		`{"access_token":"a","token_type":"Bearer","expires_in":-1}`,
 		`{"access_token":"a","token_type":"Bearer","expires_in":2147483648}`,
 	} {
@@ -548,6 +549,41 @@ func TestPollDeviceToken_AcceptsMaxTokenLifetime(t *testing.T) {
 	}
 	if token.ExpiresIn != maxTokenLifetimeSeconds {
 		t.Errorf("ExpiresIn = %d, want %d", token.ExpiresIn, maxTokenLifetimeSeconds)
+	}
+	if token.ExpiresAt.IsZero() {
+		t.Error("ExpiresAt should be set for a positive expires_in")
+	}
+}
+
+func TestPollDeviceToken_RejectsZeroAndFractionalExpiresIn(t *testing.T) {
+	// An explicit "expires_in":0 must be api_error, not silently treated as
+	// absent (the old plain-int decode made 0 indistinguishable from omitted),
+	// and a fractional lifetime is malformed per the cross-SDK whole-second rule.
+	for _, body := range []string{
+		`{"access_token":"device_access_token","token_type":"Bearer","expires_in":0}`,
+		`{"access_token":"device_access_token","token_type":"Bearer","expires_in":3600.5}`,
+	} {
+		srv := rawTokenServer(t, body)
+		sleep := &recordingSleep{}
+		_, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+			WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+		assertBasecampCode(t, err, basecamp.CodeAPI)
+		srv.Close()
+	}
+}
+
+func TestPollDeviceToken_AcceptsIntegerValuedFloatExpiresIn(t *testing.T) {
+	// 3600.0 carries no fractional part — accepted per the cross-SDK contract
+	// (the old decode into a plain int rejected it, unlike TS/Python/Ruby).
+	srv := rawTokenServer(t, `{"access_token":"device_access_token","token_type":"Bearer","expires_in":3600.0}`)
+	sleep := &recordingSleep{}
+	token, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token.ExpiresIn != 3600 {
+		t.Errorf("ExpiresIn = %d, want 3600", token.ExpiresIn)
 	}
 	if token.ExpiresAt.IsZero() {
 		t.Error("ExpiresAt should be set for a positive expires_in")

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -381,6 +381,31 @@ func TestRequestDeviceAuthorization_RequiresClientID(t *testing.T) {
 	assertBasecampCode(t, err, basecamp.CodeValidation)
 }
 
+func TestPollDeviceToken_RejectsOutOfRangeDurations(t *testing.T) {
+	// The exported entry point sanity-checks its duration inputs: a non-positive
+	// value builds a past deadline and an oversized one overflows the internal
+	// time.Duration(seconds) * time.Second math. Both surface as a usage error
+	// before any request, mirroring the TS pollDeviceToken guard.
+	cases := []struct {
+		name              string
+		interval, expires int
+	}{
+		{"expires zero", 5, 0},
+		{"expires negative", 5, -1},
+		{"expires oversized", 5, maxDeviceSeconds + 1},
+		{"interval zero", 0, 900},
+		{"interval negative", -1, 900},
+		{"interval oversized", maxDeviceSeconds + 1, 900},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := PollDeviceToken(context.Background(), "https://issuer.example/token",
+				"basecamp-cli", testDeviceCode, tc.interval, tc.expires)
+			assertBasecampCode(t, err, basecamp.CodeUsage)
+		})
+	}
+}
+
 func TestPollDeviceToken_PendingSlowDownToken(t *testing.T) {
 	srv, _ := queueTokenResponses(t, []struct {
 		status int

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -470,6 +470,36 @@ func TestPollDeviceToken_BackoffResetsAfterCompletedRoundTrip(t *testing.T) {
 	assertWaits(t, sleep.waits, want)
 }
 
+func TestPollDeviceToken_BackoffTracksGrownIntervalAfterSlowDown(t *testing.T) {
+	// slow_down grows the interval 5→10; a following network timeout must double
+	// from the GROWN interval (10→20), not the stale pre-slow_down 5 (which would
+	// give 10 and poll too aggressively under combined throttling + timeouts).
+	srv, _ := queueTokenResponses(t, []struct {
+		status int
+		body   map[string]any
+	}{
+		{http.StatusBadRequest, map[string]any{"error": "slow_down"}},
+		{http.StatusOK, tokenBody},
+	})
+	sleep := &recordingSleep{}
+	base := tlsClient(srv)
+	// Time out only the 2nd attempt — the poll right after slow_down.
+	client := &http.Client{Transport: &timeoutOnAttemptTransport{next: base.Transport, attempt: 2}}
+
+	token, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(client), WithDeviceSleep(sleep.fn))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token.AccessToken != "device_access_token" {
+		t.Errorf("AccessToken = %q", token.AccessToken)
+	}
+	// 5 (initial) → slow_down grows the interval to 10 → wait 10 → timeout doubles
+	// the backoff from 10 to 20 → wait 20 → token. The stale-backoff bug gave 10.
+	want := []time.Duration{5 * time.Second, 10 * time.Second, 20 * time.Second}
+	assertWaits(t, sleep.waits, want)
+}
+
 func TestPollDeviceToken_ExpiresAgainstInjectedClock(t *testing.T) {
 	srv, calls := queueTokenResponses(t, []struct {
 		status int
@@ -1326,6 +1356,23 @@ type timeoutNTransport struct {
 func (t *timeoutNTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if t.n > 0 {
 		t.n--
+		return nil, &url.Error{Op: "Post", URL: req.URL.String(), Err: timeoutError{}}
+	}
+	return t.next.RoundTrip(req)
+}
+
+// timeoutOnAttemptTransport returns a net timeout on the Nth RoundTrip only,
+// delegating every other attempt — for a timeout at a specific point in the poll
+// sequence (e.g. immediately after a slow_down).
+type timeoutOnAttemptTransport struct {
+	next    http.RoundTripper
+	attempt int
+	count   int
+}
+
+func (t *timeoutOnAttemptTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.count++
+	if t.count == t.attempt {
 		return nil, &url.Error{Op: "Post", URL: req.URL.String(), Err: timeoutError{}}
 	}
 	return t.next.RoundTrip(req)

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -331,6 +331,39 @@ func TestPollDeviceToken_DoublesIntervalAfterTimeout(t *testing.T) {
 	}
 }
 
+func TestPollDeviceToken_BackoffResetsAfterCompletedRoundTrip(t *testing.T) {
+	// Two connection timeouts inflate the transient backoff (5→10→20); the next
+	// completed round-trip (authorization_pending) must reset it to the
+	// server-driven interval, so later waits return to 5s — not the inflated
+	// 20s/40s a merged interval+backoff would produce.
+	srv, _ := queueTokenResponses(t, []struct {
+		status int
+		body   map[string]any
+	}{
+		{http.StatusBadRequest, map[string]any{"error": "authorization_pending"}},
+		{http.StatusBadRequest, map[string]any{"error": "authorization_pending"}},
+		{http.StatusOK, tokenBody},
+	})
+	sleep := &recordingSleep{}
+
+	// The first two attempts return network timeouts; the rest hit the server.
+	base := tlsClient(srv)
+	client := &http.Client{Transport: &timeoutNTransport{next: base.Transport, n: 2}}
+
+	token, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(client), WithDeviceSleep(sleep.fn))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token.AccessToken != "device_access_token" {
+		t.Errorf("AccessToken = %q", token.AccessToken)
+	}
+	// Waits: 5s, then timeout-doubled 10s and 20s, then back to the server
+	// interval (5s) once round-trips complete.
+	want := []time.Duration{5 * time.Second, 10 * time.Second, 20 * time.Second, 5 * time.Second, 5 * time.Second}
+	assertWaits(t, sleep.waits, want)
+}
+
 func TestPollDeviceToken_ExpiresAgainstInjectedClock(t *testing.T) {
 	srv, calls := queueTokenResponses(t, []struct {
 		status int
@@ -613,6 +646,32 @@ func TestPollDeviceToken_TokenEndpointDoesNotFollowRedirect(t *testing.T) {
 	var be *basecamp.Error
 	if !errors.As(err, &be) || be.Code != basecamp.CodeAPI {
 		t.Fatalf("want api_error for the unfollowed 302, got %v (%T)", err, err)
+	}
+}
+
+func TestPollDeviceToken_RedirectWithPendingBodyIsAPIError(t *testing.T) {
+	// Redirects are suppressed, so a 3xx reaches the classifier with its body
+	// intact. A crafted {"error":"authorization_pending"} on a 302 must surface
+	// as an api_error — not be mistaken for a pending poll that keeps the loop
+	// running.
+	srv, calls := queueTokenResponses(t, []struct {
+		status int
+		body   map[string]any
+	}{
+		{http.StatusFound, map[string]any{"error": "authorization_pending"}},
+	})
+	sleep := &recordingSleep{}
+
+	_, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+
+	var dfe *DeviceFlowError
+	if errors.As(err, &dfe) {
+		t.Fatalf("want a plain api_error, got DeviceFlowError(%q)", dfe.Reason)
+	}
+	assertBasecampCode(t, err, basecamp.CodeAPI)
+	if *calls != 1 {
+		t.Errorf("expected polling to stop after the redirect, got %d polls", *calls)
 	}
 }
 
@@ -960,6 +1019,21 @@ type timeoutOnceTransport struct {
 func (t *timeoutOnceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if !t.fired {
 		t.fired = true
+		return nil, &url.Error{Op: "Post", URL: req.URL.String(), Err: timeoutError{}}
+	}
+	return t.next.RoundTrip(req)
+}
+
+// timeoutNTransport returns a net timeout on the first n RoundTrips, then
+// delegates to next. It drives repeated-timeout backoff paths deterministically.
+type timeoutNTransport struct {
+	next http.RoundTripper
+	n    int
+}
+
+func (t *timeoutNTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if t.n > 0 {
+		t.n--
 		return nil, &url.Error{Op: "Post", URL: req.URL.String(), Err: timeoutError{}}
 	}
 	return t.next.RoundTrip(req)

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -116,6 +116,45 @@ func TestRequestDeviceAuthorization_OmitsScopeAndValidates(t *testing.T) {
 	}
 }
 
+func TestRequestDeviceAuthorization_VerificationURICompleteOptional(t *testing.T) {
+	// Present → a non-nil pointer to the value; absent → nil (not ""), preserving
+	// the optional distinction the cross-SDK contract requires.
+	present := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(deviceAuthBody)
+	}))
+	defer present.Close()
+	auth, err := RequestDeviceAuthorization(context.Background(), present.URL, "basecamp-cli", WithDeviceHTTPClient(tlsClient(present)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if auth.VerificationURIComplete == nil {
+		t.Fatal("VerificationURIComplete = nil, want non-nil when present")
+	}
+	if *auth.VerificationURIComplete != "https://issuer.example/device?user_code=WDJB-MJHT" {
+		t.Errorf("*VerificationURIComplete = %q", *auth.VerificationURIComplete)
+	}
+
+	body := map[string]any{}
+	for k, v := range deviceAuthBody {
+		if k != "verification_uri_complete" {
+			body[k] = v
+		}
+	}
+	absent := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	defer absent.Close()
+	auth2, err := RequestDeviceAuthorization(context.Background(), absent.URL, "basecamp-cli", WithDeviceHTTPClient(tlsClient(absent)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if auth2.VerificationURIComplete != nil {
+		t.Errorf("VerificationURIComplete = %v, want nil when absent", auth2.VerificationURIComplete)
+	}
+}
+
 func TestRequestDeviceAuthorization_CallerCancellationIsCancelled(t *testing.T) {
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -1486,3 +1486,25 @@ type errReadCloser struct{ err error }
 
 func (e errReadCloser) Read([]byte) (int, error) { return 0, e.err }
 func (e errReadCloser) Close() error             { return nil }
+
+func TestPollDeviceToken_ExpiresAtIsWallClock(t *testing.T) {
+	// The injected clock is a polling-deadline seam only. A token's public
+	// ExpiresAt must anchor to wall time (like exchange.go) — with an
+	// epoch-anchored injected clock the old cfg.clock() anchoring produced an
+	// ExpiresAt near 1970, an already-expired token.
+	srv, _ := queueTokenResponses(t, []struct {
+		status int
+		body   map[string]any
+	}{{http.StatusOK, tokenBody}})
+	sleep := &recordingSleep{}
+	epochClock := func() time.Time { return time.Unix(0, 0) }
+
+	token, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn), WithDeviceClock(epochClock))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token.ExpiresAt.Before(time.Now().Add(30 * time.Minute)) {
+		t.Errorf("ExpiresAt = %v, want ~1h from wall-clock now (not the injected clock)", token.ExpiresAt)
+	}
+}

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -1657,3 +1657,40 @@ func countingHTTPServer(t *testing.T) (*httptest.Server, *int) {
 	t.Cleanup(srv.Close)
 	return srv, &calls
 }
+
+func TestPerformDeviceLogin_CancelAfterAuthorizationNeverReachesDisplay(t *testing.T) {
+	// A ctx cancelled while the authorization request is in flight — here the
+	// mock endpoint cancels it as it serves the code pair, modeling an
+	// injected transport that ignores request cancellation — must surface as
+	// cancelled without ever invoking the display hook.
+	ctx, cancel := context.WithCancel(context.Background())
+	mux := http.NewServeMux()
+	var srv *httptest.Server
+	mux.HandleFunc("/device", func(w http.ResponseWriter, _ *http.Request) {
+		cancel()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(deviceAuthBody)
+	})
+	srv = httptest.NewTLSServer(mux)
+	t.Cleanup(srv.Close)
+
+	endpoint := srv.URL + "/device"
+	cfg := &Config{
+		Issuer:                      srv.URL,
+		TokenEndpoint:               srv.URL + "/token",
+		DeviceAuthorizationEndpoint: &endpoint,
+		GrantTypesSupported:         []string{DeviceCodeGrantType, "refresh_token"},
+	}
+
+	displayed := 0
+	_, err := PerformDeviceLogin(ctx, cfg, "basecamp-cli", func(DeviceAuthorization) { displayed++ },
+		WithDeviceHTTPClient(tlsClient(srv)))
+
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) || dfe.Reason != DeviceFlowCancelled {
+		t.Fatalf("want DeviceFlowError(cancelled), got %v", err)
+	}
+	if displayed != 0 {
+		t.Errorf("display fired %d times for a cancelled flow, want 0", displayed)
+	}
+}

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -109,6 +109,25 @@ func TestRequestDeviceAuthorization_CompletionAfterCancelIsCancelled(t *testing.
 	}
 }
 
+func TestRequestDeviceAuthorization_CompletionAfterCancelBeatsAPIError(t *testing.T) {
+	// Cancellation must also win over a completed NON-2XX: a context-ignoring
+	// RoundTripper that cancels the caller and then returns a 500 must surface
+	// cancelled, not the api_error classification.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := &http.Client{Transport: completeAfterCancelStatusTransport{cancel: cancel, status: http.StatusInternalServerError}}
+	_, err := RequestDeviceAuthorization(ctx, "https://device.example.com/oauth/device", "basecamp-cli",
+		WithDeviceHTTPClient(client))
+	var dfErr *DeviceFlowError
+	if !errors.As(err, &dfErr) {
+		t.Fatalf("expected *DeviceFlowError, got %T: %v", err, err)
+	}
+	if dfErr.Reason != DeviceFlowCancelled {
+		t.Errorf("Reason = %v, want DeviceFlowCancelled", dfErr.Reason)
+	}
+}
+
 func TestRequestDeviceAuthorization_OmitsScopeAndValidates(t *testing.T) {
 	var sentScope string
 	var scopePresent bool
@@ -1503,6 +1522,24 @@ func (t completeAfterCancelTransport) RoundTrip(req *http.Request) (*http.Respon
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": {"application/json"}},
 		Body:       io.NopCloser(strings.NewReader(t.body)),
+		Request:    req,
+	}, nil
+}
+
+// completeAfterCancelStatusTransport cancels the caller's context and then
+// completes a response with the given status anyway, modeling a custom
+// RoundTripper that does not honor cancellation.
+type completeAfterCancelStatusTransport struct {
+	cancel context.CancelFunc
+	status int
+}
+
+func (t completeAfterCancelStatusTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.cancel()
+	return &http.Response{
+		StatusCode: t.status,
+		Header:     http.Header{"Content-Type": {"application/json"}},
+		Body:       io.NopCloser(strings.NewReader("{}")),
 		Request:    req,
 	}, nil
 }

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -1580,3 +1581,25 @@ func TestPollDeviceToken_RequestTimeoutClampedToRemainingLifetime(t *testing.T) 
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func TestPollDeviceToken_TerminalStatusClassifiedWithoutDrainingBody(t *testing.T) {
+	// Statuses outside 200 and 4xx are terminal WITHOUT their bodies. An
+	// oversized body on a 201/500 would trip the size cap if drained — the
+	// early status check surfaces the status api_error instead (and, for a
+	// slow body, avoids a timeout+retry-until-expiry misclassification).
+	for _, status := range []int{201, 500} {
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(status)
+			_, _ = w.Write(bytes.Repeat([]byte("x"), 2*1024*1024))
+		}))
+
+		sleep := &recordingSleep{}
+		_, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+			WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+		assertBasecampCode(t, err, "api_error")
+		if !strings.Contains(err.Error(), fmt.Sprintf("status %d", status)) {
+			t.Errorf("want a status-%d error (not a size-cap error), got %v", status, err)
+		}
+		srv.Close()
+	}
+}

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -1365,16 +1365,13 @@ func TestPollDeviceToken_OversizedBodyIsAPIErrorNotRetryable(t *testing.T) {
 	}
 }
 
-func TestPerformDeviceLogin_ChargesAuthRoundTripAgainstLifetime(t *testing.T) {
-	// The code is minted server-side before the response travels back: a
-	// response arriving 6s late with expires_in 5 is dead on arrival, so the
-	// pre-request anchor must expire it — never grant a fresh full lifetime.
-	// Under the pre-fix behavior (deadline anchored after the response) the
-	// same clock would leave the full 5s window and the token endpoint would
-	// be polled. The handler runs on the server goroutine, so the clock state
-	// is atomic.
+func TestPerformDeviceLogin_AnchorsExpiryAtResponseReceipt(t *testing.T) {
+	// SPEC §16: the deadline is clock.now() + expires_in taken AFTER
+	// RequestDeviceAuthorization returns — a 6s request leg with expires_in 5
+	// must NOT expire the fresh code client-side; expiry past receipt is
+	// arbitrated by the server (expired_token). The handler runs on the
+	// server goroutine, so the clock state is atomic.
 	var nowSec atomic.Int64
-	polled := false
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path == "/device" {
@@ -1387,7 +1384,6 @@ func TestPerformDeviceLogin_ChargesAuthRoundTripAgainstLifetime(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(body)
 			return
 		}
-		polled = true
 		_ = json.NewEncoder(w).Encode(tokenBody)
 	}))
 	defer srv.Close()
@@ -1403,16 +1399,15 @@ func TestPerformDeviceLogin_ChargesAuthRoundTripAgainstLifetime(t *testing.T) {
 	clock := func() time.Time { return time.Unix(nowSec.Load(), 0) }
 	sleep := &recordingSleep{}
 
-	_, err := PerformDeviceLogin(context.Background(), config, "basecamp-cli",
+	token, err := PerformDeviceLogin(context.Background(), config, "basecamp-cli",
 		func(DeviceAuthorization) {},
 		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceClock(clock), WithDeviceSleep(sleep.fn))
 
-	var dfe *DeviceFlowError
-	if !errors.As(err, &dfe) || dfe.Reason != DeviceFlowExpired {
-		t.Fatalf("want DeviceFlowError(expired) for a response slower than expires_in, got %v", err)
+	if err != nil {
+		t.Fatalf("request-leg latency must not shrink the code window: %v", err)
 	}
-	if polled {
-		t.Error("must not poll: the authorization round-trip consumed the whole lifetime")
+	if token == nil || token.AccessToken == "" {
+		t.Fatal("expected a token from the receipt-anchored flow")
 	}
 }
 

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1361,6 +1362,57 @@ func TestPollDeviceToken_OversizedBodyIsAPIErrorNotRetryable(t *testing.T) {
 	// through the message rather than via errors.Is.
 	if !strings.Contains(be.Message, "size cap") {
 		t.Errorf("api_error message should identify the size-cap overflow, got %q", be.Message)
+	}
+}
+
+func TestPerformDeviceLogin_ChargesAuthRoundTripAgainstLifetime(t *testing.T) {
+	// The code is minted server-side before the response travels back: a
+	// response arriving 6s late with expires_in 5 is dead on arrival, so the
+	// pre-request anchor must expire it — never grant a fresh full lifetime.
+	// Under the pre-fix behavior (deadline anchored after the response) the
+	// same clock would leave the full 5s window and the token endpoint would
+	// be polled. The handler runs on the server goroutine, so the clock state
+	// is atomic.
+	var nowSec atomic.Int64
+	polled := false
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/device" {
+			nowSec.Store(6)
+			body := map[string]any{}
+			for k, v := range deviceAuthBody {
+				body[k] = v
+			}
+			body["expires_in"] = 5
+			_ = json.NewEncoder(w).Encode(body)
+			return
+		}
+		polled = true
+		_ = json.NewEncoder(w).Encode(tokenBody)
+	}))
+	defer srv.Close()
+
+	endpoint := srv.URL + "/device"
+	config := &Config{
+		Issuer:                      srv.URL,
+		TokenEndpoint:               srv.URL + "/token",
+		DeviceAuthorizationEndpoint: &endpoint,
+		GrantTypesSupported:         []string{DeviceCodeGrantType, "refresh_token"},
+	}
+
+	clock := func() time.Time { return time.Unix(nowSec.Load(), 0) }
+	sleep := &recordingSleep{}
+
+	_, err := PerformDeviceLogin(context.Background(), config, "basecamp-cli",
+		func(DeviceAuthorization) {},
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceClock(clock), WithDeviceSleep(sleep.fn))
+
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) || dfe.Reason != DeviceFlowExpired {
+		t.Fatalf("want DeviceFlowError(expired) for a response slower than expires_in, got %v", err)
+	}
+	if polled {
+		t.Error("must not poll: the authorization round-trip consumed the whole lifetime")
 	}
 }
 

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -1774,3 +1774,26 @@ func TestPollDeviceToken_CancelledDuringIgnoredTransportBeats200(t *testing.T) {
 		t.Fatalf("want DeviceFlowError(cancelled), got %v", err)
 	}
 }
+
+func TestPollDeviceToken_CancelledDuringIgnoredTransportBeatsTerminalError(t *testing.T) {
+	// Cancellation must also win over a TERMINAL error completed after the
+	// caller cancelled: a context-ignoring transport returning access_denied
+	// (or any 4xx/malformed response) post-cancellation must surface
+	// cancelled, not the terminal classification.
+	srv, _ := queueTokenResponses(t, []struct {
+		status int
+		body   map[string]any
+	}{{http.StatusBadRequest, map[string]any{"error": "access_denied"}}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := &http.Client{Transport: &contextIgnoringTransport{base: tlsClient(srv).Transport, cancel: cancel}}
+	sleep := &recordingSleep{}
+
+	_, err := PollDeviceToken(ctx, srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(client), WithDeviceSleep(sleep.fn))
+
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) || dfe.Reason != DeviceFlowCancelled {
+		t.Fatalf("want DeviceFlowError(cancelled), got %v", err)
+	}
+}

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -1621,3 +1621,39 @@ func TestNewDeviceConfig_OversizedTimeoutFallsBackToDefault(t *testing.T) {
 		t.Errorf("ceiling: got %v, want %v", cfg.timeout, maxDeviceRequestTimeout)
 	}
 }
+
+func TestPerformDeviceLogin_EmptyEndpointIsUnavailable(t *testing.T) {
+	// Present-but-empty must behave exactly like absent: unavailable, and no
+	// request is ever made (the counting server would record one).
+	srv, calls := countingHTTPServer(t)
+	empty := ""
+	cfg := &Config{
+		Issuer:                      srv.URL,
+		TokenEndpoint:               srv.URL + "/token",
+		DeviceAuthorizationEndpoint: &empty,
+		GrantTypesSupported:         []string{DeviceCodeGrantType, "refresh_token"},
+	}
+
+	_, err := PerformDeviceLogin(context.Background(), cfg, "basecamp-cli", func(DeviceAuthorization) {},
+		WithDeviceHTTPClient(tlsClient(srv)))
+
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) || dfe.Reason != DeviceFlowUnavailable {
+		t.Fatalf("want DeviceFlowError(unavailable), got %v", err)
+	}
+	if *calls != 0 {
+		t.Errorf("no request may be made for an unavailable capability, got %d", *calls)
+	}
+}
+
+// countingHTTPServer records how many requests it receives and 404s them.
+func countingHTTPServer(t *testing.T) (*httptest.Server, *int) {
+	t.Helper()
+	calls := 0
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &calls
+}

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -82,6 +82,33 @@ var tokenBody = map[string]any{
 	"expires_in":    3600,
 }
 
+func TestRequestDeviceAuthorization_CompletionAfterCancelIsCancelled(t *testing.T) {
+	// A custom RoundTripper that ignores the request context can complete a
+	// VALID response after the caller cancelled. The success path must re-check
+	// the parent context before handing back a usable device code — never a
+	// device authorization returned after the caller asked to stop.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	body, err := json.Marshal(deviceAuthBody)
+	if err != nil {
+		t.Fatalf("marshaling fixture: %v", err)
+	}
+	client := &http.Client{Transport: completeAfterCancelTransport{cancel: cancel, body: string(body)}}
+	auth, err := RequestDeviceAuthorization(ctx, "https://device.example.com/oauth/device", "basecamp-cli",
+		WithDeviceHTTPClient(client))
+	if auth != nil {
+		t.Fatal("device authorization must not be returned after cancellation")
+	}
+	var dfErr *DeviceFlowError
+	if !errors.As(err, &dfErr) {
+		t.Fatalf("expected *DeviceFlowError, got %T: %v", err, err)
+	}
+	if dfErr.Reason != DeviceFlowCancelled {
+		t.Errorf("Reason = %v, want DeviceFlowCancelled", dfErr.Reason)
+	}
+}
+
 func TestRequestDeviceAuthorization_OmitsScopeAndValidates(t *testing.T) {
 	var sentScope string
 	var scopePresent bool
@@ -1458,6 +1485,24 @@ func (t cancelOnReadTransport) RoundTrip(req *http.Request) (*http.Response, err
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": {"application/json"}},
 		Body:       cancelOnReadBody(t),
+		Request:    req,
+	}, nil
+}
+
+// completeAfterCancelTransport ignores the request context entirely: it cancels
+// the caller's context and then completes a VALID response anyway, modeling a
+// custom RoundTripper that does not honor cancellation.
+type completeAfterCancelTransport struct {
+	cancel context.CancelFunc
+	body   string
+}
+
+func (t completeAfterCancelTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.cancel()
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": {"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(t.body)),
 		Request:    req,
 	}, nil
 }

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -1125,6 +1125,38 @@ func TestPollDeviceToken_ExpiredBeforeFirstWaitDoesNotSleep(t *testing.T) {
 	}
 }
 
+func TestPerformDeviceLogin_NilDisplayIsUsageError(t *testing.T) {
+	// A nil display is the only mechanism that surfaces the verification URI
+	// and user code: skipping it would mint a code nobody can approve and
+	// poll until expiry. Reject as usage BEFORE any request.
+	requests := 0
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(deviceAuthBody)
+	}))
+	defer srv.Close()
+
+	endpoint := srv.URL + "/device"
+	config := &Config{
+		Issuer:                      srv.URL,
+		TokenEndpoint:               srv.URL + "/token",
+		DeviceAuthorizationEndpoint: &endpoint,
+		GrantTypesSupported:         []string{DeviceCodeGrantType, "refresh_token"},
+	}
+
+	_, err := PerformDeviceLogin(context.Background(), config, "basecamp-cli", nil,
+		WithDeviceHTTPClient(tlsClient(srv)))
+
+	var bcErr *basecamp.Error
+	if !errors.As(err, &bcErr) || bcErr.Code != basecamp.CodeUsage {
+		t.Fatalf("want *basecamp.Error(usage) for nil display, got %T: %v", err, err)
+	}
+	if requests != 0 {
+		t.Errorf("requests = %d, want 0 — the guard must reject before any request", requests)
+	}
+}
+
 func TestPerformDeviceLogin_CancelDuringDisplayBeatsExpiry(t *testing.T) {
 	// A display hook that both cancels the flow and consumes the whole code
 	// lifetime (a prompt closing in response to cancellation) must surface

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -1694,3 +1694,38 @@ func TestPerformDeviceLogin_CancelAfterAuthorizationNeverReachesDisplay(t *testi
 		t.Errorf("display fired %d times for a cancelled flow, want 0", displayed)
 	}
 }
+
+// contextIgnoringTransport completes requests via the base transport but with
+// the context stripped, modeling an injected RoundTripper that ignores request
+// cancellation.
+type contextIgnoringTransport struct {
+	base   http.RoundTripper
+	cancel context.CancelFunc
+}
+
+func (t *contextIgnoringTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Cancel the caller's ctx mid-request, then complete anyway.
+	t.cancel()
+	return t.base.RoundTrip(req.Clone(context.Background()))
+}
+
+func TestPollDeviceToken_CancelledDuringIgnoredTransportBeats200(t *testing.T) {
+	// A transport that ignores cancellation can return a 200 after the caller
+	// cancelled — the loop must surface cancelled, never the token.
+	srv, _ := queueTokenResponses(t, []struct {
+		status int
+		body   map[string]any
+	}{{http.StatusOK, tokenBody}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := &http.Client{Transport: &contextIgnoringTransport{base: tlsClient(srv).Transport, cancel: cancel}}
+	sleep := &recordingSleep{}
+
+	_, err := PollDeviceToken(ctx, srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(client), WithDeviceSleep(sleep.fn))
+
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) || dfe.Reason != DeviceFlowCancelled {
+		t.Fatalf("want DeviceFlowError(cancelled), got %v", err)
+	}
+}

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -1525,3 +1525,58 @@ func TestPollDeviceToken_Non200SuccessIsTerminal(t *testing.T) {
 		assertBasecampCode(t, err, basecamp.CodeAPI)
 	}
 }
+
+func TestPollDeviceToken_ProtocolErrorsOnlyOn4xx(t *testing.T) {
+	// OAuth protocol states are recognized only on a 4xx: a nonstandard 2xx or
+	// a 5xx carrying a crafted authorization_pending body must terminate as
+	// api_error, never extend polling.
+	for _, status := range []int{201, 202, 500} {
+		srv, calls := queueTokenResponses(t, []struct {
+			status int
+			body   map[string]any
+		}{{status, map[string]any{"error": "authorization_pending"}}})
+		sleep := &recordingSleep{}
+
+		_, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+			WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+		assertBasecampCode(t, err, basecamp.CodeAPI)
+		if *calls != 1 {
+			t.Errorf("status %d: polled %d times, want exactly 1 (no retry)", status, *calls)
+		}
+	}
+}
+
+func TestPollDeviceToken_RequestTimeoutClampedToRemainingLifetime(t *testing.T) {
+	// Near expiry the per-request budget must shrink to the remaining code
+	// lifetime: with 15s left, a 30s default request timeout would let a
+	// stalled POST blow through the monotonic deadline.
+	var captured time.Duration
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if d, ok := req.Context().Deadline(); ok {
+			captured = time.Until(d)
+		}
+		return nil, errors.New("stop after capturing the deadline")
+	})
+
+	// Scripted clock: anchor t=0, lifetime 20s; first wait 5s → 15s remaining
+	// at POST time.
+	times := []time.Time{time.Unix(0, 0), time.Unix(0, 0), time.Unix(5, 0)}
+	idx := 0
+	clock := func() time.Time {
+		v := times[min(idx, len(times)-1)]
+		idx++
+		return v
+	}
+	sleep := &recordingSleep{}
+
+	_, _ = PollDeviceToken(context.Background(), "https://issuer.example/token", "basecamp-cli", testDeviceCode, 5, 20,
+		WithDeviceHTTPClient(&http.Client{Transport: transport}), WithDeviceSleep(sleep.fn), WithDeviceClock(clock))
+
+	if captured <= 0 || captured > 15*time.Second+500*time.Millisecond {
+		t.Errorf("request deadline = %v from now, want ≤ ~15s (clamped to remaining lifetime, not the 30s default)", captured)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -1125,6 +1125,50 @@ func TestPollDeviceToken_ExpiredBeforeFirstWaitDoesNotSleep(t *testing.T) {
 	}
 }
 
+func TestPerformDeviceLogin_CancelDuringDisplayBeatsExpiry(t *testing.T) {
+	// A display hook that both cancels the flow and consumes the whole code
+	// lifetime (a prompt closing in response to cancellation) must surface
+	// cancelled, not expired.
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		body := map[string]any{}
+		for k, v := range deviceAuthBody {
+			body[k] = v
+		}
+		body["expires_in"] = 10
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	defer srv.Close()
+
+	endpoint := srv.URL + "/device"
+	config := &Config{
+		Issuer:                      srv.URL,
+		TokenEndpoint:               srv.URL + "/token",
+		DeviceAuthorizationEndpoint: &endpoint,
+		GrantTypesSupported:         []string{DeviceCodeGrantType, "refresh_token"},
+	}
+
+	// Clock: t0 at issuance, then past the 10s lifetime once display returns.
+	times := []time.Time{time.Unix(0, 0), time.Unix(100, 0)}
+	idx := 0
+	clock := func() time.Time {
+		tm := times[min(idx, len(times)-1)]
+		idx++
+		return tm
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_, err := PerformDeviceLogin(ctx, config, "basecamp-cli",
+		func(DeviceAuthorization) { cancel() },
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceClock(clock))
+
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) || dfe.Reason != DeviceFlowCancelled {
+		t.Fatalf("want DeviceFlowError(cancelled) — cancellation inside display wins over expiry — got %v", err)
+	}
+}
+
 func TestPerformDeviceLogin_RechecksDeadlineAfterDisplay(t *testing.T) {
 	polled := false
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -1508,3 +1508,20 @@ func TestPollDeviceToken_ExpiresAtIsWallClock(t *testing.T) {
 		t.Errorf("ExpiresAt = %v, want ~1h from wall-clock now (not the injected clock)", token.ExpiresAt)
 	}
 }
+
+func TestPollDeviceToken_Non200SuccessIsTerminal(t *testing.T) {
+	// RFC 8628/6749 token responses are exactly 200 (SPEC §16). A nonstandard
+	// 201/202 carrying an access_token must not complete polling — it is a
+	// terminal api_error, never an accepted token.
+	for _, status := range []int{201, 202} {
+		srv, _ := queueTokenResponses(t, []struct {
+			status int
+			body   map[string]any
+		}{{status, tokenBody}})
+		sleep := &recordingSleep{}
+
+		_, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+			WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+		assertBasecampCode(t, err, basecamp.CodeAPI)
+	}
+}

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -1592,6 +1593,7 @@ func TestPollDeviceToken_TerminalStatusClassifiedWithoutDrainingBody(t *testing.
 			w.WriteHeader(status)
 			_, _ = w.Write(bytes.Repeat([]byte("x"), 2*1024*1024))
 		}))
+		t.Cleanup(srv.Close)
 
 		sleep := &recordingSleep{}
 		_, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
@@ -1600,6 +1602,22 @@ func TestPollDeviceToken_TerminalStatusClassifiedWithoutDrainingBody(t *testing.
 		if !strings.Contains(err.Error(), fmt.Sprintf("status %d", status)) {
 			t.Errorf("want a status-%d error (not a size-cap error), got %v", status, err)
 		}
-		srv.Close()
+	}
+}
+
+func TestNewDeviceConfig_OversizedTimeoutFallsBackToDefault(t *testing.T) {
+	// A huge positive timeout (math.MaxInt64 ≈ 292y) would hold a stalled
+	// request open effectively forever — it must fall back to the default like
+	// zero/negative values, mirroring the other SDKs' 3600 s ceilings.
+	for _, d := range []time.Duration{time.Duration(math.MaxInt64), maxDeviceRequestTimeout + time.Second} {
+		cfg := newDeviceConfig([]DeviceOption{WithDeviceTimeout(d)})
+		if cfg.timeout != defaultDeviceRequestTimeout {
+			t.Errorf("timeout %v: got %v, want the %v default", d, cfg.timeout, defaultDeviceRequestTimeout)
+		}
+	}
+	// The ceiling itself is valid (inclusive bound).
+	cfg := newDeviceConfig([]DeviceOption{WithDeviceTimeout(maxDeviceRequestTimeout)})
+	if cfg.timeout != maxDeviceRequestTimeout {
+		t.Errorf("ceiling: got %v, want %v", cfg.timeout, maxDeviceRequestTimeout)
 	}
 }

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -862,6 +862,34 @@ func TestPollDeviceToken_AcceptsTokenWithoutExpiresIn(t *testing.T) {
 	}
 }
 
+func TestPollDeviceToken_NullOptionalFieldsAreAbsent(t *testing.T) {
+	// JSON null for refresh_token/scope/token_type is absent per SPEC — the
+	// token must be accepted with zero values (and Bearer default), never an
+	// api_error.
+	srv, _ := queueTokenResponses(t, []struct {
+		status int
+		body   map[string]any
+	}{{http.StatusOK, map[string]any{
+		"access_token":  "tok",
+		"refresh_token": nil,
+		"scope":         nil,
+		"token_type":    nil,
+	}}})
+	sleep := &recordingSleep{}
+
+	token, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token.RefreshToken != "" || token.Scope != "" {
+		t.Errorf("null optional fields must map to zero values, got %q/%q", token.RefreshToken, token.Scope)
+	}
+	if token.TokenType != "Bearer" {
+		t.Errorf("TokenType = %q, want Bearer default", token.TokenType)
+	}
+}
+
 func TestPollDeviceToken_CancelledViaContext(t *testing.T) {
 	srv, _ := queueTokenResponses(t, []struct {
 		status int

--- a/go/pkg/basecamp/oauth/oauth_test.go
+++ b/go/pkg/basecamp/oauth/oauth_test.go
@@ -494,3 +494,48 @@ func TestExchanger_Exchange_TruncatesLargeErrorDescription(t *testing.T) {
 		t.Error("Expected '...' suffix in truncated error description")
 	}
 }
+
+// TestNewDiscoverConfig_TimeoutClamp guards finding A: WithTimeout(0) (and any
+// non-positive duration) must NOT drop the fetch timeout — it clamps to the
+// default rather than leaving an unbounded fetch.
+func TestNewDiscoverConfig_TimeoutClamp(t *testing.T) {
+	cases := []struct {
+		name string
+		opts []DiscoverOption
+		want time.Duration
+	}{
+		{"default when unset", nil, defaultDiscoveryTimeout},
+		{"zero clamps to default", []DiscoverOption{WithTimeout(0)}, defaultDiscoveryTimeout},
+		{"negative clamps to default", []DiscoverOption{WithTimeout(-5 * time.Second)}, defaultDiscoveryTimeout},
+		{"positive preserved", []DiscoverOption{WithTimeout(3 * time.Second)}, 3 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := newDiscoverConfig(tc.opts).timeout; got != tc.want {
+				t.Errorf("timeout = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNewDeviceConfig_TimeoutClamp is the device-flow analogue of finding A: the
+// per-round-trip timeout clamps to the default on a non-positive value.
+func TestNewDeviceConfig_TimeoutClamp(t *testing.T) {
+	cases := []struct {
+		name string
+		opts []DeviceOption
+		want time.Duration
+	}{
+		{"default when unset", nil, defaultDeviceRequestTimeout},
+		{"zero clamps to default", []DeviceOption{WithDeviceTimeout(0)}, defaultDeviceRequestTimeout},
+		{"negative clamps to default", []DeviceOption{WithDeviceTimeout(-time.Second)}, defaultDeviceRequestTimeout},
+		{"positive preserved", []DeviceOption{WithDeviceTimeout(7 * time.Second)}, 7 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := newDeviceConfig(tc.opts).timeout; got != tc.want {
+				t.Errorf("timeout = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -311,7 +311,10 @@ val token = performDeviceLogin(
     },
 )
 
-println("Access token: ${token.accessToken}")
+// Use the token to build a client — never print or log its value.
+val client = BasecampClient {
+    accessToken(token.accessToken)
+}
 ```
 
 The two building blocks are also public if you need finer control:

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -317,22 +317,31 @@ println("Access token: ${token.accessToken}")
 The two building blocks are also public if you need finer control:
 
 ```kotlin
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+
 // deviceAuthorizationEndpoint is optional (device-only servers advertise it,
 // others omit it), so assert its presence rather than dereferencing with `!!`.
 val deviceEndpoint = config.deviceAuthorizationEndpoint
     ?: error("Selected authorization server does not offer device flow")
 
 val auth = requestDeviceAuthorization(deviceEndpoint, "basecamp-cli")
+
+// Anchor the expiry deadline at code issuance, BEFORE showing the code, so time
+// the user spends reading it counts against the code's lifetime rather than
+// resetting the clock. (performDeviceLogin does this for you.)
+val issuedAt = TimeSource.Monotonic.markNow()
 println("Enter ${auth.userCode} at ${auth.verificationUri}")
 
 // Polls until approval, denial, or expiry. The wait honours the server interval,
-// a sustained slow_down (+5s), and a monotonic expiry deadline.
+// a sustained slow_down (+5s), and the monotonic expiry deadline.
 val token = pollDeviceToken(
     tokenEndpoint = config.tokenEndpoint,
     clientId = "basecamp-cli",
     deviceCode = auth.deviceCode,
     interval = auth.interval,
     expiresIn = auth.expiresIn,
+    deadline = issuedAt + auth.expiresIn.seconds,
 )
 ```
 

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -286,6 +286,7 @@ authorization grant. The public `basecamp-cli` client is pre-registered with
 scope defaults to `read`.
 
 ```kotlin
+import com.basecamp.sdk.BasecampClient
 import com.basecamp.sdk.oauth.*
 
 // 1. Resource-first discovery selects the authorization server. Device flow needs

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -278,6 +278,75 @@ if (isTokenExpired(token)) {
 }
 ```
 
+### Device Authorization Flow (RFC 8628)
+
+For input-constrained clients (CLIs, TVs) the SDK implements the OAuth 2.0 device
+authorization grant. The public `basecamp-cli` client is pre-registered with
+`token_endpoint_auth_method: none` — it sends no client secret, and an omitted
+scope defaults to `read`.
+
+```kotlin
+import com.basecamp.sdk.oauth.*
+
+// 1. Resource-first discovery selects the authorization server. Device flow needs
+//    an AS that advertises the device_code grant AND a
+//    device_authorization_endpoint — Launchpad advertises neither, so obtain the
+//    config from discoverFromResource rather than discoverLaunchpad().
+val config = when (val result = discoverFromResource("https://3.basecampapi.com")) {
+    is DiscoveryResult.Selected -> result.config
+    is DiscoveryResult.FallBack ->
+        error("This authorization server does not offer device flow (${result.reason.code})")
+}
+
+// 2. Run the full flow: request a code, show it to the user, then poll for the
+//    token. performDeviceLogin guards capability, so it throws
+//    BasecampException.DeviceFlow(reason = "unavailable") when the server can't
+//    do device flow.
+val token = performDeviceLogin(
+    config = config,
+    clientId = "basecamp-cli",
+    display = { auth ->
+        println("Visit ${auth.verificationUri} and enter code ${auth.userCode}")
+        // Or open auth.verificationUriComplete directly when present.
+    },
+)
+
+println("Access token: ${token.accessToken}")
+```
+
+The two building blocks are also public if you need finer control:
+
+```kotlin
+// deviceAuthorizationEndpoint is optional (device-only servers advertise it,
+// others omit it), so assert its presence rather than dereferencing with `!!`.
+val deviceEndpoint = config.deviceAuthorizationEndpoint
+    ?: error("Selected authorization server does not offer device flow")
+
+val auth = requestDeviceAuthorization(deviceEndpoint, "basecamp-cli")
+println("Enter ${auth.userCode} at ${auth.verificationUri}")
+
+// Polls until approval, denial, or expiry. The wait honours the server interval,
+// a sustained slow_down (+5s), and a monotonic expiry deadline.
+val token = pollDeviceToken(
+    tokenEndpoint = config.tokenEndpoint,
+    clientId = "basecamp-cli",
+    deviceCode = auth.deviceCode,
+    interval = auth.interval,
+    expiresIn = auth.expiresIn,
+)
+```
+
+Polling is cancellation-aware: cancel the enclosing coroutine (job/scope) to stop
+it — the `CancellationException` propagates untouched. Terminal *flow* outcomes
+(the user denied, the code expired, a transport failure, or the server can't do
+device flow) surface as `BasecampException.DeviceFlow`, whose `reason`
+(`access_denied`, `expired`, `transport`, `unavailable`) derives the parent error
+`code` (`auth_required`, `network`, `validation`). Protocol faults are *not*
+`DeviceFlow`: a malformed 2xx token response (unparseable body or an empty
+`access_token`) and an unrecognized RFC 8628 error code both surface as
+`BasecampException.Api`. `refreshToken`'s `clientSecret` is optional so public
+clients like `basecamp-cli` can refresh without a secret.
+
 ## Webhook Verification
 
 Verify incoming webhook signatures using HMAC-SHA256:

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
@@ -17,6 +17,7 @@ package com.basecamp.sdk
  *         is BasecampException.Network -> println("Network error")
  *         is BasecampException.Api -> println("Server error: ${e.httpStatus}")
  *         is BasecampException.Usage -> println("Bad arguments: ${e.message}")
+ *         is BasecampException.Ambiguous -> println("Ambiguous: ${e.message}")
  *         is BasecampException.DiscoverySelection -> println("OAuth discovery: ${e.reason}")
  *         is BasecampException.DeviceFlow -> println("Device flow: ${e.reason}")
  *     }

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
@@ -18,6 +18,7 @@ package com.basecamp.sdk
  *         is BasecampException.Api -> println("Server error: ${e.httpStatus}")
  *         is BasecampException.Usage -> println("Bad arguments: ${e.message}")
  *         is BasecampException.DiscoverySelection -> println("OAuth discovery: ${e.reason}")
+ *         is BasecampException.DeviceFlow -> println("Device flow: ${e.reason}")
  *     }
  * }
  * ```
@@ -141,6 +142,39 @@ sealed class BasecampException(
         cause,
     )
 
+    /**
+     * Terminal RFC 8628 device authorization grant failure (SPEC.md §16). A
+     * single [reason] carries the precise outcome; the parent [code] (and thus
+     * [exitCode]) is DERIVED from it so callers can branch on either the precise
+     * [reason] or the coarse [code]:
+     *
+     * | reason          | code       | retryable |
+     * |-----------------|------------|-----------|
+     * | `access_denied` | auth       | no        |
+     * | `expired`       | auth       | no        |
+     * | `transport`     | network    | yes       |
+     * | `unavailable`   | validation | no        |
+     * | `cancelled`     | usage      | no        |
+     *
+     * Native coroutine cancellation propagates as [kotlin.coroutines.cancellation.CancellationException]
+     * rather than becoming `DeviceFlow(cancelled)`; the `cancelled` reason exists
+     * only for a non-native cancel signal (SPEC.md §16 terminal-outcomes table).
+     */
+    class DeviceFlow(
+        /** Typed device-flow outcome; see the table above. */
+        val reason: String,
+        message: String = deviceFlowDefaultMessage(reason),
+        cause: Throwable? = null,
+    ) : BasecampException(
+        message,
+        deviceFlowCode(reason),
+        null,
+        null,
+        reason == DEVICE_TRANSPORT,
+        null,
+        cause,
+    )
+
     companion object {
         const val CODE_AUTH = "auth_required"
         const val CODE_FORBIDDEN = "forbidden"
@@ -151,6 +185,33 @@ sealed class BasecampException(
         const val CODE_VALIDATION = "validation"
         const val CODE_AMBIGUOUS = "ambiguous"
         const val CODE_USAGE = "usage"
+
+        // RFC 8628 device-flow reasons (see [DeviceFlow]).
+        const val DEVICE_ACCESS_DENIED = "access_denied"
+        const val DEVICE_EXPIRED = "expired"
+        const val DEVICE_TRANSPORT = "transport"
+        const val DEVICE_UNAVAILABLE = "unavailable"
+        const val DEVICE_CANCELLED = "cancelled"
+
+        /** Derives a [DeviceFlow]'s parent error code from its reason. */
+        private fun deviceFlowCode(reason: String): String = when (reason) {
+            DEVICE_ACCESS_DENIED, DEVICE_EXPIRED -> CODE_AUTH
+            DEVICE_TRANSPORT -> CODE_NETWORK
+            DEVICE_UNAVAILABLE -> CODE_VALIDATION
+            DEVICE_CANCELLED -> CODE_USAGE
+            else -> CODE_API
+        }
+
+        /** Default human-readable message for a [DeviceFlow] reason. */
+        private fun deviceFlowDefaultMessage(reason: String): String = when (reason) {
+            DEVICE_ACCESS_DENIED -> "The authorization request was denied"
+            DEVICE_EXPIRED -> "Device code expired before authorization completed"
+            DEVICE_TRANSPORT -> "Device flow transport failure"
+            DEVICE_UNAVAILABLE ->
+                "The selected authorization server does not support the device authorization grant"
+            DEVICE_CANCELLED -> "Device flow cancelled"
+            else -> "Device flow failed: $reason"
+        }
 
         private const val EXIT_OK = 0
         private const val EXIT_USAGE = 1

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
@@ -148,13 +148,13 @@ sealed class BasecampException(
      * [exitCode]) is DERIVED from it so callers can branch on either the precise
      * [reason] or the coarse [code]:
      *
-     * | reason          | code       | retryable |
-     * |-----------------|------------|-----------|
-     * | `access_denied` | auth       | no        |
-     * | `expired`       | auth       | no        |
-     * | `transport`     | network    | yes       |
-     * | `unavailable`   | validation | no        |
-     * | `cancelled`     | usage      | no        |
+     * | reason          | code            | retryable |
+     * |-----------------|-----------------|-----------|
+     * | `access_denied` | `auth_required` | no        |
+     * | `expired`       | `auth_required` | no        |
+     * | `transport`     | `network`       | yes       |
+     * | `unavailable`   | `validation`    | no        |
+     * | `cancelled`     | `usage`         | no        |
      *
      * Native coroutine cancellation propagates as [kotlin.coroutines.cancellation.CancellationException]
      * rather than becoming `DeviceFlow(cancelled)`; the `cancelled` reason exists

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -282,7 +282,7 @@ private fun validateDeviceAuthorization(raw: RawDeviceAuthorization, status: Int
  * a [CancellationException] — it is never converted to a
  * [BasecampException.DeviceFlow].
  *
- * @param interval Minimum seconds between polls (falls back to 5 if not positive).
+ * @param interval Minimum seconds between polls.
  * @param expiresIn Code lifetime in seconds; anchors the default [deadline].
  * @param timeSource Monotonic clock for the deadline; tests inject virtual time.
  * @param deadline Absolute expiry deadline. Defaults to `expiresIn` from now, but
@@ -291,6 +291,8 @@ private fun validateDeviceAuthorization(raw: RawDeviceAuthorization, status: Int
  * @throws BasecampException.DeviceFlow reason `access_denied` on denial,
  *   `expired` on expiry, `transport` on a non-timeout network failure.
  * @throws BasecampException.Api on an unrecognized error code or a parse failure.
+ * @throws BasecampException.Usage when [interval] or [expiresIn] is not a
+ *   positive number of seconds within the shared device ceiling.
  */
 suspend fun pollDeviceToken(
     tokenEndpoint: String,
@@ -304,8 +306,21 @@ suspend fun pollDeviceToken(
 ): OAuthToken {
     requireSecureEndpoint(tokenEndpoint, "token endpoint")
 
+    // Caller-input sanity for this exported entry point (usage, not RFC response
+    // validation, which performDeviceLogin's path already applies): a non-positive
+    // duration builds an already-passed deadline, and an oversized one saturates
+    // Duration to infinite so the deadline NEVER passes — an unbounded poll loop.
+    // Mirrors the Go/TS/Python/Ruby caller guards.
+    for ((name, value) in listOf("expiresIn" to expiresIn, "interval" to interval)) {
+        if (value <= 0 || value > MAX_DEVICE_SECONDS) {
+            throw BasecampException.Usage(
+                "pollDeviceToken: $name must be a positive number of seconds no greater than $MAX_DEVICE_SECONDS",
+            )
+        }
+    }
+
     // Server-driven cadence: the initial interval plus sustained slow_down bumps.
-    var intervalSeconds = if (interval > 0) interval else DEFAULT_INTERVAL_SECONDS
+    var intervalSeconds = interval
     // Transient timeout backoff, tracked SEPARATELY from the server-driven
     // interval so intermittent timeouts can never permanently inflate the
     // cadence: each wait is max(interval, backoff), a timeout doubles the
@@ -414,6 +429,9 @@ private suspend fun postDeviceTokenPoll(
     // loop until expiry, and a body that parrots {"error":"authorization_pending"}
     // must not keep the loop polling. The message names the redirect explicitly.
     if (status in 300..399) {
+        // The unread body is NOT leaked by this early return: HttpStatement.execute
+        // runs cleanup() in its finally, which completes the response job and
+        // cancels the raw content channel, releasing the connection.
         return@execute PollResult.Other("unexpected redirect (HTTP $status)", status)
     }
 
@@ -476,7 +494,11 @@ private suspend fun postDeviceTokenPoll(
     } else {
         // 4xx: the OAuth error is carried in the body (3xx already returned above).
         val error = try {
-            deviceJson.decodeFromString<OAuthErrorResponse>(body).error
+            // An explicit empty "error" decodes cleanly (the field is a required
+            // non-null String, so no SerializationException fires) — normalize it to
+            // http_<status> here so a blank error code is never surfaced as a dangling
+            // message. Matches Go/TS/Python/Ruby, which all coerce a blank error code.
+            deviceJson.decodeFromString<OAuthErrorResponse>(body).error.ifEmpty { "http_$status" }
         } catch (e: SerializationException) {
             "http_$status"
         }

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -248,7 +248,9 @@ private fun validateDeviceAuthorization(raw: RawDeviceAuthorization, status: Int
  * The loop waits at least [interval] seconds between polls (via [delay]), honours
  * a sustained `slow_down` (+5s for this and every subsequent poll), enforces a
  * monotonic expiry [deadline][TimeSource] computed from [timeSource], and backs
- * off exponentially on connection timeouts. Coroutine cancellation propagates as
+ * off exponentially on connection timeouts — the backoff is transient, reset to
+ * the server-driven interval by the next completed round-trip, so intermittent
+ * timeouts never permanently inflate the cadence. Coroutine cancellation propagates as
  * a [CancellationException] — it is never converted to a
  * [BasecampException.DeviceFlow].
  *
@@ -274,7 +276,12 @@ suspend fun pollDeviceToken(
 ): OAuthToken {
     requireSecureEndpoint(tokenEndpoint, "token endpoint")
 
+    // Server-driven cadence: the initial interval plus sustained slow_down bumps.
     var intervalSeconds = if (interval > 0) interval else DEFAULT_INTERVAL_SECONDS
+    // Transient timeout backoff, tracked SEPARATELY from the server-driven
+    // interval so intermittent timeouts can never permanently inflate the
+    // cadence: each wait is max(interval, backoff), a timeout doubles the
+    // backoff (capped), and any completed round-trip resets it to the interval.
     var backoffSeconds = intervalSeconds
 
     val params = parametersOf(
@@ -294,7 +301,7 @@ suspend fun pollDeviceToken(
             // Clamp the wait to the time remaining so a long interval or an
             // exponential backoff can never overshoot the monotonic deadline.
             val remaining = -deadline.elapsedNow()
-            val wait = minOf(intervalSeconds.seconds, remaining)
+            val wait = minOf(maxOf(intervalSeconds, backoffSeconds).seconds, remaining)
             delay(if (wait > Duration.ZERO) wait else Duration.ZERO)
 
             if (deadline.hasPassedNow()) {
@@ -312,7 +319,6 @@ suspend fun pollDeviceToken(
                 if (isConnectionTimeout(e)) {
                     // Our own connection timeout → back off and keep polling.
                     backoffSeconds = minOf(backoffSeconds * 2, MAX_BACKOFF_SECONDS)
-                    intervalSeconds = maxOf(intervalSeconds, backoffSeconds)
                     continue
                 }
                 // Any other transport failure ends the flow.
@@ -323,7 +329,9 @@ suspend fun pollDeviceToken(
                 )
             }
 
-            // A successful HTTP round-trip resets the timeout backoff.
+            // Any completed HTTP round-trip — token, authorization_pending,
+            // slow_down, or another OAuth error — resets the timeout backoff to
+            // the current server-driven interval.
             backoffSeconds = intervalSeconds
 
             when (result) {
@@ -395,6 +403,13 @@ private suspend fun postDeviceTokenPoll(
                 scope = raw.scope,
             ),
         )
+    } else if (status in 300..399) {
+        // Redirects are suppressed (followRedirects = false), so a 3xx here is a
+        // misdirected or attacker-influenced endpoint — an API fault, never an
+        // OAuth poll state. Classified BEFORE body parsing so a redirect whose
+        // body parrots {"error":"authorization_pending"} cannot keep the loop
+        // polling.
+        PollResult.Other("http_$status", status)
     } else {
         val error = try {
             deviceJson.decodeFromString<OAuthErrorResponse>(body).error

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -209,9 +209,13 @@ suspend fun requestDeviceAuthorization(
             val status = response.status.value
             if (status < 200 || status >= 300) {
                 // Non-2xx (including a suppressed 3xx) is api_error, not transport.
+                // retryable = false even for a 5xx (overriding Api's 5xx default):
+                // in the device flow only the transport reason is retryable — a
+                // completed API fault ends the flow, matching the other four SDKs.
                 throw BasecampException.Api(
                     "Device authorization failed with status $status",
                     httpStatus = status,
+                    retryable = false,
                 )
             }
             val body = readBoundedText(response, MAX_DEVICE_BODY_BYTES)
@@ -390,9 +394,12 @@ suspend fun pollDeviceToken(
                 }
                 PollResult.AccessDenied -> throw BasecampException.DeviceFlow(BasecampException.DEVICE_ACCESS_DENIED)
                 PollResult.Expired -> throw BasecampException.DeviceFlow(BasecampException.DEVICE_EXPIRED)
+                // retryable = false even for a 5xx (overriding Api's 5xx default):
+                // only the transport reason is retryable in the device flow.
                 is PollResult.Other -> throw BasecampException.Api(
                     "Device token request failed: ${result.error}",
                     httpStatus = result.status,
+                    retryable = false,
                 )
             }
         }

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -367,6 +367,10 @@ suspend fun pollDeviceToken(
                 PollResult.Pending -> continue
                 PollResult.SlowDown -> {
                     intervalSeconds += SLOW_DOWN_INCREMENT_SECONDS
+                    // Re-sync the backoff to the GROWN interval (the reset above used
+                    // the pre-increment value) so a later timeout doubles from the new
+                    // interval, not the stale one.
+                    backoffSeconds = intervalSeconds
                     continue
                 }
                 PollResult.AccessDenied -> throw BasecampException.DeviceFlow(BasecampException.DEVICE_ACCESS_DENIED)

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -124,6 +124,21 @@ data class DeviceAuthorization(
     val interval: Long,
 )
 
+/**
+ * Raw token response for the device path. `expires_in` decodes as [Double] (the
+ * shared [RawTokenResponse] uses [Long], which throws on an integer-valued float
+ * like 3600.0) so the cross-SDK contract — accept 3600.0, reject fractional —
+ * can be enforced in validation rather than by decoder happenstance.
+ */
+@Serializable
+private data class RawDeviceTokenResponse(
+    @SerialName("access_token") val accessToken: String,
+    @SerialName("refresh_token") val refreshToken: String? = null,
+    @SerialName("token_type") val tokenType: String = "Bearer",
+    @SerialName("expires_in") val expiresIn: Double? = null,
+    val scope: String? = null,
+)
+
 /** Raw RFC 8628 device authorization response; all fields nullable to validate. */
 @Serializable
 private data class RawDeviceAuthorization(
@@ -391,7 +406,7 @@ private suspend fun postDeviceTokenPoll(
 
     if (status in 200..299) {
         val raw = try {
-            deviceJson.decodeFromString<RawTokenResponse>(body)
+            deviceJson.decodeFromString<RawDeviceTokenResponse>(body)
         } catch (e: SerializationException) {
             // Malformed 2xx token response — api_error, NOT a retryable transport.
             throw BasecampException.Api("Failed to parse device token response", httpStatus = status, cause = e)
@@ -401,26 +416,30 @@ private suspend fun postDeviceTokenPoll(
             // (api_error), never an accepted token nor a retryable transport error.
             throw BasecampException.Api("Device token response missing access_token", httpStatus = status)
         }
-        // A non-numeric expires_in (string/bool/1e400) already fails deserialization
-        // above as api_error. What survives is a valid Long that is non-positive or
-        // so large that `it * 1000` overflows — bound it so expiresAt never wraps.
-        raw.expiresIn?.let {
-            if (it <= 0 || it > MAX_TOKEN_LIFETIME_SECONDS) {
+        // A non-numeric expires_in (string/bool) already fails deserialization
+        // above as api_error. What survives is a Double: per the cross-SDK
+        // contract it must be a positive WHOLE number of seconds no greater than
+        // the ceiling — an explicit 0, a fractional 3600.5, or an overflowing
+        // 1e400 (parses to Infinity) is malformed, while 3600.0 is accepted and
+        // converted to whole seconds. The ceiling keeps `* 1000` from wrapping.
+        val expiresInSeconds = raw.expiresIn?.let {
+            if (it <= 0.0 || it > MAX_TOKEN_LIFETIME_SECONDS.toDouble() || it % 1.0 != 0.0) {
                 throw BasecampException.Api(
-                    "Device token response expires_in must be a positive integer no greater than " +
-                        "$MAX_TOKEN_LIFETIME_SECONDS seconds",
+                    "Device token response expires_in must be a positive whole number of seconds " +
+                        "no greater than $MAX_TOKEN_LIFETIME_SECONDS",
                     httpStatus = status,
                 )
             }
+            it.toLong()
         }
         val now = currentTimeMillis()
-        val expiresAt = raw.expiresIn?.let { now + it * 1000 }
+        val expiresAt = expiresInSeconds?.let { now + it * 1000 }
         PollResult.Token(
             OAuthToken(
                 accessToken = raw.accessToken,
                 refreshToken = raw.refreshToken,
                 tokenType = raw.tokenType,
-                expiresIn = raw.expiresIn,
+                expiresIn = expiresInSeconds,
                 expiresAt = expiresAt,
                 scope = raw.scope,
             ),

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -128,13 +128,16 @@ data class DeviceAuthorization(
  * Raw token response for the device path. `expires_in` decodes as [Double] (the
  * shared [RawTokenResponse] uses [Long], which throws on an integer-valued float
  * like 3600.0) so the cross-SDK contract — accept 3600.0, reject fractional —
- * can be enforced in validation rather than by decoder happenstance.
+ * can be enforced in validation rather than by decoder happenstance. `token_type`
+ * stays nullable (no decoder default) so an explicit `"token_type": ""` remains
+ * distinguishable from an absent field: absent defaults to Bearer, explicit empty
+ * is malformed (api_error) — matching the other SDKs.
  */
 @Serializable
 private data class RawDeviceTokenResponse(
     @SerialName("access_token") val accessToken: String,
     @SerialName("refresh_token") val refreshToken: String? = null,
-    @SerialName("token_type") val tokenType: String = "Bearer",
+    @SerialName("token_type") val tokenType: String? = null,
     @SerialName("expires_in") val expiresIn: Double? = null,
     val scope: String? = null,
 )
@@ -432,13 +435,24 @@ private suspend fun postDeviceTokenPoll(
             }
             it.toLong()
         }
+        // token_type, when present, must be non-empty — an explicit "" is
+        // malformed token metadata (api_error), while an absent field defaults
+        // to Bearer. Uniform with Go/Python/Ruby/TypeScript.
+        val tokenType = raw.tokenType?.also {
+            if (it.isEmpty()) {
+                throw BasecampException.Api(
+                    "Device token response token_type must be a non-empty string",
+                    httpStatus = status,
+                )
+            }
+        } ?: "Bearer"
         val now = currentTimeMillis()
         val expiresAt = expiresInSeconds?.let { now + it * 1000 }
         PollResult.Token(
             OAuthToken(
                 accessToken = raw.accessToken,
                 refreshToken = raw.refreshToken,
-                tokenType = raw.tokenType,
+                tokenType = tokenType,
                 expiresIn = expiresInSeconds,
                 expiresAt = expiresAt,
                 scope = raw.scope,

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -463,8 +463,9 @@ private suspend fun postDeviceTokenPoll(
         // misdirected or attacker-influenced endpoint — an API fault, never an
         // OAuth poll state. Classified BEFORE body parsing so a redirect whose
         // body parrots {"error":"authorization_pending"} cannot keep the loop
-        // polling.
-        PollResult.Other("http_$status", status)
+        // polling. The message names the redirect explicitly — it is a distinct,
+        // security-relevant failure mode, not a generic non-2xx status.
+        PollResult.Other("unexpected redirect (HTTP $status)", status)
     } else {
         val error = try {
             deviceJson.decodeFromString<OAuthErrorResponse>(body).error

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -407,8 +407,19 @@ private suspend fun postDeviceTokenPoll(
     setBody(FormDataContent(params))
 }.execute { response ->
     val status = response.status.value
-    // Bounded/streaming read: an oversized device-token body aborts here rather
-    // than buffering (readBoundedText throws api_error past the cap).
+    // A suppressed 3xx is an api fault whose body is unused (redirects are off, so a
+    // 3xx is a misdirected/attacker-influenced endpoint, never an OAuth poll state).
+    // Classify it by status BEFORE reading the body: otherwise a redirect that
+    // slowly streams its body could time out mid-read and be retried by the poll
+    // loop until expiry, and a body that parrots {"error":"authorization_pending"}
+    // must not keep the loop polling. The message names the redirect explicitly.
+    if (status in 300..399) {
+        return@execute PollResult.Other("unexpected redirect (HTTP $status)", status)
+    }
+
+    // Bounded/streaming read: an oversized device-token body aborts here rather than
+    // buffering (readBoundedText throws api_error past the cap). A 4xx body IS read —
+    // it carries authorization_pending/slow_down and other OAuth errors.
     val body = readBoundedText(response, MAX_DEVICE_BODY_BYTES)
 
     if (status in 200..299) {
@@ -462,15 +473,8 @@ private suspend fun postDeviceTokenPoll(
                 scope = raw.scope,
             ),
         )
-    } else if (status in 300..399) {
-        // Redirects are suppressed (followRedirects = false), so a 3xx here is a
-        // misdirected or attacker-influenced endpoint — an API fault, never an
-        // OAuth poll state. Classified BEFORE body parsing so a redirect whose
-        // body parrots {"error":"authorization_pending"} cannot keep the loop
-        // polling. The message names the redirect explicitly — it is a distinct,
-        // security-relevant failure mode, not a generic non-2xx status.
-        PollResult.Other("unexpected redirect (HTTP $status)", status)
     } else {
+        // 4xx: the OAuth error is carried in the body (3xx already returned above).
         val error = try {
             deviceJson.decodeFromString<OAuthErrorResponse>(body).error
         } catch (e: SerializationException) {

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -1,0 +1,483 @@
+package com.basecamp.sdk.oauth
+
+import com.basecamp.sdk.BasecampException
+import com.basecamp.sdk.http.currentTimeMillis
+import com.basecamp.sdk.requireSecureEndpoint
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.accept
+import io.ktor.client.request.forms.FormDataContent
+import io.ktor.client.request.preparePost
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.Parameters
+import io.ktor.http.parametersOf
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+
+/**
+ * RFC 8628 device authorization grant (SPEC.md §16).
+ *
+ * Three suspend functions mirror the shipping TypeScript reference in the Kotlin
+ * coroutines idiom:
+ *   - [requestDeviceAuthorization] — obtain a device/user code pair.
+ *   - [pollDeviceToken] — run the §3.5 polling loop against the token endpoint.
+ *   - [performDeviceLogin] — orchestrate request → display → poll for an
+ *     already-selected [OAuthConfig].
+ *
+ * Both network-facing functions are TLS-guarded via [requireSecureEndpoint]. The
+ * polling clock is a monotonic [TimeSource] (default [TimeSource.Monotonic]),
+ * injectable so tests lock it to virtual time. Waiting uses [delay], so `runTest`
+ * drives it with virtual time and cancellation is cooperative: a
+ * [CancellationException] propagates untouched rather than becoming a
+ * [BasecampException.DeviceFlow].
+ */
+
+/** URN grant type for the device authorization grant (RFC 8628 §3.4). */
+const val DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+
+/** Default polling interval when the server omits `interval` (RFC 8628 §3.2). */
+private const val DEFAULT_INTERVAL_SECONDS = 5L
+
+/** slow_down bumps the interval by this many seconds, sustained (RFC 8628 §3.5). */
+private const val SLOW_DOWN_INCREMENT_SECONDS = 5L
+
+/** Cap on exponential backoff after connection timeouts. */
+private const val MAX_BACKOFF_SECONDS = 60L
+
+/** Bounded per-request timeout for every device-flow HTTP round-trip. */
+private const val DEVICE_REQUEST_TIMEOUT_MS = 30_000L
+
+/** Cap on a device-flow response body (1 MiB) — device/token docs are tiny. */
+private const val MAX_DEVICE_BODY_BYTES = 1L * 1024 * 1024
+
+/**
+ * Ceiling for `expires_in`/`interval`: 2147483 s (~24.8 days) is the largest
+ * whole-second duration whose millisecond form fits a 32-bit signed timer.
+ * Shared across all five SDKs (SPEC.md) — an unbounded value such as 1e100 is
+ * a malformed response, not a schedulable deadline.
+ */
+private const val MAX_DEVICE_SECONDS = 2_147_483L
+
+private val deviceJson = Json { ignoreUnknownKeys = true }
+
+/**
+ * Builds an SSRF-hardened HTTP client for device-flow requests: redirects
+ * suppressed ([HttpClient.followRedirects] = false, so a 3xx surfaces as a
+ * non-2xx rather than the client chasing an attacker-influenced `Location`) and
+ * a bounded per-request timeout (HttpTimeout) so a stalled request can never
+ * blow past the polling deadline unbounded.
+ *
+ * When [baseClient] is supplied its engine is reused but wrapped so the hardening
+ * applies regardless; the returned wrapper is always closed by the caller and,
+ * because Ktor only closes engines it created, the borrowed engine survives.
+ */
+private fun hardenedDeviceClient(baseClient: HttpClient?): HttpClient {
+    val engine = baseClient?.engine
+    return if (engine != null) {
+        HttpClient(engine) {
+            followRedirects = false
+            expectSuccess = false
+            install(HttpTimeout) { requestTimeoutMillis = DEVICE_REQUEST_TIMEOUT_MS }
+        }
+    } else {
+        HttpClient {
+            followRedirects = false
+            expectSuccess = false
+            install(HttpTimeout) { requestTimeoutMillis = DEVICE_REQUEST_TIMEOUT_MS }
+        }
+    }
+}
+
+/**
+ * A device/user code pair from the authorization server (RFC 8628 §3.2).
+ *
+ * @property verificationUriComplete Optional pre-filled verification URI
+ *   (`verification_uri` with the user code embedded).
+ * @property expiresIn Lifetime of the codes in seconds.
+ * @property interval Minimum seconds between token polls (defaults to 5).
+ */
+data class DeviceAuthorization(
+    val deviceCode: String,
+    val userCode: String,
+    val verificationUri: String,
+    val verificationUriComplete: String?,
+    val expiresIn: Long,
+    val interval: Long,
+)
+
+/** Raw RFC 8628 device authorization response; all fields nullable to validate. */
+@Serializable
+private data class RawDeviceAuthorization(
+    @SerialName("device_code") val deviceCode: String? = null,
+    @SerialName("user_code") val userCode: String? = null,
+    @SerialName("verification_uri") val verificationUri: String? = null,
+    @SerialName("verification_uri_complete") val verificationUriComplete: String? = null,
+    // Decoded as Double so an integer-valued float (900.0) parses instead of
+    // throwing; whole-second enforcement + Long conversion happens in validation,
+    // matching the other SDKs (which accept 900.0 but reject fractional 2.5).
+    @SerialName("expires_in") val expiresIn: Double? = null,
+    val interval: Double? = null,
+)
+
+/**
+ * RFC 8628 durations are integer seconds. Returns the whole-second [Long] for a
+ * positive integer-valued number (900 or 900.0) no greater than
+ * [MAX_DEVICE_SECONDS], or null for absent, non-positive, fractional (2.5), or
+ * oversized (1e100) values — the caller raises api_error on null.
+ */
+private fun wholeSecondsOrNull(value: Double?): Long? {
+    if (value == null || value <= 0.0 || value > MAX_DEVICE_SECONDS.toDouble() || value % 1.0 != 0.0) return null
+    return value.toLong()
+}
+
+/**
+ * Requests a device/user code pair (RFC 8628 §3.1–3.2).
+ *
+ * POSTs `client_id` (and `scope` ONLY when set, so the server applies its default
+ * `read`) to [deviceAuthorizationEndpoint] as `application/x-www-form-urlencoded`.
+ * TLS-guarded before any socket opens.
+ *
+ * ```kotlin
+ * val auth = requestDeviceAuthorization(config.deviceAuthorizationEndpoint!!, "basecamp-cli")
+ * println("Visit ${auth.verificationUri} and enter ${auth.userCode}")
+ * ```
+ *
+ * @throws BasecampException.Validation if [clientId] is empty.
+ * @throws BasecampException.DeviceFlow (reason `transport`) on a network failure.
+ * @throws BasecampException.Api on a non-2xx response or invalid/incomplete body.
+ */
+suspend fun requestDeviceAuthorization(
+    deviceAuthorizationEndpoint: String,
+    clientId: String,
+    scope: String? = null,
+    client: HttpClient? = null,
+): DeviceAuthorization {
+    requireSecureEndpoint(deviceAuthorizationEndpoint, "device authorization endpoint")
+    if (clientId.isEmpty()) {
+        throw BasecampException.Validation("Client ID is required for device authorization")
+    }
+
+    val params = Parameters.build {
+        append("client_id", clientId)
+        // Omit scope entirely when unset so the server applies its default (`read`).
+        if (!scope.isNullOrEmpty()) append("scope", scope)
+    }
+
+    val httpClient = hardenedDeviceClient(client)
+    try {
+        return httpClient.preparePost(deviceAuthorizationEndpoint) {
+            accept(ContentType.Application.Json)
+            setBody(FormDataContent(params))
+        }.execute { response ->
+            val status = response.status.value
+            if (status < 200 || status >= 300) {
+                // Non-2xx (including a suppressed 3xx) is api_error, not transport.
+                throw BasecampException.Api(
+                    "Device authorization failed with status $status",
+                    httpStatus = status,
+                )
+            }
+            val body = readBoundedText(response, MAX_DEVICE_BODY_BYTES)
+            val raw = try {
+                deviceJson.decodeFromString<RawDeviceAuthorization>(body)
+            } catch (e: SerializationException) {
+                throw BasecampException.Api(
+                    "Failed to parse device authorization response",
+                    httpStatus = status,
+                    cause = e,
+                )
+            }
+            validateDeviceAuthorization(raw, status)
+        }
+    } catch (e: CancellationException) {
+        // Cooperative coroutine cancellation — propagate, never wrap.
+        throw e
+    } catch (e: BasecampException) {
+        throw e
+    } catch (e: Throwable) {
+        throw BasecampException.DeviceFlow(
+            BasecampException.DEVICE_TRANSPORT,
+            "Device authorization request failed: ${e.message ?: e::class.simpleName}",
+            cause = e,
+        )
+    } finally {
+        httpClient.close()
+    }
+}
+
+private fun validateDeviceAuthorization(raw: RawDeviceAuthorization, status: Int): DeviceAuthorization {
+    if (raw.deviceCode.isNullOrEmpty() || raw.userCode.isNullOrEmpty() || raw.verificationUri.isNullOrEmpty()) {
+        throw BasecampException.Api("Invalid device authorization response: missing required fields", httpStatus = status)
+    }
+    val expiresIn = wholeSecondsOrNull(raw.expiresIn)
+        ?: throw BasecampException.Api(
+            "Invalid device authorization response: expires_in must be a positive integer no greater than $MAX_DEVICE_SECONDS",
+            httpStatus = status,
+        )
+    val interval = when (raw.interval) {
+        null -> DEFAULT_INTERVAL_SECONDS
+        else -> wholeSecondsOrNull(raw.interval)
+            ?: throw BasecampException.Api(
+                "Invalid device authorization response: interval must be a positive integer no greater than $MAX_DEVICE_SECONDS",
+                httpStatus = status,
+            )
+    }
+    return DeviceAuthorization(
+        deviceCode = raw.deviceCode,
+        userCode = raw.userCode,
+        verificationUri = raw.verificationUri,
+        verificationUriComplete = raw.verificationUriComplete,
+        expiresIn = expiresIn,
+        interval = interval,
+    )
+}
+
+/**
+ * Polls the token endpoint until the user approves, denies, or the codes expire
+ * (RFC 8628 §3.4–3.5).
+ *
+ * The loop waits at least [interval] seconds between polls (via [delay]), honours
+ * a sustained `slow_down` (+5s for this and every subsequent poll), enforces a
+ * monotonic expiry [deadline][TimeSource] computed from [timeSource], and backs
+ * off exponentially on connection timeouts. Coroutine cancellation propagates as
+ * a [CancellationException] — it is never converted to a
+ * [BasecampException.DeviceFlow].
+ *
+ * @param interval Minimum seconds between polls (falls back to 5 if not positive).
+ * @param expiresIn Code lifetime in seconds; anchors the default [deadline].
+ * @param timeSource Monotonic clock for the deadline; tests inject virtual time.
+ * @param deadline Absolute expiry deadline. Defaults to `expiresIn` from now, but
+ *   [performDeviceLogin] passes a deadline anchored at code issuance so display
+ *   time counts against the lifetime rather than resetting it.
+ * @throws BasecampException.DeviceFlow reason `access_denied` on denial,
+ *   `expired` on expiry, `transport` on a non-timeout network failure.
+ * @throws BasecampException.Api on an unrecognized error code or a parse failure.
+ */
+suspend fun pollDeviceToken(
+    tokenEndpoint: String,
+    clientId: String,
+    deviceCode: String,
+    interval: Long,
+    expiresIn: Long,
+    timeSource: TimeSource = TimeSource.Monotonic,
+    client: HttpClient? = null,
+    deadline: TimeMark = timeSource.markNow() + expiresIn.seconds,
+): OAuthToken {
+    requireSecureEndpoint(tokenEndpoint, "token endpoint")
+
+    var intervalSeconds = if (interval > 0) interval else DEFAULT_INTERVAL_SECONDS
+    var backoffSeconds = intervalSeconds
+
+    val params = parametersOf(
+        "grant_type" to listOf(DEVICE_CODE_GRANT_TYPE),
+        "device_code" to listOf(deviceCode),
+        "client_id" to listOf(clientId),
+    )
+
+    val httpClient = hardenedDeviceClient(client)
+    try {
+        while (true) {
+            // Re-check the deadline before waiting/polling (after the display hook
+            // on the first pass, before every poll thereafter).
+            if (deadline.hasPassedNow()) {
+                throw BasecampException.DeviceFlow(BasecampException.DEVICE_EXPIRED)
+            }
+            // Clamp the wait to the time remaining so a long interval or an
+            // exponential backoff can never overshoot the monotonic deadline.
+            val remaining = -deadline.elapsedNow()
+            val wait = minOf(intervalSeconds.seconds, remaining)
+            delay(if (wait > Duration.ZERO) wait else Duration.ZERO)
+
+            if (deadline.hasPassedNow()) {
+                throw BasecampException.DeviceFlow(BasecampException.DEVICE_EXPIRED)
+            }
+
+            val result = try {
+                postDeviceTokenPoll(httpClient, tokenEndpoint, params)
+            } catch (e: CancellationException) {
+                // Cooperative coroutine cancellation — propagate, never wrap.
+                throw e
+            } catch (e: BasecampException) {
+                throw e
+            } catch (e: Throwable) {
+                if (isConnectionTimeout(e)) {
+                    // Our own connection timeout → back off and keep polling.
+                    backoffSeconds = minOf(backoffSeconds * 2, MAX_BACKOFF_SECONDS)
+                    intervalSeconds = maxOf(intervalSeconds, backoffSeconds)
+                    continue
+                }
+                // Any other transport failure ends the flow.
+                throw BasecampException.DeviceFlow(
+                    BasecampException.DEVICE_TRANSPORT,
+                    "Device token poll failed: ${e.message ?: e::class.simpleName}",
+                    cause = e,
+                )
+            }
+
+            // A successful HTTP round-trip resets the timeout backoff.
+            backoffSeconds = intervalSeconds
+
+            when (result) {
+                is PollResult.Token -> return result.token
+                PollResult.Pending -> continue
+                PollResult.SlowDown -> {
+                    intervalSeconds += SLOW_DOWN_INCREMENT_SECONDS
+                    continue
+                }
+                PollResult.AccessDenied -> throw BasecampException.DeviceFlow(BasecampException.DEVICE_ACCESS_DENIED)
+                PollResult.Expired -> throw BasecampException.DeviceFlow(BasecampException.DEVICE_EXPIRED)
+                is PollResult.Other -> throw BasecampException.Api(
+                    "Device token request failed: ${result.error}",
+                    httpStatus = result.status,
+                )
+            }
+        }
+    } finally {
+        httpClient.close()
+    }
+    // The while(true) loop only exits via `return` or `throw`, so this point is
+    // unreachable and Kotlin requires no trailing return.
+}
+
+/** One token-poll outcome (RFC 8628 §3.5). */
+private sealed interface PollResult {
+    data class Token(val token: OAuthToken) : PollResult
+    data object Pending : PollResult
+    data object SlowDown : PollResult
+    data object AccessDenied : PollResult
+    data object Expired : PollResult
+    data class Other(val error: String, val status: Int) : PollResult
+}
+
+private suspend fun postDeviceTokenPoll(
+    client: HttpClient,
+    tokenEndpoint: String,
+    params: Parameters,
+): PollResult = client.preparePost(tokenEndpoint) {
+    accept(ContentType.Application.Json)
+    setBody(FormDataContent(params))
+}.execute { response ->
+    val status = response.status.value
+    // Bounded/streaming read: an oversized device-token body aborts here rather
+    // than buffering (readBoundedText throws api_error past the cap).
+    val body = readBoundedText(response, MAX_DEVICE_BODY_BYTES)
+
+    if (status in 200..299) {
+        val raw = try {
+            deviceJson.decodeFromString<RawTokenResponse>(body)
+        } catch (e: SerializationException) {
+            // Malformed 2xx token response — api_error, NOT a retryable transport.
+            throw BasecampException.Api("Failed to parse device token response", httpStatus = status, cause = e)
+        }
+        if (raw.accessToken.isBlank()) {
+            // A 2xx with an empty/blank access_token is a server/api fault
+            // (api_error), never an accepted token nor a retryable transport error.
+            throw BasecampException.Api("Device token response missing access_token", httpStatus = status)
+        }
+        val now = currentTimeMillis()
+        val expiresAt = raw.expiresIn?.let { now + it * 1000 }
+        PollResult.Token(
+            OAuthToken(
+                accessToken = raw.accessToken,
+                refreshToken = raw.refreshToken,
+                tokenType = raw.tokenType,
+                expiresIn = raw.expiresIn,
+                expiresAt = expiresAt,
+                scope = raw.scope,
+            ),
+        )
+    } else {
+        val error = try {
+            deviceJson.decodeFromString<OAuthErrorResponse>(body).error
+        } catch (e: SerializationException) {
+            "http_$status"
+        }
+        when (error) {
+            "authorization_pending" -> PollResult.Pending
+            "slow_down" -> PollResult.SlowDown
+            "access_denied" -> PollResult.AccessDenied
+            "expired_token" -> PollResult.Expired
+            else -> PollResult.Other(error, status)
+        }
+    }
+}
+
+/**
+ * Runs the full device authorization grant against an ALREADY-SELECTED [config]
+ * (from discovery): capability guard → request → [display] → poll (SPEC.md §16).
+ *
+ * The capability guard requires BOTH [OAuthConfig.deviceAuthorizationEndpoint]
+ * present AND [OAuthConfig.grantTypesSupported] advertising the device_code grant;
+ * otherwise it raises [BasecampException.DeviceFlow] reason `unavailable`.
+ *
+ * @param display Invoked once with the code pair, after it is obtained and before
+ *   polling begins — surface `userCode` + `verificationUri` to the user here. The
+ *   expiry deadline is anchored at code issuance (BEFORE this hook), so time spent
+ *   in `display` counts against the code's lifetime rather than resetting it; a
+ *   hook that consumes the whole lifetime yields `expired` without any poll.
+ * @throws BasecampException.DeviceFlow reason `unavailable` when [config] cannot
+ *   do device flow; `expired` when the display hook outlasts the code; other
+ *   reasons on denial/expiry/transport per [pollDeviceToken].
+ */
+suspend fun performDeviceLogin(
+    config: OAuthConfig,
+    clientId: String,
+    scope: String? = null,
+    display: (DeviceAuthorization) -> Unit,
+    timeSource: TimeSource = TimeSource.Monotonic,
+    client: HttpClient? = null,
+): OAuthToken {
+    val endpoint = config.deviceAuthorizationEndpoint
+    val supportsDeviceGrant = config.grantTypesSupported.contains(DEVICE_CODE_GRANT_TYPE)
+    // An empty endpoint string is treated as absent (not device-flow-capable): it
+    // must yield `unavailable` here rather than slipping through to fail later with
+    // the wrong error category when the empty URL hits the TLS/socket layer.
+    if (endpoint.isNullOrEmpty() || !supportsDeviceGrant) {
+        throw BasecampException.DeviceFlow(BasecampException.DEVICE_UNAVAILABLE)
+    }
+
+    val auth = requestDeviceAuthorization(endpoint, clientId, scope, client)
+    // Anchor the code's expiry deadline at issuance — BEFORE the display hook — so
+    // a slow display counts against the lifetime instead of resetting it.
+    val deadline = timeSource.markNow() + auth.expiresIn.seconds
+    display(auth)
+    // If the display hook already consumed the whole lifetime, the code is dead on
+    // arrival: fail fast rather than open a doomed poll.
+    if (deadline.hasPassedNow()) {
+        throw BasecampException.DeviceFlow(BasecampException.DEVICE_EXPIRED)
+    }
+    return pollDeviceToken(
+        tokenEndpoint = config.tokenEndpoint,
+        clientId = clientId,
+        deviceCode = auth.deviceCode,
+        interval = auth.interval,
+        expiresIn = auth.expiresIn,
+        timeSource = timeSource,
+        client = client,
+        deadline = deadline,
+    )
+}
+
+/**
+ * True when [e] (or any cause in its chain) denotes a connection timeout — a
+ * signal to back off and keep polling rather than end the flow. Matched by class
+ * name so it stays engine-agnostic across Ktor transports (JVM/Native), while
+ * genuine [CancellationException]s are handled separately and never reach here.
+ */
+private fun isConnectionTimeout(e: Throwable): Boolean {
+    var current: Throwable? = e
+    while (current != null) {
+        if (current::class.simpleName?.contains("Timeout", ignoreCase = true) == true) return true
+        current = current.cause
+    }
+    return false
+}

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -67,6 +67,16 @@ private const val MAX_DEVICE_BODY_BYTES = 1L * 1024 * 1024
  */
 private const val MAX_DEVICE_SECONDS = 2_147_483L
 
+/**
+ * Ceiling for an OAuth token's `expires_in` (2147483647 s ~= 68 years):
+ * cross-runtime safe and vastly beyond any realistic token lifetime. Unlike
+ * [MAX_DEVICE_SECONDS] this bounds `expiresAt` arithmetic rather than a timer —
+ * a large finite value (e.g. `Long.MAX_VALUE`) would overflow `it * 1000` and
+ * yield a garbage deadline, so a value past this ceiling is a malformed
+ * response. Shared across all five SDKs.
+ */
+private const val MAX_TOKEN_LIFETIME_SECONDS = 2_147_483_647L
+
 private val deviceJson = Json { ignoreUnknownKeys = true }
 
 /**
@@ -390,6 +400,18 @@ private suspend fun postDeviceTokenPoll(
             // A 2xx with an empty/blank access_token is a server/api fault
             // (api_error), never an accepted token nor a retryable transport error.
             throw BasecampException.Api("Device token response missing access_token", httpStatus = status)
+        }
+        // A non-numeric expires_in (string/bool/1e400) already fails deserialization
+        // above as api_error. What survives is a valid Long that is non-positive or
+        // so large that `it * 1000` overflows — bound it so expiresAt never wraps.
+        raw.expiresIn?.let {
+            if (it <= 0 || it > MAX_TOKEN_LIFETIME_SECONDS) {
+                throw BasecampException.Api(
+                    "Device token response expires_in must be a positive integer no greater than " +
+                        "$MAX_TOKEN_LIFETIME_SECONDS seconds",
+                    httpStatus = status,
+                )
+            }
         }
         val now = currentTimeMillis()
         val expiresAt = raw.expiresIn?.let { now + it * 1000 }

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -294,12 +294,15 @@ private fun validateDeviceAuthorization(raw: RawDeviceAuthorization, status: Int
  * @param timeSource Monotonic clock for the deadline; tests inject virtual time.
  * @param deadline Absolute expiry deadline. Defaults to `expiresIn` from now, but
  *   [performDeviceLogin] passes a deadline anchored at code issuance so display
- *   time counts against the lifetime rather than resetting it.
+ *   time counts against the lifetime rather than resetting it. Must be no later
+ *   than `expiresIn` from now — a deadline can only shorten the validated
+ *   lifetime, never extend it.
  * @throws BasecampException.DeviceFlow reason `access_denied` on denial,
  *   `expired` on expiry, `transport` on a non-timeout network failure.
  * @throws BasecampException.Api on an unrecognized error code or a parse failure.
  * @throws BasecampException.Usage when [interval] or [expiresIn] is not a
- *   positive number of seconds within the shared device ceiling.
+ *   positive number of seconds within the shared device ceiling, or when
+ *   [deadline] is later than `expiresIn` from now.
  */
 suspend fun pollDeviceToken(
     tokenEndpoint: String,
@@ -324,6 +327,18 @@ suspend fun pollDeviceToken(
                 "pollDeviceToken: $name must be a positive number of seconds no greater than $MAX_DEVICE_SECONDS",
             )
         }
+    }
+
+    // A caller-supplied deadline can only SHORTEN the validated lifetime, never
+    // extend it: a mark later than expiresIn from now would keep token requests
+    // running after the server-issued code expired. The issuance-anchored mark
+    // performDeviceLogin passes is always at or before this bound (the clock
+    // only advances after issuance). An already-passed mark stays legal — it
+    // surfaces as the expired flow.
+    if (-deadline.elapsedNow() > expiresIn.seconds) {
+        throw BasecampException.Usage(
+            "pollDeviceToken: deadline must be no later than expiresIn seconds from now",
+        )
     }
 
     // Server-driven cadence: the initial interval plus sustained slow_down bumps.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -209,6 +209,12 @@ suspend fun requestDeviceAuthorization(
             accept(ContentType.Application.Json)
             setBody(FormDataContent(params))
         }.execute { response ->
+            // Re-check cancellation BEFORE classifying the completed response:
+            // an engine that ignores coroutine cancellation can cancel the
+            // caller and still complete a non-2xx or malformed response, and
+            // the native CancellationException must win over every completed
+            // outcome — matching the token poll's pre-classification re-check.
+            currentCoroutineContext().ensureActive()
             val status = response.status.value
             if (status < 200 || status >= 300) {
                 // Non-2xx (including a suppressed 3xx) is api_error, not transport.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -5,6 +5,7 @@ import com.basecamp.sdk.http.currentTimeMillis
 import com.basecamp.sdk.requireSecureEndpoint
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.timeout
 import io.ktor.client.request.accept
 import io.ktor.client.request.forms.FormDataContent
 import io.ktor.client.request.preparePost
@@ -351,12 +352,22 @@ suspend fun pollDeviceToken(
             val wait = minOf(maxOf(intervalSeconds, backoffSeconds).seconds, remaining)
             delay(if (wait > Duration.ZERO) wait else Duration.ZERO)
 
-            if (deadline.hasPassedNow()) {
+            val postRemaining = -deadline.elapsedNow()
+            if (postRemaining <= Duration.ZERO) {
                 throw BasecampException.DeviceFlow(BasecampException.DEVICE_EXPIRED)
             }
 
             val result = try {
-                postDeviceTokenPoll(httpClient, tokenEndpoint, params)
+                // Bound the request by the REMAINING code lifetime as well as
+                // the per-request timeout: near expiry, a stalled token POST
+                // must not hold the flow past the monotonic deadline for the
+                // full request budget.
+                postDeviceTokenPoll(
+                    httpClient,
+                    tokenEndpoint,
+                    params,
+                    minOf(DEVICE_REQUEST_TIMEOUT_MS, postRemaining.inWholeMilliseconds.coerceAtLeast(1)),
+                )
             } catch (e: CancellationException) {
                 // Cooperative coroutine cancellation — propagate, never wrap.
                 throw e
@@ -424,9 +435,13 @@ private suspend fun postDeviceTokenPoll(
     client: HttpClient,
     tokenEndpoint: String,
     params: Parameters,
+    perRequestTimeoutMillis: Long = DEVICE_REQUEST_TIMEOUT_MS,
 ): PollResult = client.preparePost(tokenEndpoint) {
     accept(ContentType.Application.Json)
     setBody(FormDataContent(params))
+    // Per-request override of the installed HttpTimeout: the poll loop clamps
+    // this to the remaining code lifetime near expiry.
+    timeout { requestTimeoutMillis = perRequestTimeoutMillis }
 }.execute { response ->
     val status = response.status.value
     // A suppressed 3xx is an api fault whose body is unused (redirects are off, so a
@@ -506,14 +521,23 @@ private suspend fun postDeviceTokenPoll(
         // Non-200 (a 4xx OAuth error, or a nonstandard 2xx): the OAuth error is
         // carried in the body (3xx already returned above); a body without an
         // error code falls back to http_<status> and terminates as api_error.
-        val error = try {
-            // An explicit empty "error" decodes cleanly (the field is a required
-            // non-null String, so no SerializationException fires) — normalize it to
-            // http_<status> here so a blank error code is never surfaced as a dangling
-            // message. Matches Go/TS/Python/Ruby, which all coerce a blank error code.
-            deviceJson.decodeFromString<OAuthErrorResponse>(body).error.ifEmpty { "http_$status" }
-        } catch (e: SerializationException) {
+        // OAuth protocol error codes are recognized ONLY on a 4xx (RFC 8628
+        // §3.5 error responses are 400-class): a nonstandard 2xx (201/202) or
+        // a 5xx carrying a crafted authorization_pending body must not keep
+        // the loop polling — only a 200 can produce a token and only a 4xx a
+        // protocol state.
+        val error = if (status !in 400..499) {
             "http_$status"
+        } else {
+            try {
+                // An explicit empty "error" decodes cleanly (the field is a required
+                // non-null String, so no SerializationException fires) — normalize it to
+                // http_<status> here so a blank error code is never surfaced as a dangling
+                // message. Matches Go/TS/Python/Ruby, which all coerce a blank error code.
+                deviceJson.decodeFromString<OAuthErrorResponse>(body).error.ifEmpty { "http_$status" }
+            } catch (e: SerializationException) {
+                "http_$status"
+            }
         }
         when (error) {
             "authorization_pending" -> PollResult.Pending

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -642,6 +642,12 @@ suspend fun performDeviceLogin(
         throw BasecampException.DeviceFlow(BasecampException.DEVICE_UNAVAILABLE)
     }
 
+    // The code's lifetime starts at SERVER issuance, which precedes the
+    // response: anchor conservatively BEFORE the request goes out, so a slow
+    // authorization response (or one delayed in transit) eats into the
+    // deadline instead of granting the code a fresh full lifetime. The anchor
+    // can only SHORTEN the usable window, never extend it.
+    val issuedAt = timeSource.markNow()
     val auth = requestDeviceAuthorization(endpoint, clientId, scope, client)
     // Re-check cancellation before surfacing the code: coroutine cancellation
     // normally throws at the request's own suspension points, but an injected
@@ -649,9 +655,9 @@ suspend fun performDeviceLogin(
     // cancelled — the display hook must never fire then. Mirrors the
     // Go/TS/Python/Ruby orchestrators' post-request re-check.
     currentCoroutineContext().ensureActive()
-    // Anchor the code's expiry deadline at issuance — BEFORE the display hook — so
-    // a slow display counts against the lifetime instead of resetting it.
-    val deadline = timeSource.markNow() + auth.expiresIn.seconds
+    // Derive the deadline from the pre-request anchor so neither a slow
+    // response nor a slow display hook resets the lifetime.
+    val deadline = issuedAt + auth.expiresIn.seconds
     display(auth)
     // Cancellation raised INSIDE the display hook (a prompt closing in
     // response to cancellation) wins over expiry: a hook that both cancels

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -457,6 +457,15 @@ private suspend fun postDeviceTokenPoll(
         return@execute PollResult.Other("unexpected redirect (HTTP $status)", status)
     }
 
+    // Every remaining status outside 200 and 4xx is terminal WITHOUT its body
+    // (only a 200 carries the token and only a 4xx the OAuth error code) —
+    // classify it before the read, like the 3xx above, so a 201/500 that
+    // stalls while streaming its body cannot time out mid-read and be retried
+    // as a transient failure until the code expires. Same non-leak guarantee.
+    if (status != 200 && status !in 400..499) {
+        return@execute PollResult.Other("http_$status", status)
+    }
+
     // Bounded/streaming read: an oversized device-token body aborts here rather than
     // buffering (readBoundedText throws api_error past the cap). A 4xx body IS read —
     // it carries authorization_pending/slow_down and other OAuth errors.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -231,6 +231,11 @@ suspend fun requestDeviceAuthorization(
                     cause = e,
                 )
             }
+            // A custom engine that ignores coroutine cancellation can complete
+            // a valid response after the caller cancelled: re-check before
+            // handing back a usable device code (Go/TS re-check ctx/signal at
+            // the same seam).
+            currentCoroutineContext().ensureActive()
             validateDeviceAuthorization(raw, status)
         }
     } catch (e: CancellationException) {
@@ -410,7 +415,14 @@ suspend fun pollDeviceToken(
             backoffSeconds = intervalSeconds
 
             when (result) {
-                is PollResult.Token -> return result.token
+                // Re-check cancellation before handing back the credential: a
+                // custom engine that ignores coroutine cancellation can
+                // complete a 200 after the caller cancelled (Go/TS re-check
+                // ctx/signal at the same seam).
+                is PollResult.Token -> {
+                    currentCoroutineContext().ensureActive()
+                    return result.token
+                }
                 PollResult.Pending -> continue
                 PollResult.SlowDown -> {
                     intervalSeconds += SLOW_DOWN_INCREMENT_SECONDS

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -643,6 +643,11 @@ suspend fun performDeviceLogin(
     // a slow display counts against the lifetime instead of resetting it.
     val deadline = timeSource.markNow() + auth.expiresIn.seconds
     display(auth)
+    // Cancellation raised INSIDE the display hook (a prompt closing in
+    // response to cancellation) wins over expiry: a hook that both cancels
+    // and consumes the lifetime must propagate the native
+    // CancellationException, not DeviceFlow(expired).
+    currentCoroutineContext().ensureActive()
     // If the display hook already consumed the whole lifetime, the code is dead on
     // arrival: fail fast rather than open a doomed poll.
     if (deadline.hasPassedNow()) {

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -228,6 +228,10 @@ suspend fun requestDeviceAuthorization(
                 )
             }
             val body = readBoundedText(response, MAX_DEVICE_BODY_BYTES)
+            // Re-check after the body read, BEFORE decoding: an engine whose
+            // body channel cancels the caller while yielding malformed JSON
+            // must surface the native cancellation, not the parse Api error.
+            currentCoroutineContext().ensureActive()
             val raw = try {
                 deviceJson.decodeFromString<RawDeviceAuthorization>(body)
             } catch (e: SerializationException) {
@@ -505,6 +509,10 @@ private suspend fun postDeviceTokenPoll(
     // buffering (readBoundedText throws api_error past the cap). A 4xx body IS read —
     // it carries authorization_pending/slow_down and other OAuth errors.
     val body = readBoundedText(response, MAX_DEVICE_BODY_BYTES)
+    // Re-check after the body read, BEFORE decoding: an engine whose body
+    // channel cancels the caller while yielding malformed JSON must surface
+    // the native cancellation, not the parse Api error.
+    currentCoroutineContext().ensureActive()
 
     // Exactly HTTP 200, not any 2xx: RFC 8628/6749 token responses are 200, and
     // SPEC §16 pins the contract. A nonstandard 201/202 carrying an access_token
@@ -517,9 +525,11 @@ private suspend fun postDeviceTokenPoll(
             // Malformed 2xx token response — api_error, NOT a retryable transport.
             throw BasecampException.Api("Failed to parse device token response", httpStatus = status, cause = e)
         }
-        if (raw.accessToken.isBlank()) {
-            // A 2xx with an empty/blank access_token is a server/api fault
-            // (api_error), never an accepted token nor a retryable transport error.
+        if (raw.accessToken.isEmpty()) {
+            // A 2xx with an EMPTY access_token is a server/api fault
+            // (api_error). isEmpty, not isBlank: tokens are opaque and the
+            // cross-SDK contract requires only non-emptiness — a whitespace
+            // token is the server's business.
             throw BasecampException.Api("Device token response missing access_token", httpStatus = status)
         }
         // A non-numeric expires_in (string/bool) already fails deserialization

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -234,11 +234,13 @@ suspend fun requestDeviceAuthorization(
             currentCoroutineContext().ensureActive()
             val raw = try {
                 deviceJson.decodeFromString<RawDeviceAuthorization>(body)
-            } catch (e: SerializationException) {
+            } catch (_: SerializationException) {
+                // No cause: kotlinx embeds JSON input excerpts in decoder
+                // messages, and the body carries the device_code — a logged
+                // exception chain must not disclose it.
                 throw BasecampException.Api(
                     "Failed to parse device authorization response",
                     httpStatus = status,
-                    cause = e,
                 )
             }
             // A custom engine that ignores coroutine cancellation can complete
@@ -521,9 +523,12 @@ private suspend fun postDeviceTokenPoll(
     if (status == 200) {
         val raw = try {
             deviceJson.decodeFromString<RawDeviceTokenResponse>(body)
-        } catch (e: SerializationException) {
-            // Malformed 2xx token response — api_error, NOT a retryable transport.
-            throw BasecampException.Api("Failed to parse device token response", httpStatus = status, cause = e)
+        } catch (_: SerializationException) {
+            // Malformed 2xx token response — api_error, NOT a retryable
+            // transport. No cause: kotlinx embeds JSON input excerpts in
+            // decoder messages, and the body carries the access token — a
+            // logged exception chain must not disclose it.
+            throw BasecampException.Api("Failed to parse device token response", httpStatus = status)
         }
         if (raw.accessToken.isEmpty()) {
             // A 2xx with an EMPTY access_token is a server/api fault

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -414,15 +414,15 @@ suspend fun pollDeviceToken(
             // the current server-driven interval.
             backoffSeconds = intervalSeconds
 
+            // Re-check cancellation before classifying ANY completed round
+            // trip: a custom engine that ignores coroutine cancellation can
+            // complete a 200, a terminal 4xx (access_denied, expired_token),
+            // or a malformed response after the caller cancelled — the native
+            // CancellationException must win over every completed outcome
+            // (Go/TS re-check ctx/signal at the same seam).
+            currentCoroutineContext().ensureActive()
             when (result) {
-                // Re-check cancellation before handing back the credential: a
-                // custom engine that ignores coroutine cancellation can
-                // complete a 200 after the caller cancelled (Go/TS re-check
-                // ctx/signal at the same seam).
-                is PollResult.Token -> {
-                    currentCoroutineContext().ensureActive()
-                    return result.token
-                }
+                is PollResult.Token -> return result.token
                 PollResult.Pending -> continue
                 PollResult.SlowDown -> {
                     intervalSeconds += SLOW_DOWN_INCREMENT_SECONDS

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -642,12 +642,6 @@ suspend fun performDeviceLogin(
         throw BasecampException.DeviceFlow(BasecampException.DEVICE_UNAVAILABLE)
     }
 
-    // The code's lifetime starts at SERVER issuance, which precedes the
-    // response: anchor conservatively BEFORE the request goes out, so a slow
-    // authorization response (or one delayed in transit) eats into the
-    // deadline instead of granting the code a fresh full lifetime. The anchor
-    // can only SHORTEN the usable window, never extend it.
-    val issuedAt = timeSource.markNow()
     val auth = requestDeviceAuthorization(endpoint, clientId, scope, client)
     // Re-check cancellation before surfacing the code: coroutine cancellation
     // normally throws at the request's own suspension points, but an injected
@@ -655,9 +649,11 @@ suspend fun performDeviceLogin(
     // cancelled — the display hook must never fire then. Mirrors the
     // Go/TS/Python/Ruby orchestrators' post-request re-check.
     currentCoroutineContext().ensureActive()
-    // Derive the deadline from the pre-request anchor so neither a slow
-    // response nor a slow display hook resets the lifetime.
-    val deadline = issuedAt + auth.expiresIn.seconds
+    // Anchor the code's lifetime at ISSUANCE — the response's arrival, per
+    // SPEC §16 — before the display hook, so a slow display eats into the
+    // deadline instead of resetting it. Expiry past this point is arbitrated
+    // by the server (expired_token), so receipt-anchoring fails safe.
+    val deadline = timeSource.markNow() + auth.expiresIn.seconds
     display(auth)
     // Cancellation raised INSIDE the display hook (a prompt closing in
     // response to cancellation) wins over expiry: a hook that both cancels

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -543,7 +543,12 @@ private suspend fun postDeviceTokenPoll(
                 // non-null String, so no SerializationException fires) — normalize it to
                 // http_<status> here so a blank error code is never surfaced as a dangling
                 // message. Matches Go/TS/Python/Ruby, which all coerce a blank error code.
-                deviceJson.decodeFromString<OAuthErrorResponse>(body).error.ifEmpty { "http_$status" }
+                // truncateMessage at extraction (SPEC §9's 500-unit cap): the server
+                // controls this string and an unrecognized value is interpolated into
+                // the api_error message; real protocol codes are short.
+                BasecampException.truncateMessage(
+                    deviceJson.decodeFromString<OAuthErrorResponse>(body).error.ifEmpty { "http_$status" },
+                )
             } catch (e: SerializationException) {
                 "http_$status"
             }

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -447,7 +447,11 @@ private suspend fun postDeviceTokenPoll(
     // it carries authorization_pending/slow_down and other OAuth errors.
     val body = readBoundedText(response, MAX_DEVICE_BODY_BYTES)
 
-    if (status in 200..299) {
+    // Exactly HTTP 200, not any 2xx: RFC 8628/6749 token responses are 200, and
+    // SPEC §16 pins the contract. A nonstandard 201/202 carrying an access_token
+    // must not prematurely complete polling — it falls through to the OAuth-error
+    // path below and terminates as api_error (http_<status>).
+    if (status == 200) {
         val raw = try {
             deviceJson.decodeFromString<RawDeviceTokenResponse>(body)
         } catch (e: SerializationException) {
@@ -499,7 +503,9 @@ private suspend fun postDeviceTokenPoll(
             ),
         )
     } else {
-        // 4xx: the OAuth error is carried in the body (3xx already returned above).
+        // Non-200 (a 4xx OAuth error, or a nonstandard 2xx): the OAuth error is
+        // carried in the body (3xx already returned above); a body without an
+        // error code falls back to http_<status> and terminates as api_error.
         val error = try {
             // An explicit empty "error" decodes cleanly (the field is a required
             // non-null String, so no SerializationException fires) — normalize it to

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -14,7 +14,9 @@ import io.ktor.http.ContentType
 import io.ktor.http.Parameters
 import io.ktor.http.parametersOf
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.Serializable
@@ -598,6 +600,12 @@ suspend fun performDeviceLogin(
     }
 
     val auth = requestDeviceAuthorization(endpoint, clientId, scope, client)
+    // Re-check cancellation before surfacing the code: coroutine cancellation
+    // normally throws at the request's own suspension points, but an injected
+    // engine that ignores it can complete the round-trip after the job was
+    // cancelled — the display hook must never fire then. Mirrors the
+    // Go/TS/Python/Ruby orchestrators' post-request re-check.
+    currentCoroutineContext().ensureActive()
     // Anchor the code's expiry deadline at issuance — BEFORE the display hook — so
     // a slow display counts against the lifetime instead of resetting it.
     val deadline = timeSource.markNow() + auth.expiresIn.seconds

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Discovery.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Discovery.kt
@@ -530,9 +530,13 @@ internal suspend fun readBoundedText(response: HttpResponse, maxBytes: Long): St
         total += read
         if (total > maxBytes) {
             channel.cancel(null)
+            // retryable = false even on a 5xx (overriding Api's 5xx default): an
+            // oversized body is a completed API fault, not a transient transport
+            // failure — matching the non-retryable size-cap error in the other SDKs.
             throw BasecampException.Api(
                 "OAuth response exceeds size cap",
                 httpStatus = response.status.value,
+                retryable = false,
             )
         }
         chunks.add(buffer.copyOf(read))

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Exchange.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Exchange.kt
@@ -111,24 +111,21 @@ suspend fun refreshToken(
     tokenEndpoint: String,
     refreshToken: String,
     clientId: String,
-    clientSecret: String,
+    // Nullable: the public `basecamp-cli` client is a public OAuth client
+    // (`token_endpoint_auth_method: none`) and sends no secret.
+    clientSecret: String? = null,
     useLegacyFormat: Boolean = false,
     client: HttpClient? = null,
 ): OAuthToken {
-    val params = if (useLegacyFormat) {
-        parametersOf(
-            "type" to listOf("refresh"),
-            "refresh_token" to listOf(refreshToken),
-            "client_id" to listOf(clientId),
-            "client_secret" to listOf(clientSecret),
-        )
-    } else {
-        parametersOf(
-            "grant_type" to listOf("refresh_token"),
-            "refresh_token" to listOf(refreshToken),
-            "client_id" to listOf(clientId),
-            "client_secret" to listOf(clientSecret),
-        )
+    val params = Parameters.build {
+        if (useLegacyFormat) {
+            append("type", "refresh")
+        } else {
+            append("grant_type", "refresh_token")
+        }
+        append("refresh_token", refreshToken)
+        append("client_id", clientId)
+        if (!clientSecret.isNullOrEmpty()) append("client_secret", clientSecret)
     }
 
     return postTokenRequest(tokenEndpoint, params, client)

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Exchange.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Exchange.kt
@@ -176,7 +176,13 @@ private suspend fun postTokenRequest(
             )
         }
 
-        val raw = tokenJson.decodeFromString<RawTokenResponse>(body)
+        // A token response that fails to decode may still contain credential
+        // material, and kotlinx embeds input excerpts in its exception
+        // messages — map to a status-only fault (no cause: cause messages
+        // surface in stack traces) instead of propagating it.
+        val raw = runCatching { tokenJson.decodeFromString<RawTokenResponse>(body) }.getOrElse {
+            throw BasecampException.Api("Failed to parse token response", httpStatus = response.status.value)
+        }
         val now = currentTimeMillis()
         val expiresAt = raw.expiresIn?.let { now + it * 1000 }
 

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/ErrorTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/ErrorTest.kt
@@ -154,6 +154,7 @@ class ErrorTest {
             BasecampException.Validation("invalid"),
             BasecampException.Usage("bad arg"),
             BasecampException.DiscoverySelection("ambiguous_issuers", "ambiguous"),
+            BasecampException.DeviceFlow(BasecampException.DEVICE_ACCESS_DENIED),
         )
 
         for (e in errors) {
@@ -169,6 +170,7 @@ class ErrorTest {
                 is BasecampException.Validation -> "validation"
                 is BasecampException.Usage -> "usage"
                 is BasecampException.DiscoverySelection -> "discovery_selection"
+                is BasecampException.DeviceFlow -> "device_flow"
             }
             assertTrue(code.isNotEmpty())
         }

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -609,6 +609,36 @@ class OAuthDeviceTest {
     }
 
     @Test
+    fun pollRejectsExplicitEmptyTokenTypeOn2xx() = runTest {
+        // An explicit "token_type": "" is malformed token metadata (api_error),
+        // distinct from an absent field — uniform with Go/Python/Ruby/TS.
+        val body = """{"access_token":"tok","token_type":"","expires_in":3600}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val e = assertFailsWith<BasecampException.Api> {
+            pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+        }
+        assertEquals("api_error", e.code)
+        client.close()
+    }
+
+    @Test
+    fun pollDefaultsAbsentTokenTypeToBearer() = runTest {
+        // Absent token_type defaults to Bearer (RFC 6749 responses from
+        // first-party servers always send it, but the default keeps the token
+        // usable) — only an explicit empty string is rejected.
+        val body = """{"access_token":"tok","expires_in":3600}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val token = pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+
+        assertEquals("Bearer", token.tokenType)
+        client.close()
+    }
+
+    @Test
     fun pollAcceptsMaxTokenLifetime() = runTest {
         // The 2147483647 s ceiling itself is valid — the bound is inclusive.
         val body = """{"access_token":"tok","token_type":"Bearer","expires_in":2147483647}"""

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -551,6 +551,10 @@ class OAuthDeviceTest {
         }
         assertEquals(302, e.httpStatus, "suppressed 3xx surfaces as api_error before body parsing")
         assertEquals(1, polls, "the loop must stop at the first redirect, not keep polling")
+        assertTrue(
+            e.message?.contains("redirect", ignoreCase = true) == true,
+            "the error must name the redirect explicitly, not a generic http_302",
+        )
         client.close()
     }
 

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -27,6 +27,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -565,6 +566,56 @@ class OAuthDeviceTest {
             pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
         }
         assertEquals("api_error", e.code)
+        client.close()
+    }
+
+    @Test
+    fun pollRejectsMalformedTokenExpiresInOn2xx() = runTest {
+        // A 2xx whose expires_in cannot be a schedulable lifetime is api_error:
+        // 1e400 overflows the Double range (deserialization fails into Long?), a
+        // negative or past-ceiling value would overflow `it * 1000` in expiresAt.
+        val bodies = listOf(
+            """{"access_token":"tok","token_type":"Bearer","expires_in":1e400}""",
+            """{"access_token":"tok","token_type":"Bearer","expires_in":-1}""",
+            """{"access_token":"tok","token_type":"Bearer","expires_in":0}""",
+            """{"access_token":"tok","token_type":"Bearer","expires_in":2147483648}""",
+        )
+        for (body in bodies) {
+            val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+            val client = HttpClient(engine)
+            val e = assertFailsWith<BasecampException.Api>("expected api_error for $body") {
+                pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+            }
+            assertEquals("api_error", e.code)
+            client.close()
+        }
+    }
+
+    @Test
+    fun pollAcceptsMaxTokenLifetime() = runTest {
+        // The 2147483647 s ceiling itself is valid — the bound is inclusive.
+        val body = """{"access_token":"tok","token_type":"Bearer","expires_in":2147483647}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val token = pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+
+        assertEquals(2_147_483_647L, token.expiresIn)
+        assertNotNull(token.expiresAt)
+        client.close()
+    }
+
+    @Test
+    fun pollAcceptsTokenWithoutExpiresIn() = runTest {
+        // Absent expires_in (RFC 6749 §5.1) is allowed — the token has no expiry.
+        val body = """{"access_token":"tok","token_type":"Bearer"}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val token = pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+
+        assertNull(token.expiresIn)
+        assertNull(token.expiresAt)
         client.close()
     }
 

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -372,6 +372,42 @@ class OAuthDeviceTest {
     }
 
     @Test
+    fun pollResetsTimeoutBackoffAfterCompletedRoundTrip() = runTest {
+        // The timeout backoff is transient: two timeouts inflate the wait to
+        // 10s then 20s, but the first completed round-trip (even a mere
+        // authorization_pending) resets it to the server interval — later polls
+        // must return to the 5s cadence, never stay permanently inflated.
+        val pollTimes = mutableListOf<Long>()
+        var i = 0
+        val engine = MockEngine {
+            pollTimes.add(testScheduler.currentTime)
+            i += 1
+            when (i) {
+                1, 2 -> throw SimulatedConnectTimeoutException()
+                3, 4 -> respond(errorJson("authorization_pending"), HttpStatusCode.BadRequest, jsonHeaders)
+                else -> respond(tokenJson, HttpStatusCode.OK, jsonHeaders)
+            }
+        }
+        val client = HttpClient(engine)
+
+        val token = pollDeviceToken(
+            tokenEndpoint = tokenEndpoint,
+            clientId = "basecamp-cli",
+            deviceCode = "dev-code-123",
+            interval = 5,
+            expiresIn = 900,
+            timeSource = testTimeSource,
+            client = client,
+        )
+
+        assertEquals("device_access_token", token.accessToken)
+        // Waits: 5s, then backoff 10s and 20s after the timeouts, then back to
+        // the 5s server interval once a round-trip completes.
+        assertEquals(listOf(5_000L, 15_000L, 35_000L, 40_000L, 45_000L), pollTimes)
+        client.close()
+    }
+
+    @Test
     fun pollExpiresAgainstInjectedMonotonicClock() = runTest {
         // interval (5s) exceeds the code lifetime (3s): the first wait pushes
         // virtual time past the deadline before any poll is issued.
@@ -487,6 +523,48 @@ class OAuthDeviceTest {
         }
         assertEquals("api_error", e.code)
         assertFalse(attackerContacted, "token poll must not follow the redirect")
+        client.close()
+    }
+
+    @Test
+    fun pollTreatsRedirectWithPendingBodyAsApiError() = runTest {
+        // A suppressed 3xx is an API fault even when its body parrots a valid
+        // OAuth poll state: {"error":"authorization_pending"} in a 302 must NOT
+        // keep the loop polling toward an attacker-influenced Location.
+        var polls = 0
+        val engine = MockEngine {
+            polls += 1
+            respond(
+                content = ByteReadChannel(errorJson("authorization_pending")),
+                status = HttpStatusCode.Found,
+                headers = headersOf(
+                    HttpHeaders.Location to listOf("https://attacker.example.com/oauth/token"),
+                    HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()),
+                ),
+            )
+        }
+        val client = HttpClient(engine)
+
+        val e = assertFailsWith<BasecampException.Api> {
+            pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+        }
+        assertEquals(302, e.httpStatus, "suppressed 3xx surfaces as api_error before body parsing")
+        assertEquals(1, polls, "the loop must stop at the first redirect, not keep polling")
+        client.close()
+    }
+
+    @Test
+    fun pollRejectsNonNumericExpiresInOn2xx() = runTest {
+        // A 2xx token response whose expires_in is not a number is a malformed
+        // body: SerializationException → api_error, never a token nor transport.
+        val body = """{"access_token":"tok","token_type":"Bearer","expires_in":"soon"}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val e = assertFailsWith<BasecampException.Api> {
+            pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+        }
+        assertEquals("api_error", e.code)
         client.close()
     }
 

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -555,6 +555,21 @@ class OAuthDeviceTest {
     }
 
     @Test
+    fun pollAcceptsIntegerValuedFloatExpiresInOn2xx() = runTest {
+        // 3600.0 carries no fractional part — accepted per the cross-SDK contract
+        // (the shared Long? decode rejected it, unlike TS/Python/Ruby; the device
+        // path now decodes Double? and enforces whole seconds in validation).
+        val body = """{"access_token":"tok","token_type":"Bearer","expires_in":3600.0}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val token = pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+        assertEquals(3600L, token.expiresIn)
+        assertNotNull(token.expiresAt)
+        client.close()
+    }
+
+    @Test
     fun pollRejectsNonNumericExpiresInOn2xx() = runTest {
         // A 2xx token response whose expires_in is not a number is a malformed
         // body: SerializationException → api_error, never a token nor transport.
@@ -572,13 +587,15 @@ class OAuthDeviceTest {
     @Test
     fun pollRejectsMalformedTokenExpiresInOn2xx() = runTest {
         // A 2xx whose expires_in cannot be a schedulable lifetime is api_error:
-        // 1e400 overflows the Double range (deserialization fails into Long?), a
-        // negative or past-ceiling value would overflow `it * 1000` in expiresAt.
+        // 1e400 parses to Infinity (past the ceiling), an explicit 0 or negative
+        // value violates the positive rule, a past-ceiling value would overflow
+        // `it * 1000` in expiresAt, and 3600.5 breaks the whole-second contract.
         val bodies = listOf(
             """{"access_token":"tok","token_type":"Bearer","expires_in":1e400}""",
             """{"access_token":"tok","token_type":"Bearer","expires_in":-1}""",
             """{"access_token":"tok","token_type":"Bearer","expires_in":0}""",
             """{"access_token":"tok","token_type":"Bearer","expires_in":2147483648}""",
+            """{"access_token":"tok","token_type":"Bearer","expires_in":3600.5}""",
         )
         for (body in bodies) {
             val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -559,6 +559,45 @@ class OAuthDeviceTest {
     }
 
     @Test
+    fun pollRejectsOutOfRangeCallerDurations() = runTest {
+        // Caller-input sanity on the exported entry point: an oversized expiresIn
+        // saturates Duration to infinite — a deadline that never passes, an
+        // unbounded poll loop — and non-positive values are not schedulable.
+        // Rejected as usage BEFORE any request (2_147_484 = MAX_DEVICE_SECONDS + 1).
+        val engine = MockEngine { respond(tokenJson, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val cases = listOf(5L to 0L, 5L to -1L, 5L to 2_147_484L, 0L to 900L, -1L to 900L, 2_147_484L to 900L)
+        for ((interval, expiresIn) in cases) {
+            assertFailsWith<BasecampException.Usage>("interval=$interval expiresIn=$expiresIn") {
+                pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", interval, expiresIn, testTimeSource, client)
+            }
+        }
+        assertEquals(0, engine.requestHistory.size, "guard must reject before any request")
+        client.close()
+    }
+
+    @Test
+    fun pollNormalizesEmptyTokenErrorToHttpStatus() = runTest {
+        // A 4xx token body of {"error":""} decodes cleanly (error is a required
+        // non-null String, so no SerializationException fires), so it must be
+        // normalized to http_<status> rather than surfacing a dangling, empty error
+        // code — matching Go/TS/Python/Ruby, which all coerce a blank error the same way.
+        val engine = MockEngine { respond(errorJson(""), HttpStatusCode.BadRequest, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val e = assertFailsWith<BasecampException.Api> {
+            pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+        }
+        assertEquals(400, e.httpStatus)
+        assertTrue(
+            e.message?.contains("http_400") == true,
+            "an empty error code must normalize to http_400, not a blank message: ${e.message}",
+        )
+        client.close()
+    }
+
+    @Test
     fun pollAcceptsIntegerValuedFloatExpiresInOn2xx() = runTest {
         // 3600.0 carries no fractional part — accepted per the cross-SDK contract
         // (the shared Long? decode rejected it, unlike TS/Python/Ruby; the device

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -127,6 +127,32 @@ class OAuthDeviceTest {
     }
 
     @Test
+    fun deviceApiFaultsAreNotRetryable() = runTest {
+        // Api's constructor defaults retryable = true for a 5xx, but in the device
+        // flow only the transport reason is retryable — a completed 5xx from the
+        // device-auth or token endpoint ends the flow non-retryably, matching the
+        // other four SDKs' non-retryable api_error.
+        val engine = MockEngine { respond("boom", HttpStatusCode.InternalServerError, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val requestError = assertFailsWith<BasecampException.Api> {
+            requestDeviceAuthorization(deviceEndpoint, "basecamp-cli", client = client)
+        }
+        assertEquals(500, requestError.httpStatus)
+        assertFalse(requestError.retryable, "a completed 5xx device-auth response is not retryable")
+        client.close()
+
+        val pollEngine = MockEngine { respond("""{"error":"boom"}""", HttpStatusCode.InternalServerError, jsonHeaders) }
+        val pollClient = HttpClient(pollEngine)
+        val pollError = assertFailsWith<BasecampException.Api> {
+            pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, pollClient)
+        }
+        assertEquals(500, pollError.httpStatus)
+        assertFalse(pollError.retryable, "a completed 5xx token response is not retryable")
+        pollClient.close()
+    }
+
+    @Test
     fun requestRejectsNonPositiveExpiresIn() = runTest {
         val body = """{"device_code":"d","user_code":"u","verification_uri":"$origin/device","expires_in":0}"""
         val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -1,0 +1,626 @@
+package com.basecamp.sdk
+
+import com.basecamp.sdk.oauth.DEVICE_CODE_GRANT_TYPE
+import com.basecamp.sdk.oauth.DeviceAuthorization
+import com.basecamp.sdk.oauth.OAuthConfig
+import com.basecamp.sdk.oauth.performDeviceLogin
+import com.basecamp.sdk.oauth.pollDeviceToken
+import com.basecamp.sdk.oauth.requestDeviceAuthorization
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.testTimeSource
+import kotlinx.coroutines.withTimeout
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TestTimeSource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * RFC 8628 device authorization grant tests (SPEC.md §16).
+ *
+ * `runTest` supplies virtual time so [kotlinx.coroutines.delay] resolves
+ * instantly, `testTimeSource` locks the monotonic deadline to that same virtual
+ * clock, and `testScheduler.currentTime` reads the schedule so we can assert the
+ * poll cadence (sustained slow_down, timeout backoff) without real delays.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class OAuthDeviceTest {
+
+    private val origin = "https://issuer.device-test.example"
+    private val deviceEndpoint = "$origin/oauth/device"
+    private val tokenEndpoint = "$origin/oauth/token"
+
+    private val jsonHeaders = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+
+    private val deviceAuthJson = """
+        {
+          "device_code": "dev-code-123",
+          "user_code": "WDJB-MJHT",
+          "verification_uri": "$origin/device",
+          "verification_uri_complete": "$origin/device?user_code=WDJB-MJHT",
+          "expires_in": 900,
+          "interval": 5
+        }
+    """.trimIndent()
+
+    private val tokenJson = """
+        {
+          "access_token": "device_access_token",
+          "refresh_token": "device_refresh_token",
+          "token_type": "Bearer",
+          "expires_in": 3600
+        }
+    """.trimIndent()
+
+    private fun errorJson(error: String) = """{"error":"$error"}"""
+
+    /** A non-timeout throwable whose class name does NOT match the timeout heuristic. */
+    private class SimulatedTransportException : Exception("connection reset")
+
+    /** A throwable whose class name matches the timeout heuristic (connection timeout). */
+    private class SimulatedConnectTimeoutException : Exception("simulated connect timeout")
+
+    // =========================================================================
+    // requestDeviceAuthorization
+    // =========================================================================
+
+    @Test
+    fun requestOmitsScopeWhenUnsetAndValidates() = runTest {
+        var sentBody = ""
+        val engine = MockEngine { request ->
+            sentBody = request.body.toByteArray().decodeToString()
+            respond(deviceAuthJson, HttpStatusCode.OK, jsonHeaders)
+        }
+        val client = HttpClient(engine)
+
+        val auth = requestDeviceAuthorization(deviceEndpoint, "basecamp-cli", client = client)
+
+        assertTrue(sentBody.contains("client_id=basecamp-cli"))
+        assertFalse(sentBody.contains("scope"), "scope must be omitted so the server applies its default")
+        assertEquals("dev-code-123", auth.deviceCode)
+        assertEquals("WDJB-MJHT", auth.userCode)
+        assertEquals("$origin/device", auth.verificationUri)
+        assertEquals(5L, auth.interval)
+        client.close()
+    }
+
+    @Test
+    fun requestSendsScopeWhenSet() = runTest {
+        var sentBody = ""
+        val engine = MockEngine { request ->
+            sentBody = request.body.toByteArray().decodeToString()
+            respond(deviceAuthJson, HttpStatusCode.OK, jsonHeaders)
+        }
+        val client = HttpClient(engine)
+
+        requestDeviceAuthorization(deviceEndpoint, "basecamp-cli", scope = "read write", client = client)
+
+        assertTrue(sentBody.contains("scope=read"), "scope must be sent when set")
+        client.close()
+    }
+
+    @Test
+    fun requestDefaultsIntervalToFiveWhenAbsent() = runTest {
+        val body = """{"device_code":"d","user_code":"u","verification_uri":"$origin/device","expires_in":900}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val auth = requestDeviceAuthorization(deviceEndpoint, "basecamp-cli", client = client)
+
+        assertEquals(5L, auth.interval)
+        client.close()
+    }
+
+    @Test
+    fun requestRejectsNonPositiveExpiresIn() = runTest {
+        val body = """{"device_code":"d","user_code":"u","verification_uri":"$origin/device","expires_in":0}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        assertFailsWith<BasecampException.Api> {
+            requestDeviceAuthorization(deviceEndpoint, "basecamp-cli", client = client)
+        }
+        client.close()
+    }
+
+    @Test
+    fun requestRejectsNonPositiveInterval() = runTest {
+        // A present but non-positive `interval` is invalid metadata — a poll cadence
+        // of zero/negative seconds is nonsensical, so reject it rather than default.
+        val body = """{"device_code":"d","user_code":"u","verification_uri":"$origin/device","expires_in":900,"interval":0}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        assertFailsWith<BasecampException.Api> {
+            requestDeviceAuthorization(deviceEndpoint, "basecamp-cli", client = client)
+        }
+        client.close()
+    }
+
+    @Test
+    fun requestAcceptsIntegerValuedFloatDurations() = runTest {
+        // 900.0 / 10.0 carry no fractional part → valid integer seconds. Decoding
+        // as Long would throw SerializationException; the other SDKs accept these.
+        val body = """{"device_code":"d","user_code":"u","verification_uri":"$origin/device","expires_in":900.0,"interval":10.0}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val auth = requestDeviceAuthorization(deviceEndpoint, "basecamp-cli", client = client)
+        assertEquals(900L, auth.expiresIn)
+        assertEquals(10L, auth.interval)
+        client.close()
+    }
+
+    @Test
+    fun requestRejectsFractionalExpiresIn() = runTest {
+        val body = """{"device_code":"d","user_code":"u","verification_uri":"$origin/device","expires_in":0.5}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        assertFailsWith<BasecampException.Api> {
+            requestDeviceAuthorization(deviceEndpoint, "basecamp-cli", client = client)
+        }
+        client.close()
+    }
+
+    @Test
+    fun requestRejectsFractionalInterval() = runTest {
+        val body = """{"device_code":"d","user_code":"u","verification_uri":"$origin/device","expires_in":900,"interval":2.5}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        assertFailsWith<BasecampException.Api> {
+            requestDeviceAuthorization(deviceEndpoint, "basecamp-cli", client = client)
+        }
+        client.close()
+    }
+
+    @Test
+    fun requestRejectsOversizedDurations() = runTest {
+        // 1e100 is integer-valued, so whole-second checking alone would admit it;
+        // the shared cross-SDK ceiling (2147483 s) makes it api_error. The first
+        // value past the boundary is likewise rejected.
+        val bodies = listOf(
+            """{"device_code":"d","user_code":"u","verification_uri":"$origin/device","expires_in":1e100}""",
+            """{"device_code":"d","user_code":"u","verification_uri":"$origin/device","expires_in":900,"interval":1e100}""",
+            """{"device_code":"d","user_code":"u","verification_uri":"$origin/device","expires_in":2147484}""",
+        )
+        for (body in bodies) {
+            val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+            val client = HttpClient(engine)
+
+            assertFailsWith<BasecampException.Api> {
+                requestDeviceAuthorization(deviceEndpoint, "basecamp-cli", client = client)
+            }
+            client.close()
+        }
+    }
+
+    @Test
+    fun requestAcceptsMaxDuration() = runTest {
+        // The 2147483 s ceiling itself is valid — the bound is inclusive.
+        val body = """{"device_code":"d","user_code":"u","verification_uri":"$origin/device","expires_in":2147483,"interval":2147483}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val auth = requestDeviceAuthorization(deviceEndpoint, "basecamp-cli", client = client)
+        assertEquals(2_147_483L, auth.expiresIn)
+        assertEquals(2_147_483L, auth.interval)
+        client.close()
+    }
+
+    @Test
+    fun requestRejectsEmptyDeviceCode() = runTest {
+        // A present but empty device_code is as unusable as an absent one — reject it
+        // as invalid metadata rather than carry a blank code into the poll loop.
+        val body = """{"device_code":"","user_code":"u","verification_uri":"$origin/device","expires_in":900}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        assertFailsWith<BasecampException.Api> {
+            requestDeviceAuthorization(deviceEndpoint, "basecamp-cli", client = client)
+        }
+        client.close()
+    }
+
+    @Test
+    fun requestRejectsMissingRequiredField() = runTest {
+        // Missing device_code.
+        val body = """{"user_code":"u","verification_uri":"$origin/device","expires_in":900}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        assertFailsWith<BasecampException.Api> {
+            requestDeviceAuthorization(deviceEndpoint, "basecamp-cli", client = client)
+        }
+        client.close()
+    }
+
+    @Test
+    fun requestReportsActual2xxStatusOnMalformedBody() = runTest {
+        // A malformed body returned with a non-200 success status (202) must report
+        // the real status, not a hard-coded 200, on the thrown Api error.
+        val body = """{"device_code":"d","user_code":"u","verification_uri":"$origin/device"}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.Accepted, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val e = assertFailsWith<BasecampException.Api> {
+            requestDeviceAuthorization(deviceEndpoint, "basecamp-cli", client = client)
+        }
+        assertEquals(202, e.httpStatus)
+        client.close()
+    }
+
+    @Test
+    fun requestAbortsOversizedBody() = runTest {
+        // A well-formed but oversized (> 1 MiB) body: the bounded/streaming read
+        // must abort before buffering the whole document.
+        val huge = "{\"pad\":\"" + "x".repeat(1_100_000) + "\"}"
+        val engine = MockEngine { respond(huge, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        assertFailsWith<BasecampException.Api> {
+            requestDeviceAuthorization(deviceEndpoint, "basecamp-cli", client = client)
+        }
+        client.close()
+    }
+
+    @Test
+    fun requestDoesNotFollowRedirect() = runTest {
+        var attackerContacted = false
+        val engine = MockEngine { request ->
+            if (request.url.host.contains("attacker")) {
+                attackerContacted = true
+                respond(deviceAuthJson, HttpStatusCode.OK, jsonHeaders)
+            } else {
+                respond(
+                    content = ByteReadChannel(""),
+                    status = HttpStatusCode.Found,
+                    headers = headersOf(HttpHeaders.Location, "https://attacker.example.com/oauth/device"),
+                )
+            }
+        }
+        val client = HttpClient(engine)
+
+        val e = assertFailsWith<BasecampException.Api> {
+            requestDeviceAuthorization(deviceEndpoint, "basecamp-cli", client = client)
+        }
+        assertEquals(302, e.httpStatus, "suppressed 3xx surfaces as api_error")
+        assertFalse(attackerContacted, "device POST must not follow the redirect")
+        client.close()
+    }
+
+    // =========================================================================
+    // pollDeviceToken
+    // =========================================================================
+
+    @Test
+    fun pollSustainsSlowDownIncrement() = runTest {
+        val pollTimes = mutableListOf<Long>()
+        val responses = listOf(
+            HttpStatusCode.BadRequest to errorJson("authorization_pending"),
+            HttpStatusCode.BadRequest to errorJson("slow_down"),
+            HttpStatusCode.BadRequest to errorJson("authorization_pending"),
+            HttpStatusCode.OK to tokenJson,
+        )
+        var i = 0
+        val engine = MockEngine {
+            pollTimes.add(testScheduler.currentTime)
+            val (status, body) = responses[minOf(i, responses.size - 1)]
+            i += 1
+            respond(body, status, jsonHeaders)
+        }
+        val client = HttpClient(engine)
+
+        val token = pollDeviceToken(
+            tokenEndpoint = tokenEndpoint,
+            clientId = "basecamp-cli",
+            deviceCode = "dev-code-123",
+            interval = 5,
+            expiresIn = 900,
+            timeSource = testTimeSource,
+            client = client,
+        )
+
+        assertEquals("device_access_token", token.accessToken)
+        // Waits: 5s, 5s (before slow_down), then sustained +5s → 10s, 10s.
+        // Cumulative virtual time at each poll: 5s, 10s, 20s, 30s.
+        assertEquals(listOf(5_000L, 10_000L, 20_000L, 30_000L), pollTimes)
+        client.close()
+    }
+
+    @Test
+    fun pollDoublesIntervalAfterConnectionTimeout() = runTest {
+        val pollTimes = mutableListOf<Long>()
+        var i = 0
+        val engine = MockEngine {
+            pollTimes.add(testScheduler.currentTime)
+            i += 1
+            if (i == 1) throw SimulatedConnectTimeoutException()
+            respond(tokenJson, HttpStatusCode.OK, jsonHeaders)
+        }
+        val client = HttpClient(engine)
+
+        val token = pollDeviceToken(
+            tokenEndpoint = tokenEndpoint,
+            clientId = "basecamp-cli",
+            deviceCode = "dev-code-123",
+            interval = 5,
+            expiresIn = 900,
+            timeSource = testTimeSource,
+            client = client,
+        )
+
+        assertEquals("device_access_token", token.accessToken)
+        // First wait 5s; timeout doubles the backoff → next wait 10s (t=15s).
+        assertEquals(listOf(5_000L, 15_000L), pollTimes)
+        client.close()
+    }
+
+    @Test
+    fun pollExpiresAgainstInjectedMonotonicClock() = runTest {
+        // interval (5s) exceeds the code lifetime (3s): the first wait pushes
+        // virtual time past the deadline before any poll is issued.
+        val engine = MockEngine { respond(errorJson("authorization_pending"), HttpStatusCode.BadRequest, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val e = assertFailsWith<BasecampException.DeviceFlow> {
+            pollDeviceToken(
+                tokenEndpoint = tokenEndpoint,
+                clientId = "basecamp-cli",
+                deviceCode = "dev-code-123",
+                interval = 5,
+                expiresIn = 3,
+                timeSource = testTimeSource,
+                client = client,
+            )
+        }
+        assertEquals(BasecampException.DEVICE_EXPIRED, e.reason)
+        assertEquals("auth_required", e.code)
+        assertEquals(3, e.exitCode)
+        client.close()
+    }
+
+    @Test
+    fun pollRaisesAccessDenied() = runTest {
+        val engine = MockEngine { respond(errorJson("access_denied"), HttpStatusCode.BadRequest, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val e = assertFailsWith<BasecampException.DeviceFlow> {
+            pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+        }
+        assertEquals(BasecampException.DEVICE_ACCESS_DENIED, e.reason)
+        assertEquals("auth_required", e.code)
+        client.close()
+    }
+
+    @Test
+    fun pollRaisesTransportOnNonTimeoutFailure() = runTest {
+        val engine = MockEngine { throw SimulatedTransportException() }
+        val client = HttpClient(engine)
+
+        val e = assertFailsWith<BasecampException.DeviceFlow> {
+            pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+        }
+        assertEquals(BasecampException.DEVICE_TRANSPORT, e.reason)
+        assertEquals("network", e.code)
+        assertTrue(e.retryable)
+        client.close()
+    }
+
+    @Test
+    fun pollPropagatesCoroutineCancellation() = runTest {
+        // Never approves; the poll parks in delay(5s). A 3s timeout cancels it —
+        // the CancellationException must propagate untouched (not become DeviceFlow),
+        // so withTimeout surfaces a TimeoutCancellationException.
+        val engine = MockEngine { respond(errorJson("authorization_pending"), HttpStatusCode.BadRequest, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        assertFailsWith<TimeoutCancellationException> {
+            withTimeout(3_000) {
+                pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+            }
+        }
+        client.close()
+    }
+
+    @Test
+    fun pollRejectsEmptyAccessToken() = runTest {
+        // A 2xx whose access_token is blank must be an api_error, never an accepted
+        // token and never a retryable transport error.
+        val body = """{"access_token":"","token_type":"Bearer","expires_in":3600}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val e = assertFailsWith<BasecampException.Api> {
+            pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+        }
+        assertEquals("api_error", e.code)
+        client.close()
+    }
+
+    @Test
+    fun pollAbortsOversizedTokenBody() = runTest {
+        val huge = "{\"access_token\":\"" + "x".repeat(1_100_000) + "\"}"
+        val engine = MockEngine { respond(huge, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        assertFailsWith<BasecampException.Api> {
+            pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+        }
+        client.close()
+    }
+
+    @Test
+    fun pollDoesNotFollowRedirect() = runTest {
+        var attackerContacted = false
+        val engine = MockEngine { request ->
+            if (request.url.host.contains("attacker")) {
+                attackerContacted = true
+                respond(tokenJson, HttpStatusCode.OK, jsonHeaders)
+            } else {
+                respond(
+                    content = ByteReadChannel(""),
+                    status = HttpStatusCode.Found,
+                    headers = headersOf(HttpHeaders.Location, "https://attacker.example.com/oauth/token"),
+                )
+            }
+        }
+        val client = HttpClient(engine)
+
+        val e = assertFailsWith<BasecampException.Api> {
+            pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+        }
+        assertEquals("api_error", e.code)
+        assertFalse(attackerContacted, "token poll must not follow the redirect")
+        client.close()
+    }
+
+    @Test
+    fun pollClampsBackoffToDeadline() = runTest {
+        // interval 5s, code lifetime 8s. The first poll (t=5s) times out, so the
+        // backoff would double the wait to 10s (→ t=15s). The deadline at t=8s must
+        // clamp that wait so expiry fires at t=8s instead of overshooting.
+        val pollTimes = mutableListOf<Long>()
+        val engine = MockEngine {
+            pollTimes.add(testScheduler.currentTime)
+            throw SimulatedConnectTimeoutException()
+        }
+        val client = HttpClient(engine)
+
+        val e = assertFailsWith<BasecampException.DeviceFlow> {
+            pollDeviceToken(
+                tokenEndpoint = tokenEndpoint,
+                clientId = "basecamp-cli",
+                deviceCode = "dev-code-123",
+                interval = 5,
+                expiresIn = 8,
+                timeSource = testTimeSource,
+                client = client,
+            )
+        }
+
+        assertEquals(BasecampException.DEVICE_EXPIRED, e.reason)
+        assertEquals(listOf(5_000L), pollTimes, "only one poll before the clamped wait hits expiry")
+        assertEquals(8_000L, testScheduler.currentTime, "clamped wait must not overshoot the deadline")
+        client.close()
+    }
+
+    // =========================================================================
+    // performDeviceLogin
+    // =========================================================================
+
+    @Test
+    fun performDeviceLoginGuardsCapabilityWithoutPolling() = runTest {
+        var polled = false
+        val engine = MockEngine {
+            polled = true
+            respond(tokenJson, HttpStatusCode.OK, jsonHeaders)
+        }
+        val client = HttpClient(engine)
+
+        // Endpoint present, but the device_code grant is NOT advertised.
+        val config = OAuthConfig(
+            issuer = origin,
+            tokenEndpoint = tokenEndpoint,
+            deviceAuthorizationEndpoint = deviceEndpoint,
+            grantTypesSupported = listOf("refresh_token"),
+        )
+
+        val e = assertFailsWith<BasecampException.DeviceFlow> {
+            performDeviceLogin(config, "basecamp-cli", display = {}, timeSource = testTimeSource, client = client)
+        }
+        assertEquals(BasecampException.DEVICE_UNAVAILABLE, e.reason)
+        assertEquals("validation", e.code)
+        assertFalse(polled, "capability guard must fail before any network call")
+        client.close()
+    }
+
+    @Test
+    fun performDeviceLoginFiresDisplayThenCompletes() = runTest {
+        val engine = MockEngine { request ->
+            if (request.url.encodedPath == "/oauth/device") {
+                respond(deviceAuthJson, HttpStatusCode.OK, jsonHeaders)
+            } else {
+                respond(tokenJson, HttpStatusCode.OK, jsonHeaders)
+            }
+        }
+        val client = HttpClient(engine)
+
+        val config = OAuthConfig(
+            issuer = origin,
+            tokenEndpoint = tokenEndpoint,
+            deviceAuthorizationEndpoint = deviceEndpoint,
+            grantTypesSupported = listOf(DEVICE_CODE_GRANT_TYPE, "refresh_token"),
+        )
+        var displayed: DeviceAuthorization? = null
+
+        val token = performDeviceLogin(
+            config = config,
+            clientId = "basecamp-cli",
+            display = { displayed = it },
+            timeSource = testTimeSource,
+            client = client,
+        )
+
+        assertNotNull(displayed)
+        assertEquals("WDJB-MJHT", displayed.userCode)
+        assertEquals("device_access_token", token.accessToken)
+        client.close()
+    }
+
+    @Test
+    fun performDeviceLoginExpiresWhenDisplayConsumesLifetime() = runTest {
+        var polled = false
+        val engine = MockEngine { request ->
+            if (request.url.encodedPath == "/oauth/device") {
+                respond(deviceAuthJson, HttpStatusCode.OK, jsonHeaders)
+            } else {
+                polled = true
+                respond(tokenJson, HttpStatusCode.OK, jsonHeaders)
+            }
+        }
+        val client = HttpClient(engine)
+
+        val config = OAuthConfig(
+            issuer = origin,
+            tokenEndpoint = tokenEndpoint,
+            deviceAuthorizationEndpoint = deviceEndpoint,
+            grantTypesSupported = listOf(DEVICE_CODE_GRANT_TYPE, "refresh_token"),
+        )
+
+        // A manual TestTimeSource lets the (non-suspend) display hook advance the
+        // deadline clock synchronously. The code lives 900s (deviceAuthJson); the
+        // hook burns the whole lifetime, so the deadline anchored at issuance —
+        // before display — is already past when the hook returns. The flow must
+        // fail `expired` WITHOUT ever polling the token endpoint.
+        val clock = TestTimeSource()
+        val e = assertFailsWith<BasecampException.DeviceFlow> {
+            performDeviceLogin(
+                config = config,
+                clientId = "basecamp-cli",
+                display = { clock += 900.seconds },
+                timeSource = clock,
+                client = client,
+            )
+        }
+
+        assertEquals(BasecampException.DEVICE_EXPIRED, e.reason)
+        assertFalse(polled, "a code that expired during display must not be polled")
+        client.close()
+    }
+}

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -541,6 +541,49 @@ class OAuthDeviceTest {
     }
 
     @Test
+    fun pollCancelledDuringTokenRoundTripNeverReturnsAToken() = runTest {
+        // The mock engine cancels the flow's job as it serves the TOKEN,
+        // modeling an engine that completes while ignoring cancellation — the
+        // success branch must re-check and never hand back the credential.
+        val job = Job()
+        val engine = MockEngine {
+            job.cancel()
+            respond(tokenJson, HttpStatusCode.OK, jsonHeaders)
+        }
+        val client = HttpClient(engine)
+        try {
+            assertFailsWith<CancellationException> {
+                withContext(job) {
+                    pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+                }
+            }
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun requestCancelledDuringRoundTripNeverReturnsACode() = runTest {
+        // Same seam on the authorization request: a code pair served by an
+        // engine that ignores cancellation must not reach a direct caller.
+        val job = Job()
+        val engine = MockEngine {
+            job.cancel()
+            respond(deviceAuthJson, HttpStatusCode.OK, jsonHeaders)
+        }
+        val client = HttpClient(engine)
+        try {
+            assertFailsWith<CancellationException> {
+                withContext(job) {
+                    requestDeviceAuthorization(deviceEndpoint, "basecamp-cli", client = client)
+                }
+            }
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
     fun pollRejectsEmptyAccessToken() = runTest {
         // A 2xx whose access_token is blank must be an api_error, never an accepted
         // token and never a retryable transport error.

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -1054,6 +1054,49 @@ class OAuthDeviceTest {
     }
 
     @Test
+    fun performChargesAuthRoundTripAgainstLifetime() = runTest {
+        // The code is minted server-side before the response travels back: a
+        // response arriving 6s late with expires_in 5 is dead on arrival, so
+        // the pre-request anchor must expire it — never grant a fresh full
+        // lifetime. The MockEngine handler advances the manual clock to model
+        // the slow round-trip.
+        val clock = TestTimeSource()
+        var polled = false
+        val slowAuthJson = deviceAuthJson.replace("\"expires_in\": 900", "\"expires_in\": 5")
+        val engine = MockEngine { request ->
+            if (request.url.encodedPath == "/oauth/device") {
+                clock += 6.seconds
+                respond(slowAuthJson, HttpStatusCode.OK, jsonHeaders)
+            } else {
+                polled = true
+                respond(tokenJson, HttpStatusCode.OK, jsonHeaders)
+            }
+        }
+        val client = HttpClient(engine)
+
+        val config = OAuthConfig(
+            issuer = origin,
+            tokenEndpoint = tokenEndpoint,
+            deviceAuthorizationEndpoint = deviceEndpoint,
+            grantTypesSupported = listOf(DEVICE_CODE_GRANT_TYPE, "refresh_token"),
+        )
+
+        val e = assertFailsWith<BasecampException.DeviceFlow> {
+            performDeviceLogin(
+                config = config,
+                clientId = "basecamp-cli",
+                display = { },
+                timeSource = clock,
+                client = client,
+            )
+        }
+
+        assertEquals(BasecampException.DEVICE_EXPIRED, e.reason)
+        assertFalse(polled, "a response slower than expires_in must not be polled")
+        client.close()
+    }
+
+    @Test
     fun performDeviceLoginExpiresWhenDisplayConsumesLifetime() = runTest {
         var polled = false
         val engine = MockEngine { request ->

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -821,6 +821,25 @@ class OAuthDeviceTest {
     }
 
     @Test
+    fun pollDecodeFaultOmitsTheCauseAndBody() = runTest {
+        // A malformed 2xx token body can carry the access token: the mapped
+        // fault must not chain the SerializationException, whose message
+        // embeds JSON input excerpts — a logged exception chain must not
+        // disclose the token.
+        val secret = "sk-live-SUPERSECRET"
+        val body = """{"access_token":"$secret","token_type":7}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val e = assertFailsWith<BasecampException.Api> {
+            pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+        }
+        assertNull(e.cause, "decoder cause must be dropped — its message embeds the body")
+        assertFalse(e.message!!.contains(secret))
+        client.close()
+    }
+
+    @Test
     fun pollRejectsMalformedTokenExpiresInOn2xx() = runTest {
         // A 2xx whose expires_in cannot be a schedulable lifetime is api_error:
         // 1e400 parses to Infinity (past the ceiling), an explicit 0 or negative

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -629,6 +629,19 @@ class OAuthDeviceTest {
     }
 
     @Test
+    fun pollAcceptsAWhitespaceOnlyAccessToken() = runTest {
+        // Tokens are opaque: the cross-SDK contract requires only
+        // NON-EMPTINESS — a whitespace token is the server's business.
+        val body = """{"access_token":"  ","token_type":"Bearer"}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val token = pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+        assertEquals("  ", token.accessToken)
+        client.close()
+    }
+
+    @Test
     fun pollRejectsEmptyAccessToken() = runTest {
         // A 2xx whose access_token is blank must be an api_error, never an accepted
         // token and never a retryable transport error.

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -643,6 +643,33 @@ class OAuthDeviceTest {
     }
 
     @Test
+    fun pollRejectsADeadlineBeyondTheCodeLifetime() = runTest {
+        // A caller-supplied deadline can only SHORTEN the validated lifetime:
+        // one later than expiresIn from now would keep token requests running
+        // after the server-issued code expired. Rejected as usage BEFORE any
+        // request. The equality edge — exactly expiresIn from now, the default
+        // and the issuance-anchored mark at zero elapsed — stays accepted.
+        val engine = MockEngine { respond(tokenJson, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val clock = TestTimeSource()
+        assertFailsWith<BasecampException.Usage> {
+            pollDeviceToken(
+                tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, clock, client,
+                deadline = clock.markNow() + 901.seconds,
+            )
+        }
+        assertEquals(0, engine.requestHistory.size, "guard must reject before any request")
+
+        val token = pollDeviceToken(
+            tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, clock, client,
+            deadline = clock.markNow() + 900.seconds,
+        )
+        assertEquals("device_access_token", token.accessToken)
+        client.close()
+    }
+
+    @Test
     fun pollNormalizesEmptyTokenErrorToHttpStatus() = runTest {
         // A 4xx token body of {"error":""} decodes cleanly (error is a required
         // non-null String, so no SerializationException fires), so it must be

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -1054,21 +1054,20 @@ class OAuthDeviceTest {
     }
 
     @Test
-    fun performChargesAuthRoundTripAgainstLifetime() = runTest {
-        // The code is minted server-side before the response travels back: a
-        // response arriving 6s late with expires_in 5 is dead on arrival, so
-        // the pre-request anchor must expire it — never grant a fresh full
-        // lifetime. The MockEngine handler advances the manual clock to model
-        // the slow round-trip.
+    fun performAnchorsExpiryAtResponseReceipt() = runTest {
+        // SPEC §16: the deadline is markNow() + expiresIn taken AFTER
+        // requestDeviceAuthorization returns — a 6s request leg with
+        // expires_in 5 must NOT expire the fresh code client-side; expiry
+        // past receipt is arbitrated by the server (expired_token). The
+        // MockEngine handler advances the manual clock to model the slow
+        // round-trip.
         val clock = TestTimeSource()
-        var polled = false
         val slowAuthJson = deviceAuthJson.replace("\"expires_in\": 900", "\"expires_in\": 5")
         val engine = MockEngine { request ->
             if (request.url.encodedPath == "/oauth/device") {
                 clock += 6.seconds
                 respond(slowAuthJson, HttpStatusCode.OK, jsonHeaders)
             } else {
-                polled = true
                 respond(tokenJson, HttpStatusCode.OK, jsonHeaders)
             }
         }
@@ -1081,18 +1080,15 @@ class OAuthDeviceTest {
             grantTypesSupported = listOf(DEVICE_CODE_GRANT_TYPE, "refresh_token"),
         )
 
-        val e = assertFailsWith<BasecampException.DeviceFlow> {
-            performDeviceLogin(
-                config = config,
-                clientId = "basecamp-cli",
-                display = { },
-                timeSource = clock,
-                client = client,
-            )
-        }
+        val token = performDeviceLogin(
+            config = config,
+            clientId = "basecamp-cli",
+            display = { },
+            timeSource = clock,
+            client = client,
+        )
 
-        assertEquals(BasecampException.DEVICE_EXPIRED, e.reason)
-        assertFalse(polled, "a response slower than expires_in must not be polled")
+        assertEquals("device_access_token", token.accessToken)
         client.close()
     }
 

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -722,6 +722,29 @@ class OAuthDeviceTest {
     }
 
     @Test
+    fun pollProtocolErrorsOnlyOn4xx() = runTest {
+        // OAuth protocol states are recognized only on a 4xx: a nonstandard
+        // 2xx or a 5xx carrying a crafted authorization_pending body must
+        // terminate as api_error, never extend polling.
+        for (status in listOf(HttpStatusCode.Created, HttpStatusCode.Accepted, HttpStatusCode.InternalServerError)) {
+            var polls = 0
+            val engine = MockEngine {
+                polls += 1
+                respond(errorJson("authorization_pending"), status, jsonHeaders)
+            }
+            val client = HttpClient(engine)
+
+            val e = assertFailsWith<BasecampException.Api> {
+                pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+            }
+            assertEquals("api_error", e.code)
+            assertEquals(status.value, e.httpStatus)
+            assertEquals(1, polls)
+            client.close()
+        }
+    }
+
+    @Test
     fun pollNon200SuccessIsTerminal() = runTest {
         // RFC 8628/6749 token responses are exactly 200 (SPEC §16): a
         // nonstandard 201/202 carrying an access_token must not complete polling.

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -745,6 +745,24 @@ class OAuthDeviceTest {
     }
 
     @Test
+    fun pollTerminalStatusClassifiedWithoutDrainingBody() = runTest {
+        // An oversized body on a terminal non-4xx would trip the size cap if
+        // drained — the early status check surfaces the status api_error.
+        for (status in listOf(HttpStatusCode.Created, HttpStatusCode.InternalServerError)) {
+            val engine = MockEngine { respond("x".repeat(2 * 1024 * 1024), status, jsonHeaders) }
+            val client = HttpClient(engine)
+
+            val e = assertFailsWith<BasecampException.Api> {
+                pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+            }
+            assertEquals("api_error", e.code)
+            assertEquals(status.value, e.httpStatus)
+            assertTrue(e.message!!.contains("http_${status.value}"), "want a status error, got ${e.message}")
+            client.close()
+        }
+    }
+
+    @Test
     fun pollNon200SuccessIsTerminal() = runTest {
         // RFC 8628/6749 token responses are exactly 200 (SPEC §16): a
         // nonstandard 201/202 carrying an access_token must not complete polling.

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -722,6 +722,23 @@ class OAuthDeviceTest {
     }
 
     @Test
+    fun pollNon200SuccessIsTerminal() = runTest {
+        // RFC 8628/6749 token responses are exactly 200 (SPEC §16): a
+        // nonstandard 201/202 carrying an access_token must not complete polling.
+        for (status in listOf(HttpStatusCode.Created, HttpStatusCode.Accepted)) {
+            val engine = MockEngine { respond(tokenJson, status, jsonHeaders) }
+            val client = HttpClient(engine)
+
+            val e = assertFailsWith<BasecampException.Api> {
+                pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+            }
+            assertEquals("api_error", e.code)
+            assertEquals(status.value, e.httpStatus)
+            client.close()
+        }
+    }
+
+    @Test
     fun pollAcceptsTokenWithoutExpiresIn() = runTest {
         // Absent expires_in (RFC 6749 §5.1) is allowed — the token has no expiry.
         val body = """{"access_token":"tok","token_type":"Bearer"}"""

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -586,6 +586,28 @@ class OAuthDeviceTest {
     }
 
     @Test
+    fun requestCancelledDuringRoundTripBeatsAPIError() = runTest {
+        // Cancellation must also win over a completed NON-2XX on the
+        // authorization request: an engine that cancels and then serves a 500
+        // must propagate the native CancellationException, not Api.
+        val job = Job()
+        val engine = MockEngine {
+            job.cancel()
+            respond("{}", HttpStatusCode.InternalServerError, jsonHeaders)
+        }
+        val client = HttpClient(engine)
+        try {
+            assertFailsWith<CancellationException> {
+                withContext(job) {
+                    requestDeviceAuthorization(deviceEndpoint, "basecamp-cli", client = client)
+                }
+            }
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
     fun requestCancelledDuringRoundTripNeverReturnsACode() = runTest {
         // Same seam on the authorization request: a code pair served by an
         // engine that ignores cancellation must not reach a direct caller.

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -563,6 +563,29 @@ class OAuthDeviceTest {
     }
 
     @Test
+    fun pollCancelledDuringTokenRoundTripBeatsTerminalError() = runTest {
+        // Cancellation must also win over a TERMINAL error completed after the
+        // caller cancelled: an engine that ignores cancellation and serves
+        // access_denied must surface the native CancellationException, not
+        // the DeviceFlow(access_denied) classification.
+        val job = Job()
+        val engine = MockEngine {
+            job.cancel()
+            respond(errorJson("access_denied"), HttpStatusCode.BadRequest, jsonHeaders)
+        }
+        val client = HttpClient(engine)
+        try {
+            assertFailsWith<CancellationException> {
+                withContext(job) {
+                    pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+                }
+            }
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
     fun requestCancelledDuringRoundTripNeverReturnsACode() = runTest {
         // Same seam on the authorization request: a code pair served by an
         // engine that ignores cancellation must not reach a direct caller.

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -113,7 +113,7 @@ class OAuthDeviceTest {
 
         requestDeviceAuthorization(deviceEndpoint, "basecamp-cli", scope = "read write", client = client)
 
-        assertTrue(sentBody.contains("scope=read"), "scope must be sent when set")
+        assertTrue(sentBody.contains("scope=read+write"), "the FULL scope must be sent when set: $sentBody")
         client.close()
     }
 

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -1080,4 +1080,41 @@ class OAuthDeviceTest {
         assertFalse(polled, "a code that expired during display must not be polled")
         client.close()
     }
+
+    @Test
+    fun performCancelDuringDisplayBeatsExpiry() = runTest {
+        // A display hook that both cancels the flow and consumes the whole
+        // code lifetime (a prompt closing in response to cancellation) must
+        // propagate the native CancellationException, not DeviceFlow(expired).
+        val engine = MockEngine { respond(deviceAuthJson, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val config = OAuthConfig(
+            issuer = origin,
+            tokenEndpoint = tokenEndpoint,
+            deviceAuthorizationEndpoint = deviceEndpoint,
+            grantTypesSupported = listOf(DEVICE_CODE_GRANT_TYPE, "refresh_token"),
+        )
+
+        val clock = TestTimeSource()
+        val job = Job()
+        try {
+            assertFailsWith<CancellationException> {
+                withContext(job) {
+                    performDeviceLogin(
+                        config = config,
+                        clientId = "basecamp-cli",
+                        display = {
+                            job.cancel()
+                            clock += 900.seconds
+                        },
+                        timeSource = clock,
+                        client = client,
+                    )
+                }
+            }
+        } finally {
+            client.close()
+        }
+    }
 }

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -16,7 +16,10 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.utils.io.ByteReadChannel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.testTimeSource
 import kotlinx.coroutines.withTimeout
@@ -499,6 +502,42 @@ class OAuthDeviceTest {
             }
         }
         client.close()
+    }
+
+    @Test
+    fun performCancelDuringAuthorizationNeverReachesDisplay() = runTest {
+        // The mock engine cancels the flow's job as it serves the code pair,
+        // modeling an engine that completes while ignoring cancellation — the
+        // display hook must never fire for a cancelled flow.
+        var displayed = 0
+        val job = Job()
+        val engine = MockEngine {
+            job.cancel()
+            respond(deviceAuthJson, HttpStatusCode.OK, jsonHeaders)
+        }
+        val client = HttpClient(engine)
+        try {
+            assertFailsWith<CancellationException> {
+                withContext(job) {
+                    performDeviceLogin(
+                        OAuthConfig(
+                            issuer = origin,
+                            authorizationEndpoint = null,
+                            tokenEndpoint = tokenEndpoint,
+                            deviceAuthorizationEndpoint = deviceEndpoint,
+                            grantTypesSupported = listOf(DEVICE_CODE_GRANT_TYPE, "refresh_token"),
+                        ),
+                        "basecamp-cli",
+                        display = { displayed += 1 },
+                        timeSource = testTimeSource,
+                        client = client,
+                    )
+                }
+            }
+        } finally {
+            client.close()
+        }
+        assertEquals(0, displayed, "display must never fire for a cancelled flow")
     }
 
     @Test

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
@@ -168,6 +169,7 @@ class OAuthTest {
             )
         }
         assertFalse(e.message!!.contains(secret), "parse fault must not echo the body")
+        assertNull(e.cause, "decoder cause must be dropped — its message embeds the body")
     }
 
     @Test

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthTest.kt
@@ -9,6 +9,8 @@ import java.security.MessageDigest
 import java.util.Base64
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
@@ -139,6 +141,34 @@ class OAuthTest {
     // =========================================================================
     // exchangeCode with mock HTTP
     // =========================================================================
+
+    @Test
+    fun exchangeParseFailureNeverEchoesTheBody() = runTest {
+        // A syntactically-broken token body can still carry credential
+        // material, and kotlinx embeds input excerpts in its exception
+        // messages — the mapped fault must not echo any of it.
+        val secret = "sk-live-SUPERSECRET"
+        val engine = MockEngine {
+            respond(
+                content = "{\"access_token\": \"$secret' oops",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+
+        val httpClient = HttpClient(engine)
+        val e = assertFailsWith<BasecampException.Api> {
+            exchangeCode(
+                tokenEndpoint = "https://launchpad.37signals.com/authorization/token",
+                code = "test-code",
+                redirectUri = "https://myapp.com/callback",
+                clientId = "test-client",
+                clientSecret = "test-secret",
+                client = httpClient,
+            )
+        }
+        assertFalse(e.message!!.contains(secret), "parse fault must not echo the body")
+    }
 
     @Test
     fun exchangeCodeSuccess() = runTest {

--- a/python/README.md
+++ b/python/README.md
@@ -294,7 +294,7 @@ from basecamp.oauth import discover_from_resource, perform_device_login
 result = discover_from_resource("https://3.basecampapi.com")
 if result.kind != "selected":
     raise RuntimeError(f"device flow requires a discovered AS (got fallback: {result.reason})")
-config = result.config
+config = result.selected_config()  # enforces the selected-result invariant, typed OAuthConfig
 
 def show(auth):
     print(f"Visit {auth.verification_uri} and enter code: {auth.user_code}")
@@ -311,6 +311,8 @@ An omitted `scope` lets the server apply its default (`read`).
 The two building blocks compose directly when you want finer control:
 
 ```python
+import time
+
 from basecamp.oauth import request_device_authorization, poll_device_token
 
 # `device_authorization_endpoint` is optional on a discovered config (device-only
@@ -321,13 +323,18 @@ if endpoint is None:
     raise RuntimeError("selected AS advertises no device_authorization_endpoint")
 
 auth = request_device_authorization(endpoint, "basecamp-cli")
+
+# The code's lifetime starts at issuance, not after display: anchor before the
+# display hook and poll with the remaining lifetime, so a slow display eats into
+# the deadline instead of extending it. (`perform_device_login` does this for you.)
+issued_at = time.monotonic()
 show(auth)
 token = poll_device_token(
     config.token_endpoint,
     "basecamp-cli",
     auth.device_code,
     auth.interval,
-    auth.expires_in,
+    auth.expires_in - (time.monotonic() - issued_at),
 )
 ```
 

--- a/python/README.md
+++ b/python/README.md
@@ -289,6 +289,7 @@ config MUST come from resource-first discovery. Launchpad advertises no device
 authorization endpoint, and the capability guard rejects it before any request.
 
 ```python
+from basecamp import Client
 from basecamp.oauth import discover_from_resource, perform_device_login
 
 result = discover_from_resource("https://3.basecampapi.com")

--- a/python/README.md
+++ b/python/README.md
@@ -277,6 +277,85 @@ token = exchange_code(
 )
 ```
 
+### Device Authorization Grant (RFC 8628)
+
+For input-constrained clients (CLIs, TVs), the device flow trades a redirect for
+a user code the person enters on another device. `perform_device_login` accepts
+an already-selected `OAuthConfig` (from discovery), guards the device capability,
+requests a code, surfaces it through your `display` hook, then polls for a token.
+
+The device grant lives on BC5's authorization server, not Launchpad — so the
+config MUST come from resource-first discovery. Launchpad advertises no device
+authorization endpoint, and the capability guard rejects it before any request.
+
+```python
+from basecamp.oauth import discover_from_resource, perform_device_login
+
+result = discover_from_resource("https://3.basecampapi.com")
+if result.kind != "selected":
+    raise RuntimeError(f"device flow requires a discovered AS (got fallback: {result.reason})")
+config = result.config
+
+def show(auth):
+    print(f"Visit {auth.verification_uri} and enter code: {auth.user_code}")
+
+token = perform_device_login(config, "basecamp-cli", display=show)
+print(token.access_token)
+```
+
+The capability guard requires both `config.device_authorization_endpoint` and
+`"urn:ietf:params:oauth:grant-type:device_code"` in `config.grant_types_supported`;
+otherwise it raises `DeviceFlowError(reason="unavailable")` before any request.
+An omitted `scope` lets the server apply its default (`read`).
+
+The two building blocks compose directly when you want finer control:
+
+```python
+from basecamp.oauth import request_device_authorization, poll_device_token
+
+# `device_authorization_endpoint` is optional on a discovered config (device-only
+# servers omit it). `perform_device_login` guards this for you; when composing the
+# building blocks yourself, assert the capability before requesting a code.
+endpoint = config.device_authorization_endpoint
+if endpoint is None:
+    raise RuntimeError("selected AS advertises no device_authorization_endpoint")
+
+auth = request_device_authorization(endpoint, "basecamp-cli")
+show(auth)
+token = poll_device_token(
+    config.token_endpoint,
+    "basecamp-cli",
+    auth.device_code,
+    auth.interval,
+    auth.expires_in,
+)
+```
+
+`poll_device_token` runs the RFC 8628 §3.5 loop: it waits at least `interval`
+seconds, honors `slow_down` (sustained +5s) and `authorization_pending`, backs
+off exponentially on connection timeouts, and enforces a monotonic expiry
+deadline. Pass `should_cancel` (any `() -> bool`, e.g. `threading.Event.is_set`)
+for cooperative cancellation. The `clock` and `sleep` seams are injectable for
+deterministic tests.
+
+A terminal device-flow outcome raises `DeviceFlowError` carrying one of these
+five `.reason` values, with the parent error category derived from it:
+
+| `reason` | `.code` | Retryable |
+|----------|---------|-----------|
+| `access_denied` | `auth_required` | no |
+| `expired` | `auth_required` | no |
+| `transport` | `network` | yes |
+| `unavailable` | `validation` | no |
+| `cancelled` | `usage` | no |
+
+Only these five outcomes are `DeviceFlowError`. A malformed response from an
+otherwise-successful round-trip — an unparseable body, a `2xx` missing
+`access_token`, or an unrecognized `error` code — is a server fault, not a
+device-flow outcome, so it raises `OAuthError` with type `api_error` instead.
+`.reason`-derived retryability is authoritative: only `transport` retries, and a
+caller cannot override it.
+
 ### Token Expiry
 
 ```python

--- a/python/README.md
+++ b/python/README.md
@@ -300,7 +300,8 @@ def show(auth):
     print(f"Visit {auth.verification_uri} and enter code: {auth.user_code}")
 
 token = perform_device_login(config, "basecamp-cli", display=show)
-print(token.access_token)
+# Use the token to build a client — never print or log its value.
+client = Client(access_token=token.access_token)
 ```
 
 The capability guard requires both `config.device_authorization_endpoint` and

--- a/python/README.md
+++ b/python/README.md
@@ -337,6 +337,9 @@ token = poll_device_token(
     auth.device_code,
     auth.interval,
     auth.expires_in - (time.monotonic() - issued_at),
+    # The EXACT issuance-anchored deadline: a suspension between the remaining
+    # computation above and poller entry must not extend the code lifetime.
+    deadline_at=issued_at + auth.expires_in,
 )
 ```
 

--- a/python/src/basecamp/oauth/__init__.py
+++ b/python/src/basecamp/oauth/__init__.py
@@ -8,6 +8,13 @@ from basecamp.oauth.config import (
     OAuthConfig,
     ProtectedResourceMetadata,
 )
+from basecamp.oauth.device import (
+    DEVICE_CODE_GRANT_TYPE,
+    perform_device_login,
+    poll_device_token,
+    request_device_authorization,
+)
+from basecamp.oauth.device_authorization import DeviceAuthorization
 from basecamp.oauth.discovery import (
     LAUNCHPAD_BASE_URL,
     discover,
@@ -15,7 +22,7 @@ from basecamp.oauth.discovery import (
     discover_launchpad,
     discover_protected_resource,
 )
-from basecamp.oauth.errors import DiscoverySelectionError, OAuthError
+from basecamp.oauth.errors import DeviceFlowError, DiscoverySelectionError, OAuthError
 from basecamp.oauth.exchange import exchange_code, refresh_token
 from basecamp.oauth.pkce import PKCE, generate_pkce, generate_state
 from basecamp.oauth.token import OAuthToken
@@ -39,5 +46,11 @@ __all__ = [
     "refresh_token",
     "OAuthError",
     "DiscoverySelectionError",
+    "DeviceFlowError",
+    "DeviceAuthorization",
+    "DEVICE_CODE_GRANT_TYPE",
+    "request_device_authorization",
+    "poll_device_token",
+    "perform_device_login",
     "LAUNCHPAD_BASE_URL",
 ]

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import math
+import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -81,51 +82,48 @@ def _post_form_bounded(
     :class:`httpx.TimeoutException`) so callers classify them; an oversized body
     raises :class:`OAuthError` (``api_error``).
     """
-    # Normalize first (a non-finite/non-positive timeout would disable both httpx's
-    # bound and the wall-clock deadline below), then bound the WHOLE streamed
-    # response: httpx's timeout is per-received-chunk and resets each iteration, so
-    # a slow-drip peer could otherwise hang a device request past the timeout and
-    # the device-code deadline while staying under ``max_body_bytes``. Mirrors
-    # :func:`basecamp.oauth.discovery._fetch_discovery_document`.
     timeout = _normalize_timeout(timeout, _DEVICE_TIMEOUT)
-    # Start the deadline BEFORE httpx.stream so it also bounds the header phase:
-    # httpx's read timeout is per-read and resets each time, so a peer trickling
-    # header bytes could otherwise hold the POST open past the timeout before the
-    # body loop is ever reached.
-    deadline = time.monotonic() + timeout
-    with httpx.stream(
-        "POST",
-        url,
-        data=params,
-        headers=_FORM_HEADERS,
-        timeout=timeout,
-        follow_redirects=False,
-    ) as response:
-        # Headers are now in. If reading them already outlived the deadline (a
-        # slow-drip header phase), abort before touching the body.
-        if time.monotonic() > deadline:
-            raise httpx.ReadTimeout("Device flow read exceeded the timeout deadline")
-        chunks: list[bytes] = []
-        total = 0
-        for chunk in response.iter_bytes():
-            if time.monotonic() > deadline:
-                # Surface as a read timeout so the caller's existing
-                # httpx.TimeoutException / HTTPError handling classifies it as the
-                # transport/timeout path (poll → backoff, request → transport).
-                raise httpx.ReadTimeout("Device flow read exceeded the timeout deadline")
-            total += len(chunk)
-            if total > max_body_bytes:
-                # Abort the stream — leaving the ``with`` closes the connection,
-                # so the oversized body is never fully buffered.
-                raise OAuthError("api_error", "Device flow response exceeds size cap")
-            chunks.append(chunk)
-        # The in-loop check runs BEFORE each chunk, so it can't catch the final
-        # read: EOF (or the last chunk) may land just after the deadline while
-        # staying within httpx's per-chunk timeout. Re-check after the stream ends
-        # so a slow-drip response can't extend the whole read past the deadline.
-        if time.monotonic() > deadline:
-            raise httpx.ReadTimeout("Device flow read exceeded the timeout deadline")
-        return response.status_code, b"".join(chunks)
+    client = httpx.Client(timeout=timeout, follow_redirects=False)
+
+    result: list[tuple[int, bytes]] = []
+    error: list[Exception] = []
+
+    def _worker() -> None:
+        try:
+            with client.stream("POST", url, data=params, headers=_FORM_HEADERS) as response:
+                chunks: list[bytes] = []
+                total = 0
+                for chunk in response.iter_bytes():
+                    total += len(chunk)
+                    if total > max_body_bytes:
+                        # An oversized body is api_error, not a timeout — abort the
+                        # stream so it is never fully buffered.
+                        raise OAuthError("api_error", "Device flow response exceeds size cap")
+                    chunks.append(chunk)
+                result.append((response.status_code, b"".join(chunks)))
+        except Exception as exc:  # re-raised on the caller thread below
+            error.append(exc)
+
+    # httpx's timeout is per-read — it resets on every received chunk — so it does
+    # NOT bound the WHOLE exchange against a peer that slow-drips header or body
+    # bytes just under that interval, and httpx has no total-request timeout
+    # (https://www.python-httpx.org/advanced/timeouts/). Closing the client from a
+    # watchdog does not interrupt a blocked read either. So run the request on a
+    # daemon worker and enforce a HARD wall-clock bound on the caller with
+    # join(timeout): a stalled/slow-drip request returns within `timeout` as a read
+    # timeout. The abandoned daemon worker never blocks interpreter exit and dies on
+    # its own per-read timeout; client.close() below is a best-effort unblock.
+    worker = threading.Thread(target=_worker, daemon=True)
+    worker.start()
+    worker.join(timeout)
+    try:
+        if worker.is_alive():
+            raise httpx.ReadTimeout("Device flow request exceeded the timeout deadline")
+        if error:
+            raise error[0]
+        return result[0]
+    finally:
+        client.close()
 
 
 def request_device_authorization(

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -132,8 +132,9 @@ def _post_form_bounded(
     # Run it in a DEDICATED thread with its own event loop rather than calling
     # asyncio.run() here: this sync helper may be invoked from code that already has
     # a running loop (Jupyter/FastAPI/async CLI), where asyncio.run() raises
-    # RuntimeError before any request is made. The thread always completes within
-    # ~timeout (wait_for bounds it), so joining it never blocks.
+    # RuntimeError before any request is made. wait_for bounds the thread's work at
+    # ~timeout, so the bounded join below normally returns almost immediately; the
+    # is_alive backstop after it covers only a pathological async-cleanup hang.
     result: list[tuple[int, bytes]] = []
     error: list[Exception] = []
 
@@ -155,6 +156,8 @@ def _post_form_bounded(
         raise httpx.ReadTimeout("Device flow request exceeded the timeout deadline")
     if error:
         exc = error[0]
+        # On Python >= 3.11 (this package's floor) asyncio.TimeoutError IS the
+        # builtin TimeoutError, so this catches wait_for's deadline expiry.
         if isinstance(exc, TimeoutError):
             raise httpx.ReadTimeout("Device flow request exceeded the timeout deadline") from exc
         raise exc
@@ -356,16 +359,39 @@ def poll_device_token(
     ``threading.Event.is_set`` fits directly).
 
     Raises :class:`DeviceFlowError` with a reason of ``access_denied``,
-    ``expired``, ``transport``, or ``cancelled``.
+    ``expired``, ``transport``, or ``cancelled``; :class:`OAuthError`
+    (``usage``) for out-of-range caller durations; and :class:`OAuthError`
+    (``api_error``) for a malformed, redirecting, oversized, or otherwise
+    unexpected token response.
     """
     if not is_localhost(token_endpoint):
         require_https(token_endpoint, "token endpoint")
+
+    # Caller-input sanity for this exported entry point (usage, not the RFC
+    # response validation request_device_authorization applies): a non-finite or
+    # oversized expires_in builds a deadline that NEVER passes (clock() + inf) —
+    # an unbounded poll loop — and a non-positive/oversized interval is not a
+    # schedulable wait. Fractional values are accepted: perform_device_login
+    # legitimately passes a fractional remaining lifetime after deducting
+    # display-hook time. Mirrors the Go/TS/Ruby/Kotlin caller guards.
+    for name, value in (("expires_in", expires_in), ("interval", interval)):
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(value)
+            or value <= 0
+            or value > MAX_DEVICE_SECONDS
+        ):
+            raise OAuthError(
+                "usage",
+                f"poll_device_token: {name} must be a positive number of seconds no greater than {MAX_DEVICE_SECONDS}",
+            )
 
     # The server-driven interval (initial value + sustained slow_down bumps) is
     # tracked SEPARATELY from the transient timeout backoff: each wait is
     # max(interval, backoff), and any completed round-trip snaps the backoff
     # back to the current server interval, so an inflated backoff never sticks.
-    interval_seconds = interval if interval > 0 else DEFAULT_INTERVAL_SECONDS
+    interval_seconds = interval
     backoff_seconds = interval_seconds
     deadline = clock() + expires_in
 

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -152,22 +152,27 @@ def request_device_authorization(
     if not isinstance(data, dict):
         raise OAuthError("api_error", "Device authorization response is not a JSON object", http_status=status)
 
-    return _validate_device_authorization(data)
+    return _validate_device_authorization(data, status)
 
 
-def _validate_device_authorization(data: dict[str, Any]) -> DeviceAuthorization:
+def _validate_device_authorization(data: dict[str, Any], status: int) -> DeviceAuthorization:
+    # Every validation error carries the (2xx) status so a malformed success body
+    # is diagnosable as such — uniform with the token-poll raises and the other SDKs.
     # Validate TYPES, not just presence: a non-string (list/number/null) is
     # malformed, not merely absent. A bare truthiness check let those through.
     for field in ("device_code", "user_code", "verification_uri"):
         value = data.get(field)
         if not isinstance(value, str) or not value:
-            raise OAuthError("api_error", "Invalid device authorization response: missing required fields")
+            raise OAuthError(
+                "api_error", "Invalid device authorization response: missing required fields", http_status=status
+            )
 
     complete = data.get("verification_uri_complete")
     if complete is not None and not isinstance(complete, str):
         raise OAuthError(
             "api_error",
             "Invalid device authorization response: verification_uri_complete must be a string",
+            http_status=status,
         )
 
     expires_in = _positive_int_seconds(data.get("expires_in"))
@@ -176,6 +181,7 @@ def _validate_device_authorization(data: dict[str, Any]) -> DeviceAuthorization:
             "api_error",
             "Invalid device authorization response: expires_in must be a "
             f"positive integer no greater than {MAX_DEVICE_SECONDS}",
+            http_status=status,
         )
 
     interval = DEFAULT_INTERVAL_SECONDS
@@ -186,6 +192,7 @@ def _validate_device_authorization(data: dict[str, Any]) -> DeviceAuthorization:
                 "api_error",
                 "Invalid device authorization response: interval must be a "
                 f"positive integer no greater than {MAX_DEVICE_SECONDS}",
+                http_status=status,
             )
         interval = parsed_interval
 

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -150,7 +150,7 @@ def request_device_authorization(
             http_status=status,
         )
     if not isinstance(data, dict):
-        raise OAuthError("api_error", "Device authorization response is not a JSON object")
+        raise OAuthError("api_error", "Device authorization response is not a JSON object", http_status=status)
 
     return _validate_device_authorization(data)
 
@@ -425,7 +425,7 @@ def _post_device_token(
             http_status=status,
         ) from exc
     if not isinstance(data, dict):
-        raise OAuthError("api_error", "Device token response is not a JSON object")
+        raise OAuthError("api_error", "Device token response is not a JSON object", http_status=status)
 
     if 200 <= status < 300:
         return _PollResult(token=_build_token(data, status))

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -88,6 +88,11 @@ def _post_form_bounded(
     # the device-code deadline while staying under ``max_body_bytes``. Mirrors
     # :func:`basecamp.oauth.discovery._fetch_discovery_document`.
     timeout = _normalize_timeout(timeout, _DEVICE_TIMEOUT)
+    # Start the deadline BEFORE httpx.stream so it also bounds the header phase:
+    # httpx's read timeout is per-read and resets each time, so a peer trickling
+    # header bytes could otherwise hold the POST open past the timeout before the
+    # body loop is ever reached.
+    deadline = time.monotonic() + timeout
     with httpx.stream(
         "POST",
         url,
@@ -96,7 +101,10 @@ def _post_form_bounded(
         timeout=timeout,
         follow_redirects=False,
     ) as response:
-        deadline = time.monotonic() + timeout
+        # Headers are now in. If reading them already outlived the deadline (a
+        # slow-drip header phase), abort before touching the body.
+        if time.monotonic() > deadline:
+            raise httpx.ReadTimeout("Device flow read exceeded the timeout deadline")
         chunks: list[bytes] = []
         total = 0
         for chunk in response.iter_bytes():

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -1,0 +1,407 @@
+"""RFC 8628 device authorization grant — request, poll, and orchestration.
+
+Three synchronous functions (SPEC.md §16):
+
+  - ``request_device_authorization`` obtains a device/user code pair.
+  - ``poll_device_token`` runs the §3.5 polling loop against the token endpoint.
+  - ``perform_device_login`` orchestrates both against an already-selected config.
+
+Both HTTP calls are TLS-guarded (HTTPS required off localhost, §9). The polling
+clock and sleep are injectable so tests can drive the interval schedule
+(slow_down, backoff) and expiry deterministically, with no real delays.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from basecamp._security import is_localhost, require_https
+from basecamp.oauth.config import OAuthConfig
+from basecamp.oauth.device_authorization import DeviceAuthorization
+from basecamp.oauth.errors import DeviceFlowError, OAuthError
+from basecamp.oauth.token import OAuthToken
+
+#: URN grant type for the device authorization grant (RFC 8628 §3.4).
+DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+
+#: Default polling interval when the server omits ``interval`` (RFC 8628 §3.2).
+DEFAULT_INTERVAL_SECONDS = 5
+
+#: ``slow_down`` bumps the interval by this many seconds, sustained (§3.5).
+SLOW_DOWN_INCREMENT_SECONDS = 5
+
+#: Cap on exponential backoff after connection timeouts.
+MAX_BACKOFF_SECONDS = 60
+
+#: Ceiling for ``expires_in``/``interval``: 2147483 s (~24.8 days) is the largest
+#: whole-second duration whose millisecond form fits a 32-bit signed timer.
+#: Shared across all five SDKs (SPEC.md) — an unbounded value such as 1e100 is
+#: a malformed response, not a schedulable deadline.
+MAX_DEVICE_SECONDS = 2_147_483
+
+_DEVICE_TIMEOUT = 30.0
+
+# Cap on a device-flow response body (1 MiB) — these responses are tiny; a
+# larger one is a fault, so abort rather than buffer it. Mirrors discovery.
+MAX_DEVICE_BODY_BYTES = 1 * 1024 * 1024
+
+_FORM_HEADERS = {
+    "Content-Type": "application/x-www-form-urlencoded",
+    "Accept": "application/json",
+}
+
+
+def _post_form_bounded(
+    url: str,
+    params: dict[str, str],
+    timeout: float,
+    max_body_bytes: int,
+) -> tuple[int, bytes]:
+    """SSRF-hardened form POST: suppress redirects, bound the timeout, and read
+    the body under a genuine streaming cap that aborts once ``max_body_bytes`` is
+    exceeded (never a post-hoc check on an already-buffered body). Mirrors
+    :func:`basecamp.oauth.discovery._fetch_discovery_document`.
+
+    Transport failures propagate as :class:`httpx.HTTPError` (incl.
+    :class:`httpx.TimeoutException`) so callers classify them; an oversized body
+    raises :class:`OAuthError` (``api_error``).
+    """
+    with httpx.stream(
+        "POST",
+        url,
+        data=params,
+        headers=_FORM_HEADERS,
+        timeout=timeout,
+        follow_redirects=False,
+    ) as response:
+        chunks: list[bytes] = []
+        total = 0
+        for chunk in response.iter_bytes():
+            total += len(chunk)
+            if total > max_body_bytes:
+                # Abort the stream — leaving the ``with`` closes the connection,
+                # so the oversized body is never fully buffered.
+                raise OAuthError("api_error", "Device flow response exceeds size cap")
+            chunks.append(chunk)
+        return response.status_code, b"".join(chunks)
+
+
+def request_device_authorization(
+    device_authorization_endpoint: str,
+    client_id: str,
+    scope: str | None = None,
+    *,
+    timeout: float = _DEVICE_TIMEOUT,
+    max_body_bytes: int = MAX_DEVICE_BODY_BYTES,
+) -> DeviceAuthorization:
+    """Request a device/user code pair (RFC 8628 §3.1–3.2).
+
+    POSTs ``client_id`` (and ``scope`` only when set — an omitted scope lets the
+    server apply its default, ``read``) to the TLS-guarded endpoint, then
+    validates the response: ``device_code``, ``user_code``, ``verification_uri``
+    non-empty; ``expires_in``/``interval`` positive whole seconds no greater
+    than :data:`MAX_DEVICE_SECONDS` (interval defaults to 5 when absent).
+
+    Raises :class:`DeviceFlowError` (``transport``) on a network failure and
+    :class:`OAuthError` (``api_error``) on a non-2xx status or invalid metadata.
+    """
+    if not is_localhost(device_authorization_endpoint):
+        require_https(device_authorization_endpoint, "device authorization endpoint")
+    if not client_id:
+        raise OAuthError("validation", "Client ID is required for device authorization")
+
+    params: dict[str, str] = {"client_id": client_id}
+    # Omit scope entirely when unset so the server applies its default (`read`).
+    if scope:
+        params["scope"] = scope
+
+    try:
+        status, body = _post_form_bounded(device_authorization_endpoint, params, timeout, max_body_bytes)
+    except httpx.HTTPError as exc:
+        raise DeviceFlowError("transport", f"Device authorization request failed: {exc}") from exc
+
+    try:
+        data = json.loads(body)
+    except ValueError as exc:
+        raise OAuthError(
+            "api_error",
+            "Failed to parse device authorization response",
+            http_status=status,
+        ) from exc
+
+    if not 200 <= status < 300:
+        raise OAuthError(
+            "api_error",
+            f"Device authorization failed with status {status}",
+            http_status=status,
+        )
+    if not isinstance(data, dict):
+        raise OAuthError("api_error", "Device authorization response is not a JSON object")
+
+    return _validate_device_authorization(data)
+
+
+def _validate_device_authorization(data: dict[str, Any]) -> DeviceAuthorization:
+    # Validate TYPES, not just presence: a non-string (list/number/null) is
+    # malformed, not merely absent. A bare truthiness check let those through.
+    for field in ("device_code", "user_code", "verification_uri"):
+        value = data.get(field)
+        if not isinstance(value, str) or not value:
+            raise OAuthError("api_error", "Invalid device authorization response: missing required fields")
+
+    complete = data.get("verification_uri_complete")
+    if complete is not None and not isinstance(complete, str):
+        raise OAuthError(
+            "api_error",
+            "Invalid device authorization response: verification_uri_complete must be a string",
+        )
+
+    expires_in = _positive_int_seconds(data.get("expires_in"))
+    if expires_in is None:
+        raise OAuthError(
+            "api_error",
+            "Invalid device authorization response: expires_in must be a "
+            f"positive integer no greater than {MAX_DEVICE_SECONDS}",
+        )
+
+    interval = DEFAULT_INTERVAL_SECONDS
+    if data.get("interval") is not None:
+        parsed_interval = _positive_int_seconds(data["interval"])
+        if parsed_interval is None:
+            raise OAuthError(
+                "api_error",
+                "Invalid device authorization response: interval must be a "
+                f"positive integer no greater than {MAX_DEVICE_SECONDS}",
+            )
+        interval = parsed_interval
+
+    return DeviceAuthorization(
+        device_code=data["device_code"],
+        user_code=data["user_code"],
+        verification_uri=data["verification_uri"],
+        verification_uri_complete=data.get("verification_uri_complete"),
+        expires_in=expires_in,
+        interval=interval,
+    )
+
+
+def _positive_int_seconds(value: Any) -> int | None:
+    """Coerce an RFC 8628 duration field (``expires_in``/``interval``) to a
+    positive whole-second ``int``, or ``None`` when it is not a valid one.
+
+    Accepts an ``int`` or an integer-valued ``float`` (e.g. ``5.0``). Rejects
+    fractional values (``5.9`` truncates to an interval that violates the
+    validated contract; ``0.5`` would yield a ``0``-second expiry), non-positive
+    values, values beyond :data:`MAX_DEVICE_SECONDS` (1e100 is not a schedulable
+    deadline), and ``bool`` (which is an ``int`` subclass but never a duration).
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if 0 < value <= MAX_DEVICE_SECONDS else None
+    if isinstance(value, float) and value.is_integer() and 0 < value <= MAX_DEVICE_SECONDS:
+        return int(value)
+    return None
+
+
+@dataclass
+class _PollResult:
+    """One token-endpoint round-trip: a token on success, else an error code."""
+
+    token: OAuthToken | None = None
+    error: str | None = None
+    status: int = 0
+
+
+def poll_device_token(
+    token_endpoint: str,
+    client_id: str,
+    device_code: str,
+    interval: int,
+    expires_in: float,
+    *,
+    clock: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], Any] = time.sleep,
+    should_cancel: Callable[[], bool] | None = None,
+    timeout: float = _DEVICE_TIMEOUT,
+    max_body_bytes: int = MAX_DEVICE_BODY_BYTES,
+) -> OAuthToken:
+    """Poll the token endpoint until approval, denial, or expiry (RFC 8628 §3.4–3.5).
+
+    Waits at least ``interval`` seconds between polls, enforces a monotonic
+    ``expires_in`` deadline against the injected ``clock``, sustains ``slow_down``
+    (+5s), backs off exponentially on connection timeouts, and cooperatively
+    cancels. ``should_cancel`` is a callable polled around each wait (a
+    ``threading.Event.is_set`` fits directly).
+
+    Raises :class:`DeviceFlowError` with a reason of ``access_denied``,
+    ``expired``, ``transport``, or ``cancelled``.
+    """
+    if not is_localhost(token_endpoint):
+        require_https(token_endpoint, "token endpoint")
+
+    interval_seconds = interval if interval > 0 else DEFAULT_INTERVAL_SECONDS
+    backoff_seconds = interval_seconds
+    deadline = clock() + expires_in
+
+    params = {
+        "grant_type": DEVICE_CODE_GRANT_TYPE,
+        "device_code": device_code,
+        "client_id": client_id,
+    }
+
+    while True:
+        if should_cancel is not None and should_cancel():
+            raise DeviceFlowError("cancelled", "Device flow cancelled")
+
+        # Bound the wait by the time left to the deadline so a grown backoff
+        # interval can never sleep past expiry — a stalled request or a long
+        # backoff must not blow through the monotonic deadline.
+        remaining = deadline - clock()
+        if remaining <= 0:
+            raise DeviceFlowError("expired", "Device code expired before authorization completed")
+        sleep(min(interval_seconds, remaining))
+
+        if should_cancel is not None and should_cancel():
+            raise DeviceFlowError("cancelled", "Device flow cancelled")
+
+        if clock() >= deadline:
+            raise DeviceFlowError("expired", "Device code expired before authorization completed")
+
+        try:
+            result = _post_device_token(token_endpoint, params, timeout, max_body_bytes)
+        except httpx.TimeoutException:
+            # A connection timeout → back off exponentially and keep polling.
+            backoff_seconds = min(backoff_seconds * 2, MAX_BACKOFF_SECONDS)
+            interval_seconds = max(interval_seconds, backoff_seconds)
+            continue
+        except httpx.HTTPError as exc:
+            raise DeviceFlowError("transport", f"Device token poll failed: {exc}") from exc
+
+        # A successful HTTP round-trip resets the timeout backoff.
+        backoff_seconds = interval_seconds
+
+        if result.token is not None:
+            return result.token
+
+        error = result.error
+        if error == "authorization_pending":
+            continue
+        if error == "slow_down":
+            interval_seconds += SLOW_DOWN_INCREMENT_SECONDS
+            continue
+        if error == "access_denied":
+            raise DeviceFlowError("access_denied", "The authorization request was denied")
+        if error == "expired_token":
+            raise DeviceFlowError("expired", "Device code expired before authorization completed")
+        raise OAuthError(
+            "api_error",
+            f"Device token request failed: {error}",
+            http_status=result.status,
+        )
+
+
+def _post_device_token(
+    token_endpoint: str,
+    params: dict[str, str],
+    timeout: float,
+    max_body_bytes: int,
+) -> _PollResult:
+    """One token-endpoint POST. Transport errors propagate to the caller.
+
+    The body is read under a bounded streaming cap with redirects suppressed
+    (see :func:`_post_form_bounded`), so an oversized or redirecting response
+    aborts instead of buffering.
+    """
+    status, body = _post_form_bounded(token_endpoint, params, timeout, max_body_bytes)
+
+    try:
+        data = json.loads(body)
+    except ValueError as exc:
+        raise OAuthError(
+            "api_error",
+            "Failed to parse device token response",
+            http_status=status,
+        ) from exc
+    if not isinstance(data, dict):
+        raise OAuthError("api_error", "Device token response is not a JSON object")
+
+    if 200 <= status < 300:
+        access_token = data.get("access_token")
+        if not isinstance(access_token, str) or not access_token:
+            raise OAuthError("api_error", "Device token response missing access_token")
+        return _PollResult(
+            token=OAuthToken(
+                access_token=access_token,
+                token_type=data.get("token_type", "Bearer"),
+                refresh_token=data.get("refresh_token"),
+                expires_in=data.get("expires_in"),
+                scope=data.get("scope"),
+            )
+        )
+
+    error = data.get("error") or f"http_{status}"
+    return _PollResult(error=error, status=status)
+
+
+def perform_device_login(
+    config: OAuthConfig,
+    client_id: str,
+    scope: str | None = None,
+    *,
+    display: Callable[[DeviceAuthorization], Any],
+    clock: Callable[[], float] = time.monotonic,
+    sleep: Callable[[float], Any] = time.sleep,
+    should_cancel: Callable[[], bool] | None = None,
+    timeout: float = _DEVICE_TIMEOUT,
+    max_body_bytes: int = MAX_DEVICE_BODY_BYTES,
+) -> OAuthToken:
+    """Run the full device authorization grant against an ALREADY-SELECTED config.
+
+    Capability guard: requires BOTH ``config.device_authorization_endpoint`` AND
+    ``device_code`` in ``config.grant_types_supported`` — otherwise raises
+    :class:`DeviceFlowError` (``unavailable``) before any request. Then requests
+    a device code, surfaces it through ``display``, and polls for the token.
+    """
+    supports_device_grant = DEVICE_CODE_GRANT_TYPE in (config.grant_types_supported or [])
+    if not config.device_authorization_endpoint or not supports_device_grant:
+        raise DeviceFlowError(
+            "unavailable",
+            "The selected authorization server does not support the device authorization grant",
+        )
+
+    auth = request_device_authorization(
+        config.device_authorization_endpoint,
+        client_id,
+        scope,
+        timeout=timeout,
+        max_body_bytes=max_body_bytes,
+    )
+
+    # The code's lifetime starts at issuance, not after display: a slow display
+    # hook must eat into the deadline, never reset it. Measure the elapsed time
+    # across the hook against the monotonic clock and check expiry before polling.
+    issued_at = clock()
+    display(auth)
+    remaining = auth.expires_in - (clock() - issued_at)
+    if remaining <= 0:
+        raise DeviceFlowError("expired", "Device code expired before authorization completed")
+
+    return poll_device_token(
+        config.token_endpoint,
+        client_id,
+        auth.device_code,
+        auth.interval,
+        remaining,
+        clock=clock,
+        sleep=sleep,
+        should_cancel=should_cancel,
+        timeout=timeout,
+        max_body_bytes=max_body_bytes,
+    )

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -85,11 +85,18 @@ def _post_form_bounded(
     params: dict[str, str],
     timeout: float,
     max_body_bytes: int,
+    read_body: Callable[[int], bool] = lambda _status: True,
 ) -> tuple[int, bytes]:
     """SSRF-hardened form POST: suppress redirects, bound the timeout, and read
     the body under a genuine streaming cap that aborts once ``max_body_bytes`` is
     exceeded (never a post-hoc check on an already-buffered body). Mirrors
     :func:`basecamp.oauth.discovery._fetch_discovery_document`.
+
+    ``read_body(status)`` decides — from the response status, known once headers
+    arrive — whether the body is drained. A caller returns ``False`` for statuses
+    whose body it does not use (a non-2xx device-auth, a 3xx token redirect), so a
+    slow/never-ending body cannot time out mid-read and be misclassified as a
+    retryable transport failure instead of the api_error the status already is.
 
     Transport failures propagate as :class:`httpx.HTTPError` (incl.
     :class:`httpx.TimeoutException`) so callers classify them; an oversized body
@@ -102,6 +109,8 @@ def _post_form_bounded(
             httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client,
             client.stream("POST", url, data=params, headers=_FORM_HEADERS) as response,
         ):
+            if not read_body(response.status_code):
+                return response.status_code, b""
             chunks: list[bytes] = []
             total = 0
             async for chunk in response.aiter_bytes():
@@ -182,7 +191,15 @@ def request_device_authorization(
         params["scope"] = scope
 
     try:
-        status, body = _post_form_bounded(device_authorization_endpoint, params, timeout, max_body_bytes)
+        # A non-2xx device-auth response is a hard failure whose body is unused —
+        # skip draining it so a slow error body can't time out and look like transport.
+        status, body = _post_form_bounded(
+            device_authorization_endpoint,
+            params,
+            timeout,
+            max_body_bytes,
+            read_body=lambda s: 200 <= s < 300,
+        )
     except httpx.HTTPError as exc:
         raise DeviceFlowError("transport", f"Device authorization request failed: {exc}") from exc
 
@@ -498,7 +515,16 @@ def _post_device_token(
     (see :func:`_post_form_bounded`), so an oversized or redirecting response
     aborts instead of buffering.
     """
-    status, body = _post_form_bounded(token_endpoint, params, timeout, max_body_bytes)
+    # A 3xx token response is an api fault whose body is unused — skip draining it
+    # so a slow redirect body can't time out and be retried by the poll loop until
+    # expiry. A 4xx body IS read (it carries authorization_pending/slow_down).
+    status, body = _post_form_bounded(
+        token_endpoint,
+        params,
+        timeout,
+        max_body_bytes,
+        read_body=lambda s: not (300 <= s < 400),
+    )
 
     # A redirect is never a token-endpoint outcome. Classify it before parsing
     # so a 3xx body carrying {"error": "authorization_pending"} cannot keep the

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -325,9 +325,9 @@ def _valid_token_expires_in(value: Any) -> bool:
     of seconds no greater than :data:`MAX_TOKEN_LIFETIME_SECONDS`.
 
     An integer-valued float (``3600.0``) is accepted; a fractional value (``1.5``)
-    is rejected — matching the device-duration rule and Go/Kotlin, where the
-    integer/Long typing already rejects a fractional token lifetime. ``bool`` is
-    an ``int`` subclass but never a lifetime.
+    is rejected — matching the device-duration rule; every SDK validates the
+    decoded numeric value explicitly to reject a fractional token lifetime.
+    ``bool`` is an ``int`` subclass but never a lifetime.
     """
     if isinstance(value, bool):
         return False
@@ -354,16 +354,25 @@ def _build_token(data: dict[str, Any], status: int) -> OAuthToken:
         raise OAuthError("api_error", "Device token response missing access_token", http_status=status)
 
     expires_in = data.get("expires_in")
-    if expires_in is not None and not _valid_token_expires_in(expires_in):
-        raise OAuthError(
-            "api_error",
-            "Device token response expires_in must be a finite positive whole number "
-            f"no greater than {MAX_TOKEN_LIFETIME_SECONDS} seconds",
-            http_status=status,
-        )
+    if expires_in is not None:
+        if not _valid_token_expires_in(expires_in):
+            raise OAuthError(
+                "api_error",
+                "Device token response expires_in must be a finite positive whole number "
+                f"no greater than {MAX_TOKEN_LIFETIME_SECONDS} seconds",
+                http_status=status,
+            )
+        # Coerce an integer-valued float (3600.0) to int: OAuthToken declares
+        # ``expires_in: int | None`` and computes expiry arithmetic from it.
+        expires_in = int(expires_in)
 
-    token_type = data.get("token_type", "Bearer")
-    if not isinstance(token_type, str) or not token_type:
+    # JSON null is treated as absent (the Go/Kotlin decoders cannot distinguish
+    # them) → Bearer default; only an explicit non-string or empty "" is
+    # malformed. Uniform across all five SDKs.
+    token_type = data.get("token_type")
+    if token_type is None:
+        token_type = "Bearer"
+    elif not isinstance(token_type, str) or not token_type:
         raise OAuthError("api_error", "Device token response token_type must be a non-empty string", http_status=status)
 
     refresh_token = data.get("refresh_token")

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -25,6 +25,7 @@ import httpx
 from basecamp._security import is_localhost, require_https
 from basecamp.oauth.config import OAuthConfig
 from basecamp.oauth.device_authorization import DeviceAuthorization
+from basecamp.oauth.discovery import _normalize_timeout
 from basecamp.oauth.errors import DeviceFlowError, OAuthError
 from basecamp.oauth.token import OAuthToken
 
@@ -80,6 +81,13 @@ def _post_form_bounded(
     :class:`httpx.TimeoutException`) so callers classify them; an oversized body
     raises :class:`OAuthError` (``api_error``).
     """
+    # Normalize first (a non-finite/non-positive timeout would disable both httpx's
+    # bound and the wall-clock deadline below), then bound the WHOLE streamed
+    # response: httpx's timeout is per-received-chunk and resets each iteration, so
+    # a slow-drip peer could otherwise hang a device request past the timeout and
+    # the device-code deadline while staying under ``max_body_bytes``. Mirrors
+    # :func:`basecamp.oauth.discovery._fetch_discovery_document`.
+    timeout = _normalize_timeout(timeout)
     with httpx.stream(
         "POST",
         url,
@@ -88,9 +96,15 @@ def _post_form_bounded(
         timeout=timeout,
         follow_redirects=False,
     ) as response:
+        deadline = time.monotonic() + timeout
         chunks: list[bytes] = []
         total = 0
         for chunk in response.iter_bytes():
+            if time.monotonic() > deadline:
+                # Surface as a read timeout so the caller's existing
+                # httpx.TimeoutException / HTTPError handling classifies it as the
+                # transport/timeout path (poll → backoff, request → transport).
+                raise httpx.ReadTimeout("Device flow read exceeded the timeout deadline")
             total += len(chunk)
             if total > max_body_bytes:
                 # Abort the stream — leaving the ``with`` closes the connection,

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -246,6 +246,10 @@ def poll_device_token(
     if not is_localhost(token_endpoint):
         require_https(token_endpoint, "token endpoint")
 
+    # The server-driven interval (initial value + sustained slow_down bumps) is
+    # tracked SEPARATELY from the transient timeout backoff: each wait is
+    # max(interval, backoff), and any completed round-trip snaps the backoff
+    # back to the current server interval, so an inflated backoff never sticks.
     interval_seconds = interval if interval > 0 else DEFAULT_INTERVAL_SECONDS
     backoff_seconds = interval_seconds
     deadline = clock() + expires_in
@@ -266,7 +270,7 @@ def poll_device_token(
         remaining = deadline - clock()
         if remaining <= 0:
             raise DeviceFlowError("expired", "Device code expired before authorization completed")
-        sleep(min(interval_seconds, remaining))
+        sleep(min(max(interval_seconds, backoff_seconds), remaining))
 
         if should_cancel is not None and should_cancel():
             raise DeviceFlowError("cancelled", "Device flow cancelled")
@@ -279,12 +283,13 @@ def poll_device_token(
         except httpx.TimeoutException:
             # A connection timeout → back off exponentially and keep polling.
             backoff_seconds = min(backoff_seconds * 2, MAX_BACKOFF_SECONDS)
-            interval_seconds = max(interval_seconds, backoff_seconds)
             continue
         except httpx.HTTPError as exc:
             raise DeviceFlowError("transport", f"Device token poll failed: {exc}") from exc
 
-        # A successful HTTP round-trip resets the timeout backoff.
+        # ANY completed HTTP round-trip — a token, authorization_pending,
+        # slow_down, or another OAuth error — resets the transient timeout
+        # backoff to the current server interval.
         backoff_seconds = interval_seconds
 
         if result.token is not None:
@@ -321,6 +326,16 @@ def _post_device_token(
     """
     status, body = _post_form_bounded(token_endpoint, params, timeout, max_body_bytes)
 
+    # A redirect is never a token-endpoint outcome. Classify it before parsing
+    # so a 3xx body carrying {"error": "authorization_pending"} cannot keep the
+    # poll loop alive — redirects are suppressed, not interpreted.
+    if 300 <= status < 400:
+        raise OAuthError(
+            "api_error",
+            f"Device token request failed with redirect status {status}",
+            http_status=status,
+        )
+
     try:
         data = json.loads(body)
     except ValueError as exc:
@@ -336,12 +351,25 @@ def _post_device_token(
         access_token = data.get("access_token")
         if not isinstance(access_token, str) or not access_token:
             raise OAuthError("api_error", "Device token response missing access_token")
+        # Validate expires_in BEFORE constructing the token: OAuthToken computes
+        # expires_at arithmetic from it, so a malformed value (a string, a bool,
+        # a non-positive number) must surface as api_error, never a TypeError.
+        # Absent/null stays allowed — the token then carries no expiry.
+        expires_in = data.get("expires_in")
+        if expires_in is not None and (
+            isinstance(expires_in, bool) or not isinstance(expires_in, int | float) or expires_in <= 0
+        ):
+            raise OAuthError(
+                "api_error",
+                "Device token response expires_in must be a positive number",
+                http_status=status,
+            )
         return _PollResult(
             token=OAuthToken(
                 access_token=access_token,
                 token_type=data.get("token_type", "Bearer"),
                 refresh_token=data.get("refresh_token"),
-                expires_in=data.get("expires_in"),
+                expires_in=expires_in,
                 scope=data.get("scope"),
             )
         )
@@ -369,7 +397,11 @@ def perform_device_login(
     :class:`DeviceFlowError` (``unavailable``) before any request. Then requests
     a device code, surfaces it through ``display``, and polls for the token.
     """
-    supports_device_grant = DEVICE_CODE_GRANT_TYPE in (config.grant_types_supported or [])
+    # Require a real list before the membership test: a malformed config
+    # carrying the URN as a plain str would substring-match `in` and pass the
+    # guard. A non-list grant_types_supported fails the capability check.
+    grant_types = config.grant_types_supported
+    supports_device_grant = isinstance(grant_types, list) and DEVICE_CODE_GRANT_TYPE in grant_types
     if not config.device_authorization_endpoint or not supports_device_grant:
         raise DeviceFlowError(
             "unavailable",

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -87,7 +87,7 @@ def _post_form_bounded(
     # a slow-drip peer could otherwise hang a device request past the timeout and
     # the device-code deadline while staying under ``max_body_bytes``. Mirrors
     # :func:`basecamp.oauth.discovery._fetch_discovery_document`.
-    timeout = _normalize_timeout(timeout)
+    timeout = _normalize_timeout(timeout, _DEVICE_TIMEOUT)
     with httpx.stream(
         "POST",
         url,
@@ -111,6 +111,12 @@ def _post_form_bounded(
                 # so the oversized body is never fully buffered.
                 raise OAuthError("api_error", "Device flow response exceeds size cap")
             chunks.append(chunk)
+        # The in-loop check runs BEFORE each chunk, so it can't catch the final
+        # read: EOF (or the last chunk) may land just after the deadline while
+        # staying within httpx's per-chunk timeout. Re-check after the stream ends
+        # so a slow-drip response can't extend the whole read past the deadline.
+        if time.monotonic() > deadline:
+            raise httpx.ReadTimeout("Device flow read exceeded the timeout deadline")
         return response.status_code, b"".join(chunks)
 
 

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -66,6 +66,10 @@ _MAX_DEVICE_REQUEST_TIMEOUT = 3600.0
 #: Granularity (seconds) for polling ``should_cancel`` while waiting between polls.
 _CANCEL_POLL_INTERVAL = 0.1
 
+#: Extra time (seconds) to let a timed-out request's async cancellation/cleanup
+#: unwind before the caller abandons the (daemon) worker and returns a timeout.
+_WORKER_JOIN_GRACE = 5.0
+
 # Cap on a device-flow response body (1 MiB) — these responses are tiny; a
 # larger one is a fault, so abort rather than buffer it. Mirrors discovery.
 MAX_DEVICE_BODY_BYTES = 1 * 1024 * 1024
@@ -130,9 +134,16 @@ def _post_form_bounded(
         except Exception as exc:  # captured and re-raised on the caller thread
             error.append(exc)
 
-    worker = threading.Thread(target=_runner)
+    worker = threading.Thread(target=_runner, daemon=True)
     worker.start()
-    worker.join()
+    # asyncio.wait_for cancels the request at `timeout`, so the worker normally
+    # finishes well within it. Join with a small grace for the cancellation/cleanup
+    # to unwind; if even that stalls (a pathological async cleanup hang), return a
+    # timeout rather than block the caller — the daemon worker never blocks
+    # interpreter exit. This is bounded AND non-leaking in every non-pathological case.
+    worker.join(timeout + _WORKER_JOIN_GRACE)
+    if worker.is_alive():
+        raise httpx.ReadTimeout("Device flow request exceeded the timeout deadline")
     if error:
         exc = error[0]
         if isinstance(exc, TimeoutError):
@@ -387,6 +398,10 @@ def poll_device_token(
             continue
         if error == "slow_down":
             interval_seconds += SLOW_DOWN_INCREMENT_SECONDS
+            # Re-sync the backoff to the GROWN interval (the reset above used the
+            # pre-increment value) so a later timeout doubles from the new interval,
+            # not the stale one.
+            backoff_seconds = interval_seconds
             continue
         if error == "access_denied":
             raise DeviceFlowError("access_denied", "The authorization request was denied")

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import json
 import math
+import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -112,14 +113,32 @@ def _post_form_bounded(
     # NO total-request timeout, so a peer slow-dripping header or body bytes just
     # under that interval could otherwise hold the POST open indefinitely (verified);
     # closing a sync client from a watchdog does not interrupt a blocked read either.
-    # Run the request as a coroutine under asyncio.wait_for, which CANCELS it (and
-    # closes the socket) at the deadline: the caller is bounded AND the work is
-    # actually terminated — no leaked worker, unlike a sync thread that cannot be
-    # killed. See https://www.python-httpx.org/advanced/timeouts/.
-    try:
-        return asyncio.run(asyncio.wait_for(_do(), timeout))
-    except TimeoutError as exc:
-        raise httpx.ReadTimeout("Device flow request exceeded the timeout deadline") from exc
+    # asyncio.wait_for CANCELS the request (and closes the socket) at the deadline —
+    # the caller is bounded AND the work is actually terminated, no leaked worker.
+    #
+    # Run it in a DEDICATED thread with its own event loop rather than calling
+    # asyncio.run() here: this sync helper may be invoked from code that already has
+    # a running loop (Jupyter/FastAPI/async CLI), where asyncio.run() raises
+    # RuntimeError before any request is made. The thread always completes within
+    # ~timeout (wait_for bounds it), so joining it never blocks.
+    result: list[tuple[int, bytes]] = []
+    error: list[Exception] = []
+
+    def _runner() -> None:
+        try:
+            result.append(asyncio.run(asyncio.wait_for(_do(), timeout)))
+        except Exception as exc:  # captured and re-raised on the caller thread
+            error.append(exc)
+
+    worker = threading.Thread(target=_runner)
+    worker.start()
+    worker.join()
+    if error:
+        exc = error[0]
+        if isinstance(exc, TimeoutError):
+            raise httpx.ReadTimeout("Device flow request exceeded the timeout deadline") from exc
+        raise exc
+    return result[0]
 
 
 def request_device_authorization(

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -14,6 +14,7 @@ clock and sleep are injectable so tests can drive the interval schedule
 from __future__ import annotations
 
 import json
+import math
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -44,6 +45,13 @@ MAX_BACKOFF_SECONDS = 60
 #: Shared across all five SDKs (SPEC.md) — an unbounded value such as 1e100 is
 #: a malformed response, not a schedulable deadline.
 MAX_DEVICE_SECONDS = 2_147_483
+
+#: Ceiling for an OAuth token's ``expires_in`` (2_147_483_647 s ≈ 68 years):
+#: cross-runtime safe and vastly beyond any realistic token lifetime. Unlike
+#: :data:`MAX_DEVICE_SECONDS` this bounds ``expires_at`` arithmetic rather than a
+#: timer, so a non-finite (``1e400`` parses to ``inf``) or absurd value is a
+#: malformed response — never a schedulable deadline. Shared across all five SDKs.
+MAX_TOKEN_LIFETIME_SECONDS = 2_147_483_647
 
 _DEVICE_TIMEOUT = 30.0
 
@@ -312,6 +320,56 @@ def poll_device_token(
         )
 
 
+def _build_token(data: dict[str, Any], status: int) -> OAuthToken:
+    """Construct an :class:`OAuthToken` from a validated token response.
+
+    Every optional field is type-checked BEFORE construction: ``OAuthToken``
+    computes ``expires_at`` arithmetic from ``expires_in``, so a malformed value
+    (a string, a bool, a non-finite ``inf`` from ``1e400``, a value past the
+    :data:`MAX_TOKEN_LIFETIME_SECONDS` ceiling) must surface as ``api_error``,
+    never a ``TypeError`` or an ``inf`` deadline. ``token_type``/``refresh_token``/
+    ``scope`` must be strings when present. Absent/null ``expires_in`` stays
+    allowed — the token then carries no expiry.
+    """
+    access_token = data.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        raise OAuthError("api_error", "Device token response missing access_token", http_status=status)
+
+    expires_in = data.get("expires_in")
+    if expires_in is not None and (
+        isinstance(expires_in, bool)
+        or not isinstance(expires_in, int | float)
+        or not math.isfinite(expires_in)
+        or not (0 < expires_in <= MAX_TOKEN_LIFETIME_SECONDS)
+    ):
+        raise OAuthError(
+            "api_error",
+            "Device token response expires_in must be a finite positive number "
+            f"no greater than {MAX_TOKEN_LIFETIME_SECONDS} seconds",
+            http_status=status,
+        )
+
+    token_type = data.get("token_type", "Bearer")
+    if not isinstance(token_type, str) or not token_type:
+        raise OAuthError("api_error", "Device token response token_type must be a non-empty string", http_status=status)
+
+    refresh_token = data.get("refresh_token")
+    if refresh_token is not None and not isinstance(refresh_token, str):
+        raise OAuthError("api_error", "Device token response refresh_token must be a string", http_status=status)
+
+    scope = data.get("scope")
+    if scope is not None and not isinstance(scope, str):
+        raise OAuthError("api_error", "Device token response scope must be a string", http_status=status)
+
+    return OAuthToken(
+        access_token=access_token,
+        token_type=token_type,
+        refresh_token=refresh_token,
+        expires_in=expires_in,
+        scope=scope,
+    )
+
+
 def _post_device_token(
     token_endpoint: str,
     params: dict[str, str],
@@ -348,31 +406,7 @@ def _post_device_token(
         raise OAuthError("api_error", "Device token response is not a JSON object")
 
     if 200 <= status < 300:
-        access_token = data.get("access_token")
-        if not isinstance(access_token, str) or not access_token:
-            raise OAuthError("api_error", "Device token response missing access_token")
-        # Validate expires_in BEFORE constructing the token: OAuthToken computes
-        # expires_at arithmetic from it, so a malformed value (a string, a bool,
-        # a non-positive number) must surface as api_error, never a TypeError.
-        # Absent/null stays allowed — the token then carries no expiry.
-        expires_in = data.get("expires_in")
-        if expires_in is not None and (
-            isinstance(expires_in, bool) or not isinstance(expires_in, int | float) or expires_in <= 0
-        ):
-            raise OAuthError(
-                "api_error",
-                "Device token response expires_in must be a positive number",
-                http_status=status,
-            )
-        return _PollResult(
-            token=OAuthToken(
-                access_token=access_token,
-                token_type=data.get("token_type", "Bearer"),
-                refresh_token=data.get("refresh_token"),
-                expires_in=expires_in,
-                scope=data.get("scope"),
-            )
-        )
+        return _PollResult(token=_build_token(data, status))
 
     error = data.get("error") or f"http_{status}"
     return _PollResult(error=error, status=status)

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -524,7 +524,11 @@ def _post_device_token(
     if 200 <= status < 300:
         return _PollResult(token=_build_token(data, status))
 
-    error = data.get("error") or f"http_{status}"
+    # Validate ``error`` as a non-empty string: a non-string (e.g. ``{"error": 123}``)
+    # must not be treated as an OAuth error code — fall back to ``http_<status>``,
+    # matching the other SDKs.
+    raw_error = data.get("error")
+    error = raw_error if isinstance(raw_error, str) and raw_error else f"http_{status}"
     return _PollResult(error=error, status=status)
 
 

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -320,31 +320,44 @@ def poll_device_token(
         )
 
 
+def _valid_token_expires_in(value: Any) -> bool:
+    """A token ``expires_in`` is valid when it is a finite, positive, WHOLE number
+    of seconds no greater than :data:`MAX_TOKEN_LIFETIME_SECONDS`.
+
+    An integer-valued float (``3600.0``) is accepted; a fractional value (``1.5``)
+    is rejected — matching the device-duration rule and Go/Kotlin, where the
+    integer/Long typing already rejects a fractional token lifetime. ``bool`` is
+    an ``int`` subclass but never a lifetime.
+    """
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, int):
+        return 0 < value <= MAX_TOKEN_LIFETIME_SECONDS
+    if isinstance(value, float):
+        return math.isfinite(value) and value.is_integer() and 0 < value <= MAX_TOKEN_LIFETIME_SECONDS
+    return False
+
+
 def _build_token(data: dict[str, Any], status: int) -> OAuthToken:
     """Construct an :class:`OAuthToken` from a validated token response.
 
     Every optional field is type-checked BEFORE construction: ``OAuthToken``
     computes ``expires_at`` arithmetic from ``expires_in``, so a malformed value
-    (a string, a bool, a non-finite ``inf`` from ``1e400``, a value past the
-    :data:`MAX_TOKEN_LIFETIME_SECONDS` ceiling) must surface as ``api_error``,
-    never a ``TypeError`` or an ``inf`` deadline. ``token_type``/``refresh_token``/
-    ``scope`` must be strings when present. Absent/null ``expires_in`` stays
-    allowed — the token then carries no expiry.
+    (a string, a bool, a non-finite ``inf`` from ``1e400``, a fractional value, a
+    value past the :data:`MAX_TOKEN_LIFETIME_SECONDS` ceiling) must surface as
+    ``api_error``, never a ``TypeError`` or an ``inf`` deadline.
+    ``token_type``/``refresh_token``/``scope`` must be strings when present.
+    Absent/null ``expires_in`` stays allowed — the token then carries no expiry.
     """
     access_token = data.get("access_token")
     if not isinstance(access_token, str) or not access_token:
         raise OAuthError("api_error", "Device token response missing access_token", http_status=status)
 
     expires_in = data.get("expires_in")
-    if expires_in is not None and (
-        isinstance(expires_in, bool)
-        or not isinstance(expires_in, int | float)
-        or not math.isfinite(expires_in)
-        or not (0 < expires_in <= MAX_TOKEN_LIFETIME_SECONDS)
-    ):
+    if expires_in is not None and not _valid_token_expires_in(expires_in):
         raise OAuthError(
             "api_error",
-            "Device token response expires_in must be a finite positive number "
+            "Device token response expires_in must be a finite positive whole number "
             f"no greater than {MAX_TOKEN_LIFETIME_SECONDS} seconds",
             http_status=status,
         )

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -154,6 +154,17 @@ def request_device_authorization(
     except httpx.HTTPError as exc:
         raise DeviceFlowError("transport", f"Device authorization request failed: {exc}") from exc
 
+    # Check status BEFORE parsing (as discovery does): a non-2xx here is a hard
+    # failure with no OAuth error semantics, so a non-JSON error body must surface
+    # as "failed with status …", not a misleading parse error. (The token poll is
+    # different — it MUST parse non-2xx bodies to read authorization_pending etc.)
+    if not 200 <= status < 300:
+        raise OAuthError(
+            "api_error",
+            f"Device authorization failed with status {status}",
+            http_status=status,
+        )
+
     try:
         data = json.loads(body)
     except ValueError as exc:
@@ -163,12 +174,6 @@ def request_device_authorization(
             http_status=status,
         ) from exc
 
-    if not 200 <= status < 300:
-        raise OAuthError(
-            "api_error",
-            f"Device authorization failed with status {status}",
-            http_status=status,
-        )
     if not isinstance(data, dict):
         raise OAuthError("api_error", "Device authorization response is not a JSON object", http_status=status)
 

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -13,9 +13,9 @@ clock and sleep are injectable so tests can drive the interval schedule
 
 from __future__ import annotations
 
+import asyncio
 import json
 import math
-import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -57,6 +57,14 @@ MAX_TOKEN_LIFETIME_SECONDS = 2_147_483_647
 
 _DEVICE_TIMEOUT = 30.0
 
+#: Upper bound (seconds) on a device request timeout. A per-request timeout beyond
+#: this is nonsensical, and a huge finite value would overflow the wall-clock wait
+#: primitive (asyncio.wait_for / thread join); clamp to the default above it.
+_MAX_DEVICE_REQUEST_TIMEOUT = 3600.0
+
+#: Granularity (seconds) for polling ``should_cancel`` while waiting between polls.
+_CANCEL_POLL_INTERVAL = 0.1
+
 # Cap on a device-flow response body (1 MiB) — these responses are tiny; a
 # larger one is a fault, so abort rather than buffer it. Mirrors discovery.
 MAX_DEVICE_BODY_BYTES = 1 * 1024 * 1024
@@ -82,48 +90,36 @@ def _post_form_bounded(
     :class:`httpx.TimeoutException`) so callers classify them; an oversized body
     raises :class:`OAuthError` (``api_error``).
     """
-    timeout = _normalize_timeout(timeout, _DEVICE_TIMEOUT)
-    client = httpx.Client(timeout=timeout, follow_redirects=False)
+    timeout = _normalize_timeout(timeout, _DEVICE_TIMEOUT, maximum=_MAX_DEVICE_REQUEST_TIMEOUT)
 
-    result: list[tuple[int, bytes]] = []
-    error: list[Exception] = []
+    async def _do() -> tuple[int, bytes]:
+        async with (
+            httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client,
+            client.stream("POST", url, data=params, headers=_FORM_HEADERS) as response,
+        ):
+            chunks: list[bytes] = []
+            total = 0
+            async for chunk in response.aiter_bytes():
+                total += len(chunk)
+                if total > max_body_bytes:
+                    # An oversized body is api_error, not a timeout — abort the
+                    # stream so it is never fully buffered.
+                    raise OAuthError("api_error", "Device flow response exceeds size cap")
+                chunks.append(chunk)
+            return response.status_code, b"".join(chunks)
 
-    def _worker() -> None:
-        try:
-            with client.stream("POST", url, data=params, headers=_FORM_HEADERS) as response:
-                chunks: list[bytes] = []
-                total = 0
-                for chunk in response.iter_bytes():
-                    total += len(chunk)
-                    if total > max_body_bytes:
-                        # An oversized body is api_error, not a timeout — abort the
-                        # stream so it is never fully buffered.
-                        raise OAuthError("api_error", "Device flow response exceeds size cap")
-                    chunks.append(chunk)
-                result.append((response.status_code, b"".join(chunks)))
-        except Exception as exc:  # re-raised on the caller thread below
-            error.append(exc)
-
-    # httpx's timeout is per-read — it resets on every received chunk — so it does
-    # NOT bound the WHOLE exchange against a peer that slow-drips header or body
-    # bytes just under that interval, and httpx has no total-request timeout
-    # (https://www.python-httpx.org/advanced/timeouts/). Closing the client from a
-    # watchdog does not interrupt a blocked read either. So run the request on a
-    # daemon worker and enforce a HARD wall-clock bound on the caller with
-    # join(timeout): a stalled/slow-drip request returns within `timeout` as a read
-    # timeout. The abandoned daemon worker never blocks interpreter exit and dies on
-    # its own per-read timeout; client.close() below is a best-effort unblock.
-    worker = threading.Thread(target=_worker, daemon=True)
-    worker.start()
-    worker.join(timeout)
+    # httpx's timeout is per-read (it resets on every received chunk) and httpx has
+    # NO total-request timeout, so a peer slow-dripping header or body bytes just
+    # under that interval could otherwise hold the POST open indefinitely (verified);
+    # closing a sync client from a watchdog does not interrupt a blocked read either.
+    # Run the request as a coroutine under asyncio.wait_for, which CANCELS it (and
+    # closes the socket) at the deadline: the caller is bounded AND the work is
+    # actually terminated — no leaked worker, unlike a sync thread that cannot be
+    # killed. See https://www.python-httpx.org/advanced/timeouts/.
     try:
-        if worker.is_alive():
-            raise httpx.ReadTimeout("Device flow request exceeded the timeout deadline")
-        if error:
-            raise error[0]
-        return result[0]
-    finally:
-        client.close()
+        return asyncio.run(asyncio.wait_for(_do(), timeout))
+    except TimeoutError as exc:
+        raise httpx.ReadTimeout("Device flow request exceeded the timeout deadline") from exc
 
 
 def request_device_authorization(
@@ -265,6 +261,32 @@ class _PollResult:
     status: int = 0
 
 
+def _wait_cancellable(
+    seconds: float,
+    should_cancel: Callable[[], bool] | None,
+    sleep: Callable[[float], Any],
+) -> None:
+    """Wait ``seconds``, observing cancellation DURING the wait.
+
+    ``time.sleep`` is not interruptible, so a plain ``sleep(interval)`` would not
+    notice a cancellation until the whole interval (possibly a grown ``slow_down``
+    interval) elapses. When a ``should_cancel`` probe is supplied, poll it every
+    :data:`_CANCEL_POLL_INTERVAL` and raise promptly. With no probe (the common
+    case) a single ``sleep`` preserves the exact wait schedule — matching the
+    ctx/AbortSignal/coroutine cancellation the Go/TS/Kotlin waits already have.
+    """
+    if should_cancel is None:
+        sleep(seconds)
+        return
+    remaining = seconds
+    while remaining > 0:
+        if should_cancel():
+            raise DeviceFlowError("cancelled", "Device flow cancelled")
+        step = min(remaining, _CANCEL_POLL_INTERVAL)
+        sleep(step)
+        remaining -= step
+
+
 def poll_device_token(
     token_endpoint: str,
     client_id: str,
@@ -316,7 +338,7 @@ def poll_device_token(
         remaining = deadline - clock()
         if remaining <= 0:
             raise DeviceFlowError("expired", "Device code expired before authorization completed")
-        sleep(min(max(interval_seconds, backoff_seconds), remaining))
+        _wait_cancellable(min(max(interval_seconds, backoff_seconds), remaining), should_cancel, sleep)
 
         if should_cancel is not None and should_cancel():
             raise DeviceFlowError("cancelled", "Device flow cancelled")

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -27,7 +27,7 @@ import httpx
 from basecamp._security import is_localhost, require_https
 from basecamp.oauth.config import OAuthConfig
 from basecamp.oauth.device_authorization import DeviceAuthorization
-from basecamp.oauth.discovery import _normalize_timeout
+from basecamp.oauth.discovery import _normalize_body_cap, _normalize_timeout
 from basecamp.oauth.errors import DeviceFlowError, OAuthError
 from basecamp.oauth.token import OAuthToken
 
@@ -187,6 +187,11 @@ def request_device_authorization(
         require_https(device_authorization_endpoint, "device authorization endpoint")
     if not client_id:
         raise OAuthError("validation", "Client ID is required for device authorization")
+
+    # Normalize the cap at the public boundary: an invalid runtime value (None,
+    # float("inf"), a negative) would disable the streaming memory bound
+    # (``total > inf`` never trips) — same discipline as discovery.
+    max_body_bytes = _normalize_body_cap(max_body_bytes, MAX_DEVICE_BODY_BYTES)
 
     params: dict[str, str] = {"client_id": client_id}
     # Omit scope entirely when unset so the server applies its default (`read`).
@@ -375,17 +380,26 @@ def poll_device_token(
     # legitimately passes a fractional remaining lifetime after deducting
     # display-hook time. Mirrors the Go/TS/Ruby/Kotlin caller guards.
     for name, value in (("expires_in", expires_in), ("interval", interval)):
+        # Range checks run BEFORE math.isfinite: isfinite converts an int to float,
+        # so an astronomically large int (10**400) would raise OverflowError out of
+        # the guard instead of the usage error. Int/float comparisons never convert,
+        # and NaN compares False on both, falling through to the isfinite reject.
         if (
             isinstance(value, bool)
             or not isinstance(value, (int, float))
-            or not math.isfinite(value)
             or value <= 0
             or value > MAX_DEVICE_SECONDS
+            or not math.isfinite(value)
         ):
             raise OAuthError(
                 "usage",
                 f"poll_device_token: {name} must be a positive number of seconds no greater than {MAX_DEVICE_SECONDS}",
             )
+
+    # Normalize the cap at the public boundary: an invalid runtime value (None,
+    # float("inf"), a negative) would disable the streaming memory bound
+    # (``total > inf`` never trips) — same discipline as discovery.
+    max_body_bytes = _normalize_body_cap(max_body_bytes, MAX_DEVICE_BODY_BYTES)
 
     # The server-driven interval (initial value + sustained slow_down bumps) is
     # tracked SEPARATELY from the transient timeout backoff: each wait is

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -744,19 +744,19 @@ def perform_device_login(
     if not callable(display):
         raise OAuthError("usage", "perform_device_login requires a callable display hook")
 
-    # Honor a cancellation raised BEFORE the flow does any work: the sync
-    # authorization POST cannot observe the probe in flight, so without this
-    # entry check an already-cancelled flow still performs the request and
-    # invokes the display hook.
-    if should_cancel is not None and should_cancel():
-        raise DeviceFlowError("cancelled", "Device flow cancelled")
-
     # The code's lifetime starts at SERVER issuance, which precedes the
     # response: anchor conservatively BEFORE the request goes out, so a slow
     # authorization response (or one delayed in transit) eats into the deadline
     # instead of granting the code a fresh full lifetime. The anchor can only
     # SHORTEN the usable window, never extend it.
     issued_at = _validated_clock_sample(clock(), "perform_device_login")
+
+    # Honor a cancellation raised BEFORE the flow does any work — checked AFTER
+    # the anchor so a cancel flipped during the injected clock call (itself a
+    # callback seam) still stops the request: the sync authorization POST
+    # cannot observe the probe in flight.
+    if should_cancel is not None and should_cancel():
+        raise DeviceFlowError("cancelled", "Device flow cancelled")
 
     try:
         auth = request_device_authorization(

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -229,12 +229,14 @@ def request_device_authorization(
 
     try:
         data = json.loads(body)
-    except ValueError as exc:
+    except ValueError:
+        # from None — json.JSONDecodeError retains the whole document as its
+        # .doc attribute; these bodies carry device codes and access tokens.
         raise OAuthError(
             "api_error",
             "Failed to parse device authorization response",
             http_status=status,
-        ) from exc
+        ) from None
 
     if not isinstance(data, dict):
         raise OAuthError("api_error", "Device authorization response is not a JSON object", http_status=status)
@@ -677,12 +679,14 @@ def _post_device_token(
 
     try:
         data = json.loads(body)
-    except ValueError as exc:
+    except ValueError:
+        # from None — json.JSONDecodeError retains the whole document as its
+        # .doc attribute; these bodies carry device codes and access tokens.
         raise OAuthError(
             "api_error",
             "Failed to parse device token response",
             http_status=status,
-        ) from exc
+        ) from None
     if not isinstance(data, dict):
         raise OAuthError("api_error", "Device token response is not a JSON object", http_status=status)
 

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -671,6 +671,13 @@ def perform_device_login(
             "The selected authorization server does not support the device authorization grant",
         )
 
+    # Honor a cancellation raised BEFORE the flow does any work: the sync
+    # authorization POST cannot observe the probe in flight, so without this
+    # entry check an already-cancelled flow still performs the request and
+    # invokes the display hook.
+    if should_cancel is not None and should_cancel():
+        raise DeviceFlowError("cancelled", "Device flow cancelled")
+
     auth = request_device_authorization(
         config.device_authorization_endpoint,
         client_id,
@@ -678,6 +685,11 @@ def perform_device_login(
         timeout=timeout,
         max_body_bytes=max_body_bytes,
     )
+
+    # Re-check after the round-trip, before surfacing the code: a cancel set
+    # while the authorization request was in flight must not reach display.
+    if should_cancel is not None and should_cancel():
+        raise DeviceFlowError("cancelled", "Device flow cancelled")
 
     # The code's lifetime starts at issuance, not after display: a slow display
     # hook must eat into the deadline, never reset it. Measure the elapsed time

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -430,11 +430,15 @@ def poll_device_token(
         if should_cancel is not None and should_cancel():
             raise DeviceFlowError("cancelled", "Device flow cancelled")
 
-        if clock() >= deadline:
+        post_remaining = deadline - clock()
+        if post_remaining <= 0:
             raise DeviceFlowError("expired", "Device code expired before authorization completed")
 
         try:
-            result = _post_device_token(token_endpoint, params, timeout, max_body_bytes)
+            # Bound the request by the REMAINING code lifetime as well as the
+            # per-request timeout: near expiry, a stalled token POST must not
+            # hold the flow past the monotonic deadline for the full budget.
+            result = _post_device_token(token_endpoint, params, min(timeout, post_remaining), max_body_bytes)
         except httpx.TimeoutException:
             # A connection timeout → back off exponentially and keep polling.
             backoff_seconds = min(backoff_seconds * 2, MAX_BACKOFF_SECONDS)
@@ -597,8 +601,13 @@ def _post_device_token(
     # Validate ``error`` as a non-empty string: a non-string (e.g. ``{"error": 123}``)
     # must not be treated as an OAuth error code — fall back to ``http_<status>``,
     # matching the other SDKs.
+    # Recognize OAuth protocol error codes ONLY on a 4xx (RFC 8628 §3.5 error
+    # responses are 400-class): a nonstandard 2xx (201/202) or a 5xx carrying a
+    # crafted authorization_pending body must not keep the loop polling — only
+    # a 200 can produce a token and only a 4xx a protocol state. Everything
+    # else falls back to http_<status>, which the loop terminates as api_error.
     raw_error = data.get("error")
-    error = raw_error if isinstance(raw_error, str) and raw_error else f"http_{status}"
+    error = raw_error if 400 <= status < 500 and isinstance(raw_error, str) and raw_error else f"http_{status}"
     return _PollResult(error=error, status=status)
 
 

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -456,6 +456,14 @@ def poll_device_token(
         except httpx.HTTPError as exc:
             raise DeviceFlowError("transport", f"Device token poll failed: {exc}") from exc
 
+        # Re-check cancellation the moment the round-trip completes: the sync
+        # POST cannot observe the probe while in flight (bounded only by its
+        # timeout), so a cancel raised mid-request must surface here — never a
+        # token returned after the caller asked to stop. Go/TS/Kotlin get this
+        # in-flight via ctx/AbortSignal/coroutine cancellation.
+        if should_cancel is not None and should_cancel():
+            raise DeviceFlowError("cancelled", "Device flow cancelled")
+
         # ANY completed HTTP round-trip — a token, authorization_pending,
         # slow_down, or another OAuth error — resets the transient timeout
         # backoff to the current server interval.

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -744,17 +744,10 @@ def perform_device_login(
     if not callable(display):
         raise OAuthError("usage", "perform_device_login requires a callable display hook")
 
-    # The code's lifetime starts at SERVER issuance, which precedes the
-    # response: anchor conservatively BEFORE the request goes out, so a slow
-    # authorization response (or one delayed in transit) eats into the deadline
-    # instead of granting the code a fresh full lifetime. The anchor can only
-    # SHORTEN the usable window, never extend it.
-    issued_at = _validated_clock_sample(clock(), "perform_device_login")
-
-    # Honor a cancellation raised BEFORE the flow does any work — checked AFTER
-    # the anchor so a cancel flipped during the injected clock call (itself a
-    # callback seam) still stops the request: the sync authorization POST
-    # cannot observe the probe in flight.
+    # Honor a cancellation raised BEFORE the flow does any work: the sync
+    # authorization POST cannot observe the probe in flight, so without this
+    # entry check an already-cancelled flow still performs the request and
+    # invokes the display hook.
     if should_cancel is not None and should_cancel():
         raise DeviceFlowError("cancelled", "Device flow cancelled")
 
@@ -774,8 +767,15 @@ def perform_device_login(
             raise DeviceFlowError("cancelled", "Device flow cancelled") from None
         raise
 
-    # Re-check after the round-trip, before surfacing the code: a cancel set
-    # while the authorization request was in flight must not reach display.
+    # Anchor the code's lifetime at ISSUANCE — the response's arrival, per
+    # SPEC §16 — before the display hook, so a slow display eats into the
+    # deadline instead of resetting it. Expiry past this point is arbitrated
+    # by the server (expired_token), so receipt-anchoring fails safe.
+    issued_at = _validated_clock_sample(clock(), "perform_device_login")
+
+    # Re-check after the round-trip AND after the anchor sample (itself a
+    # cancellation-capable callback seam), before surfacing the code: a
+    # cancel set in either window must not reach display.
     if should_cancel is not None and should_cancel():
         raise DeviceFlowError("cancelled", "Device flow cancelled")
 
@@ -783,7 +783,7 @@ def perform_device_login(
     remaining = auth.expires_in - (_validated_clock_sample(clock(), "perform_device_login") - issued_at)
     # Cancellation raised DURING the display hook OR during the clock sample
     # just above (the clock is a cancellation-capable callback seam, exactly
-    # like the pre-request anchor) wins over expiry: checked after the sample
+    # like the issuance anchor) wins over expiry: checked after the sample
     # and before the expiry branch, matching the TS orchestrator's ordering.
     if should_cancel is not None and should_cancel():
         raise DeviceFlowError("cancelled", "Device flow cancelled")

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -400,6 +400,11 @@ def poll_device_token(
     # float("inf"), a negative) would disable the streaming memory bound
     # (``total > inf`` never trips) — same discipline as discovery.
     max_body_bytes = _normalize_body_cap(max_body_bytes, MAX_DEVICE_BODY_BYTES)
+    # Normalize the timeout ONCE at the public boundary too: the per-poll
+    # remaining-lifetime clamp takes min() against it, and an invalid runtime
+    # value (None → TypeError from min, a negative, an oversized 1e100) must
+    # resolve to the device budget BEFORE any arithmetic touches it.
+    timeout = _normalize_timeout(timeout, _DEVICE_TIMEOUT, maximum=_MAX_DEVICE_REQUEST_TIMEOUT)
 
     # The server-driven interval (initial value + sustained slow_down bumps) is
     # tracked SEPARATELY from the transient timeout backoff: each wait is
@@ -567,7 +572,7 @@ def _post_device_token(
         params,
         timeout,
         max_body_bytes,
-        read_body=lambda s: not (300 <= s < 400),
+        read_body=lambda s: s == 200 or 400 <= s < 500,
     )
 
     # A redirect is never a token-endpoint outcome. Classify it before parsing
@@ -577,6 +582,18 @@ def _post_device_token(
         raise OAuthError(
             "api_error",
             f"Device token request failed with redirect status {status}",
+            http_status=status,
+        )
+
+    # Every remaining status outside 200 and 4xx is terminal WITHOUT its body
+    # (only a 200 carries the token and only a 4xx the OAuth error code) — the
+    # read_body predicate above already skipped the body, so a 201/500 that
+    # stalls while streaming can never time out mid-read and be retried as a
+    # transient failure until the code expires.
+    if not (status == 200 or 400 <= status < 500):
+        raise OAuthError(
+            "api_error",
+            f"Device token request failed with status {status}",
             http_status=status,
         )
 

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -359,6 +359,7 @@ def poll_device_token(
     should_cancel: Callable[[], bool] | None = None,
     timeout: float = _DEVICE_TIMEOUT,
     max_body_bytes: int = MAX_DEVICE_BODY_BYTES,
+    deadline_at: float | None = None,
 ) -> OAuthToken:
     """Poll the token endpoint until approval, denial, or expiry (RFC 8628 §3.4–3.5).
 
@@ -427,7 +428,21 @@ def poll_device_token(
             raise OAuthError("usage", "poll_device_token clock must return a finite number of seconds")
         return value
 
-    deadline = _sample_clock() + expires_in
+    # An absolute issuance-anchored deadline (perform_device_login passes
+    # issued_at + expires_in) beats re-anchoring: clock time elapsing between
+    # the caller's remaining-lifetime computation and this entry — a process
+    # suspension above all — must never be handed back to the code. It can
+    # only SHORTEN the validated lifetime, never extend it.
+    if deadline_at is not None:
+        if not math.isfinite(deadline_at) or deadline_at > _sample_clock() + expires_in:
+            raise OAuthError(
+                "usage",
+                "poll_device_token deadline_at must be a finite monotonic timestamp "
+                "no later than expires_in seconds from now",
+            )
+        deadline = deadline_at
+    else:
+        deadline = _sample_clock() + expires_in
 
     params = {
         "grant_type": DEVICE_CODE_GRANT_TYPE,
@@ -735,6 +750,10 @@ def perform_device_login(
         auth.device_code,
         auth.interval,
         remaining,
+        # The EXACT issuance-anchored deadline: a clock advance between the
+        # remaining computation above and the poller's entry must not extend
+        # the code lifetime.
+        deadline_at=issued_at + auth.expires_in,
         clock=clock,
         sleep=sleep,
         should_cancel=should_cancel,

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -675,13 +675,6 @@ def perform_device_login(
     :class:`DeviceFlowError` (``unavailable``) before any request. Then requests
     a device code, surfaces it through ``display``, and polls for the token.
     """
-    # A non-callable display is a usage error, not a late TypeError: it is
-    # the only mechanism surfacing the verification code, so dereferencing it
-    # AFTER the request would mint a code nobody can approve. Reject before
-    # any network activity (matching Go).
-    if not callable(display):
-        raise OAuthError("usage", "perform_device_login requires a callable display hook")
-
     # Require a real list before the membership test: a malformed config
     # carrying the URN as a plain str would substring-match `in` and pass the
     # guard. A non-list grant_types_supported fails the capability check.
@@ -692,6 +685,15 @@ def perform_device_login(
             "unavailable",
             "The selected authorization server does not support the device authorization grant",
         )
+
+    # A non-callable display is a usage error, not a late TypeError: it is
+    # the only mechanism surfacing the verification code, so dereferencing it
+    # AFTER the request would mint a code nobody can approve. Reject before
+    # any network activity (matching Go). Capability
+    # is checked FIRST so probing consumers keep the documented unavailable
+    # outcome.
+    if not callable(display):
+        raise OAuthError("usage", "perform_device_login requires a callable display hook")
 
     # Honor a cancellation raised BEFORE the flow does any work: the sync
     # authorization POST cannot observe the probe in flight, so without this

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -434,7 +434,17 @@ def poll_device_token(
     # suspension above all — must never be handed back to the code. It can
     # only SHORTEN the validated lifetime, never extend it.
     if deadline_at is not None:
-        if not math.isfinite(deadline_at) or deadline_at > _sample_clock() + expires_in:
+        # Type-gated and overflow-safe: bool is not a timestamp, non-numerics
+        # would raise TypeError out of isfinite, and a huge int overflows the
+        # float conversion — every invalid shape must be the typed usage
+        # error, matching the other duration guards.
+        valid = isinstance(deadline_at, (int, float)) and not isinstance(deadline_at, bool)
+        if valid:
+            try:
+                valid = math.isfinite(float(deadline_at)) and deadline_at <= _sample_clock() + expires_in
+            except OverflowError:
+                valid = False
+        if not valid:
             raise OAuthError(
                 "usage",
                 "poll_device_token deadline_at must be a finite monotonic timestamp "

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -508,6 +508,11 @@ def poll_device_token(
             backoff_seconds = min(backoff_seconds * 2, MAX_BACKOFF_SECONDS)
             continue
         except httpx.HTTPError as exc:
+            # Cancellation-beats-classification on the error path too: a cancel
+            # that flipped while the doomed request was in flight must surface
+            # as cancelled, not as the transport fault it happened to raise.
+            if should_cancel is not None and should_cancel():
+                raise DeviceFlowError("cancelled", "Device flow cancelled") from None
             raise DeviceFlowError("transport", f"Device token poll failed: {exc}") from exc
 
         # Re-check cancellation the moment the round-trip completes: the sync
@@ -746,13 +751,21 @@ def perform_device_login(
     if should_cancel is not None and should_cancel():
         raise DeviceFlowError("cancelled", "Device flow cancelled")
 
-    auth = request_device_authorization(
-        config.device_authorization_endpoint,
-        client_id,
-        scope,
-        timeout=timeout,
-        max_body_bytes=max_body_bytes,
-    )
+    try:
+        auth = request_device_authorization(
+            config.device_authorization_endpoint,
+            client_id,
+            scope,
+            timeout=timeout,
+            max_body_bytes=max_body_bytes,
+        )
+    except (DeviceFlowError, OAuthError):
+        # Cancellation-beats-classification on the error path too: a cancel
+        # that flipped while the authorization request was in flight wins over
+        # whatever fault the doomed request raised.
+        if should_cancel is not None and should_cancel():
+            raise DeviceFlowError("cancelled", "Device flow cancelled") from None
+        raise
 
     # Re-check after the round-trip, before surfacing the code: a cancel set
     # while the authorization request was in flight must not reach display.

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -587,7 +587,11 @@ def _post_device_token(
     if not isinstance(data, dict):
         raise OAuthError("api_error", "Device token response is not a JSON object", http_status=status)
 
-    if 200 <= status < 300:
+    # Exactly HTTP 200, not any 2xx: RFC 8628/6749 token responses are 200, and
+    # SPEC §16 pins the contract. A nonstandard 201/202 carrying an access_token
+    # must not prematurely complete polling — it falls through to the OAuth-error
+    # path below and terminates as api_error (http_<status>).
+    if status == 200:
         return _PollResult(token=_build_token(data, status))
 
     # Validate ``error`` as a non-empty string: a non-string (e.g. ``{"error": 123}``)

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -751,6 +751,13 @@ def perform_device_login(
     if should_cancel is not None and should_cancel():
         raise DeviceFlowError("cancelled", "Device flow cancelled")
 
+    # The code's lifetime starts at SERVER issuance, which precedes the
+    # response: anchor conservatively BEFORE the request goes out, so a slow
+    # authorization response (or one delayed in transit) eats into the deadline
+    # instead of granting the code a fresh full lifetime. The anchor can only
+    # SHORTEN the usable window, never extend it.
+    issued_at = _validated_clock_sample(clock(), "perform_device_login")
+
     try:
         auth = request_device_authorization(
             config.device_authorization_endpoint,
@@ -772,10 +779,6 @@ def perform_device_login(
     if should_cancel is not None and should_cancel():
         raise DeviceFlowError("cancelled", "Device flow cancelled")
 
-    # The code's lifetime starts at issuance, not after display: a slow display
-    # hook must eat into the deadline, never reset it. Measure the elapsed time
-    # across the hook against the monotonic clock and check expiry before polling.
-    issued_at = _validated_clock_sample(clock(), "perform_device_login")
     display(auth)
     # Cancellation raised DURING the display hook (a prompt closing in
     # response to cancellation) wins over expiry: a hook that both cancels

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -701,6 +701,11 @@ def perform_device_login(
     # across the hook against the monotonic clock and check expiry before polling.
     issued_at = clock()
     display(auth)
+    # Cancellation raised DURING the display hook (a prompt closing in
+    # response to cancellation) wins over expiry: a hook that both cancels
+    # and consumes the lifetime must surface cancelled, not expired.
+    if should_cancel is not None and should_cancel():
+        raise DeviceFlowError("cancelled", "Device flow cancelled")
     remaining = auth.expires_in - (clock() - issued_at)
     if remaining <= 0:
         raise DeviceFlowError("expired", "Device code expired before authorization completed")

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -665,6 +665,13 @@ def perform_device_login(
     :class:`DeviceFlowError` (``unavailable``) before any request. Then requests
     a device code, surfaces it through ``display``, and polls for the token.
     """
+    # A non-callable display is a usage error, not a late TypeError: it is
+    # the only mechanism surfacing the verification code, so dereferencing it
+    # AFTER the request would mint a code nobody can approve. Reject before
+    # any network activity (matching Go).
+    if not callable(display):
+        raise OAuthError("usage", "perform_device_login requires a callable display hook")
+
     # Require a real list before the membership test: a malformed config
     # carrying the URN as a plain str would substring-match `in` and pass the
     # guard. A non-list grant_types_supported fails the capability check.

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -68,7 +68,12 @@ _CANCEL_POLL_INTERVAL = 0.1
 
 #: Extra time (seconds) to let a timed-out request's async cancellation/cleanup
 #: unwind before the caller abandons the (daemon) worker and returns a timeout.
-_WORKER_JOIN_GRACE = 5.0
+#: Kept SMALL so the caller's worst-case block stays ~timeout: near expiry the
+#: request budget is clamped to the remaining code lifetime, and this grace is
+#: the only overshoot past the polling deadline — cleanup after a wait_for
+#: cancellation is just closing a socket, and joining with no grace at all
+#: would race a request that completes right at the deadline.
+_WORKER_JOIN_GRACE = 1.0
 
 # Cap on a device-flow response body (1 MiB) — these responses are tiny; a
 # larger one is a fault, so abort rather than buffer it. Mirrors discovery.

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -417,7 +417,17 @@ def poll_device_token(
     # back to the current server interval, so an inflated backoff never sticks.
     interval_seconds = interval
     backoff_seconds = interval_seconds
-    deadline = clock() + expires_in
+
+    def _sample_clock() -> float:
+        # EVERY sample of the injected clock is validated: a NaN sample makes
+        # the deadline (or a comparison against it) permanently false, so an
+        # authorization_pending endpoint would be polled indefinitely.
+        value = clock()
+        if not math.isfinite(value):
+            raise OAuthError("usage", "poll_device_token clock must return a finite number of seconds")
+        return value
+
+    deadline = _sample_clock() + expires_in
 
     params = {
         "grant_type": DEVICE_CODE_GRANT_TYPE,
@@ -432,7 +442,7 @@ def poll_device_token(
         # Bound the wait by the time left to the deadline so a grown backoff
         # interval can never sleep past expiry — a stalled request or a long
         # backoff must not blow through the monotonic deadline.
-        remaining = deadline - clock()
+        remaining = deadline - _sample_clock()
         if remaining <= 0:
             raise DeviceFlowError("expired", "Device code expired before authorization completed")
         _wait_cancellable(min(max(interval_seconds, backoff_seconds), remaining), should_cancel, sleep)
@@ -440,7 +450,7 @@ def poll_device_token(
         if should_cancel is not None and should_cancel():
             raise DeviceFlowError("cancelled", "Device flow cancelled")
 
-        post_remaining = deadline - clock()
+        post_remaining = deadline - _sample_clock()
         if post_remaining <= 0:
             raise DeviceFlowError("expired", "Device code expired before authorization completed")
 

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -24,7 +24,7 @@ from typing import Any
 
 import httpx
 
-from basecamp._security import is_localhost, require_https
+from basecamp._security import is_localhost, require_https, truncate
 from basecamp.oauth.config import OAuthConfig
 from basecamp.oauth.device_authorization import DeviceAuthorization
 from basecamp.oauth.discovery import _normalize_body_cap, _normalize_timeout
@@ -637,7 +637,12 @@ def _post_device_token(
     # a 200 can produce a token and only a 4xx a protocol state. Everything
     # else falls back to http_<status>, which the loop terminates as api_error.
     raw_error = data.get("error")
-    error = raw_error if 400 <= status < 500 and isinstance(raw_error, str) and raw_error else f"http_{status}"
+    # ``truncate`` at extraction (SPEC §9's 500-unit cap): the server controls
+    # this string and an unrecognized value is interpolated into the api_error
+    # message. Real protocol codes are short, so classification is unaffected.
+    error = (
+        truncate(raw_error) if 400 <= status < 500 and isinstance(raw_error, str) and raw_error else f"http_{status}"
+    )
     return _PollResult(error=error, status=status)
 
 

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -321,6 +321,28 @@ class _PollResult:
     status: int = 0
 
 
+def _validated_clock_sample(value: object, entry: str) -> float:
+    """Validate one sample from an injected clock seam.
+
+    Type-gated and overflow-safe like the ``deadline_at`` guard: a NaN sample
+    defeats every deadline comparison (an ``authorization_pending`` endpoint
+    would be polled indefinitely), and a string or huge-int sample must surface
+    as the typed usage error — never a raw ``TypeError``/``OverflowError`` out
+    of the deadline arithmetic.
+    """
+    result = 0.0
+    valid = False
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        try:
+            result = float(value)
+            valid = math.isfinite(result)
+        except OverflowError:
+            valid = False
+    if not valid:
+        raise OAuthError("usage", f"{entry} clock must return a finite number of seconds")
+    return result
+
+
 def _wait_cancellable(
     seconds: float,
     should_cancel: Callable[[], bool] | None,
@@ -423,10 +445,7 @@ def poll_device_token(
         # EVERY sample of the injected clock is validated: a NaN sample makes
         # the deadline (or a comparison against it) permanently false, so an
         # authorization_pending endpoint would be polled indefinitely.
-        value = clock()
-        if not math.isfinite(value):
-            raise OAuthError("usage", "poll_device_token clock must return a finite number of seconds")
-        return value
+        return _validated_clock_sample(clock(), "poll_device_token")
 
     # An absolute issuance-anchored deadline (perform_device_login passes
     # issued_at + expires_in) beats re-anchoring: clock time elapsing between
@@ -743,14 +762,14 @@ def perform_device_login(
     # The code's lifetime starts at issuance, not after display: a slow display
     # hook must eat into the deadline, never reset it. Measure the elapsed time
     # across the hook against the monotonic clock and check expiry before polling.
-    issued_at = clock()
+    issued_at = _validated_clock_sample(clock(), "perform_device_login")
     display(auth)
     # Cancellation raised DURING the display hook (a prompt closing in
     # response to cancellation) wins over expiry: a hook that both cancels
     # and consumes the lifetime must surface cancelled, not expired.
     if should_cancel is not None and should_cancel():
         raise DeviceFlowError("cancelled", "Device flow cancelled")
-    remaining = auth.expires_in - (clock() - issued_at)
+    remaining = auth.expires_in - (_validated_clock_sample(clock(), "perform_device_login") - issued_at)
     if remaining <= 0:
         raise DeviceFlowError("expired", "Device code expired before authorization completed")
 

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -780,12 +780,13 @@ def perform_device_login(
         raise DeviceFlowError("cancelled", "Device flow cancelled")
 
     display(auth)
-    # Cancellation raised DURING the display hook (a prompt closing in
-    # response to cancellation) wins over expiry: a hook that both cancels
-    # and consumes the lifetime must surface cancelled, not expired.
+    remaining = auth.expires_in - (_validated_clock_sample(clock(), "perform_device_login") - issued_at)
+    # Cancellation raised DURING the display hook OR during the clock sample
+    # just above (the clock is a cancellation-capable callback seam, exactly
+    # like the pre-request anchor) wins over expiry: checked after the sample
+    # and before the expiry branch, matching the TS orchestrator's ordering.
     if should_cancel is not None and should_cancel():
         raise DeviceFlowError("cancelled", "Device flow cancelled")
-    remaining = auth.expires_in - (_validated_clock_sample(clock(), "perform_device_login") - issued_at)
     if remaining <= 0:
         raise DeviceFlowError("expired", "Device code expired before authorization completed")
 

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -407,21 +407,27 @@ def poll_device_token(
     # schedulable wait. Fractional values are accepted: perform_device_login
     # legitimately passes a fractional remaining lifetime after deducting
     # display-hook time. Mirrors the Go/TS/Ruby/Kotlin caller guards.
-    for name, value in (("expires_in", expires_in), ("interval", interval)):
-        # Range checks run BEFORE math.isfinite: isfinite converts an int to float,
-        # so an astronomically large int (10**400) would raise OverflowError out of
-        # the guard instead of the usage error. Int/float comparisons never convert,
-        # and NaN compares False on both, falling through to the isfinite reject.
+    # Range checks run BEFORE math.isfinite: isfinite converts an int to float,
+    # so an astronomically large int (10**400) would raise OverflowError out of
+    # the guard instead of the usage error. Int/float comparisons never convert,
+    # and NaN compares False on both, falling through to the isfinite reject.
+    # The polling interval is additionally whole seconds (RFC 8628), matching
+    # the response validation and the integer-typed Go/Kotlin APIs — a
+    # fractional interval (0.001) would otherwise permit ~1000 polls/second;
+    # the integral check runs LAST so an oversized int never reaches float().
+    for name, value, whole in (("expires_in", expires_in, False), ("interval", interval, True)):
         if (
             isinstance(value, bool)
             or not isinstance(value, (int, float))
             or value <= 0
             or value > MAX_DEVICE_SECONDS
             or not math.isfinite(value)
+            or (whole and float(value) != int(value))
         ):
+            noun = "positive whole number" if whole else "positive number"
             raise OAuthError(
                 "usage",
-                f"poll_device_token: {name} must be a positive number of seconds no greater than {MAX_DEVICE_SECONDS}",
+                f"poll_device_token: {name} must be a {noun} of seconds no greater than {MAX_DEVICE_SECONDS}",
             )
 
     # Normalize the cap at the public boundary: an invalid runtime value (None,

--- a/python/src/basecamp/oauth/device_authorization.py
+++ b/python/src/basecamp/oauth/device_authorization.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DeviceAuthorization:
+    """RFC 8628 §3.2 device authorization response.
+
+    Returned by :func:`~basecamp.oauth.device.request_device_authorization`. The
+    ``device_code`` is polled at the token endpoint; ``user_code`` and
+    ``verification_uri`` (optionally ``verification_uri_complete``) are shown to
+    the user. ``interval`` defaults to 5 seconds when the server omits it.
+    """
+
+    device_code: str
+    user_code: str
+    verification_uri: str
+    expires_in: int
+    interval: int
+    verification_uri_complete: str | None = None

--- a/python/src/basecamp/oauth/discovery.py
+++ b/python/src/basecamp/oauth/discovery.py
@@ -95,6 +95,10 @@ def _normalize_timeout(timeout: object, default: float = _DISCOVERY_TIMEOUT, max
     fallback = _finite_positive_timeout(default)
     if fallback is not None and (maximum is None or fallback <= maximum):
         return fallback
+    # The final constant fallback must also honor the bound: if maximum is smaller
+    # than _DISCOVERY_TIMEOUT, return maximum rather than exceed the contract.
+    if maximum is not None and 0 < maximum < _DISCOVERY_TIMEOUT:
+        return maximum
     return _DISCOVERY_TIMEOUT
 
 

--- a/python/src/basecamp/oauth/discovery.py
+++ b/python/src/basecamp/oauth/discovery.py
@@ -71,28 +71,32 @@ def _normalize_body_cap(max_body_bytes: object) -> int:
     return max_body_bytes
 
 
-def _normalize_timeout(timeout: object) -> float:
+def _normalize_timeout(timeout: object, default: float = _DISCOVERY_TIMEOUT) -> float:
     """Coerce the public timeout to a finite, positive float.
 
     ``timeout`` is *typed* ``float``, but a caller can pass ``None``, a non-number,
     a non-positive value, or ``float("inf")``/``nan`` at runtime. An infinite or
     non-positive timeout would disable BOTH httpx's bound and the wall-clock
     deadline below (``time.monotonic() > inf`` never trips), letting a slow-drip
-    endpoint hold the SSRF-hardened fetch open indefinitely. Fall back to the
-    default so the bound can never be turned off — the same discipline as
+    endpoint hold the SSRF-hardened fetch open indefinitely. Fall back to
+    ``default`` so the bound can never be turned off — the same discipline as
     :func:`_normalize_body_cap`. ``bool`` is excluded (a subclass of ``int``, but
     a nonsensical timeout).
+
+    ``default`` is operation-specific: discovery passes ``_DISCOVERY_TIMEOUT`` (10s),
+    device flow passes ``_DEVICE_TIMEOUT`` (30s), so an invalid runtime value falls
+    back to that operation's own budget rather than a foreign one.
     """
     if isinstance(timeout, bool) or not isinstance(timeout, (int, float)):
-        return _DISCOVERY_TIMEOUT
+        return default
     try:
         value = float(timeout)
     except OverflowError:
         # An int too large to convert to float (e.g. 10**400) — treat as invalid
         # rather than letting math.isfinite/float raise out of the normalizer.
-        return _DISCOVERY_TIMEOUT
+        return default
     if not math.isfinite(value) or value <= 0:
-        return _DISCOVERY_TIMEOUT
+        return default
     return value
 
 

--- a/python/src/basecamp/oauth/discovery.py
+++ b/python/src/basecamp/oauth/discovery.py
@@ -71,7 +71,7 @@ def _normalize_body_cap(max_body_bytes: object) -> int:
     return max_body_bytes
 
 
-def _normalize_timeout(timeout: object, default: float = _DISCOVERY_TIMEOUT) -> float:
+def _normalize_timeout(timeout: object, default: float = _DISCOVERY_TIMEOUT, maximum: float | None = None) -> float:
     """Coerce the public timeout to a finite, positive float.
 
     ``timeout`` is *typed* ``float``, but a caller can pass ``None``, a non-number,
@@ -88,12 +88,14 @@ def _normalize_timeout(timeout: object, default: float = _DISCOVERY_TIMEOUT) -> 
     back to that operation's own budget rather than a foreign one.
     """
     value = _finite_positive_timeout(timeout)
-    if value is not None:
+    if value is not None and (maximum is None or value <= maximum):
         return value
-    # Validate the fallback too: a caller passing an invalid ``default`` must not be
-    # able to disable both bounds. Fall back to the discovery constant if it is bad.
+    # Validate the fallback too: a caller passing an invalid (or over-max) ``default``
+    # must not be able to disable the bound. Fall back to the discovery constant.
     fallback = _finite_positive_timeout(default)
-    return fallback if fallback is not None else _DISCOVERY_TIMEOUT
+    if fallback is not None and (maximum is None or fallback <= maximum):
+        return fallback
+    return _DISCOVERY_TIMEOUT
 
 
 def _finite_positive_timeout(value: object) -> float | None:

--- a/python/src/basecamp/oauth/discovery.py
+++ b/python/src/basecamp/oauth/discovery.py
@@ -57,18 +57,24 @@ class _IssuerBindingError(OAuthError):
         super().__init__("api_error", message, **kwargs)
 
 
-def _normalize_body_cap(max_body_bytes: object) -> int:
+def _normalize_body_cap(max_body_bytes: object, default: int = MAX_DISCOVERY_BODY_BYTES) -> int:
     """Coerce the public cap to a finite, non-negative int.
 
     ``max_body_bytes`` is *typed* ``int``, but callers can pass ``None``, a float,
     or ``float("inf")`` at runtime; any of those would disable the streaming memory
     bound (``total > inf`` never trips), defeating the SSRF guarantee. Fall back to
-    the default so the bound can never be turned off. ``bool`` is excluded (a
+    ``default`` so the bound can never be turned off. ``bool`` is excluded (a
     subclass of ``int``, but a nonsensical cap).
+
+    ``default`` is operation-specific (discovery vs device flow, mirroring
+    :func:`_normalize_timeout`) and validated too, so an invalid fallback cannot
+    disable the bound either.
     """
-    if isinstance(max_body_bytes, bool) or not isinstance(max_body_bytes, int) or max_body_bytes < 0:
-        return MAX_DISCOVERY_BODY_BYTES
-    return max_body_bytes
+    if not (isinstance(max_body_bytes, bool) or not isinstance(max_body_bytes, int) or max_body_bytes < 0):
+        return max_body_bytes
+    if not (isinstance(default, bool) or not isinstance(default, int) or default < 0):
+        return default
+    return MAX_DISCOVERY_BODY_BYTES
 
 
 def _normalize_timeout(timeout: object, default: float = _DISCOVERY_TIMEOUT, maximum: float | None = None) -> float:

--- a/python/src/basecamp/oauth/discovery.py
+++ b/python/src/basecamp/oauth/discovery.py
@@ -87,17 +87,31 @@ def _normalize_timeout(timeout: object, default: float = _DISCOVERY_TIMEOUT) -> 
     device flow passes ``_DEVICE_TIMEOUT`` (30s), so an invalid runtime value falls
     back to that operation's own budget rather than a foreign one.
     """
-    if isinstance(timeout, bool) or not isinstance(timeout, (int, float)):
-        return default
+    value = _finite_positive_timeout(timeout)
+    if value is not None:
+        return value
+    # Validate the fallback too: a caller passing an invalid ``default`` must not be
+    # able to disable both bounds. Fall back to the discovery constant if it is bad.
+    fallback = _finite_positive_timeout(default)
+    return fallback if fallback is not None else _DISCOVERY_TIMEOUT
+
+
+def _finite_positive_timeout(value: object) -> float | None:
+    """Return ``value`` as a finite, positive float, or None if it is not one.
+
+    ``bool`` is excluded (an ``int`` subclass, but a nonsensical timeout); an int
+    too large to convert to float (``10**400``) is rejected rather than letting
+    ``math.isfinite``/``float`` raise.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
     try:
-        value = float(timeout)
+        f = float(value)
     except OverflowError:
-        # An int too large to convert to float (e.g. 10**400) — treat as invalid
-        # rather than letting math.isfinite/float raise out of the normalizer.
-        return default
-    if not math.isfinite(value) or value <= 0:
-        return default
-    return value
+        return None
+    if not math.isfinite(f) or f <= 0:
+        return None
+    return f
 
 
 def _fetch_discovery_document(url: str, timeout: float, max_body_bytes: int) -> Any:

--- a/python/src/basecamp/oauth/discovery.py
+++ b/python/src/basecamp/oauth/discovery.py
@@ -70,9 +70,16 @@ def _normalize_body_cap(max_body_bytes: object, default: int = MAX_DISCOVERY_BOD
     :func:`_normalize_timeout`) and validated too, so an invalid fallback cannot
     disable the bound either.
     """
-    if not (isinstance(max_body_bytes, bool) or not isinstance(max_body_bytes, int) or max_body_bytes < 0):
-        return max_body_bytes
-    if not (isinstance(default, bool) or not isinstance(default, int) or default < 0):
+
+    def valid(value: object) -> bool:
+        # A valid cap is a genuine non-negative int; bool is an int subclass
+        # but a nonsensical cap. Stated positively — this is a security-relevant
+        # normalizer, so the predicate must read unambiguously.
+        return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+    if valid(max_body_bytes):
+        return max_body_bytes  # type: ignore[return-value]
+    if valid(default):
         return default
     return MAX_DISCOVERY_BODY_BYTES
 

--- a/python/src/basecamp/oauth/errors.py
+++ b/python/src/basecamp/oauth/errors.py
@@ -50,7 +50,7 @@ DiscoverySelectionReason = Literal[
 class OAuthError(BasecampError):
     """OAuth-specific error with a type classifier.
 
-    Types: "validation", "auth", "network", "api_error"
+    Types: "validation", "auth", "network", "api_error", "usage"
     """
 
     def __init__(self, oauth_type: str, message: str, **kwargs: Any):

--- a/python/src/basecamp/oauth/errors.py
+++ b/python/src/basecamp/oauth/errors.py
@@ -9,6 +9,29 @@ _OAUTH_TYPE_TO_CODE: dict[str, str] = {
     "auth": ErrorCode.AUTH,
     "network": ErrorCode.NETWORK,
     "api_error": ErrorCode.API,
+    "usage": ErrorCode.USAGE,
+}
+
+# Why a device authorization grant (RFC 8628) terminated. The parent error
+# category is DERIVED from the reason (SPEC.md §16), so callers can branch on
+# either ``.reason`` (precise) or ``.code``/``.exit_code`` (coarse).
+DeviceFlowReason = Literal[
+    "access_denied",
+    "expired",
+    "transport",
+    "unavailable",
+    "cancelled",
+]
+
+# Maps a device-flow reason to its parent OAuth type (and thus BasecampError
+# category): access_denied/expired → auth, transport → network (retryable),
+# unavailable → validation, cancelled → usage.
+_DEVICE_REASON_TO_TYPE: dict[str, str] = {
+    "access_denied": "auth",
+    "expired": "auth",
+    "transport": "network",
+    "unavailable": "validation",
+    "cancelled": "usage",
 }
 
 # Hard resource-first selection/validation failures. These are RAISED, never
@@ -53,3 +76,24 @@ class DiscoverySelectionError(OAuthError):
         oauth_type = "validation" if reason == "capability_unavailable" else "api_error"
         super().__init__(oauth_type, message, **kwargs)
         self.reason: DiscoverySelectionReason = reason
+
+
+class DeviceFlowError(OAuthError):
+    """Terminal RFC 8628 device authorization grant error.
+
+    Carries a :data:`DeviceFlowReason`; the parent OAuth type — and thus the
+    BasecampError ``code``/``exit_code`` — is DERIVED from that reason. Only a
+    ``transport`` failure is retryable.
+    """
+
+    def __init__(self, reason: DeviceFlowReason, message: str, **kwargs: Any):
+        # Default an unrecognized reason to api_error rather than raising a raw
+        # KeyError — mirrors OAuthError's defensive `.get()` on unknown types.
+        oauth_type = _DEVICE_REASON_TO_TYPE.get(reason, "api_error")
+        # The reason is authoritative for retryability (only ``transport`` is
+        # retryable). Overwrite — never setdefault — so a caller's ``retryable``
+        # kwarg cannot flip the invariant (transport → non-retryable, or a
+        # terminal denial → retryable).
+        kwargs["retryable"] = reason == "transport"
+        super().__init__(oauth_type, message, **kwargs)
+        self.reason: DeviceFlowReason = reason

--- a/python/src/basecamp/oauth/exchange.py
+++ b/python/src/basecamp/oauth/exchange.py
@@ -119,16 +119,19 @@ def _parse_token_response(response: httpx.Response) -> OAuthToken:
 
     try:
         data = response.json()
-    except ValueError as exc:
+    except ValueError:
         # A token response that fails to parse may still contain credential
         # material (a syntactically-broken body carrying an access_token) —
         # never echo ANY of it into an error message, where it would reach
         # logs and exception telemetry. The status is diagnosis enough.
+        # from None — json.JSONDecodeError retains the whole document as its
+        # .doc attribute, so chaining it would keep the body alive in
+        # exception telemetry.
         raise OAuthError(
             "api_error",
             "Failed to parse token response",
             http_status=response.status_code,
-        ) from exc
+        ) from None
 
     if not isinstance(data, dict):
         raise OAuthError(

--- a/python/src/basecamp/oauth/exchange.py
+++ b/python/src/basecamp/oauth/exchange.py
@@ -120,9 +120,13 @@ def _parse_token_response(response: httpx.Response) -> OAuthToken:
     try:
         data = response.json()
     except ValueError as exc:
+        # A token response that fails to parse may still contain credential
+        # material (a syntactically-broken body carrying an access_token) —
+        # never echo ANY of it into an error message, where it would reach
+        # logs and exception telemetry. The status is diagnosis enough.
         raise OAuthError(
             "api_error",
-            f"Failed to parse token response: {truncate(response.text)}",
+            "Failed to parse token response",
             http_status=response.status_code,
         ) from exc
 

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -261,6 +261,20 @@ class TestRequestDeviceAuthorization:
         assert exc_info.value.code == "api_error"
 
     @respx.mock
+    def test_rejects_non_object_body_with_http_status(self):
+        # A valid-JSON-but-non-object body (list/number/null) is malformed. It must
+        # fail as api_error AND carry the HTTP status for debugging parity with the
+        # other error raises — not drop it.
+        respx.post(DEVICE_ENDPOINT).mock(
+            return_value=httpx.Response(200, content="[]", headers={"Content-Type": "application/json"})
+        )
+
+        with pytest.raises(OAuthError) as exc_info:
+            request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+        assert exc_info.value.code == "api_error"
+        assert exc_info.value.http_status == 200
+
+    @respx.mock
     def test_oversized_body_aborts(self):
         # A body past the streaming cap must abort with api_error, never buffer.
         payload = {**DEVICE_AUTH_RESPONSE, "pad": "x" * (256 * 1024)}
@@ -584,6 +598,19 @@ class TestPollDeviceToken:
             )
         assert exc_info.value.code == "api_error"
         assert not isinstance(exc_info.value, DeviceFlowError)
+
+    @respx.mock
+    def test_rejects_non_object_token_body_with_http_status(self):
+        # A valid-JSON-but-non-object token body must fail api_error AND carry the
+        # HTTP status, matching the other token-poll error raises.
+        _queue_token_responses([httpx.Response(200, content="[]", headers={"Content-Type": "application/json"})])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.code == "api_error"
+        assert exc_info.value.http_status == 200
 
     @respx.mock
     def test_rejects_non_string_access_token(self):

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -703,6 +703,20 @@ class TestPollDeviceToken:
         assert not isinstance(exc_info.value, DeviceFlowError)
 
     @respx.mock
+    def test_redirect_token_poll_classified_by_status_without_draining_body(self):
+        # A 3xx must fail by STATUS before the body is read. Proof: an oversized 3xx
+        # body would trip the size cap ("exceeds size cap") if drained — the skip
+        # means it surfaces as a redirect api_error instead.
+        _queue_token_responses([httpx.Response(302, content=b"x" * (2 * 1024 * 1024))])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.code == "api_error"
+        assert "redirect" in str(exc_info.value)  # by status, not the size cap
+
+    @respx.mock
     def test_non_string_token_error_falls_back_to_http_status(self):
         # A non-string `error` (e.g. 123) must not be treated as an OAuth error
         # code — it falls back to http_<status>, matching the other SDKs.

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -642,6 +642,36 @@ class TestPollDeviceToken:
         assert exc_info.value.code == "usage"
 
     @respx.mock
+    def test_cancellation_during_wait_is_prompt(self):
+        # A long interval must not delay cancellation: the wait polls should_cancel
+        # in small chunks, so a cancel set mid-wait raises without sleeping the whole
+        # interval at once (a plain time.sleep is not interruptible).
+        from basecamp.oauth.device import _CANCEL_POLL_INTERVAL
+
+        _queue_token_responses([httpx.Response(400, json={"error": "authorization_pending"})])
+        recorded: list[float] = []
+
+        def sleep(seconds: float) -> None:
+            recorded.append(seconds)
+
+        def should_cancel() -> bool:
+            return len(recorded) >= 3  # cancel after the 3rd chunk
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT,
+                "basecamp-cli",
+                "dev-code-123",
+                interval=5,
+                expires_in=900,
+                sleep=sleep,
+                should_cancel=should_cancel,
+            )
+        assert exc_info.value.reason == "cancelled"
+        # Chunked into small waits, never one sleep(5).
+        assert recorded and all(s <= _CANCEL_POLL_INTERVAL for s in recorded)
+
+    @respx.mock
     def test_unknown_error_maps_to_api_error(self):
         _queue_token_responses([httpx.Response(400, json={"error": "invalid_request"})])
 

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -264,6 +264,28 @@ class TestRequestDeviceAuthorization:
         assert exc_info.value.retryable
 
     @respx.mock
+    def test_final_read_past_deadline_is_rejected(self, monkeypatch):
+        # The in-loop check runs BEFORE each chunk, so it cannot catch the final
+        # read / EOF landing past the deadline. Drive an empty body (zero in-loop
+        # iterations) with the clock advanced past the deadline so ONLY the
+        # post-loop check can fire — proving the whole-read bound holds at EOF.
+        import basecamp.oauth.device as device_mod
+
+        elapsed = {"v": 0.0}
+
+        def fake_monotonic() -> float:
+            v = elapsed["v"]
+            elapsed["v"] += 100.0
+            return v
+
+        monkeypatch.setattr(device_mod.time, "monotonic", fake_monotonic)
+        respx.post(DEVICE_ENDPOINT).mock(return_value=httpx.Response(200, content=b""))
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+        assert exc_info.value.reason == "transport"
+
+    @respx.mock
     def test_rejects_non_string_field_types(self):
         # A non-string field is malformed, not merely absent — a truthiness
         # check would let 12345 / a list slip through.

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -1,0 +1,576 @@
+"""RFC 8628 device authorization grant tests (SPEC.md §16).
+
+Timing is deterministic: the ``sleep`` seam records the interval schedule and
+returns immediately, and the monotonic ``clock`` is injected. No real delays.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from basecamp.oauth import (
+    DEVICE_CODE_GRANT_TYPE,
+    DeviceFlowError,
+    OAuthConfig,
+    OAuthError,
+    perform_device_login,
+    poll_device_token,
+    request_device_authorization,
+)
+
+ORIGIN = "https://issuer.device-test.example"
+DEVICE_ENDPOINT = f"{ORIGIN}/oauth/device"
+TOKEN_ENDPOINT = f"{ORIGIN}/oauth/token"
+
+DEVICE_AUTH_RESPONSE = {
+    "device_code": "dev-code-123",
+    "user_code": "WDJB-MJHT",
+    "verification_uri": f"{ORIGIN}/device",
+    "verification_uri_complete": f"{ORIGIN}/device?user_code=WDJB-MJHT",
+    "expires_in": 900,
+    "interval": 5,
+}
+
+TOKEN_RESPONSE = {
+    "access_token": "device_access_token",  # gitleaks:allow (test fixture)
+    "refresh_token": "device_refresh_token",  # gitleaks:allow (test fixture)
+    "token_type": "Bearer",
+    "expires_in": 3600,
+}
+
+CONFIG = OAuthConfig(
+    issuer=ORIGIN,
+    token_endpoint=TOKEN_ENDPOINT,
+    device_authorization_endpoint=DEVICE_ENDPOINT,
+    grant_types_supported=[DEVICE_CODE_GRANT_TYPE, "refresh_token"],
+)
+
+
+class RecordingSleep:
+    """A sleep seam that records requested waits and returns immediately."""
+
+    def __init__(self) -> None:
+        self.waits: list[float] = []
+
+    def __call__(self, seconds: float) -> None:
+        self.waits.append(seconds)
+
+
+def _queue_token_responses(responses: list[httpx.Response]) -> respx.Route:
+    """Serve a fixed sequence of token-endpoint responses, one per poll."""
+    return respx.post(TOKEN_ENDPOINT).mock(side_effect=responses)
+
+
+class TestRequestDeviceAuthorization:
+    @respx.mock
+    def test_omits_scope_when_unset_and_validates(self):
+        route = respx.post(DEVICE_ENDPOINT).mock(return_value=httpx.Response(200, json=DEVICE_AUTH_RESPONSE))
+
+        auth = request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+
+        body = route.calls[0].request.content.decode()
+        assert "client_id=basecamp-cli" in body
+        assert "scope" not in body  # omitted → server default (read)
+        assert auth.device_code == "dev-code-123"
+        assert auth.user_code == "WDJB-MJHT"
+        assert auth.verification_uri_complete == f"{ORIGIN}/device?user_code=WDJB-MJHT"
+        assert auth.interval == 5
+
+    @respx.mock
+    def test_sends_scope_when_set(self):
+        route = respx.post(DEVICE_ENDPOINT).mock(return_value=httpx.Response(200, json=DEVICE_AUTH_RESPONSE))
+
+        request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli", scope="read write")
+
+        assert "scope=read+write" in route.calls[0].request.content.decode()
+
+    @respx.mock
+    def test_defaults_interval_to_5_when_omitted(self):
+        payload = {k: v for k, v in DEVICE_AUTH_RESPONSE.items() if k != "interval"}
+        respx.post(DEVICE_ENDPOINT).mock(return_value=httpx.Response(200, json=payload))
+
+        auth = request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+
+        assert auth.interval == 5
+
+    @respx.mock
+    def test_rejects_non_positive_expires_in(self):
+        respx.post(DEVICE_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={**DEVICE_AUTH_RESPONSE, "expires_in": 0})
+        )
+
+        with pytest.raises(OAuthError) as exc_info:
+            request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+        assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    def test_rejects_non_positive_interval(self):
+        respx.post(DEVICE_ENDPOINT).mock(return_value=httpx.Response(200, json={**DEVICE_AUTH_RESPONSE, "interval": 0}))
+
+        with pytest.raises(OAuthError) as exc_info:
+            request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+        assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    def test_rejects_fractional_expires_in(self):
+        # A fractional expiry (e.g. 0.5s) truncates to a 0-second deadline and
+        # must be rejected outright rather than silently floored.
+        respx.post(DEVICE_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={**DEVICE_AUTH_RESPONSE, "expires_in": 5.9})
+        )
+
+        with pytest.raises(OAuthError) as exc_info:
+            request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+        assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    def test_rejects_fractional_interval(self):
+        respx.post(DEVICE_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={**DEVICE_AUTH_RESPONSE, "interval": 2.5})
+        )
+
+        with pytest.raises(OAuthError) as exc_info:
+            request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+        assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    def test_rejects_oversized_expires_in(self):
+        # 1e100 is integer-valued, so whole-second checking alone would admit
+        # it; the shared cross-SDK ceiling (2147483 s) makes it api_error.
+        respx.post(DEVICE_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={**DEVICE_AUTH_RESPONSE, "expires_in": 1e100})
+        )
+
+        with pytest.raises(OAuthError) as exc_info:
+            request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+        assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    def test_rejects_oversized_interval(self):
+        respx.post(DEVICE_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={**DEVICE_AUTH_RESPONSE, "interval": 1e100})
+        )
+
+        with pytest.raises(OAuthError) as exc_info:
+            request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+        assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    def test_rejects_just_past_max_duration(self):
+        respx.post(DEVICE_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={**DEVICE_AUTH_RESPONSE, "expires_in": 2_147_484})
+        )
+
+        with pytest.raises(OAuthError) as exc_info:
+            request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+        assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    def test_accepts_max_duration(self):
+        # The 2147483 s ceiling itself is valid — the bound is inclusive.
+        respx.post(DEVICE_ENDPOINT).mock(
+            return_value=httpx.Response(
+                200, json={**DEVICE_AUTH_RESPONSE, "expires_in": 2_147_483, "interval": 2_147_483}
+            )
+        )
+
+        auth = request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+
+        assert auth.expires_in == 2_147_483
+        assert auth.interval == 2_147_483
+
+    @respx.mock
+    def test_rejects_bool_expires_in(self):
+        # ``bool`` is an ``int`` subclass but is never a valid duration.
+        respx.post(DEVICE_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={**DEVICE_AUTH_RESPONSE, "expires_in": True})
+        )
+
+        with pytest.raises(OAuthError) as exc_info:
+            request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+        assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    def test_accepts_integer_valued_float_durations(self):
+        # ``5.0``/``900.0`` are integer-valued floats — accepted and coerced.
+        respx.post(DEVICE_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={**DEVICE_AUTH_RESPONSE, "expires_in": 900.0, "interval": 10.0})
+        )
+
+        auth = request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+
+        assert auth.expires_in == 900
+        assert isinstance(auth.expires_in, int)
+        assert auth.interval == 10
+        assert isinstance(auth.interval, int)
+
+    @respx.mock
+    def test_rejects_missing_field(self):
+        respx.post(DEVICE_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={"user_code": "X", "verification_uri": ORIGIN, "expires_in": 900})
+        )
+
+        with pytest.raises(OAuthError) as exc_info:
+            request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+        assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    def test_transport_failure_raises_device_flow_error(self):
+        respx.post(DEVICE_ENDPOINT).mock(side_effect=httpx.ConnectError("boom"))
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+        assert exc_info.value.reason == "transport"
+
+    @respx.mock
+    def test_rejects_non_string_field_types(self):
+        # A non-string field is malformed, not merely absent — a truthiness
+        # check would let 12345 / a list slip through.
+        respx.post(DEVICE_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={**DEVICE_AUTH_RESPONSE, "device_code": 12345})
+        )
+
+        with pytest.raises(OAuthError) as exc_info:
+            request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+        assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    def test_rejects_non_string_verification_uri_complete(self):
+        respx.post(DEVICE_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={**DEVICE_AUTH_RESPONSE, "verification_uri_complete": ["nope"]})
+        )
+
+        with pytest.raises(OAuthError) as exc_info:
+            request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+        assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    def test_oversized_body_aborts(self):
+        # A body past the streaming cap must abort with api_error, never buffer.
+        payload = {**DEVICE_AUTH_RESPONSE, "pad": "x" * (256 * 1024)}
+        respx.post(DEVICE_ENDPOINT).mock(return_value=httpx.Response(200, json=payload))
+
+        with pytest.raises(OAuthError) as exc_info:
+            request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli", max_body_bytes=8 * 1024)
+        assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    def test_does_not_follow_redirect(self):
+        redirect_target = "https://evil.device-test.example/steal"
+        respx.post(DEVICE_ENDPOINT).mock(
+            return_value=httpx.Response(302, headers={"Location": redirect_target}, json={"error": "moved"})
+        )
+        target = respx.get(redirect_target).mock(return_value=httpx.Response(200, json=DEVICE_AUTH_RESPONSE))
+
+        with pytest.raises(OAuthError) as exc_info:
+            request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+        assert exc_info.value.code == "api_error"
+        assert not target.called  # redirect suppressed — attacker origin never dialed
+
+
+class TestPollDeviceToken:
+    @respx.mock
+    def test_pending_then_slow_down_then_token_sustains_interval(self):
+        _queue_token_responses(
+            [
+                httpx.Response(400, json={"error": "authorization_pending"}),
+                httpx.Response(400, json={"error": "slow_down"}),
+                httpx.Response(400, json={"error": "authorization_pending"}),
+                httpx.Response(200, json=TOKEN_RESPONSE),
+            ]
+        )
+        sleep = RecordingSleep()
+
+        token = poll_device_token(
+            TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=sleep
+        )
+
+        assert token.access_token == "device_access_token"  # gitleaks:allow
+        # 5s (pending), 5s (before slow_down), then +5 sustained → 10s, 10s.
+        assert sleep.waits == [5, 5, 10, 10]
+
+    @respx.mock
+    def test_doubles_interval_after_connection_timeout_then_recovers(self):
+        _queue_token_responses(
+            [
+                httpx.TimeoutException("timed out"),
+                httpx.Response(200, json=TOKEN_RESPONSE),
+            ]
+        )
+        sleep = RecordingSleep()
+
+        token = poll_device_token(
+            TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=sleep
+        )
+
+        assert token.access_token == "device_access_token"  # gitleaks:allow
+        # First wait 5s, timeout → backoff doubles to 10s for the next wait.
+        assert sleep.waits[0] == 5
+        assert sleep.waits[1] == 10
+
+    @respx.mock
+    def test_expires_against_injected_clock(self):
+        _queue_token_responses([httpx.Response(400, json={"error": "authorization_pending"})])
+        # Clock: base at 0, then jumps past the 900s deadline on the first check.
+        times = iter([0, 1_000_000])
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT,
+                "basecamp-cli",
+                "dev-code-123",
+                interval=5,
+                expires_in=900,
+                sleep=RecordingSleep(),
+                clock=lambda: next(times),
+            )
+        assert exc_info.value.reason == "expired"
+        assert exc_info.value.code == "auth_required"
+
+    @respx.mock
+    def test_access_denied_maps_to_auth(self):
+        _queue_token_responses([httpx.Response(400, json={"error": "access_denied"})])
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.reason == "access_denied"
+        assert exc_info.value.code == "auth_required"
+
+    @respx.mock
+    def test_expired_token_error_maps_to_expired(self):
+        _queue_token_responses([httpx.Response(400, json={"error": "expired_token"})])
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.reason == "expired"
+        assert exc_info.value.code == "auth_required"
+
+    @respx.mock
+    def test_transport_failure_is_network_and_retryable(self):
+        _queue_token_responses([httpx.ConnectError("boom")])
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.reason == "transport"
+        assert exc_info.value.code == "network"
+        assert exc_info.value.retryable is True
+
+    @respx.mock
+    def test_cancellation_raises_cancelled(self):
+        _queue_token_responses([httpx.Response(400, json={"error": "authorization_pending"})])
+        cancelled = {"flag": False}
+
+        # Cancel during the first sleep, mirroring an aborted signal.
+        def sleep(_seconds: float) -> None:
+            cancelled["flag"] = True
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT,
+                "basecamp-cli",
+                "dev-code-123",
+                interval=5,
+                expires_in=900,
+                sleep=sleep,
+                should_cancel=lambda: cancelled["flag"],
+            )
+        assert exc_info.value.reason == "cancelled"
+        assert exc_info.value.code == "usage"
+
+    @respx.mock
+    def test_unknown_error_maps_to_api_error(self):
+        _queue_token_responses([httpx.Response(400, json={"error": "invalid_request"})])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.code == "api_error"
+        assert not isinstance(exc_info.value, DeviceFlowError)
+
+    @respx.mock
+    def test_rejects_non_string_access_token(self):
+        _queue_token_responses([httpx.Response(200, json={**TOKEN_RESPONSE, "access_token": 12345})])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    def test_oversized_body_aborts(self):
+        _queue_token_responses([httpx.Response(200, json={**TOKEN_RESPONSE, "pad": "x" * (256 * 1024)})])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT,
+                "basecamp-cli",
+                "dev-code-123",
+                interval=5,
+                expires_in=900,
+                sleep=RecordingSleep(),
+                max_body_bytes=8 * 1024,
+            )
+        assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    def test_does_not_follow_redirect(self):
+        redirect_target = "https://evil.device-test.example/steal"
+        respx.post(TOKEN_ENDPOINT).mock(
+            return_value=httpx.Response(302, headers={"Location": redirect_target}, json={})
+        )
+        target = respx.get(redirect_target).mock(return_value=httpx.Response(200, json=TOKEN_RESPONSE))
+
+        with pytest.raises(OAuthError):
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert not target.called  # redirect suppressed — attacker origin never dialed
+
+    @respx.mock
+    def test_deadline_clamps_backoff_wait(self):
+        # Every poll times out, so the backoff interval doubles unbounded (5 → 10
+        # → 20…). A clock advanced by each recorded sleep proves the final wait is
+        # clamped to the remaining deadline and never overshoots expiry.
+        _queue_token_responses([httpx.TimeoutException("timed out")] * 5)
+
+        now = {"t": 0.0}
+        waits: list[float] = []
+
+        def clock() -> float:
+            return now["t"]
+
+        def sleep(seconds: float) -> None:
+            waits.append(seconds)
+            now["t"] += seconds
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT,
+                "basecamp-cli",
+                "dev-code-123",
+                interval=5,
+                expires_in=20,
+                clock=clock,
+                sleep=sleep,
+            )
+
+        assert exc_info.value.reason == "expired"
+        # Waits: 5 (→t=5), 10 (→t=15), then clamped to remaining 5 (→t=20) — the
+        # grown 20s backoff never sleeps past the 20s deadline.
+        assert waits == [5, 10, 5]
+        assert now["t"] <= 20
+
+
+class TestPerformDeviceLogin:
+    @respx.mock
+    def test_capability_guard_no_device_grant_is_unavailable_and_does_not_poll(self):
+        token_route = respx.post(TOKEN_ENDPOINT).mock(return_value=httpx.Response(200, json=TOKEN_RESPONSE))
+        config = OAuthConfig(
+            issuer=ORIGIN,
+            token_endpoint=TOKEN_ENDPOINT,
+            device_authorization_endpoint=DEVICE_ENDPOINT,
+            grant_types_supported=["refresh_token"],  # no device_code grant
+        )
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            perform_device_login(config, "basecamp-cli", display=lambda _auth: None)
+
+        assert exc_info.value.reason == "unavailable"
+        assert exc_info.value.code == "validation"
+        assert not token_route.called
+
+    @respx.mock
+    def test_capability_guard_missing_endpoint_is_unavailable(self):
+        config = OAuthConfig(
+            issuer=ORIGIN,
+            token_endpoint=TOKEN_ENDPOINT,
+            device_authorization_endpoint=None,
+            grant_types_supported=[DEVICE_CODE_GRANT_TYPE],
+        )
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            perform_device_login(config, "basecamp-cli", display=lambda _auth: None)
+        assert exc_info.value.reason == "unavailable"
+
+    @respx.mock
+    def test_fires_display_hook_then_completes(self):
+        respx.post(DEVICE_ENDPOINT).mock(return_value=httpx.Response(200, json=DEVICE_AUTH_RESPONSE))
+        respx.post(TOKEN_ENDPOINT).mock(return_value=httpx.Response(200, json=TOKEN_RESPONSE))
+        shown = []
+
+        token = perform_device_login(
+            CONFIG,
+            "basecamp-cli",
+            display=shown.append,
+            sleep=RecordingSleep(),
+        )
+
+        assert len(shown) == 1
+        assert shown[0].user_code == "WDJB-MJHT"
+        assert token.access_token == "device_access_token"  # gitleaks:allow
+
+    @respx.mock
+    def test_preserves_sub_second_remaining_lifetime(self):
+        # After the display hook consumes most of a short lifetime, the fractional
+        # remaining (0.4s) must be preserved — flooring it to an int would expire
+        # the flow immediately even though time still remains.
+        respx.post(DEVICE_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={**DEVICE_AUTH_RESPONSE, "expires_in": 1})
+        )
+        respx.post(TOKEN_ENDPOINT).mock(return_value=httpx.Response(200, json=TOKEN_RESPONSE))
+        # issued_at=0.0, post-display=0.6 → remaining 0.4s; the rest anchor/poll.
+        times = iter([0.0, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6])
+
+        token = perform_device_login(
+            CONFIG,
+            "basecamp-cli",
+            display=lambda _auth: None,
+            clock=lambda: next(times),
+            sleep=RecordingSleep(),
+        )
+
+        assert token.access_token == "device_access_token"  # gitleaks:allow
+
+
+class TestDeviceFlowErrorRetryability:
+    """The reason is authoritative for retryability: only ``transport`` retries,
+    and a caller-supplied ``retryable`` kwarg must not flip that invariant."""
+
+    @pytest.mark.parametrize(
+        ("reason", "expected"),
+        [
+            ("transport", True),
+            ("access_denied", False),
+            ("expired", False),
+            ("unavailable", False),
+            ("cancelled", False),
+        ],
+    )
+    def test_retryable_derives_from_reason(self, reason, expected):
+        assert DeviceFlowError(reason, "boom").retryable is expected
+
+    def test_caller_cannot_make_transport_non_retryable(self):
+        # A rogue ``retryable=False`` must not defeat transport's retryability.
+        assert DeviceFlowError("transport", "boom", retryable=False).retryable is True
+
+    @pytest.mark.parametrize("reason", ["access_denied", "expired", "unavailable", "cancelled"])
+    def test_caller_cannot_make_terminal_reason_retryable(self, reason):
+        # A rogue ``retryable=True`` must not make a terminal denial retryable.
+        assert DeviceFlowError(reason, "boom", retryable=True).retryable is False
+
+    def test_unknown_reason_defaults_to_api_error_not_keyerror(self):
+        # An unexpected reason string must not leak a raw KeyError; it maps to
+        # api_error (defensive .get(), mirroring OAuthError) and stays non-retryable.
+        err = DeviceFlowError("bogus_reason", "boom")  # type: ignore[arg-type]
+        assert err.code == "api_error"
+        assert err.retryable is False

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -352,6 +352,29 @@ class TestRequestDeviceAuthorization:
 
 
 class TestPollDeviceToken:
+    def test_rejects_out_of_range_caller_durations(self):
+        # Caller-input sanity on the exported entry point: a non-finite expires_in
+        # builds a deadline that NEVER passes (clock() + inf → an unbounded poll
+        # loop), and zero/negative/oversized/bool durations are not schedulable.
+        # Raised as usage before any request — no mock transport needed.
+        from basecamp.oauth.device import MAX_DEVICE_SECONDS
+
+        cases = [
+            {"interval": 5, "expires_in": 0},
+            {"interval": 5, "expires_in": -1},
+            {"interval": 5, "expires_in": float("inf")},
+            {"interval": 5, "expires_in": float("nan")},
+            {"interval": 5, "expires_in": MAX_DEVICE_SECONDS + 1},
+            {"interval": 5, "expires_in": True},
+            {"interval": 0, "expires_in": 900},
+            {"interval": -1, "expires_in": 900},
+            {"interval": MAX_DEVICE_SECONDS + 1, "expires_in": 900},
+        ]
+        for kwargs in cases:
+            with pytest.raises(OAuthError) as exc_info:
+                poll_device_token(TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", **kwargs)
+            assert exc_info.value.code == "usage", kwargs
+
     @respx.mock
     def test_pending_then_slow_down_then_token_sustains_interval(self):
         _queue_token_responses(

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -703,6 +703,19 @@ class TestPollDeviceToken:
         assert not isinstance(exc_info.value, DeviceFlowError)
 
     @respx.mock
+    def test_non_string_token_error_falls_back_to_http_status(self):
+        # A non-string `error` (e.g. 123) must not be treated as an OAuth error
+        # code — it falls back to http_<status>, matching the other SDKs.
+        _queue_token_responses([httpx.Response(400, json={"error": 123})])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.code == "api_error"
+        assert "http_400" in str(exc_info.value)
+
+    @respx.mock
     def test_rejects_non_object_token_body_with_http_status(self):
         # A valid-JSON-but-non-object token body must fail api_error AND carry the
         # HTTP status, matching the other token-poll error raises.

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -6,6 +6,8 @@ returns immediately, and the monotonic ``clock`` is injected. No real delays.
 
 from __future__ import annotations
 
+import json
+
 import httpx
 import pytest
 import respx
@@ -372,6 +374,81 @@ class TestPollDeviceToken:
         assert token.expires_in is None
         assert token.expires_at is None
         assert token.is_expired() is False
+
+    @respx.mock
+    def test_rejects_infinite_expires_in_in_token_response(self):
+        # A server sending expires_in: 1e400 (parses to inf via json.loads) is
+        # numeric and positive, but it would make expires_at inf so the token
+        # would never expire. Sent as a raw body since httpx's json= encoder
+        # rejects inf. Must surface api_error.
+        raw = json.dumps({k: v for k, v in TOKEN_RESPONSE.items() if k != "expires_in"})
+        raw = raw[:-1] + ', "expires_in": 1e400}'
+        _queue_token_responses([httpx.Response(200, content=raw, headers={"Content-Type": "application/json"})])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.code == "api_error"
+        assert exc_info.value.http_status == 200
+
+    @respx.mock
+    def test_rejects_oversized_expires_in_in_token_response(self):
+        # One past the 2_147_483_647 s ceiling is a malformed lifetime, not a
+        # schedulable deadline.
+        _queue_token_responses([httpx.Response(200, json={**TOKEN_RESPONSE, "expires_in": 2_147_483_648})])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    def test_accepts_max_token_lifetime(self):
+        # The ceiling itself is accepted — the token carries the full lifetime.
+        _queue_token_responses([httpx.Response(200, json={**TOKEN_RESPONSE, "expires_in": 2_147_483_647})])
+
+        token = poll_device_token(
+            TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+        )
+
+        assert token.expires_in == 2_147_483_647
+
+    @respx.mock
+    def test_rejects_bool_expires_in_in_token_response(self):
+        # True is an int subclass but never a lifetime.
+        _queue_token_responses([httpx.Response(200, json={**TOKEN_RESPONSE, "expires_in": True})])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_rejects_non_positive_expires_in_in_token_response(self, value):
+        _queue_token_responses([httpx.Response(200, json={**TOKEN_RESPONSE, "expires_in": value})])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    @pytest.mark.parametrize("field", ["refresh_token", "token_type", "scope"])
+    def test_rejects_non_string_token_fields(self, field):
+        # A numeric refresh_token/token_type/scope is a malformed response, not a
+        # usable credential field — surface api_error rather than store a non-string.
+        _queue_token_responses([httpx.Response(200, json={**TOKEN_RESPONSE, field: 123})])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.code == "api_error"
 
     @respx.mock
     def test_expires_against_injected_clock(self):

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -438,6 +438,30 @@ class TestPollDeviceToken:
         assert exc_info.value.code == "api_error"
 
     @respx.mock
+    def test_rejects_explicit_empty_token_type(self):
+        # An explicit "" token_type is malformed token metadata → api_error,
+        # uniform across all five SDKs.
+        _queue_token_responses([httpx.Response(200, json={**TOKEN_RESPONSE, "token_type": ""})])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    def test_null_token_type_defaults_to_bearer(self):
+        # JSON null is treated as absent (the Go/Kotlin decoders cannot
+        # distinguish them) → Bearer default, uniform across all five SDKs.
+        _queue_token_responses([httpx.Response(200, json={**TOKEN_RESPONSE, "token_type": None})])
+
+        token = poll_device_token(
+            TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+        )
+
+        assert token.token_type == "Bearer"
+
+    @respx.mock
     @pytest.mark.parametrize("field", ["refresh_token", "token_type", "scope"])
     def test_rejects_non_string_token_fields(self, field):
         # A numeric refresh_token/token_type/scope is a malformed response, not a
@@ -453,7 +477,7 @@ class TestPollDeviceToken:
     @respx.mock
     def test_rejects_fractional_expires_in_in_token_response(self):
         # A fractional token lifetime is malformed under the whole-second contract
-        # (Go/Kotlin reject it by int/Long typing) → api_error, uniform across SDKs.
+        # → api_error, uniform across SDKs (each validates the decoded value).
         _queue_token_responses([httpx.Response(200, json={**TOKEN_RESPONSE, "expires_in": 1.5})])
 
         with pytest.raises(OAuthError) as exc_info:
@@ -464,15 +488,16 @@ class TestPollDeviceToken:
 
     @respx.mock
     def test_accepts_integer_valued_float_expires_in_in_token_response(self):
-        # An integer-valued float (3600.0) is accepted and coerced, matching the
-        # device-duration rule.
+        # An integer-valued float (3600.0) is accepted and coerced to int,
+        # matching the device-duration rule and OAuthToken's ``int | None`` type.
         _queue_token_responses([httpx.Response(200, json={**TOKEN_RESPONSE, "expires_in": 3600.0})])
 
         token = poll_device_token(
             TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
         )
 
-        assert token.expires_in == 3600.0
+        assert token.expires_in == 3600
+        assert isinstance(token.expires_in, int)
 
     @respx.mock
     def test_expires_against_injected_clock(self):

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -366,9 +366,13 @@ class TestPollDeviceToken:
             {"interval": 5, "expires_in": float("nan")},
             {"interval": 5, "expires_in": MAX_DEVICE_SECONDS + 1},
             {"interval": 5, "expires_in": True},
+            # An astronomically large int must reject as usage, not raise
+            # OverflowError out of math.isfinite (range checks run first).
+            {"interval": 5, "expires_in": 10**400},
             {"interval": 0, "expires_in": 900},
             {"interval": -1, "expires_in": 900},
             {"interval": MAX_DEVICE_SECONDS + 1, "expires_in": 900},
+            {"interval": 10**400, "expires_in": 900},
         ]
         for kwargs in cases:
             with pytest.raises(OAuthError) as exc_info:
@@ -790,6 +794,26 @@ class TestPollDeviceToken:
                 max_body_bytes=8 * 1024,
             )
         assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    def test_invalid_body_cap_cannot_disable_the_bound(self):
+        # An invalid runtime cap (inf here; None/negative are the same class) must
+        # normalize to the device default rather than disable the streaming bound —
+        # a 2 MiB body still aborts as api_error, matching discovery's discipline.
+        _queue_token_responses([httpx.Response(200, content=b"x" * (2 * 1024 * 1024))])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT,
+                "basecamp-cli",
+                "dev-code-123",
+                interval=5,
+                expires_in=900,
+                sleep=RecordingSleep(),
+                max_body_bytes=float("inf"),  # type: ignore[arg-type]
+            )
+        assert exc_info.value.code == "api_error"
+        assert "size cap" in str(exc_info.value)
 
     @respx.mock
     def test_does_not_follow_redirect(self):

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -44,6 +44,7 @@ TOKEN_RESPONSE = {
 
 CONFIG = OAuthConfig(
     issuer=ORIGIN,
+    authorization_endpoint=None,
     token_endpoint=TOKEN_ENDPOINT,
     device_authorization_endpoint=DEVICE_ENDPOINT,
     grant_types_supported=[DEVICE_CODE_GRANT_TYPE, "refresh_token"],
@@ -707,6 +708,7 @@ class TestPerformDeviceLogin:
         token_route = respx.post(TOKEN_ENDPOINT).mock(return_value=httpx.Response(200, json=TOKEN_RESPONSE))
         config = OAuthConfig(
             issuer=ORIGIN,
+            authorization_endpoint=None,
             token_endpoint=TOKEN_ENDPOINT,
             device_authorization_endpoint=DEVICE_ENDPOINT,
             grant_types_supported=["refresh_token"],  # no device_code grant
@@ -726,6 +728,7 @@ class TestPerformDeviceLogin:
         device_route = respx.post(DEVICE_ENDPOINT).mock(return_value=httpx.Response(200, json=DEVICE_AUTH_RESPONSE))
         config = OAuthConfig(
             issuer=ORIGIN,
+            authorization_endpoint=None,
             token_endpoint=TOKEN_ENDPOINT,
             device_authorization_endpoint=DEVICE_ENDPOINT,
             grant_types_supported=DEVICE_CODE_GRANT_TYPE,  # type: ignore[arg-type]
@@ -741,6 +744,7 @@ class TestPerformDeviceLogin:
     def test_capability_guard_missing_endpoint_is_unavailable(self):
         config = OAuthConfig(
             issuer=ORIGIN,
+            authorization_endpoint=None,
             token_endpoint=TOKEN_ENDPOINT,
             device_authorization_endpoint=None,
             grant_types_supported=[DEVICE_CODE_GRANT_TYPE],

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -240,6 +240,30 @@ class TestRequestDeviceAuthorization:
         assert exc_info.value.reason == "transport"
 
     @respx.mock
+    def test_slow_drip_read_aborts_on_wall_clock_deadline(self, monkeypatch):
+        # httpx's timeout resets on every received chunk, so a slow-drip peer would
+        # hang the request without a whole-read deadline. Advance the monotonic clock
+        # past the deadline mid-stream (each call jumps 100s > the 30s timeout, so the
+        # first in-loop check trips regardless of when the deadline was computed) and
+        # assert it surfaces as a retryable transport timeout, not a hang.
+        import basecamp.oauth.device as device_mod
+
+        elapsed = {"v": 0.0}
+
+        def fake_monotonic() -> float:
+            v = elapsed["v"]
+            elapsed["v"] += 100.0
+            return v
+
+        monkeypatch.setattr(device_mod.time, "monotonic", fake_monotonic)
+        respx.post(DEVICE_ENDPOINT).mock(return_value=httpx.Response(200, json=DEVICE_AUTH_RESPONSE))
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+        assert exc_info.value.reason == "transport"
+        assert exc_info.value.retryable
+
+    @respx.mock
     def test_rejects_non_string_field_types(self):
         # A non-string field is malformed, not merely absent — a truthiness
         # check would let 12345 / a list slip through.

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -96,6 +96,18 @@ class TestRequestDeviceAuthorization:
         assert auth.interval == 5
 
     @respx.mock
+    def test_treats_null_interval_as_absent(self):
+        # `"interval": null` is the cross-SDK contract for absent (Go/Kotlin
+        # decoders cannot distinguish null from a missing key) → default 5.
+        respx.post(DEVICE_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={**DEVICE_AUTH_RESPONSE, "interval": None})
+        )
+
+        auth = request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+
+        assert auth.interval == 5
+
+    @respx.mock
     def test_rejects_non_positive_expires_in(self):
         respx.post(DEVICE_ENDPOINT).mock(
             return_value=httpx.Response(200, json={**DEVICE_AUTH_RESPONSE, "expires_in": 0})
@@ -311,6 +323,57 @@ class TestPollDeviceToken:
         assert sleep.waits[1] == 10
 
     @respx.mock
+    def test_backoff_resets_to_server_interval_after_completed_round_trip(self):
+        # Timeout backoff is transient: it doubles per timeout, but ANY completed
+        # round-trip (here authorization_pending) snaps the wait back to the
+        # server interval — intermittent timeouts must not inflate later polls.
+        _queue_token_responses(
+            [
+                httpx.TimeoutException("timed out"),
+                httpx.TimeoutException("timed out"),
+                httpx.Response(400, json={"error": "authorization_pending"}),
+                httpx.Response(400, json={"error": "authorization_pending"}),
+                httpx.Response(200, json=TOKEN_RESPONSE),
+            ]
+        )
+        sleep = RecordingSleep()
+
+        token = poll_device_token(
+            TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=sleep
+        )
+
+        assert token.access_token == "device_access_token"  # gitleaks:allow
+        # 5s, timeout → 10s, timeout → 20s, pending → back to 5s, pending → 5s.
+        assert sleep.waits == [5, 10, 20, 5, 5]
+
+    @respx.mock
+    def test_rejects_string_expires_in_in_token_response(self):
+        # A 2xx with a valid access_token but expires_in "3600" (a string) must
+        # surface as api_error, never escape as a TypeError from expires_at math.
+        _queue_token_responses([httpx.Response(200, json={**TOKEN_RESPONSE, "expires_in": "3600"})])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.code == "api_error"
+        assert exc_info.value.http_status == 200
+
+    @respx.mock
+    def test_accepts_token_without_expires_in(self):
+        # An absent expires_in is allowed — the token simply carries no expiry.
+        payload = {k: v for k, v in TOKEN_RESPONSE.items() if k != "expires_in"}
+        _queue_token_responses([httpx.Response(200, json=payload)])
+
+        token = poll_device_token(
+            TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+        )
+
+        assert token.expires_in is None
+        assert token.expires_at is None
+        assert token.is_expired() is False
+
+    @respx.mock
     def test_expires_against_injected_clock(self):
         _queue_token_responses([httpx.Response(400, json={"error": "authorization_pending"})])
         # Clock: base at 0, then jumps past the 900s deadline on the first check.
@@ -437,6 +500,20 @@ class TestPollDeviceToken:
         assert not target.called  # redirect suppressed — attacker origin never dialed
 
     @respx.mock
+    def test_redirect_with_pending_body_is_api_error(self):
+        # A 3xx must never be interpreted as an OAuth outcome: a redirect body
+        # carrying {"error": "authorization_pending"} must not keep the poll
+        # loop alive — it surfaces as api_error.
+        _queue_token_responses([httpx.Response(302, json={"error": "authorization_pending"})])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.code == "api_error"
+        assert exc_info.value.http_status == 302
+
+    @respx.mock
     def test_deadline_clamps_backoff_wait(self):
         # Every poll times out, so the backoff interval doubles unbounded (5 → 10
         # → 20…). A clock advanced by each recorded sleep proves the final wait is
@@ -488,6 +565,24 @@ class TestPerformDeviceLogin:
         assert exc_info.value.reason == "unavailable"
         assert exc_info.value.code == "validation"
         assert not token_route.called
+
+    @respx.mock
+    def test_capability_guard_rejects_string_grant_types(self):
+        # A malformed config carrying the URN as a plain str would substring-match
+        # a bare `in` — the guard requires a real list, so this is unavailable.
+        device_route = respx.post(DEVICE_ENDPOINT).mock(return_value=httpx.Response(200, json=DEVICE_AUTH_RESPONSE))
+        config = OAuthConfig(
+            issuer=ORIGIN,
+            token_endpoint=TOKEN_ENDPOINT,
+            device_authorization_endpoint=DEVICE_ENDPOINT,
+            grant_types_supported=DEVICE_CODE_GRANT_TYPE,  # type: ignore[arg-type]
+        )
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            perform_device_login(config, "basecamp-cli", display=lambda _auth: None)
+
+        assert exc_info.value.reason == "unavailable"
+        assert not device_route.called
 
     @respx.mock
     def test_capability_guard_missing_endpoint_is_unavailable(self):

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -392,6 +392,26 @@ class TestPollDeviceToken:
         assert sleep.waits[1] == 10
 
     @respx.mock
+    def test_backoff_tracks_grown_interval_after_slow_down(self):
+        # slow_down grows the interval 5→10; a following timeout must double from
+        # the GROWN interval (10→20), not the stale pre-slow_down 5 (which gave 10).
+        _queue_token_responses(
+            [
+                httpx.Response(400, json={"error": "slow_down"}),
+                httpx.TimeoutException("timed out"),
+                httpx.Response(200, json=TOKEN_RESPONSE),
+            ]
+        )
+        sleep = RecordingSleep()
+
+        token = poll_device_token(
+            TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=sleep
+        )
+
+        assert token.access_token == "device_access_token"  # gitleaks:allow
+        assert sleep.waits == [5, 10, 20]
+
+    @respx.mock
     def test_backoff_resets_to_server_interval_after_completed_round_trip(self):
         # Timeout backoff is transient: it doubles per timeout, but ANY completed
         # round-trip (here authorization_pending) snaps the wait back to the

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -239,51 +239,45 @@ class TestRequestDeviceAuthorization:
             request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
         assert exc_info.value.reason == "transport"
 
-    @respx.mock
-    def test_slow_drip_read_aborts_on_wall_clock_deadline(self, monkeypatch):
-        # httpx's timeout resets on every received chunk, so a slow-drip peer would
-        # hang the request without a whole-read deadline. Advance the monotonic clock
-        # past the deadline mid-stream (each call jumps 100s > the 30s timeout, so the
-        # first in-loop check trips regardless of when the deadline was computed) and
-        # assert it surfaces as a retryable transport timeout, not a hang.
-        import basecamp.oauth.device as device_mod
+    def test_slow_drip_request_is_bounded_by_the_wall_clock_timeout(self):
+        # httpx's read timeout resets on every received chunk, so a peer dripping a
+        # VALID response byte-by-byte (each read under the timeout) would otherwise
+        # hold the request open far past it — httpx has no total timeout. The
+        # daemon-worker + join(timeout) bound must return WITHIN the timeout as a
+        # retryable transport failure, not run for the whole drip. A real socket is
+        # used because respx serves a complete response instantly (no drip).
+        import socket
+        import threading
+        import time as _time
 
-        elapsed = {"v": 0.0}
+        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        srv.bind(("127.0.0.1", 0))
+        srv.listen(1)
+        port = srv.getsockname()[1]
+        # ~60 bytes dripped at 0.2s each ≈ 12s total; the 0.5s timeout must win.
+        valid = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nContent-Type: application/json\r\n\r\n{}"
 
-        def fake_monotonic() -> float:
-            v = elapsed["v"]
-            elapsed["v"] += 100.0
-            return v
+        def drip() -> None:
+            conn, _ = srv.accept()
+            conn.recv(4096)
+            try:
+                for byte in valid:
+                    conn.sendall(bytes([byte]))
+                    _time.sleep(0.2)
+            except OSError:
+                pass
 
-        monkeypatch.setattr(device_mod.time, "monotonic", fake_monotonic)
-        respx.post(DEVICE_ENDPOINT).mock(return_value=httpx.Response(200, json=DEVICE_AUTH_RESPONSE))
-
-        with pytest.raises(DeviceFlowError) as exc_info:
-            request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
-        assert exc_info.value.reason == "transport"
-        assert exc_info.value.retryable
-
-    @respx.mock
-    def test_final_read_past_deadline_is_rejected(self, monkeypatch):
-        # The in-loop check runs BEFORE each chunk, so it cannot catch the final
-        # read / EOF landing past the deadline. Drive an empty body (zero in-loop
-        # iterations) with the clock advanced past the deadline so ONLY the
-        # post-loop check can fire — proving the whole-read bound holds at EOF.
-        import basecamp.oauth.device as device_mod
-
-        elapsed = {"v": 0.0}
-
-        def fake_monotonic() -> float:
-            v = elapsed["v"]
-            elapsed["v"] += 100.0
-            return v
-
-        monkeypatch.setattr(device_mod.time, "monotonic", fake_monotonic)
-        respx.post(DEVICE_ENDPOINT).mock(return_value=httpx.Response(200, content=b""))
-
-        with pytest.raises(DeviceFlowError) as exc_info:
-            request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
-        assert exc_info.value.reason == "transport"
+        threading.Thread(target=drip, daemon=True).start()
+        try:
+            start = _time.monotonic()
+            with pytest.raises(DeviceFlowError) as exc_info:
+                request_device_authorization(f"http://127.0.0.1:{port}/device", "basecamp-cli", timeout=0.5)
+            elapsed = _time.monotonic() - start
+            assert exc_info.value.reason == "transport"
+            assert exc_info.value.retryable
+            assert elapsed < 4, f"request not bounded by the timeout: took {elapsed:.2f}s"
+        finally:
+            srv.close()
 
     @respx.mock
     def test_rejects_non_string_field_types(self):

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -308,6 +308,18 @@ class TestRequestDeviceAuthorization:
         assert exc_info.value.code == "api_error"
 
     @respx.mock
+    def test_non_2xx_with_non_json_body_reports_status_not_parse_error(self):
+        # Status is checked BEFORE parsing (as discovery does): a non-2xx with a
+        # non-JSON body must surface as "failed with status", not a parse error.
+        respx.post(DEVICE_ENDPOINT).mock(return_value=httpx.Response(503, content=b"<html>Service Unavailable</html>"))
+
+        with pytest.raises(OAuthError) as exc_info:
+            request_device_authorization(DEVICE_ENDPOINT, "basecamp-cli")
+        assert exc_info.value.code == "api_error"
+        assert exc_info.value.http_status == 503
+        assert "status" in str(exc_info.value).lower()
+
+    @respx.mock
     def test_rejects_non_object_body_with_http_status(self):
         # A valid-JSON-but-non-object body (list/number/null) is malformed. It must
         # fail as api_error AND carry the HTTP status for debugging parity with the

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -451,6 +451,30 @@ class TestPollDeviceToken:
         assert exc_info.value.code == "api_error"
 
     @respx.mock
+    def test_rejects_fractional_expires_in_in_token_response(self):
+        # A fractional token lifetime is malformed under the whole-second contract
+        # (Go/Kotlin reject it by int/Long typing) → api_error, uniform across SDKs.
+        _queue_token_responses([httpx.Response(200, json={**TOKEN_RESPONSE, "expires_in": 1.5})])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    def test_accepts_integer_valued_float_expires_in_in_token_response(self):
+        # An integer-valued float (3600.0) is accepted and coerced, matching the
+        # device-duration rule.
+        _queue_token_responses([httpx.Response(200, json={**TOKEN_RESPONSE, "expires_in": 3600.0})])
+
+        token = poll_device_token(
+            TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+        )
+
+        assert token.expires_in == 3600.0
+
+    @respx.mock
     def test_expires_against_injected_clock(self):
         _queue_token_responses([httpx.Response(400, json={"error": "authorization_pending"})])
         # Clock: base at 0, then jumps past the 900s deadline on the first check.

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -617,7 +617,7 @@ class TestPollDeviceToken:
     def test_rejects_a_deadline_at_beyond_the_code_lifetime(self):
         # deadline_at can only SHORTEN the validated lifetime (mirrors the TS
         # deadlineAtMs bound); NaN defeats every comparison.
-        for bad in (float("nan"), 10_000_000.0):
+        for bad in (float("nan"), 10_000_000.0, "soon", True, 10**400):
             with pytest.raises(OAuthError) as exc_info:
                 poll_device_token(
                     TOKEN_ENDPOINT,

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -373,6 +373,10 @@ class TestPollDeviceToken:
             {"interval": -1, "expires_in": 900},
             {"interval": MAX_DEVICE_SECONDS + 1, "expires_in": 900},
             {"interval": 10**400, "expires_in": 900},
+            # Whole seconds (RFC 8628): a fractional interval would permit
+            # ~1000 polls per second. expires_in stays legitimately fractional.
+            {"interval": 0.001, "expires_in": 900},
+            {"interval": 2.5, "expires_in": 900},
         ]
         for kwargs in cases:
             with pytest.raises(OAuthError) as exc_info:

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -911,6 +911,8 @@ class TestPollDeviceTokenTerminalStatusBodySkip:
         assert exc_info.value.code == "api_error"
         assert f"status {status}" in str(exc_info.value)
 
+
+class TestPollDeviceTokenTimeoutNormalization:
     @respx.mock
     def test_invalid_timeout_normalizes_at_entry(self):
         # timeout=None previously reached min(None, float) → raw TypeError

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -878,6 +878,22 @@ class TestPollDeviceToken:
         assert now["t"] <= 20
 
 
+class TestPollDeviceTokenExact200:
+    @respx.mock
+    @pytest.mark.parametrize("status", [201, 202])
+    def test_non_200_success_is_terminal(self, status):
+        # RFC 8628/6749 token responses are exactly 200 (SPEC §16): a
+        # nonstandard 2xx carrying an access_token must not complete polling.
+        _queue_token_responses([httpx.Response(status, json=TOKEN_RESPONSE)])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.code == "api_error"
+        assert exc_info.value.http_status == status
+
+
 class TestPerformDeviceLogin:
     @respx.mock
     def test_capability_guard_no_device_grant_is_unavailable_and_does_not_poll(self):

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -960,6 +960,50 @@ class TestPollDeviceTokenCancelAfterRoundTrip:
         assert exc_info.value.reason == "cancelled"
 
 
+class TestPerformDeviceLoginCancellation:
+    @respx.mock
+    def test_already_cancelled_flow_makes_no_request(self):
+        route = respx.post(DEVICE_ENDPOINT).mock(return_value=httpx.Response(200, json=DEVICE_AUTH_RESPONSE))
+        displayed = []
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            perform_device_login(
+                CONFIG,
+                "basecamp-cli",
+                display=displayed.append,
+                sleep=RecordingSleep(),
+                should_cancel=lambda: True,
+            )
+        assert exc_info.value.reason == "cancelled"
+        assert len(route.calls) == 0
+        assert displayed == []
+
+    @respx.mock
+    def test_cancel_during_the_authorization_request_never_reaches_display(self):
+        # The mock endpoint flips the probe as it serves the code pair, so the
+        # entry check passes and only the post-request re-check can catch it —
+        # the display hook must never fire for a cancelled flow.
+        state = {"cancelled": False}
+
+        def serve(_request):
+            state["cancelled"] = True
+            return httpx.Response(200, json=DEVICE_AUTH_RESPONSE)
+
+        respx.post(DEVICE_ENDPOINT).mock(side_effect=serve)
+        displayed = []
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            perform_device_login(
+                CONFIG,
+                "basecamp-cli",
+                display=displayed.append,
+                sleep=RecordingSleep(),
+                should_cancel=lambda: state["cancelled"],
+            )
+        assert exc_info.value.reason == "cancelled"
+        assert displayed == []
+
+
 class TestPollDeviceTokenExact200:
     @respx.mock
     @pytest.mark.parametrize("status", [201, 202])

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -1004,6 +1004,18 @@ class TestPerformDeviceLoginCancellation:
         assert displayed == []
 
     @respx.mock
+    def test_rejects_a_non_callable_display_before_any_request(self):
+        # display is the only mechanism surfacing the verification code:
+        # dereferencing None AFTER the request would mint a code nobody can
+        # approve. Reject as usage with zero network activity.
+        route = respx.post(DEVICE_ENDPOINT).mock(return_value=httpx.Response(200, json=DEVICE_AUTH_RESPONSE))
+
+        with pytest.raises(OAuthError) as exc_info:
+            perform_device_login(CONFIG, "basecamp-cli", display=None)  # type: ignore[arg-type]
+        assert exc_info.value.code == "usage"
+        assert len(route.calls) == 0
+
+    @respx.mock
     def test_cancel_during_display_beats_expiry(self):
         # A display hook that both cancels the flow and consumes the whole
         # code lifetime (a prompt closing in response to cancellation) must

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -1095,6 +1095,33 @@ class TestPerformDeviceLoginCancellation:
         assert displayed == []
 
     @respx.mock
+    def test_cancel_during_the_post_display_clock_sample_beats_expiry(self):
+        # The post-display sample is the same cancellation-capable callback
+        # seam as the pre-request anchor: a cancel flipped inside it — even
+        # one returning a beyond-deadline value — must surface cancelled,
+        # never expired.
+        respx.post(DEVICE_ENDPOINT).mock(return_value=httpx.Response(200, json=DEVICE_AUTH_RESPONSE))
+        state = {"cancelled": False, "calls": 0}
+
+        def clock() -> float:
+            state["calls"] += 1
+            if state["calls"] >= 2:
+                state["cancelled"] = True
+                return 10_000.0
+            return 0.0
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            perform_device_login(
+                CONFIG,
+                "basecamp-cli",
+                display=lambda _auth: None,
+                sleep=RecordingSleep(),
+                clock=clock,
+                should_cancel=lambda: state["cancelled"],
+            )
+        assert exc_info.value.reason == "cancelled"
+
+    @respx.mock
     def test_cancel_during_the_anchor_clock_sample_stops_the_request(self):
         # The injected clock is itself a callback seam: a cancel flipped inside
         # the pre-request anchor sample must stop the flow before the

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -614,6 +614,21 @@ class TestPollDeviceToken:
         assert isinstance(token.expires_in, int)
 
     @respx.mock
+    def test_rejects_a_non_finite_clock_sample_as_usage(self):
+        # A NaN clock sample makes every deadline comparison false — an
+        # authorization_pending endpoint would be polled indefinitely.
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT,
+                "basecamp-cli",
+                "dev-code-123",
+                interval=5,
+                expires_in=900,
+                clock=lambda: float("nan"),
+                sleep=RecordingSleep(),
+            )
+        assert exc_info.value.code == "usage"
+
     def test_expires_against_injected_clock(self):
         _queue_token_responses([httpx.Response(400, json={"error": "authorization_pending"})])
         # Clock: base at 0, then jumps past the 900s deadline on the first check.

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -1122,12 +1122,13 @@ class TestPerformDeviceLoginCancellation:
         assert exc_info.value.reason == "cancelled"
 
     @respx.mock
-    def test_cancel_during_the_anchor_clock_sample_stops_the_request(self):
-        # The injected clock is itself a callback seam: a cancel flipped inside
-        # the pre-request anchor sample must stop the flow before the
-        # authorization request fires.
-        route = respx.post(DEVICE_ENDPOINT).mock(return_value=httpx.Response(200, json=DEVICE_AUTH_RESPONSE))
+    def test_cancel_during_the_anchor_clock_sample_never_reaches_display(self):
+        # The injected clock is itself a callback seam: a cancel flipped
+        # inside the post-response issuance anchor must surface cancelled
+        # before the display hook fires.
+        respx.post(DEVICE_ENDPOINT).mock(return_value=httpx.Response(200, json=DEVICE_AUTH_RESPONSE))
         state = {"cancelled": False}
+        displayed: list[object] = []
 
         def clock() -> float:
             state["cancelled"] = True
@@ -1137,19 +1138,20 @@ class TestPerformDeviceLoginCancellation:
             perform_device_login(
                 CONFIG,
                 "basecamp-cli",
-                display=lambda _auth: None,
+                display=displayed.append,
                 sleep=RecordingSleep(),
                 clock=clock,
                 should_cancel=lambda: state["cancelled"],
             )
         assert exc_info.value.reason == "cancelled"
-        assert len(route.calls) == 0
+        assert displayed == []
 
     @respx.mock
-    def test_slow_authorization_response_counts_against_the_code_lifetime(self):
-        # The code is minted server-side before the response travels back: a
-        # response arriving 6s late with expires_in 5 is dead on arrival, so
-        # the pre-request anchor must expire it — never grant a fresh lifetime.
+    def test_expiry_anchors_at_response_receipt_not_request_start(self):
+        # SPEC §16: the deadline is clock() + expires_in taken AFTER the
+        # authorization request returns — a 6s request leg with expires_in 5
+        # must NOT expire the fresh code client-side; expiry past receipt is
+        # arbitrated by the server (expired_token).
         state = {"t": 0.0}
 
         def serve(_request):
@@ -1157,18 +1159,16 @@ class TestPerformDeviceLoginCancellation:
             return httpx.Response(200, json={**DEVICE_AUTH_RESPONSE, "expires_in": 5})
 
         respx.post(DEVICE_ENDPOINT).mock(side_effect=serve)
-        token_route = respx.post(TOKEN_ENDPOINT).mock(return_value=httpx.Response(200, json=TOKEN_RESPONSE))
+        respx.post(TOKEN_ENDPOINT).mock(return_value=httpx.Response(200, json=TOKEN_RESPONSE))
 
-        with pytest.raises(DeviceFlowError) as exc_info:
-            perform_device_login(
-                CONFIG,
-                "basecamp-cli",
-                display=lambda _auth: None,
-                sleep=RecordingSleep(),
-                clock=lambda: state["t"],
-            )
-        assert exc_info.value.reason == "expired"
-        assert len(token_route.calls) == 0
+        token = perform_device_login(
+            CONFIG,
+            "basecamp-cli",
+            display=lambda _auth: None,
+            sleep=RecordingSleep(),
+            clock=lambda: state["t"],
+        )
+        assert token.access_token == TOKEN_RESPONSE["access_token"]
 
     @respx.mock
     def test_cancellation_wins_over_a_device_auth_fault(self):

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -733,6 +733,31 @@ class TestPollDeviceToken:
         assert exc_info.value.retryable is True
 
     @respx.mock
+    def test_cancellation_wins_over_a_transport_fault(self):
+        # Cancellation-beats-classification on the error path: the mock flips
+        # the probe as the doomed request fails, so the poll must surface
+        # cancelled — never the transport fault the request happened to raise.
+        state = {"cancelled": False}
+
+        def explode(_request):
+            state["cancelled"] = True
+            raise httpx.ConnectError("boom")
+
+        respx.post(TOKEN_ENDPOINT).mock(side_effect=explode)
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT,
+                "basecamp-cli",
+                "dev-code-123",
+                interval=5,
+                expires_in=900,
+                sleep=RecordingSleep(),
+                should_cancel=lambda: state["cancelled"],
+            )
+        assert exc_info.value.reason == "cancelled"
+
+    @respx.mock
     def test_cancellation_raises_cancelled(self):
         _queue_token_responses([httpx.Response(400, json={"error": "authorization_pending"})])
         cancelled = {"flag": False}
@@ -1056,6 +1081,31 @@ class TestPerformDeviceLoginCancellation:
             return httpx.Response(200, json=DEVICE_AUTH_RESPONSE)
 
         respx.post(DEVICE_ENDPOINT).mock(side_effect=serve)
+        displayed = []
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            perform_device_login(
+                CONFIG,
+                "basecamp-cli",
+                display=displayed.append,
+                sleep=RecordingSleep(),
+                should_cancel=lambda: state["cancelled"],
+            )
+        assert exc_info.value.reason == "cancelled"
+        assert displayed == []
+
+    @respx.mock
+    def test_cancellation_wins_over_a_device_auth_fault(self):
+        # Same contract on the error path: the authorization request fails AND
+        # the probe flipped mid-flight — cancelled must win over transport,
+        # and the display hook must never fire.
+        state = {"cancelled": False}
+
+        def explode(_request):
+            state["cancelled"] = True
+            raise httpx.ConnectError("boom")
+
+        respx.post(DEVICE_ENDPOINT).mock(side_effect=explode)
         displayed = []
 
         with pytest.raises(DeviceFlowError) as exc_info:

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -1095,6 +1095,31 @@ class TestPerformDeviceLoginCancellation:
         assert displayed == []
 
     @respx.mock
+    def test_slow_authorization_response_counts_against_the_code_lifetime(self):
+        # The code is minted server-side before the response travels back: a
+        # response arriving 6s late with expires_in 5 is dead on arrival, so
+        # the pre-request anchor must expire it — never grant a fresh lifetime.
+        state = {"t": 0.0}
+
+        def serve(_request):
+            state["t"] += 6.0
+            return httpx.Response(200, json={**DEVICE_AUTH_RESPONSE, "expires_in": 5})
+
+        respx.post(DEVICE_ENDPOINT).mock(side_effect=serve)
+        token_route = respx.post(TOKEN_ENDPOINT).mock(return_value=httpx.Response(200, json=TOKEN_RESPONSE))
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            perform_device_login(
+                CONFIG,
+                "basecamp-cli",
+                display=lambda _auth: None,
+                sleep=RecordingSleep(),
+                clock=lambda: state["t"],
+            )
+        assert exc_info.value.reason == "expired"
+        assert len(token_route.calls) == 0
+
+    @respx.mock
     def test_cancellation_wins_over_a_device_auth_fault(self):
         # Same contract on the error path: the authorization request fails AND
         # the probe flipped mid-flight — cancelled must win over transport,

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -646,6 +646,40 @@ class TestPollDeviceToken:
             )
         assert exc_info.value.code == "usage"
 
+    def test_rejects_malformed_clock_samples_as_usage(self):
+        # A string, bool, or huge-int sample must surface as the typed usage
+        # error — never a raw TypeError/OverflowError out of the deadline
+        # arithmetic. Covers both the poller and the login orchestrator seams.
+        for bad in ("now", True, 10**400):
+            with pytest.raises(OAuthError) as exc_info:
+                poll_device_token(
+                    TOKEN_ENDPOINT,
+                    "basecamp-cli",
+                    "dev-code-123",
+                    interval=5,
+                    expires_in=900,
+                    clock=lambda bad=bad: bad,
+                    sleep=RecordingSleep(),
+                )
+            assert exc_info.value.code == "usage", f"clock sample {bad!r}"
+
+    def test_rejects_a_malformed_later_clock_sample_as_usage(self):
+        # EVERY sample is validated, not just the first: a clock that goes bad
+        # mid-flight (sample 2 here, before the first request) must surface the
+        # same typed usage error instead of a raw TypeError.
+        times = iter([0.0, "now"])
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT,
+                "basecamp-cli",
+                "dev-code-123",
+                interval=5,
+                expires_in=900,
+                clock=lambda: next(times),
+                sleep=RecordingSleep(),
+            )
+        assert exc_info.value.code == "usage"
+
     def test_expires_against_injected_clock(self):
         _queue_token_responses([httpx.Response(400, json={"error": "authorization_pending"})])
         # Clock: base at 0, then jumps past the 900s deadline on the first check.

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -931,6 +931,35 @@ class TestPollDeviceTokenTimeoutNormalization:
         assert token.access_token == "device_access_token"  # gitleaks:allow
 
 
+class TestPollDeviceTokenCancelAfterRoundTrip:
+    @respx.mock
+    def test_cancel_set_during_the_request_beats_a_200(self):
+        # The sync POST cannot observe should_cancel in flight; a cancel set
+        # while the request runs must surface after the round-trip — never a
+        # token returned post-cancellation. The mock endpoint itself flips the
+        # probe as it serves the 200, so every check BEFORE the POST sees
+        # not-cancelled and only the post-request re-check can catch it.
+        state = {"cancelled": False}
+
+        def serve(_request):
+            state["cancelled"] = True  # cancel arrives while the POST is in flight
+            return httpx.Response(200, json=TOKEN_RESPONSE)
+
+        respx.post(TOKEN_ENDPOINT).mock(side_effect=serve)
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT,
+                "basecamp-cli",
+                "dev-code-123",
+                interval=5,
+                expires_in=900,
+                sleep=RecordingSleep(),
+                should_cancel=lambda: state["cancelled"],
+            )
+        assert exc_info.value.reason == "cancelled"
+
+
 class TestPollDeviceTokenExact200:
     @respx.mock
     @pytest.mark.parametrize("status", [201, 202])

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -1003,6 +1003,32 @@ class TestPerformDeviceLoginCancellation:
         assert exc_info.value.reason == "cancelled"
         assert displayed == []
 
+    @respx.mock
+    def test_cancel_during_display_beats_expiry(self):
+        # A display hook that both cancels the flow and consumes the whole
+        # code lifetime (a prompt closing in response to cancellation) must
+        # surface cancelled, not expired.
+        respx.post(DEVICE_ENDPOINT).mock(return_value=httpx.Response(200, json=DEVICE_AUTH_RESPONSE))
+        state = {"cancelled": False}
+
+        def display(_auth):
+            state["cancelled"] = True
+
+        # issued_at = 0; the clock reads 950 after the hook — past the 900s
+        # lifetime. Cancellation must still win.
+        times = iter([0.0, 950.0, 950.0, 950.0])
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            perform_device_login(
+                CONFIG,
+                "basecamp-cli",
+                display=display,
+                clock=lambda: next(times),
+                sleep=RecordingSleep(),
+                should_cancel=lambda: state["cancelled"],
+            )
+        assert exc_info.value.reason == "cancelled"
+
 
 class TestPollDeviceTokenExact200:
     @respx.mock

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -895,6 +895,40 @@ class TestPollDeviceTokenProtocolErrorsOnlyOn4xx:
         assert len(route.calls) == 1
 
 
+class TestPollDeviceTokenTerminalStatusBodySkip:
+    @respx.mock
+    @pytest.mark.parametrize("status", [201, 500])
+    def test_terminal_status_classified_without_draining_body(self, status):
+        # An oversized body on a terminal non-4xx would trip the size cap if
+        # drained — the read_body predicate skips it and the status api_error
+        # surfaces instead.
+        _queue_token_responses([httpx.Response(status, content=b"x" * (2 * 1024 * 1024))])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.code == "api_error"
+        assert f"status {status}" in str(exc_info.value)
+
+    @respx.mock
+    def test_invalid_timeout_normalizes_at_entry(self):
+        # timeout=None previously reached min(None, float) → raw TypeError
+        # mid-poll; entry normalization resolves it to the device budget.
+        _queue_token_responses([httpx.Response(200, json=TOKEN_RESPONSE)])
+
+        token = poll_device_token(
+            TOKEN_ENDPOINT,
+            "basecamp-cli",
+            "dev-code-123",
+            interval=5,
+            expires_in=900,
+            sleep=RecordingSleep(),
+            timeout=None,
+        )
+        assert token.access_token == "device_access_token"  # gitleaks:allow
+
+
 class TestPollDeviceTokenExact200:
     @respx.mock
     @pytest.mark.parametrize("status", [201, 202])

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -614,6 +614,23 @@ class TestPollDeviceToken:
         assert isinstance(token.expires_in, int)
 
     @respx.mock
+    def test_rejects_a_deadline_at_beyond_the_code_lifetime(self):
+        # deadline_at can only SHORTEN the validated lifetime (mirrors the TS
+        # deadlineAtMs bound); NaN defeats every comparison.
+        for bad in (float("nan"), 10_000_000.0):
+            with pytest.raises(OAuthError) as exc_info:
+                poll_device_token(
+                    TOKEN_ENDPOINT,
+                    "basecamp-cli",
+                    "dev-code-123",
+                    interval=5,
+                    expires_in=900,
+                    clock=lambda: 0.0,
+                    deadline_at=bad,
+                    sleep=RecordingSleep(),
+                )
+            assert exc_info.value.code == "usage"
+
     def test_rejects_a_non_finite_clock_sample_as_usage(self):
         # A NaN clock sample makes every deadline comparison false — an
         # authorization_pending endpoint would be polled indefinitely.

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -878,6 +878,23 @@ class TestPollDeviceToken:
         assert now["t"] <= 20
 
 
+class TestPollDeviceTokenProtocolErrorsOnlyOn4xx:
+    @respx.mock
+    @pytest.mark.parametrize("status", [201, 202, 500])
+    def test_pending_outside_4xx_is_terminal(self, status):
+        # OAuth protocol states are recognized only on a 4xx: a nonstandard
+        # 2xx or a 5xx carrying a crafted pending body must not extend polling.
+        route = _queue_token_responses([httpx.Response(status, json={"error": "authorization_pending"})])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.code == "api_error"
+        assert exc_info.value.http_status == status
+        assert len(route.calls) == 1
+
+
 class TestPollDeviceTokenExact200:
     @respx.mock
     @pytest.mark.parametrize("status", [201, 202])

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -1095,6 +1095,30 @@ class TestPerformDeviceLoginCancellation:
         assert displayed == []
 
     @respx.mock
+    def test_cancel_during_the_anchor_clock_sample_stops_the_request(self):
+        # The injected clock is itself a callback seam: a cancel flipped inside
+        # the pre-request anchor sample must stop the flow before the
+        # authorization request fires.
+        route = respx.post(DEVICE_ENDPOINT).mock(return_value=httpx.Response(200, json=DEVICE_AUTH_RESPONSE))
+        state = {"cancelled": False}
+
+        def clock() -> float:
+            state["cancelled"] = True
+            return 0.0
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            perform_device_login(
+                CONFIG,
+                "basecamp-cli",
+                display=lambda _auth: None,
+                sleep=RecordingSleep(),
+                clock=clock,
+                should_cancel=lambda: state["cancelled"],
+            )
+        assert exc_info.value.reason == "cancelled"
+        assert len(route.calls) == 0
+
+    @respx.mock
     def test_slow_authorization_response_counts_against_the_code_lifetime(self):
         # The code is minted server-side before the response travels back: a
         # response arriving 6s late with expires_in 5 is dead on arrival, so

--- a/python/tests/oauth/test_exchange.py
+++ b/python/tests/oauth/test_exchange.py
@@ -37,6 +37,10 @@ class TestExchangeCode:
             )
         assert exc_info.value.oauth_type == "api_error"
         assert secret not in str(exc_info.value)
+        # from None: JSONDecodeError retains the whole body as .doc — the
+        # chain must be suppressed, not merely sanitized.
+        assert exc_info.value.__cause__ is None
+        assert exc_info.value.__suppress_context__
 
     @respx.mock
     def test_exchange_code(self):

--- a/python/tests/oauth/test_exchange.py
+++ b/python/tests/oauth/test_exchange.py
@@ -21,6 +21,24 @@ TOKEN_RESPONSE = {
 
 class TestExchangeCode:
     @respx.mock
+    def test_parse_failure_never_echoes_the_body(self):
+        # A syntactically-broken token body can still carry credential
+        # material — the parse error must not echo any of it into the
+        # message, where it would reach logs and exception telemetry.
+        secret = "sk-live-SUPERSECRET"
+        respx.post(TOKEN_ENDPOINT).mock(return_value=httpx.Response(200, text='{"access_token": "' + secret + "' oops"))
+
+        with pytest.raises(OAuthError) as exc_info:
+            exchange_code(
+                TOKEN_ENDPOINT,
+                code="auth-code-123",
+                redirect_uri="https://myapp.com/callback",
+                client_id="client-id",
+            )
+        assert exc_info.value.oauth_type == "api_error"
+        assert secret not in str(exc_info.value)
+
+    @respx.mock
     def test_exchange_code(self):
         route = respx.post(TOKEN_ENDPOINT).mock(return_value=httpx.Response(200, json=TOKEN_RESPONSE))
 

--- a/python/tests/oauth/test_resource_discovery.py
+++ b/python/tests/oauth/test_resource_discovery.py
@@ -235,6 +235,10 @@ def test_timeout_normalizes_to_operation_specific_default() -> None:
     # primitive) falls back to the default; within the maximum it is preserved.
     assert _normalize_timeout(1e300, 30.0, maximum=3600.0) == 30.0
     assert _normalize_timeout(60.0, 30.0, maximum=3600.0) == 60.0
+    # The maximum is inclusive (`value <= maximum`): a value exactly at it is kept.
+    assert _normalize_timeout(3600.0, 30.0, maximum=3600.0) == 3600.0
+    # And an impossible maximum (below the discovery constant) is itself honored.
+    assert _normalize_timeout(None, None, maximum=2.0) == 2.0  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize("raw", ["https:\\\\host", "https://host\n", "https://host ", "https://ho st"])

--- a/python/tests/oauth/test_resource_discovery.py
+++ b/python/tests/oauth/test_resource_discovery.py
@@ -217,6 +217,18 @@ def test_timeout_normalizes_non_finite_to_default() -> None:
     assert _normalize_timeout(30) == 30.0
 
 
+def test_timeout_normalizes_to_operation_specific_default() -> None:
+    from basecamp.oauth.discovery import _DISCOVERY_TIMEOUT, _normalize_timeout
+
+    # An invalid timeout falls back to the caller-supplied default, so device flow
+    # (30s) does not silently inherit discovery's 10s budget.
+    assert _normalize_timeout(None) == _DISCOVERY_TIMEOUT
+    assert _normalize_timeout(None, 30.0) == 30.0
+    assert _normalize_timeout(float("inf"), 30.0) == 30.0
+    # A valid value is preserved regardless of the default.
+    assert _normalize_timeout(5.0, 30.0) == 5.0
+
+
 @pytest.mark.parametrize("raw", ["https:\\\\host", "https://host\n", "https://host ", "https://ho st"])
 def test_origin_root_rejects_normalized_spellings(raw: str) -> None:
     # Parsers strip C0 controls / whitespace or percent-encode a space into the

--- a/python/tests/oauth/test_resource_discovery.py
+++ b/python/tests/oauth/test_resource_discovery.py
@@ -227,6 +227,10 @@ def test_timeout_normalizes_to_operation_specific_default() -> None:
     assert _normalize_timeout(float("inf"), 30.0) == 30.0
     # A valid value is preserved regardless of the default.
     assert _normalize_timeout(5.0, 30.0) == 5.0
+    # An INVALID default must not disable the bounds either: fall back to the
+    # discovery constant rather than returning the bad default.
+    assert _normalize_timeout(None, float("inf")) == _DISCOVERY_TIMEOUT
+    assert _normalize_timeout("bad", None) == _DISCOVERY_TIMEOUT  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize("raw", ["https:\\\\host", "https://host\n", "https://host ", "https://ho st"])

--- a/python/tests/oauth/test_resource_discovery.py
+++ b/python/tests/oauth/test_resource_discovery.py
@@ -231,6 +231,10 @@ def test_timeout_normalizes_to_operation_specific_default() -> None:
     # discovery constant rather than returning the bad default.
     assert _normalize_timeout(None, float("inf")) == _DISCOVERY_TIMEOUT
     assert _normalize_timeout("bad", None) == _DISCOVERY_TIMEOUT  # type: ignore[arg-type]
+    # A finite value ABOVE the maximum (which would overflow the wall-clock wait
+    # primitive) falls back to the default; within the maximum it is preserved.
+    assert _normalize_timeout(1e300, 30.0, maximum=3600.0) == 30.0
+    assert _normalize_timeout(60.0, 30.0, maximum=3600.0) == 60.0
 
 
 @pytest.mark.parametrize("raw", ["https:\\\\host", "https://host\n", "https://host ", "https://ho st"])

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -133,6 +133,74 @@ if token.expired?
 end
 ```
 
+### Device Authorization Grant (RFC 8628)
+
+For input-constrained clients (CLIs, TVs) that can't host a redirect URI, the
+device flow trades a redirect for a user-entered code. Basecamp pre-registers the
+public `basecamp-cli` client (`token_endpoint_auth_method: none`, no secret); an
+omitted scope defaults to `read`.
+
+```ruby
+# The device grant runs against an ALREADY-SELECTED config whose issuer advertises
+# a device_authorization_endpoint. Resolve one with resource-first discovery —
+# NOT discover_launchpad: Launchpad advertises no device endpoint, so the
+# capability guard would reject it.
+result = Basecamp::Oauth.discover_from_resource("https://3.basecampapi.com")
+raise "device login is not available for this resource" unless result.selected?
+config = result.config
+
+# One call runs the whole grant against the SELECTED config: it guards
+# capability, requests a device/user code, shows it via the display hook, then
+# polls the token endpoint until the user approves.
+token = Basecamp::Oauth.perform_device_login(
+  config: config,
+  client_id: "basecamp-cli",
+  display: ->(auth) do
+    puts "Visit #{auth.verification_uri} and enter code: #{auth.user_code}"
+    puts "Or open: #{auth.verification_uri_complete}" if auth.verification_uri_complete
+  end
+)
+
+client = Basecamp.client(access_token: token.access_token)
+```
+
+The capability guard requires BOTH `config.device_authorization_endpoint` AND the
+device_code grant in `config.grant_types_supported`; otherwise it raises
+`Basecamp::Oauth::DeviceFlowError` with `reason: :unavailable` before any request
+is issued. The two lower-level steps are also exposed directly:
+
+```ruby
+auth = Basecamp::Oauth.request_device_authorization(
+  device_authorization_endpoint: config.device_authorization_endpoint,
+  client_id: "basecamp-cli"
+)
+
+token = Basecamp::Oauth.poll_device_token(
+  token_endpoint: config.token_endpoint,
+  client_id: "basecamp-cli",
+  device_code: auth.device_code,
+  interval: auth.interval,
+  expires_in: auth.expires_in
+)
+```
+
+The polling loop waits at least `interval` seconds between polls against a
+**monotonic** deadline, sustains a `slow_down` bump (+5s for every later poll),
+and backs off exponentially on connection timeouts. A terminal outcome raises
+`DeviceFlowError` carrying a `reason` whose parent `type` is derived from it:
+
+| `reason` | `type` | Meaning |
+|---|---|---|
+| `:access_denied` | `auth` | The user declined the request |
+| `:expired` | `auth` | The code expired before approval |
+| `:transport` | `network` (retryable) | A network failure ended the flow |
+| `:unavailable` | `validation` | The config can't do device flow |
+| `:cancelled` | `usage` | The caller cancelled the flow |
+
+`poll_device_token` and `perform_device_login` accept injectable `clock`,
+`sleeper`, and `cancelled` callables — pass a `cancelled` probe (e.g. one that
+checks a signal set by SIGINT) to abort a pending login cleanly.
+
 ### Resource-First Discovery (RFC 9728 + RFC 8414)
 
 BC5's Authorization Server (AS) metadata lives only at the canonical issuer (the

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -165,7 +165,10 @@ client = Basecamp.client(access_token: token.access_token)
 ```
 
 The capability guard requires BOTH `config.device_authorization_endpoint` AND the
-device_code grant in `config.grant_types_supported`; otherwise it raises
+exact grant-type URN `urn:ietf:params:oauth:grant-type:device_code` in
+`config.grant_types_supported` — servers advertise the full URN, so checking for
+a bare `device_code` entry would wrongly conclude the flow is unavailable;
+otherwise it raises
 `Basecamp::Oauth::DeviceFlowError` with `reason: :unavailable` before any request
 is issued. The two lower-level steps are also exposed directly:
 

--- a/ruby/lib/basecamp/oauth.rb
+++ b/ruby/lib/basecamp/oauth.rb
@@ -147,6 +147,49 @@ module Basecamp
       token.expired?(buffer_seconds)
     end
 
+    # Requests an RFC 8628 device/user code pair. Thin delegator to
+    # {DeviceFlow.request_device_authorization}.
+    #
+    # @return [DeviceAuthorization]
+    def self.request_device_authorization(device_authorization_endpoint:, client_id:, scope: nil, timeout: 30)
+      DeviceFlow.request_device_authorization(
+        device_authorization_endpoint: device_authorization_endpoint,
+        client_id: client_id, scope: scope, timeout: timeout
+      )
+    end
+
+    # Polls the token endpoint for a device grant (RFC 8628 §3.5). Thin delegator
+    # to {DeviceFlow.poll_device_token}; +clock+, +sleeper+, and +cancelled+ are
+    # injectable for tests.
+    #
+    # @return [Token]
+    def self.poll_device_token(
+      token_endpoint:, client_id:, device_code:, interval:, expires_in:,
+      clock: DeviceFlow::DEFAULT_CLOCK, sleeper: DeviceFlow::DEFAULT_SLEEPER,
+      cancelled: DeviceFlow::DEFAULT_CANCELLED, timeout: 30
+    )
+      DeviceFlow.poll_device_token(
+        token_endpoint: token_endpoint, client_id: client_id,
+        device_code: device_code, interval: interval, expires_in: expires_in,
+        clock: clock, sleeper: sleeper, cancelled: cancelled, timeout: timeout
+      )
+    end
+
+    # Runs the full device authorization grant against an already-selected
+    # {Config} (RFC 8628). Thin delegator to {DeviceFlow.perform_device_login}.
+    #
+    # @return [Token]
+    def self.perform_device_login(
+      config:, client_id:, display:, scope: nil,
+      clock: DeviceFlow::DEFAULT_CLOCK, sleeper: DeviceFlow::DEFAULT_SLEEPER,
+      cancelled: DeviceFlow::DEFAULT_CANCELLED, timeout: 30
+    )
+      DeviceFlow.perform_device_login(
+        config: config, client_id: client_id, display: display, scope: scope,
+        clock: clock, sleeper: sleeper, cancelled: cancelled, timeout: timeout
+      )
+    end
+
     # Selects an issuer from the advertised set and — once a BC5 issuer is
     # committed — binds its AS metadata. From this point on, every failure is
     # fatal: no Launchpad request may be issued.

--- a/ruby/lib/basecamp/oauth.rb
+++ b/ruby/lib/basecamp/oauth.rb
@@ -151,7 +151,7 @@ module Basecamp
     # {DeviceFlow.request_device_authorization}.
     #
     # @return [DeviceAuthorization]
-    def self.request_device_authorization(device_authorization_endpoint:, client_id:, scope: nil, timeout: 30)
+    def self.request_device_authorization(device_authorization_endpoint:, client_id:, scope: nil, timeout: DeviceFlow::DEVICE_REQUEST_TIMEOUT)
       DeviceFlow.request_device_authorization(
         device_authorization_endpoint: device_authorization_endpoint,
         client_id: client_id, scope: scope, timeout: timeout
@@ -166,7 +166,7 @@ module Basecamp
     def self.poll_device_token(
       token_endpoint:, client_id:, device_code:, interval:, expires_in:,
       clock: DeviceFlow::DEFAULT_CLOCK, sleeper: DeviceFlow::DEFAULT_SLEEPER,
-      cancelled: DeviceFlow::DEFAULT_CANCELLED, timeout: 30
+      cancelled: DeviceFlow::DEFAULT_CANCELLED, timeout: DeviceFlow::DEVICE_REQUEST_TIMEOUT
     )
       DeviceFlow.poll_device_token(
         token_endpoint: token_endpoint, client_id: client_id,
@@ -182,7 +182,7 @@ module Basecamp
     def self.perform_device_login(
       config:, client_id:, display:, scope: nil,
       clock: DeviceFlow::DEFAULT_CLOCK, sleeper: DeviceFlow::DEFAULT_SLEEPER,
-      cancelled: DeviceFlow::DEFAULT_CANCELLED, timeout: 30
+      cancelled: DeviceFlow::DEFAULT_CANCELLED, timeout: DeviceFlow::DEVICE_REQUEST_TIMEOUT
     )
       DeviceFlow.perform_device_login(
         config: config, client_id: client_id, display: display, scope: scope,

--- a/ruby/lib/basecamp/oauth.rb
+++ b/ruby/lib/basecamp/oauth.rb
@@ -166,12 +166,14 @@ module Basecamp
     def self.poll_device_token(
       token_endpoint:, client_id:, device_code:, interval:, expires_in:,
       clock: DeviceFlow::DEFAULT_CLOCK, sleeper: DeviceFlow::DEFAULT_SLEEPER,
-      cancelled: DeviceFlow::DEFAULT_CANCELLED, timeout: DeviceFlow::DEVICE_REQUEST_TIMEOUT
+      cancelled: DeviceFlow::DEFAULT_CANCELLED, timeout: DeviceFlow::DEVICE_REQUEST_TIMEOUT,
+      deadline_at: nil
     )
       DeviceFlow.poll_device_token(
         token_endpoint: token_endpoint, client_id: client_id,
         device_code: device_code, interval: interval, expires_in: expires_in,
-        clock: clock, sleeper: sleeper, cancelled: cancelled, timeout: timeout
+        clock: clock, sleeper: sleeper, cancelled: cancelled, timeout: timeout,
+        deadline_at: deadline_at
       )
     end
 

--- a/ruby/lib/basecamp/oauth/device_authorization.rb
+++ b/ruby/lib/basecamp/oauth/device_authorization.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Oauth
+    # RFC 8628 device authorization response (the device/user code pair the user
+    # approves out of band).
+    #
+    # @attr device_code [String] The device verification code polled at the token
+    #   endpoint.
+    # @attr user_code [String] The code the user enters at the verification URI.
+    # @attr verification_uri [String] Where the user goes to approve the request.
+    # @attr verification_uri_complete [String, nil] The verification URI with the
+    #   user code pre-filled (optional; absent when the server omits it).
+    # @attr expires_in [Integer] Lifetime of the device/user codes in seconds.
+    # @attr interval [Integer] Minimum seconds to wait between token polls
+    #   (defaults to 5 when the server omits it).
+    DeviceAuthorization = Data.define(
+      :device_code,
+      :user_code,
+      :verification_uri,
+      :verification_uri_complete,
+      :expires_in,
+      :interval
+    ) do
+      def initialize(
+        device_code:,
+        user_code:,
+        verification_uri:,
+        expires_in:,
+        interval:,
+        verification_uri_complete: nil
+      )
+        super
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -88,6 +88,10 @@ module Basecamp
           # default (read) — Ruby treats "" as truthy, so guard on emptiness too.
           params["scope"] = scope unless scope.nil? || scope.empty?
 
+          # Normalize ONCE at operation entry and thread the SAME value to both the
+          # client construction and the request, so a non-finite/non-positive input
+          # cannot leave the socket timeout unbounded on the default-built client.
+          timeout = Fetcher.normalize_timeout(timeout, default: DEVICE_REQUEST_TIMEOUT)
           client = http_client || build_client(timeout)
           status, body = begin
             post_form(client, device_authorization_endpoint, params, timeout: timeout, max_body_bytes: max_body_bytes)
@@ -137,6 +141,9 @@ module Basecamp
           backoff_seconds = interval_seconds
           deadline = clock.call + expires_in
 
+          # Normalize ONCE, outside the polling loop, and reuse for the client and
+          # every per-poll request (see request_device_authorization).
+          timeout = Fetcher.normalize_timeout(timeout, default: DEVICE_REQUEST_TIMEOUT)
           client = http_client || build_client(timeout)
           params = {
             "grant_type" => DEVICE_CODE_GRANT_TYPE,
@@ -286,13 +293,11 @@ module Basecamp
           # +on_data+ (leaving +response.body+ empty); a test double that ignores
           # the block falls back to the buffered body, still size-capped.
           def post_form(client, url, params, timeout:, max_body_bytes:)
-            # Normalize ONCE and reuse for BOTH the wall-clock deadline and the
-            # Faraday socket timeout: req.options.timeout bounds only each socket
-            # read and resets on every on_data chunk, so a slow-drip peer could
-            # otherwise hang a device request past the timeout / code expiry while
-            # staying under the cap. Falling back to the device budget (not
-            # discovery's) keeps an invalid input from silently shrinking it.
-            timeout = Fetcher.normalize_timeout(timeout, default: DEVICE_REQUEST_TIMEOUT)
+            # +timeout+ is already normalized by the caller (request/poll entry). The
+            # wall-clock deadline bounds the WHOLE read: req.options.timeout below
+            # bounds only each socket read and resets on every on_data chunk, so a
+            # slow-drip peer could otherwise hang a device request past the timeout /
+            # code expiry while staying under the cap.
             deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
             chunks, on_data = Fetcher.bounded_reader(max_body_bytes, deadline: deadline)
             response = client.post(url) do |req|
@@ -325,8 +330,11 @@ module Basecamp
           end
 
           def parse_device_authorization(status, body)
-            data = parse_json_object(body, status, "device authorization")
-
+            # Check status BEFORE parsing (as discovery does): a non-2xx here is a
+            # hard failure with no OAuth error semantics, so a non-JSON error body
+            # (common for 500/502) must surface as "failed with status …", not a
+            # misleading parse error. The token poll is different — it parses non-2xx
+            # bodies to read authorization_pending / slow_down.
             unless (200..299).cover?(status)
               raise OauthError.new(
                 "api_error",
@@ -335,6 +343,7 @@ module Basecamp
               )
             end
 
+            data = parse_json_object(body, status, "device authorization")
             build_device_authorization(data, status)
           end
 

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -315,7 +315,7 @@ module Basecamp
               )
             end
 
-            build_device_authorization(data)
+            build_device_authorization(data, status)
           end
 
           # Parse a JSON object, type-checking rather than trusting truthiness: a
@@ -332,21 +332,29 @@ module Basecamp
             raise OauthError.new("api_error", "Failed to parse #{label} response", http_status: status)
           end
 
-          def build_device_authorization(data)
+          # Every validation error carries the (2xx) status so a malformed success
+          # body is diagnosable as such — uniform with the token raises and the
+          # other SDKs.
+          def build_device_authorization(data, status)
             device_code = data["device_code"]
             user_code = data["user_code"]
             verification_uri = data["verification_uri"]
             # Type-check the required strings — don't coerce via +.to_s+, which
             # would silently accept a numeric or boolean field as a "present" code.
             unless [ device_code, user_code, verification_uri ].all? { |field| field.is_a?(String) && !field.empty? }
-              raise OauthError.new("api_error", "Invalid device authorization response: missing or malformed required fields")
+              raise OauthError.new(
+                "api_error",
+                "Invalid device authorization response: missing or malformed required fields",
+                http_status: status
+              )
             end
 
             complete = data["verification_uri_complete"]
             unless complete.nil? || complete.is_a?(String)
               raise OauthError.new(
                 "api_error",
-                "Invalid device authorization response: verification_uri_complete must be a string"
+                "Invalid device authorization response: verification_uri_complete must be a string",
+                http_status: status
               )
             end
 
@@ -355,7 +363,8 @@ module Basecamp
               raise OauthError.new(
                 "api_error",
                 "Invalid device authorization response: expires_in must be a positive integer " \
-                "no greater than #{MAX_DEVICE_SECONDS}"
+                "no greater than #{MAX_DEVICE_SECONDS}",
+                http_status: status
               )
             end
 
@@ -365,14 +374,14 @@ module Basecamp
               verification_uri: verification_uri,
               verification_uri_complete: complete,
               expires_in: expires_in,
-              interval: resolve_interval(data["interval"])
+              interval: resolve_interval(data["interval"], status)
             )
           end
 
           # Default 5 when absent; any present value must be a positive integer
           # number of seconds (RFC 8628). Integer-valued floats (5.0) are fine;
           # fractional values (2.5) are malformed and rejected for cross-SDK parity.
-          def resolve_interval(raw)
+          def resolve_interval(raw, status)
             if raw.nil?
               DEFAULT_INTERVAL_SECONDS
             elsif positive_integer_seconds?(raw)
@@ -381,7 +390,8 @@ module Basecamp
               raise OauthError.new(
                 "api_error",
                 "Invalid device authorization response: interval must be a positive integer " \
-                "no greater than #{MAX_DEVICE_SECONDS}"
+                "no greater than #{MAX_DEVICE_SECONDS}",
+                http_status: status
               )
             end
           end

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -444,6 +444,9 @@ module Basecamp
                 http_status: status
               )
             end
+            # Coerce an integer-valued Float (3600.0) to Integer so {Token} always
+            # carries whole seconds, matching the other SDKs' coercion.
+            expires_in = expires_in.to_i unless expires_in.nil?
 
             token_type = data["token_type"]
             unless token_type.nil? || (token_type.is_a?(String) && !token_type.empty?)

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -198,6 +198,10 @@ module Basecamp
               next
             when "slow_down"
               interval_seconds += SLOW_DOWN_INCREMENT_SECONDS
+              # Re-sync the backoff to the GROWN interval (the reset above used the
+              # pre-increment value) so a later timeout doubles from the new
+              # interval, not the stale one.
+              backoff_seconds = interval_seconds
             when "access_denied"
               raise DeviceFlowError.new(:access_denied, "The authorization request was denied")
             when "expired_token"

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -136,7 +136,8 @@ module Basecamp
         # @raise [DeviceFlowError] +:access_denied+, +:expired+, +:transport+, or
         #   +:cancelled+
         # @raise [OauthError] +api_error+ on an unrecognized token error, oversized
-        #   body, or +validation+ on a redirect-following injected client
+        #   body, or +validation+ on a redirect-following injected client; +usage+
+        #   on an out-of-range +interval+/+expires_in+
         def poll_device_token(
           token_endpoint:, client_id:, device_code:, interval:, expires_in:,
           clock: DEFAULT_CLOCK, sleeper: DEFAULT_SLEEPER, cancelled: DEFAULT_CANCELLED,
@@ -145,7 +146,25 @@ module Basecamp
           Basecamp::Security.require_https_unless_localhost!(token_endpoint, "token endpoint")
           Fetcher.ensure_redirects_suppressed!(http_client) if http_client
 
-          interval_seconds = interval.positive? ? interval : DEFAULT_INTERVAL_SECONDS
+          # Caller-input sanity for this public entry point (usage, not the RFC
+          # response validation request_device_authorization applies): a nil or
+          # non-numeric duration would raise NoMethodError/TypeError below, a
+          # non-finite expires_in builds a deadline that NEVER passes (an unbounded
+          # poll loop), and an oversized/non-positive interval is not a schedulable
+          # wait. Fractional values are accepted — perform_device_login legitimately
+          # passes a fractional remaining lifetime after deducting display-hook
+          # time. Mirrors the Go/TS/Python/Kotlin caller guards.
+          { "expires_in" => expires_in, "interval" => interval }.each do |name, value|
+            unless valid_device_seconds?(value)
+              raise OauthError.new(
+                "usage",
+                "poll_device_token: #{name} must be a positive number of seconds " \
+                "no greater than #{MAX_DEVICE_SECONDS}"
+              )
+            end
+          end
+
+          interval_seconds = interval
           backoff_seconds = interval_seconds
           deadline = clock.call + expires_in
 
@@ -288,12 +307,15 @@ module Basecamp
             has_endpoint && grants.is_a?(Array) && grants.include?(DEVICE_CODE_GRANT_TYPE)
           end
 
+          # A positive, finite, real number of seconds within the shared device
+          # ceiling. +real?+ gates out Complex before +finite?+/+positive?+ (which
+          # Complex does not define), matching {Fetcher.valid_timeout?}.
+          def valid_device_seconds?(value)
+            value.is_a?(Numeric) && value.real? && value.finite? && value.positive? && value <= MAX_DEVICE_SECONDS
+          end
+
           def build_client(timeout)
-            Faraday.new do |conn|
-              conn.options.timeout = timeout
-              conn.options.open_timeout = timeout
-              conn.adapter Faraday.default_adapter
-            end
+            Fetcher.build_client(timeout)
           end
 
           # Waits +seconds+ while observing cancellation DURING the wait. A plain
@@ -343,6 +365,25 @@ module Basecamp
               req.options.open_timeout = timeout
               req.options.on_data = on_data
             end
+
+            # Status-first backstop on the completed response. The +on_data+ SkipBody
+            # fast-path only fires when the adapter streams AND passes +env+ (Faraday
+            # >= 2.5). A buffered adapter that ignores +on_data+, an older Faraday
+            # (2.0–2.4) that omits +env+, or a header-only response reaches here with
+            # the skip-status body un-skipped — re-apply +skip_status+ to the final
+            # +response.status+ so a 3xx/non-2xx fault is classified by status for
+            # every client shape and supported Faraday version, never buffered into
+            # a size-cap error the caller must then untangle.
+            #
+            # Known residual: Faraday exposes no headers-time callback, so a response
+            # whose headers arrive but whose body then stalls PAST the read timeout
+            # never returns from +client.post+ — it surfaces as a bounded transport
+            # timeout (request path: :transport; poll path: backoff, capped by code
+            # expiry) rather than this status-first classification. That degradation
+            # is bounded and redirect-safe (3xx Locations are never followed); exact
+            # headers-first semantics for it belong to the transport primitive shared
+            # with discovery, tracked as a pre-go-live hardening follow-up.
+            return [ response.status, "" ] if skip_status && skip_status.call(response.status)
 
             body =
               if chunks.empty?
@@ -441,7 +482,9 @@ module Basecamp
               user_code: user_code,
               verification_uri: verification_uri,
               verification_uri_complete: complete,
-              expires_in: expires_in,
+              # Coerce an integer-valued Float (900.0) to Integer so the model always
+              # carries whole seconds, matching +build_token+ and the other SDKs.
+              expires_in: expires_in.to_i,
               interval: resolve_interval(data["interval"], status)
             )
           end
@@ -453,7 +496,8 @@ module Basecamp
             if raw.nil?
               DEFAULT_INTERVAL_SECONDS
             elsif positive_integer_seconds?(raw)
-              raw
+              # Coerce an integer-valued Float (5.0) to Integer for whole-second parity.
+              raw.to_i
             else
               raise OauthError.new(
                 "api_error",

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -97,7 +97,12 @@ module Basecamp
           timeout = Fetcher.normalize_timeout(timeout, default: DEVICE_REQUEST_TIMEOUT)
           client = http_client || build_client(timeout)
           status, body = begin
-            post_form(client, device_authorization_endpoint, params, timeout: timeout, max_body_bytes: max_body_bytes)
+            post_form(
+              client, device_authorization_endpoint, params,
+              timeout: timeout, max_body_bytes: max_body_bytes,
+              # A non-2xx device-auth response is a hard failure whose body is unused.
+              skip_status: ->(s) { !(200..299).cover?(s) }
+            )
           rescue Faraday::Error => e
             raise DeviceFlowError.new(:transport, "Device authorization request failed: #{e.message}")
           end
@@ -321,14 +326,15 @@ module Basecamp
           # so a stalled socket can't hang the poll. A real adapter streams to
           # +on_data+ (leaving +response.body+ empty); a test double that ignores
           # the block falls back to the buffered body, still size-capped.
-          def post_form(client, url, params, timeout:, max_body_bytes:)
+          def post_form(client, url, params, timeout:, max_body_bytes:, skip_status: nil)
             # +timeout+ is already normalized by the caller (request/poll entry). The
             # wall-clock deadline bounds the WHOLE read: req.options.timeout below
             # bounds only each socket read and resets on every on_data chunk, so a
             # slow-drip peer could otherwise hang a device request past the timeout /
-            # code expiry while staying under the cap.
+            # code expiry while staying under the cap. +skip_status+ stops the read
+            # for a status whose body the caller doesn't use (non-2xx / 3xx).
             deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
-            chunks, on_data = Fetcher.bounded_reader(max_body_bytes, deadline: deadline)
+            chunks, on_data = Fetcher.bounded_reader(max_body_bytes, deadline: deadline, skip_status: skip_status)
             response = client.post(url) do |req|
               req.headers["Content-Type"] = "application/x-www-form-urlencoded"
               req.headers["Accept"] = "application/json"
@@ -349,6 +355,10 @@ module Basecamp
               end
 
             [ response.status, body.dup.force_encoding(Encoding::UTF_8) ]
+          rescue Fetcher::SkipBody => e
+            # The body was intentionally not drained (its status is unused) — return
+            # it empty and let the caller classify by status.
+            [ e.status, "" ]
           rescue Fetcher::BodyTooLarge
             raise OauthError.new("api_error", "Device flow response exceeds size cap")
           rescue Fetcher::ReadDeadlineExceeded
@@ -465,7 +475,13 @@ module Basecamp
           # when the server reports an OAuth error. Raises +api_error+ on a
           # malformed, redirecting, or 2xx-but-tokenless response.
           def post_device_token(client, token_endpoint, params, timeout:, max_body_bytes:)
-            status, body = post_form(client, token_endpoint, params, timeout: timeout, max_body_bytes: max_body_bytes)
+            status, body = post_form(
+              client, token_endpoint, params,
+              timeout: timeout, max_body_bytes: max_body_bytes,
+              # A 3xx token response is a redirect fault whose body is unused; a 4xx
+              # body IS read (it carries authorization_pending/slow_down).
+              skip_status: ->(s) { (300..399).cover?(s) }
+            )
 
             # A redirect is never a valid token-endpoint outcome: it is not
             # followed (redirect-following clients are rejected up front), and

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -287,14 +287,6 @@ module Basecamp
             end
           end
 
-          # POSTs a form body and reads the response under the same bounded/
-          # streaming cap as discovery (SPEC.md §9): the +on_data+ proc aborts the
-          # read the moment the accumulated size exceeds the cap, so an oversized
-          # response is never fully buffered. Returns +[status, body]+. The
-          # per-request timeout is always set here — even on an injected client —
-          # so a stalled socket can't hang the poll. A real adapter streams to
-          # +on_data+ (leaving +response.body+ empty); a test double that ignores
-          # the block falls back to the buffered body, still size-capped.
           # Waits +seconds+ while observing cancellation DURING the wait. A plain
           # +sleep+ is not interruptible, so a cancellation set mid-wait would not be
           # noticed until the whole (possibly grown +slow_down+) interval elapses.
@@ -317,6 +309,14 @@ module Basecamp
             end
           end
 
+          # POSTs a form body and reads the response under the same bounded/
+          # streaming cap as discovery (SPEC.md §9): the +on_data+ proc aborts the
+          # read the moment the accumulated size exceeds the cap, so an oversized
+          # response is never fully buffered. Returns +[status, body]+. The
+          # per-request timeout is always set here — even on an injected client —
+          # so a stalled socket can't hang the poll. A real adapter streams to
+          # +on_data+ (leaving +response.body+ empty); a test double that ignores
+          # the block falls back to the buffered body, still size-capped.
           def post_form(client, url, params, timeout:, max_body_bytes:)
             # +timeout+ is already normalized by the caller (request/poll entry). The
             # wall-clock deadline bounds the WHOLE read: req.options.timeout below

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -24,6 +24,11 @@ module Basecamp
       # +slow_down+ bumps the interval by this many seconds, sustained (§3.5).
       SLOW_DOWN_INCREMENT_SECONDS = 5
 
+      # Default per-request timeout for every device-flow HTTP round-trip. Also the
+      # fallback Fetcher.normalize_timeout uses for an invalid device timeout, so an
+      # invalid value can't silently borrow discovery's shorter budget.
+      DEVICE_REQUEST_TIMEOUT = 30
+
       # Cap on exponential backoff after connection timeouts.
       MAX_BACKOFF_SECONDS = 60
 
@@ -70,7 +75,7 @@ module Basecamp
         # @raise [DeviceFlowError] +:transport+ on a network failure
         def request_device_authorization(
           device_authorization_endpoint:, client_id:, scope: nil,
-          http_client: nil, timeout: 30, max_body_bytes: Fetcher::DEFAULT_MAX_BODY_BYTES
+          http_client: nil, timeout: DEVICE_REQUEST_TIMEOUT, max_body_bytes: Fetcher::DEFAULT_MAX_BODY_BYTES
         )
           Basecamp::Security.require_https_unless_localhost!(device_authorization_endpoint, "device authorization endpoint")
           raise OauthError.new("validation", "Client ID is required for device authorization") if client_id.to_s.empty?
@@ -123,7 +128,7 @@ module Basecamp
         def poll_device_token(
           token_endpoint:, client_id:, device_code:, interval:, expires_in:,
           clock: DEFAULT_CLOCK, sleeper: DEFAULT_SLEEPER, cancelled: DEFAULT_CANCELLED,
-          http_client: nil, timeout: 30, max_body_bytes: Fetcher::DEFAULT_MAX_BODY_BYTES
+          http_client: nil, timeout: DEVICE_REQUEST_TIMEOUT, max_body_bytes: Fetcher::DEFAULT_MAX_BODY_BYTES
         )
           Basecamp::Security.require_https_unless_localhost!(token_endpoint, "token endpoint")
           Fetcher.ensure_redirects_suppressed!(http_client) if http_client
@@ -215,7 +220,7 @@ module Basecamp
         def perform_device_login(
           config:, client_id:, display:, scope: nil,
           clock: DEFAULT_CLOCK, sleeper: DEFAULT_SLEEPER, cancelled: DEFAULT_CANCELLED,
-          http_client: nil, timeout: 30, max_body_bytes: Fetcher::DEFAULT_MAX_BODY_BYTES
+          http_client: nil, timeout: DEVICE_REQUEST_TIMEOUT, max_body_bytes: Fetcher::DEFAULT_MAX_BODY_BYTES
         )
           unless device_grant_available?(config)
             raise DeviceFlowError.new(
@@ -281,11 +286,14 @@ module Basecamp
           # +on_data+ (leaving +response.body+ empty); a test double that ignores
           # the block falls back to the buffered body, still size-capped.
           def post_form(client, url, params, timeout:, max_body_bytes:)
-            # Wall-clock deadline over the WHOLE read, exactly as Fetcher.fetch_json:
-            # req.options.timeout below bounds only each socket read and resets on
-            # every on_data chunk, so a slow-drip peer could otherwise hang a device
-            # request long past the timeout / code expiry while staying under the cap.
-            deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + Fetcher.normalize_timeout(timeout)
+            # Normalize ONCE and reuse for BOTH the wall-clock deadline and the
+            # Faraday socket timeout: req.options.timeout bounds only each socket
+            # read and resets on every on_data chunk, so a slow-drip peer could
+            # otherwise hang a device request past the timeout / code expiry while
+            # staying under the cap. Falling back to the device budget (not
+            # discovery's) keeps an invalid input from silently shrinking it.
+            timeout = Fetcher.normalize_timeout(timeout, default: DEVICE_REQUEST_TIMEOUT)
+            deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
             chunks, on_data = Fetcher.bounded_reader(max_body_bytes, deadline: deadline)
             response = client.post(url) do |req|
               req.headers["Content-Type"] = "application/x-www-form-urlencoded"

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -29,6 +29,9 @@ module Basecamp
       # invalid value can't silently borrow discovery's shorter budget.
       DEVICE_REQUEST_TIMEOUT = 30
 
+      # Granularity (seconds) for polling the +cancelled+ probe while waiting.
+      CANCEL_POLL_INTERVAL_SECONDS = 0.1
+
       # Cap on exponential backoff after connection timeouts.
       MAX_BACKOFF_SECONDS = 60
 
@@ -164,7 +167,7 @@ module Basecamp
             now = clock.call
             raise DeviceFlowError.new(:expired, "Device code expired before authorization completed") if now >= deadline
 
-            sleeper.call([ [ interval_seconds, backoff_seconds ].max, deadline - now ].min)
+            wait_cancellable([ [ interval_seconds, backoff_seconds ].max, deadline - now ].min, cancelled, sleeper)
 
             raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
             raise DeviceFlowError.new(:expired, "Device code expired before authorization completed") if clock.call >= deadline
@@ -292,6 +295,28 @@ module Basecamp
           # so a stalled socket can't hang the poll. A real adapter streams to
           # +on_data+ (leaving +response.body+ empty); a test double that ignores
           # the block falls back to the buffered body, still size-capped.
+          # Waits +seconds+ while observing cancellation DURING the wait. A plain
+          # +sleep+ is not interruptible, so a cancellation set mid-wait would not be
+          # noticed until the whole (possibly grown +slow_down+) interval elapses.
+          # With the default no-op probe a single sleep preserves the exact wait
+          # schedule; only a real probe needs the finer-grained interrupt polling —
+          # matching the ctx/AbortSignal/coroutine cancellation Go/TS/Kotlin waits have.
+          def wait_cancellable(seconds, cancelled, sleeper)
+            if cancelled.equal?(DEFAULT_CANCELLED)
+              sleeper.call(seconds)
+              return
+            end
+
+            remaining = seconds
+            while remaining.positive?
+              raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
+
+              step = [ remaining, CANCEL_POLL_INTERVAL_SECONDS ].min
+              sleeper.call(step)
+              remaining -= step
+            end
+          end
+
           def post_form(client, url, params, timeout:, max_body_bytes:)
             # +timeout+ is already normalized by the caller (request/poll entry). The
             # wall-clock deadline bounds the WHOLE read: req.options.timeout below

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -106,7 +106,9 @@ module Basecamp
         # @param client_id [String] the public client id
         # @param device_code [String] the device code from {request_device_authorization}
         # @param interval [Integer] polling interval in seconds
-        # @param expires_in [Integer] code lifetime in seconds (monotonic deadline)
+        # @param expires_in [Numeric] code lifetime in seconds until the monotonic
+        #   deadline; may be fractional (perform_device_login passes the remaining
+        #   lifetime after deducting display-hook time)
         # @param clock [#call] monotonic clock returning seconds
         # @param sleeper [#call] receives the wait in seconds
         # @param cancelled [#call] cancellation probe; a truthy result ends the flow

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -135,11 +135,14 @@ module Basecamp
             # Check the monotonic deadline BEFORE waiting, then clamp the wait so a
             # long interval or timeout backoff can never overshoot expiry. The
             # per-request timeout (set on every request in +post_form+) bounds a
-            # stalled socket, so nothing here blows past the deadline.
+            # stalled socket, so nothing here blows past the deadline. The wait is
+            # the LARGER of the server-driven interval and the transient timeout
+            # backoff — the two schedules stay separate so a backoff can drain
+            # back down to the server interval once round-trips resume.
             now = clock.call
             raise DeviceFlowError.new(:expired, "Device code expired before authorization completed") if now >= deadline
 
-            sleeper.call([ interval_seconds, deadline - now ].min)
+            sleeper.call([ [ interval_seconds, backoff_seconds ].max, deadline - now ].min)
 
             raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
             raise DeviceFlowError.new(:expired, "Device code expired before authorization completed") if clock.call >= deadline
@@ -148,16 +151,18 @@ module Basecamp
               post_device_token(client, token_endpoint, params, timeout: timeout, max_body_bytes: max_body_bytes)
             rescue Faraday::TimeoutError
               # A connection timeout is transient: back off exponentially and
-              # keep polling rather than ending the flow. The next wait is still
-              # clamped to the deadline at the top of the loop.
+              # keep polling rather than ending the flow. Only the backoff grows —
+              # the server-driven interval is left untouched so it can govern
+              # again once a round-trip completes. The next wait is still clamped
+              # to the deadline at the top of the loop.
               backoff_seconds = [ backoff_seconds * 2, MAX_BACKOFF_SECONDS ].min
-              interval_seconds = [ interval_seconds, backoff_seconds ].max
               next
             rescue Faraday::Error => e
               raise DeviceFlowError.new(:transport, "Device token poll failed: #{e.message}")
             end
 
-            # A successful HTTP round-trip resets the timeout backoff.
+            # ANY completed HTTP round-trip resets the timeout backoff to the
+            # current server-driven interval.
             backoff_seconds = interval_seconds
 
             kind, value, status = outcome
@@ -382,9 +387,22 @@ module Basecamp
 
           # Returns +[:token, Token, status]+ on success or +[:error, code, status]+
           # when the server reports an OAuth error. Raises +api_error+ on a
-          # malformed or 2xx-but-tokenless response.
+          # malformed, redirecting, or 2xx-but-tokenless response.
           def post_device_token(client, token_endpoint, params, timeout:, max_body_bytes:)
             status, body = post_form(client, token_endpoint, params, timeout: timeout, max_body_bytes: max_body_bytes)
+
+            # A redirect is never a valid token-endpoint outcome: it is not
+            # followed (redirect-following clients are rejected up front), and
+            # its body must not be classified as an OAuth error — a 3xx carrying
+            # {"error":"authorization_pending"} would otherwise poll forever.
+            if (300..399).cover?(status)
+              raise OauthError.new(
+                "api_error",
+                "Device token request failed: unexpected redirect (status #{status})",
+                http_status: status
+              )
+            end
+
             data = parse_json_object(body, status, "device token")
 
             if (200..299).cover?(status)
@@ -394,19 +412,32 @@ module Basecamp
                 raise OauthError.new("api_error", "Device token response missing access_token", http_status: status)
               end
 
-              [ :token, build_token(data), status ]
+              [ :token, build_token(data, status), status ]
             else
               error = data["error"]
               [ :error, error.is_a?(String) && !error.empty? ? error : "http_#{status}", status ]
             end
           end
 
-          def build_token(data)
+          # Constructs the {Token}, validating +expires_in+ first: when present
+          # it must be a positive Numeric — {Token#initialize} performs +Time+
+          # arithmetic on it, so an unchecked string would escape as a TypeError
+          # instead of +api_error+. Absent/nil stays allowed (no expiry).
+          def build_token(data, status)
+            expires_in = data["expires_in"]
+            unless expires_in.nil? || (expires_in.is_a?(Numeric) && expires_in.positive?)
+              raise OauthError.new(
+                "api_error",
+                "Invalid device token response: expires_in must be a positive number",
+                http_status: status
+              )
+            end
+
             Token.new(
               access_token: data["access_token"],
               refresh_token: data["refresh_token"],
               token_type: data["token_type"] || "Bearer",
-              expires_in: data["expires_in"],
+              expires_in: expires_in,
               scope: data["scope"]
             )
           end

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -439,7 +439,7 @@ module Basecamp
             unless valid_token_expires_in?(expires_in)
               raise OauthError.new(
                 "api_error",
-                "Invalid device token response: expires_in must be a finite positive number " \
+                "Invalid device token response: expires_in must be a finite positive whole number " \
                   "no greater than #{MAX_TOKEN_LIFETIME_SECONDS} seconds",
                 http_status: status
               )
@@ -481,14 +481,18 @@ module Basecamp
             )
           end
 
-          # A token +expires_in+ is valid when absent/nil or a finite positive
-          # Numeric within {MAX_TOKEN_LIFETIME_SECONDS}. +Float::INFINITY+ (from a
-          # JSON +1e400+) is Numeric and positive but not finite, so +finite?+
-          # rejects it before it can poison the deadline arithmetic.
+          # A token +expires_in+ is valid when absent/nil or a finite, positive,
+          # WHOLE-second Numeric within {MAX_TOKEN_LIFETIME_SECONDS}. An
+          # integer-valued float (+3600.0+) is accepted; a fractional value
+          # (+1.5+) is rejected — matching the device-duration rule and Go/Kotlin,
+          # whose integer/Long typing already rejects a fractional lifetime.
+          # +Float::INFINITY+ (from a JSON +1e400+) is Numeric and positive but not
+          # finite, so +finite?+ rejects it before it can poison deadline math.
           def valid_token_expires_in?(value)
             return true if value.nil?
 
-            value.is_a?(Numeric) && value.finite? && value.positive? && value <= MAX_TOKEN_LIFETIME_SECONDS
+            value.is_a?(Numeric) && value.finite? && value.positive? &&
+              value <= MAX_TOKEN_LIFETIME_SECONDS && (value % 1).zero?
           end
       end
     end

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -33,6 +33,14 @@ module Basecamp
       # value such as 1e100 is a malformed response, not a schedulable deadline.
       MAX_DEVICE_SECONDS = 2_147_483
 
+      # Ceiling for an OAuth token's +expires_in+ (2_147_483_647 s ~= 68 years):
+      # cross-runtime safe and vastly beyond any realistic token lifetime.
+      # Unlike +MAX_DEVICE_SECONDS+ this bounds +Time+ arithmetic rather than a
+      # timer, so a non-finite value (+1e400+ parses to +Float::INFINITY+, which
+      # would raise a raw +FloatDomainError+) or an absurd one is a malformed
+      # response — never a schedulable deadline. Shared across all five SDKs.
+      MAX_TOKEN_LIFETIME_SECONDS = 2_147_483_647
+
       # Monotonic clock (seconds). Injectable so tests can advance time.
       DEFAULT_CLOCK = -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) }
 
@@ -419,27 +427,68 @@ module Basecamp
             end
           end
 
-          # Constructs the {Token}, validating +expires_in+ first: when present
-          # it must be a positive Numeric — {Token#initialize} performs +Time+
-          # arithmetic on it, so an unchecked string would escape as a TypeError
-          # instead of +api_error+. Absent/nil stays allowed (no expiry).
+          # Constructs the {Token}, type-checking every optional field first:
+          # {Token#initialize} performs +Time+ arithmetic on +expires_in+, so a
+          # malformed value (a String, a non-finite +Float::INFINITY+ from
+          # +1e400+, a value past {MAX_TOKEN_LIFETIME_SECONDS}) must surface as
+          # +api_error+ rather than escape as a TypeError or FloatDomainError.
+          # +token_type+/+refresh_token+/+scope+ must be Strings when present.
+          # Absent/nil +expires_in+ stays allowed (no expiry).
           def build_token(data, status)
             expires_in = data["expires_in"]
-            unless expires_in.nil? || (expires_in.is_a?(Numeric) && expires_in.positive?)
+            unless valid_token_expires_in?(expires_in)
               raise OauthError.new(
                 "api_error",
-                "Invalid device token response: expires_in must be a positive number",
+                "Invalid device token response: expires_in must be a finite positive number " \
+                  "no greater than #{MAX_TOKEN_LIFETIME_SECONDS} seconds",
+                http_status: status
+              )
+            end
+
+            token_type = data["token_type"]
+            unless token_type.nil? || (token_type.is_a?(String) && !token_type.empty?)
+              raise OauthError.new(
+                "api_error",
+                "Invalid device token response: token_type must be a non-empty string",
+                http_status: status
+              )
+            end
+
+            refresh_token = data["refresh_token"]
+            unless refresh_token.nil? || refresh_token.is_a?(String)
+              raise OauthError.new(
+                "api_error",
+                "Invalid device token response: refresh_token must be a string",
+                http_status: status
+              )
+            end
+
+            scope = data["scope"]
+            unless scope.nil? || scope.is_a?(String)
+              raise OauthError.new(
+                "api_error",
+                "Invalid device token response: scope must be a string",
                 http_status: status
               )
             end
 
             Token.new(
               access_token: data["access_token"],
-              refresh_token: data["refresh_token"],
-              token_type: data["token_type"] || "Bearer",
+              refresh_token: refresh_token,
+              token_type: token_type || "Bearer",
               expires_in: expires_in,
-              scope: data["scope"]
+              scope: scope
             )
+          end
+
+          # A token +expires_in+ is valid when absent/nil or a finite positive
+          # Numeric within {MAX_TOKEN_LIFETIME_SECONDS}. +Float::INFINITY+ (from a
+          # JSON +1e400+) is Numeric and positive but not finite, so +finite?+
+          # rejects it before it can poison the deadline arithmetic.
+          def valid_token_expires_in?(value)
+            return true if value.nil?
+
+            value.is_a?(Numeric) && value.finite? && value.positive? && value <= MAX_TOKEN_LIFETIME_SECONDS
           end
       end
     end

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -94,7 +94,10 @@ module Basecamp
           # Normalize ONCE at operation entry and thread the SAME value to both the
           # client construction and the request, so a non-finite/non-positive input
           # cannot leave the socket timeout unbounded on the default-built client.
+          # The body cap gets the same discipline: an invalid value (nil, Infinity,
+          # negative) would disable the streaming memory bound entirely.
           timeout = Fetcher.normalize_timeout(timeout, default: DEVICE_REQUEST_TIMEOUT)
+          max_body_bytes = Fetcher.normalize_body_cap(max_body_bytes)
           client = http_client || build_client(timeout)
           status, body = begin
             post_form(
@@ -169,8 +172,10 @@ module Basecamp
           deadline = clock.call + expires_in
 
           # Normalize ONCE, outside the polling loop, and reuse for the client and
-          # every per-poll request (see request_device_authorization).
+          # every per-poll request (see request_device_authorization). The body cap
+          # gets the same discipline — an invalid value would disable the bound.
           timeout = Fetcher.normalize_timeout(timeout, default: DEVICE_REQUEST_TIMEOUT)
+          max_body_bytes = Fetcher.normalize_body_cap(max_body_bytes)
           client = http_client || build_client(timeout)
           params = {
             "grant_type" => DEVICE_CODE_GRANT_TYPE,

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -281,7 +281,12 @@ module Basecamp
           # +on_data+ (leaving +response.body+ empty); a test double that ignores
           # the block falls back to the buffered body, still size-capped.
           def post_form(client, url, params, timeout:, max_body_bytes:)
-            chunks, on_data = Fetcher.bounded_reader(max_body_bytes)
+            # Wall-clock deadline over the WHOLE read, exactly as Fetcher.fetch_json:
+            # req.options.timeout below bounds only each socket read and resets on
+            # every on_data chunk, so a slow-drip peer could otherwise hang a device
+            # request long past the timeout / code expiry while staying under the cap.
+            deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + Fetcher.normalize_timeout(timeout)
+            chunks, on_data = Fetcher.bounded_reader(max_body_bytes, deadline: deadline)
             response = client.post(url) do |req|
               req.headers["Content-Type"] = "application/x-www-form-urlencoded"
               req.headers["Accept"] = "application/json"
@@ -304,6 +309,11 @@ module Basecamp
             [ response.status, body.dup.force_encoding(Encoding::UTF_8) ]
           rescue Fetcher::BodyTooLarge
             raise OauthError.new("api_error", "Device flow response exceeds size cap")
+          rescue Fetcher::ReadDeadlineExceeded
+            # Surface as a Faraday timeout so the caller's existing transport/timeout
+            # rescues classify it (request → :transport, poll → backoff) — a slow-drip
+            # read is a transport timeout, not an api_error.
+            raise Faraday::TimeoutError, "Device flow read exceeded the timeout deadline"
           end
 
           def parse_device_authorization(status, body)

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -1,0 +1,416 @@
+# frozen_string_literal: true
+
+require "faraday"
+require "json"
+require "uri"
+
+module Basecamp
+  module Oauth
+    # RFC 8628 device authorization grant — request, poll, and orchestrate.
+    #
+    # {request_device_authorization} obtains a device/user code pair;
+    # {poll_device_token} runs the §3.5 polling loop against the token endpoint;
+    # {perform_device_login} guards capability on an already-selected {Config},
+    # surfaces the code through a display hook, and polls. All device-auth and
+    # token requests are TLS-guarded (SPEC.md §9). The polling clock and sleeper
+    # are injectable so tests run without real delays.
+    module DeviceFlow
+      # URN grant type for the device authorization grant.
+      DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+
+      # Default polling interval when the server omits +interval+ (RFC 8628 §3.2).
+      DEFAULT_INTERVAL_SECONDS = 5
+
+      # +slow_down+ bumps the interval by this many seconds, sustained (§3.5).
+      SLOW_DOWN_INCREMENT_SECONDS = 5
+
+      # Cap on exponential backoff after connection timeouts.
+      MAX_BACKOFF_SECONDS = 60
+
+      # Ceiling for +expires_in+/+interval+: 2147483 s (~24.8 days) is the
+      # largest whole-second duration whose millisecond form fits a 32-bit
+      # signed timer. Shared across all five SDKs (SPEC.md) — an unbounded
+      # value such as 1e100 is a malformed response, not a schedulable deadline.
+      MAX_DEVICE_SECONDS = 2_147_483
+
+      # Monotonic clock (seconds). Injectable so tests can advance time.
+      DEFAULT_CLOCK = -> { Process.clock_gettime(Process::CLOCK_MONOTONIC) }
+
+      # Real sleeper (seconds). Injectable so tests assert the wait schedule.
+      DEFAULT_SLEEPER = ->(seconds) { sleep(seconds) }
+
+      # Cooperative cancellation probe. Injectable; default never cancels.
+      DEFAULT_CANCELLED = -> { false }
+
+      class << self
+        # Requests a device/user code pair (RFC 8628 §3.1–3.2).
+        #
+        # POSTs +client_id+ and, only when set, +scope+ (an omitted scope lets the
+        # server apply its default, +read+). Validates that the codes are present,
+        # +expires_in+ is positive, and +interval+ (default 5) is positive.
+        #
+        # @param device_authorization_endpoint [String] the endpoint from discovery
+        # @param client_id [String] the public client id (e.g. +basecamp-cli+)
+        # @param scope [String, nil] requested scope; omitted from the request when nil
+        # @param http_client [Faraday::Connection, nil] HTTP client (default if nil)
+        # @param timeout [Integer] request timeout in seconds
+        # @param max_body_bytes [Integer] bounded read cap in bytes
+        # @return [DeviceAuthorization]
+        # @raise [OauthError] +validation+ on a missing client id or a redirect-
+        #   following injected client; +api_error+ on a non-2xx response, oversized
+        #   body, or invalid metadata
+        # @raise [DeviceFlowError] +:transport+ on a network failure
+        def request_device_authorization(
+          device_authorization_endpoint:, client_id:, scope: nil,
+          http_client: nil, timeout: 30, max_body_bytes: Fetcher::DEFAULT_MAX_BODY_BYTES
+        )
+          Basecamp::Security.require_https_unless_localhost!(device_authorization_endpoint, "device authorization endpoint")
+          raise OauthError.new("validation", "Client ID is required for device authorization") if client_id.to_s.empty?
+          # SSRF: an injected client must not chase an attacker-controlled Location,
+          # exactly as the discovery hops require (SPEC.md §16).
+          Fetcher.ensure_redirects_suppressed!(http_client) if http_client
+
+          params = { "client_id" => client_id }
+          # Omit scope entirely when unset OR blank so the server applies its
+          # default (read) — Ruby treats "" as truthy, so guard on emptiness too.
+          params["scope"] = scope unless scope.nil? || scope.empty?
+
+          client = http_client || build_client(timeout)
+          status, body = begin
+            post_form(client, device_authorization_endpoint, params, timeout: timeout, max_body_bytes: max_body_bytes)
+          rescue Faraday::Error => e
+            raise DeviceFlowError.new(:transport, "Device authorization request failed: #{e.message}")
+          end
+
+          parse_device_authorization(status, body)
+        end
+
+        # Polls the token endpoint until the user approves, denies, or the codes
+        # expire (RFC 8628 §3.4–3.5).
+        #
+        # Waits at least +interval+ seconds between polls against a MONOTONIC
+        # deadline. Handles +authorization_pending+ (keep polling), sustained
+        # +slow_down+ (+5s for this and every later poll), +access_denied+ and
+        # +expired_token+ (terminal), connection timeouts (exponential backoff),
+        # and cooperative cancellation.
+        #
+        # @param token_endpoint [String] the token endpoint from discovery
+        # @param client_id [String] the public client id
+        # @param device_code [String] the device code from {request_device_authorization}
+        # @param interval [Integer] polling interval in seconds
+        # @param expires_in [Integer] code lifetime in seconds (monotonic deadline)
+        # @param clock [#call] monotonic clock returning seconds
+        # @param sleeper [#call] receives the wait in seconds
+        # @param cancelled [#call] cancellation probe; a truthy result ends the flow
+        # @param http_client [Faraday::Connection, nil] HTTP client (default if nil)
+        # @param timeout [Integer] per-request timeout in seconds
+        # @param max_body_bytes [Integer] bounded read cap in bytes
+        # @return [Token]
+        # @raise [DeviceFlowError] +:access_denied+, +:expired+, +:transport+, or
+        #   +:cancelled+
+        # @raise [OauthError] +api_error+ on an unrecognized token error, oversized
+        #   body, or +validation+ on a redirect-following injected client
+        def poll_device_token(
+          token_endpoint:, client_id:, device_code:, interval:, expires_in:,
+          clock: DEFAULT_CLOCK, sleeper: DEFAULT_SLEEPER, cancelled: DEFAULT_CANCELLED,
+          http_client: nil, timeout: 30, max_body_bytes: Fetcher::DEFAULT_MAX_BODY_BYTES
+        )
+          Basecamp::Security.require_https_unless_localhost!(token_endpoint, "token endpoint")
+          Fetcher.ensure_redirects_suppressed!(http_client) if http_client
+
+          interval_seconds = interval.positive? ? interval : DEFAULT_INTERVAL_SECONDS
+          backoff_seconds = interval_seconds
+          deadline = clock.call + expires_in
+
+          client = http_client || build_client(timeout)
+          params = {
+            "grant_type" => DEVICE_CODE_GRANT_TYPE,
+            "device_code" => device_code,
+            "client_id" => client_id
+          }
+
+          loop do
+            raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
+
+            # Check the monotonic deadline BEFORE waiting, then clamp the wait so a
+            # long interval or timeout backoff can never overshoot expiry. The
+            # per-request timeout (set on every request in +post_form+) bounds a
+            # stalled socket, so nothing here blows past the deadline.
+            now = clock.call
+            raise DeviceFlowError.new(:expired, "Device code expired before authorization completed") if now >= deadline
+
+            sleeper.call([ interval_seconds, deadline - now ].min)
+
+            raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
+            raise DeviceFlowError.new(:expired, "Device code expired before authorization completed") if clock.call >= deadline
+
+            outcome = begin
+              post_device_token(client, token_endpoint, params, timeout: timeout, max_body_bytes: max_body_bytes)
+            rescue Faraday::TimeoutError
+              # A connection timeout is transient: back off exponentially and
+              # keep polling rather than ending the flow. The next wait is still
+              # clamped to the deadline at the top of the loop.
+              backoff_seconds = [ backoff_seconds * 2, MAX_BACKOFF_SECONDS ].min
+              interval_seconds = [ interval_seconds, backoff_seconds ].max
+              next
+            rescue Faraday::Error => e
+              raise DeviceFlowError.new(:transport, "Device token poll failed: #{e.message}")
+            end
+
+            # A successful HTTP round-trip resets the timeout backoff.
+            backoff_seconds = interval_seconds
+
+            kind, value, status = outcome
+            return value if kind == :token
+
+            case value
+            when "authorization_pending"
+              next
+            when "slow_down"
+              interval_seconds += SLOW_DOWN_INCREMENT_SECONDS
+            when "access_denied"
+              raise DeviceFlowError.new(:access_denied, "The authorization request was denied")
+            when "expired_token"
+              raise DeviceFlowError.new(:expired, "Device code expired before authorization completed")
+            else
+              raise OauthError.new("api_error", "Device token request failed: #{value}", http_status: status)
+            end
+          end
+        end
+
+        # Runs the full device authorization grant against an already-selected
+        # {Config} (RFC 8628; SPEC.md §16).
+        #
+        # The capability guard requires BOTH +device_authorization_endpoint+ AND
+        # the device_code grant in +grant_types_supported+; otherwise it raises
+        # +:unavailable+ before any request is issued.
+        #
+        # @param config [Config] the already-selected authorization-server config
+        # @param client_id [String] the public client id
+        # @param display [#call] receives the {DeviceAuthorization} once, before polling
+        # @param scope [String, nil] requested scope; omitted when nil
+        # @param clock [#call] monotonic clock returning seconds
+        # @param sleeper [#call] receives the wait in seconds
+        # @param cancelled [#call] cancellation probe
+        # @param http_client [Faraday::Connection, nil] HTTP client (default if nil)
+        # @param timeout [Integer] request timeout in seconds
+        # @return [Token]
+        # @raise [DeviceFlowError] +:unavailable+ when the config cannot do device
+        #   flow; other reasons on denial/expiry/transport/cancellation
+        def perform_device_login(
+          config:, client_id:, display:, scope: nil,
+          clock: DEFAULT_CLOCK, sleeper: DEFAULT_SLEEPER, cancelled: DEFAULT_CANCELLED,
+          http_client: nil, timeout: 30, max_body_bytes: Fetcher::DEFAULT_MAX_BODY_BYTES
+        )
+          unless device_grant_available?(config)
+            raise DeviceFlowError.new(
+              :unavailable,
+              "The selected authorization server does not support the device authorization grant"
+            )
+          end
+
+          auth = request_device_authorization(
+            device_authorization_endpoint: config.device_authorization_endpoint,
+            client_id: client_id, scope: scope,
+            http_client: http_client, timeout: timeout, max_body_bytes: max_body_bytes
+          )
+
+          # The code's lifetime starts at ISSUANCE, not after display: a slow
+          # display hook must eat into the deadline, never reset it. Anchor the
+          # issuance instant on the monotonic clock, run the hook, then poll with
+          # only the REMAINING lifetime. If the hook consumed the whole budget,
+          # raise +expired+ without a single poll.
+          issued_at = clock.call
+          display.call(auth)
+          remaining = auth.expires_in - (clock.call - issued_at)
+          if remaining <= 0
+            raise DeviceFlowError.new(:expired, "Device code expired before authorization completed")
+          end
+
+          poll_device_token(
+            token_endpoint: config.token_endpoint,
+            client_id: client_id, device_code: auth.device_code,
+            interval: auth.interval, expires_in: remaining,
+            clock: clock, sleeper: sleeper, cancelled: cancelled,
+            http_client: http_client, timeout: timeout, max_body_bytes: max_body_bytes
+          )
+        end
+
+        private
+
+          # Capability guard: BOTH a present endpoint AND the advertised grant
+          # type. +grant_types_supported+ must be an Array checked for exact
+          # membership — a String (or a superstring containing the grant URN)
+          # must never satisfy the guard via +String#include?+ substring matching.
+          # A blank endpoint is treated as absent.
+          def device_grant_available?(config)
+            has_endpoint = !config.device_authorization_endpoint.to_s.strip.empty?
+            grants = config.grant_types_supported
+            has_endpoint && grants.is_a?(Array) && grants.include?(DEVICE_CODE_GRANT_TYPE)
+          end
+
+          def build_client(timeout)
+            Faraday.new do |conn|
+              conn.options.timeout = timeout
+              conn.options.open_timeout = timeout
+              conn.adapter Faraday.default_adapter
+            end
+          end
+
+          # POSTs a form body and reads the response under the same bounded/
+          # streaming cap as discovery (SPEC.md §9): the +on_data+ proc aborts the
+          # read the moment the accumulated size exceeds the cap, so an oversized
+          # response is never fully buffered. Returns +[status, body]+. The
+          # per-request timeout is always set here — even on an injected client —
+          # so a stalled socket can't hang the poll. A real adapter streams to
+          # +on_data+ (leaving +response.body+ empty); a test double that ignores
+          # the block falls back to the buffered body, still size-capped.
+          def post_form(client, url, params, timeout:, max_body_bytes:)
+            chunks, on_data = Fetcher.bounded_reader(max_body_bytes)
+            response = client.post(url) do |req|
+              req.headers["Content-Type"] = "application/x-www-form-urlencoded"
+              req.headers["Accept"] = "application/json"
+              req.body = URI.encode_www_form(params)
+              req.options.timeout = timeout
+              req.options.open_timeout = timeout
+              req.options.on_data = on_data
+            end
+
+            body =
+              if chunks.empty?
+                raw = response.body.to_s
+                raise Fetcher::BodyTooLarge if raw.bytesize > max_body_bytes
+
+                raw
+              else
+                chunks.join
+              end
+
+            [ response.status, body.dup.force_encoding(Encoding::UTF_8) ]
+          rescue Fetcher::BodyTooLarge
+            raise OauthError.new("api_error", "Device flow response exceeds size cap")
+          end
+
+          def parse_device_authorization(status, body)
+            data = parse_json_object(body, status, "device authorization")
+
+            unless (200..299).cover?(status)
+              raise OauthError.new(
+                "api_error",
+                "Device authorization failed with status #{status}",
+                http_status: status
+              )
+            end
+
+            build_device_authorization(data)
+          end
+
+          # Parse a JSON object, type-checking rather than trusting truthiness: a
+          # non-object body (array, number, string) is malformed and must not be
+          # indexed as if it were a Hash.
+          def parse_json_object(body, status, label)
+            data = JSON.parse(body)
+            unless data.is_a?(Hash)
+              raise OauthError.new("api_error", "Invalid #{label} response: not a JSON object", http_status: status)
+            end
+
+            data
+          rescue JSON::ParserError
+            raise OauthError.new("api_error", "Failed to parse #{label} response", http_status: status)
+          end
+
+          def build_device_authorization(data)
+            device_code = data["device_code"]
+            user_code = data["user_code"]
+            verification_uri = data["verification_uri"]
+            # Type-check the required strings — don't coerce via +.to_s+, which
+            # would silently accept a numeric or boolean field as a "present" code.
+            unless [ device_code, user_code, verification_uri ].all? { |field| field.is_a?(String) && !field.empty? }
+              raise OauthError.new("api_error", "Invalid device authorization response: missing or malformed required fields")
+            end
+
+            complete = data["verification_uri_complete"]
+            unless complete.nil? || complete.is_a?(String)
+              raise OauthError.new(
+                "api_error",
+                "Invalid device authorization response: verification_uri_complete must be a string"
+              )
+            end
+
+            expires_in = data["expires_in"]
+            unless positive_integer_seconds?(expires_in)
+              raise OauthError.new(
+                "api_error",
+                "Invalid device authorization response: expires_in must be a positive integer " \
+                "no greater than #{MAX_DEVICE_SECONDS}"
+              )
+            end
+
+            DeviceAuthorization.new(
+              device_code: device_code,
+              user_code: user_code,
+              verification_uri: verification_uri,
+              verification_uri_complete: complete,
+              expires_in: expires_in,
+              interval: resolve_interval(data["interval"])
+            )
+          end
+
+          # Default 5 when absent; any present value must be a positive integer
+          # number of seconds (RFC 8628). Integer-valued floats (5.0) are fine;
+          # fractional values (2.5) are malformed and rejected for cross-SDK parity.
+          def resolve_interval(raw)
+            if raw.nil?
+              DEFAULT_INTERVAL_SECONDS
+            elsif positive_integer_seconds?(raw)
+              raw
+            else
+              raise OauthError.new(
+                "api_error",
+                "Invalid device authorization response: interval must be a positive integer " \
+                "no greater than #{MAX_DEVICE_SECONDS}"
+              )
+            end
+          end
+
+          # RFC 8628 durations are integer seconds. Accept a positive Numeric with
+          # no fractional part (5 or 5.0) up to MAX_DEVICE_SECONDS; reject
+          # fractional (2.5), oversized (1e100), and non-numeric values.
+          def positive_integer_seconds?(value)
+            value.is_a?(Numeric) && value.positive? && value <= MAX_DEVICE_SECONDS && (value % 1).zero?
+          end
+
+          # Returns +[:token, Token, status]+ on success or +[:error, code, status]+
+          # when the server reports an OAuth error. Raises +api_error+ on a
+          # malformed or 2xx-but-tokenless response.
+          def post_device_token(client, token_endpoint, params, timeout:, max_body_bytes:)
+            status, body = post_form(client, token_endpoint, params, timeout: timeout, max_body_bytes: max_body_bytes)
+            data = parse_json_object(body, status, "device token")
+
+            if (200..299).cover?(status)
+              access_token = data["access_token"]
+              # Require a genuine non-empty String — not a truthy/coercible value.
+              unless access_token.is_a?(String) && !access_token.empty?
+                raise OauthError.new("api_error", "Device token response missing access_token", http_status: status)
+              end
+
+              [ :token, build_token(data), status ]
+            else
+              error = data["error"]
+              [ :error, error.is_a?(String) && !error.empty? ? error : "http_#{status}", status ]
+            end
+          end
+
+          def build_token(data)
+            Token.new(
+              access_token: data["access_token"],
+              refresh_token: data["refresh_token"],
+              token_type: data["token_type"] || "Bearer",
+              expires_in: data["expires_in"],
+              scope: data["scope"]
+            )
+          end
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -144,7 +144,8 @@ module Basecamp
         def poll_device_token(
           token_endpoint:, client_id:, device_code:, interval:, expires_in:,
           clock: DEFAULT_CLOCK, sleeper: DEFAULT_SLEEPER, cancelled: DEFAULT_CANCELLED,
-          http_client: nil, timeout: DEVICE_REQUEST_TIMEOUT, max_body_bytes: Fetcher::DEFAULT_MAX_BODY_BYTES
+          http_client: nil, timeout: DEVICE_REQUEST_TIMEOUT, max_body_bytes: Fetcher::DEFAULT_MAX_BODY_BYTES,
+          deadline_at: nil
         )
           Basecamp::Security.require_https_unless_localhost!(token_endpoint, "token endpoint")
           Fetcher.ensure_redirects_suppressed!(http_client) if http_client
@@ -169,7 +170,25 @@ module Basecamp
 
           interval_seconds = interval
           backoff_seconds = interval_seconds
-          deadline = clock.call + expires_in
+          # An absolute issuance-anchored deadline (perform_device_login
+          # passes issued_at + expires_in) beats re-anchoring: clock time
+          # elapsing between the caller's remaining-lifetime computation and
+          # this entry — a process suspension above all — must never be handed
+          # back to the code. It can only SHORTEN the validated lifetime.
+          deadline =
+            if deadline_at.nil?
+              clock.call + expires_in
+            else
+              unless deadline_at.is_a?(Numeric) && deadline_at.to_f.finite? \
+                  && deadline_at <= clock.call + expires_in
+                raise OauthError.new(
+                  "usage",
+                  "poll_device_token deadline_at must be a finite monotonic timestamp " \
+                  "no later than expires_in seconds from now"
+                )
+              end
+              deadline_at
+            end
 
           # Normalize ONCE, outside the polling loop, and reuse for the client and
           # every per-poll request (see request_device_authorization). The body cap
@@ -333,6 +352,10 @@ module Basecamp
             token_endpoint: config.token_endpoint,
             client_id: client_id, device_code: auth.device_code,
             interval: auth.interval, expires_in: remaining,
+            # The EXACT issuance-anchored deadline: a clock advance between
+            # the remaining computation above and the poller's entry must not
+            # extend the code lifetime.
+            deadline_at: issued_at + auth.expires_in,
             clock: clock, sleeper: sleeper, cancelled: cancelled,
             http_client: http_client, timeout: timeout, max_body_bytes: max_body_bytes
           )

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -284,6 +284,14 @@ module Basecamp
             )
           end
 
+          # A non-callable display is a usage error, not a late NoMethodError:
+          # it is the only mechanism surfacing the verification code, so
+          # dereferencing it AFTER the request would mint a code nobody can
+          # approve. Reject before any network activity (matching Go).
+          unless display.respond_to?(:call)
+            raise OauthError.new("usage", "perform_device_login requires a callable display hook")
+          end
+
           # Honor a cancellation raised BEFORE the flow does any work: the sync
           # authorization POST cannot observe the probe in flight, so without
           # this entry check an already-cancelled flow still performs the

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -308,6 +308,11 @@ module Basecamp
           # raise +expired+ without a single poll.
           issued_at = clock.call
           display.call(auth)
+          # Cancellation raised DURING the display hook (a prompt closing in
+          # response to cancellation) wins over expiry: a hook that both
+          # cancels and consumes the lifetime must surface cancelled.
+          raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
+
           remaining = auth.expires_in - (clock.call - issued_at)
           if remaining <= 0
             raise DeviceFlowError.new(:expired, "Device code expired before authorization completed")

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -604,7 +604,11 @@ module Basecamp
               # back to http_<status>, which the loop terminates as api_error.
               error = data["error"]
               recognized = (400..499).cover?(status) && error.is_a?(String) && !error.empty?
-              [ :error, recognized ? error : "http_#{status}", status ]
+              # Truncate at extraction (SPEC §9's 500-unit cap): the server
+              # controls this string and an unrecognized value is interpolated
+              # into the api_error message. Real protocol codes are short, so
+              # classification is unaffected.
+              [ :error, recognized ? Basecamp::Security.truncate(error) : "http_#{status}", status ]
             end
           end
 

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -177,10 +177,10 @@ module Basecamp
           # back to the code. It can only SHORTEN the validated lifetime.
           deadline =
             if deadline_at.nil?
-              clock.call + expires_in
+              sample_clock(clock, "poll_device_token") + expires_in
             else
               unless deadline_at.is_a?(Numeric) && deadline_at.real? \
-                  && deadline_at.to_f.finite? && deadline_at <= clock.call + expires_in
+                  && deadline_at.to_f.finite? && deadline_at <= sample_clock(clock, "poll_device_token") + expires_in
                 raise OauthError.new(
                   "usage",
                   "poll_device_token deadline_at must be a finite monotonic timestamp " \
@@ -212,14 +212,14 @@ module Basecamp
             # the LARGER of the server-driven interval and the transient timeout
             # backoff — the two schedules stay separate so a backoff can drain
             # back down to the server interval once round-trips resume.
-            now = clock.call
+            now = sample_clock(clock, "poll_device_token")
             raise DeviceFlowError.new(:expired, "Device code expired before authorization completed") if now >= deadline
 
             wait_cancellable([ [ interval_seconds, backoff_seconds ].max, deadline - now ].min, cancelled, sleeper)
 
             raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
 
-            post_remaining = deadline - clock.call
+            post_remaining = deadline - sample_clock(clock, "poll_device_token")
             raise DeviceFlowError.new(:expired, "Device code expired before authorization completed") if post_remaining <= 0
 
             outcome = begin
@@ -336,14 +336,14 @@ module Basecamp
           # issuance instant on the monotonic clock, run the hook, then poll with
           # only the REMAINING lifetime. If the hook consumed the whole budget,
           # raise +expired+ without a single poll.
-          issued_at = clock.call
+          issued_at = sample_clock(clock, "perform_device_login")
           display.call(auth)
           # Cancellation raised DURING the display hook (a prompt closing in
           # response to cancellation) wins over expiry: a hook that both
           # cancels and consumes the lifetime must surface cancelled.
           raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
 
-          remaining = auth.expires_in - (clock.call - issued_at)
+          remaining = auth.expires_in - (sample_clock(clock, "perform_device_login") - issued_at)
           if remaining <= 0
             raise DeviceFlowError.new(:expired, "Device code expired before authorization completed")
           end
@@ -377,6 +377,19 @@ module Basecamp
           # A positive, finite, real number of seconds within the shared device
           # ceiling. +real?+ gates out Complex before +finite?+/+positive?+ (which
           # Complex does not define), matching {Fetcher.valid_timeout?}.
+          # EVERY sample of the injected clock seam is validated: a String or
+          # Complex sample would raise a raw TypeError out of the deadline
+          # arithmetic, and a NaN sample makes every deadline comparison
+          # permanently false — polling an authorization_pending endpoint
+          # forever. A malformed sample is the typed usage fault instead.
+          def sample_clock(clock, entry)
+            value = clock.call
+            unless value.is_a?(Numeric) && value.real? && value.to_f.finite?
+              raise OauthError.new("usage", "#{entry} clock must return a finite number of seconds")
+            end
+            value
+          end
+
           def valid_device_seconds?(value)
             value.is_a?(Numeric) && value.real? && value.finite? && value.positive? && value <= MAX_DEVICE_SECONDS
           end

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -158,14 +158,24 @@ module Basecamp
           # wait. Fractional values are accepted — perform_device_login legitimately
           # passes a fractional remaining lifetime after deducting display-hook
           # time. Mirrors the Go/TS/Python/Kotlin caller guards.
-          { "expires_in" => expires_in, "interval" => interval }.each do |name, value|
-            unless valid_device_seconds?(value)
-              raise OauthError.new(
-                "usage",
-                "poll_device_token: #{name} must be a positive number of seconds " \
-                "no greater than #{MAX_DEVICE_SECONDS}"
-              )
-            end
+          unless valid_device_seconds?(expires_in)
+            raise OauthError.new(
+              "usage",
+              "poll_device_token: expires_in must be a positive number of seconds " \
+              "no greater than #{MAX_DEVICE_SECONDS}"
+            )
+          end
+          # The polling interval is additionally whole seconds (RFC 8628),
+          # matching the response validation and the integer-typed Go/Kotlin
+          # APIs — a fractional interval (0.001) would otherwise permit ~1000
+          # polls per second. real? in valid_device_seconds? screens Complex
+          # before the modulo runs.
+          unless valid_device_seconds?(interval) && (interval % 1).zero?
+            raise OauthError.new(
+              "usage",
+              "poll_device_token: interval must be a positive whole number of seconds " \
+              "no greater than #{MAX_DEVICE_SECONDS}"
+            )
           end
 
           interval_seconds = interval

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -545,7 +545,10 @@ module Basecamp
 
             data
           rescue JSON::ParserError
-            raise OauthError.new("api_error", "Failed to parse #{label} response", http_status: status)
+            # cause: nil — the parser error's message embeds the offending
+            # input, and these bodies carry device codes and access tokens:
+            # full_message and cause-aware loggers must not disclose them.
+            raise OauthError.new("api_error", "Failed to parse #{label} response", http_status: status), cause: nil
           end
 
           # Every validation error carries the (2xx) status so a malformed success

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -353,12 +353,14 @@ module Basecamp
           raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
 
           display.call(auth)
-          # Cancellation raised DURING the display hook (a prompt closing in
-          # response to cancellation) wins over expiry: a hook that both
-          # cancels and consumes the lifetime must surface cancelled.
+          remaining = auth.expires_in - (sample_clock(clock, "perform_device_login") - issued_at)
+          # Cancellation raised DURING the display hook OR during the clock
+          # sample just above (the clock is a cancellation-capable callback
+          # seam, exactly like the pre-request anchor) wins over expiry:
+          # checked after the sample and before the expiry branch, matching
+          # the TS orchestrator's ordering.
           raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
 
-          remaining = auth.expires_in - (sample_clock(clock, "perform_device_login") - issued_at)
           if remaining <= 0
             raise DeviceFlowError.new(:expired, "Device code expired before authorization completed")
           end

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -284,11 +284,22 @@ module Basecamp
             )
           end
 
+          # Honor a cancellation raised BEFORE the flow does any work: the sync
+          # authorization POST cannot observe the probe in flight, so without
+          # this entry check an already-cancelled flow still performs the
+          # request and invokes the display hook.
+          raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
+
           auth = request_device_authorization(
             device_authorization_endpoint: config.device_authorization_endpoint,
             client_id: client_id, scope: scope,
             http_client: http_client, timeout: timeout, max_body_bytes: max_body_bytes
           )
+
+          # Re-check after the round-trip, before surfacing the code: a cancel
+          # set while the authorization request was in flight must not reach
+          # the display hook.
+          raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
 
           # The code's lifetime starts at ISSUANCE, not after display: a slow
           # display hook must eat into the deadline, never reset it. Anchor the

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -319,17 +319,10 @@ module Basecamp
             raise OauthError.new("usage", "perform_device_login requires a callable display hook")
           end
 
-          # The code's lifetime starts at SERVER issuance, which precedes the
-          # response: anchor conservatively BEFORE the request goes out, so a
-          # slow authorization response (or one delayed in transit) eats into
-          # the deadline instead of granting the code a fresh full lifetime.
-          # The anchor can only SHORTEN the usable window, never extend it.
-          issued_at = sample_clock(clock, "perform_device_login")
-
-          # Honor a cancellation raised BEFORE the flow does any work — checked
-          # AFTER the anchor so a cancel flipped during the injected clock call
-          # (itself a callback seam) still stops the request: the sync
-          # authorization POST cannot observe the probe in flight.
+          # Honor a cancellation raised BEFORE the flow does any work: the
+          # sync authorization POST cannot observe the probe in flight, so
+          # without this entry check an already-cancelled flow still performs
+          # the request and invokes the display hook.
           raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
 
           auth = begin
@@ -347,16 +340,23 @@ module Basecamp
             raise
           end
 
-          # Re-check after the round-trip, before surfacing the code: a cancel
-          # set while the authorization request was in flight must not reach
-          # the display hook.
+          # Anchor the code's lifetime at ISSUANCE — the response's arrival,
+          # per SPEC §16 — before the display hook, so a slow display eats
+          # into the deadline instead of resetting it. Expiry past this point
+          # is arbitrated by the server (expired_token), so receipt-anchoring
+          # fails safe.
+          issued_at = sample_clock(clock, "perform_device_login")
+
+          # Re-check after the round-trip AND after the anchor sample (itself
+          # a cancellation-capable callback seam), before surfacing the code:
+          # a cancel set in either window must not reach the display hook.
           raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
 
           display.call(auth)
           remaining = auth.expires_in - (sample_clock(clock, "perform_device_login") - issued_at)
           # Cancellation raised DURING the display hook OR during the clock
           # sample just above (the clock is a cancellation-capable callback
-          # seam, exactly like the pre-request anchor) wins over expiry:
+          # seam, exactly like the issuance anchor) wins over expiry:
           # checked after the sample and before the expiry branch, matching
           # the TS orchestrator's ordering.
           raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -470,7 +470,13 @@ module Basecamp
             # would otherwise hold the POST open indefinitely — on_data (a
             # body callback) never runs during the header phase, leaving
             # nothing else to enforce the wall clock on an injected client.
-            response = Timeout.timeout(timeout, Faraday::TimeoutError) do
+            # The window is the REMAINING budget, not a fresh +timeout+: time
+            # spent before dispatch (descheduling included) already counts
+            # against the deadline, so the request can never run past it.
+            remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+            raise Faraday::TimeoutError, "request budget exhausted before dispatch" if remaining <= 0
+
+            response = Timeout.timeout(remaining, Faraday::TimeoutError) do
               client.post(url) do |req|
                 req.headers["Content-Type"] = "application/x-www-form-urlencoded"
                 req.headers["Accept"] = "application/json"
@@ -499,6 +505,15 @@ module Basecamp
             # headers-first semantics for it belong to the transport primitive shared
             # with discovery, tracked as a pre-go-live hardening follow-up.
             return [ response.status, "" ] if skip_status && skip_status.call(response.status)
+
+            # Timeout.timeout's interrupt can be delivered late: a response
+            # whose final byte lands just before the deadline but whose block
+            # returns just after it would otherwise be accepted past the wall
+            # clock. Status-first classification above outranks this re-check
+            # (a completed skip-status is definitive); everything else past
+            # the deadline is refused as the same transport-shaped timeout.
+            raise Faraday::TimeoutError, "response completed after the deadline" \
+              if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
 
             body =
               if chunks.empty?

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -535,7 +535,7 @@ module Basecamp
               timeout: timeout, max_body_bytes: max_body_bytes,
               # A 3xx token response is a redirect fault whose body is unused; a 4xx
               # body IS read (it carries authorization_pending/slow_down).
-              skip_status: ->(s) { (300..399).cover?(s) }
+              skip_status: ->(s) { !(s == 200 || (400..499).cover?(s)) }
             )
 
             # A redirect is never a valid token-endpoint outcome: it is not
@@ -546,6 +546,19 @@ module Basecamp
               raise OauthError.new(
                 "api_error",
                 "Device token request failed: unexpected redirect (status #{status})",
+                http_status: status
+              )
+            end
+
+            # Every remaining status outside 200 and 4xx is terminal WITHOUT
+            # its body (only a 200 carries the token and only a 4xx the OAuth
+            # error code) — the skip_status above already refused the body, so
+            # a 201/500 that stalls while streaming can never time out
+            # mid-read and be retried as a transient failure until expiry.
+            unless status == 200 || (400..499).cover?(status)
+              raise OauthError.new(
+                "api_error",
+                "Device token request failed with status #{status}",
                 http_status: status
               )
             end

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -546,7 +546,12 @@ module Basecamp
 
             data = parse_json_object(body, status, "device token")
 
-            if (200..299).cover?(status)
+            # Exactly HTTP 200, not any 2xx: RFC 8628/6749 token responses are
+            # 200, and SPEC.md §16 pins the contract. A nonstandard 201/202
+            # carrying an access_token must not prematurely complete polling —
+            # it falls through to the OAuth-error path below and terminates as
+            # api_error (http_<status>).
+            if status == 200
               access_token = data["access_token"]
               # Require a genuine non-empty String — not a truthy/coercible value.
               unless access_token.is_a?(String) && !access_token.empty?

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -325,6 +325,13 @@ module Basecamp
           # request and invokes the display hook.
           raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
 
+          # The code's lifetime starts at SERVER issuance, which precedes the
+          # response: anchor conservatively BEFORE the request goes out, so a
+          # slow authorization response (or one delayed in transit) eats into
+          # the deadline instead of granting the code a fresh full lifetime.
+          # The anchor can only SHORTEN the usable window, never extend it.
+          issued_at = sample_clock(clock, "perform_device_login")
+
           auth = begin
             request_device_authorization(
               device_authorization_endpoint: config.device_authorization_endpoint,
@@ -345,12 +352,6 @@ module Basecamp
           # the display hook.
           raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
 
-          # The code's lifetime starts at ISSUANCE, not after display: a slow
-          # display hook must eat into the deadline, never reset it. Anchor the
-          # issuance instant on the monotonic clock, run the hook, then poll with
-          # only the REMAINING lifetime. If the hook consumed the whole budget,
-          # raise +expired+ without a single poll.
-          issued_at = sample_clock(clock, "perform_device_login")
           display.call(auth)
           # Cancellation raised DURING the display hook (a prompt closing in
           # response to cancellation) wins over expiry: a hook that both

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -237,6 +237,11 @@ module Basecamp
               backoff_seconds = [ backoff_seconds * 2, MAX_BACKOFF_SECONDS ].min
               next
             rescue Faraday::Error => e
+              # Cancellation-beats-classification on the error path too: a
+              # cancel that flipped while the doomed request was in flight must
+              # surface as cancelled, not as the transport fault it raised.
+              raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
+
               raise DeviceFlowError.new(:transport, "Device token poll failed: #{e.message}")
             end
 
@@ -320,11 +325,20 @@ module Basecamp
           # request and invokes the display hook.
           raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
 
-          auth = request_device_authorization(
-            device_authorization_endpoint: config.device_authorization_endpoint,
-            client_id: client_id, scope: scope,
-            http_client: http_client, timeout: timeout, max_body_bytes: max_body_bytes
-          )
+          auth = begin
+            request_device_authorization(
+              device_authorization_endpoint: config.device_authorization_endpoint,
+              client_id: client_id, scope: scope,
+              http_client: http_client, timeout: timeout, max_body_bytes: max_body_bytes
+            )
+          rescue DeviceFlowError, OauthError
+            # Cancellation-beats-classification on the error path too: a cancel
+            # that flipped while the authorization request was in flight wins
+            # over whatever fault the doomed request raised.
+            raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
+
+            raise
+          end
 
           # Re-check after the round-trip, before surfacing the code: a cancel
           # set while the authorization request was in flight must not reach

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -272,6 +272,9 @@ module Basecamp
         # @return [Token]
         # @raise [DeviceFlowError] +:unavailable+ when the config cannot do device
         #   flow; other reasons on denial/expiry/transport/cancellation
+        # @raise [OauthError] +usage+ when +display+ is not callable (checked
+        #   before any request — DeviceFlowError subclasses OauthError, so a
+        #   rescue of the former alone would miss this)
         def perform_device_login(
           config:, client_id:, display:, scope: nil,
           clock: DEFAULT_CLOCK, sleeper: DEFAULT_SLEEPER, cancelled: DEFAULT_CANCELLED,

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -319,18 +319,18 @@ module Basecamp
             raise OauthError.new("usage", "perform_device_login requires a callable display hook")
           end
 
-          # Honor a cancellation raised BEFORE the flow does any work: the sync
-          # authorization POST cannot observe the probe in flight, so without
-          # this entry check an already-cancelled flow still performs the
-          # request and invokes the display hook.
-          raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
-
           # The code's lifetime starts at SERVER issuance, which precedes the
           # response: anchor conservatively BEFORE the request goes out, so a
           # slow authorization response (or one delayed in transit) eats into
           # the deadline instead of granting the code a fresh full lifetime.
           # The anchor can only SHORTEN the usable window, never extend it.
           issued_at = sample_clock(clock, "perform_device_login")
+
+          # Honor a cancellation raised BEFORE the flow does any work — checked
+          # AFTER the anchor so a cancel flipped during the injected clock call
+          # (itself a callback seam) still stops the request: the sync
+          # authorization POST cannot observe the probe in flight.
+          raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
 
           auth = begin
             request_device_authorization(

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -2,6 +2,7 @@
 
 require "faraday"
 require "json"
+require "timeout"
 require "uri"
 
 module Basecamp
@@ -464,13 +465,20 @@ module Basecamp
             # for a status whose body the caller doesn't use (non-2xx / 3xx).
             deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
             chunks, on_data = Fetcher.bounded_reader(max_body_bytes, deadline: deadline, skip_status: skip_status)
-            response = client.post(url) do |req|
-              req.headers["Content-Type"] = "application/x-www-form-urlencoded"
-              req.headers["Accept"] = "application/json"
-              req.body = URI.encode_www_form(params)
-              req.options.timeout = timeout
-              req.options.open_timeout = timeout
-              req.options.on_data = on_data
+            # Timeout.timeout wraps the WHOLE call: the per-read timeout resets
+            # on every socket read, so a peer dripping HEADER bytes under it
+            # would otherwise hold the POST open indefinitely — on_data (a
+            # body callback) never runs during the header phase, leaving
+            # nothing else to enforce the wall clock on an injected client.
+            response = Timeout.timeout(timeout, Faraday::TimeoutError) do
+              client.post(url) do |req|
+                req.headers["Content-Type"] = "application/x-www-form-urlencoded"
+                req.headers["Accept"] = "application/json"
+                req.body = URI.encode_www_form(params)
+                req.options.timeout = timeout
+                req.options.open_timeout = timeout
+                req.options.on_data = on_data
+              end
             end
 
             # Status-first backstop on the completed response. The +on_data+ SkipBody

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -221,6 +221,12 @@ module Basecamp
               raise DeviceFlowError.new(:transport, "Device token poll failed: #{e.message}")
             end
 
+            # Re-check cancellation the moment the round-trip completes: the
+            # sync POST cannot observe the probe while in flight (bounded only
+            # by its timeout), so a cancel raised mid-request must surface
+            # here — never a token returned after the caller asked to stop.
+            raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
+
             # ANY completed HTTP round-trip resets the timeout backoff to the
             # current server-driven interval.
             backoff_seconds = interval_seconds

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -199,10 +199,16 @@ module Basecamp
             wait_cancellable([ [ interval_seconds, backoff_seconds ].max, deadline - now ].min, cancelled, sleeper)
 
             raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
-            raise DeviceFlowError.new(:expired, "Device code expired before authorization completed") if clock.call >= deadline
+
+            post_remaining = deadline - clock.call
+            raise DeviceFlowError.new(:expired, "Device code expired before authorization completed") if post_remaining <= 0
 
             outcome = begin
-              post_device_token(client, token_endpoint, params, timeout: timeout, max_body_bytes: max_body_bytes)
+              # Bound the request by the REMAINING code lifetime as well as the
+              # per-request timeout: near expiry, a stalled token POST must not
+              # hold the flow past the monotonic deadline for the full budget.
+              post_device_token(client, token_endpoint, params,
+                timeout: [ timeout, post_remaining ].min, max_body_bytes: max_body_bytes)
             rescue Faraday::TimeoutError
               # A connection timeout is transient: back off exponentially and
               # keep polling rather than ending the flow. Only the backoff grows —
@@ -560,8 +566,15 @@ module Basecamp
 
               [ :token, build_token(data, status), status ]
             else
+              # Recognize OAuth protocol error codes ONLY on a 4xx (RFC 8628
+              # §3.5 error responses are 400-class): a nonstandard 2xx
+              # (201/202) or a 5xx carrying a crafted authorization_pending
+              # body must not keep the loop polling — only a 200 can produce a
+              # token and only a 4xx a protocol state. Everything else falls
+              # back to http_<status>, which the loop terminates as api_error.
               error = data["error"]
-              [ :error, error.is_a?(String) && !error.empty? ? error : "http_#{status}", status ]
+              recognized = (400..499).cover?(status) && error.is_a?(String) && !error.empty?
+              [ :error, recognized ? error : "http_#{status}", status ]
             end
           end
 

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -179,8 +179,8 @@ module Basecamp
             if deadline_at.nil?
               clock.call + expires_in
             else
-              unless deadline_at.is_a?(Numeric) && deadline_at.to_f.finite? \
-                  && deadline_at <= clock.call + expires_in
+              unless deadline_at.is_a?(Numeric) && deadline_at.real? \
+                  && deadline_at.to_f.finite? && deadline_at <= clock.call + expires_in
                 raise OauthError.new(
                   "usage",
                   "poll_device_token deadline_at must be a finite monotonic timestamp " \

--- a/ruby/lib/basecamp/oauth/device_flow_error.rb
+++ b/ruby/lib/basecamp/oauth/device_flow_error.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Basecamp
+  module Oauth
+    # A terminal RFC 8628 device-flow outcome. Carries a +reason+; the parent
+    # {OauthError} +type+ is DERIVED from that reason (SPEC.md §16) so callers can
+    # branch on either the precise +reason+ or the coarse +type+.
+    #
+    # | reason           | parent type          |
+    # |------------------|----------------------|
+    # | +:access_denied+ | +auth+               |
+    # | +:expired+       | +auth+               |
+    # | +:transport+     | +network+ (retryable)|
+    # | +:unavailable+   | +validation+         |
+    # | +:cancelled+     | +usage+              |
+    #
+    # @attr reason [Symbol] the device-flow termination reason
+    class DeviceFlowError < OauthError
+      # Maps a device-flow reason to its parent {OauthError} type.
+      REASON_TYPES = {
+        access_denied: "auth",
+        expired: "auth",
+        transport: "network",
+        unavailable: "validation",
+        cancelled: "usage"
+      }.freeze
+
+      attr_reader :reason
+
+      # @param reason [Symbol] the device-flow termination reason
+      # @param message [String] human-readable description
+      # @param http_status [Integer, nil] HTTP status code, if applicable
+      # @param hint [String, nil] helpful hint for resolving the error
+      def initialize(reason, message, http_status: nil, hint: nil)
+        super(
+          REASON_TYPES.fetch(reason, "api_error"),
+          message,
+          http_status: http_status,
+          hint: hint,
+          retryable: reason == :transport
+        )
+        @reason = reason
+      end
+    end
+  end
+end

--- a/ruby/lib/basecamp/oauth/discovery.rb
+++ b/ruby/lib/basecamp/oauth/discovery.rb
@@ -31,13 +31,8 @@ module Basecamp
         # Normalize the public cap to a finite non-negative Integer: a nil, float,
         # or Float::INFINITY would otherwise disable the streaming memory bound
         # (an infinite/undefined cap never trips +total > max_body_bytes+),
-        # reintroducing an SSRF/OOM risk. Mirrors Resource#initialize.
-        @max_body_bytes =
-          if max_body_bytes.is_a?(Integer) && max_body_bytes >= 0
-            max_body_bytes
-          else
-            Fetcher::DEFAULT_MAX_BODY_BYTES
-          end
+        # reintroducing an SSRF/OOM risk. Shared with Resource and the device flow.
+        @max_body_bytes = Fetcher.normalize_body_cap(max_body_bytes)
       end
 
       # Discovers OAuth configuration from

--- a/ruby/lib/basecamp/oauth/exchange.rb
+++ b/ruby/lib/basecamp/oauth/exchange.rb
@@ -175,11 +175,13 @@ module Basecamp
         # material (a syntactically-broken body carrying an access_token) —
         # never echo ANY of it into an error message, where it would reach
         # logs and exception telemetry. The status is diagnosis enough.
+        # cause: nil — the parser error's message embeds the offending input,
+        # so the implicit cause chain would leak it via full_message.
         raise OauthError.new(
           "api_error",
           "Failed to parse token response",
           http_status: response.status
-        )
+        ), cause: nil
       end
 
       def handle_error_response(status, data)

--- a/ruby/lib/basecamp/oauth/exchange.rb
+++ b/ruby/lib/basecamp/oauth/exchange.rb
@@ -171,9 +171,13 @@ module Basecamp
           scope: data["scope"]
         )
       rescue JSON::ParserError
+        # A token response that fails to parse may still contain credential
+        # material (a syntactically-broken body carrying an access_token) —
+        # never echo ANY of it into an error message, where it would reach
+        # logs and exception telemetry. The status is diagnosis enough.
         raise OauthError.new(
           "api_error",
-          "Failed to parse token response: #{Basecamp::Security.truncate(response.body)}",
+          "Failed to parse token response",
           http_status: response.status
         )
       end

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -45,12 +45,19 @@ module Basecamp
       # (10s), device flow passes its own 30s budget, so an invalid runtime value
       # falls back to that operation's own timeout rather than a foreign one.
       def self.normalize_timeout(timeout, default: DEFAULT_TIMEOUT)
-        # +real?+ gates out Complex before +finite?+/+positive?+ (which Complex does
-        # not define — calling them would raise NoMethodError). Integer, Float, and
-        # Rational are all real and answer both.
-        return timeout if timeout.is_a?(Numeric) && timeout.real? && timeout.finite? && timeout.positive?
+        return timeout if valid_timeout?(timeout)
+        # Validate the fallback too: a caller passing an invalid +default+ must not
+        # be able to disable both timeout bounds. Fall back to the finite constant.
+        return default if valid_timeout?(default)
 
-        default
+        DEFAULT_TIMEOUT
+      end
+
+      # +real?+ gates out Complex before +finite?+/+positive?+ (which Complex does
+      # not define — calling them would raise NoMethodError). Integer, Float, and
+      # Rational are all real and answer both.
+      def self.valid_timeout?(value)
+        value.is_a?(Numeric) && value.real? && value.finite? && value.positive?
       end
 
       # Raised internally to abort a streaming read once the cap is exceeded.

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -63,8 +63,8 @@ module Basecamp
       # Coerce the public body cap to a non-negative Integer. A nil, non-Integer
       # (+Float::INFINITY+ included), or negative value would disable the streaming
       # memory bound (+total > cap+ never trips), defeating the bounded-read
-      # guarantee. The ONE shared policy for Discovery, Resource, and the device
-      # flow; the +default+ is validated too, so an invalid fallback cannot
+      # guarantee. This is the one shared policy for Discovery, Resource, and the
+      # device flow; the +default+ is validated too, so an invalid fallback cannot
       # disable the bound either.
       def self.normalize_body_cap(cap, default: DEFAULT_MAX_BODY_BYTES)
         return cap if valid_body_cap?(cap)

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -63,8 +63,9 @@ module Basecamp
       # Coerce the public body cap to a non-negative Integer. A nil, non-Integer
       # (+Float::INFINITY+ included), or negative value would disable the streaming
       # memory bound (+total > cap+ never trips), defeating the bounded-read
-      # guarantee. Mirrors the discovery initializer's normalization; the +default+
-      # is validated too, so an invalid fallback cannot disable the bound either.
+      # guarantee. The ONE shared policy for Discovery, Resource, and the device
+      # flow; the +default+ is validated too, so an invalid fallback cannot
+      # disable the bound either.
       def self.normalize_body_cap(cap, default: DEFAULT_MAX_BODY_BYTES)
         return cap if valid_body_cap?(cap)
         return default if valid_body_cap?(default)

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -60,6 +60,22 @@ module Basecamp
         value.is_a?(Numeric) && value.real? && value.finite? && value.positive?
       end
 
+      # Coerce the public body cap to a non-negative Integer. A nil, non-Integer
+      # (+Float::INFINITY+ included), or negative value would disable the streaming
+      # memory bound (+total > cap+ never trips), defeating the bounded-read
+      # guarantee. Mirrors the discovery initializer's normalization; the +default+
+      # is validated too, so an invalid fallback cannot disable the bound either.
+      def self.normalize_body_cap(cap, default: DEFAULT_MAX_BODY_BYTES)
+        return cap if valid_body_cap?(cap)
+        return default if valid_body_cap?(default)
+
+        DEFAULT_MAX_BODY_BYTES
+      end
+
+      def self.valid_body_cap?(value)
+        value.is_a?(Integer) && value >= 0
+      end
+
       # Raised internally to abort a streaming read once the cap is exceeded.
       # Never escapes this module — it is mapped to an OauthError.
       class BodyTooLarge < StandardError; end

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -68,6 +68,19 @@ module Basecamp
       # Never escapes this module — it is mapped to a retryable +network+ OauthError.
       class ReadDeadlineExceeded < StandardError; end
 
+      # Raised from +on_data+ to STOP reading a response whose body the caller does
+      # not use (a non-2xx device-auth, a 3xx token redirect). Draining a slow such
+      # body would otherwise time out and be misclassified as a transport failure.
+      # Carries the response status so the caller can classify by it. Never escapes.
+      class SkipBody < StandardError
+        attr_reader :status
+
+        def initialize(status)
+          @status = status
+          super("device flow response body skipped for status #{status}")
+        end
+      end
+
       # Builds a +[chunks, on_data]+ pair for a genuine bounded/streaming read.
       # Assign +on_data+ to a request's +req.options.on_data+; after the request
       # returns, +chunks.join+ is the accumulated body. The proc raises
@@ -87,10 +100,15 @@ module Basecamp
       # @param max_body_bytes [Integer] bounded read cap in bytes
       # @param deadline [Float, nil] monotonic clock deadline (CLOCK_MONOTONIC seconds)
       # @return [Array(Array<String>, Proc)] the chunk buffer and the +on_data+ proc
-      def self.bounded_reader(max_body_bytes, deadline: nil)
+      def self.bounded_reader(max_body_bytes, deadline: nil, skip_status: nil)
         chunks = []
         total = 0
-        reader = proc do |chunk, _received|
+        reader = proc do |chunk, _received, env|
+          # Faraday passes +env+ (with the response status) once headers are in; it
+          # is nil on a 2-arg call. If the caller does not use this status's body,
+          # stop before draining it — a slow such body would otherwise time out.
+          raise SkipBody.new(env.status) if skip_status && env && skip_status.call(env.status)
+
           if deadline && Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
             raise ReadDeadlineExceeded
           end

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -41,13 +41,16 @@ module Basecamp
       #
       # @param timeout [Object] caller-supplied timeout
       # @return [Numeric] a finite, positive timeout in seconds
-      def self.normalize_timeout(timeout)
+      # +default+ is operation-specific: discovery falls back to +DEFAULT_TIMEOUT+
+      # (10s), device flow passes its own 30s budget, so an invalid runtime value
+      # falls back to that operation's own timeout rather than a foreign one.
+      def self.normalize_timeout(timeout, default: DEFAULT_TIMEOUT)
         # +real?+ gates out Complex before +finite?+/+positive?+ (which Complex does
         # not define — calling them would raise NoMethodError). Integer, Float, and
         # Rational are all real and answer both.
         return timeout if timeout.is_a?(Numeric) && timeout.real? && timeout.finite? && timeout.positive?
 
-        DEFAULT_TIMEOUT
+        default
       end
 
       # Raised internally to abort a streaming read once the cap is exceeded.

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -104,9 +104,16 @@ module Basecamp
         chunks = []
         total = 0
         reader = proc do |chunk, _received, env|
-          # Faraday passes +env+ (with the response status) once headers are in; it
-          # is nil on a 2-arg call. If the caller does not use this status's body,
-          # stop before draining it — a slow such body would otherwise time out.
+          # Fast-path status-first skip: Faraday >= 2.5 passes +env+ (with the
+          # response status) to +on_data+ once headers are in, so a body the caller
+          # will not use (a non-2xx device-auth / a 3xx token redirect) is abandoned
+          # at the FIRST body chunk rather than drained. +env+ is nil on older
+          # Faraday (2.0–2.4) or a 2-arg call; every response that COMPLETES is
+          # still classified by status via the caller's post-request re-check (see
+          # +DeviceFlow#post_form+). +on_data+ is a body callback, not a headers
+          # callback, so the one unreachable case — headers arrive, then the body
+          # stalls past the read timeout — surfaces as a bounded transport timeout
+          # instead (never followed, never unbounded; see +post_form+).
           raise SkipBody.new(env.status) if skip_status && env && skip_status.call(env.status)
 
           if deadline && Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -95,7 +95,7 @@ module Basecamp
       class ReadDeadlineExceeded < StandardError; end
 
       # Raised from +on_data+ to STOP reading a response whose body the caller does
-      # not use (a non-2xx device-auth, a 3xx token redirect). Draining a slow such
+      # not use (a non-2xx device-auth, a 3xx token redirect). Draining such a slow
       # body would otherwise time out and be misclassified as a transport failure.
       # Carries the response status so the caller can classify by it. Never escapes.
       class SkipBody < StandardError

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -53,11 +53,20 @@ module Basecamp
         DEFAULT_TIMEOUT
       end
 
+      # Upper bound (seconds) for any single OAuth request timeout. A huge but
+      # FINITE caller value (1e100) would pass a bare finite/positive check and
+      # hold both Faraday's socket timeout and the monotonic deadline open
+      # effectively forever — the same cap discipline as Python
+      # (_MAX_DEVICE_REQUEST_TIMEOUT = 3600) and TS (resolveDeviceTimeoutMs
+      # rejects oversized values back to the default).
+      MAX_REQUEST_TIMEOUT = 3600
+
       # +real?+ gates out Complex before +finite?+/+positive?+ (which Complex does
       # not define — calling them would raise NoMethodError). Integer, Float, and
       # Rational are all real and answer both.
       def self.valid_timeout?(value)
-        value.is_a?(Numeric) && value.real? && value.finite? && value.positive?
+        value.is_a?(Numeric) && value.real? && value.finite? && value.positive? \
+          && value <= MAX_REQUEST_TIMEOUT
       end
 
       # Coerce the public body cap to a non-negative Integer. A nil, non-Integer

--- a/ruby/lib/basecamp/oauth/oauth_error.rb
+++ b/ruby/lib/basecamp/oauth/oauth_error.rb
@@ -4,7 +4,9 @@ module Basecamp
   module Oauth
     # OAuth-specific error class.
     #
-    # @attr type [String] Error type ("validation", "auth", "network", "api_error")
+    # @attr type [String] Error type ("validation", "auth", "network",
+    #   "api_error", or "usage" — the parent type {DeviceFlowError} derives for
+    #   a cancelled device flow)
     # @attr http_status [Integer, nil] HTTP status code if applicable
     # @attr hint [String, nil] Helpful hint for resolving the error
     # @attr retryable [Boolean] Whether the request can be retried

--- a/ruby/lib/basecamp/oauth/resource.rb
+++ b/ruby/lib/basecamp/oauth/resource.rb
@@ -18,12 +18,8 @@ module Basecamp
         # Normalize the public cap to a finite non-negative Integer: a nil, float,
         # or Float::INFINITY would otherwise disable the streaming memory bound
         # (an infinite/undefined cap never trips), reintroducing an SSRF/OOM risk.
-        @max_body_bytes =
-          if max_body_bytes.is_a?(Integer) && max_body_bytes >= 0
-            max_body_bytes
-          else
-            Fetcher::DEFAULT_MAX_BODY_BYTES
-          end
+        # Shared with Discovery and the device flow.
+        @max_body_bytes = Fetcher.normalize_body_cap(max_body_bytes)
       end
 
       # Discovers protected-resource metadata from

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -425,7 +425,7 @@ class OAuthDeviceTest < Minitest::Test
 
   def test_poll_rejects_fractional_expires_in_on_token_response
     # A fractional token lifetime is malformed under the whole-second contract
-    # (Go/Kotlin reject it by int/Long typing) → api_error, uniform across SDKs.
+    # → api_error, uniform across SDKs (each validates the decoded value).
     stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response.merge("expires_in" => 1.5)))
 
     assert_poll_api_error
@@ -440,7 +440,30 @@ class OAuthDeviceTest < Minitest::Test
       device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
     )
 
-    assert_equal 3600.0, token.expires_in
+    assert_equal 3600, token.expires_in
+    assert_kind_of Integer, token.expires_in
+  end
+
+  def test_poll_rejects_explicit_empty_token_type
+    # An explicit "" token_type is malformed token metadata → api_error,
+    # uniform across all five SDKs.
+    stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response.merge("token_type" => "")))
+
+    assert_poll_api_error
+  end
+
+  def test_poll_defaults_null_token_type_to_bearer
+    # JSON null is treated as absent (the Go/Kotlin decoders cannot distinguish
+    # them) → Bearer default, uniform across all five SDKs.
+    stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response.merge("token_type" => nil)))
+    _waits, sleeper = recording_sleeper
+
+    token = Basecamp::Oauth.poll_device_token(
+      token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+      device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+    )
+
+    assert_equal "Bearer", token.token_type
   end
 
   def test_poll_rejects_non_string_token_fields

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -615,6 +615,28 @@ class OAuthDeviceTest < Minitest::Test
     assert_equal "usage", error.type
   end
 
+  def test_poll_cancellation_during_wait_is_prompt
+    # A long interval must not delay cancellation: the wait polls the cancelled
+    # probe in small chunks, so a cancel set mid-wait raises without sleeping the
+    # whole interval at once (a plain sleep is not interruptible).
+    recorded = []
+    sleeper = ->(seconds) { recorded << seconds }
+    cancelled = -> { recorded.length >= 3 } # cancel after the 3rd chunk
+
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth.poll_device_token(
+        token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+        device_code: "dev-code-123", interval: 5, expires_in: 900,
+        sleeper: sleeper, cancelled: cancelled
+      )
+    end
+
+    assert_equal :cancelled, error.reason
+    # Chunked into small waits, never one sleeper.call(5).
+    assert recorded.any?
+    assert(recorded.all? { |s| s <= Basecamp::Oauth::DeviceFlow::CANCEL_POLL_INTERVAL_SECONDS })
+  end
+
   # --- perform_device_login --------------------------------------------------
 
   def test_perform_guards_capability_endpoint_present_but_no_device_grant

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -315,6 +315,82 @@ class OAuthDeviceTest < Minitest::Test
     assert_equal 10, waits[1]
   end
 
+  def test_poll_backoff_resets_to_server_interval_after_completed_round_trip
+    # Contract: the server-driven interval and the transient timeout backoff are
+    # SEPARATE schedules. Two timeouts double the backoff (10s, 20s) without
+    # touching the 5s server interval; the first completed round-trip (a plain
+    # authorization_pending) resets the backoff, so waits return to 5s.
+    client = SequencedHttpClient.new([
+      Faraday::TimeoutError.new("timed out"),
+      Faraday::TimeoutError.new("timed out"),
+      { status: 400, body: { "error" => "authorization_pending" }.to_json },
+      { status: 400, body: { "error" => "authorization_pending" }.to_json },
+      { status: 200, body: token_response.to_json }
+    ])
+    waits, sleeper = recording_sleeper
+
+    token = Basecamp::Oauth::DeviceFlow.poll_device_token(
+      token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+      device_code: "dev-code-123", interval: 5, expires_in: 900,
+      sleeper: sleeper, http_client: client
+    )
+
+    assert_equal "device_access_token", token.access_token
+    assert_equal [ 5, 10, 20, 5, 5 ], waits
+  end
+
+  def test_poll_rejects_non_numeric_expires_in_on_token_response
+    # A 2xx with a valid access_token but expires_in "3600" (string) is
+    # malformed: it must surface as api_error, not escape as a TypeError from
+    # Token's expiry arithmetic.
+    stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response.merge("expires_in" => "3600")))
+    _waits, sleeper = recording_sleeper
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth.poll_device_token(
+        token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+        device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+      )
+    end
+    assert_equal "api_error", error.type
+    assert_equal 200, error.http_status
+  end
+
+  def test_poll_accepts_token_response_without_expires_in
+    # expires_in is optional (RFC 6749 §5.1): absent means no known expiry, so
+    # the Token carries nil expires_in/expires_at rather than raising.
+    stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response.tap { |body| body.delete("expires_in") }))
+    _waits, sleeper = recording_sleeper
+
+    token = Basecamp::Oauth.poll_device_token(
+      token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+      device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+    )
+
+    assert_equal "device_access_token", token.access_token
+    assert_nil token.expires_in
+    assert_nil token.expires_at
+  end
+
+  def test_poll_treats_redirect_as_api_error_even_with_pending_body
+    # A 3xx is never a valid token-endpoint outcome. Redirects are not followed,
+    # and a redirect whose body smuggles {"error":"authorization_pending"} must
+    # end the flow as api_error — not keep the loop polling forever.
+    stub_request(:post, TOKEN_ENDPOINT)
+      .to_return(json({ "error" => "authorization_pending" }, status: 302))
+    _waits, sleeper = recording_sleeper
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth.poll_device_token(
+        token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+        device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+      )
+    end
+    assert_equal "api_error", error.type
+    assert_equal 302, error.http_status
+    assert_requested(:post, TOKEN_ENDPOINT, times: 1)
+  end
+
   def test_poll_expires_against_injected_monotonic_clock
     times = [ 0, 1_000_000 ]
     i = 0

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -615,6 +615,39 @@ class OAuthDeviceTest < Minitest::Test
     assert_equal "usage", error.type
   end
 
+  # Streams an oversized 302 body to on_data WITH env (as the live net/http adapter
+  # does), so the status-skip path is exercised without a real socket (which WebMock
+  # blocks in the suite). If the body were drained it would trip the size cap.
+  class RedirectStreamAdapter < Faraday::Adapter
+    def call(env)
+      on_data = env.request.on_data
+      if on_data
+        env.status = 302
+        on_data.call("x" * (2 * 1024 * 1024), 2 * 1024 * 1024, env)
+      end
+      save_response(env, 302, "", { "Location" => "https://x/" })
+      @app.call(env)
+    end
+  end
+
+  def test_token_poll_redirect_classified_by_status_without_draining_body
+    # A 3xx must fail by STATUS before the body is drained — surfacing a redirect
+    # api_error, not the size cap (which draining the oversized body would trip) and
+    # not a timeout the poll loop would retry.
+    connection = Faraday.new { |conn| conn.adapter RedirectStreamAdapter }
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth::DeviceFlow.poll_device_token(
+        token_endpoint: "https://issuer.example/token", client_id: "basecamp-cli",
+        device_code: "d", interval: 5, expires_in: 900,
+        http_client: connection, clock: -> { 0.0 }, sleeper: ->(_seconds) { }
+      )
+    end
+
+    assert_equal "api_error", error.type
+    assert_match(/redirect/i, error.message)
+  end
+
   def test_poll_cancellation_during_wait_is_prompt
     # A long interval must not delay cancellation: the wait polls the cancelled
     # probe in small chunks, so a cancel set mid-wait raises without sleeping the

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -72,6 +72,20 @@ class OAuthDeviceTest < Minitest::Test
     { status: status, body: body.to_json, headers: { "Content-Type" => "application/json" } }
   end
 
+  # Polls the already-stubbed TOKEN_ENDPOINT once and asserts the token response
+  # was rejected as api_error. Returns the raised error for further assertions.
+  def assert_poll_api_error
+    _waits, sleeper = recording_sleeper
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth.poll_device_token(
+        token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+        device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+      )
+    end
+    assert_equal "api_error", error.type
+    error
+  end
+
   # --- request_device_authorization -----------------------------------------
 
   def test_request_omits_scope_when_unset_and_validates_response
@@ -370,6 +384,52 @@ class OAuthDeviceTest < Minitest::Test
     assert_equal "device_access_token", token.access_token
     assert_nil token.expires_in
     assert_nil token.expires_at
+  end
+
+  def test_poll_rejects_infinite_expires_in_on_token_response
+    # A server sending expires_in: 1e400 parses to Float::INFINITY — numeric and
+    # positive, but Token's expiry arithmetic would raise a raw FloatDomainError.
+    # It must surface as api_error. Sent raw since to_json rejects Infinity.
+    raw = token_response.reject { |k, _| k == "expires_in" }.to_json.sub(/\}\z/, ', "expires_in": 1e400}')
+    stub_request(:post, TOKEN_ENDPOINT)
+      .to_return(status: 200, body: raw, headers: { "Content-Type" => "application/json" })
+
+    assert_equal 200, assert_poll_api_error.http_status
+  end
+
+  def test_poll_rejects_oversized_expires_in_on_token_response
+    # One past the 2_147_483_647 s ceiling is a malformed lifetime, not schedulable.
+    stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response.merge("expires_in" => 2_147_483_648)))
+
+    assert_poll_api_error
+  end
+
+  def test_poll_accepts_max_token_lifetime
+    stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response.merge("expires_in" => 2_147_483_647)))
+    _waits, sleeper = recording_sleeper
+
+    token = Basecamp::Oauth.poll_device_token(
+      token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+      device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+    )
+
+    assert_equal 2_147_483_647, token.expires_in
+  end
+
+  def test_poll_rejects_non_positive_expires_in_on_token_response
+    [ 0, -1 ].each do |value|
+      stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response.merge("expires_in" => value)))
+      assert_poll_api_error
+    end
+  end
+
+  def test_poll_rejects_non_string_token_fields
+    # A numeric refresh_token/token_type/scope is malformed, not a credential
+    # field — surface api_error rather than store a non-String.
+    %w[refresh_token token_type scope].each do |field|
+      stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response.merge(field => 123)))
+      assert_poll_api_error
+    end
   end
 
   def test_poll_treats_redirect_as_api_error_even_with_pending_body

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -1,0 +1,546 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# RFC 8628 device authorization grant tests (SPEC.md §16).
+#
+# Timing is deterministic: an injected sleeper records the requested waits and
+# returns immediately, and an injected monotonic clock advances on demand. No
+# test performs a real delay.
+class OAuthDeviceTest < Minitest::Test
+  include TestHelper
+
+  ORIGIN = "https://issuer.device-test.example"
+  DEVICE_ENDPOINT = "#{ORIGIN}/oauth/device".freeze
+  TOKEN_ENDPOINT = "#{ORIGIN}/oauth/token".freeze
+  DEVICE_GRANT = Basecamp::Oauth::DeviceFlow::DEVICE_CODE_GRANT_TYPE
+
+  # A Faraday-shaped double that returns a scripted sequence of outcomes. Each
+  # step is either a StandardError (raised) or a Hash (a status/body response).
+  class SequencedHttpClient
+    Response = Struct.new(:status, :body)
+
+    def initialize(steps)
+      @steps = steps
+      @index = 0
+    end
+
+    def post(_url)
+      step = @steps[@index]
+      @index += 1
+      raise step if step.is_a?(StandardError)
+
+      Response.new(step[:status], step[:body])
+    end
+  end
+
+  def device_auth_response(overrides = {})
+    {
+      "device_code" => "dev-code-123",
+      "user_code" => "WDJB-MJHT",
+      "verification_uri" => "#{ORIGIN}/device",
+      "verification_uri_complete" => "#{ORIGIN}/device?user_code=WDJB-MJHT",
+      "expires_in" => 900,
+      "interval" => 5
+    }.merge(overrides)
+  end
+
+  def token_response
+    {
+      "access_token" => "device_access_token",
+      "refresh_token" => "device_refresh_token",
+      "token_type" => "Bearer",
+      "expires_in" => 3600
+    }
+  end
+
+  def recording_sleeper
+    waits = []
+    [ waits, ->(seconds) { waits << seconds } ]
+  end
+
+  # A monotonic clock that returns a scripted sequence, holding the final value.
+  def scripted_clock(values)
+    i = -1
+    lambda do
+      i += 1
+      values[[ i, values.length - 1 ].min]
+    end
+  end
+
+  def json(body, status: 200)
+    { status: status, body: body.to_json, headers: { "Content-Type" => "application/json" } }
+  end
+
+  # --- request_device_authorization -----------------------------------------
+
+  def test_request_omits_scope_when_unset_and_validates_response
+    stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response))
+
+    auth = Basecamp::Oauth.request_device_authorization(
+      device_authorization_endpoint: DEVICE_ENDPOINT, client_id: "basecamp-cli"
+    )
+
+    assert_equal "dev-code-123", auth.device_code
+    assert_equal "WDJB-MJHT", auth.user_code
+    assert_equal 5, auth.interval
+    assert_requested(:post, DEVICE_ENDPOINT) do |req|
+      params = URI.decode_www_form(req.body).to_h
+      assert_equal "basecamp-cli", params["client_id"]
+      assert_not params.key?("scope") # omitted → server default (read)
+    end
+  end
+
+  def test_request_sends_scope_when_set
+    stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response))
+
+    Basecamp::Oauth.request_device_authorization(
+      device_authorization_endpoint: DEVICE_ENDPOINT, client_id: "basecamp-cli", scope: "read write"
+    )
+
+    assert_requested(:post, DEVICE_ENDPOINT) do |req|
+      assert_equal "read write", URI.decode_www_form(req.body).to_h["scope"]
+    end
+  end
+
+  def test_request_omits_blank_scope
+    # Ruby treats "" as truthy, so a blank scope must still be omitted — otherwise
+    # the server can't apply its default (read).
+    stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response))
+
+    Basecamp::Oauth.request_device_authorization(
+      device_authorization_endpoint: DEVICE_ENDPOINT, client_id: "basecamp-cli", scope: ""
+    )
+
+    assert_requested(:post, DEVICE_ENDPOINT) do |req|
+      assert_not URI.decode_www_form(req.body).to_h.key?("scope")
+    end
+  end
+
+  def test_request_rejects_fractional_expires_in
+    # RFC 8628 durations are integer seconds; a fractional value is malformed.
+    stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response("expires_in" => 0.5)))
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth.request_device_authorization(
+        device_authorization_endpoint: DEVICE_ENDPOINT, client_id: "basecamp-cli"
+      )
+    end
+    assert_equal "api_error", error.type
+  end
+
+  def test_request_rejects_fractional_interval
+    stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response("interval" => 2.5)))
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth.request_device_authorization(
+        device_authorization_endpoint: DEVICE_ENDPOINT, client_id: "basecamp-cli"
+      )
+    end
+    assert_equal "api_error", error.type
+  end
+
+  def test_request_rejects_oversized_expires_in
+    # 1e100 is integer-valued, so whole-second checking alone would admit it;
+    # the shared cross-SDK ceiling (2147483 s) makes it api_error.
+    stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response("expires_in" => 1e100)))
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth.request_device_authorization(
+        device_authorization_endpoint: DEVICE_ENDPOINT, client_id: "basecamp-cli"
+      )
+    end
+    assert_equal "api_error", error.type
+  end
+
+  def test_request_rejects_oversized_interval
+    stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response("interval" => 1e100)))
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth.request_device_authorization(
+        device_authorization_endpoint: DEVICE_ENDPOINT, client_id: "basecamp-cli"
+      )
+    end
+    assert_equal "api_error", error.type
+  end
+
+  def test_request_rejects_just_past_max_duration
+    stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response("expires_in" => 2_147_484)))
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth.request_device_authorization(
+        device_authorization_endpoint: DEVICE_ENDPOINT, client_id: "basecamp-cli"
+      )
+    end
+    assert_equal "api_error", error.type
+  end
+
+  def test_request_accepts_max_duration
+    # The 2147483 s ceiling itself is valid — the bound is inclusive.
+    stub_request(:post, DEVICE_ENDPOINT)
+      .to_return(json(device_auth_response("expires_in" => 2_147_483, "interval" => 2_147_483)))
+
+    auth = Basecamp::Oauth.request_device_authorization(
+      device_authorization_endpoint: DEVICE_ENDPOINT, client_id: "basecamp-cli"
+    )
+    assert_equal 2_147_483, auth.expires_in
+    assert_equal 2_147_483, auth.interval
+  end
+
+  def test_request_accepts_integer_valued_float_expires_in
+    # 900.0 carries no fractional part, so it is a valid integer number of seconds.
+    stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response("expires_in" => 900.0)))
+
+    auth = Basecamp::Oauth.request_device_authorization(
+      device_authorization_endpoint: DEVICE_ENDPOINT, client_id: "basecamp-cli"
+    )
+    assert_equal 900, auth.expires_in.to_i
+  end
+
+  def test_request_defaults_interval_to_5_when_omitted
+    stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response("interval" => nil)))
+
+    auth = Basecamp::Oauth.request_device_authorization(
+      device_authorization_endpoint: DEVICE_ENDPOINT, client_id: "basecamp-cli"
+    )
+
+    assert_equal 5, auth.interval
+  end
+
+  def test_request_rejects_non_positive_expires_in
+    stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response("expires_in" => 0)))
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth.request_device_authorization(
+        device_authorization_endpoint: DEVICE_ENDPOINT, client_id: "basecamp-cli"
+      )
+    end
+    assert_equal "api_error", error.type
+  end
+
+  def test_request_rejects_non_positive_interval
+    stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response("interval" => 0)))
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth.request_device_authorization(
+        device_authorization_endpoint: DEVICE_ENDPOINT, client_id: "basecamp-cli"
+      )
+    end
+    assert_equal "api_error", error.type
+  end
+
+  def test_request_rejects_missing_field
+    body = { "user_code" => "X", "verification_uri" => ORIGIN, "expires_in" => 900 }
+    stub_request(:post, DEVICE_ENDPOINT).to_return(json(body))
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth.request_device_authorization(
+        device_authorization_endpoint: DEVICE_ENDPOINT, client_id: "basecamp-cli"
+      )
+    end
+    assert_equal "api_error", error.type
+  end
+
+  def test_request_rejects_wrong_typed_device_code
+    # A numeric device_code must be rejected: the old `.to_s.empty?` probe would
+    # have coerced 123456 to "123456" and accepted it as a valid code.
+    stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response("device_code" => 123_456)))
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth.request_device_authorization(
+        device_authorization_endpoint: DEVICE_ENDPOINT, client_id: "basecamp-cli"
+      )
+    end
+    assert_equal "api_error", error.type
+  end
+
+  def test_request_rejects_wrong_typed_verification_uri_complete
+    stub_request(:post, DEVICE_ENDPOINT)
+      .to_return(json(device_auth_response("verification_uri_complete" => 42)))
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth.request_device_authorization(
+        device_authorization_endpoint: DEVICE_ENDPOINT, client_id: "basecamp-cli"
+      )
+    end
+    assert_equal "api_error", error.type
+  end
+
+  def test_request_requires_client_id
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth.request_device_authorization(
+        device_authorization_endpoint: DEVICE_ENDPOINT, client_id: ""
+      )
+    end
+    assert_equal "validation", error.type
+  end
+
+  # --- poll_device_token -----------------------------------------------------
+
+  def test_poll_pending_then_slow_down_then_token_sustains_plus_5s
+    stub_request(:post, TOKEN_ENDPOINT).to_return(
+      json({ "error" => "authorization_pending" }, status: 400),
+      json({ "error" => "slow_down" }, status: 400),
+      json({ "error" => "authorization_pending" }, status: 400),
+      json(token_response)
+    )
+    waits, sleeper = recording_sleeper
+
+    token = Basecamp::Oauth.poll_device_token(
+      token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+      device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+    )
+
+    assert_equal "device_access_token", token.access_token
+    # 5s (pending), 5s (before slow_down), then +5 sustained → 10s, 10s.
+    assert_equal [ 5, 5, 10, 10 ], waits
+  end
+
+  def test_poll_doubles_interval_after_connection_timeout_then_recovers
+    client = SequencedHttpClient.new([
+      Faraday::TimeoutError.new("timed out"),
+      { status: 200, body: token_response.to_json }
+    ])
+    waits, sleeper = recording_sleeper
+
+    token = Basecamp::Oauth::DeviceFlow.poll_device_token(
+      token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+      device_code: "dev-code-123", interval: 5, expires_in: 900,
+      sleeper: sleeper, http_client: client
+    )
+
+    assert_equal "device_access_token", token.access_token
+    # First wait 5s; timeout doubles the backoff to 10s for the next wait.
+    assert_equal 5, waits[0]
+    assert_equal 10, waits[1]
+  end
+
+  def test_poll_expires_against_injected_monotonic_clock
+    times = [ 0, 1_000_000 ]
+    i = 0
+    clock = lambda do
+      t = times[[ i, times.length - 1 ].min]
+      i += 1
+      t
+    end
+    _waits, sleeper = recording_sleeper
+
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth.poll_device_token(
+        token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+        device_code: "dev-code-123", interval: 5, expires_in: 900,
+        sleeper: sleeper, clock: clock
+      )
+    end
+
+    assert_equal :expired, error.reason
+    assert_equal "auth", error.type
+  end
+
+  def test_poll_raises_access_denied
+    stub_request(:post, TOKEN_ENDPOINT).to_return(json({ "error" => "access_denied" }, status: 400))
+    _waits, sleeper = recording_sleeper
+
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth.poll_device_token(
+        token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+        device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+      )
+    end
+
+    assert_equal :access_denied, error.reason
+    assert_equal "auth", error.type
+  end
+
+  def test_poll_raises_expired_on_expired_token_error
+    stub_request(:post, TOKEN_ENDPOINT).to_return(json({ "error" => "expired_token" }, status: 400))
+    _waits, sleeper = recording_sleeper
+
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth.poll_device_token(
+        token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+        device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+      )
+    end
+
+    assert_equal :expired, error.reason
+    assert_equal "auth", error.type
+  end
+
+  def test_poll_rejects_wrong_typed_access_token
+    # A 2xx body whose access_token is not a non-empty String is malformed: the
+    # old `.to_s.empty?` probe would have accepted a numeric token.
+    stub_request(:post, TOKEN_ENDPOINT).to_return(json({ "access_token" => 999, "token_type" => "Bearer" }))
+    _waits, sleeper = recording_sleeper
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth.poll_device_token(
+        token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+        device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+      )
+    end
+    assert_equal "api_error", error.type
+  end
+
+  def test_poll_clamps_wait_to_deadline_so_backoff_never_overshoots
+    # interval (100s) far exceeds the 10s remaining before expiry. The wait must
+    # be clamped to the deadline, not the raw interval, so a long interval or a
+    # timeout backoff can never blow past the code lifetime.
+    clock = scripted_clock([ 0, 0, 10 ])
+    waits, sleeper = recording_sleeper
+
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth.poll_device_token(
+        token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+        device_code: "dev-code-123", interval: 100, expires_in: 10,
+        clock: clock, sleeper: sleeper
+      )
+    end
+
+    assert_equal :expired, error.reason
+    assert_equal [ 10 ], waits # clamped to remaining, not the 100s interval
+    assert_not_requested(:post, TOKEN_ENDPOINT)
+  end
+
+  def test_poll_raises_transport_on_non_timeout_failure
+    client = SequencedHttpClient.new([ Faraday::ConnectionFailed.new("boom") ])
+    _waits, sleeper = recording_sleeper
+
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth::DeviceFlow.poll_device_token(
+        token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+        device_code: "dev-code-123", interval: 5, expires_in: 900,
+        sleeper: sleeper, http_client: client
+      )
+    end
+
+    assert_equal :transport, error.reason
+    assert_equal "network", error.type
+    assert error.retryable
+  end
+
+  def test_poll_raises_cancelled_when_cancellation_probe_trips
+    cancel_flag = false
+    sleeper = ->(_seconds) { cancel_flag = true }
+    cancelled = -> { cancel_flag }
+
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth.poll_device_token(
+        token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+        device_code: "dev-code-123", interval: 5, expires_in: 900,
+        sleeper: sleeper, cancelled: cancelled
+      )
+    end
+
+    assert_equal :cancelled, error.reason
+    assert_equal "usage", error.type
+  end
+
+  # --- perform_device_login --------------------------------------------------
+
+  def test_perform_guards_capability_endpoint_present_but_no_device_grant
+    polled = stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response))
+    config = Basecamp::Oauth::Config.new(
+      issuer: ORIGIN, token_endpoint: TOKEN_ENDPOINT,
+      device_authorization_endpoint: DEVICE_ENDPOINT,
+      grant_types_supported: [ "refresh_token" ] # no device_code grant
+    )
+
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth.perform_device_login(
+        config: config, client_id: "basecamp-cli", display: ->(_auth) { }
+      )
+    end
+
+    assert_equal :unavailable, error.reason
+    assert_equal "validation", error.type
+    assert_not_requested(polled)
+  end
+
+  def test_perform_guards_capability_grant_present_but_no_endpoint
+    config = Basecamp::Oauth::Config.new(
+      issuer: ORIGIN, token_endpoint: TOKEN_ENDPOINT,
+      grant_types_supported: [ DEVICE_GRANT ] # device grant but no endpoint
+    )
+
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth.perform_device_login(
+        config: config, client_id: "basecamp-cli", display: ->(_auth) { }
+      )
+    end
+
+    assert_equal :unavailable, error.reason
+  end
+
+  def test_perform_fires_display_hook_then_completes
+    stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response))
+    stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response))
+    _waits, sleeper = recording_sleeper
+    config = Basecamp::Oauth::Config.new(
+      issuer: ORIGIN, token_endpoint: TOKEN_ENDPOINT,
+      device_authorization_endpoint: DEVICE_ENDPOINT,
+      grant_types_supported: [ DEVICE_GRANT, "refresh_token" ]
+    )
+
+    displayed = nil
+    token = Basecamp::Oauth.perform_device_login(
+      config: config, client_id: "basecamp-cli",
+      display: ->(auth) { displayed = auth }, sleeper: sleeper
+    )
+
+    assert_equal "WDJB-MJHT", displayed.user_code
+    assert_equal "device_access_token", token.access_token
+  end
+
+  def test_perform_raises_expired_when_display_hook_consumes_whole_lifetime
+    stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response)) # expires_in 900
+    polled = stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response))
+    _waits, sleeper = recording_sleeper
+    # issued_at = 0; the clock reads 950s AFTER the display hook returns — past
+    # the 900s code lifetime. The deadline is anchored at ISSUANCE, so a slow
+    # display cannot reset it: expiry is raised without a single poll.
+    clock = scripted_clock([ 0, 950 ])
+    config = Basecamp::Oauth::Config.new(
+      issuer: ORIGIN, token_endpoint: TOKEN_ENDPOINT,
+      device_authorization_endpoint: DEVICE_ENDPOINT,
+      grant_types_supported: [ DEVICE_GRANT ]
+    )
+
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth.perform_device_login(
+        config: config, client_id: "basecamp-cli",
+        display: ->(_auth) { }, clock: clock, sleeper: sleeper
+      )
+    end
+
+    assert_equal :expired, error.reason
+    assert_not_requested(polled)
+  end
+
+  def test_perform_anchors_deadline_at_issuance_so_slow_display_shrinks_remaining
+    stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response)) # expires_in 900, interval 5
+    polled = stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response))
+    waits, sleeper = recording_sleeper
+    # issued_at = 0; display returns at t=897, leaving only 3s of the 900s budget.
+    # poll must see remaining = 3 (deadline anchored at issuance), so its first
+    # wait clamps to 3s and it expires — proving the slow display did NOT reset
+    # the code lifetime back to the full 900s.
+    clock = scripted_clock([ 0, 897, 897, 897, 900 ])
+    config = Basecamp::Oauth::Config.new(
+      issuer: ORIGIN, token_endpoint: TOKEN_ENDPOINT,
+      device_authorization_endpoint: DEVICE_ENDPOINT,
+      grant_types_supported: [ DEVICE_GRANT ]
+    )
+
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth.perform_device_login(
+        config: config, client_id: "basecamp-cli",
+        display: ->(_auth) { }, clock: clock, sleeper: sleeper
+      )
+    end
+
+    assert_equal :expired, error.reason
+    assert_equal [ 3 ], waits # clamped to the 3s remaining, not the full 900s
+    assert_not_requested(polled)
+  end
+end

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -494,6 +494,25 @@ class OAuthDeviceTest < Minitest::Test
     assert_requested(:post, TOKEN_ENDPOINT, times: 1)
   end
 
+  def test_poll_invalid_body_cap_cannot_disable_the_bound
+    # An invalid runtime cap (Infinity here; nil/negative are the same class) must
+    # normalize to the default rather than disable the streaming/buffered bound —
+    # a 2 MiB body still aborts as the size-cap api_error, matching discovery.
+    stub_request(:post, TOKEN_ENDPOINT).to_return(json({ "pad" => "x" * (2 * 1024 * 1024) }))
+    _waits, sleeper = recording_sleeper
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth::DeviceFlow.poll_device_token(
+        token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+        device_code: "dev-code-123", interval: 5, expires_in: 900,
+        sleeper: sleeper, max_body_bytes: Float::INFINITY
+      )
+    end
+
+    assert_equal "api_error", error.type
+    assert_match(/size cap/i, error.message)
+  end
+
   def test_poll_rejects_out_of_range_caller_durations
     # Caller-input sanity on the public entry point: nil/non-numeric would raise
     # NoMethodError/TypeError deeper in, a non-finite expires_in builds a deadline

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -423,6 +423,26 @@ class OAuthDeviceTest < Minitest::Test
     end
   end
 
+  def test_poll_rejects_fractional_expires_in_on_token_response
+    # A fractional token lifetime is malformed under the whole-second contract
+    # (Go/Kotlin reject it by int/Long typing) → api_error, uniform across SDKs.
+    stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response.merge("expires_in" => 1.5)))
+
+    assert_poll_api_error
+  end
+
+  def test_poll_accepts_integer_valued_float_expires_in_on_token_response
+    stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response.merge("expires_in" => 3600.0)))
+    _waits, sleeper = recording_sleeper
+
+    token = Basecamp::Oauth.poll_device_token(
+      token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+      device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+    )
+
+    assert_equal 3600.0, token.expires_in
+  end
+
   def test_poll_rejects_non_string_token_fields
     # A numeric refresh_token/token_type/scope is malformed, not a credential
     # field — surface api_error rather than store a non-String.

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -494,6 +494,33 @@ class OAuthDeviceTest < Minitest::Test
     assert_requested(:post, TOKEN_ENDPOINT, times: 1)
   end
 
+  def test_poll_rejects_out_of_range_caller_durations
+    # Caller-input sanity on the public entry point: nil/non-numeric would raise
+    # NoMethodError/TypeError deeper in, a non-finite expires_in builds a deadline
+    # that NEVER passes (an unbounded poll loop), and zero/negative/oversized
+    # values are not schedulable waits. All surface as usage before any request.
+    [
+      { interval: 5, expires_in: nil },
+      { interval: 5, expires_in: 0 },
+      { interval: 5, expires_in: -1 },
+      { interval: 5, expires_in: Float::INFINITY },
+      { interval: 5, expires_in: Float::NAN },
+      { interval: 5, expires_in: 2_147_484 },
+      { interval: nil, expires_in: 900 },
+      { interval: 0, expires_in: 900 },
+      { interval: 2_147_484, expires_in: 900 }
+    ].each do |args|
+      error = assert_raises(Basecamp::Oauth::OauthError, args.inspect) do
+        Basecamp::Oauth.poll_device_token(
+          token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+          device_code: "dev-code-123", **args
+        )
+      end
+      assert_equal "usage", error.type, args.inspect
+    end
+    assert_not_requested(:post, TOKEN_ENDPOINT)
+  end
+
   def test_poll_expires_against_injected_monotonic_clock
     times = [ 0, 1_000_000 ]
     i = 0
@@ -646,6 +673,35 @@ class OAuthDeviceTest < Minitest::Test
 
     assert_equal "api_error", error.type
     assert_match(/redirect/i, error.message)
+  end
+
+  def test_token_poll_redirect_classified_by_status_on_buffered_adapter
+    # Faraday's built-in Test adapter buffers the whole body and IGNORES +on_data+ —
+    # exactly like any adapter on Faraday 2.0–2.4, which never passes +env+ to
+    # +on_data+. The SkipBody fast-path can never fire, so the post-request status
+    # backstop in +post_form+ must classify the redirect by its completed status
+    # BEFORE the oversized buffered body trips the size cap.
+    stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.post("https://issuer.example/token") do
+        [ 302, { "Location" => "https://x/" }, "x" * (2 * 1024 * 1024) ]
+      end
+    end
+    connection = Faraday.new { |conn| conn.adapter :test, stubs }
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth::DeviceFlow.poll_device_token(
+        token_endpoint: "https://issuer.example/token", client_id: "basecamp-cli",
+        device_code: "d", interval: 5, expires_in: 900,
+        http_client: connection, clock: -> { 0.0 }, sleeper: ->(_seconds) { }
+      )
+    end
+
+    # Redirect api_error by status — NOT the size cap the 2 MiB buffered body would
+    # trip if the backstop failed to short-circuit before reading it.
+    assert_equal "api_error", error.type
+    assert_equal 302, error.http_status
+    assert_match(/redirect/i, error.message)
+    assert_no_match(/size cap/i, error.message)
   end
 
   def test_poll_cancellation_during_wait_is_prompt

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -944,6 +944,34 @@ class OAuthDeviceTest < Minitest::Test
     assert_equal "device_access_token", token.access_token
   end
 
+  def test_perform_cancel_during_the_anchor_clock_call_stops_the_request
+    # The injected clock is itself a callback seam: a cancel flipped inside the
+    # pre-request anchor sample must stop the flow before the authorization
+    # request fires.
+    requested = stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response))
+    state = { cancelled: false }
+    clock = lambda do
+      state[:cancelled] = true
+      0
+    end
+    _waits, sleeper = recording_sleeper
+    config = Basecamp::Oauth::Config.new(
+      issuer: ORIGIN, token_endpoint: TOKEN_ENDPOINT,
+      device_authorization_endpoint: DEVICE_ENDPOINT,
+      grant_types_supported: [ DEVICE_GRANT, "refresh_token" ]
+    )
+
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth.perform_device_login(
+        config: config, client_id: "basecamp-cli", display: ->(_auth) { },
+        sleeper: sleeper, clock: clock, cancelled: -> { state[:cancelled] }
+      )
+    end
+
+    assert_equal :cancelled, error.reason
+    assert_not_requested(requested)
+  end
+
   def test_perform_slow_authorization_response_counts_against_the_code_lifetime
     # The code is minted server-side before the response travels back: a
     # response arriving 6s late with expires_in 5 is dead on arrival, so the

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -944,6 +944,37 @@ class OAuthDeviceTest < Minitest::Test
     assert_equal "device_access_token", token.access_token
   end
 
+  def test_perform_slow_authorization_response_counts_against_the_code_lifetime
+    # The code is minted server-side before the response travels back: a
+    # response arriving 6s late with expires_in 5 is dead on arrival, so the
+    # pre-request anchor must expire it — never grant a fresh lifetime.
+    state = { t: 0 }
+    auth_body = device_auth_response("expires_in" => 5).to_json
+    client = Object.new
+    client.define_singleton_method(:post) do |_url|
+      state[:t] += 6
+      SequencedHttpClient::Response.new(200, auth_body)
+    end
+    polled = stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response))
+    _waits, sleeper = recording_sleeper
+    config = Basecamp::Oauth::Config.new(
+      issuer: ORIGIN, token_endpoint: TOKEN_ENDPOINT,
+      device_authorization_endpoint: DEVICE_ENDPOINT,
+      grant_types_supported: [ DEVICE_GRANT, "refresh_token" ]
+    )
+
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth::DeviceFlow.perform_device_login(
+        config: config, client_id: "basecamp-cli",
+        display: ->(_auth) { }, sleeper: sleeper,
+        http_client: client, clock: -> { state[:t] }
+      )
+    end
+
+    assert_equal :expired, error.reason
+    assert_not_requested(polled)
+  end
+
   def test_perform_cancellation_wins_over_a_device_auth_fault
     # Same contract on the error path: the authorization request fails AND the
     # probe flipped mid-flight — cancelled must win over transport, and the

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -614,7 +614,11 @@ class OAuthDeviceTest < Minitest::Test
       { interval: 5, expires_in: 2_147_484 },
       { interval: nil, expires_in: 900 },
       { interval: 0, expires_in: 900 },
-      { interval: 2_147_484, expires_in: 900 }
+      { interval: 2_147_484, expires_in: 900 },
+      # Whole seconds (RFC 8628): a fractional interval would permit ~1000
+      # polls per second. expires_in stays legitimately fractional.
+      { interval: 0.001, expires_in: 900 },
+      { interval: 2.5, expires_in: 900 }
     ].each do |args|
       error = assert_raises(Basecamp::Oauth::OauthError, args.inspect) do
         Basecamp::Oauth.poll_device_token(

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -944,6 +944,39 @@ class OAuthDeviceTest < Minitest::Test
     assert_equal "device_access_token", token.access_token
   end
 
+  def test_perform_cancel_during_the_post_display_clock_call_beats_expiry
+    # The post-display sample is the same cancellation-capable callback seam
+    # as the pre-request anchor: a cancel flipped inside it — even one
+    # returning a beyond-deadline value — must surface cancelled, never
+    # expired.
+    stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response))
+    state = { cancelled: false, calls: 0 }
+    clock = lambda do
+      state[:calls] += 1
+      if state[:calls] >= 2
+        state[:cancelled] = true
+        10_000
+      else
+        0
+      end
+    end
+    _waits, sleeper = recording_sleeper
+    config = Basecamp::Oauth::Config.new(
+      issuer: ORIGIN, token_endpoint: TOKEN_ENDPOINT,
+      device_authorization_endpoint: DEVICE_ENDPOINT,
+      grant_types_supported: [ DEVICE_GRANT, "refresh_token" ]
+    )
+
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth.perform_device_login(
+        config: config, client_id: "basecamp-cli", display: ->(_auth) { },
+        sleeper: sleeper, clock: clock, cancelled: -> { state[:cancelled] }
+      )
+    end
+
+    assert_equal :cancelled, error.reason
+  end
+
   def test_perform_cancel_during_the_anchor_clock_call_stops_the_request
     # The injected clock is itself a callback seam: a cancel flipped inside the
     # pre-request anchor sample must stop the flow before the authorization

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -600,6 +600,30 @@ class OAuthDeviceTest < Minitest::Test
     assert_match(/size cap/i, error.message)
   end
 
+  def test_poll_parse_fault_suppresses_the_parser_cause
+    # A malformed 200 token body can carry the access token, and
+    # JSON::ParserError embeds the offending input in its message — the
+    # mapped fault must not chain it (full_message and cause-aware loggers
+    # would disclose the body).
+    secret = "sk-live-SUPERSECRET"
+    stub_request(:post, TOKEN_ENDPOINT).to_return(
+      status: 200, headers: { "Content-Type" => "application/json" },
+      body: "{\"access_token\": \"#{secret}' oops"
+    )
+    _waits, sleeper = recording_sleeper
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth.poll_device_token(
+        token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+        device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+      )
+    end
+
+    assert_equal "api_error", error.type
+    assert_not_includes error.message, secret
+    assert_nil error.cause
+  end
+
   def test_poll_rejects_out_of_range_caller_durations
     # Caller-input sanity on the public entry point: nil/non-numeric would raise
     # NoMethodError/TypeError deeper in, a non-finite expires_in builds a deadline

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -961,6 +961,32 @@ class OAuthDeviceTest < Minitest::Test
     assert_not_requested(polled)
   end
 
+  def test_perform_cancel_during_display_beats_expiry
+    # A display hook that both cancels the flow and consumes the whole code
+    # lifetime (a prompt closing in response to cancellation) must surface
+    # cancelled, not expired.
+    stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response)) # expires_in 900
+    _waits, sleeper = recording_sleeper
+    clock = scripted_clock([ 0, 950 ])
+    state = { cancelled: false }
+    config = Basecamp::Oauth::Config.new(
+      issuer: ORIGIN, token_endpoint: TOKEN_ENDPOINT,
+      device_authorization_endpoint: DEVICE_ENDPOINT,
+      grant_types_supported: [ DEVICE_GRANT ]
+    )
+
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth.perform_device_login(
+        config: config, client_id: "basecamp-cli",
+        display: ->(_auth) { state[:cancelled] = true },
+        cancelled: -> { state[:cancelled] },
+        clock: clock, sleeper: sleeper
+      )
+    end
+
+    assert_equal :cancelled, error.reason
+  end
+
   def test_perform_anchors_deadline_at_issuance_so_slow_display_shrinks_remaining
     stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response)) # expires_in 900, interval 5
     polled = stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response))

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -961,6 +961,27 @@ class OAuthDeviceTest < Minitest::Test
     assert_not_requested(polled)
   end
 
+  def test_perform_rejects_a_non_callable_display_before_any_request
+    # display is the only mechanism surfacing the verification code:
+    # dereferencing nil AFTER the request would mint a code nobody can
+    # approve. Reject as usage with zero network activity.
+    requested = stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response))
+    config = Basecamp::Oauth::Config.new(
+      issuer: ORIGIN, token_endpoint: TOKEN_ENDPOINT,
+      device_authorization_endpoint: DEVICE_ENDPOINT,
+      grant_types_supported: [ DEVICE_GRANT ]
+    )
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth.perform_device_login(
+        config: config, client_id: "basecamp-cli", display: nil
+      )
+    end
+
+    assert_equal "usage", error.type
+    assert_not_requested(requested)
+  end
+
   def test_perform_cancel_during_display_beats_expiry
     # A display hook that both cancels the flow and consumes the whole code
     # lifetime (a prompt closing in response to cancellation) must surface

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -710,6 +710,43 @@ class OAuthDeviceTest < Minitest::Test
     assert_not_requested(:post, TOKEN_ENDPOINT)
   end
 
+  def test_poll_rejects_malformed_clock_samples_as_usage
+    # A String or huge-int sample must surface as the typed usage fault —
+    # never a raw TypeError out of the deadline arithmetic, and never an
+    # Infinity that defeats every deadline comparison.
+    [ "now", 10**400, Complex(1, 1) ].each do |bad|
+      _waits, sleeper = recording_sleeper
+      error = assert_raises(Basecamp::Oauth::OauthError, "clock sample #{bad.inspect}") do
+        Basecamp::Oauth.poll_device_token(
+          token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+          device_code: "dev-code-123", interval: 5, expires_in: 900,
+          clock: -> { bad }, sleeper: sleeper
+        )
+      end
+      assert_equal "usage", error.type, "clock sample #{bad.inspect}"
+      assert_match(/clock must return a finite number of seconds/, error.message)
+    end
+  end
+
+  def test_poll_rejects_a_malformed_later_clock_sample_as_usage
+    # EVERY sample is validated, not just the first: a clock that goes bad
+    # mid-flight (sample 2 here, before the first request) must surface the
+    # same typed usage fault instead of a raw TypeError.
+    clock = scripted_clock([ 0, "now" ])
+    _waits, sleeper = recording_sleeper
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth.poll_device_token(
+        token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+        device_code: "dev-code-123", interval: 5, expires_in: 900,
+        clock: clock, sleeper: sleeper
+      )
+    end
+
+    assert_equal "usage", error.type
+    assert_not_requested(:post, TOKEN_ENDPOINT)
+  end
+
   def test_poll_raises_transport_on_non_timeout_failure
     client = SequencedHttpClient.new([ Faraday::ConnectionFailed.new("boom") ])
     _waits, sleeper = recording_sleeper

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -779,6 +779,48 @@ class OAuthDeviceTest < Minitest::Test
     assert_not_requested(:post, TOKEN_ENDPOINT)
   end
 
+  def test_poll_header_drip_on_injected_client_is_bounded
+    # An injected Faraday client's per-read timeout resets on every socket
+    # read: a peer dripping HEADER bytes under it would hold the POST open
+    # indefinitely (on_data never runs during the header phase). The outer
+    # wall clock must cut it at ~timeout and surface the transport-shaped
+    # timeout the poll loop's backoff understands.
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    thread = Thread.new do
+      conn = server.accept
+      # Drip one header byte per 0.1s for ~5s — far past the 0.5s timeout,
+      # each gap well under the per-read timeout.
+      "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n".each_char do |ch|
+        conn.write(ch)
+        sleep(0.1)
+      end
+    rescue IOError, SystemCallError
+      nil
+    end
+
+    WebMock.disable!
+    # Adapter-only: the SSRF guard refuses middleware it cannot verify
+    # redirect-free (Faraday.new's default stack includes UrlEncoded).
+    connection = Faraday.new { |f| f.adapter :net_http }
+    _waits, sleeper = recording_sleeper
+    started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth::DeviceFlow.request_device_authorization(
+        device_authorization_endpoint: "http://127.0.0.1:#{port}/device",
+        client_id: "basecamp-cli", http_client: connection, timeout: 0.5
+      )
+    end
+    took = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+
+    assert_equal :transport, error.reason
+    assert_operator took, :<, 2.0, "header drip must be cut by the wall clock, took #{took.round(2)}s"
+  ensure
+    WebMock.enable!
+    thread&.kill&.join
+    server&.close
+  end
+
   def test_poll_cancellation_wins_over_a_transport_fault
     # Cancellation-beats-classification on the error path: the probe flips as
     # the doomed request fails (index goes positive before the step raises),

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -821,6 +821,56 @@ class OAuthDeviceTest < Minitest::Test
     server&.close
   end
 
+  def test_injected_client_dispatch_refused_when_budget_already_spent
+    # The wall-clock wrap must grant the REMAINING budget, not a fresh full
+    # timeout: when the deadline has already passed by dispatch time (thread
+    # descheduled after the deadline was captured), the POST must be refused
+    # rather than handed a whole new request window.
+    fetcher = Basecamp::Oauth::Fetcher
+    original = fetcher.method(:bounded_reader)
+    fetcher.define_singleton_method(:bounded_reader) do |*args, **kwargs|
+      sleep 0.1 # burn the entire budget between deadline capture and dispatch
+      original.call(*args, **kwargs)
+    end
+    dispatched = false
+    client = Object.new
+    client.define_singleton_method(:post) { |_url| dispatched = true }
+
+    assert_raises(Faraday::TimeoutError) do
+      Basecamp::Oauth::DeviceFlow.send(
+        :post_form, client, TOKEN_ENDPOINT, { "grant_type" => "test" },
+        timeout: 0.05, max_body_bytes: 1024
+      )
+    end
+    assert_equal false, dispatched, "POST must not dispatch on an exhausted budget"
+  ensure
+    fetcher.define_singleton_method(:bounded_reader, original)
+  end
+
+  def test_injected_client_response_completing_past_the_deadline_is_refused
+    # Timeout.timeout's interrupt can be delivered late: simulate that race by
+    # neutering the wrap so the request returns a 200 after the deadline has
+    # passed. The post-return monotonic re-check must refuse the late response
+    # as the same transport-shaped timeout — never hand back a token past the
+    # wall clock.
+    original = Timeout.method(:timeout)
+    Timeout.define_singleton_method(:timeout) { |*_args, &block| block.call }
+    client = Object.new
+    client.define_singleton_method(:post) do |_url|
+      sleep 0.1 # completes past the 0.05s deadline; the interrupt never lands
+      SequencedHttpClient::Response.new(200, +%({"access_token":"late"}))
+    end
+
+    assert_raises(Faraday::TimeoutError) do
+      Basecamp::Oauth::DeviceFlow.send(
+        :post_form, client, TOKEN_ENDPOINT, { "grant_type" => "test" },
+        timeout: 0.05, max_body_bytes: 1024
+      )
+    end
+  ensure
+    Timeout.define_singleton_method(:timeout, original)
+  end
+
   def test_poll_cancellation_wins_over_a_transport_fault
     # Cancellation-beats-classification on the error path: the probe flips as
     # the doomed request fails (index goes positive before the step raises),

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -977,11 +977,11 @@ class OAuthDeviceTest < Minitest::Test
     assert_equal :cancelled, error.reason
   end
 
-  def test_perform_cancel_during_the_anchor_clock_call_stops_the_request
-    # The injected clock is itself a callback seam: a cancel flipped inside the
-    # pre-request anchor sample must stop the flow before the authorization
-    # request fires.
-    requested = stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response))
+  def test_perform_cancel_during_the_anchor_clock_call_never_reaches_display
+    # The injected clock is itself a callback seam: a cancel flipped inside
+    # the post-response issuance anchor must surface cancelled before the
+    # display hook fires.
+    stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response))
     state = { cancelled: false }
     clock = lambda do
       state[:cancelled] = true
@@ -994,29 +994,36 @@ class OAuthDeviceTest < Minitest::Test
       grant_types_supported: [ DEVICE_GRANT, "refresh_token" ]
     )
 
+    displayed = []
     error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
       Basecamp::Oauth.perform_device_login(
-        config: config, client_id: "basecamp-cli", display: ->(_auth) { },
+        config: config, client_id: "basecamp-cli",
+        display: ->(auth) { displayed << auth },
         sleeper: sleeper, clock: clock, cancelled: -> { state[:cancelled] }
       )
     end
 
     assert_equal :cancelled, error.reason
-    assert_not_requested(requested)
+    assert_empty displayed
   end
 
-  def test_perform_slow_authorization_response_counts_against_the_code_lifetime
-    # The code is minted server-side before the response travels back: a
-    # response arriving 6s late with expires_in 5 is dead on arrival, so the
-    # pre-request anchor must expire it — never grant a fresh lifetime.
+  def test_perform_expiry_anchors_at_response_receipt_not_request_start
+    # SPEC §16: the deadline is clock() + expires_in taken AFTER the
+    # authorization request returns — a 6s request leg with expires_in 5 must
+    # NOT expire the fresh code client-side; expiry past receipt is
+    # arbitrated by the server (expired_token).
     state = { t: 0 }
     auth_body = device_auth_response("expires_in" => 5).to_json
+    token_body = token_response.to_json
     client = Object.new
-    client.define_singleton_method(:post) do |_url|
-      state[:t] += 6
-      SequencedHttpClient::Response.new(200, auth_body)
+    client.define_singleton_method(:post) do |url|
+      if url.include?("/oauth/device")
+        state[:t] += 6
+        SequencedHttpClient::Response.new(200, auth_body)
+      else
+        SequencedHttpClient::Response.new(200, token_body)
+      end
     end
-    polled = stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response))
     _waits, sleeper = recording_sleeper
     config = Basecamp::Oauth::Config.new(
       issuer: ORIGIN, token_endpoint: TOKEN_ENDPOINT,
@@ -1024,16 +1031,13 @@ class OAuthDeviceTest < Minitest::Test
       grant_types_supported: [ DEVICE_GRANT, "refresh_token" ]
     )
 
-    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
-      Basecamp::Oauth::DeviceFlow.perform_device_login(
-        config: config, client_id: "basecamp-cli",
-        display: ->(_auth) { }, sleeper: sleeper,
-        http_client: client, clock: -> { state[:t] }
-      )
-    end
+    token = Basecamp::Oauth::DeviceFlow.perform_device_login(
+      config: config, client_id: "basecamp-cli",
+      display: ->(_auth) { }, sleeper: sleeper,
+      http_client: client, clock: -> { state[:t] }
+    )
 
-    assert_equal :expired, error.reason
-    assert_not_requested(polled)
+    assert_equal "device_access_token", token.access_token
   end
 
   def test_perform_cancellation_wins_over_a_device_auth_fault

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -388,6 +388,28 @@ class OAuthDeviceTest < Minitest::Test
     end
   end
 
+  def test_poll_protocol_errors_only_on_4xx
+    # OAuth protocol states are recognized only on a 4xx: a nonstandard 2xx or
+    # a 5xx carrying a crafted authorization_pending body must terminate as
+    # api_error, never extend polling.
+    [ 201, 202, 500 ].each do |status|
+      stub_request(:post, TOKEN_ENDPOINT)
+        .to_return(json({ "error" => "authorization_pending" }, status: status))
+      _waits, sleeper = recording_sleeper
+
+      error = assert_raises(Basecamp::Oauth::OauthError) do
+        Basecamp::Oauth.poll_device_token(
+          token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+          device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+        )
+      end
+      assert_equal "api_error", error.type
+      assert_equal status, error.http_status
+      assert_requested :post, TOKEN_ENDPOINT, times: 1
+      WebMock.reset!
+    end
+  end
+
   def test_poll_accepts_token_response_without_expires_in
     # expires_in is optional (RFC 6749 §5.1): absent means no known expiry, so
     # the Token carries nil expires_in/expires_at rather than raising.

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -410,6 +410,26 @@ class OAuthDeviceTest < Minitest::Test
     end
   end
 
+  def test_poll_terminal_status_classified_without_draining_body
+    # An oversized body on a terminal non-4xx would trip the size cap if
+    # drained — skip_status refuses the body and the status api_error surfaces.
+    [ 201, 500 ].each do |status|
+      stub_request(:post, TOKEN_ENDPOINT)
+        .to_return(status: status, body: "x" * (2 * 1024 * 1024))
+      _waits, sleeper = recording_sleeper
+
+      error = assert_raises(Basecamp::Oauth::OauthError) do
+        Basecamp::Oauth.poll_device_token(
+          token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+          device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+        )
+      end
+      assert_equal "api_error", error.type
+      assert_match(/status #{status}/, error.message)
+      WebMock.reset!
+    end
+  end
+
   def test_poll_accepts_token_response_without_expires_in
     # expires_in is optional (RFC 6749 §5.1): absent means no known expiry, so
     # the Token carries nil expires_in/expires_at rather than raising.

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -370,6 +370,24 @@ class OAuthDeviceTest < Minitest::Test
     assert_equal 200, error.http_status
   end
 
+  def test_poll_non_200_success_is_terminal
+    # RFC 8628/6749 token responses are exactly 200 (SPEC.md §16): a
+    # nonstandard 201/202 carrying an access_token must not complete polling.
+    [ 201, 202 ].each do |status|
+      stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response, status: status))
+      _waits, sleeper = recording_sleeper
+
+      error = assert_raises(Basecamp::Oauth::OauthError) do
+        Basecamp::Oauth.poll_device_token(
+          token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+          device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+        )
+      end
+      assert_equal "api_error", error.type
+      assert_equal status, error.http_status
+    end
+  end
+
   def test_poll_accepts_token_response_without_expires_in
     # expires_in is optional (RFC 6749 §5.1): absent means no known expiry, so
     # the Token carries nil expires_in/expires_at rather than raising.

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -20,6 +20,10 @@ class OAuthDeviceTest < Minitest::Test
   class SequencedHttpClient
     Response = Struct.new(:status, :body)
 
+    # Exposed so cancellation tests can flip a probe the moment a request
+    # has been attempted (index goes positive before a step raises).
+    attr_reader :index
+
     def initialize(steps)
       @steps = steps
       @index = 0
@@ -747,6 +751,25 @@ class OAuthDeviceTest < Minitest::Test
     assert_not_requested(:post, TOKEN_ENDPOINT)
   end
 
+  def test_poll_cancellation_wins_over_a_transport_fault
+    # Cancellation-beats-classification on the error path: the probe flips as
+    # the doomed request fails (index goes positive before the step raises),
+    # so the poll must surface cancelled — never the transport fault.
+    client = SequencedHttpClient.new([ Faraday::ConnectionFailed.new("boom") ])
+    _waits, sleeper = recording_sleeper
+
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth::DeviceFlow.poll_device_token(
+        token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+        device_code: "dev-code-123", interval: 5, expires_in: 900,
+        http_client: client, sleeper: sleeper,
+        cancelled: -> { client.index.positive? }
+      )
+    end
+
+    assert_equal :cancelled, error.reason
+  end
+
   def test_poll_raises_transport_on_non_timeout_failure
     client = SequencedHttpClient.new([ Faraday::ConnectionFailed.new("boom") ])
     _waits, sleeper = recording_sleeper
@@ -919,6 +942,31 @@ class OAuthDeviceTest < Minitest::Test
 
     assert_equal "WDJB-MJHT", displayed.user_code
     assert_equal "device_access_token", token.access_token
+  end
+
+  def test_perform_cancellation_wins_over_a_device_auth_fault
+    # Same contract on the error path: the authorization request fails AND the
+    # probe flipped mid-flight — cancelled must win over transport, and the
+    # display hook must never fire.
+    client = SequencedHttpClient.new([ Faraday::ConnectionFailed.new("boom") ])
+    _waits, sleeper = recording_sleeper
+    config = Basecamp::Oauth::Config.new(
+      issuer: ORIGIN, token_endpoint: TOKEN_ENDPOINT,
+      device_authorization_endpoint: DEVICE_ENDPOINT,
+      grant_types_supported: [ DEVICE_GRANT, "refresh_token" ]
+    )
+
+    displayed = []
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth::DeviceFlow.perform_device_login(
+        config: config, client_id: "basecamp-cli",
+        display: ->(auth) { displayed << auth }, sleeper: sleeper,
+        http_client: client, cancelled: -> { client.index.positive? }
+      )
+    end
+
+    assert_equal :cancelled, error.reason
+    assert_empty displayed
   end
 
   def test_perform_already_cancelled_flow_makes_no_request

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -982,6 +982,21 @@ class OAuthDeviceTest < Minitest::Test
     assert_not_requested(requested)
   end
 
+  def test_poll_rejects_a_deadline_at_beyond_the_code_lifetime
+    # deadline_at can only SHORTEN the validated lifetime (mirrors the TS
+    # deadlineAtMs bound).
+    [ Float::NAN, 10_000_000.0 ].each do |bad|
+      error = assert_raises(Basecamp::Oauth::OauthError) do
+        Basecamp::Oauth.poll_device_token(
+          token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+          device_code: "dev-code-123", interval: 5, expires_in: 900,
+          clock: -> { 0.0 }, deadline_at: bad, sleeper: ->(_s) { }
+        )
+      end
+      assert_equal "usage", error.type
+    end
+  end
+
   def test_perform_cancel_during_display_beats_expiry
     # A display hook that both cancels the flow and consumes the whole code
     # lifetime (a prompt closing in response to cancellation) must surface

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -884,6 +884,58 @@ class OAuthDeviceTest < Minitest::Test
     assert_equal "device_access_token", token.access_token
   end
 
+  def test_perform_already_cancelled_flow_makes_no_request
+    requested = stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response))
+    _waits, sleeper = recording_sleeper
+    config = Basecamp::Oauth::Config.new(
+      issuer: ORIGIN, token_endpoint: TOKEN_ENDPOINT,
+      device_authorization_endpoint: DEVICE_ENDPOINT,
+      grant_types_supported: [ DEVICE_GRANT, "refresh_token" ]
+    )
+
+    displayed = []
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth.perform_device_login(
+        config: config, client_id: "basecamp-cli",
+        display: ->(auth) { displayed << auth }, sleeper: sleeper,
+        cancelled: -> { true }
+      )
+    end
+
+    assert_equal :cancelled, error.reason
+    assert_not_requested(requested)
+    assert_empty displayed
+  end
+
+  def test_perform_cancel_during_authorization_request_never_reaches_display
+    # The stub flips the probe as it serves the code pair, so the entry check
+    # passes and only the post-request re-check can catch it — the display
+    # hook must never fire for a cancelled flow.
+    cancelled = { flag: false }
+    stub_request(:post, DEVICE_ENDPOINT).to_return do |_request|
+      cancelled[:flag] = true
+      { status: 200, body: device_auth_response.to_json, headers: { "Content-Type" => "application/json" } }
+    end
+    _waits, sleeper = recording_sleeper
+    config = Basecamp::Oauth::Config.new(
+      issuer: ORIGIN, token_endpoint: TOKEN_ENDPOINT,
+      device_authorization_endpoint: DEVICE_ENDPOINT,
+      grant_types_supported: [ DEVICE_GRANT, "refresh_token" ]
+    )
+
+    displayed = []
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth.perform_device_login(
+        config: config, client_id: "basecamp-cli",
+        display: ->(auth) { displayed << auth }, sleeper: sleeper,
+        cancelled: -> { cancelled[:flag] }
+      )
+    end
+
+    assert_equal :cancelled, error.reason
+    assert_empty displayed
+  end
+
   def test_perform_raises_expired_when_display_hook_consumes_whole_lifetime
     stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response)) # expires_in 900
     polled = stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response))

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -985,7 +985,7 @@ class OAuthDeviceTest < Minitest::Test
   def test_poll_rejects_a_deadline_at_beyond_the_code_lifetime
     # deadline_at can only SHORTEN the validated lifetime (mirrors the TS
     # deadlineAtMs bound).
-    [ Float::NAN, 10_000_000.0 ].each do |bad|
+    [ Float::NAN, 10_000_000.0, Complex(1, 2), "soon" ].each do |bad|
       error = assert_raises(Basecamp::Oauth::OauthError) do
         Basecamp::Oauth.poll_device_token(
           token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -430,6 +430,29 @@ class OAuthDeviceTest < Minitest::Test
     end
   end
 
+  def test_poll_cancel_set_during_the_request_beats_a_200
+    # The sync POST cannot observe the cancelled probe in flight; a cancel set
+    # while the request runs must surface after the round-trip — never a token
+    # returned post-cancellation. The stub itself flips the probe as it serves
+    # the 200, so every check BEFORE the POST sees not-cancelled and only the
+    # post-request re-check can catch it.
+    cancelled = { flag: false }
+    stub_request(:post, TOKEN_ENDPOINT).to_return do |_request|
+      cancelled[:flag] = true # cancel arrives while the POST is in flight
+      { status: 200, body: token_response.to_json, headers: { "Content-Type" => "application/json" } }
+    end
+    _waits, sleeper = recording_sleeper
+
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth.poll_device_token(
+        token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+        device_code: "dev-code-123", interval: 5, expires_in: 900,
+        sleeper: sleeper, cancelled: -> { cancelled[:flag] }
+      )
+    end
+    assert_equal :cancelled, error.reason
+  end
+
   def test_poll_accepts_token_response_without_expires_in
     # expires_in is optional (RFC 6749 §5.1): absent means no known expiry, so
     # the Token carries nil expires_in/expires_at rather than raising.

--- a/ruby/test/basecamp/oauth_ssrf_test.rb
+++ b/ruby/test/basecamp/oauth_ssrf_test.rb
@@ -302,6 +302,16 @@ class OAuthSsrfTest < Minitest::Test
     assert_equal 2.5, Basecamp::Oauth::Discovery.new(timeout: 2.5).instance_variable_get(:@timeout)
   end
 
+  def test_normalize_timeout_honors_operation_default
+    # An invalid timeout falls back to the caller-supplied default, so device flow
+    # (30s) does not silently borrow discovery's shorter 10s budget.
+    assert_equal Basecamp::Oauth::Fetcher::DEFAULT_TIMEOUT, Basecamp::Oauth::Fetcher.normalize_timeout(nil)
+    assert_equal 30, Basecamp::Oauth::Fetcher.normalize_timeout(nil, default: 30)
+    assert_equal 30, Basecamp::Oauth::Fetcher.normalize_timeout(Float::INFINITY, default: 30)
+    # A valid value is preserved regardless of the default.
+    assert_equal 5, Basecamp::Oauth::Fetcher.normalize_timeout(5, default: 30)
+  end
+
   def test_redirect_is_not_followed
     issuer = "https://issuer.redirect-test.example"
     attacker = "https://attacker.example.com"

--- a/ruby/test/basecamp/oauth_ssrf_test.rb
+++ b/ruby/test/basecamp/oauth_ssrf_test.rb
@@ -310,6 +310,12 @@ class OAuthSsrfTest < Minitest::Test
     assert_equal 30, Basecamp::Oauth::Fetcher.normalize_timeout(Float::INFINITY, default: 30)
     # A valid value is preserved regardless of the default.
     assert_equal 5, Basecamp::Oauth::Fetcher.normalize_timeout(5, default: 30)
+    # An INVALID default must not disable the bounds either: fall back to the
+    # finite constant rather than returning the bad default.
+    assert_equal Basecamp::Oauth::Fetcher::DEFAULT_TIMEOUT,
+      Basecamp::Oauth::Fetcher.normalize_timeout(nil, default: Float::INFINITY)
+    assert_equal Basecamp::Oauth::Fetcher::DEFAULT_TIMEOUT,
+      Basecamp::Oauth::Fetcher.normalize_timeout("bad", default: nil)
   end
 
   def test_redirect_is_not_followed

--- a/ruby/test/basecamp/oauth_ssrf_test.rb
+++ b/ruby/test/basecamp/oauth_ssrf_test.rb
@@ -126,6 +126,33 @@ class OAuthSsrfTest < Minitest::Test
     # The read aborted mid-stream: fewer bytes were delivered than the full body.
     assert_operator meter[:delivered], :<, body.bytesize
   end
+  def test_device_over_cap_body_aborts_before_buffering_whole_body
+    endpoint = "https://issuer.ssrf-test.example/oauth/device"
+    # A well-formed device-auth doc padded far past the cap.
+    oversized = {
+      "device_code" => "d", "user_code" => "u", "verification_uri" => "https://x",
+      "expires_in" => 900, "pad" => "x" * (256 * 1024)
+    }.to_json
+
+    meter = { delivered: 0 }
+    connection = Faraday.new do |conn|
+      conn.adapter StreamingAdapter, body: oversized, chunk_size: 4096, meter: meter
+    end
+
+    cap = 8 * 1024
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth::DeviceFlow.request_device_authorization(
+        device_authorization_endpoint: endpoint, client_id: "basecamp-cli",
+        http_client: connection, max_body_bytes: cap
+      )
+    end
+    assert_equal "api_error", error.type
+
+    # The device response read is bounded exactly like discovery: it aborts once
+    # the accumulated bytes exceed the cap, never buffering the whole 256 KiB body.
+    assert_operator meter[:delivered], :<=, cap + 4096
+    assert_operator meter[:delivered], :<, oversized.bytesize
+  end
 
   # A middleware whose name matches the redirect detector. Standing in for
   # faraday-follow_redirects without taking the dependency.
@@ -133,6 +160,32 @@ class OAuthSsrfTest < Minitest::Test
     def call(env)
       @app.call(env)
     end
+  end
+
+  def test_device_injected_client_carrying_redirect_middleware_is_rejected
+    connection = Faraday.new do |conn|
+      conn.use RedirectFollowingMiddleware
+      conn.adapter Faraday.default_adapter
+    end
+
+    # Device flow applies the same redirect-suppression guard as discovery, so an
+    # injected redirect-following client is refused before any request is issued.
+    auth_error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth::DeviceFlow.request_device_authorization(
+        device_authorization_endpoint: "https://issuer.ssrf-test.example/oauth/device",
+        client_id: "basecamp-cli", http_client: connection
+      )
+    end
+    assert_equal "validation", auth_error.type
+
+    poll_error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth::DeviceFlow.poll_device_token(
+        token_endpoint: "https://issuer.ssrf-test.example/oauth/token",
+        client_id: "basecamp-cli", device_code: "d", interval: 5, expires_in: 900,
+        http_client: connection
+      )
+    end
+    assert_equal "validation", poll_error.type
   end
 
   def test_injected_client_carrying_redirect_middleware_is_rejected

--- a/ruby/test/basecamp/oauth_ssrf_test.rb
+++ b/ruby/test/basecamp/oauth_ssrf_test.rb
@@ -154,6 +154,34 @@ class OAuthSsrfTest < Minitest::Test
     assert_operator meter[:delivered], :<, oversized.bytesize
   end
 
+  def test_device_slow_drip_aborts_on_wall_clock_deadline
+    endpoint = "https://issuer.ssrf-test.example/oauth/device"
+    # An in-cap device-auth doc dripped one byte at a time: the per-read socket
+    # timeout never trips (each chunk resets it), so only the whole-read wall-clock
+    # deadline can stop it — the device path must bound reads exactly like discovery.
+    body = {
+      "device_code" => "d", "user_code" => "u", "verification_uri" => "https://x",
+      "expires_in" => 900
+    }.to_json
+
+    meter = { delivered: 0 }
+    connection = Faraday.new do |conn|
+      conn.adapter SlowDripAdapter, body: body, chunk_size: 1, pause: 0.02, meter: meter
+    end
+
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth::DeviceFlow.request_device_authorization(
+        device_authorization_endpoint: endpoint, client_id: "basecamp-cli",
+        http_client: connection, timeout: 0.1
+      )
+    end
+    # A slow-drip timeout is a transport failure (retryable), not an api_error.
+    assert_equal :transport, error.reason
+
+    # The read aborted mid-stream: fewer bytes delivered than the full body.
+    assert_operator meter[:delivered], :<, body.bytesize
+  end
+
   # A middleware whose name matches the redirect detector. Standing in for
   # faraday-follow_redirects without taking the dependency.
   class RedirectFollowingMiddleware < Faraday::Middleware

--- a/ruby/test/basecamp/oauth_ssrf_test.rb
+++ b/ruby/test/basecamp/oauth_ssrf_test.rb
@@ -316,6 +316,12 @@ class OAuthSsrfTest < Minitest::Test
       Basecamp::Oauth::Fetcher.normalize_timeout(nil, default: Float::INFINITY)
     assert_equal Basecamp::Oauth::Fetcher::DEFAULT_TIMEOUT,
       Basecamp::Oauth::Fetcher.normalize_timeout("bad", default: nil)
+    # A huge-but-FINITE timeout (1e100) would hold the socket timeout and the
+    # monotonic deadline open effectively forever — capped at MAX_REQUEST_TIMEOUT,
+    # falling back to the operation default (Python/TS cap the same way).
+    assert_equal 30, Basecamp::Oauth::Fetcher.normalize_timeout(1e100, default: 30)
+    assert_equal Basecamp::Oauth::Fetcher::MAX_REQUEST_TIMEOUT,
+      Basecamp::Oauth::Fetcher.normalize_timeout(Basecamp::Oauth::Fetcher::MAX_REQUEST_TIMEOUT)
   end
 
   def test_redirect_is_not_followed

--- a/ruby/test/basecamp/oauth_test.rb
+++ b/ruby/test/basecamp/oauth_test.rb
@@ -226,6 +226,9 @@ class OAuthTest < Minitest::Test
 
     assert_equal "api_error", error.type
     assert_not_includes error.message, secret
+    # cause: nil — JSON::ParserError's message embeds the offending input,
+    # so the implicit chain would leak it via full_message.
+    assert_nil error.cause
   end
 
   def test_exchange_code

--- a/ruby/test/basecamp/oauth_test.rb
+++ b/ruby/test/basecamp/oauth_test.rb
@@ -207,6 +207,27 @@ class OAuthTest < Minitest::Test
     assert_equal "resource_discovery_failed", result.reason
   end
 
+  def test_exchange_parse_failure_never_echoes_the_body
+    # A syntactically-broken token body can still carry credential material —
+    # the parse error must not echo any of it into the message, where it
+    # would reach logs and exception telemetry.
+    secret = "sk-live-SUPERSECRET"
+    stub_request(:post, "https://launchpad.37signals.com/authorization/token")
+      .to_return(status: 200, body: "{\"access_token\": \"#{secret}' oops", headers: { "Content-Type" => "application/json" })
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth.exchange_code(
+        token_endpoint: "https://launchpad.37signals.com/authorization/token",
+        code: "auth_code_123",
+        redirect_uri: "https://myapp.com/callback",
+        client_id: "my_client_id"
+      )
+    end
+
+    assert_equal "api_error", error.type
+    assert_not_includes error.message, secret
+  end
+
   def test_exchange_code
     token_response = {
       "access_token" => "access_token_123",

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -241,7 +241,14 @@ endpoint, so `performDeviceLogin`'s capability guard rejects it with
 `DeviceFlowError("unavailable")`.)
 
 ```ts
-import { createBasecampClient, discoverFromResource, performDeviceLogin, DeviceFlowError } from "@37signals/basecamp";
+import {
+  createBasecampClient,
+  discoverFromResource,
+  performDeviceLogin,
+  refreshToken,
+  isTokenExpired,
+  DeviceFlowError,
+} from "@37signals/basecamp";
 
 // 1. Select an AS config. Discovery can select a config WITHOUT the device
 //    endpoint or device_code grant — performDeviceLogin then rejects it with
@@ -272,9 +279,17 @@ try {
     accessToken: token.accessToken,
   });
   // A long-lived CLI should PERSIST the whole token (incl. token.refreshToken)
-  // and, once isTokenExpired(token), mint a fresh one with refreshToken({ ... })
-  // as shown above — a client built from a static accessToken stops working when
-  // the device access token expires.
+  // and mint a fresh one once it expires — a client built from a static
+  // accessToken stops working when the device access token expires. Refresh
+  // against the SAME first-party token endpoint with the standard grant
+  // (device tokens never use Launchpad's legacy `type=refresh` format):
+  if (isTokenExpired(token)) {
+    const fresh = await refreshToken({
+      tokenEndpoint: result.config.tokenEndpoint,
+      clientId: "basecamp-cli", // public client — no secret
+      refreshToken: token.refreshToken!,
+    });
+  }
 } catch (err) {
   if (err instanceof DeviceFlowError) {
     // err.reason: "access_denied" | "expired" | "transport" | "unavailable" | "cancelled"

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -278,17 +278,23 @@ try {
     accountId: process.env.BASECAMP_ACCOUNT_ID!,
     accessToken: token.accessToken,
   });
-  // A long-lived CLI should PERSIST the whole token (incl. token.refreshToken)
-  // and mint a fresh one once it expires — a client built from a static
-  // accessToken stops working when the device access token expires. Refresh
-  // against the SAME first-party token endpoint with the standard grant
-  // (device tokens never use Launchpad's legacy `type=refresh` format):
+  // A long-lived CLI should PERSIST the whole token and mint a fresh one once it
+  // expires — a client built from a static accessToken stops working when the
+  // device access token expires. A device-token response MAY omit refresh_token,
+  // so GUARD it: refresh only when one was issued, otherwise re-run the device
+  // login to reauthenticate. Refresh hits the SAME first-party token endpoint
+  // with the standard grant (device tokens never use Launchpad's legacy
+  // `type=refresh` format):
   if (isTokenExpired(token)) {
-    const fresh = await refreshToken({
-      tokenEndpoint: result.config.tokenEndpoint,
-      clientId: "basecamp-cli", // public client — no secret
-      refreshToken: token.refreshToken!,
-    });
+    if (token.refreshToken) {
+      const fresh = await refreshToken({
+        tokenEndpoint: result.config.tokenEndpoint,
+        clientId: "basecamp-cli", // public client — no secret
+        refreshToken: token.refreshToken,
+      });
+    } else {
+      // No refresh token was issued — start a new device login to reauthenticate.
+    }
   }
 } catch (err) {
   if (err instanceof DeviceFlowError) {

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -292,10 +292,15 @@ try {
         clientId: "basecamp-cli", // public client — no secret
         refreshToken: token.refreshToken,
       });
-      // ...persist `fresh` and rebuild the client from fresh.accessToken.
+      // A refresh response MAY omit refresh_token (the server keeps the current
+      // one). Persist the fresh access token but FALL BACK to the prior refresh
+      // token when none was returned, so the next refresh still works:
+      const nextRefresh = fresh.refreshToken ?? token.refreshToken;
+      // ...persist { ...fresh, refreshToken: nextRefresh } and rebuild the client.
     } else {
       // No refresh token was issued: refreshing is impossible, so the user must
-      // authorize again. Re-run the device login to get a new token — don't keep
+      // authorize again. Re-run the device login to get a new token — pass the
+      // SAME abort signal so Ctrl-C cancels this second poll too, and don't keep
       // using the expired one.
       const reauthed = await performDeviceLogin({
         config: result.config,
@@ -303,6 +308,7 @@ try {
         display: ({ userCode, verificationUri }) => {
           console.log(`Visit ${verificationUri} and enter code: ${userCode}`);
         },
+        signal: abortController.signal,
       });
       // ...persist `reauthed` and rebuild the client from reauthed.accessToken.
     }

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -292,8 +292,19 @@ try {
         clientId: "basecamp-cli", // public client — no secret
         refreshToken: token.refreshToken,
       });
+      // ...persist `fresh` and rebuild the client from fresh.accessToken.
     } else {
-      // No refresh token was issued — start a new device login to reauthenticate.
+      // No refresh token was issued: refreshing is impossible, so the user must
+      // authorize again. Re-run the device login to get a new token — don't keep
+      // using the expired one.
+      const reauthed = await performDeviceLogin({
+        config: result.config,
+        clientId: "basecamp-cli",
+        display: ({ userCode, verificationUri }) => {
+          console.log(`Visit ${verificationUri} and enter code: ${userCode}`);
+        },
+      });
+      // ...persist `reauthed` and rebuild the client from reauthed.accessToken.
     }
   }
 } catch (err) {

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -241,9 +241,11 @@ endpoint, so `performDeviceLogin`'s capability guard rejects it with
 `DeviceFlowError("unavailable")`.)
 
 ```ts
-import { discoverFromResource, performDeviceLogin, DeviceFlowError } from "@37signals/basecamp";
+import { createBasecampClient, discoverFromResource, performDeviceLogin, DeviceFlowError } from "@37signals/basecamp";
 
-// 1. Select the first-party AS config (device endpoint + device_code grant).
+// 1. Select an AS config. Discovery can select a config WITHOUT the device
+//    endpoint or device_code grant — performDeviceLogin then rejects it with
+//    DeviceFlowError("unavailable").
 const result = await discoverFromResource("https://3.basecampapi.com");
 if (result.kind !== "selected") {
   // "resource_discovery_failed" | "no_as_advertised" → Launchpad has no device
@@ -263,13 +265,22 @@ try {
     },
     signal: abortController.signal, // optional: cancel the poll
   });
-  console.log(token.accessToken);
+  // Use the token — hand it to a client or persist it via your token store.
+  // Never print the token value itself.
+  const client = createBasecampClient({
+    accountId: process.env.BASECAMP_ACCOUNT_ID!,
+    accessToken: token.accessToken,
+  });
 } catch (err) {
   if (err instanceof DeviceFlowError) {
     // err.reason: "access_denied" | "expired" | "transport" | "unavailable" | "cancelled"
     // err.code (parent category) is derived from the reason:
     //   access_denied/expired → auth_required, transport → network,
     //   unavailable → validation, cancelled → usage
+  } else {
+    // performDeviceLogin can also reject with BasecampError (e.g. a malformed
+    // or non-2xx server response) — don't swallow those.
+    throw err;
   }
 }
 ```

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -271,6 +271,10 @@ try {
     accountId: process.env.BASECAMP_ACCOUNT_ID!,
     accessToken: token.accessToken,
   });
+  // A long-lived CLI should PERSIST the whole token (incl. token.refreshToken)
+  // and, once isTokenExpired(token), mint a fresh one with refreshToken({ ... })
+  // as shown above — a client built from a static accessToken stops working when
+  // the device access token expires.
 } catch (err) {
   if (err instanceof DeviceFlowError) {
     // err.reason: "access_denied" | "expired" | "transport" | "unavailable" | "cancelled"

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -227,6 +227,58 @@ Hard cases throw `DiscoverySelectionError` (with a `.reason`); soft cases return
 > discovery hops are SSRF-hardened (HTTPS-only origins, suppressed redirects,
 > bounded body reads).
 
+### Device flow (RFC 8628)
+
+For CLIs and headless/remote environments, use the device authorization grant
+with the public `basecamp-cli` client (no secret). `performDeviceLogin` takes an
+already-selected config, guards the device capability, shows the user code via a
+display hook, and polls for the token:
+
+The device authorization endpoint lives on the **first-party** authorization
+server, not Launchpad — so select a first-party issuer with `discoverFromResource`
+and hand its config to `performDeviceLogin`. (Launchpad advertises no device
+endpoint, so `performDeviceLogin`'s capability guard rejects it with
+`DeviceFlowError("unavailable")`.)
+
+```ts
+import { discoverFromResource, performDeviceLogin, DeviceFlowError } from "@37signals/basecamp";
+
+// 1. Select the first-party AS config (device endpoint + device_code grant).
+const result = await discoverFromResource("https://3.basecampapi.com");
+if (result.kind !== "selected") {
+  // "resource_discovery_failed" | "no_as_advertised" → Launchpad has no device
+  // flow; use the interactive (authorization-code) login instead.
+  throw new Error(`Device flow unavailable: ${result.reason}`);
+}
+
+// 2. Run the device grant against the selected config.
+const abortController = new AbortController();
+try {
+  const token = await performDeviceLogin({
+    config: result.config,
+    clientId: "basecamp-cli",
+    // scope omitted → server default (read)
+    display: ({ userCode, verificationUri }) => {
+      console.log(`Visit ${verificationUri} and enter code: ${userCode}`);
+    },
+    signal: abortController.signal, // optional: cancel the poll
+  });
+  console.log(token.accessToken);
+} catch (err) {
+  if (err instanceof DeviceFlowError) {
+    // err.reason: "access_denied" | "expired" | "transport" | "unavailable" | "cancelled"
+    // err.code (parent category) is derived from the reason:
+    //   access_denied/expired → auth_required, transport → network,
+    //   unavailable → validation, cancelled → usage
+  }
+}
+```
+
+The poll loop honors `interval`, sustains `slow_down` (+5s), backs off
+exponentially on connection timeouts, and enforces a monotonic expiry deadline.
+`requestDeviceAuthorization` and `pollDeviceToken` are exported for lower-level
+use; the polling clock is injectable for testing.
+
 ## Services
 
 The SDK provides typed services for the complete Basecamp API:

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -483,9 +483,10 @@ export type {
   FallbackReason,
   DiscoverySelectionErrorReason,
   DiscoverFromResourceResult,
+  DeviceAuthorization,
 } from "./oauth/types.js";
 
-// OAuth functions
+// OAuth discovery (single-hop RFC 8414 + resource-first RFC 9728)
 export {
   discover,
   discoverProtectedResource,
@@ -497,6 +498,30 @@ export {
   type DiscoverOptions,
   type DiscoverFromResourceOptions,
 } from "./oauth/discovery.js";
+
+// Device authorization grant (RFC 8628)
+export {
+  requestDeviceAuthorization,
+  pollDeviceToken,
+  DEVICE_CODE_GRANT_TYPE,
+  type RequestDeviceAuthorizationParams,
+  type PollDeviceTokenParams,
+  type MonotonicClock,
+} from "./oauth/device.js";
+export {
+  performDeviceLogin,
+  type DeviceLoginOptions,
+} from "./oauth/device-login.js";
+export {
+  DeviceFlowError,
+  type DeviceFlowReason,
+} from "./oauth/device-errors.js";
+
+// Interactive login (authorization-code flow orchestrator)
+export {
+  performInteractiveLogin,
+  type InteractiveLoginOptions,
+} from "./oauth/interactive-login.js";
 
 export {
   exchangeCode,

--- a/typescript/src/oauth/device-errors.ts
+++ b/typescript/src/oauth/device-errors.ts
@@ -1,0 +1,60 @@
+/**
+ * Terminal errors for the RFC 8628 device authorization grant.
+ *
+ * A single {@link DeviceFlowError} carries a {@link DeviceFlowReason}; the parent
+ * BasecampError category is DERIVED from the reason (SPEC.md §16), so callers can
+ * branch on either `.reason` (precise) or `.code`/`.exitCode` (coarse).
+ */
+
+import { BasecampError, type ErrorCode, type BasecampErrorOptions } from "../errors.js";
+
+/**
+ * Why a device flow terminated.
+ *
+ * - `access_denied` — the user declined the authorization → auth
+ * - `expired` — the device/user code expired before approval → auth
+ * - `transport` — a network failure ended the flow → network (retryable)
+ * - `unavailable` — the selected AS cannot do device flow → validation
+ * - `cancelled` — the caller cancelled (aborted) the flow → usage
+ */
+export type DeviceFlowReason =
+  | "access_denied"
+  | "expired"
+  | "transport"
+  | "unavailable"
+  | "cancelled";
+
+/** Maps a device-flow reason to its parent BasecampError category. */
+function categoryFor(reason: DeviceFlowReason): ErrorCode {
+  switch (reason) {
+    case "access_denied":
+    case "expired":
+      return "auth_required";
+    case "transport":
+      return "network";
+    case "unavailable":
+      return "validation";
+    case "cancelled":
+      return "usage";
+  }
+}
+
+/**
+ * Terminal device-flow error. Its `code` (and thus `exitCode`) is derived from
+ * `reason`; `transport` is retryable.
+ */
+export class DeviceFlowError extends BasecampError {
+  readonly reason: DeviceFlowReason;
+
+  constructor(reason: DeviceFlowReason, message: string, options?: BasecampErrorOptions) {
+    // The reason derives retryability authoritatively: spread caller options
+    // FIRST so a caller-supplied `retryable` cannot flip the reason's verdict
+    // (only `transport` is retryable).
+    super(categoryFor(reason), message, {
+      ...options,
+      retryable: reason === "transport",
+    });
+    this.name = "DeviceFlowError";
+    this.reason = reason;
+  }
+}

--- a/typescript/src/oauth/device-errors.ts
+++ b/typescript/src/oauth/device-errors.ts
@@ -36,6 +36,12 @@ function categoryFor(reason: DeviceFlowReason): ErrorCode {
       return "validation";
     case "cancelled":
       return "usage";
+    default:
+      // DeviceFlowReason is an exhaustive union in TS, but this is a public
+      // runtime class: a JS caller can still construct new DeviceFlowError(
+      // "some_new_reason", …). Fall back to "usage" (caller misuse) rather than
+      // returning undefined, which would give BasecampError an invalid code.
+      return "usage";
   }
 }
 

--- a/typescript/src/oauth/device-errors.ts
+++ b/typescript/src/oauth/device-errors.ts
@@ -39,9 +39,10 @@ function categoryFor(reason: DeviceFlowReason): ErrorCode {
     default:
       // DeviceFlowReason is an exhaustive union in TS, but this is a public
       // runtime class: a JS caller can still construct new DeviceFlowError(
-      // "some_new_reason", …). Fall back to "usage" (caller misuse) rather than
+      // "some_new_reason", …). Fall back to "api_error" — the cross-SDK default
+      // for unknown reasons (Go/Ruby/Python/Kotlin do the same) — rather than
       // returning undefined, which would give BasecampError an invalid code.
-      return "usage";
+      return "api_error";
   }
 }
 

--- a/typescript/src/oauth/device-errors.ts
+++ b/typescript/src/oauth/device-errors.ts
@@ -57,4 +57,9 @@ export class DeviceFlowError extends BasecampError {
     this.name = "DeviceFlowError";
     this.reason = reason;
   }
+
+  /** Serializes like BasecampError, plus the precise device-flow reason. */
+  toJSON(): Record<string, unknown> {
+    return { ...super.toJSON(), reason: this.reason };
+  }
 }

--- a/typescript/src/oauth/device-login.ts
+++ b/typescript/src/oauth/device-login.ts
@@ -1,0 +1,95 @@
+/**
+ * RFC 8628 device login orchestration.
+ *
+ * `performDeviceLogin` accepts an ALREADY-SELECTED OAuthConfig (from discovery),
+ * guards the device capability, requests a device code, surfaces it through a
+ * display hook, and polls for the token.
+ */
+
+import { DeviceFlowError } from "./device-errors.js";
+import {
+  requestDeviceAuthorization,
+  pollDeviceToken,
+  DEVICE_CODE_GRANT_TYPE,
+  defaultClock,
+  type MonotonicClock,
+} from "./device.js";
+import type { OAuthConfig, OAuthToken, DeviceAuthorization } from "./types.js";
+
+/**
+ * Options for {@link performDeviceLogin}.
+ */
+export interface DeviceLoginOptions {
+  /** The already-selected authorization-server config (from discovery). */
+  config: OAuthConfig;
+  /** The public client id (e.g. "basecamp-cli"). */
+  clientId: string;
+  /** Requested scope. Omitted → server default (`read`). */
+  scope?: string;
+  /**
+   * Display hook: show the user the verification URI + user code. Called once,
+   * after the device code is obtained and before polling begins.
+   */
+  display: (auth: DeviceAuthorization) => void | Promise<void>;
+  /** Cancellation signal for the polling loop. */
+  signal?: AbortSignal;
+  /** Injectable monotonic clock (ms) for the polling deadline. */
+  clock?: MonotonicClock;
+  /** Custom fetch (testing). */
+  fetch?: typeof globalThis.fetch;
+  /**
+   * Injectable sleep (testing). Forwarded to the poll loop so tests can drive the
+   * interval schedule without real delays; defaults to a real, abortable timer.
+   */
+  sleepFn?: (ms: number, signal?: AbortSignal) => Promise<void>;
+}
+
+/**
+ * Runs the full device authorization grant against a selected config.
+ *
+ * @throws DeviceFlowError("unavailable") when the config cannot do device flow;
+ *   other DeviceFlowError reasons on denial/expiry/transport/cancellation.
+ */
+export async function performDeviceLogin(options: DeviceLoginOptions): Promise<OAuthToken> {
+  const { config, clientId, scope, display, signal, clock = defaultClock, fetch: customFetch, sleepFn } = options;
+
+  // Capability guard requires BOTH the endpoint and the advertised grant type.
+  const supportsDeviceGrant = config.grantTypesSupported?.includes(DEVICE_CODE_GRANT_TYPE) ?? false;
+  if (!config.deviceAuthorizationEndpoint || !supportsDeviceGrant) {
+    throw new DeviceFlowError(
+      "unavailable",
+      "The selected authorization server does not support the device authorization grant"
+    );
+  }
+
+  const auth = await requestDeviceAuthorization({
+    deviceAuthorizationEndpoint: config.deviceAuthorizationEndpoint,
+    clientId,
+    scope,
+    fetch: customFetch,
+  });
+
+  // The code's lifetime starts at issuance, not after display: a slow display
+  // hook must eat into the deadline, never reset it. Capture the monotonic clock
+  // (ms) at issuance, then deduct the elapsed display time so polling anchors its
+  // deadline against the REMAINING lifetime. `expiresIn` is seconds; `clock()` is
+  // ms, so convert the elapsed span before subtracting.
+  const issuedAt = clock();
+  await display(auth);
+  const remainingSeconds = auth.expiresIn - (clock() - issuedAt) / 1000;
+  if (remainingSeconds <= 0) {
+    throw new DeviceFlowError("expired", "Device code expired before authorization completed");
+  }
+
+  return pollDeviceToken({
+    tokenEndpoint: config.tokenEndpoint,
+    clientId,
+    deviceCode: auth.deviceCode,
+    interval: auth.interval,
+    expiresIn: remainingSeconds,
+    signal,
+    clock,
+    fetch: customFetch,
+    sleepFn,
+  });
+}

--- a/typescript/src/oauth/device-login.ts
+++ b/typescript/src/oauth/device-login.ts
@@ -54,7 +54,12 @@ export async function performDeviceLogin(options: DeviceLoginOptions): Promise<O
   const { config, clientId, scope, display, signal, clock = defaultClock, fetch: customFetch, sleepFn } = options;
 
   // Capability guard requires BOTH the endpoint and the advertised grant type.
-  const supportsDeviceGrant = config.grantTypesSupported?.includes(DEVICE_CODE_GRANT_TYPE) ?? false;
+  // Require a genuine array: a manually-constructed config could supply
+  // grantTypesSupported as a string, and String.prototype.includes would
+  // substring-match and wrongly pass the guard (the other SDKs defend the same
+  // way — Python/Ruby check the collection type, Go/Kotlin are statically typed).
+  const supportsDeviceGrant =
+    Array.isArray(config.grantTypesSupported) && config.grantTypesSupported.includes(DEVICE_CODE_GRANT_TYPE);
   if (!config.deviceAuthorizationEndpoint || !supportsDeviceGrant) {
     throw new DeviceFlowError(
       "unavailable",

--- a/typescript/src/oauth/device-login.ts
+++ b/typescript/src/oauth/device-login.ts
@@ -31,7 +31,11 @@ export interface DeviceLoginOptions {
    * after the device code is obtained and before polling begins.
    */
   display: (auth: DeviceAuthorization) => void | Promise<void>;
-  /** Cancellation signal for the polling loop. */
+  /**
+   * Cancellation signal for the polling loop — deliberately scoped to the only
+   * long-lived phase. The initial device-code request is bounded by its own
+   * 30s timeout, and the display hook is the caller's code.
+   */
   signal?: AbortSignal;
   /** Injectable monotonic clock (ms) for the polling deadline. */
   clock?: MonotonicClock;

--- a/typescript/src/oauth/device-login.ts
+++ b/typescript/src/oauth/device-login.ts
@@ -12,6 +12,7 @@ import {
   requestDeviceAuthorization,
   pollDeviceToken,
   throwIfAborted,
+  validatedClockSample,
   DEVICE_CODE_GRANT_TYPE,
   defaultClock,
   type MonotonicClock,
@@ -87,6 +88,14 @@ export async function performDeviceLogin(options: DeviceLoginOptions): Promise<O
   // must not fire the authorization request or surface a code via display.
   throwIfAborted(signal);
 
+  // The code's lifetime starts at SERVER issuance, which precedes the response:
+  // anchor conservatively BEFORE the request goes out, so a slow authorization
+  // response (or one delayed in transit) eats into the deadline instead of
+  // granting the code a fresh full lifetime. The anchor can only SHORTEN the
+  // usable window, never extend it. Validated like the poller's samples — a
+  // malformed injected clock is the typed usage error before any network I/O.
+  const issuedAt = validatedClockSample(clock(), "performDeviceLogin");
+
   const auth = await requestDeviceAuthorization({
     deviceAuthorizationEndpoint: config.deviceAuthorizationEndpoint,
     clientId,
@@ -101,12 +110,6 @@ export async function performDeviceLogin(options: DeviceLoginOptions): Promise<O
   // completion must not reach the display hook.
   throwIfAborted(signal);
 
-  // The code's lifetime starts at issuance, not after display: a slow display
-  // hook must eat into the deadline, never reset it. Capture the monotonic clock
-  // (ms) at issuance, then deduct the elapsed display time so polling anchors its
-  // deadline against the REMAINING lifetime. `expiresIn` is seconds; `clock()` is
-  // ms, so convert the elapsed span before subtracting.
-  const issuedAt = clock();
   // Race an async display hook against the abort signal: a hook awaiting user
   // interaction must not hold a cancelled flow open until it settles. On
   // abort the hook's promise is left to settle on its own (JS cannot cancel
@@ -142,7 +145,11 @@ export async function performDeviceLogin(options: DeviceLoginOptions): Promise<O
         }
       );
   });
-  const remainingSeconds = auth.expiresIn - (clock() - issuedAt) / 1000;
+  // Deduct everything since the pre-request anchor — request round-trip AND
+  // display time — so polling gets only the REMAINING lifetime. `expiresIn` is
+  // seconds; the clock is ms, so convert the elapsed span before subtracting.
+  const remainingSeconds =
+    auth.expiresIn - (validatedClockSample(clock(), "performDeviceLogin") - issuedAt) / 1000;
   // Re-check after the clock read: an abort landing after the display race
   // settled (its listener is already removed) must still win over expiry —
   // cancellation beats every other classification.

--- a/typescript/src/oauth/device-login.ts
+++ b/typescript/src/oauth/device-login.ts
@@ -6,6 +6,7 @@
  * display hook, and polls for the token.
  */
 
+import { BasecampError } from "../errors.js";
 import { DeviceFlowError } from "./device-errors.js";
 import {
   requestDeviceAuthorization,
@@ -72,6 +73,14 @@ export async function performDeviceLogin(options: DeviceLoginOptions): Promise<O
       "unavailable",
       "The selected authorization server does not support the device authorization grant"
     );
+  }
+
+  // A non-function display is a usage error, not a late TypeError: it is the
+  // only mechanism surfacing the verification code, so dereferencing it AFTER
+  // the request would mint a code nobody can approve. Reject before any
+  // network activity (matching Go) — a JS caller can pass anything.
+  if (typeof display !== "function") {
+    throw new BasecampError("usage", "performDeviceLogin requires a display callback function");
   }
 
   // Honor a cancellation raised before any work: an already-aborted signal

--- a/typescript/src/oauth/device-login.ts
+++ b/typescript/src/oauth/device-login.ts
@@ -106,6 +106,11 @@ export async function performDeviceLogin(options: DeviceLoginOptions): Promise<O
     const onAbort = () => reject(new DeviceFlowError("cancelled", "Device flow cancelled"));
     signal?.addEventListener("abort", onAbort, { once: true });
     if (signal?.aborted) {
+      // The abort won between the entry throwIfAborted and the registration
+      // above: the event is already spent, so the once-listener would never
+      // fire — and never auto-remove. Drop it before rejecting manually
+      // (same race handling as the sleep helper).
+      signal.removeEventListener("abort", onAbort);
       onAbort();
       return;
     }

--- a/typescript/src/oauth/device-login.ts
+++ b/typescript/src/oauth/device-login.ts
@@ -110,7 +110,13 @@ export async function performDeviceLogin(options: DeviceLoginOptions): Promise<O
       return;
     }
     Promise.resolve()
-      .then(() => display(auth))
+      .then(() => {
+        // The abort can win between scheduling and this deferred callback —
+        // the outer promise has already rejected then, but this callback still
+        // runs. Re-check so a cancelled flow never surfaces the code.
+        if (signal?.aborted) return undefined;
+        return display(auth);
+      })
       .then(
         () => {
           signal?.removeEventListener("abort", onAbort);
@@ -133,6 +139,10 @@ export async function performDeviceLogin(options: DeviceLoginOptions): Promise<O
     deviceCode: auth.deviceCode,
     interval: auth.interval,
     expiresIn: remainingSeconds,
+    // Absolute issuance-anchored deadline: clock time elapsing between the
+    // remainingSeconds computation above and pollDeviceToken's own clock()
+    // anchor would otherwise be handed BACK to the code's lifetime.
+    deadlineAtMs: issuedAt + auth.expiresIn * 1000,
     signal,
     clock,
     fetch: customFetch,

--- a/typescript/src/oauth/device-login.ts
+++ b/typescript/src/oauth/device-login.ts
@@ -10,6 +10,7 @@ import { DeviceFlowError } from "./device-errors.js";
 import {
   requestDeviceAuthorization,
   pollDeviceToken,
+  throwIfAborted,
   DEVICE_CODE_GRANT_TYPE,
   defaultClock,
   type MonotonicClock,
@@ -71,12 +72,23 @@ export async function performDeviceLogin(options: DeviceLoginOptions): Promise<O
     );
   }
 
+  // Honor a cancellation raised before any work: an already-aborted signal
+  // must not fire the authorization request or surface a code via display.
+  throwIfAborted(signal);
+
   const auth = await requestDeviceAuthorization({
     deviceAuthorizationEndpoint: config.deviceAuthorizationEndpoint,
     clientId,
     scope,
     fetch: customFetch,
+    // Threaded so an abort DURING the request cancels it in flight and
+    // surfaces as the contractual cancelled — never a code shown post-cancel.
+    signal,
   });
+
+  // Re-check before surfacing the code: an abort racing the request's
+  // completion must not reach the display hook.
+  throwIfAborted(signal);
 
   // The code's lifetime starts at issuance, not after display: a slow display
   // hook must eat into the deadline, never reset it. Capture the monotonic clock

--- a/typescript/src/oauth/device-login.ts
+++ b/typescript/src/oauth/device-login.ts
@@ -143,6 +143,10 @@ export async function performDeviceLogin(options: DeviceLoginOptions): Promise<O
       );
   });
   const remainingSeconds = auth.expiresIn - (clock() - issuedAt) / 1000;
+  // Re-check after the clock read: an abort landing after the display race
+  // settled (its listener is already removed) must still win over expiry —
+  // cancellation beats every other classification.
+  throwIfAborted(signal);
   if (remainingSeconds <= 0) {
     throw new DeviceFlowError("expired", "Device code expired before authorization completed");
   }

--- a/typescript/src/oauth/device-login.ts
+++ b/typescript/src/oauth/device-login.ts
@@ -88,14 +88,6 @@ export async function performDeviceLogin(options: DeviceLoginOptions): Promise<O
   // must not fire the authorization request or surface a code via display.
   throwIfAborted(signal);
 
-  // The code's lifetime starts at SERVER issuance, which precedes the response:
-  // anchor conservatively BEFORE the request goes out, so a slow authorization
-  // response (or one delayed in transit) eats into the deadline instead of
-  // granting the code a fresh full lifetime. The anchor can only SHORTEN the
-  // usable window, never extend it. Validated like the poller's samples — a
-  // malformed injected clock is the typed usage error before any network I/O.
-  const issuedAt = validatedClockSample(clock(), "performDeviceLogin");
-
   const auth = await requestDeviceAuthorization({
     deviceAuthorizationEndpoint: config.deviceAuthorizationEndpoint,
     clientId,
@@ -106,8 +98,17 @@ export async function performDeviceLogin(options: DeviceLoginOptions): Promise<O
     signal,
   });
 
+  // Anchor the code's lifetime at ISSUANCE — the response's arrival, per
+  // SPEC §16 — before the display hook, so a slow display eats into the
+  // deadline instead of resetting it. Expiry past this point is arbitrated
+  // by the server (expired_token), so receipt-anchoring fails safe.
+  // Validated like the poller's samples — a malformed injected clock is the
+  // typed usage error before the code is surfaced.
+  const issuedAt = validatedClockSample(clock(), "performDeviceLogin");
+
   // Re-check before surfacing the code: an abort racing the request's
-  // completion must not reach the display hook.
+  // completion — or landing during the clock sample above (itself a callback
+  // seam) — must not reach the display hook.
   throwIfAborted(signal);
 
   // Race an async display hook against the abort signal: a hook awaiting user
@@ -145,9 +146,9 @@ export async function performDeviceLogin(options: DeviceLoginOptions): Promise<O
         }
       );
   });
-  // Deduct everything since the pre-request anchor — request round-trip AND
-  // display time — so polling gets only the REMAINING lifetime. `expiresIn` is
-  // seconds; the clock is ms, so convert the elapsed span before subtracting.
+  // Deduct the elapsed display time from the issuance anchor so polling gets
+  // only the REMAINING lifetime. `expiresIn` is seconds; the clock is ms, so
+  // convert the elapsed span before subtracting.
   const remainingSeconds =
     auth.expiresIn - (validatedClockSample(clock(), "performDeviceLogin") - issuedAt) / 1000;
   // Re-check after the clock read: an abort landing after the display race

--- a/typescript/src/oauth/device-login.ts
+++ b/typescript/src/oauth/device-login.ts
@@ -98,7 +98,30 @@ export async function performDeviceLogin(options: DeviceLoginOptions): Promise<O
   // deadline against the REMAINING lifetime. `expiresIn` is seconds; `clock()` is
   // ms, so convert the elapsed span before subtracting.
   const issuedAt = clock();
-  await display(auth);
+  // Race an async display hook against the abort signal: a hook awaiting user
+  // interaction must not hold a cancelled flow open until it settles. On
+  // abort the hook's promise is left to settle on its own (JS cannot cancel
+  // it) — the flow rejects promptly and never proceeds to polling.
+  await new Promise<void>((resolve, reject) => {
+    const onAbort = () => reject(new DeviceFlowError("cancelled", "Device flow cancelled"));
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (signal?.aborted) {
+      onAbort();
+      return;
+    }
+    Promise.resolve()
+      .then(() => display(auth))
+      .then(
+        () => {
+          signal?.removeEventListener("abort", onAbort);
+          resolve();
+        },
+        (err) => {
+          signal?.removeEventListener("abort", onAbort);
+          reject(err);
+        }
+      );
+  });
   const remainingSeconds = auth.expiresIn - (clock() - issuedAt) / 1000;
   if (remainingSeconds <= 0) {
     throw new DeviceFlowError("expired", "Device code expired before authorization completed");

--- a/typescript/src/oauth/device-login.ts
+++ b/typescript/src/oauth/device-login.ts
@@ -33,9 +33,11 @@ export interface DeviceLoginOptions {
    */
   display: (auth: DeviceAuthorization) => void | Promise<void>;
   /**
-   * Cancellation signal for the polling loop — deliberately scoped to the only
-   * long-lived phase. The initial device-code request is bounded by its own
-   * 30s timeout, and the display hook is the caller's code.
+   * Cancellation signal for the WHOLE flow: checked before any work, threaded
+   * into the device-code request (an abort cancels it in flight), re-checked
+   * before the display hook, and honored throughout the polling loop. An
+   * abort anywhere rejects with DeviceFlowError("cancelled") — a code is
+   * never surfaced after cancellation.
    */
   signal?: AbortSignal;
   /** Injectable monotonic clock (ms) for the polling deadline. */

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -163,7 +163,7 @@ export async function requestDeviceAuthorization(
     });
   }
 
-  return validateDeviceAuthorization(data as RawDeviceAuthorization);
+  return validateDeviceAuthorization(data as RawDeviceAuthorization, response.status);
 }
 
 /**
@@ -181,7 +181,9 @@ function isNonEmptyString(value: unknown): value is string {
   return typeof value === "string" && value.length > 0;
 }
 
-function validateDeviceAuthorization(data: RawDeviceAuthorization): DeviceAuthorization {
+function validateDeviceAuthorization(data: RawDeviceAuthorization, status: number): DeviceAuthorization {
+  // Every validation error carries the (2xx) status so a malformed success body
+  // is diagnosable as such — uniform with the token-poll raises and the other SDKs.
   // Type-check, not just truthiness: a JSON number is truthy but is not a usable
   // code/URI, so it must fail as api_error rather than flow into the poll loop.
   if (
@@ -189,7 +191,9 @@ function validateDeviceAuthorization(data: RawDeviceAuthorization): DeviceAuthor
     !isNonEmptyString(data.user_code) ||
     !isNonEmptyString(data.verification_uri)
   ) {
-    throw new BasecampError("api_error", "Invalid device authorization response: missing or non-string required fields");
+    throw new BasecampError("api_error", "Invalid device authorization response: missing or non-string required fields", {
+      httpStatus: status,
+    });
   }
   // expires_in drives a monotonic deadline; interval drives poll delays. Both
   // must be positive integers within MAX_DEVICE_SECONDS — a fractional value
@@ -199,7 +203,8 @@ function validateDeviceAuthorization(data: RawDeviceAuthorization): DeviceAuthor
   if (!isPositiveInteger(data.expires_in) || data.expires_in > MAX_DEVICE_SECONDS) {
     throw new BasecampError(
       "api_error",
-      `Invalid device authorization response: expires_in must be a positive integer no greater than ${MAX_DEVICE_SECONDS}`
+      `Invalid device authorization response: expires_in must be a positive integer no greater than ${MAX_DEVICE_SECONDS}`,
+      { httpStatus: status }
     );
   }
   let interval = DEFAULT_INTERVAL_SECONDS;
@@ -209,7 +214,8 @@ function validateDeviceAuthorization(data: RawDeviceAuthorization): DeviceAuthor
     if (!isPositiveInteger(data.interval) || data.interval > MAX_DEVICE_SECONDS) {
       throw new BasecampError(
         "api_error",
-        `Invalid device authorization response: interval must be a positive integer no greater than ${MAX_DEVICE_SECONDS}`
+        `Invalid device authorization response: interval must be a positive integer no greater than ${MAX_DEVICE_SECONDS}`,
+        { httpStatus: status }
       );
     }
     interval = data.interval;
@@ -217,7 +223,9 @@ function validateDeviceAuthorization(data: RawDeviceAuthorization): DeviceAuthor
   // Optional, but when present it must be a string — a non-string (number/array)
   // would return a malformed DeviceAuthorization shape to callers.
   if (data.verification_uri_complete !== undefined && typeof data.verification_uri_complete !== "string") {
-    throw new BasecampError("api_error", "Invalid device authorization response: verification_uri_complete must be a string");
+    throw new BasecampError("api_error", "Invalid device authorization response: verification_uri_complete must be a string", {
+      httpStatus: status,
+    });
   }
   return {
     deviceCode: data.device_code,

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -445,7 +445,9 @@ async function postDeviceToken(
       // Non-empty string, not merely truthy: a numeric access_token is not a
       // usable credential and must fail as api_error, not be returned downstream.
       if (!isNonEmptyString(token.access_token)) {
-        throw new BasecampError("api_error", "Device token response missing or non-string access_token");
+        throw new BasecampError("api_error", "Device token response missing or non-string access_token", {
+          httpStatus: response.status,
+        });
       }
       // expires_in is optional (RFC 6749 §5.1), but when present it must be a
       // finite positive WHOLE number within MAX_TOKEN_LIFETIME_SECONDS. A
@@ -460,19 +462,26 @@ async function postDeviceToken(
             token.expires_in <= 0 || token.expires_in > MAX_TOKEN_LIFETIME_SECONDS)) {
         throw new BasecampError(
           "api_error",
-          `Device token response expires_in must be a finite positive whole number no greater than ${MAX_TOKEN_LIFETIME_SECONDS} seconds`
+          `Device token response expires_in must be a finite positive whole number no greater than ${MAX_TOKEN_LIFETIME_SECONDS} seconds`,
+          { httpStatus: response.status }
         );
       }
       // token_type/refresh_token/scope are optional strings — a non-string value
       // is a malformed response, not a usable credential field.
       if (token.token_type != null && !isNonEmptyString(token.token_type)) {
-        throw new BasecampError("api_error", "Device token response token_type must be a non-empty string");
+        throw new BasecampError("api_error", "Device token response token_type must be a non-empty string", {
+          httpStatus: response.status,
+        });
       }
       if (token.refresh_token != null && typeof token.refresh_token !== "string") {
-        throw new BasecampError("api_error", "Device token response refresh_token must be a string");
+        throw new BasecampError("api_error", "Device token response refresh_token must be a string", {
+          httpStatus: response.status,
+        });
       }
       if (token.scope != null && typeof token.scope !== "string") {
-        throw new BasecampError("api_error", "Device token response scope must be a string");
+        throw new BasecampError("api_error", "Device token response scope must be a string", {
+          httpStatus: response.status,
+        });
       }
       return {
         kind: "token",

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -401,6 +401,10 @@ async function postDeviceToken(
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
   const onAbort = () => controller.abort();
   signal?.addEventListener("abort", onAbort, { once: true });
+  // If the signal was ALREADY aborted, the "abort" event has fired and the
+  // once-listener never runs — abort the controller directly so the fetch below
+  // does not proceed (and even return a token) after cancellation.
+  if (signal?.aborted) controller.abort();
   try {
     const response = await customFetch(tokenEndpoint, {
       method: "POST",
@@ -444,16 +448,19 @@ async function postDeviceToken(
         throw new BasecampError("api_error", "Device token response missing or non-string access_token");
       }
       // expires_in is optional (RFC 6749 §5.1), but when present it must be a
-      // finite positive number within MAX_TOKEN_LIFETIME_SECONDS. A non-finite
-      // value (1e400 → Infinity) or a very large finite one would flow into Date
-      // arithmetic and yield an Invalid Date whose getTime() is NaN, so expiry
-      // checks downstream would treat the token as never expiring.
+      // finite positive WHOLE number within MAX_TOKEN_LIFETIME_SECONDS. A
+      // non-finite value (1e400 → Infinity) or a very large finite one would flow
+      // into Date arithmetic and yield an Invalid Date whose getTime() is NaN, so
+      // expiry checks downstream would treat the token as never expiring. Whole
+      // seconds match the device-duration rule and Go/Kotlin (int/Long typing
+      // already rejects a fractional lifetime); an integer-valued float (3600.0)
+      // is still accepted.
       if (token.expires_in != null &&
-          (typeof token.expires_in !== "number" || !Number.isFinite(token.expires_in) ||
+          (typeof token.expires_in !== "number" || !Number.isInteger(token.expires_in) ||
             token.expires_in <= 0 || token.expires_in > MAX_TOKEN_LIFETIME_SECONDS)) {
         throw new BasecampError(
           "api_error",
-          `Device token response expires_in must be a finite positive number no greater than ${MAX_TOKEN_LIFETIME_SECONDS} seconds`
+          `Device token response expires_in must be a finite positive whole number no greater than ${MAX_TOKEN_LIFETIME_SECONDS} seconds`
         );
       }
       // token_type/refresh_token/scope are optional strings — a non-string value
@@ -493,14 +500,18 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
       reject(new DOMException("Aborted", "AbortError"));
       return;
     }
-    const timer = setTimeout(() => {
-      signal?.removeEventListener("abort", onAbort);
-      resolve();
-    }, ms);
+    // Declare the handler before the timer so neither forward-references the
+    // other's binding (avoids "used before declaration"); `timer` is assigned
+    // immediately below, before either callback can run.
+    let timer: ReturnType<typeof setTimeout>;
     const onAbort = () => {
       clearTimeout(timer);
       reject(new DOMException("Aborted", "AbortError"));
     };
+    timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
     signal?.addEventListener("abort", onAbort, { once: true });
   });
 }

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -149,6 +149,9 @@ export async function requestDeviceAuthorization(
     // slow/never-ending error body could time out mid-read and be misclassified
     // as a retryable transport failure instead of the api_error it is.
     if (response.status < 200 || response.status >= 300) {
+      // Release the unread stream (non-blocking) so repeated failures don't retain
+      // sockets / connection-pool resources; the status error surfaces immediately.
+      void response.body?.cancel().catch(() => {});
       throw new BasecampError("api_error", `Device authorization failed with status ${response.status}`, {
         httpStatus: response.status,
       });
@@ -459,6 +462,9 @@ async function postDeviceToken(
     // connection timeout, which the poll loop would back off and retry (until the
     // device code expires) instead of surfacing the api_error now.
     if (response.status >= 300 && response.status < 400) {
+      // Release the unread stream (non-blocking) so a redirecting endpoint under a
+      // long poll can't retain sockets / connection-pool resources.
+      void response.body?.cancel().catch(() => {});
       throw new BasecampError("api_error", `Device token endpoint returned redirect status ${response.status}`, {
         httpStatus: response.status,
       });

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -144,6 +144,15 @@ export async function requestDeviceAuthorization(
         cause: err instanceof Error ? err : undefined,
       });
     }
+    // A non-2xx (including a suppressed 3xx) is a hard failure whose body is
+    // unused, so surface it by status BEFORE draining the body. Otherwise a
+    // slow/never-ending error body could time out mid-read and be misclassified
+    // as a retryable transport failure instead of the api_error it is.
+    if (response.status < 200 || response.status >= 300) {
+      throw new BasecampError("api_error", `Device authorization failed with status ${response.status}`, {
+        httpStatus: response.status,
+      });
+    }
     // Bounded/streaming read: an oversized body aborts before it is fully
     // buffered. The abort timer stays armed until the read completes, so a
     // stalled response STREAM times out just like a stalled request; an
@@ -162,12 +171,6 @@ export async function requestDeviceAuthorization(
     clearTimeout(timeoutId);
   }
 
-  // Reject any non-2xx (including a suppressed 3xx) before parsing.
-  if (response.status < 200 || response.status >= 300) {
-    throw new BasecampError("api_error", `Device authorization failed with status ${response.status}`, {
-      httpStatus: response.status,
-    });
-  }
   let data: unknown;
   try {
     data = JSON.parse(text);
@@ -450,14 +453,20 @@ async function postDeviceToken(
       // api_error below rather than followed.
       redirect: "manual",
     });
-    // Bounded/streaming read: an oversized body aborts before it is fully buffered.
-    const text = await readBodyBounded(response, MAX_DEVICE_BODY_BYTES, "device token");
-    // A suppressed 3xx is never a valid OAuth response — fail as api_error.
+    // A suppressed 3xx is never a valid OAuth response and its body is unused —
+    // fail by status BEFORE draining the body. Otherwise a redirect that slowly
+    // streams its body could time out mid-read and be misclassified as a
+    // connection timeout, which the poll loop would back off and retry (until the
+    // device code expires) instead of surfacing the api_error now.
     if (response.status >= 300 && response.status < 400) {
       throw new BasecampError("api_error", `Device token endpoint returned redirect status ${response.status}`, {
         httpStatus: response.status,
       });
     }
+    // Bounded/streaming read: an oversized body aborts before it is fully buffered.
+    // A 4xx still reads the body — that is how authorization_pending/slow_down and
+    // other OAuth errors are carried.
+    const text = await readBodyBounded(response, MAX_DEVICE_BODY_BYTES, "device token");
     let parsed: unknown;
     try {
       parsed = JSON.parse(text);
@@ -530,7 +539,11 @@ async function postDeviceToken(
         },
       };
     }
-    const error = (data as OAuthErrorResponse).error || `http_${response.status}`;
+    // Validate `error` as a non-empty string: a non-string (e.g. `{"error": 123}`)
+    // must not be treated as an OAuth error code — fall back to http_<status>,
+    // matching the other SDKs (Ruby String-checks, Kotlin falls back on decode).
+    const rawError = (data as { error?: unknown }).error;
+    const error = typeof rawError === "string" && rawError !== "" ? rawError : `http_${response.status}`;
     return { kind: "error", error, status: response.status };
   } finally {
     clearTimeout(timeoutId);

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -452,9 +452,9 @@ async function postDeviceToken(
       // non-finite value (1e400 → Infinity) or a very large finite one would flow
       // into Date arithmetic and yield an Invalid Date whose getTime() is NaN, so
       // expiry checks downstream would treat the token as never expiring. Whole
-      // seconds match the device-duration rule and Go/Kotlin (int/Long typing
-      // already rejects a fractional lifetime); an integer-valued float (3600.0)
-      // is still accepted.
+      // seconds match the device-duration rule — every SDK validates the decoded
+      // numeric value explicitly to reject a fractional lifetime; an
+      // integer-valued float (3600.0) is still accepted.
       if (token.expires_in != null &&
           (typeof token.expires_in !== "number" || !Number.isInteger(token.expires_in) ||
             token.expires_in <= 0 || token.expires_in > MAX_TOKEN_LIFETIME_SECONDS)) {

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -28,6 +28,18 @@ const DEFAULT_INTERVAL_SECONDS = 5;
  */
 const MAX_DEVICE_SECONDS = 2_147_483;
 
+/**
+ * Upper bound (seconds) for an OAuth token's `expires_in`: 2_147_483_647 s
+ * (~68 years) — cross-runtime safe and vastly beyond any realistic token
+ * lifetime. Unlike {@link MAX_DEVICE_SECONDS} this bounds `expiresAt` Date
+ * arithmetic rather than a timer: a very large finite value (or a non-finite one
+ * from `1e400`) makes `new Date(Date.now() + expires_in * 1000)` an Invalid Date
+ * whose `getTime()` is NaN, so downstream expiry checks would treat the token as
+ * never expiring. A value past this ceiling is a malformed response. Shared
+ * across all five SDKs.
+ */
+const MAX_TOKEN_LIFETIME_SECONDS = 2_147_483_647;
+
 /** slow_down bumps the interval by this many seconds, sustained (RFC 8628 §3.5). */
 const SLOW_DOWN_INCREMENT_SECONDS = 5;
 
@@ -431,14 +443,38 @@ async function postDeviceToken(
       if (!isNonEmptyString(token.access_token)) {
         throw new BasecampError("api_error", "Device token response missing or non-string access_token");
       }
+      // expires_in is optional (RFC 6749 §5.1), but when present it must be a
+      // finite positive number within MAX_TOKEN_LIFETIME_SECONDS. A non-finite
+      // value (1e400 → Infinity) or a very large finite one would flow into Date
+      // arithmetic and yield an Invalid Date whose getTime() is NaN, so expiry
+      // checks downstream would treat the token as never expiring.
+      if (token.expires_in != null &&
+          (typeof token.expires_in !== "number" || !Number.isFinite(token.expires_in) ||
+            token.expires_in <= 0 || token.expires_in > MAX_TOKEN_LIFETIME_SECONDS)) {
+        throw new BasecampError(
+          "api_error",
+          `Device token response expires_in must be a finite positive number no greater than ${MAX_TOKEN_LIFETIME_SECONDS} seconds`
+        );
+      }
+      // token_type/refresh_token/scope are optional strings — a non-string value
+      // is a malformed response, not a usable credential field.
+      if (token.token_type != null && !isNonEmptyString(token.token_type)) {
+        throw new BasecampError("api_error", "Device token response token_type must be a non-empty string");
+      }
+      if (token.refresh_token != null && typeof token.refresh_token !== "string") {
+        throw new BasecampError("api_error", "Device token response refresh_token must be a string");
+      }
+      if (token.scope != null && typeof token.scope !== "string") {
+        throw new BasecampError("api_error", "Device token response scope must be a string");
+      }
       return {
         kind: "token",
         token: {
           accessToken: token.access_token,
           refreshToken: token.refresh_token,
           tokenType: token.token_type || "Bearer",
-          expiresIn: token.expires_in,
-          expiresAt: token.expires_in ? new Date(Date.now() + token.expires_in * 1000) : undefined,
+          expiresIn: token.expires_in ?? undefined,
+          expiresAt: token.expires_in != null ? new Date(Date.now() + token.expires_in * 1000) : undefined,
           scope: token.scope,
         },
       };

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -1,0 +1,447 @@
+/**
+ * RFC 8628 device authorization grant — request + poll.
+ *
+ * `requestDeviceAuthorization` obtains a device/user code pair;
+ * `pollDeviceToken` runs the §3.5 polling loop against the token endpoint. Both
+ * are TLS-guarded. The polling clock is monotonic and injectable for tests.
+ */
+
+import { BasecampError } from "../errors.js";
+import { requireSecureEndpoint } from "../security.js";
+import { readBodyBounded } from "./discovery.js";
+import { DeviceFlowError } from "./device-errors.js";
+import type { DeviceAuthorization, OAuthToken, RawTokenResponse, OAuthErrorResponse } from "./types.js";
+
+/** URN grant type for the device authorization grant. */
+export const DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code";
+
+/** Default polling interval when the server omits `interval` (RFC 8628 §3.2). */
+const DEFAULT_INTERVAL_SECONDS = 5;
+
+/**
+ * Upper bound (seconds) for `expires_in` / `interval`: 2_147_483 s (~24.8 days),
+ * the largest whole-second duration whose millisecond form (2_147_483_000 ms)
+ * fits a 32-bit signed timer. Beyond it a `setTimeout` silently clamps an
+ * out-of-range delay to 1 ms (hot poll loop) and deadline arithmetic can
+ * overflow. Far above any real device-code lifetime. Shared across all five SDKs
+ * (SPEC.md §16).
+ */
+const MAX_DEVICE_SECONDS = 2_147_483;
+
+/** slow_down bumps the interval by this many seconds, sustained (RFC 8628 §3.5). */
+const SLOW_DOWN_INCREMENT_SECONDS = 5;
+
+/** Cap on exponential backoff after connection timeouts. */
+const MAX_BACKOFF_SECONDS = 60;
+
+/** Cap on a device-auth / token response body (1 MiB) — these docs are tiny. */
+const MAX_DEVICE_BODY_BYTES = 1 * 1024 * 1024;
+
+/** Monotonic clock in milliseconds. Injectable so tests can advance time. */
+export type MonotonicClock = () => number;
+
+/** Default monotonic clock (ms): `performance.now()` when present, else `Date.now()`. */
+export const defaultClock: MonotonicClock = () =>
+  typeof performance !== "undefined" ? performance.now() : Date.now();
+
+/** Raw RFC 8628 device authorization response. */
+interface RawDeviceAuthorization {
+  device_code?: string;
+  user_code?: string;
+  verification_uri?: string;
+  verification_uri_complete?: string;
+  expires_in?: number;
+  interval?: number;
+}
+
+/**
+ * Parameters for {@link requestDeviceAuthorization}.
+ */
+export interface RequestDeviceAuthorizationParams {
+  /** The device_authorization_endpoint from discovery. */
+  deviceAuthorizationEndpoint: string;
+  /** The public client id (e.g. "basecamp-cli"). */
+  clientId: string;
+  /** Requested scope. Omitted from the request entirely when unset → server default `read`. */
+  scope?: string;
+  /** Custom fetch (testing). */
+  fetch?: typeof globalThis.fetch;
+  /** Request timeout in milliseconds (default: 30000). */
+  timeoutMs?: number;
+}
+
+/**
+ * Requests a device/user code pair (RFC 8628 §3.1–3.2).
+ *
+ * @throws DeviceFlowError("transport") on a network failure; BasecampError on
+ *   validation / non-2xx.
+ */
+export async function requestDeviceAuthorization(
+  params: RequestDeviceAuthorizationParams
+): Promise<DeviceAuthorization> {
+  const { deviceAuthorizationEndpoint, clientId, scope, fetch: customFetch = globalThis.fetch, timeoutMs = 30000 } = params;
+
+  requireSecureEndpoint(deviceAuthorizationEndpoint, "device authorization endpoint");
+  if (!clientId) {
+    throw new BasecampError("validation", "Client ID is required for device authorization");
+  }
+
+  const body = new URLSearchParams();
+  body.set("client_id", clientId);
+  // Omit scope entirely when unset so the server applies its default (`read`).
+  if (scope) body.set("scope", scope);
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  let response: Response;
+  try {
+    response = await customFetch(deviceAuthorizationEndpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+      body: body.toString(),
+      signal: controller.signal,
+      // Never chase an attacker-influenced Location: a 3xx surfaces below as a
+      // non-2xx api_error rather than a followed request.
+      redirect: "manual",
+    });
+  } catch (err) {
+    throw new DeviceFlowError("transport", `Device authorization request failed: ${errMessage(err)}`, {
+      cause: err instanceof Error ? err : undefined,
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+
+  // Bounded/streaming read: an oversized body aborts before it is fully buffered.
+  const text = await readBodyBounded(response, MAX_DEVICE_BODY_BYTES, "device authorization");
+  // Reject any non-2xx (including a suppressed 3xx) before parsing.
+  if (response.status < 200 || response.status >= 300) {
+    throw new BasecampError("api_error", `Device authorization failed with status ${response.status}`, {
+      httpStatus: response.status,
+    });
+  }
+  let data: unknown;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    throw new BasecampError("api_error", "Failed to parse device authorization response", {
+      httpStatus: response.status,
+    });
+  }
+  // A valid-JSON-but-non-object body (null, array, number, string) is malformed —
+  // fail as api_error before any property deref, never a raw TypeError.
+  if (typeof data !== "object" || data === null || Array.isArray(data)) {
+    throw new BasecampError("api_error", "Device authorization response is not a JSON object", {
+      httpStatus: response.status,
+    });
+  }
+
+  return validateDeviceAuthorization(data as RawDeviceAuthorization);
+}
+
+/**
+ * True iff `value` is a positive integer. Rejects fractional numbers, booleans
+ * (`typeof true === "boolean"`), NaN, Infinity, and undefined — narrowing to
+ * `number` so validated fields carry a definite type downstream.
+ */
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value > 0;
+}
+
+/** True iff `value` is a non-empty string. Rejects numbers/booleans/null so a
+ * malformed server response can't smuggle a non-string code/URI past validation. */
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+function validateDeviceAuthorization(data: RawDeviceAuthorization): DeviceAuthorization {
+  // Type-check, not just truthiness: a JSON number is truthy but is not a usable
+  // code/URI, so it must fail as api_error rather than flow into the poll loop.
+  if (
+    !isNonEmptyString(data.device_code) ||
+    !isNonEmptyString(data.user_code) ||
+    !isNonEmptyString(data.verification_uri)
+  ) {
+    throw new BasecampError("api_error", "Invalid device authorization response: missing or non-string required fields");
+  }
+  // expires_in drives a monotonic deadline; interval drives poll delays. Both
+  // must be positive integers within MAX_DEVICE_SECONDS — a fractional value
+  // (0.5) yields a sub-second delay and a huge value overflows the ms timer
+  // (Node clamps an out-of-range setTimeout to 1 ms → hot poll loop). Booleans
+  // and non-int-valued numbers are likewise rejected.
+  if (!isPositiveInteger(data.expires_in) || data.expires_in > MAX_DEVICE_SECONDS) {
+    throw new BasecampError(
+      "api_error",
+      `Invalid device authorization response: expires_in must be a positive integer no greater than ${MAX_DEVICE_SECONDS}`
+    );
+  }
+  let interval = DEFAULT_INTERVAL_SECONDS;
+  if (data.interval !== undefined) {
+    if (!isPositiveInteger(data.interval) || data.interval > MAX_DEVICE_SECONDS) {
+      throw new BasecampError(
+        "api_error",
+        `Invalid device authorization response: interval must be a positive integer no greater than ${MAX_DEVICE_SECONDS}`
+      );
+    }
+    interval = data.interval;
+  }
+  // Optional, but when present it must be a string — a non-string (number/array)
+  // would return a malformed DeviceAuthorization shape to callers.
+  if (data.verification_uri_complete !== undefined && typeof data.verification_uri_complete !== "string") {
+    throw new BasecampError("api_error", "Invalid device authorization response: verification_uri_complete must be a string");
+  }
+  return {
+    deviceCode: data.device_code,
+    userCode: data.user_code,
+    verificationUri: data.verification_uri,
+    verificationUriComplete: data.verification_uri_complete,
+    expiresIn: data.expires_in,
+    interval,
+  };
+}
+
+/**
+ * Parameters for {@link pollDeviceToken}.
+ */
+export interface PollDeviceTokenParams {
+  /** The token_endpoint from discovery. */
+  tokenEndpoint: string;
+  /** The public client id. */
+  clientId: string;
+  /** The device_code from {@link requestDeviceAuthorization}. */
+  deviceCode: string;
+  /** Polling interval in seconds. */
+  interval: number;
+  /** Code lifetime in seconds (monotonic deadline). */
+  expiresIn: number;
+  /** Cancellation signal — aborting rejects with DeviceFlowError("cancelled"). */
+  signal?: AbortSignal;
+  /** Injectable monotonic clock (ms). Default performance.now(). */
+  clock?: MonotonicClock;
+  /** Custom fetch (testing). */
+  fetch?: typeof globalThis.fetch;
+  /** Per-request timeout in milliseconds (default: 30000). */
+  timeoutMs?: number;
+  /**
+   * Injectable sleep (testing). Receives the wait in ms and the cancellation
+   * signal; defaults to a real, abortable timer. Lets tests assert the interval
+   * schedule (slow_down, backoff) without real delays.
+   */
+  sleepFn?: (ms: number, signal?: AbortSignal) => Promise<void>;
+}
+
+/**
+ * Polls the token endpoint until the user approves, denies, or the codes expire
+ * (RFC 8628 §3.4–3.5). Handles authorization_pending, sustained slow_down (+5s),
+ * a monotonic expiry deadline, exponential backoff on connection timeouts, and
+ * cooperative cancellation.
+ */
+export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OAuthToken> {
+  const {
+    tokenEndpoint,
+    clientId,
+    deviceCode,
+    expiresIn,
+    signal,
+    clock = defaultClock,
+    fetch: customFetch = globalThis.fetch,
+    timeoutMs = 30000,
+    sleepFn = sleep,
+  } = params;
+
+  requireSecureEndpoint(tokenEndpoint, "token endpoint");
+
+  let intervalSeconds = params.interval > 0 ? params.interval : DEFAULT_INTERVAL_SECONDS;
+  let backoffSeconds = intervalSeconds;
+  const deadline = clock() + expiresIn * 1000;
+
+  const body = new URLSearchParams();
+  body.set("grant_type", DEVICE_CODE_GRANT_TYPE);
+  body.set("device_code", deviceCode);
+  body.set("client_id", clientId);
+
+  for (;;) {
+    throwIfAborted(signal);
+
+    // Read the clock ONCE per iteration and reuse it for both the deadline check
+    // and the remaining-lifetime clamp: two separate reads could straddle the
+    // deadline and yield a negative wait for the (possibly injected) sleep seam.
+    const now = clock();
+    // Check the deadline before sleeping so a long display hook, a stalled prior
+    // request, or a long backoff cannot carry us past expiry undetected.
+    if (now >= deadline) {
+      throw new DeviceFlowError("expired", "Device code expired before authorization completed");
+    }
+    // Clamp the wait to the remaining lifetime (guaranteed > 0 here) so the
+    // backoff/interval never overshoots the monotonic deadline.
+    const remainingMs = deadline - now;
+    const waitMs = Math.min(intervalSeconds * 1000, remainingMs);
+    try {
+      await sleepFn(waitMs, signal);
+    } catch (err) {
+      // The caller aborted the signal mid-wait: surface the contractual
+      // cancellation, never let a raw AbortError/DOMException escape.
+      if (isAbort(err)) {
+        throw new DeviceFlowError("cancelled", "Device flow cancelled");
+      }
+      throw err;
+    }
+
+    if (clock() >= deadline) {
+      throw new DeviceFlowError("expired", "Device code expired before authorization completed");
+    }
+
+    let result: TokenPollResult;
+    try {
+      result = await postDeviceToken(tokenEndpoint, body, customFetch, timeoutMs, signal);
+    } catch (err) {
+      if (isAbort(err) && signal?.aborted) {
+        throw new DeviceFlowError("cancelled", "Device flow cancelled");
+      }
+      if (isAbort(err)) {
+        // Our own per-request timeout fired → connection timeout: back off and retry.
+        backoffSeconds = Math.min(backoffSeconds * 2, MAX_BACKOFF_SECONDS);
+        intervalSeconds = Math.max(intervalSeconds, backoffSeconds);
+        continue;
+      }
+      // An already-typed BasecampError (e.g. a malformed 2xx token response, an
+      // oversized body, or a redirect) is a server/API fault — propagate it
+      // unchanged rather than mislabeling it a retryable transport failure.
+      if (err instanceof BasecampError) throw err;
+      // Any other transport failure ends the flow.
+      throw new DeviceFlowError("transport", `Device token poll failed: ${errMessage(err)}`, {
+        cause: err instanceof Error ? err : undefined,
+      });
+    }
+
+    // A successful HTTP round-trip resets the timeout backoff.
+    backoffSeconds = intervalSeconds;
+
+    if (result.kind === "token") return result.token;
+
+    switch (result.error) {
+      case "authorization_pending":
+        continue;
+      case "slow_down":
+        intervalSeconds += SLOW_DOWN_INCREMENT_SECONDS;
+        continue;
+      case "access_denied":
+        throw new DeviceFlowError("access_denied", "The authorization request was denied");
+      case "expired_token":
+        throw new DeviceFlowError("expired", "Device code expired before authorization completed");
+      default:
+        throw new BasecampError("api_error", `Device token request failed: ${result.error}`, {
+          httpStatus: result.status,
+        });
+    }
+  }
+}
+
+type TokenPollResult =
+  | { kind: "token"; token: OAuthToken }
+  | { kind: "error"; error: string; status: number };
+
+async function postDeviceToken(
+  tokenEndpoint: string,
+  body: URLSearchParams,
+  customFetch: typeof globalThis.fetch,
+  timeoutMs: number,
+  signal: AbortSignal | undefined
+): Promise<TokenPollResult> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const onAbort = () => controller.abort();
+  signal?.addEventListener("abort", onAbort, { once: true });
+  try {
+    const response = await customFetch(tokenEndpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+      body: body.toString(),
+      signal: controller.signal,
+      // Never chase a Location: a redirected token poll is treated as an
+      // api_error below rather than followed.
+      redirect: "manual",
+    });
+    // Bounded/streaming read: an oversized body aborts before it is fully buffered.
+    const text = await readBodyBounded(response, MAX_DEVICE_BODY_BYTES, "device token");
+    // A suppressed 3xx is never a valid OAuth response — fail as api_error.
+    if (response.status >= 300 && response.status < 400) {
+      throw new BasecampError("api_error", `Device token endpoint returned redirect status ${response.status}`, {
+        httpStatus: response.status,
+      });
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      throw new BasecampError("api_error", "Failed to parse device token response", {
+        httpStatus: response.status,
+      });
+    }
+    // A valid-JSON-but-non-object body (null, array, number, string) is a
+    // malformed OAuth response — fail as api_error before any property deref,
+    // never a raw crash on `data.access_token`/`data.error`.
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      throw new BasecampError("api_error", "Device token response is not a JSON object", {
+        httpStatus: response.status,
+      });
+    }
+    const data = parsed as RawTokenResponse | OAuthErrorResponse;
+    if (response.ok) {
+      const token = data as RawTokenResponse;
+      // Non-empty string, not merely truthy: a numeric access_token is not a
+      // usable credential and must fail as api_error, not be returned downstream.
+      if (!isNonEmptyString(token.access_token)) {
+        throw new BasecampError("api_error", "Device token response missing or non-string access_token");
+      }
+      return {
+        kind: "token",
+        token: {
+          accessToken: token.access_token,
+          refreshToken: token.refresh_token,
+          tokenType: token.token_type || "Bearer",
+          expiresIn: token.expires_in,
+          expiresAt: token.expires_in ? new Date(Date.now() + token.expires_in * 1000) : undefined,
+          scope: token.scope,
+        },
+      };
+    }
+    const error = (data as OAuthErrorResponse).error || `http_${response.status}`;
+    return { kind: "error", error, status: response.status };
+  } finally {
+    clearTimeout(timeoutId);
+    signal?.removeEventListener("abort", onAbort);
+  }
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("Aborted", "AbortError"));
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException("Aborted", "AbortError"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw new DeviceFlowError("cancelled", "Device flow cancelled");
+  }
+}
+
+function isAbort(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -80,7 +80,9 @@ interface RawDeviceAuthorization {
   device_code?: string;
   user_code?: string;
   verification_uri?: string;
-  verification_uri_complete?: string;
+  // May be a JSON null on the wire — treated as absent (normalized to undefined),
+  // matching the Go/Kotlin decoders that cannot distinguish null from absent.
+  verification_uri_complete?: string | null;
   expires_in?: number;
   interval?: number | null;
 }
@@ -110,7 +112,7 @@ export interface RequestDeviceAuthorizationParams {
 export async function requestDeviceAuthorization(
   params: RequestDeviceAuthorizationParams
 ): Promise<DeviceAuthorization> {
-  const { deviceAuthorizationEndpoint, clientId, scope, fetch: customFetch = globalThis.fetch, timeoutMs = 30000 } = params;
+  const { deviceAuthorizationEndpoint, clientId, scope, fetch: customFetch = globalThis.fetch, timeoutMs = DEFAULT_DEVICE_TIMEOUT_MS } = params;
 
   requireSecureEndpoint(deviceAuthorizationEndpoint, "device authorization endpoint");
   if (!clientId) {
@@ -307,7 +309,7 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
     signal,
     clock = defaultClock,
     fetch: customFetch = globalThis.fetch,
-    timeoutMs = 30000,
+    timeoutMs = DEFAULT_DEVICE_TIMEOUT_MS,
     sleepFn = sleep,
   } = params;
 

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -567,6 +567,14 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
       resolve();
     }, ms);
     signal?.addEventListener("abort", onAbort, { once: true });
+    // Race: the signal can abort between the `signal?.aborted` check above and
+    // attaching this listener. With { once }, that abort event is already spent, so
+    // the listener would never fire and the promise would only settle at the full
+    // timeout. Re-check and handle it manually, dropping the now-dead listener.
+    if (signal?.aborted) {
+      signal.removeEventListener("abort", onAbort);
+      onAbort();
+    }
   });
 }
 

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -71,7 +71,12 @@ const MAX_DEVICE_BODY_BYTES = 1 * 1024 * 1024;
 /** Monotonic clock in milliseconds. Injectable so tests can advance time. */
 export type MonotonicClock = () => number;
 
-/** Default monotonic clock (ms): `performance.now()` when present, else `Date.now()`. */
+/**
+ * Default monotonic clock (ms): `performance.now()`, which every supported
+ * Node/browser runtime provides. The `Date.now()` branch is a last resort for
+ * exotic runtimes without `performance` — wall-clock, so not strictly monotonic;
+ * inject a real monotonic clock there if NTP steps matter.
+ */
 export const defaultClock: MonotonicClock = () =>
   typeof performance !== "undefined" ? performance.now() : Date.now();
 

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -220,9 +220,15 @@ function validateDeviceAuthorization(data: RawDeviceAuthorization, status: numbe
     }
     interval = data.interval;
   }
-  // Optional, but when present it must be a string — a non-string (number/array)
-  // would return a malformed DeviceAuthorization shape to callers.
-  if (data.verification_uri_complete !== undefined && typeof data.verification_uri_complete !== "string") {
+  // Optional; when present it must be a string. A JSON `null` is treated as
+  // ABSENT (cross-SDK contract: the Go and Kotlin decoders cannot distinguish
+  // null from absent) and normalized to undefined below — a non-string value
+  // (number/array) is still rejected as a malformed shape.
+  if (
+    data.verification_uri_complete !== undefined &&
+    data.verification_uri_complete !== null &&
+    typeof data.verification_uri_complete !== "string"
+  ) {
     throw new BasecampError("api_error", "Invalid device authorization response: verification_uri_complete must be a string", {
       httpStatus: status,
     });
@@ -231,7 +237,7 @@ function validateDeviceAuthorization(data: RawDeviceAuthorization, status: numbe
     deviceCode: data.device_code,
     userCode: data.user_code,
     verificationUri: data.verification_uri,
-    verificationUriComplete: data.verification_uri_complete,
+    verificationUriComplete: data.verification_uri_complete ?? undefined,
     expiresIn: data.expires_in,
     interval,
   };
@@ -511,10 +517,20 @@ async function postDeviceToken(
   }
 }
 
+// A plain Error tagged "AbortError" rather than `new DOMException(...)`:
+// DOMException is not guaranteed in every JS runtime that can run this SDK
+// (referencing it there throws ReferenceError). isAbort() matches on
+// `name === "AbortError"`, so cancellation stays runtime-agnostic.
+function abortError(): Error {
+  const err = new Error("Aborted");
+  err.name = "AbortError";
+  return err;
+}
+
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
     if (signal?.aborted) {
-      reject(new DOMException("Aborted", "AbortError"));
+      reject(abortError());
       return;
     }
     // Declare the handler before the timer so neither forward-references the
@@ -523,13 +539,7 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
     let timer: ReturnType<typeof setTimeout>;
     const onAbort = () => {
       clearTimeout(timer);
-      // A plain Error tagged "AbortError" rather than `new DOMException(...)`:
-      // DOMException is not guaranteed in every JS runtime that can run this SDK
-      // (referencing it there throws ReferenceError). isAbort() matches on
-      // `name === "AbortError"`, so this stays runtime-agnostic.
-      const abortError = new Error("Aborted");
-      abortError.name = "AbortError";
-      reject(abortError);
+      reject(abortError());
     };
     timer = setTimeout(() => {
       signal?.removeEventListener("abort", onAbort);

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -28,6 +28,25 @@ const DEFAULT_INTERVAL_SECONDS = 5;
  */
 const MAX_DEVICE_SECONDS = 2_147_483;
 
+/** Default per-request timeout (ms) for every device-flow HTTP round-trip. */
+const DEFAULT_DEVICE_TIMEOUT_MS = 30_000;
+
+/**
+ * Coerce a caller-supplied request timeout (ms) to a finite, positive, timer-safe
+ * value. `setTimeout` silently coerces a non-finite delay (NaN/Infinity) or one
+ * beyond its 32-bit range to ~1 ms — an immediate abort that would masquerade as a
+ * `DeviceFlowError("transport")` (and, in the poll loop, as repeated timeout
+ * backoffs). Fall back to the default instead, mirroring how Python/Ruby normalize
+ * an invalid device timeout. `MAX_DEVICE_SECONDS * 1000` stays safely under the
+ * 2^31 ms `setTimeout` ceiling.
+ */
+function resolveDeviceTimeoutMs(timeoutMs: number): number {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0 || timeoutMs > MAX_DEVICE_SECONDS * 1000) {
+    return DEFAULT_DEVICE_TIMEOUT_MS;
+  }
+  return timeoutMs;
+}
+
 /**
  * Upper bound (seconds) for an OAuth token's `expires_in`: 2_147_483_647 s
  * (~68 years) — cross-runtime safe and vastly beyond any realistic token
@@ -104,7 +123,7 @@ export async function requestDeviceAuthorization(
   if (scope) body.set("scope", scope);
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const timeoutId = setTimeout(() => controller.abort(), resolveDeviceTimeoutMs(timeoutMs));
   let response: Response;
   let text: string;
   try {
@@ -412,7 +431,7 @@ async function postDeviceToken(
   signal: AbortSignal | undefined
 ): Promise<TokenPollResult> {
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  const timeoutId = setTimeout(() => controller.abort(), resolveDeviceTimeoutMs(timeoutMs));
   const onAbort = () => controller.abort();
   signal?.addEventListener("abort", onAbort, { once: true });
   // If the signal was ALREADY aborted, the "abort" event has fired and the

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -51,7 +51,7 @@ interface RawDeviceAuthorization {
   verification_uri?: string;
   verification_uri_complete?: string;
   expires_in?: number;
-  interval?: number;
+  interval?: number | null;
 }
 
 /**
@@ -94,26 +94,41 @@ export async function requestDeviceAuthorization(
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
   let response: Response;
+  let text: string;
   try {
-    response = await customFetch(deviceAuthorizationEndpoint, {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
-      body: body.toString(),
-      signal: controller.signal,
-      // Never chase an attacker-influenced Location: a 3xx surfaces below as a
-      // non-2xx api_error rather than a followed request.
-      redirect: "manual",
-    });
-  } catch (err) {
-    throw new DeviceFlowError("transport", `Device authorization request failed: ${errMessage(err)}`, {
-      cause: err instanceof Error ? err : undefined,
-    });
+    try {
+      response = await customFetch(deviceAuthorizationEndpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+        body: body.toString(),
+        signal: controller.signal,
+        // Never chase an attacker-influenced Location: a 3xx surfaces below as a
+        // non-2xx api_error rather than a followed request.
+        redirect: "manual",
+      });
+    } catch (err) {
+      throw new DeviceFlowError("transport", `Device authorization request failed: ${errMessage(err)}`, {
+        cause: err instanceof Error ? err : undefined,
+      });
+    }
+    // Bounded/streaming read: an oversized body aborts before it is fully
+    // buffered. The abort timer stays armed until the read completes, so a
+    // stalled response STREAM times out just like a stalled request; an
+    // oversized body is already api_error, and any other stream failure
+    // (including the timeout's AbortError) maps to transport rather than
+    // escaping raw.
+    try {
+      text = await readBodyBounded(response, MAX_DEVICE_BODY_BYTES, "device authorization");
+    } catch (err) {
+      if (err instanceof BasecampError) throw err;
+      throw new DeviceFlowError("transport", `Device authorization response read failed: ${errMessage(err)}`, {
+        cause: err instanceof Error ? err : undefined,
+      });
+    }
   } finally {
     clearTimeout(timeoutId);
   }
 
-  // Bounded/streaming read: an oversized body aborts before it is fully buffered.
-  const text = await readBodyBounded(response, MAX_DEVICE_BODY_BYTES, "device authorization");
   // Reject any non-2xx (including a suppressed 3xx) before parsing.
   if (response.status < 200 || response.status >= 300) {
     throw new BasecampError("api_error", `Device authorization failed with status ${response.status}`, {
@@ -176,7 +191,9 @@ function validateDeviceAuthorization(data: RawDeviceAuthorization): DeviceAuthor
     );
   }
   let interval = DEFAULT_INTERVAL_SECONDS;
-  if (data.interval !== undefined) {
+  // A JSON `null` interval is treated as ABSENT (cross-SDK contract: the Go and
+  // Kotlin decoders cannot distinguish null from absent), so it takes the default.
+  if (data.interval !== undefined && data.interval !== null) {
     if (!isPositiveInteger(data.interval) || data.interval > MAX_DEVICE_SECONDS) {
       throw new BasecampError(
         "api_error",
@@ -251,7 +268,24 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
 
   requireSecureEndpoint(tokenEndpoint, "token endpoint");
 
-  let intervalSeconds = params.interval > 0 ? params.interval : DEFAULT_INTERVAL_SECONDS;
+  // Caller-input sanity (usage, not the RFC response validation): a non-finite
+  // or oversized duration builds a broken deadline or an unschedulable wait.
+  // Fractional values are ACCEPTED — performDeviceLogin legitimately passes a
+  // fractional remaining lifetime after deducting display-hook time; whole-second
+  // enforcement applies only to raw server responses (validateDeviceAuthorization).
+  for (const [name, value] of [["expiresIn", expiresIn], ["interval", params.interval]] as const) {
+    if (!Number.isFinite(value) || value <= 0 || value > MAX_DEVICE_SECONDS) {
+      throw new BasecampError(
+        "usage",
+        `pollDeviceToken: ${name} must be a positive number of seconds no greater than ${MAX_DEVICE_SECONDS}`
+      );
+    }
+  }
+
+  // Server-driven poll interval (initial + sustained slow_down bumps), tracked
+  // SEPARATELY from the transient-timeout backoff: the wait is the larger of the
+  // two, so intermittent timeouts never permanently inflate the poll cadence.
+  let intervalSeconds = params.interval;
   let backoffSeconds = intervalSeconds;
   const deadline = clock() + expiresIn * 1000;
 
@@ -272,10 +306,11 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
     if (now >= deadline) {
       throw new DeviceFlowError("expired", "Device code expired before authorization completed");
     }
-    // Clamp the wait to the remaining lifetime (guaranteed > 0 here) so the
-    // backoff/interval never overshoots the monotonic deadline.
+    // Wait the larger of the server interval and the timeout backoff, clamped
+    // to the remaining lifetime (guaranteed > 0 here) so the wait never
+    // overshoots the monotonic deadline.
     const remainingMs = deadline - now;
-    const waitMs = Math.min(intervalSeconds * 1000, remainingMs);
+    const waitMs = Math.min(Math.max(intervalSeconds, backoffSeconds) * 1000, remainingMs);
     try {
       await sleepFn(waitMs, signal);
     } catch (err) {
@@ -299,9 +334,9 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
         throw new DeviceFlowError("cancelled", "Device flow cancelled");
       }
       if (isAbort(err)) {
-        // Our own per-request timeout fired → connection timeout: back off and retry.
+        // Our own per-request timeout fired → connection timeout: back off and
+        // retry. The server interval is left untouched so recovery is instant.
         backoffSeconds = Math.min(backoffSeconds * 2, MAX_BACKOFF_SECONDS);
-        intervalSeconds = Math.max(intervalSeconds, backoffSeconds);
         continue;
       }
       // An already-typed BasecampError (e.g. a malformed 2xx token response, an
@@ -314,7 +349,8 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
       });
     }
 
-    // A successful HTTP round-trip resets the timeout backoff.
+    // ANY completed HTTP round-trip (token, authorization_pending, slow_down,
+    // other OAuth error) resets the timeout backoff to the server interval.
     backoffSeconds = intervalSeconds;
 
     if (result.kind === "token") return result.token;
@@ -324,6 +360,7 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
         continue;
       case "slow_down":
         intervalSeconds += SLOW_DOWN_INCREMENT_SECONDS;
+        backoffSeconds = intervalSeconds;
         continue;
       case "access_denied":
         throw new DeviceFlowError("access_denied", "The authorization request was denied");

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -523,7 +523,13 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
     let timer: ReturnType<typeof setTimeout>;
     const onAbort = () => {
       clearTimeout(timer);
-      reject(new DOMException("Aborted", "AbortError"));
+      // A plain Error tagged "AbortError" rather than `new DOMException(...)`:
+      // DOMException is not guaranteed in every JS runtime that can run this SDK
+      // (referencing it there throws ReferenceError). isAbort() matches on
+      // `name === "AbortError"`, so this stays runtime-agnostic.
+      const abortError = new Error("Aborted");
+      abortError.name = "AbortError";
+      reject(abortError);
     };
     timer = setTimeout(() => {
       signal?.removeEventListener("abort", onAbort);

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -495,7 +495,11 @@ async function postDeviceToken(
       });
     }
     const data = parsed as RawTokenResponse | OAuthErrorResponse;
-    if (response.ok) {
+    // Exactly HTTP 200, not response.ok (any 2xx): RFC 8628/6749 token
+    // responses are 200, and SPEC §16 pins the contract. A nonstandard 201/202
+    // carrying an access_token must not prematurely complete polling — it
+    // falls through to the OAuth-error path and terminates as api_error.
+    if (response.status === 200) {
       const token = data as RawTokenResponse;
       // Non-empty string, not merely truthy: a numeric access_token is not a
       // usable credential and must fail as api_error, not be returned downstream.

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -67,7 +67,7 @@ function resolveDeviceTimeoutMs(timeoutMs: number): number {
  * never expiring. A value past this ceiling is a malformed response. Shared
  * across all five SDKs.
  */
-const MAX_TOKEN_LIFETIME_SECONDS = 2_147_483_647;
+export const MAX_TOKEN_LIFETIME_SECONDS = 2_147_483_647;
 
 /** slow_down bumps the interval by this many seconds, sustained (RFC 8628 §3.5). */
 const SLOW_DOWN_INCREMENT_SECONDS = 5;

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -674,11 +674,13 @@ async function postDeviceToken(
           kind: "token",
           token: {
             accessToken: token.access_token,
-            refreshToken: token.refresh_token,
+            // `?? undefined`: validation admits JSON null (absent per SPEC),
+            // but the public type is `string | undefined` — never leak null.
+            refreshToken: token.refresh_token ?? undefined,
             tokenType: token.token_type || "Bearer",
             expiresIn: token.expires_in ?? undefined,
             expiresAt: token.expires_in != null ? new Date(Date.now() + token.expires_in * 1000) : undefined,
-            scope: token.scope,
+            scope: token.scope ?? undefined,
           },
         };
       }

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -32,16 +32,26 @@ const MAX_DEVICE_SECONDS = 2_147_483;
 const DEFAULT_DEVICE_TIMEOUT_MS = 30_000;
 
 /**
+ * Ceiling (ms) for a caller-supplied per-request timeout: the shared 3600 s
+ * bound (Go's maxDeviceRequestTimeout, Python's _MAX_DEVICE_REQUEST_TIMEOUT,
+ * Ruby's Fetcher::MAX_REQUEST_TIMEOUT). A large finite value — up to the
+ * ~24.8-day MAX_DEVICE_SECONDS timer bound this previously allowed — would
+ * hold a stalled request open for weeks, defeating the bounded-request
+ * guarantee.
+ */
+const MAX_DEVICE_REQUEST_TIMEOUT_MS = 3600 * 1000;
+
+/**
  * Coerce a caller-supplied request timeout (ms) to a finite, positive, timer-safe
- * value. `setTimeout` silently coerces a non-finite delay (NaN/Infinity) or one
- * beyond its 32-bit range to ~1 ms — an immediate abort that would masquerade as a
- * `DeviceFlowError("transport")` (and, in the poll loop, as repeated timeout
- * backoffs). Fall back to the default instead, mirroring how Python/Ruby normalize
- * an invalid device timeout. `MAX_DEVICE_SECONDS * 1000` stays safely under the
- * 2^31 ms `setTimeout` ceiling.
+ * value no greater than the shared ceiling. `setTimeout` silently coerces a
+ * non-finite delay (NaN/Infinity) or one beyond its 32-bit range to ~1 ms — an
+ * immediate abort that would masquerade as a `DeviceFlowError("transport")`
+ * (and, in the poll loop, as repeated timeout backoffs). Fall back to the
+ * default instead, mirroring how the other SDKs normalize an invalid device
+ * timeout.
  */
 function resolveDeviceTimeoutMs(timeoutMs: number): number {
-  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0 || timeoutMs > MAX_DEVICE_SECONDS * 1000) {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0 || timeoutMs > MAX_DEVICE_REQUEST_TIMEOUT_MS) {
     return DEFAULT_DEVICE_TIMEOUT_MS;
   }
   return timeoutMs;

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -492,7 +492,14 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
     // other OAuth error) resets the timeout backoff to the server interval.
     backoffSeconds = intervalSeconds;
 
-    if (result.kind === "token") return result.token;
+    // A custom fetch that ignores its AbortSignal can complete a 200 after the
+    // caller aborted: re-check before handing back the credential — never a
+    // token returned after the caller asked to stop (Go's success branch does
+    // the same via ctx.Err()).
+    if (result.kind === "token") {
+      throwIfAborted(signal);
+      return result.token;
+    }
 
     switch (result.error) {
       case "authorization_pending":

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -331,7 +331,8 @@ export interface PollDeviceTokenParams {
    * Absolute monotonic deadline (ms, same clock as `clock`) anchoring the
    * code's expiry at ISSUANCE. When set it overrides the `clock() + expiresIn`
    * anchoring so time elapsed before this call is never handed back to the
-   * lifetime; `expiresIn` still gates the caller-input validation.
+   * lifetime. Must be finite and no later than `expiresIn` seconds from now —
+   * a deadline can only shorten the validated lifetime, never extend it.
    */
   deadlineAtMs?: number;
   /** Cancellation signal — aborting rejects with DeviceFlowError("cancelled"). */
@@ -387,17 +388,19 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
 
   // Same caller-input sanity for the optional absolute deadline: Infinity polls
   // forever, NaN defeats every deadline comparison and wait clamp, and a
-  // finite-but-absurd future timestamp reintroduces the unbounded lifetime
-  // MAX_DEVICE_SECONDS exists to prevent. A deadline at/below "now" is legal —
-  // it surfaces as device_flow_expired, matching an issuance-anchored deadline
-  // fully consumed by a slow display hook.
+  // deadline later than the VALIDATED expiresIn would extend polling past the
+  // server-issued code lifetime. The bound is expiresIn from now — the
+  // issuance-anchored deadline performDeviceLogin passes is always at or
+  // before it (the clock only advances after issuance). A deadline at/below
+  // "now" is legal — it surfaces as device_flow_expired, matching an
+  // issuance-anchored deadline fully consumed by a slow display hook.
   if (
     params.deadlineAtMs !== undefined &&
-    (!Number.isFinite(params.deadlineAtMs) || params.deadlineAtMs > clock() + MAX_DEVICE_SECONDS * 1000)
+    (!Number.isFinite(params.deadlineAtMs) || params.deadlineAtMs > clock() + expiresIn * 1000)
   ) {
     throw new BasecampError(
       "usage",
-      `pollDeviceToken: deadlineAtMs must be a finite epoch-milliseconds timestamp no more than ${MAX_DEVICE_SECONDS} seconds in the future`
+      "pollDeviceToken: deadlineAtMs must be a finite timestamp no later than expiresIn seconds from now"
     );
   }
 

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -406,16 +406,22 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
 
   // Caller-input sanity (usage, not the RFC response validation): a non-finite
   // or oversized duration builds a broken deadline or an unschedulable wait.
-  // Fractional values are ACCEPTED — performDeviceLogin legitimately passes a
-  // fractional remaining lifetime after deducting display-hook time; whole-second
-  // enforcement applies only to raw server responses (validateDeviceAuthorization).
-  for (const [name, value] of [["expiresIn", expiresIn], ["interval", params.interval]] as const) {
-    if (!Number.isFinite(value) || value <= 0 || value > MAX_DEVICE_SECONDS) {
-      throw new BasecampError(
-        "usage",
-        `pollDeviceToken: ${name} must be a positive number of seconds no greater than ${MAX_DEVICE_SECONDS}`
-      );
-    }
+  // expiresIn MAY be fractional — performDeviceLogin legitimately passes a
+  // fractional remaining lifetime after deducting display-hook time — but the
+  // polling interval is whole seconds (RFC 8628), matching the response
+  // validation and the integer-typed Go/Kotlin APIs: a fractional interval
+  // (0.001) would otherwise permit ~1000 polls per second.
+  if (!Number.isFinite(expiresIn) || expiresIn <= 0 || expiresIn > MAX_DEVICE_SECONDS) {
+    throw new BasecampError(
+      "usage",
+      `pollDeviceToken: expiresIn must be a positive number of seconds no greater than ${MAX_DEVICE_SECONDS}`
+    );
+  }
+  if (!Number.isInteger(params.interval) || params.interval <= 0 || params.interval > MAX_DEVICE_SECONDS) {
+    throw new BasecampError(
+      "usage",
+      `pollDeviceToken: interval must be a positive whole number of seconds no greater than ${MAX_DEVICE_SECONDS}`
+    );
   }
 
   // Same caller-input sanity for the optional absolute deadline: Infinity polls

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -477,10 +477,11 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
     }
     // Wait the larger of the server interval and the timeout backoff, clamped
     // to the remaining lifetime (guaranteed >= 1ms here) so the wait never
-    // overshoots the monotonic deadline. Ceil to whole milliseconds — timers
-    // truncate fractional delays toward 0.
+    // overshoots the monotonic deadline. FLOOR to whole milliseconds: ceil
+    // would round a fractional remainder past the deadline, and the <1ms
+    // guard above keeps the floor at >= 1.
     const remainingMs = deadline - now;
-    const waitMs = Math.ceil(Math.min(Math.max(intervalSeconds, backoffSeconds) * 1000, remainingMs));
+    const waitMs = Math.floor(Math.min(Math.max(intervalSeconds, backoffSeconds) * 1000, remainingMs));
     try {
       await sleepFn(waitMs, signal);
     } catch (err) {

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -480,7 +480,10 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
     // degrading into a 0ms hot loop.
     const waitMs = Math.max(1, Math.floor(Math.min(Math.max(intervalSeconds, backoffSeconds) * 1000, remainingMs)));
     try {
-      await sleepFn(waitMs, signal);
+      // Race the injected sleep against the signal: a custom sleepFn that
+      // ignores its signal argument must not hold a cancelled poll open until
+      // its timer fires (or forever, for a never-settling seam).
+      await (signal ? raceAbort(signal, () => sleepFn(waitMs, signal)) : sleepFn(waitMs, signal));
     } catch (err) {
       // The caller aborted the signal mid-wait: surface the contractual
       // cancellation, never let a raw AbortError/DOMException escape.

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -54,7 +54,9 @@ function resolveDeviceTimeoutMs(timeoutMs: number): number {
   if (!Number.isFinite(timeoutMs) || timeoutMs <= 0 || timeoutMs > MAX_DEVICE_REQUEST_TIMEOUT_MS) {
     return DEFAULT_DEVICE_TIMEOUT_MS;
   }
-  return timeoutMs;
+  // Whole milliseconds, at least 1: timers truncate fractional delays toward
+  // 0, so 0.5 would become an immediate abort.
+  return Math.max(1, Math.floor(timeoutMs));
 }
 
 /**
@@ -416,15 +418,19 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
   // before it (the clock only advances after issuance). A deadline at/below
   // "now" is legal — it surfaces as device_flow_expired, matching an
   // issuance-anchored deadline fully consumed by a slow display hook.
-  // A single entry sample validates the injected clock (a NaN/Infinity sample
-  // poisons the deadline math, and setTimeout(NaN) coerces to 0 — a tight
-  // poll loop instead of a fast usage failure) and anchors both the
-  // deadlineAtMs bound and the default deadline without consuming extra
-  // scripted-clock steps in tests.
-  const nowMs = clock();
-  if (!Number.isFinite(nowMs)) {
-    throw new BasecampError("usage", "pollDeviceToken: clock must return a finite number of milliseconds");
-  }
+  // EVERY sample of the injected clock is validated, not just the first: a
+  // NaN/Infinity sample poisons the deadline math, and setTimeout(NaN)
+  // coerces to 0 — a tight poll loop instead of a fast usage failure. The
+  // wrapper preserves scripted-clock step counts (one underlying call per
+  // sample).
+  const safeClock: MonotonicClock = () => {
+    const sample = clock();
+    if (!Number.isFinite(sample)) {
+      throw new BasecampError("usage", "pollDeviceToken: clock must return a finite number of milliseconds");
+    }
+    return sample;
+  };
+  const nowMs = safeClock();
   if (
     params.deadlineAtMs !== undefined &&
     (!Number.isFinite(params.deadlineAtMs) || params.deadlineAtMs > nowMs + expiresIn * 1000)
@@ -460,17 +466,21 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
     // Read the clock ONCE per iteration and reuse it for both the deadline check
     // and the remaining-lifetime clamp: two separate reads could straddle the
     // deadline and yield a negative wait for the (possibly injected) sleep seam.
-    const now = clock();
+    const now = safeClock();
     // Check the deadline before sleeping so a long display hook, a stalled prior
     // request, or a long backoff cannot carry us past expiry undetected.
-    if (now >= deadline) {
+    // Sub-millisecond remainders count as expired: performance.now() is
+    // fractional, and a <1ms residue would truncate into 0ms timers — a tight
+    // loop right at expiry.
+    if (deadline - now < 1) {
       throw new DeviceFlowError("expired", "Device code expired before authorization completed");
     }
     // Wait the larger of the server interval and the timeout backoff, clamped
-    // to the remaining lifetime (guaranteed > 0 here) so the wait never
-    // overshoots the monotonic deadline.
+    // to the remaining lifetime (guaranteed >= 1ms here) so the wait never
+    // overshoots the monotonic deadline. Ceil to whole milliseconds — timers
+    // truncate fractional delays toward 0.
     const remainingMs = deadline - now;
-    const waitMs = Math.min(Math.max(intervalSeconds, backoffSeconds) * 1000, remainingMs);
+    const waitMs = Math.ceil(Math.min(Math.max(intervalSeconds, backoffSeconds) * 1000, remainingMs));
     try {
       await sleepFn(waitMs, signal);
     } catch (err) {
@@ -482,8 +492,8 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
       throw err;
     }
 
-    const postRemainingMs = deadline - clock();
-    if (postRemainingMs <= 0) {
+    const postRemainingMs = deadline - safeClock();
+    if (postRemainingMs < 1) {
       throw new DeviceFlowError("expired", "Device code expired before authorization completed");
     }
 

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -475,7 +475,10 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
     // would round a fractional remainder past the deadline, and the <1ms
     // guard above keeps the floor at >= 1.
     const remainingMs = deadline - now;
-    const waitMs = Math.floor(Math.min(Math.max(intervalSeconds, backoffSeconds) * 1000, remainingMs));
+    // max(1, floor(...)): floor stays inside the remaining lifetime, and the
+    // 1ms floor keeps a caller-supplied sub-millisecond interval from
+    // degrading into a 0ms hot loop.
+    const waitMs = Math.max(1, Math.floor(Math.min(Math.max(intervalSeconds, backoffSeconds) * 1000, remainingMs)));
     try {
       await sleepFn(waitMs, signal);
     } catch (err) {

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -159,53 +159,75 @@ export async function requestDeviceAuthorization(
   let response: Response;
   let text: string;
   try {
-    try {
-      response = await customFetch(deviceAuthorizationEndpoint, {
-        method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
-        body: body.toString(),
-        signal: controller.signal,
-        // Never chase an attacker-influenced Location: a 3xx surfaces below as a
-        // non-2xx api_error rather than a followed request.
-        redirect: "manual",
-      });
-    } catch (err) {
-      if (isAbort(err) && signal?.aborted) {
-        throw new DeviceFlowError("cancelled", "Device flow cancelled");
+    // The whole round trip runs INSIDE a race against the controller's signal:
+    // a cooperative fetch rejects on abort anyway, but a custom fetch that
+    // ignores its AbortSignal must not hold this call past its timeout or hand
+    // back a code pair after cancellation — the race rejects the moment the
+    // timeout or the caller's abort fires, and a late settlement is discarded.
+    ({ response, text } = await raceAbort(controller.signal, async () => {
+      let raced: Response;
+      try {
+        raced = await customFetch(deviceAuthorizationEndpoint, {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+          body: body.toString(),
+          signal: controller.signal,
+          // Never chase an attacker-influenced Location: a 3xx surfaces below as a
+          // non-2xx api_error rather than a followed request.
+          redirect: "manual",
+        });
+      } catch (err) {
+        if (isAbort(err) && signal?.aborted) {
+          throw new DeviceFlowError("cancelled", "Device flow cancelled");
+        }
+        throw new DeviceFlowError("transport", `Device authorization request failed: ${errMessage(err)}`, {
+          cause: err instanceof Error ? err : undefined,
+        });
       }
-      throw new DeviceFlowError("transport", `Device authorization request failed: ${errMessage(err)}`, {
-        cause: err instanceof Error ? err : undefined,
-      });
-    }
-    // A non-2xx (including a suppressed 3xx) is a hard failure whose body is
-    // unused, so surface it by status BEFORE draining the body. Otherwise a
-    // slow/never-ending error body could time out mid-read and be misclassified
-    // as a retryable transport failure instead of the api_error it is.
-    if (response.status < 200 || response.status >= 300) {
-      // Release the unread stream (non-blocking) so repeated failures don't retain
-      // sockets / connection-pool resources; the status error surfaces immediately.
-      void response.body?.cancel().catch(() => {});
-      throw new BasecampError("api_error", `Device authorization failed with status ${response.status}`, {
-        httpStatus: response.status,
-      });
-    }
-    // Bounded/streaming read: an oversized body aborts before it is fully
-    // buffered. The abort timer stays armed until the read completes, so a
-    // stalled response STREAM times out just like a stalled request; an
-    // oversized body is already api_error, and any other stream failure
-    // (including the timeout's AbortError) maps to transport rather than
-    // escaping raw.
-    try {
-      text = await readBodyBounded(response, MAX_DEVICE_BODY_BYTES, "device authorization");
-    } catch (err) {
-      if (err instanceof BasecampError) throw err;
-      if (isAbort(err) && signal?.aborted) {
-        throw new DeviceFlowError("cancelled", "Device flow cancelled");
+      // A non-2xx (including a suppressed 3xx) is a hard failure whose body is
+      // unused, so surface it by status BEFORE draining the body. Otherwise a
+      // slow/never-ending error body could time out mid-read and be misclassified
+      // as a retryable transport failure instead of the api_error it is.
+      if (raced.status < 200 || raced.status >= 300) {
+        // Release the unread stream (non-blocking) so repeated failures don't retain
+        // sockets / connection-pool resources; the status error surfaces immediately.
+        void raced.body?.cancel().catch(() => {});
+        throw new BasecampError("api_error", `Device authorization failed with status ${raced.status}`, {
+          httpStatus: raced.status,
+        });
       }
-      throw new DeviceFlowError("transport", `Device authorization response read failed: ${errMessage(err)}`, {
-        cause: err instanceof Error ? err : undefined,
-      });
+      // Bounded/streaming read: an oversized body aborts before it is fully
+      // buffered. The abort timer stays armed until the read completes, so a
+      // stalled response STREAM times out just like a stalled request; an
+      // oversized body is already api_error, and any other stream failure
+      // (including the timeout's AbortError) maps to transport rather than
+      // escaping raw.
+      let racedText: string;
+      try {
+        racedText = await readBodyBounded(raced, MAX_DEVICE_BODY_BYTES, "device authorization");
+      } catch (err) {
+        if (err instanceof BasecampError) throw err;
+        if (isAbort(err) && signal?.aborted) {
+          throw new DeviceFlowError("cancelled", "Device flow cancelled");
+        }
+        throw new DeviceFlowError("transport", `Device authorization response read failed: ${errMessage(err)}`, {
+          cause: err instanceof Error ? err : undefined,
+        });
+      }
+      return { response: raced, text: racedText };
+    }));
+  } catch (err) {
+    // Already-classified failures from the raced work pass through; a raw
+    // AbortError here means the race itself lost — the caller aborted, or the
+    // timeout fired while a non-cooperative fetch refused to settle.
+    if (err instanceof DeviceFlowError || err instanceof BasecampError) throw err;
+    if (isAbort(err) && signal?.aborted) {
+      throw new DeviceFlowError("cancelled", "Device flow cancelled");
     }
+    if (isAbort(err)) {
+      throw new DeviceFlowError("transport", "Device authorization request failed: timed out");
+    }
+    throw err;
   } finally {
     clearTimeout(timeoutId);
     signal?.removeEventListener("abort", onAbort);
@@ -540,136 +562,144 @@ async function postDeviceToken(
   // does not proceed (and even return a token) after cancellation.
   if (signal?.aborted) controller.abort();
   try {
-    const response = await customFetch(tokenEndpoint, {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
-      body: body.toString(),
-      signal: controller.signal,
-      // Never chase a Location: a redirected token poll is treated as an
-      // api_error below rather than followed.
-      redirect: "manual",
+    // The whole round trip runs INSIDE a race against the controller's signal
+    // (which fires on the per-request timeout AND the caller's abort): a custom
+    // fetch that ignores its AbortSignal must not hold the poll past its
+    // timeout or hand back a token after cancellation. The race's AbortError
+    // classifies in the poll loop exactly like a cooperative fetch's — caller
+    // abort → cancelled, timeout → transient backoff.
+    return await raceAbort(controller.signal, async () => {
+      const response = await customFetch(tokenEndpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" },
+        body: body.toString(),
+        signal: controller.signal,
+        // Never chase a Location: a redirected token poll is treated as an
+        // api_error below rather than followed.
+        redirect: "manual",
+      });
+      // A suppressed 3xx is never a valid OAuth response and its body is unused —
+      // fail by status BEFORE draining the body. Otherwise a redirect that slowly
+      // streams its body could time out mid-read and be misclassified as a
+      // connection timeout, which the poll loop would back off and retry (until the
+      // device code expires) instead of surfacing the api_error now.
+      if (response.status >= 300 && response.status < 400) {
+        // Release the unread stream (non-blocking) so a redirecting endpoint under a
+        // long poll can't retain sockets / connection-pool resources.
+        void response.body?.cancel().catch(() => {});
+        throw new BasecampError("api_error", `Device token endpoint returned redirect status ${response.status}`, {
+          httpStatus: response.status,
+        });
+      }
+      // Every remaining status outside 200 and 4xx is terminal WITHOUT its body
+      // (only a 200 carries the token and only a 4xx the OAuth error code) —
+      // classify it before the read, like the 3xx above, so a 201/500 that
+      // stalls while streaming its body cannot abort mid-read and be retried as
+      // a transient timeout until the code expires.
+      if (response.status !== 200 && !(response.status >= 400 && response.status < 500)) {
+        void response.body?.cancel().catch(() => {});
+        throw new BasecampError("api_error", `Device token request failed with status ${response.status}`, {
+          httpStatus: response.status,
+        });
+      }
+      // Bounded/streaming read: an oversized body aborts before it is fully buffered.
+      // A 4xx still reads the body — that is how authorization_pending/slow_down and
+      // other OAuth errors are carried.
+      const text = await readBodyBounded(response, MAX_DEVICE_BODY_BYTES, "device token");
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        throw new BasecampError("api_error", "Failed to parse device token response", {
+          httpStatus: response.status,
+        });
+      }
+      // A valid-JSON-but-non-object body (null, array, number, string) is a
+      // malformed OAuth response — fail as api_error before any property deref,
+      // never a raw crash on `data.access_token`/`data.error`.
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        throw new BasecampError("api_error", "Device token response is not a JSON object", {
+          httpStatus: response.status,
+        });
+      }
+      const data = parsed as RawTokenResponse | OAuthErrorResponse;
+      // Exactly HTTP 200, not response.ok (any 2xx): RFC 8628/6749 token
+      // responses are 200, and SPEC §16 pins the contract. A nonstandard 201/202
+      // carrying an access_token must not prematurely complete polling — it
+      // falls through to the OAuth-error path and terminates as api_error.
+      if (response.status === 200) {
+        const token = data as RawTokenResponse;
+        // Non-empty string, not merely truthy: a numeric access_token is not a
+        // usable credential and must fail as api_error, not be returned downstream.
+        if (!isNonEmptyString(token.access_token)) {
+          throw new BasecampError("api_error", "Device token response missing or non-string access_token", {
+            httpStatus: response.status,
+          });
+        }
+        // expires_in is optional (RFC 6749 §5.1), but when present it must be a
+        // finite positive WHOLE number within MAX_TOKEN_LIFETIME_SECONDS. A
+        // non-finite value (1e400 → Infinity) or a very large finite one would flow
+        // into Date arithmetic and yield an Invalid Date whose getTime() is NaN, so
+        // expiry checks downstream would treat the token as never expiring. Whole
+        // seconds match the device-duration rule — every SDK validates the decoded
+        // numeric value explicitly to reject a fractional lifetime; an
+        // integer-valued float (3600.0) is still accepted.
+        if (token.expires_in != null &&
+            (typeof token.expires_in !== "number" || !Number.isInteger(token.expires_in) ||
+              token.expires_in <= 0 || token.expires_in > MAX_TOKEN_LIFETIME_SECONDS)) {
+          throw new BasecampError(
+            "api_error",
+            `Device token response expires_in must be a finite positive whole number no greater than ${MAX_TOKEN_LIFETIME_SECONDS} seconds`,
+            { httpStatus: response.status }
+          );
+        }
+        // token_type/refresh_token/scope are optional strings — a non-string value
+        // is a malformed response, not a usable credential field.
+        if (token.token_type != null && !isNonEmptyString(token.token_type)) {
+          throw new BasecampError("api_error", "Device token response token_type must be a non-empty string", {
+            httpStatus: response.status,
+          });
+        }
+        if (token.refresh_token != null && typeof token.refresh_token !== "string") {
+          throw new BasecampError("api_error", "Device token response refresh_token must be a string", {
+            httpStatus: response.status,
+          });
+        }
+        if (token.scope != null && typeof token.scope !== "string") {
+          throw new BasecampError("api_error", "Device token response scope must be a string", {
+            httpStatus: response.status,
+          });
+        }
+        return {
+          kind: "token",
+          token: {
+            accessToken: token.access_token,
+            refreshToken: token.refresh_token,
+            tokenType: token.token_type || "Bearer",
+            expiresIn: token.expires_in ?? undefined,
+            expiresAt: token.expires_in != null ? new Date(Date.now() + token.expires_in * 1000) : undefined,
+            scope: token.scope,
+          },
+        };
+      }
+      // Recognize OAuth protocol error codes ONLY on a 4xx (RFC 8628 §3.5 error
+      // responses are 400-class): a nonstandard 2xx (201/202) or a 5xx carrying
+      // a crafted authorization_pending body must not keep the loop polling —
+      // only a 200 can produce a token and only a 4xx a protocol state. The
+      // `error` must also be a non-empty string: a non-string (`{"error": 123}`)
+      // is not an OAuth error code. Everything else falls back to http_<status>,
+      // which the loop terminates as api_error.
+      const rawError = (data as { error?: unknown }).error;
+      // truncateErrorMessage at extraction (SPEC §9's 500-unit cap): the server
+      // controls this string and an unrecognized value is interpolated into the
+      // api_error message. Real protocol codes are short, so classification is
+      // unaffected.
+      const error =
+        response.status >= 400 && response.status < 500 && typeof rawError === "string" && rawError !== ""
+          ? truncateErrorMessage(rawError)
+          : `http_${response.status}`;
+      return { kind: "error", error, status: response.status };
     });
-    // A suppressed 3xx is never a valid OAuth response and its body is unused —
-    // fail by status BEFORE draining the body. Otherwise a redirect that slowly
-    // streams its body could time out mid-read and be misclassified as a
-    // connection timeout, which the poll loop would back off and retry (until the
-    // device code expires) instead of surfacing the api_error now.
-    if (response.status >= 300 && response.status < 400) {
-      // Release the unread stream (non-blocking) so a redirecting endpoint under a
-      // long poll can't retain sockets / connection-pool resources.
-      void response.body?.cancel().catch(() => {});
-      throw new BasecampError("api_error", `Device token endpoint returned redirect status ${response.status}`, {
-        httpStatus: response.status,
-      });
-    }
-    // Every remaining status outside 200 and 4xx is terminal WITHOUT its body
-    // (only a 200 carries the token and only a 4xx the OAuth error code) —
-    // classify it before the read, like the 3xx above, so a 201/500 that
-    // stalls while streaming its body cannot abort mid-read and be retried as
-    // a transient timeout until the code expires.
-    if (response.status !== 200 && !(response.status >= 400 && response.status < 500)) {
-      void response.body?.cancel().catch(() => {});
-      throw new BasecampError("api_error", `Device token request failed with status ${response.status}`, {
-        httpStatus: response.status,
-      });
-    }
-    // Bounded/streaming read: an oversized body aborts before it is fully buffered.
-    // A 4xx still reads the body — that is how authorization_pending/slow_down and
-    // other OAuth errors are carried.
-    const text = await readBodyBounded(response, MAX_DEVICE_BODY_BYTES, "device token");
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(text);
-    } catch {
-      throw new BasecampError("api_error", "Failed to parse device token response", {
-        httpStatus: response.status,
-      });
-    }
-    // A valid-JSON-but-non-object body (null, array, number, string) is a
-    // malformed OAuth response — fail as api_error before any property deref,
-    // never a raw crash on `data.access_token`/`data.error`.
-    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-      throw new BasecampError("api_error", "Device token response is not a JSON object", {
-        httpStatus: response.status,
-      });
-    }
-    const data = parsed as RawTokenResponse | OAuthErrorResponse;
-    // Exactly HTTP 200, not response.ok (any 2xx): RFC 8628/6749 token
-    // responses are 200, and SPEC §16 pins the contract. A nonstandard 201/202
-    // carrying an access_token must not prematurely complete polling — it
-    // falls through to the OAuth-error path and terminates as api_error.
-    if (response.status === 200) {
-      const token = data as RawTokenResponse;
-      // Non-empty string, not merely truthy: a numeric access_token is not a
-      // usable credential and must fail as api_error, not be returned downstream.
-      if (!isNonEmptyString(token.access_token)) {
-        throw new BasecampError("api_error", "Device token response missing or non-string access_token", {
-          httpStatus: response.status,
-        });
-      }
-      // expires_in is optional (RFC 6749 §5.1), but when present it must be a
-      // finite positive WHOLE number within MAX_TOKEN_LIFETIME_SECONDS. A
-      // non-finite value (1e400 → Infinity) or a very large finite one would flow
-      // into Date arithmetic and yield an Invalid Date whose getTime() is NaN, so
-      // expiry checks downstream would treat the token as never expiring. Whole
-      // seconds match the device-duration rule — every SDK validates the decoded
-      // numeric value explicitly to reject a fractional lifetime; an
-      // integer-valued float (3600.0) is still accepted.
-      if (token.expires_in != null &&
-          (typeof token.expires_in !== "number" || !Number.isInteger(token.expires_in) ||
-            token.expires_in <= 0 || token.expires_in > MAX_TOKEN_LIFETIME_SECONDS)) {
-        throw new BasecampError(
-          "api_error",
-          `Device token response expires_in must be a finite positive whole number no greater than ${MAX_TOKEN_LIFETIME_SECONDS} seconds`,
-          { httpStatus: response.status }
-        );
-      }
-      // token_type/refresh_token/scope are optional strings — a non-string value
-      // is a malformed response, not a usable credential field.
-      if (token.token_type != null && !isNonEmptyString(token.token_type)) {
-        throw new BasecampError("api_error", "Device token response token_type must be a non-empty string", {
-          httpStatus: response.status,
-        });
-      }
-      if (token.refresh_token != null && typeof token.refresh_token !== "string") {
-        throw new BasecampError("api_error", "Device token response refresh_token must be a string", {
-          httpStatus: response.status,
-        });
-      }
-      if (token.scope != null && typeof token.scope !== "string") {
-        throw new BasecampError("api_error", "Device token response scope must be a string", {
-          httpStatus: response.status,
-        });
-      }
-      return {
-        kind: "token",
-        token: {
-          accessToken: token.access_token,
-          refreshToken: token.refresh_token,
-          tokenType: token.token_type || "Bearer",
-          expiresIn: token.expires_in ?? undefined,
-          expiresAt: token.expires_in != null ? new Date(Date.now() + token.expires_in * 1000) : undefined,
-          scope: token.scope,
-        },
-      };
-    }
-    // Recognize OAuth protocol error codes ONLY on a 4xx (RFC 8628 §3.5 error
-    // responses are 400-class): a nonstandard 2xx (201/202) or a 5xx carrying
-    // a crafted authorization_pending body must not keep the loop polling —
-    // only a 200 can produce a token and only a 4xx a protocol state. The
-    // `error` must also be a non-empty string: a non-string (`{"error": 123}`)
-    // is not an OAuth error code. Everything else falls back to http_<status>,
-    // which the loop terminates as api_error.
-    const rawError = (data as { error?: unknown }).error;
-    // truncateErrorMessage at extraction (SPEC §9's 500-unit cap): the server
-    // controls this string and an unrecognized value is interpolated into the
-    // api_error message. Real protocol codes are short, so classification is
-    // unaffected.
-    const error =
-      response.status >= 400 && response.status < 500 && typeof rawError === "string" && rawError !== ""
-        ? truncateErrorMessage(rawError)
-        : `http_${response.status}`;
-    return { kind: "error", error, status: response.status };
   } finally {
     clearTimeout(timeoutId);
     signal?.removeEventListener("abort", onAbort);
@@ -684,6 +714,37 @@ function abortError(): Error {
   const err = new Error("Aborted");
   err.name = "AbortError";
   return err;
+}
+
+/**
+ * Races `run` against `signal`: rejects with AbortError the moment the signal
+ * fires, even if the underlying promise NEVER settles. A cooperative fetch
+ * already rejects on abort — this enforces the same contract on a custom fetch
+ * that ignores its AbortSignal, so a late 200 cannot hand back a result and a
+ * never-settling fetch cannot hold the public call past its timeout. An
+ * already-aborted signal rejects without invoking `run`. A late settlement is
+ * discarded (settling an already-settled promise is a no-op), and its
+ * rejection path stays handled — no unhandled rejection escapes.
+ */
+function raceAbort<T>(signal: AbortSignal, run: () => Promise<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(abortError());
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+    run().then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (err) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(err);
+      }
+    );
+  });
 }
 
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -132,6 +132,12 @@ export async function requestDeviceAuthorization(
 ): Promise<DeviceAuthorization> {
   const { deviceAuthorizationEndpoint, clientId, scope, fetch: customFetch = globalThis.fetch, timeoutMs = DEFAULT_DEVICE_TIMEOUT_MS, signal } = params;
 
+  // An already-aborted signal makes no request at all — reject before the
+  // fetch path so a direct caller cannot send (or a recording customFetch
+  // observe) a device-code request post-cancellation. performDeviceLogin
+  // checks at its own entry too; this covers direct callers.
+  throwIfAborted(signal);
+
   requireSecureEndpoint(deviceAuthorizationEndpoint, "device authorization endpoint");
   if (!clientId) {
     throw new BasecampError("validation", "Client ID is required for device authorization");

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -116,18 +116,21 @@ export interface RequestDeviceAuthorizationParams {
   fetch?: typeof globalThis.fetch;
   /** Request timeout in milliseconds (default: 30000). */
   timeoutMs?: number;
+  /** Cancellation signal — aborting rejects with DeviceFlowError("cancelled"). */
+  signal?: AbortSignal;
 }
 
 /**
  * Requests a device/user code pair (RFC 8628 §3.1–3.2).
  *
- * @throws DeviceFlowError("transport") on a network failure; BasecampError on
+ * @throws DeviceFlowError("cancelled") when the signal aborts;
+ *   DeviceFlowError("transport") on a network failure; BasecampError on
  *   validation / non-2xx.
  */
 export async function requestDeviceAuthorization(
   params: RequestDeviceAuthorizationParams
 ): Promise<DeviceAuthorization> {
-  const { deviceAuthorizationEndpoint, clientId, scope, fetch: customFetch = globalThis.fetch, timeoutMs = DEFAULT_DEVICE_TIMEOUT_MS } = params;
+  const { deviceAuthorizationEndpoint, clientId, scope, fetch: customFetch = globalThis.fetch, timeoutMs = DEFAULT_DEVICE_TIMEOUT_MS, signal } = params;
 
   requireSecureEndpoint(deviceAuthorizationEndpoint, "device authorization endpoint");
   if (!clientId) {
@@ -141,6 +144,12 @@ export async function requestDeviceAuthorization(
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), resolveDeviceTimeoutMs(timeoutMs));
+  // Chain the caller's cancellation into the request like postDeviceToken:
+  // an already-aborted signal must not fire the POST at all, and an abort
+  // mid-request surfaces as the contractual cancelled — never transport.
+  const onAbort = () => controller.abort();
+  signal?.addEventListener("abort", onAbort, { once: true });
+  if (signal?.aborted) controller.abort();
   let response: Response;
   let text: string;
   try {
@@ -155,6 +164,9 @@ export async function requestDeviceAuthorization(
         redirect: "manual",
       });
     } catch (err) {
+      if (isAbort(err) && signal?.aborted) {
+        throw new DeviceFlowError("cancelled", "Device flow cancelled");
+      }
       throw new DeviceFlowError("transport", `Device authorization request failed: ${errMessage(err)}`, {
         cause: err instanceof Error ? err : undefined,
       });
@@ -181,12 +193,16 @@ export async function requestDeviceAuthorization(
       text = await readBodyBounded(response, MAX_DEVICE_BODY_BYTES, "device authorization");
     } catch (err) {
       if (err instanceof BasecampError) throw err;
+      if (isAbort(err) && signal?.aborted) {
+        throw new DeviceFlowError("cancelled", "Device flow cancelled");
+      }
       throw new DeviceFlowError("transport", `Device authorization response read failed: ${errMessage(err)}`, {
         cause: err instanceof Error ? err : undefined,
       });
     }
   } finally {
     clearTimeout(timeoutId);
+    signal?.removeEventListener("abort", onAbort);
   }
 
   let data: unknown;
@@ -655,7 +671,7 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   });
 }
 
-function throwIfAborted(signal?: AbortSignal): void {
+export function throwIfAborted(signal?: AbortSignal): void {
   if (signal?.aborted) {
     throw new DeviceFlowError("cancelled", "Device flow cancelled");
   }

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -227,6 +227,12 @@ export async function requestDeviceAuthorization(
     });
   }
 
+  // Re-check after the round-trip: a custom fetch that ignores its
+  // AbortSignal can complete after the abort, and a direct caller must get
+  // cancelled — never a code minted post-cancellation. (performDeviceLogin
+  // re-checks too; this covers direct callers.)
+  throwIfAborted(signal);
+
   return validateDeviceAuthorization(data as RawDeviceAuthorization, response.status);
 }
 
@@ -321,6 +327,13 @@ export interface PollDeviceTokenParams {
   interval: number;
   /** Code lifetime in seconds (monotonic deadline). */
   expiresIn: number;
+  /**
+   * Absolute monotonic deadline (ms, same clock as `clock`) anchoring the
+   * code's expiry at ISSUANCE. When set it overrides the `clock() + expiresIn`
+   * anchoring so time elapsed before this call is never handed back to the
+   * lifetime; `expiresIn` still gates the caller-input validation.
+   */
+  deadlineAtMs?: number;
   /** Cancellation signal — aborting rejects with DeviceFlowError("cancelled"). */
   signal?: AbortSignal;
   /** Injectable monotonic clock (ms). Default performance.now(). */
@@ -384,7 +397,7 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
   // two, so intermittent timeouts never permanently inflate the poll cadence.
   let intervalSeconds = params.interval;
   let backoffSeconds = intervalSeconds;
-  const deadline = clock() + expiresIn * 1000;
+  const deadline = params.deadlineAtMs ?? clock() + expiresIn * 1000;
 
   const body = new URLSearchParams();
   body.set("grant_type", DEVICE_CODE_GRANT_TYPE);

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -340,6 +340,13 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
     }
   }
 
+  // Normalize the per-request timeout ONCE at entry: the remaining-lifetime
+  // clamp below takes min() against it, and an invalid runtime value (NaN,
+  // Infinity, non-positive) would otherwise poison the min into the 30s
+  // default INSIDE postDeviceToken — letting a near-expiry poll run the full
+  // default budget past the deadline.
+  const effectiveTimeoutMs = resolveDeviceTimeoutMs(timeoutMs);
+
   // Server-driven poll interval (initial + sustained slow_down bumps), tracked
   // SEPARATELY from the transient-timeout backoff: the wait is the larger of the
   // two, so intermittent timeouts never permanently inflate the poll cadence.
@@ -394,7 +401,7 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
         tokenEndpoint,
         body,
         customFetch,
-        Math.min(timeoutMs, postRemainingMs),
+        Math.min(effectiveTimeoutMs, postRemainingMs),
         signal
       );
     } catch (err) {
@@ -481,6 +488,17 @@ async function postDeviceToken(
       // long poll can't retain sockets / connection-pool resources.
       void response.body?.cancel().catch(() => {});
       throw new BasecampError("api_error", `Device token endpoint returned redirect status ${response.status}`, {
+        httpStatus: response.status,
+      });
+    }
+    // Every remaining status outside 200 and 4xx is terminal WITHOUT its body
+    // (only a 200 carries the token and only a 4xx the OAuth error code) —
+    // classify it before the read, like the 3xx above, so a 201/500 that
+    // stalls while streaming its body cannot abort mid-read and be retried as
+    // a transient timeout until the code expires.
+    if (response.status !== 200 && !(response.status >= 400 && response.status < 500)) {
+      void response.body?.cancel().catch(() => {});
+      throw new BasecampError("api_error", `Device token request failed with status ${response.status}`, {
         httpStatus: response.status,
       });
     }

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -6,7 +6,7 @@
  * are TLS-guarded. The polling clock is monotonic and injectable for tests.
  */
 
-import { BasecampError } from "../errors.js";
+import { BasecampError, truncateErrorMessage } from "../errors.js";
 import { requireSecureEndpoint } from "../security.js";
 import { readBodyBounded } from "./discovery.js";
 import { DeviceFlowError } from "./device-errors.js";
@@ -600,9 +600,13 @@ async function postDeviceToken(
     // is not an OAuth error code. Everything else falls back to http_<status>,
     // which the loop terminates as api_error.
     const rawError = (data as { error?: unknown }).error;
+    // truncateErrorMessage at extraction (SPEC §9's 500-unit cap): the server
+    // controls this string and an unrecognized value is interpolated into the
+    // api_error message. Real protocol codes are short, so classification is
+    // unaffected.
     const error =
       response.status >= 400 && response.status < 500 && typeof rawError === "string" && rawError !== ""
-        ? rawError
+        ? truncateErrorMessage(rawError)
         : `http_${response.status}`;
     return { kind: "error", error, status: response.status };
   } finally {

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -385,6 +385,22 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
     }
   }
 
+  // Same caller-input sanity for the optional absolute deadline: Infinity polls
+  // forever, NaN defeats every deadline comparison and wait clamp, and a
+  // finite-but-absurd future timestamp reintroduces the unbounded lifetime
+  // MAX_DEVICE_SECONDS exists to prevent. A deadline at/below "now" is legal —
+  // it surfaces as device_flow_expired, matching an issuance-anchored deadline
+  // fully consumed by a slow display hook.
+  if (
+    params.deadlineAtMs !== undefined &&
+    (!Number.isFinite(params.deadlineAtMs) || params.deadlineAtMs > clock() + MAX_DEVICE_SECONDS * 1000)
+  ) {
+    throw new BasecampError(
+      "usage",
+      `pollDeviceToken: deadlineAtMs must be a finite epoch-milliseconds timestamp no more than ${MAX_DEVICE_SECONDS} seconds in the future`
+    );
+  }
+
   // Normalize the per-request timeout ONCE at entry: the remaining-lifetime
   // clamp below takes min() against it, and an invalid runtime value (NaN,
   // Infinity, non-positive) would otherwise poison the min into the 30s

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -756,16 +756,21 @@ function raceAbort<T>(signal: AbortSignal, run: () => Promise<T>): Promise<T> {
       return;
     }
     signal.addEventListener("abort", onAbort, { once: true });
-    run().then(
-      (value) => {
-        signal.removeEventListener("abort", onAbort);
-        resolve(value);
-      },
-      (err) => {
-        signal.removeEventListener("abort", onAbort);
-        reject(err);
-      }
-    );
+    // Microtask wrapper: a user-provided seam (custom fetch/sleepFn) can
+    // throw SYNCHRONOUSLY despite the TS type — without this, that throw
+    // would escape before the handlers attach and strand the listener.
+    Promise.resolve()
+      .then(run)
+      .then(
+        (value) => {
+          signal.removeEventListener("abort", onAbort);
+          resolve(value);
+        },
+        (err) => {
+          signal.removeEventListener("abort", onAbort);
+          reject(err);
+        }
+      );
   });
 }
 

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -380,13 +380,23 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
       throw err;
     }
 
-    if (clock() >= deadline) {
+    const postRemainingMs = deadline - clock();
+    if (postRemainingMs <= 0) {
       throw new DeviceFlowError("expired", "Device code expired before authorization completed");
     }
 
     let result: TokenPollResult;
     try {
-      result = await postDeviceToken(tokenEndpoint, body, customFetch, timeoutMs, signal);
+      // Bound the request by the REMAINING code lifetime as well as the
+      // per-request timeout: near expiry, a stalled token POST must not hold
+      // the flow past the monotonic deadline for the full request budget.
+      result = await postDeviceToken(
+        tokenEndpoint,
+        body,
+        customFetch,
+        Math.min(timeoutMs, postRemainingMs),
+        signal
+      );
     } catch (err) {
       if (isAbort(err) && signal?.aborted) {
         throw new DeviceFlowError("cancelled", "Device flow cancelled");
@@ -554,11 +564,18 @@ async function postDeviceToken(
         },
       };
     }
-    // Validate `error` as a non-empty string: a non-string (e.g. `{"error": 123}`)
-    // must not be treated as an OAuth error code — fall back to http_<status>,
-    // matching the other SDKs (Ruby String-checks, Kotlin falls back on decode).
+    // Recognize OAuth protocol error codes ONLY on a 4xx (RFC 8628 §3.5 error
+    // responses are 400-class): a nonstandard 2xx (201/202) or a 5xx carrying
+    // a crafted authorization_pending body must not keep the loop polling —
+    // only a 200 can produce a token and only a 4xx a protocol state. The
+    // `error` must also be a non-empty string: a non-string (`{"error": 123}`)
+    // is not an OAuth error code. Everything else falls back to http_<status>,
+    // which the loop terminates as api_error.
     const rawError = (data as { error?: unknown }).error;
-    const error = typeof rawError === "string" && rawError !== "" ? rawError : `http_${response.status}`;
+    const error =
+      response.status >= 400 && response.status < 500 && typeof rawError === "string" && rawError !== ""
+        ? rawError
+        : `http_${response.status}`;
     return { kind: "error", error, status: response.status };
   } finally {
     clearTimeout(timeoutId);

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -416,9 +416,18 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
   // before it (the clock only advances after issuance). A deadline at/below
   // "now" is legal — it surfaces as device_flow_expired, matching an
   // issuance-anchored deadline fully consumed by a slow display hook.
+  // A single entry sample validates the injected clock (a NaN/Infinity sample
+  // poisons the deadline math, and setTimeout(NaN) coerces to 0 — a tight
+  // poll loop instead of a fast usage failure) and anchors both the
+  // deadlineAtMs bound and the default deadline without consuming extra
+  // scripted-clock steps in tests.
+  const nowMs = clock();
+  if (!Number.isFinite(nowMs)) {
+    throw new BasecampError("usage", "pollDeviceToken: clock must return a finite number of milliseconds");
+  }
   if (
     params.deadlineAtMs !== undefined &&
-    (!Number.isFinite(params.deadlineAtMs) || params.deadlineAtMs > clock() + expiresIn * 1000)
+    (!Number.isFinite(params.deadlineAtMs) || params.deadlineAtMs > nowMs + expiresIn * 1000)
   ) {
     throw new BasecampError(
       "usage",
@@ -438,7 +447,7 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
   // two, so intermittent timeouts never permanently inflate the poll cadence.
   let intervalSeconds = params.interval;
   let backoffSeconds = intervalSeconds;
-  const deadline = params.deadlineAtMs ?? clock() + expiresIn * 1000;
+  const deadline = params.deadlineAtMs ?? nowMs + expiresIn * 1000;
 
   const body = new URLSearchParams();
   body.set("grant_type", DEVICE_CODE_GRANT_TYPE);

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -86,6 +86,20 @@ export type MonotonicClock = () => number;
 export const defaultClock: MonotonicClock = () =>
   typeof performance !== "undefined" ? performance.now() : Date.now();
 
+/**
+ * Validate one sample from an injected clock seam. `Number.isFinite` performs
+ * no coercion, so a bigint, string, or Symbol sample fails exactly like a
+ * NaN/Infinity one — the typed usage error, never a raw TypeError out of later
+ * deadline arithmetic. Shared by the poller and the login orchestrator so both
+ * validate EVERY sample the same way.
+ */
+export function validatedClockSample(sample: unknown, entry: string): number {
+  if (typeof sample !== "number" || !Number.isFinite(sample)) {
+    throw new BasecampError("usage", `${entry}: clock must return a finite number of milliseconds`);
+  }
+  return sample;
+}
+
 /** Raw RFC 8628 device authorization response. */
 interface RawDeviceAuthorization {
   device_code?: string;
@@ -417,13 +431,7 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
   // coerces to 0 — a tight poll loop instead of a fast usage failure. The
   // wrapper preserves scripted-clock step counts (one underlying call per
   // sample).
-  const safeClock: MonotonicClock = () => {
-    const sample = clock();
-    if (!Number.isFinite(sample)) {
-      throw new BasecampError("usage", "pollDeviceToken: clock must return a finite number of milliseconds");
-    }
-    return sample;
-  };
+  const safeClock: MonotonicClock = () => validatedClockSample(clock(), "pollDeviceToken");
   const nowMs = safeClock();
   if (
     params.deadlineAtMs !== undefined &&

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -760,7 +760,13 @@ function raceAbort<T>(signal: AbortSignal, run: () => Promise<T>): Promise<T> {
     // throw SYNCHRONOUSLY despite the TS type — without this, that throw
     // would escape before the handlers attach and strand the listener.
     Promise.resolve()
-      .then(run)
+      .then(() => {
+        // The abort can win between entry and this microtask (the outer
+        // promise has already rejected) — never invoke the seam post-abort;
+        // an AbortSignal-ignoring fetch would still send the POST.
+        if (signal.aborted) throw abortError();
+        return run();
+      })
       .then(
         (value) => {
           signal.removeEventListener("abort", onAbort);

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -10,6 +10,11 @@ import { BasecampError, truncateErrorMessage } from "../errors.js";
 import { requireSecureEndpoint } from "../security.js";
 import { readBodyBounded } from "./discovery.js";
 import { DeviceFlowError } from "./device-errors.js";
+import { MAX_TOKEN_LIFETIME_SECONDS } from "./limits.js";
+
+// Re-exported for existing importers; the declaration lives in limits.ts so
+// non-device consumers need not pull this module.
+export { MAX_TOKEN_LIFETIME_SECONDS };
 import type { DeviceAuthorization, OAuthToken, RawTokenResponse, OAuthErrorResponse } from "./types.js";
 
 /** URN grant type for the device authorization grant. */
@@ -59,17 +64,6 @@ function resolveDeviceTimeoutMs(timeoutMs: number): number {
   return Math.max(1, Math.floor(timeoutMs));
 }
 
-/**
- * Upper bound (seconds) for an OAuth token's `expires_in`: 2_147_483_647 s
- * (~68 years) — cross-runtime safe and vastly beyond any realistic token
- * lifetime. Unlike {@link MAX_DEVICE_SECONDS} this bounds `expiresAt` Date
- * arithmetic rather than a timer: a very large finite value (or a non-finite one
- * from `1e400`) makes `new Date(Date.now() + expires_in * 1000)` an Invalid Date
- * whose `getTime()` is NaN, so downstream expiry checks would treat the token as
- * never expiring. A value past this ceiling is a malformed response. Shared
- * across all five SDKs.
- */
-export const MAX_TOKEN_LIFETIME_SECONDS = 2_147_483_647;
 
 /** slow_down bumps the interval by this many seconds, sustained (RFC 8628 §3.5). */
 const SLOW_DOWN_INCREMENT_SECONDS = 5;

--- a/typescript/src/oauth/exchange.ts
+++ b/typescript/src/oauth/exchange.ts
@@ -320,6 +320,16 @@ async function doTokenRequest(
       );
     }
 
+    // A valid-JSON-but-non-object body (null, array, number, string) is a
+    // malformed response on EVERY status — the error branch below would
+    // otherwise deref null and surface a raw TypeError misclassified as
+    // retryable network. Fail as api_error carrying the HTTP status.
+    if (typeof data !== "object" || data === null || Array.isArray(data)) {
+      throw new BasecampError("api_error", "Token response is not a JSON object", {
+        httpStatus: response.status,
+      });
+    }
+
     // Check for error response
     if (!response.ok) {
       const errorData = data as OAuthErrorResponse;
@@ -334,15 +344,6 @@ async function doTokenRequest(
       }
 
       throw new BasecampError("api_error", message, {
-        httpStatus: response.status,
-      });
-    }
-
-    // A valid-JSON-but-non-object body (null, array, number, string) is a
-    // malformed response — fail as api_error before any property deref,
-    // never a raw TypeError misclassified as retryable network.
-    if (typeof data !== "object" || data === null || Array.isArray(data)) {
-      throw new BasecampError("api_error", "Token response is not a JSON object", {
         httpStatus: response.status,
       });
     }

--- a/typescript/src/oauth/exchange.ts
+++ b/typescript/src/oauth/exchange.ts
@@ -346,13 +346,15 @@ async function doTokenRequest(
 
     return {
       accessToken: tokenData.access_token,
-      refreshToken: tokenData.refresh_token,
+      // `?? undefined`: JSON null is legal on the wire for the optional
+      // fields (absent per SPEC) — never leak null through the public type.
+      refreshToken: tokenData.refresh_token ?? undefined,
       tokenType: tokenData.token_type || "Bearer",
       expiresIn: tokenData.expires_in,
       expiresAt: tokenData.expires_in
         ? new Date(Date.now() + tokenData.expires_in * 1000)
         : undefined,
-      scope: tokenData.scope,
+      scope: tokenData.scope ?? undefined,
     };
   } catch (err) {
     if (err instanceof BasecampError) {

--- a/typescript/src/oauth/exchange.ts
+++ b/typescript/src/oauth/exchange.ts
@@ -311,13 +311,13 @@ async function doTokenRequest(
     try {
       data = JSON.parse(responseText);
     } catch {
-      // Truncate response text to avoid leaking sensitive data in error messages
-      const truncated = responseText.length > 500 ? responseText.slice(0, 497) + "..." : responseText;
-      throw new BasecampError(
-        "api_error",
-        `Failed to parse token response: ${truncated}`,
-        { httpStatus: response.status }
-      );
+      // A token response that fails to parse may still contain credential
+      // material (a syntactically-broken body carrying an access_token) —
+      // never echo ANY of it into an error message, where it would reach
+      // logs and exception telemetry. The status is diagnosis enough.
+      throw new BasecampError("api_error", "Failed to parse token response", {
+        httpStatus: response.status,
+      });
     }
 
     // A valid-JSON-but-non-object body (null, array, number, string) is a

--- a/typescript/src/oauth/exchange.ts
+++ b/typescript/src/oauth/exchange.ts
@@ -5,7 +5,7 @@
  * Supports both standard OAuth 2.0 and Basecamp's Launchpad legacy format.
  */
 
-import { MAX_TOKEN_LIFETIME_SECONDS } from "./device.js";
+import { MAX_TOKEN_LIFETIME_SECONDS } from "./limits.js";
 import { BasecampError } from "../errors.js";
 import { isLocalhost } from "../security.js";
 import type {

--- a/typescript/src/oauth/exchange.ts
+++ b/typescript/src/oauth/exchange.ts
@@ -333,7 +333,13 @@ async function doTokenRequest(
     // Check for error response
     if (!response.ok) {
       const errorData = data as OAuthErrorResponse;
-      const rawMessage = errorData.error_description || errorData.error || "Token request failed";
+      // Non-string error/error_description (numbers, objects) must not throw
+      // a raw TypeError below — that would be misclassified as retryable
+      // network, losing the api_error status context.
+      const rawMessage =
+        (typeof errorData.error_description === "string" && errorData.error_description) ||
+        (typeof errorData.error === "string" && errorData.error) ||
+        "Token request failed";
       const message = rawMessage.length > 500 ? rawMessage.slice(0, 497) + "..." : rawMessage;
 
       if (response.status === 401 || errorData.error === "invalid_grant") {

--- a/typescript/src/oauth/exchange.ts
+++ b/typescript/src/oauth/exchange.ts
@@ -5,6 +5,7 @@
  * Supports both standard OAuth 2.0 and Basecamp's Launchpad legacy format.
  */
 
+import { MAX_TOKEN_LIFETIME_SECONDS } from "./device.js";
 import { BasecampError } from "../errors.js";
 import { isLocalhost } from "../security.js";
 import type {
@@ -337,6 +338,15 @@ async function doTokenRequest(
       });
     }
 
+    // A valid-JSON-but-non-object body (null, array, number, string) is a
+    // malformed response — fail as api_error before any property deref,
+    // never a raw TypeError misclassified as retryable network.
+    if (typeof data !== "object" || data === null || Array.isArray(data)) {
+      throw new BasecampError("api_error", "Token response is not a JSON object", {
+        httpStatus: response.status,
+      });
+    }
+
     // Parse successful response
     const tokenData = data as RawTokenResponse;
 
@@ -356,6 +366,34 @@ async function doTokenRequest(
       throw new BasecampError("api_error", "Token response token_type must be a non-empty string when present", {
         httpStatus: response.status,
       });
+    }
+
+    // The remaining optional fields get the device-flow strictness: a
+    // non-string refresh_token/scope or a non-finite/fractional/oversized
+    // expires_in would leak malformed values through the public OAuthToken
+    // type (or build an Invalid Date expiry).
+    if (tokenData.refresh_token != null && typeof tokenData.refresh_token !== "string") {
+      throw new BasecampError("api_error", "Token response refresh_token must be a string", {
+        httpStatus: response.status,
+      });
+    }
+    if (tokenData.scope != null && typeof tokenData.scope !== "string") {
+      throw new BasecampError("api_error", "Token response scope must be a string", {
+        httpStatus: response.status,
+      });
+    }
+    if (
+      tokenData.expires_in != null &&
+      (typeof tokenData.expires_in !== "number" ||
+        !Number.isInteger(tokenData.expires_in) ||
+        tokenData.expires_in <= 0 ||
+        tokenData.expires_in > MAX_TOKEN_LIFETIME_SECONDS)
+    ) {
+      throw new BasecampError(
+        "api_error",
+        `Token response expires_in must be a finite positive whole number no greater than ${MAX_TOKEN_LIFETIME_SECONDS} seconds`,
+        { httpStatus: response.status }
+      );
     }
 
     return {

--- a/typescript/src/oauth/exchange.ts
+++ b/typescript/src/oauth/exchange.ts
@@ -340,8 +340,13 @@ async function doTokenRequest(
     // Parse successful response
     const tokenData = data as RawTokenResponse;
 
-    if (!tokenData.access_token) {
-      throw new BasecampError("api_error", "Token response missing access_token");
+    // Non-empty STRING, not merely truthy: a numeric access_token is not a
+    // usable credential. Carry the HTTP status like every other malformed-
+    // response raise so failures are diagnosable.
+    if (typeof tokenData.access_token !== "string" || tokenData.access_token === "") {
+      throw new BasecampError("api_error", "Token response missing or non-string access_token", {
+        httpStatus: response.status,
+      });
     }
 
     // Absent/null token_type defaults to Bearer, but a present-but-empty (or

--- a/typescript/src/oauth/exchange.ts
+++ b/typescript/src/oauth/exchange.ts
@@ -344,12 +344,21 @@ async function doTokenRequest(
       throw new BasecampError("api_error", "Token response missing access_token");
     }
 
+    // Absent/null token_type defaults to Bearer, but a present-but-empty (or
+    // non-string) one is a malformed response — matching the stricter
+    // device-flow validation rather than silently coercing "" to Bearer.
+    if (tokenData.token_type != null && (typeof tokenData.token_type !== "string" || tokenData.token_type === "")) {
+      throw new BasecampError("api_error", "Token response token_type must be a non-empty string when present", {
+        httpStatus: response.status,
+      });
+    }
+
     return {
       accessToken: tokenData.access_token,
       // `?? undefined`: JSON null is legal on the wire for the optional
       // fields (absent per SPEC) — never leak null through the public type.
       refreshToken: tokenData.refresh_token ?? undefined,
-      tokenType: tokenData.token_type || "Bearer",
+      tokenType: tokenData.token_type ?? "Bearer",
       expiresIn: tokenData.expires_in,
       expiresAt: tokenData.expires_in
         ? new Date(Date.now() + tokenData.expires_in * 1000)

--- a/typescript/src/oauth/index.ts
+++ b/typescript/src/oauth/index.ts
@@ -50,7 +50,26 @@ export type {
   FallbackReason,
   DiscoverySelectionErrorReason,
   DiscoverFromResourceResult,
+  DeviceAuthorization,
 } from "./types.js";
+
+// Device flow (RFC 8628)
+export {
+  requestDeviceAuthorization,
+  pollDeviceToken,
+  DEVICE_CODE_GRANT_TYPE,
+  type RequestDeviceAuthorizationParams,
+  type PollDeviceTokenParams,
+  type MonotonicClock,
+} from "./device.js";
+export {
+  performDeviceLogin,
+  type DeviceLoginOptions,
+} from "./device-login.js";
+export {
+  DeviceFlowError,
+  type DeviceFlowReason,
+} from "./device-errors.js";
 
 // Discovery
 export {

--- a/typescript/src/oauth/limits.ts
+++ b/typescript/src/oauth/limits.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared OAuth limits (SPEC §16), split out so the token-exchange path can
+ * import them without pulling the whole device-flow module.
+ */
+
+/**
+ * Upper bound (seconds) for an OAuth token's `expires_in`: 2_147_483_647 s
+ * (~68 years) — cross-runtime safe and vastly beyond any realistic token
+ * lifetime. A very large finite value (or a non-finite one from `1e400`)
+ * makes `new Date(Date.now() + expires_in * 1000)` an Invalid Date whose
+ * `getTime()` is NaN, so downstream expiry checks would treat the token as
+ * never expiring. A value past this ceiling is a malformed response. Shared
+ * across all five SDKs.
+ */
+export const MAX_TOKEN_LIFETIME_SECONDS = 2_147_483_647;

--- a/typescript/src/oauth/types.ts
+++ b/typescript/src/oauth/types.ts
@@ -81,6 +81,24 @@ export type DiscoverFromResourceResult =
   | { kind: "fallback"; reason: FallbackReason };
 
 /**
+ * RFC 8628 device authorization response.
+ */
+export interface DeviceAuthorization {
+  /** The device verification code. */
+  deviceCode: string;
+  /** The end-user code shown to the user. */
+  userCode: string;
+  /** The end-user verification URI. */
+  verificationUri: string;
+  /** The verification URI with the user code embedded (optional). */
+  verificationUriComplete?: string;
+  /** Lifetime of the device/user codes in seconds. */
+  expiresIn: number;
+  /** Minimum polling interval in seconds (defaults to 5 when the server omits it). */
+  interval: number;
+}
+
+/**
  * OAuth 2.0 access token response.
  */
 export interface OAuthToken {

--- a/typescript/src/oauth/types.ts
+++ b/typescript/src/oauth/types.ts
@@ -164,10 +164,13 @@ export interface RefreshRequest {
  */
 export interface RawTokenResponse {
   access_token: string;
-  refresh_token?: string;
+  // JSON null is legal on the wire for the optional fields (SPEC treats it
+  // as absent); consumers normalize null to undefined before it reaches the
+  // public OAuthToken type.
+  refresh_token?: string | null;
   token_type: string;
   expires_in?: number;
-  scope?: string;
+  scope?: string | null;
 }
 
 /**

--- a/typescript/src/oauth/types.ts
+++ b/typescript/src/oauth/types.ts
@@ -168,7 +168,8 @@ export interface RawTokenResponse {
   // as absent); consumers normalize null to undefined before it reaches the
   // public OAuthToken type.
   refresh_token?: string | null;
-  token_type: string;
+  // Absent/null token_type is valid on the wire (defaults to Bearer).
+  token_type?: string | null;
   expires_in?: number;
   scope?: string | null;
 }

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -522,6 +522,30 @@ describe("pollDeviceToken", () => {
     expect(err.code).toBe("usage");
   });
 
+  it("does not return a token when the signal was aborted before the token POST", async () => {
+    // Regression: a signal aborted during a sleep that RESOLVES (rather than
+    // rejecting) hands postDeviceToken an already-aborted signal. Without an
+    // explicit already-aborted check the once-listener never fires, the fetch
+    // proceeds, and a 200 would return a token AFTER cancellation. It must cancel.
+    queueTokenResponses([{ status: 200, body: tokenResponse }]);
+    const controller = new AbortController();
+    const fn = (_ms: number): Promise<void> => {
+      controller.abort();
+      return Promise.resolve();
+    };
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: fn,
+      signal: controller.signal,
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect(err.reason).toBe("cancelled");
+  });
+
   it("raises cancelled when the sleep itself rejects with an AbortError", async () => {
     // The default sleep() rejects with an AbortError when the caller aborts
     // mid-wait; that rejection must surface as cancelled, never leak raw.
@@ -660,6 +684,37 @@ describe("pollDeviceToken", () => {
       sleepFn: fn,
     });
     expect(token.expiresIn).toBe(2_147_483_647);
+  });
+
+  it("rejects a fractional expires_in on a 2xx token response as api_error", async () => {
+    // Whole-second contract: Go/Kotlin reject a fractional lifetime by int/Long
+    // typing; TS/Python/Ruby reject it explicitly so all five behave uniformly.
+    queueTokenResponses([{ status: 200, body: { ...tokenResponse, expires_in: 1.5 } }]);
+    const { fn } = recordingSleep();
+    await expect(
+      pollDeviceToken({
+        tokenEndpoint: TOKEN_ENDPOINT,
+        clientId: "basecamp-cli",
+        deviceCode: "dev-code-123",
+        interval: 5,
+        expiresIn: 900,
+        sleepFn: fn,
+      })
+    ).rejects.toMatchObject({ code: "api_error" });
+  });
+
+  it("accepts an integer-valued float expires_in on a 2xx token response (3600.0)", async () => {
+    queueTokenResponses([{ status: 200, body: { ...tokenResponse, expires_in: 3600.0 } }]);
+    const { fn } = recordingSleep();
+    const token = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: fn,
+    });
+    expect(token.expiresIn).toBe(3600);
   });
 
   it.each([
@@ -959,6 +1014,24 @@ describe("performDeviceLogin", () => {
     expect(polled).toBe(false);
   });
 
+  it("guards capability: a string grantTypesSupported does not substring-match → unavailable", async () => {
+    // A manually-constructed config could supply grantTypesSupported as a string;
+    // String.prototype.includes would substring-match and wrongly pass the guard.
+    // The Array.isArray check rejects it (Python/Ruby defend the same way).
+    let polled = false;
+    server.use(mswHttp.post(TOKEN_ENDPOINT, () => { polled = true; return HttpResponse.json(tokenResponse); }));
+
+    const err = await performDeviceLogin({
+      config: { ...config, grantTypesSupported: DEVICE_CODE_GRANT_TYPE as unknown as string[] },
+      clientId: "basecamp-cli",
+      display: () => {},
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect(err.reason).toBe("unavailable");
+    expect(polled).toBe(false);
+  });
+
   it("fires the display hook then completes", async () => {
     server.use(
       mswHttp.post(DEVICE_ENDPOINT, () => HttpResponse.json(deviceAuthResponse)),
@@ -1047,6 +1120,15 @@ describe("DeviceFlowError retryability", () => {
       const err = new DeviceFlowError(reason, "x", { retryable: true });
       expect(err.retryable).toBe(false);
     }
+  });
+
+  it("falls back to a usage category for an unknown reason (JS caller safety)", () => {
+    // DeviceFlowReason is an exhaustive TS union, but this is a public runtime
+    // class: a JS caller can construct an unknown reason. categoryFor must not
+    // leave BasecampError with an undefined code.
+    const err = new DeviceFlowError("bogus_reason" as never, "x");
+    expect(err.code).toBe("usage");
+    expect(err.retryable).toBe(false);
   });
 
   it("serializes the reason via toJSON (and through JSON.stringify)", () => {

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -753,6 +753,37 @@ describe("pollDeviceToken", () => {
     }
   );
 
+  it("rejects an explicit empty token_type on a 2xx token response as api_error", async () => {
+    // An explicit "" token_type is malformed token metadata — uniform across
+    // all five SDKs (absent/null defaults to Bearer instead).
+    queueTokenResponses([{ status: 200, body: { ...tokenResponse, token_type: "" } }]);
+    const { fn } = recordingSleep();
+    await expect(
+      pollDeviceToken({
+        tokenEndpoint: TOKEN_ENDPOINT,
+        clientId: "basecamp-cli",
+        deviceCode: "dev-code-123",
+        interval: 5,
+        expiresIn: 900,
+        sleepFn: fn,
+      })
+    ).rejects.toMatchObject({ code: "api_error" });
+  });
+
+  it("defaults a null token_type to Bearer (JSON null is treated as absent)", async () => {
+    queueTokenResponses([{ status: 200, body: { ...tokenResponse, token_type: null } }]);
+    const { fn } = recordingSleep();
+    const token = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: fn,
+    });
+    expect(token.tokenType).toBe("Bearer");
+  });
+
   it("rejects a 2xx token response whose access_token is non-string as api_error", async () => {
     // A numeric access_token is truthy but not a usable credential — fail fast
     // as api_error rather than return an unusable token downstream.
@@ -1122,12 +1153,13 @@ describe("DeviceFlowError retryability", () => {
     }
   });
 
-  it("falls back to a usage category for an unknown reason (JS caller safety)", () => {
+  it("falls back to an api_error category for an unknown reason (JS caller safety)", () => {
     // DeviceFlowReason is an exhaustive TS union, but this is a public runtime
     // class: a JS caller can construct an unknown reason. categoryFor must not
-    // leave BasecampError with an undefined code.
+    // leave BasecampError with an undefined code; the cross-SDK default for an
+    // unknown reason is api_error (matching Go/Ruby/Python/Kotlin).
     const err = new DeviceFlowError("bogus_reason" as never, "x");
-    expect(err.code).toBe("usage");
+    expect(err.code).toBe("api_error");
     expect(err.retryable).toBe(false);
   });
 

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -296,6 +296,21 @@ describe("requestDeviceAuthorization", () => {
       requestDeviceAuthorization({ deviceAuthorizationEndpoint: DEVICE_ENDPOINT, clientId: "basecamp-cli" })
     ).rejects.toMatchObject({ code: "api_error" });
   });
+
+  it("treats a JSON null verification_uri_complete as absent → undefined (cross-SDK contract)", async () => {
+    // Go/Kotlin decoders cannot distinguish null from absent for optional strings,
+    // so null must be accepted as absent here, not rejected — and normalized to undefined.
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () =>
+        HttpResponse.json({ ...deviceAuthResponse, verification_uri_complete: null })
+      )
+    );
+    const auth = await requestDeviceAuthorization({
+      deviceAuthorizationEndpoint: DEVICE_ENDPOINT,
+      clientId: "basecamp-cli",
+    });
+    expect(auth.verificationUriComplete).toBeUndefined();
+  });
 });
 
 describe("pollDeviceToken", () => {

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -311,6 +311,19 @@ describe("requestDeviceAuthorization", () => {
     });
     expect(auth.verificationUriComplete).toBeUndefined();
   });
+
+  it("normalizes an invalid timeoutMs instead of aborting immediately", async () => {
+    // Infinity would clamp setTimeout to ~1ms → an immediate abort masquerading
+    // as a transport failure. The resolver falls back to the default, so the
+    // request completes normally.
+    server.use(mswHttp.post(DEVICE_ENDPOINT, () => HttpResponse.json(deviceAuthResponse)));
+    const auth = await requestDeviceAuthorization({
+      deviceAuthorizationEndpoint: DEVICE_ENDPOINT,
+      clientId: "basecamp-cli",
+      timeoutMs: Infinity,
+    });
+    expect(auth.deviceCode).toBe("dev-code-123");
+  });
 });
 
 describe("pollDeviceToken", () => {

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -736,7 +736,7 @@ describe("pollDeviceToken", () => {
   });
 
   it.each(["refresh_token", "token_type", "scope"])(
-    "rejects a non-string %s on a 2xx token response as api_error",
+    "rejects a non-string %s on a 2xx token response as api_error (carrying the status)",
     async (field) => {
       queueTokenResponses([{ status: 200, body: { ...tokenResponse, [field]: 123 } }]);
       const { fn } = recordingSleep();
@@ -749,7 +749,9 @@ describe("pollDeviceToken", () => {
           expiresIn: 900,
           sleepFn: fn,
         })
-      ).rejects.toMatchObject({ code: "api_error" });
+        // A malformed 2xx token field must carry the HTTP status (SPEC §16),
+        // consistent with the other token-poll raises and the other SDKs.
+      ).rejects.toMatchObject({ code: "api_error", httpStatus: 200 });
     }
   );
 

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -1023,6 +1023,48 @@ describe("device transport hardening", () => {
     expect(attackerContacted).toBe(false);
   });
 
+  it("treats a non-string token error as http_<status> (cross-SDK parity)", async () => {
+    queueTokenResponses([{ status: 400, body: { error: 123 } }]);
+    const { fn } = recordingSleep();
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: fn,
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(BasecampError);
+    expect(err.code).toBe("api_error");
+    // 123 is not a valid error code → falls back to http_400, never surfaced as-is.
+    expect(err.message).toContain("http_400");
+  });
+
+  it("fails a redirecting token poll by status without draining a huge body", async () => {
+    // A 3xx must surface as api_error by STATUS before the body is read — else a
+    // slow or oversized redirect body could time out (retried) or trip the size cap.
+    server.use(
+      mswHttp.post(
+        TOKEN_ENDPOINT,
+        () => new HttpResponse("x".repeat(2 * 1024 * 1024), { status: 302, headers: { Location: "https://x/" } })
+      )
+    );
+    const { fn } = recordingSleep();
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: fn,
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(BasecampError);
+    expect(err.code).toBe("api_error");
+    expect(err.message).toContain("redirect"); // by status, not "too large"
+  });
+
   it("clamps the backoff wait to the monotonic deadline (never overshoots expiry)", async () => {
     // Every poll times out (connection timeout), forcing sustained backoff.
     const fakeFetch: typeof globalThis.fetch = async () => {

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -104,15 +104,17 @@ describe("requestDeviceAuthorization", () => {
     expect(auth.interval).toBe(5);
   });
 
-  it("rejects a non-positive expires_in", async () => {
+  it("rejects a non-positive expires_in (carrying the status)", async () => {
     server.use(
       mswHttp.post(DEVICE_ENDPOINT, () =>
         HttpResponse.json({ ...deviceAuthResponse, expires_in: 0 })
       )
     );
+    // A malformed 2xx device-auth field carries the HTTP status, like the
+    // token-poll raises and the other SDKs.
     await expect(
       requestDeviceAuthorization({ deviceAuthorizationEndpoint: DEVICE_ENDPOINT, clientId: "basecamp-cli" })
-    ).rejects.toMatchObject({ code: "api_error" });
+    ).rejects.toMatchObject({ code: "api_error", httpStatus: 200 });
   });
 
   it("rejects a fractional expires_in", async () => {

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -1,0 +1,750 @@
+/**
+ * RFC 8628 device authorization grant tests.
+ *
+ * Timing is made deterministic with an injected sleep (records the interval
+ * schedule, resolves immediately) and an injected monotonic clock.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { http as mswHttp, HttpResponse } from "msw";
+import { server } from "../setup.js";
+import {
+  requestDeviceAuthorization,
+  pollDeviceToken,
+  performDeviceLogin,
+  DeviceFlowError,
+  DEVICE_CODE_GRANT_TYPE,
+} from "../../src/oauth/index.js";
+import type { OAuthConfig } from "../../src/oauth/types.js";
+import { BasecampError } from "../../src/errors.js";
+
+const ORIGIN = "https://issuer.device-test.example";
+const DEVICE_ENDPOINT = `${ORIGIN}/oauth/device`;
+const TOKEN_ENDPOINT = `${ORIGIN}/oauth/token`;
+
+const deviceAuthResponse = {
+  device_code: "dev-code-123",
+  user_code: "WDJB-MJHT",
+  verification_uri: `${ORIGIN}/device`,
+  verification_uri_complete: `${ORIGIN}/device?user_code=WDJB-MJHT`,
+  expires_in: 900,
+  interval: 5,
+};
+
+const tokenResponse = {
+  access_token: "device_access_token",
+  refresh_token: "device_refresh_token",
+  token_type: "Bearer",
+  expires_in: 3600,
+};
+
+/** A sleep that records requested waits and resolves immediately. */
+function recordingSleep() {
+  const waits: number[] = [];
+  const fn = (ms: number): Promise<void> => {
+    waits.push(ms);
+    return Promise.resolve();
+  };
+  return { waits, fn };
+}
+
+/** Serves a fixed sequence of token-endpoint responses, one per poll. */
+function queueTokenResponses(responses: Array<{ status: number; body: object }>) {
+  let i = 0;
+  server.use(
+    mswHttp.post(TOKEN_ENDPOINT, () => {
+      const r = responses[Math.min(i, responses.length - 1)];
+      i += 1;
+      return HttpResponse.json(r.body, { status: r.status });
+    })
+  );
+  return () => i;
+}
+
+const config: OAuthConfig = {
+  issuer: ORIGIN,
+  tokenEndpoint: TOKEN_ENDPOINT,
+  deviceAuthorizationEndpoint: DEVICE_ENDPOINT,
+  grantTypesSupported: [DEVICE_CODE_GRANT_TYPE, "refresh_token"],
+};
+
+describe("requestDeviceAuthorization", () => {
+  it("omits scope when unset and validates the response", async () => {
+    let sentScope: string | null = "unset";
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, async ({ request }) => {
+        const params = new URLSearchParams(await request.text());
+        sentScope = params.get("scope");
+        expect(params.get("client_id")).toBe("basecamp-cli");
+        return HttpResponse.json(deviceAuthResponse);
+      })
+    );
+
+    const auth = await requestDeviceAuthorization({
+      deviceAuthorizationEndpoint: DEVICE_ENDPOINT,
+      clientId: "basecamp-cli",
+    });
+
+    expect(sentScope).toBeNull(); // scope omitted → server default (read)
+    expect(auth.deviceCode).toBe("dev-code-123");
+    expect(auth.userCode).toBe("WDJB-MJHT");
+    expect(auth.interval).toBe(5);
+  });
+
+  it("defaults interval to 5 when the server omits it", async () => {
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () =>
+        HttpResponse.json({ ...deviceAuthResponse, interval: undefined })
+      )
+    );
+    const auth = await requestDeviceAuthorization({
+      deviceAuthorizationEndpoint: DEVICE_ENDPOINT,
+      clientId: "basecamp-cli",
+    });
+    expect(auth.interval).toBe(5);
+  });
+
+  it("rejects a non-positive expires_in", async () => {
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () =>
+        HttpResponse.json({ ...deviceAuthResponse, expires_in: 0 })
+      )
+    );
+    await expect(
+      requestDeviceAuthorization({ deviceAuthorizationEndpoint: DEVICE_ENDPOINT, clientId: "basecamp-cli" })
+    ).rejects.toMatchObject({ code: "api_error" });
+  });
+
+  it("rejects a fractional expires_in", async () => {
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () =>
+        HttpResponse.json({ ...deviceAuthResponse, expires_in: 0.5 })
+      )
+    );
+    await expect(
+      requestDeviceAuthorization({ deviceAuthorizationEndpoint: DEVICE_ENDPOINT, clientId: "basecamp-cli" })
+    ).rejects.toMatchObject({ code: "api_error" });
+  });
+
+  it("rejects a fractional interval", async () => {
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () =>
+        HttpResponse.json({ ...deviceAuthResponse, interval: 2.5 })
+      )
+    );
+    await expect(
+      requestDeviceAuthorization({ deviceAuthorizationEndpoint: DEVICE_ENDPOINT, clientId: "basecamp-cli" })
+    ).rejects.toMatchObject({ code: "api_error" });
+  });
+
+  it("rejects an oversized expires_in (1e100 is integer-valued but not schedulable)", async () => {
+    // Number.isInteger(1e100) is true, so whole-second checking alone would
+    // admit it; the shared cross-SDK ceiling (2147483 s) makes it api_error
+    // before any ms-timer arithmetic can overflow or clamp.
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () =>
+        HttpResponse.json({ ...deviceAuthResponse, expires_in: 1e100 })
+      )
+    );
+    await expect(
+      requestDeviceAuthorization({ deviceAuthorizationEndpoint: DEVICE_ENDPOINT, clientId: "basecamp-cli" })
+    ).rejects.toMatchObject({ code: "api_error" });
+  });
+
+  it("rejects an oversized interval", async () => {
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () =>
+        HttpResponse.json({ ...deviceAuthResponse, interval: 1e100 })
+      )
+    );
+    await expect(
+      requestDeviceAuthorization({ deviceAuthorizationEndpoint: DEVICE_ENDPOINT, clientId: "basecamp-cli" })
+    ).rejects.toMatchObject({ code: "api_error" });
+  });
+
+  it("rejects the first duration past the ceiling but accepts the ceiling itself", async () => {
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () =>
+        HttpResponse.json({ ...deviceAuthResponse, expires_in: 2_147_484 })
+      )
+    );
+    await expect(
+      requestDeviceAuthorization({ deviceAuthorizationEndpoint: DEVICE_ENDPOINT, clientId: "basecamp-cli" })
+    ).rejects.toMatchObject({ code: "api_error" });
+
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () =>
+        HttpResponse.json({ ...deviceAuthResponse, expires_in: 2_147_483, interval: 2_147_483 })
+      )
+    );
+    const auth = await requestDeviceAuthorization({
+      deviceAuthorizationEndpoint: DEVICE_ENDPOINT,
+      clientId: "basecamp-cli",
+    });
+    expect(auth.expiresIn).toBe(2_147_483);
+    expect(auth.interval).toBe(2_147_483);
+  });
+
+  it("rejects a valid-JSON-but-non-object body as api_error, not a TypeError", async () => {
+    for (const body of ["null", "[]", '"a string"', "42"]) {
+      server.use(
+        mswHttp.post(DEVICE_ENDPOINT, () =>
+          new HttpResponse(body, { status: 200, headers: { "Content-Type": "application/json" } })
+        )
+      );
+      await expect(
+        requestDeviceAuthorization({ deviceAuthorizationEndpoint: DEVICE_ENDPOINT, clientId: "basecamp-cli" })
+      ).rejects.toMatchObject({ code: "api_error" });
+    }
+  });
+
+  it("rejects a boolean expires_in (typeof guard, not just Number.isInteger)", async () => {
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () =>
+        HttpResponse.json({ ...deviceAuthResponse, expires_in: true })
+      )
+    );
+    await expect(
+      requestDeviceAuthorization({ deviceAuthorizationEndpoint: DEVICE_ENDPOINT, clientId: "basecamp-cli" })
+    ).rejects.toMatchObject({ code: "api_error" });
+  });
+
+  it("rejects a non-positive interval", async () => {
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () =>
+        HttpResponse.json({ ...deviceAuthResponse, interval: 0 })
+      )
+    );
+    await expect(
+      requestDeviceAuthorization({ deviceAuthorizationEndpoint: DEVICE_ENDPOINT, clientId: "basecamp-cli" })
+    ).rejects.toMatchObject({ code: "api_error" });
+  });
+
+  it("accepts an integer-valued float expires_in (e.g. 900.0)", async () => {
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () =>
+        HttpResponse.json({ ...deviceAuthResponse, expires_in: 900.0 })
+      )
+    );
+    const auth = await requestDeviceAuthorization({
+      deviceAuthorizationEndpoint: DEVICE_ENDPOINT,
+      clientId: "basecamp-cli",
+    });
+    expect(auth.expiresIn).toBe(900);
+  });
+
+  it("rejects a missing field", async () => {
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () =>
+        HttpResponse.json({ user_code: "X", verification_uri: ORIGIN, expires_in: 900 })
+      )
+    );
+    await expect(
+      requestDeviceAuthorization({ deviceAuthorizationEndpoint: DEVICE_ENDPOINT, clientId: "basecamp-cli" })
+    ).rejects.toMatchObject({ code: "api_error" });
+  });
+
+  it("rejects a non-string device_code (typeof guard, not just truthiness)", async () => {
+    // A numeric device_code is truthy but not a usable code — it must fail as
+    // api_error rather than flow into the poll loop.
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () =>
+        HttpResponse.json({ ...deviceAuthResponse, device_code: 123456 })
+      )
+    );
+    await expect(
+      requestDeviceAuthorization({ deviceAuthorizationEndpoint: DEVICE_ENDPOINT, clientId: "basecamp-cli" })
+    ).rejects.toMatchObject({ code: "api_error" });
+  });
+
+  it("rejects a non-string verification_uri_complete", async () => {
+    // Optional, but a non-string value would return a malformed shape to callers.
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () =>
+        HttpResponse.json({ ...deviceAuthResponse, verification_uri_complete: 42 })
+      )
+    );
+    await expect(
+      requestDeviceAuthorization({ deviceAuthorizationEndpoint: DEVICE_ENDPOINT, clientId: "basecamp-cli" })
+    ).rejects.toMatchObject({ code: "api_error" });
+  });
+});
+
+describe("pollDeviceToken", () => {
+  it("pending → slow_down → token, with sustained +5s interval and hook flow", async () => {
+    queueTokenResponses([
+      { status: 400, body: { error: "authorization_pending" } },
+      { status: 400, body: { error: "slow_down" } },
+      { status: 400, body: { error: "authorization_pending" } },
+      { status: 200, body: tokenResponse },
+    ]);
+    const { waits, fn } = recordingSleep();
+
+    const token = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: fn,
+    });
+
+    expect(token.accessToken).toBe("device_access_token");
+    // Waits: 5s (pending), 5s (before slow_down), then +5 sustained → 10s, 10s.
+    expect(waits).toEqual([5000, 5000, 10000, 10000]);
+  });
+
+  it("doubles the interval after a connection timeout, then recovers", async () => {
+    server.use(mswHttp.post(TOKEN_ENDPOINT, () => HttpResponse.json(tokenResponse)));
+    const { waits, fn } = recordingSleep();
+
+    // A custom fetch that turns the first attempt into an AbortError (timeout),
+    // then delegates to the real (MSW-mocked) fetch.
+    let attempts = 0;
+    const fakeFetch: typeof globalThis.fetch = async (input, init) => {
+      attempts += 1;
+      if (attempts === 1) {
+        const e = new Error("timed out");
+        e.name = "AbortError";
+        throw e;
+      }
+      return globalThis.fetch(input, init);
+    };
+
+    const token = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: fn,
+      fetch: fakeFetch,
+    });
+
+    expect(token.accessToken).toBe("device_access_token");
+    // First wait 5s, timeout → backoff doubles to 10s for the next wait.
+    expect(waits[0]).toBe(5000);
+    expect(waits[1]).toBe(10000);
+  });
+
+  it("expires against the injected monotonic clock (parent category auth)", async () => {
+    queueTokenResponses([{ status: 400, body: { error: "authorization_pending" } }]);
+    const { fn } = recordingSleep();
+    // Clock: base at 0, then jumps past the 900s deadline on the first check.
+    const times = [0, 1_000_000];
+    let idx = 0;
+    const clock = () => times[Math.min(idx++, times.length - 1)];
+
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: fn,
+      clock,
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect(err.reason).toBe("expired");
+    expect(err.code).toBe("auth_required");
+  });
+
+  it("raises access_denied (parent category auth)", async () => {
+    queueTokenResponses([{ status: 400, body: { error: "access_denied" } }]);
+    const { fn } = recordingSleep();
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: fn,
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect(err.reason).toBe("access_denied");
+    expect(err.code).toBe("auth_required");
+  });
+
+  it("raises transport (network, retryable) on a non-timeout failure", async () => {
+    server.use(mswHttp.post(TOKEN_ENDPOINT, () => HttpResponse.error()));
+    const { fn } = recordingSleep();
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: fn,
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect(err.reason).toBe("transport");
+    expect(err.code).toBe("network");
+    expect(err.retryable).toBe(true);
+  });
+
+  it("raises cancelled when the signal aborts (parent category usage)", async () => {
+    queueTokenResponses([{ status: 400, body: { error: "authorization_pending" } }]);
+    const controller = new AbortController();
+    // Abort on the first sleep.
+    const fn = (_ms: number): Promise<void> => {
+      controller.abort();
+      return Promise.resolve();
+    };
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: fn,
+      signal: controller.signal,
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect(err.reason).toBe("cancelled");
+    expect(err.code).toBe("usage");
+  });
+
+  it("raises cancelled when the sleep itself rejects with an AbortError", async () => {
+    // The default sleep() rejects with an AbortError when the caller aborts
+    // mid-wait; that rejection must surface as cancelled, never leak raw.
+    queueTokenResponses([{ status: 400, body: { error: "authorization_pending" } }]);
+    const controller = new AbortController();
+    const fn = (): Promise<void> => {
+      const e = new Error("The operation was aborted");
+      e.name = "AbortError";
+      return Promise.reject(e);
+    };
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: fn,
+      signal: controller.signal,
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect(err.reason).toBe("cancelled");
+  });
+
+  it("never passes a negative wait to the sleep seam when the clock crosses the deadline mid-iteration", async () => {
+    // A single cached clock read per iteration keeps remainingMs > 0. With two
+    // separate reads straddling the deadline, the second could yield a negative
+    // wait for the injected sleeper.
+    queueTokenResponses([{ status: 400, body: { error: "authorization_pending" } }]);
+    const waits: number[] = [];
+    // deadline = times[0] + 10_000 = 10_000. The check reads just-below, the
+    // (pre-fix) second read would cross → negative; post-sleep read expires.
+    const times = [0, 9_999, 10_001, 10_050];
+    let i = 0;
+    const clock = (): number => times[Math.min(i++, times.length - 1)];
+    const sleepFn = (ms: number): Promise<void> => {
+      waits.push(ms);
+      return Promise.resolve();
+    };
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 10,
+      clock,
+      sleepFn,
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect(err.reason).toBe("expired");
+    expect(waits.every((w) => w >= 0)).toBe(true);
+  });
+
+  it("rejects a 2xx token response whose access_token is non-string as api_error", async () => {
+    // A numeric access_token is truthy but not a usable credential — fail fast
+    // as api_error rather than return an unusable token downstream.
+    queueTokenResponses([{ status: 200, body: { access_token: 12345, token_type: "Bearer" } }]);
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: () => Promise.resolve(),
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(BasecampError);
+    expect(err.code).toBe("api_error");
+  });
+});
+
+describe("device transport hardening", () => {
+  it("propagates a malformed 2xx token response as api_error, not retryable transport", async () => {
+    // 200 OK whose body is not valid JSON.
+    server.use(
+      mswHttp.post(TOKEN_ENDPOINT, () =>
+        new HttpResponse("not json", { status: 200, headers: { "Content-Type": "application/json" } })
+      )
+    );
+    const { fn } = recordingSleep();
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: fn,
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(BasecampError);
+    expect(err).not.toBeInstanceOf(DeviceFlowError); // NOT re-wrapped as transport
+    expect(err.code).toBe("api_error");
+    expect(err.retryable).toBe(false);
+  });
+
+  it.each([
+    ["null", "null"],
+    ["array", "[]"],
+    ["number", "42"],
+    ["string", '"a-bare-string"'],
+  ])("propagates a valid-JSON-but-non-object 2xx token body (%s) as api_error, no raw deref", async (_label, bodyJson) => {
+    server.use(
+      mswHttp.post(TOKEN_ENDPOINT, () =>
+        new HttpResponse(bodyJson, { status: 200, headers: { "Content-Type": "application/json" } })
+      )
+    );
+    const { fn } = recordingSleep();
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: fn,
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(BasecampError);
+    expect(err).not.toBeInstanceOf(DeviceFlowError); // NOT re-wrapped as transport
+    expect(err.code).toBe("api_error");
+    expect(err.retryable).toBe(false);
+  });
+
+  it("propagates a 2xx missing access_token as api_error, not transport", async () => {
+    server.use(
+      mswHttp.post(TOKEN_ENDPOINT, () => HttpResponse.json({ token_type: "Bearer" }, { status: 200 }))
+    );
+    const { fn } = recordingSleep();
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: fn,
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(BasecampError);
+    expect(err).not.toBeInstanceOf(DeviceFlowError);
+    expect(err.code).toBe("api_error");
+    expect(err.retryable).toBe(false);
+  });
+
+  it("rejects an oversized device authorization body via the bounded read", async () => {
+    // A valid-JSON body padded far past the 1 MiB cap; the streaming reader
+    // aborts before the whole body is buffered.
+    const oversized =
+      `{"device_code":"d","user_code":"u","verification_uri":"${ORIGIN}/v",` +
+      `"expires_in":900,"pad":"${"x".repeat(2 * 1024 * 1024)}"}`;
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () =>
+        new HttpResponse(oversized, { status: 200, headers: { "Content-Type": "application/json" } })
+      )
+    );
+    await expect(
+      requestDeviceAuthorization({ deviceAuthorizationEndpoint: DEVICE_ENDPOINT, clientId: "basecamp-cli" })
+    ).rejects.toMatchObject({ code: "api_error" });
+  });
+
+  it("does not follow a redirect on the device authorization POST", async () => {
+    let attackerContacted = false;
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () =>
+        new HttpResponse(null, { status: 302, headers: { Location: "https://attacker.example/device" } })
+      ),
+      mswHttp.post("https://attacker.example/device", () => {
+        attackerContacted = true;
+        return HttpResponse.json(deviceAuthResponse);
+      })
+    );
+    await expect(
+      requestDeviceAuthorization({ deviceAuthorizationEndpoint: DEVICE_ENDPOINT, clientId: "basecamp-cli" })
+    ).rejects.toMatchObject({ code: "api_error" });
+    expect(attackerContacted).toBe(false);
+  });
+
+  it("does not follow a redirect on the token poll (api_error, not transport)", async () => {
+    let attackerContacted = false;
+    server.use(
+      mswHttp.post(TOKEN_ENDPOINT, () =>
+        new HttpResponse(null, { status: 302, headers: { Location: "https://attacker.example/token" } })
+      ),
+      mswHttp.post("https://attacker.example/token", () => {
+        attackerContacted = true;
+        return HttpResponse.json(tokenResponse);
+      })
+    );
+    const { fn } = recordingSleep();
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: fn,
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(BasecampError);
+    expect(err.code).toBe("api_error");
+    expect(attackerContacted).toBe(false);
+  });
+
+  it("clamps the backoff wait to the monotonic deadline (never overshoots expiry)", async () => {
+    // Every poll times out (connection timeout), forcing sustained backoff.
+    const fakeFetch: typeof globalThis.fetch = async () => {
+      const e = new Error("timed out");
+      e.name = "AbortError";
+      throw e;
+    };
+    // Virtual clock advanced only by the injected sleep, so waits map to elapsed time.
+    let t = 0;
+    const clock = () => t;
+    const waits: number[] = [];
+    const sleepFn = (ms: number): Promise<void> => {
+      waits.push(ms);
+      t += ms;
+      return Promise.resolve();
+    };
+
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 25,
+      expiresIn: 30, // 30s total lifetime
+      clock,
+      sleepFn,
+      fetch: fakeFetch,
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect(err.reason).toBe("expired");
+    // Backoff would ask for 50s on the 2nd wait; the clamp caps it to the
+    // remaining lifetime so no single wait — and the total — overshoots expiry.
+    expect(Math.max(...waits)).toBeLessThanOrEqual(30000);
+    expect(waits.reduce((a, b) => a + b, 0)).toBeLessThanOrEqual(30000);
+  });
+});
+
+describe("performDeviceLogin", () => {
+  it("guards capability: endpoint present but no device grant → unavailable (validation), no poll", async () => {
+    let polled = false;
+    server.use(mswHttp.post(TOKEN_ENDPOINT, () => { polled = true; return HttpResponse.json(tokenResponse); }));
+
+    const err = await performDeviceLogin({
+      config: { ...config, grantTypesSupported: ["refresh_token"] }, // no device_code grant
+      clientId: "basecamp-cli",
+      display: () => {},
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect(err.reason).toBe("unavailable");
+    expect(err.code).toBe("validation");
+    expect(polled).toBe(false);
+  });
+
+  it("fires the display hook then completes", async () => {
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () => HttpResponse.json(deviceAuthResponse)),
+      mswHttp.post(TOKEN_ENDPOINT, () => HttpResponse.json(tokenResponse))
+    );
+    const display = vi.fn();
+    const { fn: sleepFn } = recordingSleep();
+
+    const token = await performDeviceLogin({
+      config,
+      clientId: "basecamp-cli",
+      display,
+      sleepFn,
+    });
+
+    expect(display).toHaveBeenCalledOnce();
+    expect(display.mock.calls[0][0].userCode).toBe("WDJB-MJHT");
+    expect(token.accessToken).toBe("device_access_token");
+  });
+
+  it("deducts display time: a hook that burns the whole expires_in → expired, never polls", async () => {
+    let polled = false;
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () => HttpResponse.json(deviceAuthResponse)), // expires_in: 900
+      mswHttp.post(TOKEN_ENDPOINT, () => {
+        polled = true;
+        return HttpResponse.json(tokenResponse);
+      })
+    );
+
+    // Injected monotonic clock (ms). The display hook consumes the entire 900s
+    // lifetime, so the remaining lifetime is 0 and polling must never start.
+    let now = 0;
+    const clock = () => now;
+
+    const err = await performDeviceLogin({
+      config,
+      clientId: "basecamp-cli",
+      clock,
+      display: () => {
+        now += deviceAuthResponse.expires_in * 1000;
+      },
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect(err.reason).toBe("expired");
+    expect(polled).toBe(false);
+  });
+
+  it("polls with the remaining lifetime after a fast display", async () => {
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () => HttpResponse.json(deviceAuthResponse)),
+      mswHttp.post(TOKEN_ENDPOINT, () => HttpResponse.json(tokenResponse))
+    );
+
+    // A fast display consumes only 10ms of the 900s lifetime → polling proceeds.
+    let now = 0;
+    const clock = () => now;
+    const { waits, fn: sleepFn } = recordingSleep();
+
+    const token = await performDeviceLogin({
+      config,
+      clientId: "basecamp-cli",
+      clock,
+      display: () => {
+        now += 10;
+      },
+      sleepFn,
+    });
+
+    expect(token.accessToken).toBe("device_access_token");
+    // First wait is the interval (5s), clamped to the remaining lifetime.
+    expect(waits[0]).toBe(5000);
+  });
+});
+
+describe("DeviceFlowError retryability", () => {
+  it("derives retryable from the reason and ignores a caller-supplied override", () => {
+    // transport → retryable, even if the caller passes retryable: false.
+    const transport = new DeviceFlowError("transport", "x", { retryable: false });
+    expect(transport.retryable).toBe(true);
+    expect(transport.code).toBe("network");
+
+    // Non-transport reasons are never retryable, even if the caller passes true.
+    for (const reason of ["access_denied", "expired", "unavailable", "cancelled"] as const) {
+      const err = new DeviceFlowError(reason, "x", { retryable: true });
+      expect(err.retryable).toBe(false);
+    }
+  });
+});

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -574,6 +574,130 @@ describe("pollDeviceToken", () => {
     expect(waits.every((w) => w >= 0)).toBe(true);
   });
 
+  it("rejects a 2xx token response with a non-numeric expires_in as api_error", async () => {
+    // "soon" would otherwise flow into Date arithmetic → invalid Date (NaN),
+    // making downstream expiry checks treat the token as never expiring.
+    queueTokenResponses([{ status: 200, body: { ...tokenResponse, expires_in: "soon" } }]);
+    const { fn } = recordingSleep();
+    await expect(
+      pollDeviceToken({
+        tokenEndpoint: TOKEN_ENDPOINT,
+        clientId: "basecamp-cli",
+        deviceCode: "dev-code-123",
+        interval: 5,
+        expiresIn: 900,
+        sleepFn: fn,
+      })
+    ).rejects.toMatchObject({ code: "api_error" });
+  });
+
+  it("accepts a 2xx token response without expires_in (no expiry)", async () => {
+    const { expires_in: _omitted, ...noExpiry } = tokenResponse;
+    queueTokenResponses([{ status: 200, body: noExpiry }]);
+    const { fn } = recordingSleep();
+    const token = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: fn,
+    });
+    expect(token.accessToken).toBe("device_access_token");
+    expect(token.expiresIn).toBeUndefined();
+    expect(token.expiresAt).toBeUndefined();
+  });
+
+  it("rejects an infinite expires_in (1e400) as api_error", async () => {
+    // JSON.parse("1e400") → Infinity. Number.isFinite rejects it before it can
+    // become new Date(Infinity) whose getTime() is NaN (token never expires).
+    // Sent as a raw body since JSON.stringify(Infinity) would emit null.
+    server.use(
+      mswHttp.post(TOKEN_ENDPOINT, () =>
+        new HttpResponse(
+          '{"access_token":"device_access_token","refresh_token":"r","token_type":"Bearer","expires_in":1e400}',
+          { status: 200, headers: { "Content-Type": "application/json" } }
+        )
+      )
+    );
+    const { fn } = recordingSleep();
+    await expect(
+      pollDeviceToken({
+        tokenEndpoint: TOKEN_ENDPOINT,
+        clientId: "basecamp-cli",
+        deviceCode: "dev-code-123",
+        interval: 5,
+        expiresIn: 900,
+        sleepFn: fn,
+      })
+    ).rejects.toMatchObject({ code: "api_error" });
+  });
+
+  it("rejects an expires_in past the 2_147_483_647 s ceiling as api_error", async () => {
+    queueTokenResponses([{ status: 200, body: { ...tokenResponse, expires_in: 2_147_483_648 } }]);
+    const { fn } = recordingSleep();
+    await expect(
+      pollDeviceToken({
+        tokenEndpoint: TOKEN_ENDPOINT,
+        clientId: "basecamp-cli",
+        deviceCode: "dev-code-123",
+        interval: 5,
+        expiresIn: 900,
+        sleepFn: fn,
+      })
+    ).rejects.toMatchObject({ code: "api_error" });
+  });
+
+  it("accepts the token-lifetime ceiling (2_147_483_647 s)", async () => {
+    queueTokenResponses([{ status: 200, body: { ...tokenResponse, expires_in: 2_147_483_647 } }]);
+    const { fn } = recordingSleep();
+    const token = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: fn,
+    });
+    expect(token.expiresIn).toBe(2_147_483_647);
+  });
+
+  it.each([
+    ["zero", 0],
+    ["negative", -1],
+  ])("rejects a %s expires_in on a 2xx token response as api_error", async (_label, expiresIn) => {
+    queueTokenResponses([{ status: 200, body: { ...tokenResponse, expires_in: expiresIn } }]);
+    const { fn } = recordingSleep();
+    await expect(
+      pollDeviceToken({
+        tokenEndpoint: TOKEN_ENDPOINT,
+        clientId: "basecamp-cli",
+        deviceCode: "dev-code-123",
+        interval: 5,
+        expiresIn: 900,
+        sleepFn: fn,
+      })
+    ).rejects.toMatchObject({ code: "api_error" });
+  });
+
+  it.each(["refresh_token", "token_type", "scope"])(
+    "rejects a non-string %s on a 2xx token response as api_error",
+    async (field) => {
+      queueTokenResponses([{ status: 200, body: { ...tokenResponse, [field]: 123 } }]);
+      const { fn } = recordingSleep();
+      await expect(
+        pollDeviceToken({
+          tokenEndpoint: TOKEN_ENDPOINT,
+          clientId: "basecamp-cli",
+          deviceCode: "dev-code-123",
+          interval: 5,
+          expiresIn: 900,
+          sleepFn: fn,
+        })
+      ).rejects.toMatchObject({ code: "api_error" });
+    }
+  );
+
   it("rejects a 2xx token response whose access_token is non-string as api_error", async () => {
     // A numeric access_token is truthy but not a usable credential — fail fast
     // as api_error rather than return an unusable token downstream.

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -257,6 +257,32 @@ describe("requestDeviceAuthorization", () => {
     ).rejects.toMatchObject({ code: "api_error" });
   });
 
+  it("treats a JSON null interval as absent → default 5 (cross-SDK contract)", async () => {
+    // Go and Kotlin decoders cannot distinguish null from absent, so a null
+    // duration is treated as absent everywhere.
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () =>
+        HttpResponse.json({ ...deviceAuthResponse, interval: null })
+      )
+    );
+    const auth = await requestDeviceAuthorization({
+      deviceAuthorizationEndpoint: DEVICE_ENDPOINT,
+      clientId: "basecamp-cli",
+    });
+    expect(auth.interval).toBe(5);
+  });
+
+  it("still rejects a JSON null expires_in (required, no default)", async () => {
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () =>
+        HttpResponse.json({ ...deviceAuthResponse, expires_in: null })
+      )
+    );
+    await expect(
+      requestDeviceAuthorization({ deviceAuthorizationEndpoint: DEVICE_ENDPOINT, clientId: "basecamp-cli" })
+    ).rejects.toMatchObject({ code: "api_error" });
+  });
+
   it("rejects a non-string verification_uri_complete", async () => {
     // Optional, but a non-string value would return a malformed shape to callers.
     server.use(
@@ -325,6 +351,97 @@ describe("pollDeviceToken", () => {
     // First wait 5s, timeout → backoff doubles to 10s for the next wait.
     expect(waits[0]).toBe(5000);
     expect(waits[1]).toBe(10000);
+  });
+
+  it("resets the timeout backoff after any completed round-trip (waits return to the server interval)", async () => {
+    // timeout, timeout, pending, pending → token. The two timeouts double the
+    // backoff (10s, 20s); the first completed round-trip (the pending) resets
+    // it to the server interval, so later waits return to 5s — never staying
+    // inflated by earlier transient timeouts.
+    queueTokenResponses([
+      { status: 400, body: { error: "authorization_pending" } },
+      { status: 400, body: { error: "authorization_pending" } },
+      { status: 200, body: tokenResponse },
+    ]);
+    const { waits, fn } = recordingSleep();
+    let attempts = 0;
+    const fakeFetch: typeof globalThis.fetch = async (input, init) => {
+      attempts += 1;
+      if (attempts <= 2) {
+        const e = new Error("timed out");
+        e.name = "AbortError";
+        throw e;
+      }
+      return globalThis.fetch(input, init);
+    };
+
+    const token = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: fn,
+      fetch: fakeFetch,
+    });
+
+    expect(token.accessToken).toBe("device_access_token");
+    expect(waits).toEqual([5000, 10000, 20000, 5000, 5000]);
+  });
+
+  it.each([
+    ["NaN", NaN],
+    ["Infinity", Infinity],
+    ["zero", 0],
+    ["negative", -1],
+    ["oversized", 1e100],
+  ])("rejects a nonsense caller expiresIn (%s) as usage before any request", async (_label, expiresIn) => {
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn,
+      sleepFn: () => Promise.resolve(),
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(BasecampError);
+    expect(err.code).toBe("usage");
+  });
+
+  it.each([
+    ["NaN", NaN],
+    ["Infinity", Infinity],
+    ["zero", 0],
+    ["negative", -1],
+    ["oversized", 1e100],
+  ])("rejects a nonsense caller interval (%s) as usage before any request", async (_label, interval) => {
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval,
+      expiresIn: 900,
+      sleepFn: () => Promise.resolve(),
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(BasecampError);
+    expect(err.code).toBe("usage");
+  });
+
+  it("accepts fractional caller durations (remaining-lifetime deduction produces them)", async () => {
+    // performDeviceLogin passes a fractional remaining lifetime after deducting
+    // display-hook time — caller sanity here must not impose whole seconds.
+    queueTokenResponses([{ status: 200, body: tokenResponse }]);
+    const { waits, fn } = recordingSleep();
+    const token = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 2.5,
+      expiresIn: 42.5,
+      sleepFn: fn,
+    });
+    expect(token.accessToken).toBe("device_access_token");
+    expect(waits).toEqual([2500]);
   });
 
   it("expires against the injected monotonic clock (parent category auth)", async () => {
@@ -561,6 +678,66 @@ describe("device transport hardening", () => {
     ).rejects.toMatchObject({ code: "api_error" });
   });
 
+  it("maps a body stream failure on the device authorization read to transport, not a raw error", async () => {
+    // Headers arrive fine, then the body stream errors mid-read (connection
+    // reset). The failure must surface as DeviceFlowError("transport"), never
+    // escape as the raw stream error.
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () => {
+        const stream = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('{"device_code":"d'));
+            controller.error(new Error("connection reset mid-body"));
+          },
+        });
+        return new HttpResponse(stream, { status: 200, headers: { "Content-Type": "application/json" } });
+      })
+    );
+    const err = await requestDeviceAuthorization({
+      deviceAuthorizationEndpoint: DEVICE_ENDPOINT,
+      clientId: "basecamp-cli",
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect(err.reason).toBe("transport");
+    expect(err.code).toBe("network");
+  });
+
+  it("times out a stalled device authorization body stream (abort timer covers the read)", async () => {
+    // Headers arrive, one chunk arrives, then the stream stalls forever. The
+    // request timeout must stay armed through the body read: its abort errors
+    // the read, mapping to transport instead of hanging indefinitely.
+    //
+    // msw's interceptor does not propagate a signal abort into an in-flight
+    // body stream, so this uses a custom fetch that wires the abort the way a
+    // real runtime (undici) does: aborting the signal errors the reader. With
+    // the pre-fix code (timer cleared before the read) the abort never fires
+    // and this test hangs.
+    const stalledFetch: typeof globalThis.fetch = async (_input, init) => {
+      const signal = init?.signal ?? undefined;
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode('{"device_code":"d'));
+          // Never close, never enqueue again — a stalled stream that only
+          // ends when the request signal aborts.
+          signal?.addEventListener(
+            "abort",
+            () => controller.error(new DOMException("Aborted", "AbortError")),
+            { once: true }
+          );
+        },
+      });
+      return new Response(stream, { status: 200, headers: { "Content-Type": "application/json" } });
+    };
+    const err = await requestDeviceAuthorization({
+      deviceAuthorizationEndpoint: DEVICE_ENDPOINT,
+      clientId: "basecamp-cli",
+      fetch: stalledFetch,
+      timeoutMs: 50,
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect(err.reason).toBe("transport");
+  }, 2000);
+
   it("does not follow a redirect on the device authorization POST", async () => {
     let attackerContacted = false;
     server.use(
@@ -746,5 +923,15 @@ describe("DeviceFlowError retryability", () => {
       const err = new DeviceFlowError(reason, "x", { retryable: true });
       expect(err.retryable).toBe(false);
     }
+  });
+
+  it("serializes the reason via toJSON (and through JSON.stringify)", () => {
+    const err = new DeviceFlowError("access_denied", "denied");
+    const json = err.toJSON();
+    expect(json.reason).toBe("access_denied");
+    expect(json.name).toBe("DeviceFlowError");
+    expect(json.code).toBe("auth_required");
+    expect(json.message).toBe("denied");
+    expect(JSON.parse(JSON.stringify(err)).reason).toBe("access_denied");
   });
 });

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -457,6 +457,46 @@ describe("pollDeviceToken", () => {
     expect(err.code).toBe("usage");
   });
 
+  it.each([
+    ["NaN", NaN],
+    ["Infinity", Infinity],
+    ["-Infinity", -Infinity],
+    ["absurdly far future", Number.MAX_SAFE_INTEGER],
+  ])("rejects a nonsense caller deadlineAtMs (%s) as usage before any request", async (_label, deadlineAtMs) => {
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      deadlineAtMs,
+      sleepFn: () => Promise.resolve(),
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(BasecampError);
+    expect(err.code).toBe("usage");
+  });
+
+  it("treats a finite deadlineAtMs already in the past as expiry, not usage", async () => {
+    // An issuance-anchored deadline fully consumed by a slow display hook is a
+    // legitimate runtime outcome — it must surface as the expired flow, not a
+    // caller-input rejection.
+    queueTokenResponses([{ status: 400, body: { error: "authorization_pending" } }]);
+    const { fn } = recordingSleep();
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      deadlineAtMs: 500,
+      clock: () => 1_000,
+      sleepFn: fn,
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect(err.reason).toBe("expired");
+    expect(err.code).toBe("auth_required");
+  });
+
   it("accepts fractional caller durations (remaining-lifetime deduction produces them)", async () => {
     // performDeviceLogin passes a fractional remaining lifetime after deducting
     // display-hook time — caller sanity here must not impose whole seconds.

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -1382,6 +1382,34 @@ describe("requestDeviceAuthorization direct-caller cancellation", () => {
   });
 });
 
+describe("performDeviceLogin abort during an async display hook", () => {
+  it("rejects promptly instead of waiting for the hook to settle", async () => {
+    queueTokenResponses([{ status: 200, body: tokenResponse }]);
+    server.use(mswHttp.post(DEVICE_ENDPOINT, () => HttpResponse.json(deviceAuthResponse)));
+    const controller = new AbortController();
+    let hookSettled = false;
+
+    const login = performDeviceLogin({
+      config,
+      clientId: "basecamp-cli",
+      // A hook that never settles on its own — models a UI prompt awaiting
+      // user interaction. The abort must win the race.
+      display: () =>
+        new Promise<void>((resolve) => {
+          setTimeout(() => {
+            hookSettled = true;
+            resolve();
+          }, 60_000);
+        }),
+      signal: controller.signal,
+    });
+
+    controller.abort();
+    await expect(login).rejects.toMatchObject({ reason: "cancelled" });
+    expect(hookSettled).toBe(false);
+  });
+});
+
 describe("performDeviceLogin cancellation around the authorization request", () => {
   it("makes no request and never fires display when already aborted", async () => {
     let requests = 0;

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -444,6 +444,9 @@ describe("pollDeviceToken", () => {
     ["zero", 0],
     ["negative", -1],
     ["oversized", 1e100],
+    // Whole seconds (RFC 8628): a fractional interval would permit ~1000
+    // polls per second.
+    ["fractional", 0.001],
   ])("rejects a nonsense caller interval (%s) as usage before any request", async (_label, interval) => {
     const err = await pollDeviceToken({
       tokenEndpoint: TOKEN_ENDPOINT,
@@ -541,21 +544,22 @@ describe("pollDeviceToken", () => {
     expect(err.code).toBe("auth_required");
   });
 
-  it("accepts fractional caller durations (remaining-lifetime deduction produces them)", async () => {
+  it("accepts a fractional caller expiresIn (remaining-lifetime deduction produces it)", async () => {
     // performDeviceLogin passes a fractional remaining lifetime after deducting
-    // display-hook time — caller sanity here must not impose whole seconds.
+    // display-hook time — caller sanity must not impose whole seconds THERE.
+    // The interval, by contrast, is whole seconds (RFC 8628).
     queueTokenResponses([{ status: 200, body: tokenResponse }]);
     const { waits, fn } = recordingSleep();
     const token = await pollDeviceToken({
       tokenEndpoint: TOKEN_ENDPOINT,
       clientId: "basecamp-cli",
       deviceCode: "dev-code-123",
-      interval: 2.5,
+      interval: 2,
       expiresIn: 42.5,
       sleepFn: fn,
     });
     expect(token.accessToken).toBe("device_access_token");
-    expect(waits).toEqual([2500]);
+    expect(waits).toEqual([2000]);
   });
 
   it("expires against the injected monotonic clock (parent category auth)", async () => {

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -476,6 +476,36 @@ describe("pollDeviceToken", () => {
     expect(err.code).toBe("usage");
   });
 
+  it("rejects a deadlineAtMs beyond the code lifetime (cannot extend polling past expiresIn)", async () => {
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      deadlineAtMs: 900_001,
+      clock: () => 0,
+      sleepFn: () => Promise.resolve(),
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(BasecampError);
+    expect(err.code).toBe("usage");
+  });
+
+  it("accepts a deadlineAtMs exactly at the code lifetime (issuance-anchored equality edge)", async () => {
+    queueTokenResponses([{ status: 200, body: tokenResponse }]);
+    const token = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      deadlineAtMs: 900_000,
+      clock: () => 0,
+      sleepFn: () => Promise.resolve(),
+    });
+    expect(token.accessToken).toBe("device_access_token");
+  });
+
   it("treats a finite deadlineAtMs already in the past as expiry, not usage", async () => {
     // An issuance-anchored deadline fully consumed by a slow display hook is a
     // legitimate runtime outcome — it must surface as the expired flow, not a

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -1410,6 +1410,56 @@ describe("performDeviceLogin abort during an async display hook", () => {
   });
 });
 
+describe("requestDeviceAuthorization post-completion abort", () => {
+  it("returns cancelled when a signal-ignoring fetch completes after the abort", async () => {
+    const controller = new AbortController();
+    // A fetch that IGNORES its AbortSignal: aborts the caller mid-flight and
+    // completes the response anyway.
+    const ignoringFetch: typeof globalThis.fetch = async () => {
+      controller.abort();
+      return HttpResponse.json(deviceAuthResponse);
+    };
+
+    await expect(
+      requestDeviceAuthorization({
+        deviceAuthorizationEndpoint: DEVICE_ENDPOINT,
+        clientId: "basecamp-cli",
+        fetch: ignoringFetch,
+        signal: controller.signal,
+      })
+    ).rejects.toMatchObject({ reason: "cancelled" });
+  });
+});
+
+describe("performDeviceLogin issuance-anchored polling deadline", () => {
+  it("does not hand display time back to the code lifetime", async () => {
+    // Stepped clock: issuance at t=0; display consumes 890 of the 900s
+    // lifetime; polls then advance past the 900s issuance deadline. Without
+    // the absolute-deadline handoff, pollDeviceToken would re-anchor at its
+    // own entry clock() and grant a fresh 10s from there PLUS the drift
+    // between the two clock reads.
+    const times = [0, 890_000, 890_000, 890_000, 901_000];
+    let i = 0;
+    const clock = () => times[Math.min(i++, times.length - 1)];
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () => HttpResponse.json(deviceAuthResponse)),
+      mswHttp.post(TOKEN_ENDPOINT, () =>
+        HttpResponse.json({ error: "authorization_pending" }, { status: 400 })
+      )
+    );
+
+    await expect(
+      performDeviceLogin({
+        config,
+        clientId: "basecamp-cli",
+        display: () => {},
+        clock,
+        sleepFn: recordingSleep().fn,
+      })
+    ).rejects.toMatchObject({ reason: "expired" });
+  });
+});
+
 describe("performDeviceLogin cancellation around the authorization request", () => {
   it("makes no request and never fires display when already aborted", async () => {
     let requests = 0;

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -1339,6 +1339,59 @@ describe("performDeviceLogin", () => {
     expect(token.accessToken).toBe("device_access_token");
   });
 
+  it("charges the authorization round-trip against the code lifetime: a slow response → expired, never polls", async () => {
+    // The code is minted server-side before the response travels back: a
+    // 6s-late response carrying expires_in: 5 is already dead on arrival, so
+    // the pre-request anchor must expire it — never grant a fresh lifetime.
+    let polled = false;
+    let now = 0;
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () => {
+        now += 6_000;
+        return HttpResponse.json({ ...deviceAuthResponse, expires_in: 5 });
+      }),
+      mswHttp.post(TOKEN_ENDPOINT, () => {
+        polled = true;
+        return HttpResponse.json(tokenResponse);
+      })
+    );
+
+    const err = await performDeviceLogin({
+      config,
+      clientId: "basecamp-cli",
+      display: () => {},
+      clock: () => now,
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect(err.reason).toBe("expired");
+    expect(polled).toBe(false);
+  });
+
+  it("rejects a malformed login clock sample as usage before any request", async () => {
+    // The orchestrator validates its own samples like the poller does: a NaN
+    // clock is the typed usage error before any network activity — never a
+    // raw TypeError out of the deadline arithmetic after the code is shown.
+    let requested = false;
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () => {
+        requested = true;
+        return HttpResponse.json(deviceAuthResponse);
+      })
+    );
+
+    const err = await performDeviceLogin({
+      config,
+      clientId: "basecamp-cli",
+      display: () => {},
+      clock: () => NaN,
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(BasecampError);
+    expect(err.code).toBe("usage");
+    expect(requested).toBe(false);
+  });
+
   it("deducts display time: a hook that burns the whole expires_in → expired, never polls", async () => {
     let polled = false;
     server.use(

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -1247,3 +1247,22 @@ describe("DeviceFlowError retryability", () => {
     expect(JSON.parse(JSON.stringify(err)).reason).toBe("access_denied");
   });
 });
+
+describe("pollDeviceToken exact-200 contract", () => {
+  it.each([201, 202])("treats a %d carrying an access_token as terminal api_error", async (status) => {
+    // RFC 8628/6749 token responses are exactly 200 (SPEC §16): a nonstandard
+    // 2xx must not prematurely complete polling.
+    queueTokenResponses([{ status, body: tokenResponse }]);
+
+    await expect(
+      pollDeviceToken({
+        tokenEndpoint: TOKEN_ENDPOINT,
+        clientId: "basecamp-cli",
+        deviceCode: "dev-code-123",
+        interval: 5,
+        expiresIn: 900,
+        sleepFn: recordingSleep().fn,
+      })
+    ).rejects.toMatchObject({ code: "api_error" });
+  });
+});

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -1339,57 +1339,50 @@ describe("performDeviceLogin", () => {
     expect(token.accessToken).toBe("device_access_token");
   });
 
-  it("charges the authorization round-trip against the code lifetime: a slow response → expired, never polls", async () => {
-    // The code is minted server-side before the response travels back: a
-    // 6s-late response carrying expires_in: 5 is already dead on arrival, so
-    // the pre-request anchor must expire it — never grant a fresh lifetime.
-    let polled = false;
+  it("anchors expiry at response receipt (SPEC §16): request-leg latency does not shrink the window", async () => {
+    // The deadline is clock.now() + expiresIn taken AFTER
+    // requestDeviceAuthorization returns — a 6s request leg with
+    // expires_in: 5 must NOT expire the fresh code client-side; expiry past
+    // receipt is arbitrated by the server (expired_token).
     let now = 0;
     server.use(
       mswHttp.post(DEVICE_ENDPOINT, () => {
         now += 6_000;
         return HttpResponse.json({ ...deviceAuthResponse, expires_in: 5 });
       }),
-      mswHttp.post(TOKEN_ENDPOINT, () => {
-        polled = true;
-        return HttpResponse.json(tokenResponse);
-      })
+      mswHttp.post(TOKEN_ENDPOINT, () => HttpResponse.json(tokenResponse))
     );
+    const { fn: sleepFn } = recordingSleep();
 
-    const err = await performDeviceLogin({
+    const token = await performDeviceLogin({
       config,
       clientId: "basecamp-cli",
       display: () => {},
       clock: () => now,
-    }).catch((e) => e);
+      sleepFn,
+    });
 
-    expect(err).toBeInstanceOf(DeviceFlowError);
-    expect(err.reason).toBe("expired");
-    expect(polled).toBe(false);
+    expect(token.accessToken).toBe("device_access_token");
   });
 
-  it("rejects a malformed login clock sample as usage before any request", async () => {
+  it("rejects a malformed login clock sample as usage before the code is surfaced", async () => {
     // The orchestrator validates its own samples like the poller does: a NaN
-    // clock is the typed usage error before any network activity — never a
-    // raw TypeError out of the deadline arithmetic after the code is shown.
-    let requested = false;
-    server.use(
-      mswHttp.post(DEVICE_ENDPOINT, () => {
-        requested = true;
-        return HttpResponse.json(deviceAuthResponse);
-      })
-    );
+    // clock is the typed usage error at the issuance anchor — never a raw
+    // TypeError out of the deadline arithmetic, and never a code shown on a
+    // flow that cannot compute its own deadline.
+    server.use(mswHttp.post(DEVICE_ENDPOINT, () => HttpResponse.json(deviceAuthResponse)));
+    const display = vi.fn();
 
     const err = await performDeviceLogin({
       config,
       clientId: "basecamp-cli",
-      display: () => {},
+      display,
       clock: () => NaN,
     }).catch((e) => e);
 
     expect(err).toBeInstanceOf(BasecampError);
     expect(err.code).toBe("usage");
-    expect(requested).toBe(false);
+    expect(display).not.toHaveBeenCalled();
   });
 
   it("deducts display time: a hook that burns the whole expires_in → expired, never polls", async () => {

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -476,6 +476,20 @@ describe("pollDeviceToken", () => {
     expect(err.code).toBe("usage");
   });
 
+  it.each([NaN, Infinity])("rejects an injected clock returning %s as usage", async (sample) => {
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      clock: () => sample,
+      sleepFn: () => Promise.resolve(),
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(BasecampError);
+    expect(err.code).toBe("usage");
+  });
+
   it("rejects a deadlineAtMs beyond the code lifetime (cannot extend polling past expiresIn)", async () => {
     const err = await pollDeviceToken({
       tokenEndpoint: TOKEN_ENDPOINT,

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -1266,3 +1266,28 @@ describe("pollDeviceToken exact-200 contract", () => {
     ).rejects.toMatchObject({ code: "api_error" });
   });
 });
+
+describe("pollDeviceToken protocol errors only on 4xx", () => {
+  it.each([201, 202, 500])(
+    "terminates on a %d carrying authorization_pending instead of polling",
+    async (status) => {
+      // OAuth protocol states are recognized only on a 4xx: a nonstandard 2xx
+      // or a 5xx carrying a crafted pending body must not extend the flow.
+      const polled = queueTokenResponses([
+        { status, body: { error: "authorization_pending" } },
+      ]);
+
+      await expect(
+        pollDeviceToken({
+          tokenEndpoint: TOKEN_ENDPOINT,
+          clientId: "basecamp-cli",
+          deviceCode: "dev-code-123",
+          interval: 5,
+          expiresIn: 900,
+          sleepFn: recordingSleep().fn,
+        })
+      ).rejects.toMatchObject({ code: "api_error" });
+      expect(polled()).toBe(1);
+    }
+  );
+});

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -1332,3 +1332,30 @@ describe("pollDeviceToken terminal statuses without body reads", () => {
     expect(token.accessToken).toBe("device_access_token");
   });
 });
+
+describe("resolveDeviceTimeoutMs ceiling", () => {
+  it("falls back to the default beyond the shared 3600s ceiling", async () => {
+    // A large finite timeoutMs (up to the old ~24.8-day bound) would hold a
+    // stalled request open for weeks — beyond 3600s it must resolve to the
+    // default like NaN/non-positive values, matching Go/Python/Ruby.
+    let requests = 0;
+    server.use(
+      mswHttp.post(TOKEN_ENDPOINT, () => {
+        requests += 1;
+        return HttpResponse.json(tokenResponse);
+      })
+    );
+
+    const token = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      timeoutMs: 24 * 24 * 3600 * 1000,
+      sleepFn: recordingSleep().fn,
+    });
+    expect(token.accessToken).toBe("device_access_token");
+    expect(requests).toBe(1);
+  });
+});

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -622,6 +622,57 @@ describe("pollDeviceToken", () => {
     expect(err.code).toBe("usage");
   });
 
+  it("does not accept a late 200 from a fetch that outlives the per-request timeout", async () => {
+    // A non-cooperative fetch that ignores its AbortSignal and settles with a
+    // valid 200 AFTER the per-request timeout fired: the race must discard the
+    // late result (timeout → transient backoff), and the flow must end by its
+    // own deadline — never by accepting the late token.
+    let calls = 0;
+    const lateFetch = (async () => {
+      calls += 1;
+      await new Promise((r) => setTimeout(r, 50));
+      return new Response(JSON.stringify(tokenResponse), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+    // Clock: deadline anchored at 0; after round 1's timeout the clock jumps
+    // past the deadline so round 2 surfaces expired.
+    const times = [0, 0, 0, 1_000_000];
+    let idx = 0;
+    const clock = () => times[Math.min(idx++, times.length - 1)];
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      timeoutMs: 1,
+      fetch: lateFetch,
+      clock,
+      sleepFn: () => Promise.resolve(),
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect(err.reason).toBe("expired");
+    expect(calls).toBe(1);
+  });
+
+  it("releases the call at its timeout when a fetch never settles", async () => {
+    // The starkest non-cooperative fetch: a promise that NEVER settles. The
+    // public call must still return on its own schedule — the race, not the
+    // fetch, owns the timeout.
+    const neverFetch = (() =>
+      new Promise<Response>(() => {})) as unknown as typeof fetch;
+    const err = await requestDeviceAuthorization({
+      deviceAuthorizationEndpoint: DEVICE_ENDPOINT,
+      clientId: "basecamp-cli",
+      fetch: neverFetch,
+      timeoutMs: 20,
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect(err.reason).toBe("transport");
+  });
+
   it("does not return a token when a signal-ignoring fetch completes after abort", async () => {
     // A custom fetch that ignores its AbortSignal can complete a 200 AFTER the
     // caller aborted. The success branch must re-check the signal before

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -622,6 +622,34 @@ describe("pollDeviceToken", () => {
     expect(err.code).toBe("usage");
   });
 
+  it("does not return a token when a signal-ignoring fetch completes after abort", async () => {
+    // A custom fetch that ignores its AbortSignal can complete a 200 AFTER the
+    // caller aborted. The success branch must re-check the signal before
+    // handing back the credential — never a token returned after the caller
+    // asked to stop.
+    const controller = new AbortController();
+    const ignoringFetch = (async () => {
+      controller.abort();
+      return new Response(JSON.stringify(tokenResponse), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+    const err = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      signal: controller.signal,
+      fetch: ignoringFetch,
+      sleepFn: () => Promise.resolve(),
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(DeviceFlowError);
+    expect(err.reason).toBe("cancelled");
+    expect(err.code).toBe("usage");
+  });
+
   it("does not return a token when the signal was aborted before the token POST", async () => {
     // Regression: a signal aborted during a sleep that RESOLVES (rather than
     // rejecting) hands postDeviceToken an already-aborted signal. Without an

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -15,7 +15,7 @@ import {
   DeviceFlowError,
   DEVICE_CODE_GRANT_TYPE,
 } from "../../src/oauth/index.js";
-import type { OAuthConfig } from "../../src/oauth/types.js";
+import type { OAuthConfig, DeviceAuthorization } from "../../src/oauth/types.js";
 import { BasecampError } from "../../src/errors.js";
 
 const ORIGIN = "https://issuer.device-test.example";
@@ -979,6 +979,25 @@ describe("pollDeviceToken", () => {
     }).catch((e) => e);
     expect(err).toBeInstanceOf(BasecampError);
     expect(err.code).toBe("api_error");
+  });
+});
+
+describe("performDeviceLogin display guard", () => {
+  it("rejects a non-function display as usage before any request", async () => {
+    let requests = 0;
+    const recordingFetch = (async () => {
+      requests += 1;
+      return new Response("{}", { status: 500 });
+    }) as unknown as typeof fetch;
+    const err = await performDeviceLogin({
+      config,
+      clientId: "basecamp-cli",
+      display: undefined as unknown as (auth: DeviceAuthorization) => void,
+      fetch: recordingFetch,
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(BasecampError);
+    expect(err.code).toBe("usage");
+    expect(requests).toBe(0);
   });
 });
 

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -1359,3 +1359,53 @@ describe("resolveDeviceTimeoutMs ceiling", () => {
     expect(requests).toBe(1);
   });
 });
+
+describe("performDeviceLogin cancellation around the authorization request", () => {
+  it("makes no request and never fires display when already aborted", async () => {
+    let requests = 0;
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () => {
+        requests += 1;
+        return HttpResponse.json(deviceAuthResponse);
+      })
+    );
+    const controller = new AbortController();
+    controller.abort();
+    const displayed: unknown[] = [];
+
+    await expect(
+      performDeviceLogin({
+        config,
+        clientId: "basecamp-cli",
+        display: (auth) => { displayed.push(auth); },
+        signal: controller.signal,
+      })
+    ).rejects.toMatchObject({ reason: "cancelled" });
+    expect(requests).toBe(0);
+    expect(displayed).toEqual([]);
+  });
+
+  it("an abort during the authorization request never reaches display", async () => {
+    // The mock endpoint aborts the signal as it serves the code pair, so the
+    // entry check passes and only the in-flight/post-request handling can
+    // catch it — the display hook must never fire for a cancelled flow.
+    const controller = new AbortController();
+    server.use(
+      mswHttp.post(DEVICE_ENDPOINT, () => {
+        controller.abort();
+        return HttpResponse.json(deviceAuthResponse);
+      })
+    );
+    const displayed: unknown[] = [];
+
+    await expect(
+      performDeviceLogin({
+        config,
+        clientId: "basecamp-cli",
+        display: (auth) => { displayed.push(auth); },
+        signal: controller.signal,
+      })
+    ).rejects.toMatchObject({ reason: "cancelled" });
+    expect(displayed).toEqual([]);
+  });
+});

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -1360,6 +1360,28 @@ describe("resolveDeviceTimeoutMs ceiling", () => {
   });
 });
 
+describe("requestDeviceAuthorization direct-caller cancellation", () => {
+  it("makes no fetch when the signal is already aborted", async () => {
+    let fetches = 0;
+    const countingFetch: typeof globalThis.fetch = async (input, init) => {
+      fetches += 1;
+      return globalThis.fetch(input, init);
+    };
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      requestDeviceAuthorization({
+        deviceAuthorizationEndpoint: DEVICE_ENDPOINT,
+        clientId: "basecamp-cli",
+        fetch: countingFetch,
+        signal: controller.signal,
+      })
+    ).rejects.toMatchObject({ reason: "cancelled" });
+    expect(fetches).toBe(0);
+  });
+});
+
 describe("performDeviceLogin cancellation around the authorization request", () => {
   it("makes no request and never fires display when already aborted", async () => {
     let requests = 0;

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -1291,3 +1291,44 @@ describe("pollDeviceToken protocol errors only on 4xx", () => {
     }
   );
 });
+
+describe("pollDeviceToken terminal statuses without body reads", () => {
+  it.each([201, 500])("classifies a %d by status without draining an oversized body", async (status) => {
+    // An oversized body on a terminal non-4xx would trip the size cap if
+    // drained — the early status check surfaces the status api_error instead.
+    server.use(
+      mswHttp.post(TOKEN_ENDPOINT, () =>
+        new HttpResponse("x".repeat(2 * 1024 * 1024), { status })
+      )
+    );
+
+    await expect(
+      pollDeviceToken({
+        tokenEndpoint: TOKEN_ENDPOINT,
+        clientId: "basecamp-cli",
+        deviceCode: "dev-code-123",
+        interval: 5,
+        expiresIn: 900,
+        sleepFn: recordingSleep().fn,
+      })
+    ).rejects.toMatchObject({ code: "api_error", message: expect.stringContaining(`status ${status}`) });
+  });
+
+  it("normalizes an invalid timeoutMs before the remaining-lifetime clamp", async () => {
+    // A NaN timeoutMs poisoned Math.min into NaN, which postDeviceToken then
+    // resolved to the full 30s default — bypassing the near-expiry clamp. The
+    // entry normalization keeps the flow working (and clamped) regardless.
+    queueTokenResponses([{ status: 200, body: tokenResponse }]);
+
+    const token = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      timeoutMs: Number.NaN,
+      sleepFn: recordingSleep().fn,
+    });
+    expect(token.accessToken).toBe("device_access_token");
+  });
+});

--- a/typescript/tests/oauth/oauth.test.ts
+++ b/typescript/tests/oauth/oauth.test.ts
@@ -230,6 +230,23 @@ describe("Token Exchange", () => {
   };
 
   describe("exchangeCode", () => {
+    it("rejects a numeric access_token as api_error with the HTTP status", async () => {
+      server.use(
+        http.post(tokenEndpoint, () =>
+          HttpResponse.json({ access_token: 123 })
+        )
+      );
+      const err = await exchangeCode({
+        tokenEndpoint,
+        code: "auth_code_123",
+        redirectUri: "https://myapp.com/callback",
+        clientId: "my_client_id",
+      }).catch((e) => e);
+      expect(err).toBeInstanceOf(BasecampError);
+      expect(err.code).toBe("api_error");
+      expect(err.httpStatus).toBe(200);
+    });
+
     it("rejects a present-but-empty token_type as api_error (null/absent default to Bearer)", async () => {
       server.use(
         http.post(tokenEndpoint, () =>

--- a/typescript/tests/oauth/oauth.test.ts
+++ b/typescript/tests/oauth/oauth.test.ts
@@ -230,6 +230,19 @@ describe("Token Exchange", () => {
   };
 
   describe("exchangeCode", () => {
+    it("rejects a non-2xx null body as api_error with the status (never raw TypeError → network)", async () => {
+      server.use(http.post(tokenEndpoint, () => HttpResponse.json(null, { status: 400 })));
+      const err = await exchangeCode({
+        tokenEndpoint,
+        code: "auth_code_123",
+        redirectUri: "https://myapp.com/callback",
+        clientId: "my_client_id",
+      }).catch((e) => e);
+      expect(err).toBeInstanceOf(BasecampError);
+      expect(err.code).toBe("api_error");
+      expect(err.httpStatus).toBe(400);
+    });
+
     it.each([
       ["null body", null],
       ["array body", []],

--- a/typescript/tests/oauth/oauth.test.ts
+++ b/typescript/tests/oauth/oauth.test.ts
@@ -230,6 +230,25 @@ describe("Token Exchange", () => {
   };
 
   describe("exchangeCode", () => {
+    it("never echoes the body when a token response fails to parse", async () => {
+      // A syntactically-broken token body can still carry credential
+      // material — the parse error must not echo any of it into the
+      // message, where it would reach logs and exception telemetry.
+      const secret = "sk-live-SUPERSECRET";
+      server.use(
+        http.post(tokenEndpoint, () => new HttpResponse(`{"access_token": "${secret}' oops`, { status: 200 }))
+      );
+      const err = await exchangeCode({
+        tokenEndpoint,
+        code: "auth_code_123",
+        redirectUri: "https://myapp.com/callback",
+        clientId: "my_client_id",
+      }).catch((e) => e);
+      expect(err).toBeInstanceOf(BasecampError);
+      expect(err.code).toBe("api_error");
+      expect(err.message).not.toContain(secret);
+    });
+
     it("rejects a non-2xx null body as api_error with the status (never raw TypeError → network)", async () => {
       server.use(http.post(tokenEndpoint, () => HttpResponse.json(null, { status: 400 })));
       const err = await exchangeCode({

--- a/typescript/tests/oauth/oauth.test.ts
+++ b/typescript/tests/oauth/oauth.test.ts
@@ -230,6 +230,26 @@ describe("Token Exchange", () => {
   };
 
   describe("exchangeCode", () => {
+    it.each([
+      ["null body", null],
+      ["array body", []],
+      ["numeric refresh_token", { access_token: "a", refresh_token: 123 }],
+      ["numeric scope", { access_token: "a", scope: 7 }],
+      ["fractional expires_in", { access_token: "a", expires_in: 3600.5 }],
+      ["oversized expires_in", { access_token: "a", expires_in: 9_000_000_000_000_000_000 }],
+    ])("rejects a malformed 200 token body (%s) as api_error with the HTTP status", async (_label, body) => {
+      server.use(http.post(tokenEndpoint, () => HttpResponse.json(body as never)));
+      const err = await exchangeCode({
+        tokenEndpoint,
+        code: "auth_code_123",
+        redirectUri: "https://myapp.com/callback",
+        clientId: "my_client_id",
+      }).catch((e) => e);
+      expect(err).toBeInstanceOf(BasecampError);
+      expect(err.code).toBe("api_error");
+      expect(err.httpStatus).toBe(200);
+    });
+
     it("rejects a numeric access_token as api_error with the HTTP status", async () => {
       server.use(
         http.post(tokenEndpoint, () =>

--- a/typescript/tests/oauth/oauth.test.ts
+++ b/typescript/tests/oauth/oauth.test.ts
@@ -230,6 +230,35 @@ describe("Token Exchange", () => {
   };
 
   describe("exchangeCode", () => {
+    it("rejects a present-but-empty token_type as api_error (null/absent default to Bearer)", async () => {
+      server.use(
+        http.post(tokenEndpoint, () =>
+          HttpResponse.json({ access_token: "a", token_type: "" })
+        )
+      );
+      const err = await exchangeCode({
+        tokenEndpoint,
+        code: "auth_code_123",
+        redirectUri: "https://myapp.com/callback",
+        clientId: "my_client_id",
+      }).catch((e) => e);
+      expect(err).toBeInstanceOf(BasecampError);
+      expect(err.code).toBe("api_error");
+
+      server.use(
+        http.post(tokenEndpoint, () =>
+          HttpResponse.json({ access_token: "a", token_type: null })
+        )
+      );
+      const token = await exchangeCode({
+        tokenEndpoint,
+        code: "auth_code_123",
+        redirectUri: "https://myapp.com/callback",
+        clientId: "my_client_id",
+      });
+      expect(token.tokenType).toBe("Bearer");
+    });
+
     it("exchanges authorization code for tokens (standard format)", async () => {
       server.use(
         http.post(tokenEndpoint, async ({ request }) => {


### PR DESCRIPTION
# Device flow (RFC 8628)

> **Part 2 of 2.** #369 (resource-first discovery) is now merged; this PR is restacked directly on `main` and reviewed on its own.

## Why this exists

Not every client can open a browser to sign in. Command-line tools, CI tasks, and input-constrained or headless devices need a login flow that works with nothing but a code and a URL the user visits elsewhere. This PR adds the **OAuth 2.0 Device Authorization Grant (RFC 8628)** to every SDK, giving those clients a first-class, browserless path to a Basecamp access token.

It is the second half of Basecamp's OAuth modernization: #369 taught the SDKs to *discover* the right authorization server; this PR teaches them to *authenticate* against it without a browser.

## What you get — one uniform API across TypeScript, Python, Go, Ruby, and Kotlin

- **`requestDeviceAuthorization(...)`** — begin the grant; returns the user code, verification URL, and polling parameters.
- **`pollDeviceToken(...)`** — poll to completion, honoring the server's pacing (`authorization_pending`, sustained `slow_down`), a monotonic expiry deadline, backoff on transient transport failure, and caller cancellation.
- **`performDeviceLogin(...)`** — the end-to-end convenience path: takes an already-discovered config, guards that the server actually supports the device grant, surfaces the user code/URL through a display hook, and polls until the user approves.

Terminal outcomes are a single typed `DeviceFlowError` whose category is derived from the reason (denied/expired → auth, transport → retryable network, unsupported → validation, cancelled → native cancellation), uniform across all five languages.

## Compatibility & rollout

- **Additive.** New surface only; nothing existing changes.
- **Activates with the server.** The device grant becomes usable once a Basecamp authorization server advertises a device-authorization endpoint and the `device_code` grant. Today's Launchpad metadata advertises neither, so `performDeviceLogin` reports `unavailable` against it by design — the capability lights up when the first-party server does, with no client change required.
- Targeted at the pre-registered public `basecamp-cli` client (no client secret, grants `device_code` + `refresh_token`).

## Design intent

- **Correct pacing and lifetimes.** The poll loop uses a monotonic, injectable clock; sustains `slow_down` increments; anchors expiry to a real deadline rather than a running counter; and never overflows timer arithmetic. Durations are validated uniformly across languages (positive whole seconds within a safe bound; integer-valued floats accepted, fractional rejected).
- **Malformed responses fail cleanly.** A tokenless or non-object success body, a non-string code/URL, or an out-of-range lifetime is a typed `api_error` — never a raw crash or a misclassified retryable transport error.
- **Same contract, five languages.** Shared specification and per-SDK regression tests keep polling, backoff, cancellation, the capability guard, and error mapping behaviorally identical everywhere.

## Verification

`make check` — all five SDKs (plus Swift) and the conformance/lint gates — passes at the branch tip.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the OAuth 2.0 device authorization flow (RFC 8628) across TypeScript, Python, Go, Ruby, and Kotlin so `basecamp-cli` can log in without a browser, with one uniform API and hardened behavior across all SDKs.

- **New Features**
  - Unified APIs: `requestDeviceAuthorization`, `pollDeviceToken` (issuance‑anchored deadline), `performDeviceLogin`, and `DeviceFlowError` (parent code derived from reason).
  - Capability guard via discovery: requires a non‑empty `device_authorization_endpoint` and `grant_types_supported` ∋ `device_code` (Launchpad → `unavailable`).
  - Kotlin `refreshToken` accepts `clientSecret: String? = null` for the public client.

- **Hardening & Fixes**
  - Protocol/status handling: token success requires exactly HTTP 200; 3xx/201/202/5xx terminate by status before reading; OAuth error codes honored only on 4xx; unused bodies are cancelled/skipped; extracted error strings are truncated; all malformed‑2xx device/token errors carry `httpStatus`.
  - Timeouts and lifetime: per‑request device timeouts are normalized once (default 30s; cap 3600s) and each poll clamps the request to the remaining lifetime; streaming reads run under wall‑clock deadlines; body caps are normalized across discovery/resource/device; TypeScript races whole round‑trips against timeout/abort.
  - Polling correctness: interval and timeout backoff are separate (wait = max(interval, backoff)); backoff doubles (cap 60), resets after any completed round‑trip, and re‑syncs after `slow_down`; waits clamp to the remaining lifetime. `performDeviceLogin` passes an issuance‑anchored absolute deadline; caller‑supplied deadlines are validated and bounded by the code lifetime.
  - Cancellation safety: cancellation wins before/after requests and display, and before returning codes/tokens; TypeScript races an async display hook against abort and re‑checks; Go/Kotlin/TS re‑check before success/classification returns; Python/Ruby add post‑round‑trip probe checks; non‑callable/missing `display` is rejected; empty device endpoints are `unavailable`.
  - Strict validation (device + exchange): `access_token` non‑empty string; `expires_in` positive whole seconds ≤ 2_147_483_647 (integer‑valued floats accepted); `token_type` absent/null → Bearer, present‑empty/non‑string → error; optional `refresh_token`/`scope` strings or absent/null. Device‑auth fields are validated; `verification_uri_complete` may be null/absent (Go as `*string`; TS normalizes null to absent). TypeScript’s exchange parser now applies the same strict field rules and carries `httpStatus`.
  - Caller guards & transport: poll entries reject out‑of‑range durations/deadlines and validate injected clocks and `deadlineAtMs` (bounded by the code lifetime); all hops require HTTPS, suppress redirects, and read bodies under normalized caps; parsers never echo response bodies on parse failures.

<sup>Written for commit 9f41bb4ffafb7b0c6dcfa8f74c87cfc1e1891d9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

