### PR TITLE
OAuth transport hardening: headers-first, totally-bounded fetches (Ruby + Python)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1216,6 +1216,19 @@ every `fetchJSON` above MUST:
 
 Non-2xx on either hop → `api_error` (not `network`).
 
+#### Injected-client fidelity tier `[static]`
+
+SDKs that accept a caller-supplied HTTP client (Ruby `http_client:`, and any
+future equivalent) MUST hold the same security invariants on it — redirect
+suppression, bounded/streaming body cap, and a wall-clock bound on the whole
+request — but MAY deliver coarser timing and classification fidelity than the
+default transport: status classification may occur only after the body read
+completes (no headers-time seam), and deadline enforcement is wall-clock
+around the call rather than woven through each read. A definitive completed
+status still outranks a deadline race; a response completing past the
+deadline without one is refused as a transport timeout. Callers needing exact
+headers-time classification use the default transport.
+
 ### Launchpad Legacy Format
 
 The Basecamp Launchpad OAuth endpoints use a mix of standard and legacy parameters:

--- a/python/README.md
+++ b/python/README.md
@@ -214,6 +214,11 @@ redirects, bound the timeout, and read the body under a genuine streaming cap
 that aborts before an oversized body is buffered. Non-2xx on either hop maps to
 `api_error`.
 
+**Timing contract.** A bounded OAuth request returns within its `timeout` plus
+at most 1 second of cleanup grace, spent only when the request already missed
+its deadline. Budget `timeout + 1` when folding these calls into your own
+deadlines.
+
 ### PKCE and Authorization URL
 
 ```python

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -1,0 +1,125 @@
+"""Bounded HTTP transport shared by the OAuth discovery and device-flow fetches.
+
+Sync httpx has NO total-request timeout: its timeout is per-read and RESETS on
+every received chunk, so a peer dripping header or body bytes just under that
+interval can hold a request open indefinitely (verified), and closing a sync
+client from a watchdog thread does not interrupt a blocked read either. The
+core here runs an async client under ``asyncio.wait_for`` on a dedicated
+worker thread, so the deadline CANCELS the request (and closes the socket) —
+the caller is bounded regardless of chunk cadence AND the work is actually
+terminated, no leaked connection.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Callable
+
+import httpx
+
+from basecamp.oauth.errors import OAuthError
+
+#: Extra time (seconds) to let a timed-out request's async cancellation/cleanup
+#: unwind before the caller abandons the (daemon) worker and returns a timeout.
+_WORKER_JOIN_GRACE = 5.0
+
+#: Upper bound (seconds) on a bounded request timeout. A per-request timeout
+#: beyond this is nonsensical, and a huge finite value would overflow the
+#: wall-clock wait primitive (asyncio.wait_for / thread join); callers clamp
+#: to their operation default above it (see ``_normalize_timeout``).
+_MAX_REQUEST_TIMEOUT = 3600.0
+
+
+def request_bounded(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str],
+    params: dict[str, str] | None = None,
+    timeout: float,
+    max_body_bytes: int,
+    read_body: Callable[[int], bool] = lambda _status: True,
+    context: str = "OAuth",
+) -> tuple[int, bytes]:
+    """SSRF-hardened request: suppress redirects, bound the WHOLE round-trip by
+    ``timeout``, and read the body under a genuine streaming cap that aborts once
+    ``max_body_bytes`` is exceeded (never a post-hoc check on an already-buffered
+    body). ``params``, when given, is sent as a form body (POST).
+
+    ``timeout`` must arrive ALREADY normalized — finite, positive, and no greater
+    than :data:`_MAX_REQUEST_TIMEOUT` (callers run it through
+    ``discovery._normalize_timeout``, which this module cannot import without a
+    cycle). An unnormalized value would disable the ``wait_for`` deadline
+    (``inf`` never fires) or overflow the wait primitive.
+
+    ``read_body(status)`` decides — from the response status, known once headers
+    arrive — whether the body is drained. A caller returns ``False`` for statuses
+    whose body it does not use, so a slow/never-ending body cannot time out
+    mid-read and be misclassified as a retryable transport failure instead of
+    the api_error the status already is.
+
+    Transport failures propagate as :class:`httpx.HTTPError` (incl.
+    :class:`httpx.TimeoutException`) so callers classify them; an oversized body
+    raises :class:`OAuthError` (``api_error``). ``context`` labels both messages.
+    """
+
+    async def _do() -> tuple[int, bytes]:
+        async with (
+            httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client,
+            client.stream(method, url, data=params, headers=headers) as response,
+        ):
+            if not read_body(response.status_code):
+                return response.status_code, b""
+            chunks: list[bytes] = []
+            total = 0
+            async for chunk in response.aiter_bytes():
+                total += len(chunk)
+                if total > max_body_bytes:
+                    # An oversized body is api_error, not a timeout — abort the
+                    # stream so it is never fully buffered.
+                    raise OAuthError("api_error", f"{context} response exceeds size cap")
+                chunks.append(chunk)
+            return response.status_code, b"".join(chunks)
+
+    # httpx's timeout is per-read (it resets on every received chunk) and httpx has
+    # NO total-request timeout, so a peer slow-dripping header or body bytes just
+    # under that interval could otherwise hold the request open indefinitely
+    # (verified); closing a sync client from a watchdog does not interrupt a blocked
+    # read either. asyncio.wait_for CANCELS the request (and closes the socket) at
+    # the deadline — the caller is bounded AND the work is actually terminated, no
+    # leaked worker.
+    #
+    # Run it in a DEDICATED thread with its own event loop rather than calling
+    # asyncio.run() here: this sync helper may be invoked from code that already has
+    # a running loop (Jupyter/FastAPI/async CLI), where asyncio.run() raises
+    # RuntimeError before any request is made. wait_for bounds the thread's work at
+    # ~timeout, so the bounded join below normally returns almost immediately; the
+    # is_alive backstop after it covers only a pathological async-cleanup hang.
+    result: list[tuple[int, bytes]] = []
+    error: list[Exception] = []
+
+    def _runner() -> None:
+        try:
+            result.append(asyncio.run(asyncio.wait_for(_do(), timeout)))
+        except Exception as exc:  # captured and re-raised on the caller thread
+            error.append(exc)
+
+    worker = threading.Thread(target=_runner, daemon=True)
+    worker.start()
+    # asyncio.wait_for cancels the request at `timeout`, so the worker normally
+    # finishes well within it. Join with a small grace for the cancellation/cleanup
+    # to unwind; if even that stalls (a pathological async cleanup hang), return a
+    # timeout rather than block the caller — the daemon worker never blocks
+    # interpreter exit. This is bounded AND non-leaking in every non-pathological case.
+    worker.join(timeout + _WORKER_JOIN_GRACE)
+    if worker.is_alive():
+        raise httpx.ReadTimeout(f"{context} request exceeded the timeout deadline")
+    if error:
+        exc = error[0]
+        # On Python >= 3.11 (this package's floor) asyncio.TimeoutError IS the
+        # builtin TimeoutError, so this catches wait_for's deadline expiry.
+        if isinstance(exc, TimeoutError):
+            raise httpx.ReadTimeout(f"{context} request exceeded the timeout deadline") from exc
+        raise exc
+    return result[0]

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -68,6 +68,11 @@ def request_bounded(
     raises :class:`OAuthError` (``api_error``). ``context`` labels both messages.
     """
 
+    if params is not None and method != "POST":
+        # A form body on a non-POST would emit e.g. a GET-with-body — commonly
+        # rejected server-side and hard to debug; fail fast on the misuse.
+        raise ValueError("request_bounded: params (a form body) is only valid with POST")
+
     async def _do() -> tuple[int, bytes]:
         async with (
             httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client,

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -22,7 +22,11 @@ from basecamp.oauth.errors import OAuthError
 
 #: Extra time (seconds) to let a timed-out request's async cancellation/cleanup
 #: unwind before the caller abandons the (daemon) worker and returns a timeout.
-_WORKER_JOIN_GRACE = 5.0
+#: Kept SMALL so the caller's worst-case block stays ~timeout: cleanup after a
+#: wait_for cancellation is just closing a socket, and joining with no grace at
+#: all would race a request that completes right at the deadline. The daemon
+#: worker never blocks interpreter exit if even this stalls.
+_WORKER_JOIN_GRACE = 1.0
 
 #: Upper bound (seconds) on a bounded request timeout. A per-request timeout
 #: beyond this is nonsensical, and a huge finite value would overflow the

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -108,7 +108,12 @@ def request_bounded(
         # read the RAW wire bytes; a server compressing anyway hands over
         # compressed bytes bounded by the cap, which then fail classification
         # upstream instead of exhausting memory.
-        request_headers = {**headers, "Accept-Encoding": "identity"}
+        # Case-insensitive replacement: a caller passing "accept-encoding"
+        # would otherwise coexist with our key and emit duplicate headers,
+        # undermining the identity-only compression-bomb bound (the Ruby
+        # transport filters the same way).
+        request_headers = {k: v for k, v in headers.items() if k.lower() != "accept-encoding"}
+        request_headers["Accept-Encoding"] = "identity"
         async with (
             httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client,
             client.stream(method, url, data=params, headers=request_headers) as response,
@@ -126,6 +131,12 @@ def request_bounded(
             async for chunk in response.aiter_raw():
                 total += len(chunk)
                 if total > max_body_bytes:
+                    # Deadline first, symmetric with body completion: a chunk
+                    # becoming runnable past the bound must classify as the
+                    # timeout it is, not race ahead of wait_for into a
+                    # terminal api_error.
+                    if time.monotonic() > deadline_ts:
+                        raise TimeoutError(f"{context} body exceeded the total deadline")
                     # An oversized body is api_error, not a timeout — abort the
                     # stream so it is never fully buffered. Record the terminal
                     # error BEFORE the context managers unwind: their awaited

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -103,6 +103,12 @@ def request_bounded(
             f"no greater than {_MAX_REQUEST_TIMEOUT}"
         )
 
+    # The body cap gets the same fail-fast discipline: a bool, float (inf
+    # included), or non-positive value would disable or crash the streaming
+    # bound this core exists to provide.
+    if isinstance(max_body_bytes, bool) or not isinstance(max_body_bytes, int) or max_body_bytes <= 0:
+        raise ValueError("request_bounded: max_body_bytes must be a positive int")
+
     async def _do() -> tuple[int, bytes]:
         # Identity encoding + aiter_raw(): httpx transparently inflates
         # gzip/deflate in aiter_bytes(), so the per-chunk cap would measure

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -69,7 +69,7 @@ def request_bounded(
     raises :class:`OAuthError` (``api_error``). ``context`` labels both messages.
     """
 
-    if params is not None and method != "POST":
+    if params is not None and method.upper() != "POST":
         # A form body on a non-POST would emit e.g. a GET-with-body — commonly
         # rejected server-side and hard to debug; fail fast on the misuse.
         raise ValueError("request_bounded: params (a form body) is only valid with POST")

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -11,6 +11,12 @@ terminated. (One documented residual below: a getaddrinfo blocked in the OS
 resolver runs on an executor thread cancellation cannot interrupt, so a
 slow-DNS attempt's daemon worker outlives the deadline until the resolver's
 own OS-bounded timeout.)
+
+Timing contract: a bounded request returns within ``timeout`` plus a fixed
+cleanup grace of at most 1 second (``_WORKER_JOIN_GRACE``), spent only when
+the request already missed its deadline and its cancellation is unwinding.
+Callers folding these timeouts into their own budgets should budget
+``timeout + 1``.
 """
 
 from __future__ import annotations

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -154,59 +154,71 @@ def request_bounded(
 
     async def _request(client: httpx.AsyncClient) -> tuple[int, bytes]:
         async with client.stream(method, url, data=params, headers=request_headers) as response:
-            if not read_body(response.status_code):
-                # Deadline first, symmetric with the body paths: headers
-                # becoming runnable past the total bound mean the status was
-                # NOT known before the deadline — classify as the timeout it
-                # is rather than racing ahead of wait_for's already-due
-                # callback into a status fault.
-                if time.monotonic() > deadline_ts:
-                    raise TimeoutError(f"{context} headers arrived past the total deadline")
-                # Record the KNOWN, in-deadline outcome before the context
-                # managers unwind: the awaited response/client cleanup can
-                # cross the total deadline and be cancelled by wait_for, and a
-                # skipped non-2xx must classify by status (api_error), never
-                # soften into a retryable timeout because only its CLEANUP was
-                # late.
-                outcome.append((response.status_code, b""))
-                return response.status_code, b""
-            chunks: list[bytes] = []
-            total = 0
-            async for chunk in response.aiter_raw():
-                total += len(chunk)
-                if total > max_body_bytes:
-                    # Deadline first, symmetric with body completion: a chunk
-                    # becoming runnable past the bound must classify as the
-                    # timeout it is, not race ahead of wait_for into a
-                    # terminal api_error.
-                    if time.monotonic() > deadline_ts:
-                        raise TimeoutError(f"{context} body exceeded the total deadline")
-                    # An oversized body is api_error, not a timeout — abort the
-                    # stream so it is never fully buffered. Record the terminal
-                    # error BEFORE the context managers unwind: their awaited
-                    # cleanup can cross the deadline and be cancelled by
-                    # wait_for, which would otherwise soften this documented
-                    # size-cap error into a retryable timeout.
-                    exc = OAuthError("api_error", f"{context} response exceeds size cap")
-                    error_outcome.append(exc)
-                    raise exc
-                chunks.append(chunk)
-            # Same completed-outcome recording as the skip path — but ONLY
-            # when the body finished inside the deadline: the task can run
-            # ahead of wait_for's already-due timeout callback, and a body
-            # completing past the advertised bound must not be accepted.
-            # (Skipped statuses stay status-first regardless — their
-            # classification is header-time knowledge.)
+            try:
+                return await _read(response)
+            except httpx.HTTPError as exc:
+                # Stamp INSIDE the response context: response.aclose() runs
+                # before any outer handler sees a body-phase fault, and a
+                # cleanup that crosses the deadline (or is cancelled by
+                # wait_for) would otherwise erase an in-deadline wire fault.
+                if not wire_fault and not isinstance(exc, httpx.TimeoutException):
+                    wire_fault.append((exc, time.monotonic()))
+                raise
+
+    async def _read(response: httpx.Response) -> tuple[int, bytes]:
+        if not read_body(response.status_code):
+            # Deadline first, symmetric with the body paths: headers
+            # becoming runnable past the total bound mean the status was
+            # NOT known before the deadline — classify as the timeout it
+            # is rather than racing ahead of wait_for's already-due
+            # callback into a status fault.
             if time.monotonic() > deadline_ts:
-                # The body finished past the advertised bound but this
-                # coroutine ran ahead of wait_for's already-due timeout
-                # callback — raising (not returning) keeps the late body out
-                # of `result` too, so the caller classifies it as the timeout
-                # it is.
-                raise TimeoutError(f"{context} body completed past the total deadline")
-            joined = b"".join(chunks)
-            outcome.append((response.status_code, joined))
-            return response.status_code, joined
+                raise TimeoutError(f"{context} headers arrived past the total deadline")
+            # Record the KNOWN, in-deadline outcome before the context
+            # managers unwind: the awaited response/client cleanup can
+            # cross the total deadline and be cancelled by wait_for, and a
+            # skipped non-2xx must classify by status (api_error), never
+            # soften into a retryable timeout because only its CLEANUP was
+            # late.
+            outcome.append((response.status_code, b""))
+            return response.status_code, b""
+        chunks: list[bytes] = []
+        total = 0
+        async for chunk in response.aiter_raw():
+            total += len(chunk)
+            if total > max_body_bytes:
+                # Deadline first, symmetric with body completion: a chunk
+                # becoming runnable past the bound must classify as the
+                # timeout it is, not race ahead of wait_for into a
+                # terminal api_error.
+                if time.monotonic() > deadline_ts:
+                    raise TimeoutError(f"{context} body exceeded the total deadline")
+                # An oversized body is api_error, not a timeout — abort the
+                # stream so it is never fully buffered. Record the terminal
+                # error BEFORE the context managers unwind: their awaited
+                # cleanup can cross the deadline and be cancelled by
+                # wait_for, which would otherwise soften this documented
+                # size-cap error into a retryable timeout.
+                exc = OAuthError("api_error", f"{context} response exceeds size cap")
+                error_outcome.append(exc)
+                raise exc
+            chunks.append(chunk)
+        # Same completed-outcome recording as the skip path — but ONLY
+        # when the body finished inside the deadline: the task can run
+        # ahead of wait_for's already-due timeout callback, and a body
+        # completing past the advertised bound must not be accepted.
+        # (Skipped statuses stay status-first regardless — their
+        # classification is header-time knowledge.)
+        if time.monotonic() > deadline_ts:
+            # The body finished past the advertised bound but this
+            # coroutine ran ahead of wait_for's already-due timeout
+            # callback — raising (not returning) keeps the late body out
+            # of `result` too, so the caller classifies it as the timeout
+            # it is.
+            raise TimeoutError(f"{context} body completed past the total deadline")
+        joined = b"".join(chunks)
+        outcome.append((response.status_code, joined))
+        return response.status_code, joined
 
     # httpx's timeout is per-read (it resets on every received chunk) and httpx has
     # NO total-request timeout, so a peer slow-dripping header or body bytes just

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -204,7 +204,7 @@ def request_bounded(
     # ~timeout, so the bounded join below normally returns almost immediately; the
     # is_alive backstop after it covers only a pathological async-cleanup hang.
     result: list[tuple[int, bytes]] = []
-    error: list[Exception] = []
+    error: list[tuple[Exception, float]] = []
     # Completed outcomes recorded INSIDE _do before async cleanup: when
     # wait_for cancels mid-unwind, the response is already known and must win
     # over the cancellation (status-first classification for skipped statuses;
@@ -230,7 +230,11 @@ def request_bounded(
                 raise TimeoutError(f"{context} deadline expired before the request started")
             result.append(asyncio.run(asyncio.wait_for(_do(), remaining)))
         except Exception as exc:  # captured and re-raised on the caller thread
-            error.append(exc)
+            # Stamp the capture instant: the caller must classify a wire
+            # fault by WHEN it happened (in or past the deadline), and its
+            # own clock read after the join would misdate an in-deadline
+            # fault whose join crossed the bound.
+            error.append((exc, time.monotonic()))
 
     worker = threading.Thread(target=_runner, daemon=True)
     worker.start()
@@ -246,7 +250,7 @@ def request_bounded(
     if worker.is_alive():
         raise httpx.ReadTimeout(f"{context} request exceeded the timeout deadline")
     if error:
-        exc = error[0]
+        exc, captured_at = error[0]
         # On Python >= 3.11 (this package's floor) asyncio.TimeoutError IS the
         # builtin TimeoutError, so this catches wait_for's deadline expiry.
         if isinstance(exc, TimeoutError):
@@ -260,6 +264,16 @@ def request_bounded(
                 # dominates the deadline race.
                 return outcome[0]
             raise httpx.ReadTimeout(f"{context} request exceeded the timeout deadline") from exc
+        if (
+            isinstance(exc, httpx.HTTPError)
+            and not isinstance(exc, httpx.TimeoutException)
+            and captured_at > deadline_ts
+        ):
+            # A wire fault that became runnable past the total deadline is the
+            # timeout it raced (wait_for's already-due cancellation), not a
+            # distinct transport fault: a late connection reset must feed the
+            # poll loop's transient backoff, never terminate the flow.
+            raise httpx.ReadTimeout(f"{context} failed past the total deadline") from exc
         raise exc
     if not result:
         # The worker died without a result AND without recording an exception

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -200,7 +200,12 @@ def request_bounded(
 
     def _runner() -> None:
         try:
-            result.append(asyncio.run(asyncio.wait_for(_do(), timeout)))
+            # Budget from the CALLER'S deadline, not a fresh full timeout: a
+            # late-scheduled worker (thread/CPU pressure) must not start a
+            # whole new window after the advertised bound — near zero, the
+            # request times out immediately instead of POSTing past it.
+            remaining = max(0.001, deadline_ts - time.monotonic())
+            result.append(asyncio.run(asyncio.wait_for(_do(), remaining)))
         except Exception as exc:  # captured and re-raised on the caller thread
             error.append(exc)
 

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -37,7 +37,7 @@ _WORKER_JOIN_GRACE = 1.0
 #: beyond this is nonsensical, and a huge finite value would overflow the
 #: wall-clock wait primitive (asyncio.wait_for / thread join); callers clamp
 #: to their operation default above it (see ``_normalize_timeout``).
-_MAX_REQUEST_TIMEOUT = 3600.0
+MAX_REQUEST_TIMEOUT = 3600.0
 
 
 def request_bounded(
@@ -57,7 +57,7 @@ def request_bounded(
     body). ``params``, when given, is sent as a form body (POST).
 
     ``timeout`` must arrive ALREADY normalized — finite, positive, and no greater
-    than :data:`_MAX_REQUEST_TIMEOUT` (callers run it through
+    than :data:`MAX_REQUEST_TIMEOUT` (callers run it through
     ``discovery._normalize_timeout``, which this module cannot import without a
     cycle). An unnormalized value would disable the ``wait_for`` deadline
     (``inf`` never fires) or overflow the wait primitive.
@@ -95,12 +95,12 @@ def request_bounded(
         isinstance(timeout, bool)
         or not isinstance(timeout, (int, float))
         or timeout <= 0
-        or timeout > _MAX_REQUEST_TIMEOUT
+        or timeout > MAX_REQUEST_TIMEOUT
         or not math.isfinite(timeout)
     ):
         raise ValueError(
             "request_bounded: timeout must be a finite positive number of seconds "
-            f"no greater than {_MAX_REQUEST_TIMEOUT}"
+            f"no greater than {MAX_REQUEST_TIMEOUT}"
         )
 
     # The body cap gets the same fail-fast discipline: a bool, float (inf

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -127,8 +127,14 @@ def request_bounded(
                 total += len(chunk)
                 if total > max_body_bytes:
                     # An oversized body is api_error, not a timeout — abort the
-                    # stream so it is never fully buffered.
-                    raise OAuthError("api_error", f"{context} response exceeds size cap")
+                    # stream so it is never fully buffered. Record the terminal
+                    # error BEFORE the context managers unwind: their awaited
+                    # cleanup can cross the deadline and be cancelled by
+                    # wait_for, which would otherwise soften this documented
+                    # size-cap error into a retryable timeout.
+                    exc = OAuthError("api_error", f"{context} response exceeds size cap")
+                    error_outcome.append(exc)
+                    raise exc
                 chunks.append(chunk)
             # Same completed-outcome recording as the skip path — but ONLY
             # when the body finished inside the deadline: the task can run
@@ -176,6 +182,10 @@ def request_bounded(
     # completed inside the monotonic deadline below).
     deadline_ts = time.monotonic() + timeout
     outcome: list[tuple[int, bytes]] = []
+    # Terminal errors recorded before async cleanup, same rationale as
+    # `outcome`: a documented api fault must survive a cleanup-crossing
+    # cancellation.
+    error_outcome: list[Exception] = []
 
     def _runner() -> None:
         try:
@@ -198,6 +208,10 @@ def request_bounded(
         # On Python >= 3.11 (this package's floor) asyncio.TimeoutError IS the
         # builtin TimeoutError, so this catches wait_for's deadline expiry.
         if isinstance(exc, TimeoutError):
+            if error_outcome:
+                # A documented terminal fault (the size cap) fired before the
+                # deadline — only its cleanup crossed it. The fault dominates.
+                raise error_outcome[0]
             if outcome:
                 # The response COMPLETED before the deadline — only the async
                 # cleanup crossed it and was cancelled. The known outcome

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -7,7 +7,10 @@ client from a watchdog thread does not interrupt a blocked read either. The
 core here runs an async client under ``asyncio.wait_for`` on a dedicated
 worker thread, so the deadline CANCELS the request (and closes the socket) —
 the caller is bounded regardless of chunk cadence AND the work is actually
-terminated, no leaked connection.
+terminated. (One documented residual below: a getaddrinfo blocked in the OS
+resolver runs on an executor thread cancellation cannot interrupt, so a
+slow-DNS attempt's daemon worker outlives the deadline until the resolver's
+own OS-bounded timeout.)
 """
 
 from __future__ import annotations
@@ -202,9 +205,13 @@ def request_bounded(
         try:
             # Budget from the CALLER'S deadline, not a fresh full timeout: a
             # late-scheduled worker (thread/CPU pressure) must not start a
-            # whole new window after the advertised bound — near zero, the
-            # request times out immediately instead of POSTing past it.
-            remaining = max(0.001, deadline_ts - time.monotonic())
+            # whole new window after the advertised bound.
+            remaining = deadline_ts - time.monotonic()
+            if remaining <= 0:
+                # Past the deadline before the request even started: refuse to
+                # open a connection at all (a device-token POST after code
+                # expiry above all).
+                raise TimeoutError(f"{context} deadline expired before the request started")
             result.append(asyncio.run(asyncio.wait_for(_do(), remaining)))
         except Exception as exc:  # captured and re-raised on the caller thread
             error.append(exc)
@@ -216,7 +223,10 @@ def request_bounded(
     # to unwind; if even that stalls (a pathological async cleanup hang), return a
     # timeout rather than block the caller — the daemon worker never blocks
     # interpreter exit. This is bounded AND non-leaking in every non-pathological case.
-    worker.join(timeout + _WORKER_JOIN_GRACE)
+    # Join with the REMAINING deadline budget (not the full timeout): a
+    # late-started worker already consumed part of the window, and the caller's
+    # total bound must hold regardless of scheduling pressure.
+    worker.join(max(0.001, deadline_ts - time.monotonic()) + _WORKER_JOIN_GRACE)
     if worker.is_alive():
         raise httpx.ReadTimeout(f"{context} request exceeded the timeout deadline")
     if error:

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -70,6 +70,10 @@ def request_bounded(
     raises :class:`OAuthError` (``api_error``). ``context`` labels both messages.
     """
 
+    # Fail fast on unknown verbs (a typo like "POTS" would otherwise go to
+    # httpx as-is), matching the Ruby primitive's :get/:post contract.
+    if method.upper() not in ("GET", "POST"):
+        raise ValueError("request_bounded: method must be GET or POST")
     if params is not None and method.upper() != "POST":
         # A form body on a non-POST would emit e.g. a GET-with-body — commonly
         # rejected server-side and hard to debug; fail fast on the misuse.
@@ -139,8 +143,9 @@ def request_bounded(
                 # of `result` too, so the caller classifies it as the timeout
                 # it is.
                 raise TimeoutError(f"{context} body completed past the total deadline")
-            outcome.append((response.status_code, b"".join(chunks)))
-            return response.status_code, b"".join(chunks)
+            joined = b"".join(chunks)
+            outcome.append((response.status_code, joined))
+            return response.status_code, joined
 
     # httpx's timeout is per-read (it resets on every received chunk) and httpx has
     # NO total-request timeout, so a peer slow-dripping header or body bytes just

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -159,4 +159,10 @@ def request_bounded(
         if isinstance(exc, TimeoutError):
             raise httpx.ReadTimeout(f"{context} request exceeded the timeout deadline") from exc
         raise exc
+    if not result:
+        # The worker died without a result AND without recording an exception
+        # (a BaseException such as KeyboardInterrupt escaping the except
+        # Exception net). Fail closed inside the documented contract rather
+        # than leak an IndexError.
+        raise httpx.TransportError(f"{context} request worker exited without a result")
     return result[0]

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -277,18 +277,20 @@ def request_bounded(
         raise httpx.ReadTimeout(f"{context} request exceeded the timeout deadline")
     if error:
         exc, captured_at = error[0]
+        # Recorded outcomes dominate WHATEVER the exception is — a wait_for
+        # cancellation of late cleanup, or an httpx error raised BY the
+        # response/client __aexit__ while closing an unconsumed stream. A
+        # known non-2xx skip or completed body must not soften into a
+        # retryable network error, and a documented terminal fault (the size
+        # cap) must not become a transport failure, because only CLEANUP
+        # misbehaved after the fact.
+        if error_outcome:
+            raise error_outcome[0]
+        if outcome:
+            return outcome[0]
         # On Python >= 3.11 (this package's floor) asyncio.TimeoutError IS the
         # builtin TimeoutError, so this catches wait_for's deadline expiry.
         if isinstance(exc, TimeoutError):
-            if error_outcome:
-                # A documented terminal fault (the size cap) fired before the
-                # deadline — only its cleanup crossed it. The fault dominates.
-                raise error_outcome[0]
-            if outcome:
-                # The response COMPLETED before the deadline — only the async
-                # cleanup crossed it and was cancelled. The known outcome
-                # dominates the deadline race.
-                return outcome[0]
             if wire_fault and wire_fault[0][1] <= deadline_ts:
                 # A wire fault observed IN deadline whose cleanup was
                 # cancelled by wait_for: the terminal transport failure

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -13,6 +13,7 @@ terminated, no leaked connection.
 from __future__ import annotations
 
 import asyncio
+import math
 import threading
 from collections.abc import Callable
 
@@ -73,6 +74,27 @@ def request_bounded(
         # rejected server-side and hard to debug; fail fast on the misuse.
         raise ValueError("request_bounded: params (a form body) is only valid with POST")
 
+    # Defensive enforcement of the caller-normalization contract: an inf/nan/
+    # non-positive/oversized timeout would disable or overflow the wait_for
+    # deadline and the thread join — the very bound this module exists to
+    # provide. Callers run through _normalize_timeout; a violation here is a
+    # programming error, so fail fast. Range checks run BEFORE math.isfinite:
+    # isfinite converts an int to float, so an astronomically large int
+    # (10**400) would raise OverflowError out of the guard instead of this
+    # ValueError; int/float comparisons never convert, and NaN compares False
+    # on both, falling through to the isfinite reject.
+    if (
+        isinstance(timeout, bool)
+        or not isinstance(timeout, (int, float))
+        or timeout <= 0
+        or timeout > _MAX_REQUEST_TIMEOUT
+        or not math.isfinite(timeout)
+    ):
+        raise ValueError(
+            "request_bounded: timeout must be a finite positive number of seconds "
+            f"no greater than {_MAX_REQUEST_TIMEOUT}"
+        )
+
     async def _do() -> tuple[int, bytes]:
         async with (
             httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client,
@@ -96,8 +118,14 @@ def request_bounded(
     # under that interval could otherwise hold the request open indefinitely
     # (verified); closing a sync client from a watchdog does not interrupt a blocked
     # read either. asyncio.wait_for CANCELS the request (and closes the socket) at
-    # the deadline — the caller is bounded AND the work is actually terminated, no
-    # leaked worker.
+    # the deadline — the caller is bounded AND the socket work is actually
+    # terminated. Known residual: a getaddrinfo blocked in the OS resolver runs on
+    # an executor thread that cancellation cannot interrupt, so a slow-DNS attempt
+    # leaves a daemon worker alive until the RESOLVER's own timeout (seconds to
+    # ~30s, OS-bounded) — the caller still returns at the deadline, the stragglers
+    # are bounded in lifetime by the resolver and in count by the attempt rate,
+    # and they never block interpreter exit. Sync Python offers no stronger
+    # DNS bound short of process isolation.
     #
     # Run it in a DEDICATED thread with its own event loop rather than calling
     # asyncio.run() here: this sync helper may be invoked from code that already has

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -111,24 +111,49 @@ def request_bounded(
     if isinstance(max_body_bytes, bool) or not isinstance(max_body_bytes, int) or max_body_bytes < 0:
         raise ValueError("request_bounded: max_body_bytes must be a non-negative int")
 
+    # Identity encoding + aiter_raw(): httpx transparently inflates
+    # gzip/deflate in aiter_bytes(), so the per-chunk cap would measure
+    # DECODED bytes — a small compressed body could balloon far past
+    # max_body_bytes in memory (compression bomb). Request identity and
+    # read the RAW wire bytes; a server compressing anyway hands over
+    # compressed bytes bounded by the cap, which then fail classification
+    # upstream instead of exhausting memory.
+    # Case-insensitive replacement: a caller passing "accept-encoding"
+    # would otherwise coexist with our key and emit duplicate headers,
+    # undermining the identity-only compression-bomb bound (the Ruby
+    # transport filters the same way).
+    request_headers = {k: v for k, v in headers.items() if k.lower() != "accept-encoding"}
+    request_headers["Accept-Encoding"] = "identity"
+
     async def _do() -> tuple[int, bytes]:
-        # Identity encoding + aiter_raw(): httpx transparently inflates
-        # gzip/deflate in aiter_bytes(), so the per-chunk cap would measure
-        # DECODED bytes — a small compressed body could balloon far past
-        # max_body_bytes in memory (compression bomb). Request identity and
-        # read the RAW wire bytes; a server compressing anyway hands over
-        # compressed bytes bounded by the cap, which then fail classification
-        # upstream instead of exhausting memory.
-        # Case-insensitive replacement: a caller passing "accept-encoding"
-        # would otherwise coexist with our key and emit duplicate headers,
-        # undermining the identity-only compression-bomb bound (the Ruby
-        # transport filters the same way).
-        request_headers = {k: v for k, v in headers.items() if k.lower() != "accept-encoding"}
-        request_headers["Accept-Encoding"] = "identity"
-        async with (
-            httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client,
-            client.stream(method, url, data=params, headers=request_headers) as response,
-        ):
+        try:
+            return await _do_inner()
+        except httpx.HTTPError as exc:
+            # Backstop stamp for faults that escape before the interior
+            # try (client construction above all); the interior stamp — taken
+            # before any context manager unwinds — wins when present.
+            if not wire_fault and not isinstance(exc, httpx.TimeoutException):
+                wire_fault.append((exc, time.monotonic()))
+            raise
+
+    async def _do_inner() -> tuple[int, bytes]:
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client:
+            try:
+                return await _request(client)
+            except httpx.HTTPError as exc:
+                # Stamp non-timeout wire faults at the exception SITE, before
+                # the client's cleanup unwinds: __aexit__ can cross the
+                # deadline (misdating an in-deadline fault as post-deadline)
+                # or be cancelled by wait_for (replacing the fault with
+                # TimeoutError entirely) — either way the terminal transport
+                # failure must survive, mirroring completed-outcome
+                # preservation.
+                if not wire_fault and not isinstance(exc, httpx.TimeoutException):
+                    wire_fault.append((exc, time.monotonic()))
+                raise
+
+    async def _request(client: httpx.AsyncClient) -> tuple[int, bytes]:
+        async with client.stream(method, url, data=params, headers=request_headers) as response:
             if not read_body(response.status_code):
                 # Deadline first, symmetric with the body paths: headers
                 # becoming runnable past the total bound mean the status was
@@ -205,6 +230,7 @@ def request_bounded(
     # is_alive backstop after it covers only a pathological async-cleanup hang.
     result: list[tuple[int, bytes]] = []
     error: list[tuple[Exception, float]] = []
+    wire_fault: list[tuple[Exception, float]] = []
     # Completed outcomes recorded INSIDE _do before async cleanup: when
     # wait_for cancels mid-unwind, the response is already known and must win
     # over the cancellation (status-first classification for skipped statuses;
@@ -263,17 +289,23 @@ def request_bounded(
                 # cleanup crossed it and was cancelled. The known outcome
                 # dominates the deadline race.
                 return outcome[0]
+            if wire_fault and wire_fault[0][1] <= deadline_ts:
+                # A wire fault observed IN deadline whose cleanup was
+                # cancelled by wait_for: the terminal transport failure
+                # dominates the cancellation that replaced it.
+                raise wire_fault[0][0]
             raise httpx.ReadTimeout(f"{context} request exceeded the timeout deadline") from exc
-        if (
-            isinstance(exc, httpx.HTTPError)
-            and not isinstance(exc, httpx.TimeoutException)
-            and captured_at > deadline_ts
-        ):
-            # A wire fault that became runnable past the total deadline is the
-            # timeout it raced (wait_for's already-due cancellation), not a
-            # distinct transport fault: a late connection reset must feed the
-            # poll loop's transient backoff, never terminate the flow.
-            raise httpx.ReadTimeout(f"{context} failed past the total deadline") from exc
+        if isinstance(exc, httpx.HTTPError) and not isinstance(exc, httpx.TimeoutException):
+            # Date the fault by its exception-SITE stamp when available — the
+            # runner-level stamp lands after cleanup, which can cross the
+            # deadline and misdate an in-deadline fault.
+            stamped_at = wire_fault[0][1] if wire_fault else captured_at
+            if stamped_at > deadline_ts:
+                # A wire fault that became runnable past the total deadline is
+                # the timeout it raced (wait_for's already-due cancellation),
+                # not a distinct transport fault: a late connection reset must
+                # feed the poll loop's transient backoff, never terminate.
+                raise httpx.ReadTimeout(f"{context} failed past the total deadline") from exc
         raise exc
     if not result:
         # The worker died without a result AND without recording an exception

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -130,11 +130,19 @@ def request_bounded(
             client.stream(method, url, data=params, headers=request_headers) as response,
         ):
             if not read_body(response.status_code):
-                # Record the KNOWN outcome before the context managers unwind:
-                # the awaited response/client cleanup can cross the total
-                # deadline and be cancelled by wait_for, and a skipped non-2xx
-                # must classify by status (api_error), never soften into a
-                # retryable timeout because only its cleanup was late.
+                # Deadline first, symmetric with the body paths: headers
+                # becoming runnable past the total bound mean the status was
+                # NOT known before the deadline — classify as the timeout it
+                # is rather than racing ahead of wait_for's already-due
+                # callback into a status fault.
+                if time.monotonic() > deadline_ts:
+                    raise TimeoutError(f"{context} headers arrived past the total deadline")
+                # Record the KNOWN, in-deadline outcome before the context
+                # managers unwind: the awaited response/client cleanup can
+                # cross the total deadline and be cancelled by wait_for, and a
+                # skipped non-2xx must classify by status (api_error), never
+                # soften into a retryable timeout because only its CLEANUP was
+                # late.
                 outcome.append((response.status_code, b""))
                 return response.status_code, b""
             chunks: list[bytes] = []

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -132,8 +132,14 @@ def request_bounded(
             # completing past the advertised bound must not be accepted.
             # (Skipped statuses stay status-first regardless — their
             # classification is header-time knowledge.)
-            if time.monotonic() <= deadline_ts:
-                outcome.append((response.status_code, b"".join(chunks)))
+            if time.monotonic() > deadline_ts:
+                # The body finished past the advertised bound but this
+                # coroutine ran ahead of wait_for's already-due timeout
+                # callback — raising (not returning) keeps the late body out
+                # of `result` too, so the caller classifies it as the timeout
+                # it is.
+                raise TimeoutError(f"{context} body completed past the total deadline")
+            outcome.append((response.status_code, b"".join(chunks)))
             return response.status_code, b"".join(chunks)
 
     # httpx's timeout is per-read (it resets on every received chunk) and httpx has

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -104,10 +104,12 @@ def request_bounded(
         )
 
     # The body cap gets the same fail-fast discipline: a bool, float (inf
-    # included), or non-positive value would disable or crash the streaming
-    # bound this core exists to provide.
-    if isinstance(max_body_bytes, bool) or not isinstance(max_body_bytes, int) or max_body_bytes <= 0:
-        raise ValueError("request_bounded: max_body_bytes must be a positive int")
+    # included), or negative value would disable or crash the streaming bound
+    # this core exists to provide. Same predicate as ``_normalize_body_cap``
+    # so the transport can never reject a cap the public entry points accept —
+    # zero is a legitimate strict cap (any non-empty body trips it).
+    if isinstance(max_body_bytes, bool) or not isinstance(max_body_bytes, int) or max_body_bytes < 0:
+        raise ValueError("request_bounded: max_body_bytes must be a non-negative int")
 
     async def _do() -> tuple[int, bytes]:
         # Identity encoding + aiter_raw(): httpx transparently inflates

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -109,6 +109,12 @@ def request_bounded(
             client.stream(method, url, data=params, headers=request_headers) as response,
         ):
             if not read_body(response.status_code):
+                # Record the KNOWN outcome before the context managers unwind:
+                # the awaited response/client cleanup can cross the total
+                # deadline and be cancelled by wait_for, and a skipped non-2xx
+                # must classify by status (api_error), never soften into a
+                # retryable timeout because only its cleanup was late.
+                outcome.append((response.status_code, b""))
                 return response.status_code, b""
             chunks: list[bytes] = []
             total = 0
@@ -119,6 +125,9 @@ def request_bounded(
                     # stream so it is never fully buffered.
                     raise OAuthError("api_error", f"{context} response exceeds size cap")
                 chunks.append(chunk)
+            # Same completed-outcome recording as the skip path: a fully read
+            # body must not be discarded because cleanup crossed the deadline.
+            outcome.append((response.status_code, b"".join(chunks)))
             return response.status_code, b"".join(chunks)
 
     # httpx's timeout is per-read (it resets on every received chunk) and httpx has
@@ -143,6 +152,11 @@ def request_bounded(
     # is_alive backstop after it covers only a pathological async-cleanup hang.
     result: list[tuple[int, bytes]] = []
     error: list[Exception] = []
+    # Completed outcomes recorded INSIDE _do before async cleanup: when
+    # wait_for cancels mid-unwind, the response is already known and must win
+    # over the cancellation (status-first classification for skipped statuses;
+    # a fully read body likewise survives a late cleanup).
+    outcome: list[tuple[int, bytes]] = []
 
     def _runner() -> None:
         try:
@@ -165,6 +179,11 @@ def request_bounded(
         # On Python >= 3.11 (this package's floor) asyncio.TimeoutError IS the
         # builtin TimeoutError, so this catches wait_for's deadline expiry.
         if isinstance(exc, TimeoutError):
+            if outcome:
+                # The response COMPLETED before the deadline — only the async
+                # cleanup crossed it and was cancelled. The known outcome
+                # dominates the deadline race.
+                return outcome[0]
             raise httpx.ReadTimeout(f"{context} request exceeded the timeout deadline") from exc
         raise exc
     if not result:

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -96,15 +96,23 @@ def request_bounded(
         )
 
     async def _do() -> tuple[int, bytes]:
+        # Identity encoding + aiter_raw(): httpx transparently inflates
+        # gzip/deflate in aiter_bytes(), so the per-chunk cap would measure
+        # DECODED bytes — a small compressed body could balloon far past
+        # max_body_bytes in memory (compression bomb). Request identity and
+        # read the RAW wire bytes; a server compressing anyway hands over
+        # compressed bytes bounded by the cap, which then fail classification
+        # upstream instead of exhausting memory.
+        request_headers = {**headers, "Accept-Encoding": "identity"}
         async with (
             httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client,
-            client.stream(method, url, data=params, headers=headers) as response,
+            client.stream(method, url, data=params, headers=request_headers) as response,
         ):
             if not read_body(response.status_code):
                 return response.status_code, b""
             chunks: list[bytes] = []
             total = 0
-            async for chunk in response.aiter_bytes():
+            async for chunk in response.aiter_raw():
                 total += len(chunk)
                 if total > max_body_bytes:
                     # An oversized body is api_error, not a timeout — abort the

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import math
 import threading
+import time
 from collections.abc import Callable
 
 import httpx
@@ -125,9 +126,14 @@ def request_bounded(
                     # stream so it is never fully buffered.
                     raise OAuthError("api_error", f"{context} response exceeds size cap")
                 chunks.append(chunk)
-            # Same completed-outcome recording as the skip path: a fully read
-            # body must not be discarded because cleanup crossed the deadline.
-            outcome.append((response.status_code, b"".join(chunks)))
+            # Same completed-outcome recording as the skip path — but ONLY
+            # when the body finished inside the deadline: the task can run
+            # ahead of wait_for's already-due timeout callback, and a body
+            # completing past the advertised bound must not be accepted.
+            # (Skipped statuses stay status-first regardless — their
+            # classification is header-time knowledge.)
+            if time.monotonic() <= deadline_ts:
+                outcome.append((response.status_code, b"".join(chunks)))
             return response.status_code, b"".join(chunks)
 
     # httpx's timeout is per-read (it resets on every received chunk) and httpx has
@@ -155,7 +161,9 @@ def request_bounded(
     # Completed outcomes recorded INSIDE _do before async cleanup: when
     # wait_for cancels mid-unwind, the response is already known and must win
     # over the cancellation (status-first classification for skipped statuses;
-    # a fully read body likewise survives a late cleanup).
+    # a fully read body likewise survives a late cleanup — but only when it
+    # completed inside the monotonic deadline below).
+    deadline_ts = time.monotonic() + timeout
     outcome: list[tuple[int, bytes]] = []
 
     def _runner() -> None:

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -33,6 +33,16 @@ from basecamp.oauth.errors import OAuthError
 #: worker never blocks interpreter exit if even this stalls.
 _WORKER_JOIN_GRACE = 1.0
 
+#: Cap on concurrently OUTSTANDING transport workers. A worker abandoned on a
+#: stuck resolver (getaddrinfo is uninterruptible; asyncio.run then blocks in
+#: shutdown_default_executor) parks itself AND an executor thread — and
+#: concurrent.futures joins executor threads at interpreter shutdown, so
+#: unbounded accumulation against a black-holed resolver could pile up
+#: threads and delay process exit. Each worker releases its own slot when it
+#: actually finishes; an abandoned worker keeps its slot held until the
+#: resolver unsticks, so at most this many can ever be outstanding.
+_WORKER_SLOTS = threading.BoundedSemaphore(8)
+
 #: Upper bound (seconds) on a bounded request timeout. A per-request timeout
 #: beyond this is nonsensical, and a huge finite value would overflow the
 #: wall-clock wait primitive (asyncio.wait_for / thread join); callers clamp
@@ -257,6 +267,15 @@ def request_bounded(
 
     def _runner() -> None:
         try:
+            _run_bounded()
+        finally:
+            # The worker itself releases the slot: an abandoned (still-stuck)
+            # worker keeps its slot held, which is exactly what bounds the
+            # pile-up.
+            _WORKER_SLOTS.release()
+
+    def _run_bounded() -> None:
+        try:
             # Budget from the CALLER'S deadline, not a fresh full timeout: a
             # late-scheduled worker (thread/CPU pressure) must not start a
             # whole new window after the advertised bound.
@@ -274,13 +293,25 @@ def request_bounded(
             # fault whose join crossed the bound.
             error.append((exc, time.monotonic()))
 
+    # Acquire a worker slot inside the remaining budget: if every slot is
+    # held by workers stuck on uninterruptible resolver calls, fail as the
+    # timeout this request would have become anyway — without adding another
+    # stuck thread to the pile.
+    if not _WORKER_SLOTS.acquire(timeout=max(0.001, deadline_ts - time.monotonic())):
+        raise httpx.ConnectTimeout(f"{context} transport worker slots exhausted")
     worker = threading.Thread(target=_runner, daemon=True)
-    worker.start()
+    try:
+        worker.start()
+    except BaseException:
+        _WORKER_SLOTS.release()
+        raise
     # asyncio.wait_for cancels the request at `timeout`, so the worker normally
     # finishes well within it. Join with a small grace for the cancellation/cleanup
-    # to unwind; if even that stalls (a pathological async cleanup hang), return a
-    # timeout rather than block the caller — the daemon worker never blocks
-    # interpreter exit. This is bounded AND non-leaking in every non-pathological case.
+    # to unwind; if even that stalls (an uninterruptible resolver call above
+    # all), return a timeout rather than block the caller. The abandoned
+    # worker holds its _WORKER_SLOTS slot until it unsticks, bounding how many
+    # can ever pile up (executor threads are joined at interpreter shutdown,
+    # so the pile-up — not this single worker — is what could delay exit).
     # Join with the REMAINING deadline budget (not the full timeout): a
     # late-started worker already consumed part of the window, and the caller's
     # total bound must hold regardless of scheduling pressure.

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -379,7 +379,7 @@ def poll_device_token(
     # remaining-lifetime clamp takes min() against it, and an invalid runtime
     # value (None → TypeError from min, a negative, an oversized 1e100) must
     # resolve to the device budget BEFORE any arithmetic touches it.
-    timeout = _normalize_timeout(timeout, _DEVICE_TIMEOUT, maximum=_MAX_DEVICE_REQUEST_TIMEOUT)
+    timeout = _normalize_timeout(timeout, _DEVICE_TIMEOUT, maximum=_MAX_REQUEST_TIMEOUT)
 
     # The server-driven interval (initial value + sustained slow_down bumps) is
     # tracked SEPARATELY from the transient timeout backoff: each wait is

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -23,7 +23,7 @@ from typing import Any
 import httpx
 
 from basecamp._security import is_localhost, require_https, truncate
-from basecamp.oauth._transport import _MAX_REQUEST_TIMEOUT, request_bounded
+from basecamp.oauth._transport import MAX_REQUEST_TIMEOUT, request_bounded
 from basecamp.oauth.config import OAuthConfig
 from basecamp.oauth.device_authorization import DeviceAuthorization
 from basecamp.oauth.discovery import _normalize_body_cap, _normalize_timeout
@@ -95,7 +95,7 @@ def _post_form_bounded(
     """
     # Normalize BEFORE the transport core, which requires a finite, positive,
     # in-range timeout (see request_bounded).
-    timeout = _normalize_timeout(timeout, _DEVICE_TIMEOUT, maximum=_MAX_REQUEST_TIMEOUT)
+    timeout = _normalize_timeout(timeout, _DEVICE_TIMEOUT, maximum=MAX_REQUEST_TIMEOUT)
     return request_bounded(
         "POST",
         url,
@@ -379,7 +379,7 @@ def poll_device_token(
     # remaining-lifetime clamp takes min() against it, and an invalid runtime
     # value (None → TypeError from min, a negative, an oversized 1e100) must
     # resolve to the device budget BEFORE any arithmetic touches it.
-    timeout = _normalize_timeout(timeout, _DEVICE_TIMEOUT, maximum=_MAX_REQUEST_TIMEOUT)
+    timeout = _normalize_timeout(timeout, _DEVICE_TIMEOUT, maximum=MAX_REQUEST_TIMEOUT)
 
     # The server-driven interval (initial value + sustained slow_down bumps) is
     # tracked SEPARATELY from the transient timeout backoff: each wait is

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -13,10 +13,8 @@ clock and sleep are injectable so tests can drive the interval schedule
 
 from __future__ import annotations
 
-import asyncio
 import json
 import math
-import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -25,6 +23,7 @@ from typing import Any
 import httpx
 
 from basecamp._security import is_localhost, require_https, truncate
+from basecamp.oauth._transport import _MAX_REQUEST_TIMEOUT, request_bounded
 from basecamp.oauth.config import OAuthConfig
 from basecamp.oauth.device_authorization import DeviceAuthorization
 from basecamp.oauth.discovery import _normalize_body_cap, _normalize_timeout
@@ -58,22 +57,8 @@ MAX_TOKEN_LIFETIME_SECONDS = 2_147_483_647
 
 _DEVICE_TIMEOUT = 30.0
 
-#: Upper bound (seconds) on a device request timeout. A per-request timeout beyond
-#: this is nonsensical, and a huge finite value would overflow the wall-clock wait
-#: primitive (asyncio.wait_for / thread join); clamp to the default above it.
-_MAX_DEVICE_REQUEST_TIMEOUT = 3600.0
-
 #: Granularity (seconds) for polling ``should_cancel`` while waiting between polls.
 _CANCEL_POLL_INTERVAL = 0.1
-
-#: Extra time (seconds) to let a timed-out request's async cancellation/cleanup
-#: unwind before the caller abandons the (daemon) worker and returns a timeout.
-#: Kept SMALL so the caller's worst-case block stays ~timeout: near expiry the
-#: request budget is clamped to the remaining code lifetime, and this grace is
-#: the only overshoot past the polling deadline — cleanup after a wait_for
-#: cancellation is just closing a socket, and joining with no grace at all
-#: would race a request that completes right at the deadline.
-_WORKER_JOIN_GRACE = 1.0
 
 # Cap on a device-flow response body (1 MiB) — these responses are tiny; a
 # larger one is a fault, so abort rather than buffer it. Mirrors discovery.
@@ -94,8 +79,9 @@ def _post_form_bounded(
 ) -> tuple[int, bytes]:
     """SSRF-hardened form POST: suppress redirects, bound the timeout, and read
     the body under a genuine streaming cap that aborts once ``max_body_bytes`` is
-    exceeded (never a post-hoc check on an already-buffered body). Mirrors
-    :func:`basecamp.oauth.discovery._fetch_discovery_document`.
+    exceeded (never a post-hoc check on an already-buffered body). Delegates to
+    :func:`basecamp.oauth._transport.request_bounded`, which also bounds the
+    WHOLE round-trip (httpx's per-read timeout alone cannot).
 
     ``read_body(status)`` decides — from the response status, known once headers
     arrive — whether the body is drained. A caller returns ``False`` for statuses
@@ -107,66 +93,19 @@ def _post_form_bounded(
     :class:`httpx.TimeoutException`) so callers classify them; an oversized body
     raises :class:`OAuthError` (``api_error``).
     """
-    timeout = _normalize_timeout(timeout, _DEVICE_TIMEOUT, maximum=_MAX_DEVICE_REQUEST_TIMEOUT)
-
-    async def _do() -> tuple[int, bytes]:
-        async with (
-            httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client,
-            client.stream("POST", url, data=params, headers=_FORM_HEADERS) as response,
-        ):
-            if not read_body(response.status_code):
-                return response.status_code, b""
-            chunks: list[bytes] = []
-            total = 0
-            async for chunk in response.aiter_bytes():
-                total += len(chunk)
-                if total > max_body_bytes:
-                    # An oversized body is api_error, not a timeout — abort the
-                    # stream so it is never fully buffered.
-                    raise OAuthError("api_error", "Device flow response exceeds size cap")
-                chunks.append(chunk)
-            return response.status_code, b"".join(chunks)
-
-    # httpx's timeout is per-read (it resets on every received chunk) and httpx has
-    # NO total-request timeout, so a peer slow-dripping header or body bytes just
-    # under that interval could otherwise hold the POST open indefinitely (verified);
-    # closing a sync client from a watchdog does not interrupt a blocked read either.
-    # asyncio.wait_for CANCELS the request (and closes the socket) at the deadline —
-    # the caller is bounded AND the work is actually terminated, no leaked worker.
-    #
-    # Run it in a DEDICATED thread with its own event loop rather than calling
-    # asyncio.run() here: this sync helper may be invoked from code that already has
-    # a running loop (Jupyter/FastAPI/async CLI), where asyncio.run() raises
-    # RuntimeError before any request is made. wait_for bounds the thread's work at
-    # ~timeout, so the bounded join below normally returns almost immediately; the
-    # is_alive backstop after it covers only a pathological async-cleanup hang.
-    result: list[tuple[int, bytes]] = []
-    error: list[Exception] = []
-
-    def _runner() -> None:
-        try:
-            result.append(asyncio.run(asyncio.wait_for(_do(), timeout)))
-        except Exception as exc:  # captured and re-raised on the caller thread
-            error.append(exc)
-
-    worker = threading.Thread(target=_runner, daemon=True)
-    worker.start()
-    # asyncio.wait_for cancels the request at `timeout`, so the worker normally
-    # finishes well within it. Join with a small grace for the cancellation/cleanup
-    # to unwind; if even that stalls (a pathological async cleanup hang), return a
-    # timeout rather than block the caller — the daemon worker never blocks
-    # interpreter exit. This is bounded AND non-leaking in every non-pathological case.
-    worker.join(timeout + _WORKER_JOIN_GRACE)
-    if worker.is_alive():
-        raise httpx.ReadTimeout("Device flow request exceeded the timeout deadline")
-    if error:
-        exc = error[0]
-        # On Python >= 3.11 (this package's floor) asyncio.TimeoutError IS the
-        # builtin TimeoutError, so this catches wait_for's deadline expiry.
-        if isinstance(exc, TimeoutError):
-            raise httpx.ReadTimeout("Device flow request exceeded the timeout deadline") from exc
-        raise exc
-    return result[0]
+    # Normalize BEFORE the transport core, which requires a finite, positive,
+    # in-range timeout (see request_bounded).
+    timeout = _normalize_timeout(timeout, _DEVICE_TIMEOUT, maximum=_MAX_REQUEST_TIMEOUT)
+    return request_bounded(
+        "POST",
+        url,
+        headers=_FORM_HEADERS,
+        params=params,
+        timeout=timeout,
+        max_body_bytes=max_body_bytes,
+        read_body=read_body,
+        context="Device flow",
+    )
 
 
 def request_device_authorization(

--- a/python/src/basecamp/oauth/discovery.py
+++ b/python/src/basecamp/oauth/discovery.py
@@ -22,7 +22,7 @@ import httpx
 
 from basecamp._security import require_origin_root
 from basecamp.errors import BasecampError
-from basecamp.oauth._transport import _MAX_REQUEST_TIMEOUT, request_bounded
+from basecamp.oauth._transport import MAX_REQUEST_TIMEOUT, request_bounded
 from basecamp.oauth.config import (
     DiscoveryResult,
     FallbackReason,
@@ -147,7 +147,7 @@ def _fetch_discovery_document(url: str, timeout: float, max_body_bytes: int) -> 
     # Normalize BEFORE the transport core, which requires a finite, positive,
     # in-range timeout: a non-finite/non-positive value must not disable the
     # total-request bound (see _normalize_timeout / request_bounded).
-    timeout = _normalize_timeout(timeout, maximum=_MAX_REQUEST_TIMEOUT)
+    timeout = _normalize_timeout(timeout, maximum=MAX_REQUEST_TIMEOUT)
     try:
         # STATUS DOMINATES THE BODY (SPEC.md: non-2xx on either hop → api_error,
         # never network): skip draining a non-2xx body so a stalled/dripped error

--- a/python/src/basecamp/oauth/discovery.py
+++ b/python/src/basecamp/oauth/discovery.py
@@ -20,7 +20,7 @@ from typing import Any
 
 import httpx
 
-from basecamp._security import require_origin_root, truncate
+from basecamp._security import require_origin_root
 from basecamp.errors import BasecampError
 from basecamp.oauth._transport import _MAX_REQUEST_TIMEOUT, request_bounded
 from basecamp.oauth.config import (
@@ -149,15 +149,20 @@ def _fetch_discovery_document(url: str, timeout: float, max_body_bytes: int) -> 
     # total-request bound (see _normalize_timeout / request_bounded).
     timeout = _normalize_timeout(timeout, maximum=_MAX_REQUEST_TIMEOUT)
     try:
-        # The body is ALWAYS drained (the default read_body): unlike the device
-        # flow, a non-2xx discovery body is used — truncated into the api_error
-        # message below.
+        # STATUS DOMINATES THE BODY (SPEC.md: non-2xx on either hop → api_error,
+        # never network): skip draining a non-2xx body so a stalled/dripped error
+        # body cannot convert the required api_error into a retryable network
+        # timeout. The body text was only optional diagnostics — the other SDKs
+        # read it best-effort at most (TS swallows read failures, Go ignores the
+        # read error, Kotlin never reads it); category, retryability, and
+        # http_status are the observable contract.
         status, body = request_bounded(
             "GET",
             url,
             headers={"Accept": "application/json"},
             timeout=timeout,
             max_body_bytes=max_body_bytes,
+            read_body=lambda status_code: 200 <= status_code < 300,
             context="OAuth discovery",
         )
     except httpx.TimeoutException as exc:
@@ -170,7 +175,7 @@ def _fetch_discovery_document(url: str, timeout: float, max_body_bytes: int) -> 
     if not 200 <= status < 300:
         raise OAuthError(
             "api_error",
-            f"OAuth discovery failed with status {status}: {truncate(body.decode(errors='replace'))}",
+            f"OAuth discovery failed with status {status}",
             http_status=status,
         )
 

--- a/python/src/basecamp/oauth/discovery.py
+++ b/python/src/basecamp/oauth/discovery.py
@@ -16,13 +16,13 @@ from __future__ import annotations
 
 import json
 import math
-import time
 from typing import Any
 
 import httpx
 
 from basecamp._security import require_origin_root, truncate
 from basecamp.errors import BasecampError
+from basecamp.oauth._transport import _MAX_REQUEST_TIMEOUT, request_bounded
 from basecamp.oauth.config import (
     DiscoveryResult,
     FallbackReason,
@@ -89,10 +89,11 @@ def _normalize_timeout(timeout: object, default: float = _DISCOVERY_TIMEOUT, max
 
     ``timeout`` is *typed* ``float``, but a caller can pass ``None``, a non-number,
     a non-positive value, or ``float("inf")``/``nan`` at runtime. An infinite or
-    non-positive timeout would disable BOTH httpx's bound and the wall-clock
-    deadline below (``time.monotonic() > inf`` never trips), letting a slow-drip
-    endpoint hold the SSRF-hardened fetch open indefinitely. Fall back to
-    ``default`` so the bound can never be turned off — the same discipline as
+    non-positive timeout would disable BOTH httpx's per-read bound and the
+    total-request ``asyncio.wait_for`` deadline (an ``inf`` deadline never
+    fires), letting a slow-drip endpoint hold the SSRF-hardened fetch open
+    indefinitely. Fall back to ``default`` so the bound can never be turned off
+    — the same discipline as
     :func:`_normalize_body_cap`. ``bool`` is excluded (a subclass of ``int``, but
     a nonsensical timeout).
 
@@ -137,41 +138,28 @@ def _fetch_discovery_document(url: str, timeout: float, max_body_bytes: int) -> 
     """SSRF-hardened GET of a discovery document.
 
     The origin must already be validated (via :func:`require_origin_root`); this
-    suppresses redirects, bounds the timeout, reads the body under a genuine
-    streaming cap that aborts once ``max_body_bytes`` is exceeded, and maps any
-    non-2xx status to ``api_error`` (not ``network``).
+    suppresses redirects, bounds the WHOLE round-trip (via
+    :func:`basecamp.oauth._transport.request_bounded`), reads the body under a
+    genuine streaming cap that aborts once ``max_body_bytes`` is exceeded, and
+    maps any non-2xx status to ``api_error`` (not ``network``).
     """
     max_body_bytes = _normalize_body_cap(max_body_bytes)
-    # Normalize BEFORE httpx and before the deadline: a non-finite/non-positive
-    # timeout must not disable either bound (see _normalize_timeout).
-    timeout = _normalize_timeout(timeout)
+    # Normalize BEFORE the transport core, which requires a finite, positive,
+    # in-range timeout: a non-finite/non-positive value must not disable the
+    # total-request bound (see _normalize_timeout / request_bounded).
+    timeout = _normalize_timeout(timeout, maximum=_MAX_REQUEST_TIMEOUT)
     try:
-        with httpx.stream(
+        # The body is ALWAYS drained (the default read_body): unlike the device
+        # flow, a non-2xx discovery body is used — truncated into the api_error
+        # message below.
+        status, body = request_bounded(
             "GET",
             url,
             headers={"Accept": "application/json"},
             timeout=timeout,
-            follow_redirects=False,
-        ) as response:
-            # httpx's timeout is per-operation and RESETS after each received
-            # chunk, so a peer dripping one byte at a time never trips the read
-            # timeout and can hold the caller arbitrarily long. Bound the WHOLE
-            # response with a wall-clock deadline so a slow-drip stream is aborted
-            # as a retryable network timeout regardless of chunk cadence.
-            deadline = time.monotonic() + timeout
-            chunks: list[bytes] = []
-            total = 0
-            for chunk in response.iter_bytes():
-                if time.monotonic() > deadline:
-                    raise OAuthError("network", "OAuth discovery timed out", retryable=True)
-                total += len(chunk)
-                if total > max_body_bytes:
-                    # Abort the stream — leaving the ``with`` closes the
-                    # connection, so the oversized body is never fully buffered.
-                    raise OAuthError("api_error", "OAuth discovery response exceeds size cap")
-                chunks.append(chunk)
-            status = response.status_code
-            body = b"".join(chunks)
+            max_body_bytes=max_body_bytes,
+            context="OAuth discovery",
+        )
     except httpx.TimeoutException as exc:
         raise OAuthError("network", "OAuth discovery timed out", retryable=True) from exc
     except httpx.HTTPError as exc:

--- a/python/tests/oauth/test_transport.py
+++ b/python/tests/oauth/test_transport.py
@@ -74,6 +74,41 @@ def test_discovery_header_stall_is_bounded_and_leaks_no_worker() -> None:
     assert _settled_thread_count(baseline) == baseline, "leaked transport worker thread"
 
 
+def test_discovery_non_2xx_with_stalled_body_is_immediate_api_error() -> None:
+    # SPEC.md: non-2xx on either discovery hop → api_error, never network —
+    # status dominates even when the error body stalls forever, so the fetch
+    # classifies at header time instead of timing the body out.
+    srv, port = _serve_on_localhost()
+    stop = threading.Event()
+
+    def stall() -> None:
+        conn, _ = srv.accept()
+        conn.recv(4096)
+        try:
+            conn.sendall(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 1000\r\n\r\n")
+            stop.wait()
+        except OSError:
+            pass
+        finally:
+            conn.close()
+
+    server = threading.Thread(target=stall, daemon=True)
+    server.start()
+    timeout = 0.5
+    try:
+        start = time.monotonic()
+        with pytest.raises(OAuthError) as exc_info:
+            discover_protected_resource(f"http://127.0.0.1:{port}", timeout=timeout)
+        elapsed = time.monotonic() - start
+        assert exc_info.value.code == "api_error"
+        assert exc_info.value.http_status == 500
+        assert elapsed < timeout, f"status must classify at header time, not after a body timeout: {elapsed:.2f}s"
+    finally:
+        stop.set()
+        server.join(2)
+        srv.close()
+
+
 def test_discovery_slow_drip_is_bounded_by_the_total_timeout() -> None:
     # httpx's read timeout resets on every received chunk, so a peer dripping a
     # VALID discovery document byte-by-byte (each read under the timeout) would

--- a/python/tests/oauth/test_transport.py
+++ b/python/tests/oauth/test_transport.py
@@ -74,6 +74,21 @@ def test_discovery_header_stall_is_bounded_and_leaks_no_worker() -> None:
     assert _settled_thread_count(baseline) == baseline, "leaked transport worker thread"
 
 
+def test_params_with_non_post_fails_fast() -> None:
+    # A form body on a GET would emit a GET-with-body; misuse fails fast instead.
+    from basecamp.oauth._transport import request_bounded
+
+    with pytest.raises(ValueError, match="only valid with POST"):
+        request_bounded(
+            "GET",
+            "https://issuer.example/x",
+            headers={},
+            params={"a": "b"},
+            timeout=1.0,
+            max_body_bytes=1024,
+        )
+
+
 def test_discovery_non_2xx_with_stalled_body_is_immediate_api_error() -> None:
     # SPEC.md: non-2xx on either discovery hop → api_error, never network —
     # status dominates even when the error body stalls forever, so the fetch

--- a/python/tests/oauth/test_transport.py
+++ b/python/tests/oauth/test_transport.py
@@ -1,0 +1,119 @@
+"""Real-socket transport-bounding tests for the shared bounded request core.
+
+respx serves a complete response instantly, so it can exercise neither a
+header-then-stall nor a byte-drip; these tests run a real localhost TCP server
+(discovery's origin validation exempts http on localhost) and drive the
+discovery fetch through :func:`basecamp.oauth._transport.request_bounded`.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import time
+
+import pytest
+
+from basecamp.oauth import OAuthError, discover_protected_resource
+from basecamp.oauth._transport import _WORKER_JOIN_GRACE
+
+
+def _serve_on_localhost() -> tuple[socket.socket, int]:
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.bind(("127.0.0.1", 0))
+    srv.listen(1)
+    return srv, srv.getsockname()[1]
+
+
+def _settled_thread_count(baseline: int, deadline_s: float = 5.0) -> int:
+    # The transport worker is a daemon thread that asyncio.wait_for bounds at
+    # ~timeout; give its cancellation/cleanup a moment to unwind before counting.
+    deadline = time.monotonic() + deadline_s
+    while threading.active_count() > baseline and time.monotonic() < deadline:
+        time.sleep(0.05)
+    return threading.active_count()
+
+
+def test_discovery_header_stall_is_bounded_and_leaks_no_worker() -> None:
+    # The peer sends complete headers then stalls forever without a body byte.
+    # The fetch must surface a retryable network timeout within ~timeout (plus
+    # the worker-join grace), and the transport's worker thread must be gone —
+    # not parked forever on the dead connection.
+    srv, port = _serve_on_localhost()
+    stop = threading.Event()
+
+    def stall() -> None:
+        conn, _ = srv.accept()
+        conn.recv(4096)
+        try:
+            conn.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: 100\r\nContent-Type: application/json\r\n\r\n")
+            stop.wait()
+        except OSError:
+            pass
+        finally:
+            conn.close()
+
+    baseline = threading.active_count()
+    server = threading.Thread(target=stall, daemon=True)
+    server.start()
+    timeout = 0.5
+    try:
+        start = time.monotonic()
+        with pytest.raises(OAuthError) as exc_info:
+            discover_protected_resource(f"http://127.0.0.1:{port}", timeout=timeout)
+        elapsed = time.monotonic() - start
+        assert exc_info.value.code == "network"
+        assert exc_info.value.retryable
+        assert "timed out" in str(exc_info.value)
+        assert elapsed < timeout + _WORKER_JOIN_GRACE + 1.0, f"fetch not bounded by the timeout: took {elapsed:.2f}s"
+    finally:
+        stop.set()
+        server.join(2)
+        srv.close()
+    assert _settled_thread_count(baseline) == baseline, "leaked transport worker thread"
+
+
+def test_discovery_slow_drip_is_bounded_by_the_total_timeout() -> None:
+    # httpx's read timeout resets on every received chunk, so a peer dripping a
+    # VALID discovery document byte-by-byte (each read under the timeout) would
+    # otherwise hold the fetch open far past it — httpx has no total timeout.
+    # asyncio.wait_for must cancel the whole round-trip at ~timeout regardless
+    # of chunk cadence, surfacing a retryable network timeout.
+    srv, port = _serve_on_localhost()
+    origin = f"http://127.0.0.1:{port}"
+    body = json.dumps({"resource": origin}).encode()
+    payload = (
+        f"HTTP/1.1 200 OK\r\nContent-Length: {len(body)}\r\nContent-Type: application/json\r\n\r\n"
+    ).encode() + body
+
+    def drip() -> None:
+        conn, _ = srv.accept()
+        conn.recv(4096)
+        try:
+            # ~100+ bytes dripped at 0.2s each ≈ 20s+ total; the 0.5s timeout must win.
+            for byte in payload:
+                conn.sendall(bytes([byte]))
+                time.sleep(0.2)
+        except OSError:
+            pass
+        finally:
+            conn.close()
+
+    baseline = threading.active_count()
+    server = threading.Thread(target=drip, daemon=True)
+    server.start()
+    timeout = 0.5
+    try:
+        start = time.monotonic()
+        with pytest.raises(OAuthError) as exc_info:
+            discover_protected_resource(origin, timeout=timeout)
+        elapsed = time.monotonic() - start
+        assert exc_info.value.code == "network"
+        assert exc_info.value.retryable
+        assert "timed out" in str(exc_info.value)
+        assert elapsed < timeout + _WORKER_JOIN_GRACE + 1.0, f"fetch not bounded by the timeout: took {elapsed:.2f}s"
+    finally:
+        srv.close()
+        server.join(5)
+    assert _settled_thread_count(baseline) == baseline, "leaked transport worker thread"

--- a/python/tests/oauth/test_transport.py
+++ b/python/tests/oauth/test_transport.py
@@ -92,6 +92,7 @@ def test_discovery_non_2xx_with_stalled_body_is_immediate_api_error() -> None:
         finally:
             conn.close()
 
+    baseline = threading.active_count()
     server = threading.Thread(target=stall, daemon=True)
     server.start()
     timeout = 0.5
@@ -107,6 +108,7 @@ def test_discovery_non_2xx_with_stalled_body_is_immediate_api_error() -> None:
         stop.set()
         server.join(2)
         srv.close()
+    assert _settled_thread_count(baseline) == baseline, "leaked transport worker thread"
 
 
 def test_discovery_slow_drip_is_bounded_by_the_total_timeout() -> None:

--- a/python/tests/oauth/test_transport.py
+++ b/python/tests/oauth/test_transport.py
@@ -169,3 +169,24 @@ def test_discovery_slow_drip_is_bounded_by_the_total_timeout() -> None:
         srv.close()
         server.join(5)
     assert _settled_thread_count(baseline) == baseline, "leaked transport worker thread"
+
+
+@pytest.mark.parametrize(
+    "timeout",
+    [None, "5", True, 0, -1, float("inf"), float("nan"), 3601.0, 10**400],
+)
+def test_invalid_timeout_fails_fast(timeout) -> None:
+    # request_bounded's whole purpose is a TOTAL request bound; an unnormalized
+    # timeout (inf/nan/non-positive/oversized/huge-int) would disable or
+    # overflow asyncio.wait_for and the thread join. Callers normalize, but the
+    # contract is enforced here too — a violation is a programming error.
+    from basecamp.oauth._transport import request_bounded
+
+    with pytest.raises(ValueError, match="timeout must be a finite positive"):
+        request_bounded(
+            "GET",
+            "https://issuer.example/x",
+            headers={},
+            timeout=timeout,
+            max_body_bytes=1024,
+        )

--- a/python/tests/oauth/test_transport.py
+++ b/python/tests/oauth/test_transport.py
@@ -183,6 +183,48 @@ def test_skipped_status_survives_cleanup_crossing_the_deadline(monkeypatch) -> N
         srv.close()
 
 
+def test_size_cap_error_survives_cleanup_crossing_the_deadline(monkeypatch) -> None:
+    # An oversized body trips the documented api_error size cap; when async
+    # cleanup then crosses the deadline and wait_for cancels, the terminal
+    # fault must survive — never soften into a retryable timeout.
+    real_aexit = httpx.AsyncClient.__aexit__
+
+    async def slow_aexit(self, *args):
+        await asyncio.sleep(1.5)  # crosses the 0.5s deadline
+        return await real_aexit(self, *args)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__aexit__", slow_aexit)
+
+    srv, port = _serve_on_localhost()
+    big = b"x" * (2 * 1024 * 1024)
+
+    def serve() -> None:
+        conn, _ = srv.accept()
+        conn.recv(4096)
+        try:
+            conn.sendall(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: "
+                + str(len(big)).encode()
+                + b"\r\n\r\n"
+                + big
+            )
+        except OSError:
+            pass
+        finally:
+            conn.close()
+
+    server = threading.Thread(target=serve, daemon=True)
+    server.start()
+    try:
+        with pytest.raises(OAuthError) as exc_info:
+            discover_protected_resource(f"http://127.0.0.1:{port}", timeout=0.5)
+        assert exc_info.value.code == "api_error"
+        assert "size cap" in str(exc_info.value)
+    finally:
+        server.join(3)
+        srv.close()
+
+
 def test_compressed_bodies_are_never_inflated_by_the_transport() -> None:
     # Transparent decompression would let a compression bomb balloon past the
     # byte cap BEFORE the per-chunk check ran (httpx inflates in

--- a/python/tests/oauth/test_transport.py
+++ b/python/tests/oauth/test_transport.py
@@ -108,12 +108,12 @@ def test_params_with_non_post_fails_fast() -> None:
 
 def test_invalid_max_body_bytes_fails_fast() -> None:
     # The cap IS the streaming bound this core exists to provide — a bool,
-    # float (inf included), or non-positive value would disable or crash it,
+    # float (inf included), or negative value would disable or crash it,
     # so misuse rejects before any connection.
     from basecamp.oauth._transport import request_bounded
 
-    for cap in (None, True, False, 0, -8, 1.5, float("inf")):
-        with pytest.raises(ValueError, match="max_body_bytes must be a positive int"):
+    for cap in (None, True, False, -8, 1.5, float("inf")):
+        with pytest.raises(ValueError, match="max_body_bytes must be a non-negative int"):
             request_bounded(
                 "GET",
                 "https://issuer.example/x",
@@ -122,6 +122,43 @@ def test_invalid_max_body_bytes_fails_fast() -> None:
                 timeout=1.0,
                 max_body_bytes=cap,  # type: ignore[arg-type]
             )
+
+
+def test_zero_max_body_bytes_is_a_strict_cap_not_a_usage_error() -> None:
+    # _normalize_body_cap accepts zero as a legitimate strict cap, so the
+    # transport must too: the request goes out and any non-empty body trips
+    # the bound, surfacing as the documented cap fault — never ValueError.
+    from basecamp.oauth._transport import request_bounded
+
+    srv, port = _serve_on_localhost()
+
+    def respond() -> None:
+        conn, _ = srv.accept()
+        conn.recv(4096)
+        try:
+            conn.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nhi")
+        except OSError:
+            pass
+        finally:
+            conn.close()
+
+    server = threading.Thread(target=respond, daemon=True)
+    server.start()
+    try:
+        with pytest.raises(OAuthError) as excinfo:
+            request_bounded(
+                "GET",
+                f"http://127.0.0.1:{port}/doc",
+                headers={},
+                params=None,
+                timeout=2.0,
+                max_body_bytes=0,
+            )
+        assert excinfo.value.oauth_type == "api_error"
+        assert "size cap" in str(excinfo.value)
+    finally:
+        server.join(timeout=5)
+        srv.close()
 
 
 def test_discovery_non_2xx_with_stalled_body_is_immediate_api_error() -> None:

--- a/python/tests/oauth/test_transport.py
+++ b/python/tests/oauth/test_transport.py
@@ -126,6 +126,47 @@ def test_discovery_non_2xx_with_stalled_body_is_immediate_api_error() -> None:
     assert _settled_thread_count(baseline) == baseline, "leaked transport worker thread"
 
 
+def test_compressed_bodies_are_never_inflated_by_the_transport() -> None:
+    # Transparent decompression would let a compression bomb balloon past the
+    # byte cap BEFORE the per-chunk check ran (httpx inflates in
+    # aiter_bytes). The transport requests identity and reads RAW wire bytes:
+    # a server compressing anyway hands over compressed bytes bounded by the
+    # cap, and classification (a JSON parse failure) happens on the small
+    # payload — memory never exceeds the advertised bound.
+    import gzip as gzip_mod
+
+    compressed = gzip_mod.compress(b"x" * 10_000_000)  # ~10 MB decoded
+    assert len(compressed) < 20_000, "bomb premise: tiny on the wire"
+
+    srv, port = _serve_on_localhost()
+
+    def serve() -> None:
+        conn, _ = srv.accept()
+        conn.recv(4096)
+        try:
+            conn.sendall(
+                b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+                b"Content-Encoding: gzip\r\nContent-Length: " + str(len(compressed)).encode() + b"\r\n\r\n" + compressed
+            )
+        except OSError:
+            pass
+        finally:
+            conn.close()
+
+    server = threading.Thread(target=serve, daemon=True)
+    server.start()
+    try:
+        with pytest.raises(OAuthError) as exc_info:
+            discover_protected_resource(f"http://127.0.0.1:{port}", timeout=2)
+        # The raw bytes flowed through under the cap and failed JSON parsing —
+        # never a decoded blow-up into the size cap.
+        assert exc_info.value.code == "api_error"
+        assert "size cap" not in str(exc_info.value)
+    finally:
+        server.join(2)
+        srv.close()
+
+
 def test_discovery_slow_drip_is_bounded_by_the_total_timeout() -> None:
     # httpx's read timeout resets on every received chunk, so a peer dripping a
     # VALID discovery document byte-by-byte (each read under the timeout) would

--- a/python/tests/oauth/test_transport.py
+++ b/python/tests/oauth/test_transport.py
@@ -124,6 +124,56 @@ def test_invalid_max_body_bytes_fails_fast() -> None:
             )
 
 
+def test_skip_status_headers_past_the_deadline_classify_as_timeout(monkeypatch) -> None:
+    # Headers that become runnable past the total deadline mean the status was
+    # NOT known before the bound — the skip path must surface the timeout, not
+    # race ahead of wait_for into a status fault. The clock is faked ONLY
+    # inside the transport module (asyncio/httpx keep the real one): it jumps
+    # past any deadline the moment the server has served the late headers.
+    import time as real_time
+
+    from basecamp.oauth import _transport
+    from basecamp.oauth._transport import request_bounded
+
+    srv, port = _serve_on_localhost()
+    served = threading.Event()
+
+    def respond() -> None:
+        conn, _ = srv.accept()
+        conn.recv(4096)
+        try:
+            conn.sendall(b"HTTP/1.1 500 Nope\r\nContent-Length: 2\r\nConnection: close\r\n\r\nno")
+        except OSError:
+            pass
+        finally:
+            served.set()
+            conn.close()
+
+    class FakeTime:
+        @staticmethod
+        def monotonic() -> float:
+            return 1e9 if served.is_set() else real_time.monotonic()
+
+    monkeypatch.setattr(_transport, "time", FakeTime)
+
+    server = threading.Thread(target=respond, daemon=True)
+    server.start()
+    try:
+        with pytest.raises(httpx.TimeoutException):
+            request_bounded(
+                "GET",
+                f"http://127.0.0.1:{port}/doc",
+                headers={},
+                params=None,
+                timeout=10.0,
+                max_body_bytes=1024,
+                read_body=lambda _status: False,
+            )
+    finally:
+        server.join(timeout=5)
+        srv.close()
+
+
 def test_zero_max_body_bytes_is_a_strict_cap_not_a_usage_error() -> None:
     # _normalize_body_cap accepts zero as a legitimate strict cap, so the
     # transport must too: the request goes out and any non-empty body trips

--- a/python/tests/oauth/test_transport.py
+++ b/python/tests/oauth/test_transport.py
@@ -8,11 +8,13 @@ discovery fetch through :func:`basecamp.oauth._transport.request_bounded`.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import socket
 import threading
 import time
 
+import httpx
 import pytest
 
 from basecamp.oauth import OAuthError, discover_protected_resource
@@ -124,6 +126,46 @@ def test_discovery_non_2xx_with_stalled_body_is_immediate_api_error() -> None:
         server.join(2)
         srv.close()
     assert _settled_thread_count(baseline) == baseline, "leaked transport worker thread"
+
+
+def test_skipped_status_survives_cleanup_crossing_the_deadline(monkeypatch) -> None:
+    # A skipped non-2xx whose headers arrive just before the total deadline
+    # must classify by STATUS even when the awaited response/client cleanup
+    # crosses the deadline and is cancelled by wait_for — never soften into a
+    # retryable timeout. Deterministic: the patched client aclose stalls past
+    # the deadline after the response is already known.
+    # Patch __aexit__ (NOT aclose — AsyncClient.__aexit__ closes the
+    # transport directly and never routes through aclose).
+    real_aexit = httpx.AsyncClient.__aexit__
+
+    async def slow_aexit(self, *args):
+        await asyncio.sleep(1.5)  # crosses the 0.5s deadline
+        return await real_aexit(self, *args)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__aexit__", slow_aexit)
+
+    srv, port = _serve_on_localhost()
+
+    def serve() -> None:
+        conn, _ = srv.accept()
+        conn.recv(4096)
+        try:
+            conn.sendall(b"HTTP/1.1 500 Internal Server Error\r\nContent-Length: 0\r\n\r\n")
+        except OSError:
+            pass
+        finally:
+            conn.close()
+
+    server = threading.Thread(target=serve, daemon=True)
+    server.start()
+    try:
+        with pytest.raises(OAuthError) as exc_info:
+            discover_protected_resource(f"http://127.0.0.1:{port}", timeout=0.5)
+        assert exc_info.value.code == "api_error"
+        assert exc_info.value.http_status == 500
+    finally:
+        server.join(3)
+        srv.close()
 
 
 def test_compressed_bodies_are_never_inflated_by_the_transport() -> None:

--- a/python/tests/oauth/test_transport.py
+++ b/python/tests/oauth/test_transport.py
@@ -9,6 +9,7 @@ discovery fetch through :func:`basecamp.oauth._transport.request_bounded`.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import socket
 import threading
@@ -221,6 +222,62 @@ def test_recorded_skip_outcome_survives_a_cleanup_http_error(monkeypatch) -> Non
         )
         assert status == 500
         assert body == b""
+    finally:
+        server.join(timeout=5)
+        srv.close()
+
+
+def test_mid_body_wire_error_survives_response_cleanup_crossing_the_deadline(monkeypatch) -> None:
+    # A body-phase reset is stamped INSIDE the response context: response
+    # cleanup (aclose) runs before any outer handler, so a cleanup crossing
+    # the deadline would otherwise erase the in-deadline wire fault into a
+    # retryable timeout. The fake clock flips only once aclose begins.
+    import time as real_time
+
+    from basecamp.oauth import _transport
+    from basecamp.oauth._transport import request_bounded
+
+    srv, port = _serve_on_localhost()
+    past_deadline = threading.Event()
+
+    def reset_mid_body() -> None:
+        conn, _ = srv.accept()
+        conn.recv(4096)
+        with contextlib.suppress(OSError):
+            conn.sendall(b"HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\npartial")
+        conn.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, b"\x01\x00\x00\x00\x00\x00\x00\x00")
+        conn.close()
+
+    class FakeTime:
+        @staticmethod
+        def monotonic() -> float:
+            return 1e9 if past_deadline.is_set() else real_time.monotonic()
+
+    monkeypatch.setattr(_transport, "time", FakeTime)
+
+    real_aclose = httpx.Response.aclose
+
+    async def flagging_aclose(self):  # noqa: ANN001
+        past_deadline.set()
+        return await real_aclose(self)
+
+    monkeypatch.setattr(httpx.Response, "aclose", flagging_aclose)
+
+    server = threading.Thread(target=reset_mid_body, daemon=True)
+    server.start()
+    try:
+        with pytest.raises(httpx.HTTPError) as exc_info:
+            request_bounded(
+                "GET",
+                f"http://127.0.0.1:{port}/doc",
+                headers={},
+                params=None,
+                timeout=10.0,
+                max_body_bytes=1024,
+            )
+        assert not isinstance(exc_info.value, httpx.TimeoutException), (
+            "an in-deadline mid-body wire fault must stay terminal"
+        )
     finally:
         server.join(timeout=5)
         srv.close()

--- a/python/tests/oauth/test_transport.py
+++ b/python/tests/oauth/test_transport.py
@@ -106,6 +106,24 @@ def test_params_with_non_post_fails_fast() -> None:
         )
 
 
+def test_invalid_max_body_bytes_fails_fast() -> None:
+    # The cap IS the streaming bound this core exists to provide — a bool,
+    # float (inf included), or non-positive value would disable or crash it,
+    # so misuse rejects before any connection.
+    from basecamp.oauth._transport import request_bounded
+
+    for cap in (None, True, False, 0, -8, 1.5, float("inf")):
+        with pytest.raises(ValueError, match="max_body_bytes must be a positive int"):
+            request_bounded(
+                "GET",
+                "https://issuer.example/x",
+                headers={},
+                params=None,
+                timeout=1.0,
+                max_body_bytes=cap,  # type: ignore[arg-type]
+            )
+
+
 def test_discovery_non_2xx_with_stalled_body_is_immediate_api_error() -> None:
     # SPEC.md: non-2xx on either discovery hop → api_error, never network —
     # status dominates even when the error body stalls forever, so the fetch

--- a/python/tests/oauth/test_transport.py
+++ b/python/tests/oauth/test_transport.py
@@ -136,7 +136,7 @@ def test_skip_status_headers_past_the_deadline_classify_as_timeout(monkeypatch) 
     from basecamp.oauth._transport import request_bounded
 
     srv, port = _serve_on_localhost()
-    served = threading.Event()
+    past_deadline = threading.Event()
 
     def respond() -> None:
         conn, _ = srv.accept()
@@ -146,13 +146,20 @@ def test_skip_status_headers_past_the_deadline_classify_as_timeout(monkeypatch) 
         except OSError:
             pass
         finally:
-            served.set()
             conn.close()
+
+    def skip_and_flip(_status: int) -> bool:
+        # Flip the fake clock HERE — inside the transport's own skip
+        # decision — so the deadline gate that runs immediately after reads
+        # a past-deadline "now". Flipping from the server thread raced the
+        # client processing the headers first.
+        past_deadline.set()
+        return False
 
     class FakeTime:
         @staticmethod
         def monotonic() -> float:
-            return 1e9 if served.is_set() else real_time.monotonic()
+            return 1e9 if past_deadline.is_set() else real_time.monotonic()
 
     monkeypatch.setattr(_transport, "time", FakeTime)
 
@@ -167,7 +174,7 @@ def test_skip_status_headers_past_the_deadline_classify_as_timeout(monkeypatch) 
                 params=None,
                 timeout=10.0,
                 max_body_bytes=1024,
-                read_body=lambda _status: False,
+                read_body=skip_and_flip,
             )
     finally:
         server.join(timeout=5)

--- a/python/tests/oauth/test_transport.py
+++ b/python/tests/oauth/test_transport.py
@@ -181,6 +181,61 @@ def test_skip_status_headers_past_the_deadline_classify_as_timeout(monkeypatch) 
         srv.close()
 
 
+def test_in_deadline_wire_error_survives_cleanup_crossing_the_deadline(monkeypatch) -> None:
+    # The mirror edge: a connection reset observed IN deadline whose async
+    # cleanup (__aexit__) crosses it must surface as the terminal transport
+    # fault — never be misdated by a post-cleanup stamp into a retryable
+    # timeout. The fake clock flips only once cleanup begins, so the
+    # exception-site stamp reads real (in-deadline) time.
+    import time as real_time
+
+    from basecamp.oauth import _transport
+    from basecamp.oauth._transport import request_bounded
+
+    srv, port = _serve_on_localhost()
+    cleanup_started = threading.Event()
+
+    def reset_connection() -> None:
+        conn, _ = srv.accept()
+        conn.recv(4096)
+        conn.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, b"\x01\x00\x00\x00\x00\x00\x00\x00")
+        conn.close()
+
+    class FakeTime:
+        @staticmethod
+        def monotonic() -> float:
+            return 1e9 if cleanup_started.is_set() else real_time.monotonic()
+
+    monkeypatch.setattr(_transport, "time", FakeTime)
+
+    real_aexit = httpx.AsyncClient.__aexit__
+
+    async def flagging_aexit(self, *args):  # noqa: ANN001, ANN002
+        cleanup_started.set()
+        return await real_aexit(self, *args)
+
+    monkeypatch.setattr(httpx.AsyncClient, "__aexit__", flagging_aexit)
+
+    server = threading.Thread(target=reset_connection, daemon=True)
+    server.start()
+    try:
+        with pytest.raises(httpx.HTTPError) as exc_info:
+            request_bounded(
+                "GET",
+                f"http://127.0.0.1:{port}/doc",
+                headers={},
+                params=None,
+                timeout=10.0,
+                max_body_bytes=1024,
+            )
+        assert not isinstance(exc_info.value, httpx.TimeoutException), (
+            "an in-deadline wire fault must stay terminal, not soften into a timeout"
+        )
+    finally:
+        server.join(timeout=5)
+        srv.close()
+
+
 def test_wire_error_past_the_deadline_classifies_as_timeout(monkeypatch) -> None:
     # A connection reset that becomes runnable past the total deadline is the
     # timeout it raced, not a distinct transport fault — the poll loop must

--- a/python/tests/oauth/test_transport.py
+++ b/python/tests/oauth/test_transport.py
@@ -385,6 +385,34 @@ def test_wire_error_past_the_deadline_classifies_as_timeout(monkeypatch) -> None
         srv.close()
 
 
+def test_exhausted_worker_slots_fail_fast_as_timeout() -> None:
+    # When every transport-worker slot is held (workers stuck on
+    # uninterruptible resolver calls), a new request must fail within its
+    # budget as the timeout it would have become — never add another stuck
+    # thread to the pile.
+    from basecamp.oauth import _transport
+    from basecamp.oauth._transport import request_bounded
+
+    held = 0
+    while _transport._WORKER_SLOTS.acquire(blocking=False):
+        held += 1
+    try:
+        started = time.monotonic()
+        with pytest.raises(httpx.TimeoutException, match="worker slots exhausted"):
+            request_bounded(
+                "GET",
+                "http://127.0.0.1:9/doc",
+                headers={},
+                params=None,
+                timeout=0.3,
+                max_body_bytes=1024,
+            )
+        assert time.monotonic() - started < 2.0
+    finally:
+        for _ in range(held):
+            _transport._WORKER_SLOTS.release()
+
+
 def test_zero_max_body_bytes_is_a_strict_cap_not_a_usage_error() -> None:
     # _normalize_body_cap accepts zero as a legitimate strict cap, so the
     # transport must too: the request goes out and any non-empty body trips

--- a/python/tests/oauth/test_transport.py
+++ b/python/tests/oauth/test_transport.py
@@ -181,6 +181,51 @@ def test_skip_status_headers_past_the_deadline_classify_as_timeout(monkeypatch) 
         srv.close()
 
 
+def test_recorded_skip_outcome_survives_a_cleanup_http_error(monkeypatch) -> None:
+    # A recorded outcome dominates an httpx error raised BY cleanup: a known
+    # non-2xx skip must not soften into a retryable network error because
+    # closing the unconsumed stream misbehaved after the fact.
+    from basecamp.oauth._transport import request_bounded
+
+    srv, port = _serve_on_localhost()
+
+    def respond() -> None:
+        conn, _ = srv.accept()
+        conn.recv(4096)
+        try:
+            conn.sendall(b"HTTP/1.1 500 Nope\r\nContent-Length: 2\r\nConnection: close\r\n\r\nno")
+        except OSError:
+            pass
+        finally:
+            conn.close()
+
+    real_aclose = httpx.Response.aclose
+
+    async def exploding_aclose(self):  # noqa: ANN001
+        await real_aclose(self)
+        raise httpx.ReadError("cleanup boom")
+
+    monkeypatch.setattr(httpx.Response, "aclose", exploding_aclose)
+
+    server = threading.Thread(target=respond, daemon=True)
+    server.start()
+    try:
+        status, body = request_bounded(
+            "GET",
+            f"http://127.0.0.1:{port}/doc",
+            headers={},
+            params=None,
+            timeout=10.0,
+            max_body_bytes=1024,
+            read_body=lambda _status: False,
+        )
+        assert status == 500
+        assert body == b""
+    finally:
+        server.join(timeout=5)
+        srv.close()
+
+
 def test_in_deadline_wire_error_survives_cleanup_crossing_the_deadline(monkeypatch) -> None:
     # The mirror edge: a connection reset observed IN deadline whose async
     # cleanup (__aexit__) crosses it must surface as the terminal transport

--- a/python/tests/oauth/test_transport.py
+++ b/python/tests/oauth/test_transport.py
@@ -181,6 +181,53 @@ def test_skip_status_headers_past_the_deadline_classify_as_timeout(monkeypatch) 
         srv.close()
 
 
+def test_wire_error_past_the_deadline_classifies_as_timeout(monkeypatch) -> None:
+    # A connection reset that becomes runnable past the total deadline is the
+    # timeout it raced, not a distinct transport fault — the poll loop must
+    # back off transiently, never terminate. The fake clock (transport-module
+    # scoped) jumps past any deadline before the server closes the connection,
+    # so the error is captured strictly after the jump.
+    import time as real_time
+
+    from basecamp.oauth import _transport
+    from basecamp.oauth._transport import request_bounded
+
+    srv, port = _serve_on_localhost()
+    past_deadline = threading.Event()
+
+    def reset_connection() -> None:
+        conn, _ = srv.accept()
+        conn.recv(4096)
+        past_deadline.set()
+        # An abrupt close mid-request surfaces as an httpx wire error (never
+        # a timeout) on the client side.
+        conn.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, b"\x01\x00\x00\x00\x00\x00\x00\x00")
+        conn.close()
+
+    class FakeTime:
+        @staticmethod
+        def monotonic() -> float:
+            return 1e9 if past_deadline.is_set() else real_time.monotonic()
+
+    monkeypatch.setattr(_transport, "time", FakeTime)
+
+    server = threading.Thread(target=reset_connection, daemon=True)
+    server.start()
+    try:
+        with pytest.raises(httpx.TimeoutException):
+            request_bounded(
+                "GET",
+                f"http://127.0.0.1:{port}/doc",
+                headers={},
+                params=None,
+                timeout=10.0,
+                max_body_bytes=1024,
+            )
+    finally:
+        server.join(timeout=5)
+        srv.close()
+
+
 def test_zero_max_body_bytes_is_a_strict_cap_not_a_usage_error() -> None:
     # _normalize_body_cap accepts zero as a legitimate strict cap, so the
     # transport must too: the request goes out and any non-empty body trips

--- a/python/tests/oauth/test_transport.py
+++ b/python/tests/oauth/test_transport.py
@@ -76,6 +76,21 @@ def test_discovery_header_stall_is_bounded_and_leaks_no_worker() -> None:
     assert _settled_thread_count(baseline) == baseline, "leaked transport worker thread"
 
 
+def test_unknown_method_fails_fast() -> None:
+    # An unknown verb must fail fast, never reach httpx.
+    from basecamp.oauth._transport import request_bounded
+
+    with pytest.raises(ValueError, match="must be GET or POST"):
+        request_bounded(
+            "POTS",
+            "https://issuer.example/x",
+            headers={},
+            params=None,
+            timeout=1.0,
+            max_body_bytes=1024,
+        )
+
+
 def test_params_with_non_post_fails_fast() -> None:
     # A form body on a GET would emit a GET-with-body; misuse fails fast instead.
     from basecamp.oauth._transport import request_bounded

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -92,17 +92,15 @@ module Basecamp
           # default (read) — Ruby treats "" as truthy, so guard on emptiness too.
           params["scope"] = scope unless scope.nil? || scope.empty?
 
-          # Normalize ONCE at operation entry and thread the SAME value to both the
-          # client construction and the request, so a non-finite/non-positive input
-          # cannot leave the socket timeout unbounded on the default-built client.
-          # The body cap gets the same discipline: an invalid value (nil, Infinity,
-          # negative) would disable the streaming memory bound entirely.
+          # Normalize ONCE at operation entry and thread the SAME value to every
+          # request, so a non-finite/non-positive input cannot leave the socket
+          # timeout unbounded. The body cap gets the same discipline: an invalid
+          # value (nil, Infinity, negative) would disable the streaming bound.
           timeout = Fetcher.normalize_timeout(timeout, default: DEVICE_REQUEST_TIMEOUT)
           max_body_bytes = Fetcher.normalize_body_cap(max_body_bytes)
-          client = http_client || build_client(timeout)
           status, body = begin
             post_form(
-              client, device_authorization_endpoint, params,
+              http_client, device_authorization_endpoint, params,
               timeout: timeout, max_body_bytes: max_body_bytes,
               # A non-2xx device-auth response is a hard failure whose body is unused.
               skip_status: ->(s) { !(200..299).cover?(s) }
@@ -201,12 +199,11 @@ module Basecamp
               deadline_at
             end
 
-          # Normalize ONCE, outside the polling loop, and reuse for the client and
-          # every per-poll request (see request_device_authorization). The body cap
-          # gets the same discipline — an invalid value would disable the bound.
+          # Normalize ONCE, outside the polling loop, and reuse for every per-poll
+          # request (see request_device_authorization). The body cap gets the same
+          # discipline — an invalid value would disable the bound.
           timeout = Fetcher.normalize_timeout(timeout, default: DEVICE_REQUEST_TIMEOUT)
           max_body_bytes = Fetcher.normalize_body_cap(max_body_bytes)
-          client = http_client || build_client(timeout)
           params = {
             "grant_type" => DEVICE_CODE_GRANT_TYPE,
             "device_code" => device_code,
@@ -237,7 +234,7 @@ module Basecamp
               # Bound the request by the REMAINING code lifetime as well as the
               # per-request timeout: near expiry, a stalled token POST must not
               # hold the flow past the monotonic deadline for the full budget.
-              post_device_token(client, token_endpoint, params,
+              post_device_token(http_client, token_endpoint, params,
                 timeout: [ timeout, post_remaining ].min, max_body_bytes: max_body_bytes)
             rescue Faraday::TimeoutError
               # A connection timeout is transient: back off exponentially and
@@ -422,10 +419,6 @@ module Basecamp
             value.is_a?(Numeric) && value.real? && value.finite? && value.positive? && value <= MAX_DEVICE_SECONDS
           end
 
-          def build_client(timeout)
-            Fetcher.build_client(timeout)
-          end
-
           # Waits +seconds+ while observing cancellation DURING the wait. A plain
           # +sleep+ is not interruptible, so a cancellation set mid-wait would not be
           # noticed until the whole (possibly grown +slow_down+) interval elapses.
@@ -448,21 +441,31 @@ module Basecamp
             end
           end
 
-          # POSTs a form body and reads the response under the same bounded/
-          # streaming cap as discovery (SPEC.md §9): the +on_data+ proc aborts the
-          # read the moment the accumulated size exceeds the cap, so an oversized
-          # response is never fully buffered. Returns +[status, body]+. The
-          # per-request timeout is always set here — even on an injected client —
-          # so a stalled socket can't hang the poll. A real adapter streams to
-          # +on_data+ (leaving +response.body+ empty); a test double that ignores
-          # the block falls back to the buffered body, still size-capped.
+          # POSTs a form body and returns +[status, body]+, reading under the same
+          # bounded/streaming cap as discovery (SPEC.md §9).
+          #
+          # With a nil +client+ the POST runs on the headers-first
+          # {Fetcher.stream_http} primitive: +skip_status+ classifies by status at
+          # HEADER time (a skipped body is never read, even one that stalls
+          # forever), and a watchdog bounds the whole request — including a
+          # stalled or byte-dripped header phase — at the timeout. An INJECTED
+          # Faraday connection keeps the Faraday path below.
           def post_form(client, url, params, timeout:, max_body_bytes:, skip_status: nil)
-            # +timeout+ is already normalized by the caller (request/poll entry). The
-            # wall-clock deadline bounds the WHOLE read: req.options.timeout below
-            # bounds only each socket read and resets on every on_data chunk, so a
-            # slow-drip peer could otherwise hang a device request past the timeout /
-            # code expiry while staying under the cap. +skip_status+ stops the read
-            # for a status whose body the caller doesn't use (non-2xx / 3xx).
+            if client.nil?
+              return Fetcher.stream_http(
+                :post, url,
+                headers: { "Content-Type" => "application/x-www-form-urlencoded", "Accept" => "application/json" },
+                form: params, timeout: timeout, max_body_bytes: max_body_bytes, skip_status: skip_status
+              )
+            end
+
+            # Injected-client (Faraday) path. +timeout+ is already normalized by the
+            # caller (request/poll entry). The wall-clock deadline bounds the WHOLE
+            # read: req.options.timeout below bounds only each socket read and resets
+            # on every on_data chunk, so a slow-drip peer could otherwise hang a
+            # device request past the timeout / code expiry while staying under the
+            # cap. +skip_status+ stops the read for a status whose body the caller
+            # doesn't use (non-2xx / 3xx).
             deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
             chunks, on_data = Fetcher.bounded_reader(max_body_bytes, deadline: deadline, skip_status: skip_status)
             # Timeout.timeout wraps the WHOLE call: the per-read timeout resets
@@ -496,14 +499,13 @@ module Basecamp
             # every client shape and supported Faraday version, never buffered into
             # a size-cap error the caller must then untangle.
             #
-            # Known residual: Faraday exposes no headers-time callback, so a response
-            # whose headers arrive but whose body then stalls PAST the read timeout
-            # never returns from +client.post+ — it surfaces as a bounded transport
-            # timeout (request path: :transport; poll path: backoff, capped by code
-            # expiry) rather than this status-first classification. That degradation
-            # is bounded and redirect-safe (3xx Locations are never followed); exact
-            # headers-first semantics for it belong to the transport primitive shared
-            # with discovery, tracked as a pre-go-live hardening follow-up.
+            # Known residual — INJECTED clients only (the default path above is
+            # exact): Faraday exposes no headers-time callback, so a response whose
+            # headers arrive but whose body then stalls PAST the read timeout never
+            # returns from +client.post+ — it surfaces as a bounded transport timeout
+            # (request path: :transport; poll path: backoff, capped by code expiry)
+            # rather than this status-first classification. Bounded and
+            # redirect-safe (3xx Locations are never followed).
             return [ response.status, "" ] if skip_status && skip_status.call(response.status)
 
             # Timeout.timeout's interrupt can be delivered late: a response

--- a/ruby/lib/basecamp/oauth/discovery.rb
+++ b/ruby/lib/basecamp/oauth/discovery.rb
@@ -27,7 +27,10 @@ module Basecamp
         # wall-clock deadline: a non-finite/non-positive timeout must not disable
         # either bound (see Fetcher.normalize_timeout).
         @timeout = Fetcher.normalize_timeout(timeout)
-        @http_client = http_client || Fetcher.build_client(@timeout)
+        # nil selects the headers-first {Fetcher.stream_http} transport (total
+        # wall-clock bound incl. the header phase); an injected connection keeps
+        # the Faraday path, verified redirect-free above.
+        @http_client = http_client
         # Normalize the public cap to a finite non-negative Integer: a nil, float,
         # or Float::INFINITY would otherwise disable the streaming memory bound
         # (an infinite/undefined cap never trips +total > max_body_bytes+),

--- a/ruby/lib/basecamp/oauth/discovery.rb
+++ b/ruby/lib/basecamp/oauth/discovery.rb
@@ -23,7 +23,8 @@ module Basecamp
       # @param max_body_bytes [Integer] bounded read cap in bytes
       def initialize(http_client: nil, timeout: 10, max_body_bytes: Fetcher::DEFAULT_MAX_BODY_BYTES)
         Fetcher.ensure_redirects_suppressed!(http_client) if http_client
-        # Normalize before building the client and before the fetch computes its
+        # Normalize before storing (nil selects the headers-first Net::HTTP
+        # transport; an injected client is kept) and before the fetch computes its
         # wall-clock deadline: a non-finite/non-positive timeout must not disable
         # either bound (see Fetcher.normalize_timeout).
         @timeout = Fetcher.normalize_timeout(timeout)

--- a/ruby/lib/basecamp/oauth/discovery.rb
+++ b/ruby/lib/basecamp/oauth/discovery.rb
@@ -18,8 +18,11 @@ module Basecamp
         end
       end
 
-      # @param http_client [Faraday::Connection, nil] HTTP client (SSRF-hardened default if nil)
-      # @param timeout [Integer] request timeout in seconds (default: 10)
+      # @param http_client [Faraday::Connection, nil] injected Faraday client
+      #   (kept, verified redirect-free); nil selects the default headers-first
+      #   Net::HTTP transport ({Fetcher.stream_http})
+      # @param timeout [Numeric] request timeout in seconds (default: 10); an
+      #   invalid value falls back via {Fetcher.normalize_timeout}
       # @param max_body_bytes [Integer] bounded read cap in bytes
       def initialize(http_client: nil, timeout: 10, max_body_bytes: Fetcher::DEFAULT_MAX_BODY_BYTES)
         Fetcher.ensure_redirects_suppressed!(http_client) if http_client

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -2,6 +2,9 @@
 
 require "faraday"
 require "json"
+require "net/http"
+require "openssl"
+require "uri"
 
 module Basecamp
   module Oauth

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -450,9 +450,18 @@ module Basecamp
         ensure
           # Block-form start would close the session itself; with the explicit
           # start (needed so ONLY connection setup sits under Timeout.timeout)
-          # close it here.
+          # close it here. When the connect timeout fires between Net::HTTP's
+          # connect assigning a live @socket and do_start marking the session
+          # started, started? is still false and Net::HTTP's own connect
+          # rescue is out of scope — close the orphaned socket directly or it
+          # leaks until GC.
           begin
-            http.finish if http.started?
+            if http.started?
+              http.finish
+            else
+              orphan = http.instance_variable_get(:@socket)
+              orphan&.close
+            end
           rescue IOError
             # Already closed by the watchdog.
           end

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -331,9 +331,15 @@ module Basecamp
         # pass it explicitly; a nil p_addr disables the broken built-in.
         proxy_uri = uri.find_proxy
         http = if proxy_uri
+                 # Percent-decode the credentials: URI#user/#password return the
+                 # encoded forms, and the explicit-proxy Net::HTTP.new does NOT
+                 # unescape them the way its :ENV mode does — p%40ss would be
+                 # sent verbatim in Proxy-Authorization and fail authentication.
                  Net::HTTP.new(
                    uri.hostname, uri.port,
-                   proxy_uri.hostname, proxy_uri.port, proxy_uri.user, proxy_uri.password
+                   proxy_uri.hostname, proxy_uri.port,
+                   proxy_uri.user && URI.decode_www_form_component(proxy_uri.user),
+                   proxy_uri.password && URI.decode_www_form_component(proxy_uri.password)
                  )
         else
                  Net::HTTP.new(uri.hostname, uri.port, nil)

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -205,14 +205,128 @@ module Basecamp
         )
       end
 
+      # Headers-first bounded HTTP over Net::HTTP — the default transport for
+      # every SDK-built OAuth fetch (both discovery hops and the device flow).
+      # Injected Faraday connections keep the Faraday path; this primitive exists
+      # because Faraday cannot provide these two guarantees:
+      #
+      # 1. **Status at header time.** Faraday's +on_data+ is a body callback, so a
+      #    response whose body never arrives can only be classified after a
+      #    timeout. Net::HTTP's block form yields the response once HEADERS are
+      #    in: +skip_status+ classifies by status BEFORE any body read, and
+      #    raising out of the block makes +Net::HTTP.start+'s ensure close the
+      #    socket with the body undrained — exact status-first classification
+      #    (SPEC.md §16) for every response shape, including a stalled body.
+      # 2. **A total wall-clock bound.** A per-read timeout resets on every byte,
+      #    so a peer dripping header or body bytes defeats it. A WATCHDOG thread
+      #    closes the connection at a monotonic deadline, which interrupts even a
+      #    blocked or dripped HEADER read (closing the socket from another thread
+      #    raises IOError in the blocked reader — verified on a live socket).
+      #    +max_retries = 0+ is load-bearing: Net::HTTP's idempotent-retry would
+      #    otherwise silently REOPEN the connection the watchdog just closed.
+      #
+      # The body streams under the same cap + deadline as the Faraday path, and
+      # redirects are structurally never followed (+Net::HTTP#request+ has no
+      # follow logic). Transport failures surface as Faraday errors
+      # (+TimeoutError+ for timeout/deadline, +ConnectionFailed+ otherwise) so
+      # both transport paths classify through the same caller rescues.
+      #
+      # @param method [Symbol] +:get+ or +:post+
+      # @param url [String] fully-qualified URL (already origin-validated)
+      # @param headers [Hash] request headers
+      # @param form [Hash, nil] form params; www-form-encoded into the POST body
+      # @param timeout [Numeric] total request bound in seconds (already
+      #   normalized by the caller); connect is separately bounded by the same
+      #   value, so the absolute worst case is ~2x timeout when the deadline
+      #   fires mid-connect
+      # @param max_body_bytes [Integer] bounded read cap in bytes
+      # @param skip_status [Proc, nil] statuses whose body is never read
+      # @return [Array(Integer, String)] status and (possibly empty) body
+      def self.stream_http(method, url, headers: {}, form: nil, timeout:, max_body_bytes: DEFAULT_MAX_BODY_BYTES, skip_status: nil)
+        uri = URI.parse(url)
+        # URI#hostname strips IPv6 brackets ("[::1]" -> "::1"), which is the form
+        # Net::HTTP.new expects. ENV proxy handling matches faraday-net_http.
+        http = Net::HTTP.new(uri.hostname, uri.port)
+        http.use_ssl = uri.scheme == "https"
+        http.open_timeout = timeout
+        http.read_timeout = timeout
+        http.max_retries = 0
+
+        request = method == :post ? Net::HTTP::Post.new(uri) : Net::HTTP::Get.new(uri)
+        headers.each { |name, value| request[name] = value }
+        request.body = URI.encode_www_form(form) if form
+
+        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+        deadline_fired = false
+        watchdog = Thread.new do
+          remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          sleep(remaining) if remaining.positive?
+          deadline_fired = true
+          # Retry until the session exists to close: the deadline can fire while
+          # the session is still CONNECTING (finish then raises IOError), and a
+          # one-shot close would leave the subsequent header read unbounded. The
+          # ensure below kills this thread the moment the request completes, so
+          # the loop cannot outlive the call.
+          begin
+            http.finish
+          rescue IOError
+            sleep(0.05)
+            retry
+          end
+        end
+
+        status = nil
+        chunks = []
+        total = 0
+        http.start do |session|
+          session.request(request) do |response|
+            status = response.code.to_i
+            # Status-first: a skipped status's body is NEVER read — the raise
+            # unwinds through start, whose ensure closes the socket undrained.
+            raise SkipBody.new(status) if skip_status&.call(status)
+
+            response.read_body do |chunk|
+              raise ReadDeadlineExceeded if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+
+              total += chunk.bytesize
+              raise BodyTooLarge if total > max_body_bytes
+
+              chunks << chunk
+            end
+          end
+        end
+        [ status, chunks.join.force_encoding(Encoding::UTF_8) ]
+      rescue SkipBody => e
+        [ e.status, "" ]
+      rescue Net::OpenTimeout, Net::ReadTimeout => e
+        raise Faraday::TimeoutError, "OAuth request timed out: #{e.message}"
+      rescue IOError => e
+        # The watchdog's close raises IOError in the blocked reader; only map it
+        # to a timeout when the deadline actually fired — any other IOError (a
+        # peer closing mid-headers, for example) is a connection failure.
+        raise Faraday::TimeoutError, "OAuth request exceeded the timeout deadline" if deadline_fired
+
+        raise Faraday::ConnectionFailed, e.message
+      rescue SystemCallError, SocketError => e
+        raise Faraday::ConnectionFailed, e.message
+      ensure
+        watchdog&.kill
+        watchdog&.join
+      end
+
       # Fetches +url+ and returns the parsed JSON object (a Hash).
       #
-      # The request timeout is applied per-request (not only on the connection)
-      # so a bounded read is enforced even when the caller INJECTS its own
-      # connection: an injected client's adapter default would otherwise leave the
-      # requested +timeout+ unenforced. This mirrors the device flow's +post_form+.
+      # With a nil +http_client+ the fetch runs on the headers-first
+      # {stream_http} primitive (total wall-clock bound incl. the header phase).
+      # An INJECTED connection keeps the Faraday path: the request timeout is
+      # applied per-request (not only on the connection) so a bounded read is
+      # enforced even under the injected adapter's defaults, and the wall-clock
+      # deadline bounds the whole body read — but Faraday exposes no
+      # headers-time callback, so a body that stalls past the read timeout on
+      # the injected path surfaces as a bounded transport timeout.
       #
-      # @param http_client [Faraday::Connection] the SSRF-hardened connection
+      # @param http_client [Faraday::Connection, nil] injected connection, or
+      #   nil for the default headers-first transport
       # @param url [String] fully-qualified well-known URL to fetch
       # @param timeout [Integer] per-request timeout in seconds
       # @param max_body_bytes [Integer] bounded read cap in bytes
@@ -220,6 +334,46 @@ module Basecamp
       # @raise [OauthError] +api_error+ on non-2xx, oversized body, non-object
       #   JSON, or parse failure; +network+ on transport failure
       def self.fetch_json(http_client, url, timeout:, max_body_bytes: DEFAULT_MAX_BODY_BYTES)
+        status, body =
+          if http_client.nil?
+            stream_http(
+              :get, url,
+              headers: { "Accept" => "application/json" },
+              timeout: timeout, max_body_bytes: max_body_bytes
+            )
+          else
+            faraday_fetch(http_client, url, timeout: timeout, max_body_bytes: max_body_bytes)
+          end
+
+        unless (200..299).cover?(status)
+          raise OauthError.new(
+            "api_error",
+            "OAuth discovery failed with status #{status}: #{Basecamp::Security.truncate(body)}",
+            http_status: status
+          )
+        end
+
+        data = JSON.parse(body)
+        raise OauthError.new("api_error", "OAuth discovery response is not a JSON object") unless data.is_a?(Hash)
+
+        data
+      rescue BodyTooLarge
+        raise OauthError.new("api_error", "OAuth discovery response exceeds size cap")
+      rescue ReadDeadlineExceeded
+        raise OauthError.new("network", "OAuth discovery timed out", retryable: true)
+      rescue Faraday::Error => e
+        raise OauthError.new("network", "OAuth discovery failed: #{e.message}", retryable: true)
+      rescue JSON::ParserError => e
+        raise OauthError.new("api_error", "Failed to parse OAuth discovery response: #{e.message}")
+      end
+
+      # The Faraday transport for an INJECTED connection. The request timeout is
+      # applied per-request (not only on the connection) so a bounded read is
+      # enforced even under the injected adapter's defaults, and the wall-clock
+      # deadline bounds the whole body read.
+      #
+      # @return [Array(Integer, String)] status and body
+      def self.faraday_fetch(http_client, url, timeout:, max_body_bytes:)
         # Wall-clock deadline over the WHOLE read: req.options.timeout below bounds
         # only each socket read and resets on every chunk, so a slow-drip peer could
         # otherwise hang the fetch indefinitely while staying under max_body_bytes.
@@ -237,28 +391,7 @@ module Basecamp
           req.options.open_timeout = timeout
         end
 
-        body = chunks.join.force_encoding(Encoding::UTF_8)
-
-        unless (200..299).cover?(response.status)
-          raise OauthError.new(
-            "api_error",
-            "OAuth discovery failed with status #{response.status}: #{Basecamp::Security.truncate(body)}",
-            http_status: response.status
-          )
-        end
-
-        data = JSON.parse(body)
-        raise OauthError.new("api_error", "OAuth discovery response is not a JSON object") unless data.is_a?(Hash)
-
-        data
-      rescue BodyTooLarge
-        raise OauthError.new("api_error", "OAuth discovery response exceeds size cap")
-      rescue ReadDeadlineExceeded
-        raise OauthError.new("network", "OAuth discovery timed out", retryable: true)
-      rescue Faraday::Error => e
-        raise OauthError.new("network", "OAuth discovery failed: #{e.message}", retryable: true)
-      rescue JSON::ParserError => e
-        raise OauthError.new("api_error", "Failed to parse OAuth discovery response: #{e.message}")
+        [ response.status, chunks.join.force_encoding(Encoding::UTF_8) ]
       end
     end
   end

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -396,6 +396,14 @@ module Basecamp
               chunks << chunk
             end
           end
+          # Final monotonic re-check AFTER the response completes: a peer can
+          # deliver the last body chunk just before the deadline and the
+          # terminating EOF just after it — read_body runs no further per-chunk
+          # check, and the request thread can process that completion before
+          # the watchdog sets deadline_fired. A completed response is never
+          # accepted past the advertised total-request bound. (Skipped statuses
+          # keep status-first classification — SkipBody unwinds before this.)
+          raise ReadDeadlineExceeded if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
         ensure
           # Block-form start would close the session itself; with the explicit
           # start (needed so ONLY connection setup sits under Timeout.timeout)

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -321,8 +321,23 @@ module Basecamp
         end
 
         # URI#hostname strips IPv6 brackets ("[::1]" -> "::1"), which is the form
-        # Net::HTTP.new expects. ENV proxy handling matches faraday-net_http.
-        http = Net::HTTP.new(uri.hostname, uri.port)
+        # Net::HTTP.new expects.
+        #
+        # Net::HTTP's built-in :ENV proxy detection hardcodes an http:// URI
+        # before calling find_proxy, so an HTTPS_PROXY-only environment would
+        # silently bypass its proxy for HTTPS endpoints (and http_proxy would
+        # wrongly govern TLS requests). Resolve the proxy against the REAL
+        # scheme — matching faraday-net_http's per-scheme resolution — and
+        # pass it explicitly; a nil p_addr disables the broken built-in.
+        proxy_uri = uri.find_proxy
+        http = if proxy_uri
+                 Net::HTTP.new(
+                   uri.hostname, uri.port,
+                   proxy_uri.hostname, proxy_uri.port, proxy_uri.user, proxy_uri.password
+                 )
+        else
+                 Net::HTTP.new(uri.hostname, uri.port, nil)
+        end
         http.use_ssl = uri.scheme == "https"
         http.open_timeout = timeout
         http.read_timeout = timeout

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -296,6 +296,12 @@ module Basecamp
           raise OauthError.new("validation", \
             "stream_http timeout must be a positive number of seconds no greater than #{MAX_REQUEST_TIMEOUT}")
         end
+        # The body cap gets the same fail-closed discipline: nil, a Float
+        # (Infinity included), or a non-positive value would disable or crash
+        # the streaming bound.
+        unless max_body_bytes.is_a?(Integer) && max_body_bytes.positive?
+          raise OauthError.new("validation", "stream_http max_body_bytes must be a positive Integer")
+        end
 
         # URI#hostname strips IPv6 brackets ("[::1]" -> "::1"), which is the form
         # Net::HTTP.new expects. ENV proxy handling matches faraday-net_http.

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -2,6 +2,7 @@
 
 require "faraday"
 require "json"
+require "cgi/escape"
 require "net/http"
 require "openssl"
 require "timeout"
@@ -339,11 +340,13 @@ module Basecamp
                  # encoded forms, and the explicit-proxy Net::HTTP.new does NOT
                  # unescape them the way its :ENV mode does — p%40ss would be
                  # sent verbatim in Proxy-Authorization and fail authentication.
+                 # unescapeURIComponent, NOT form decoding: a literal + in a
+                 # userinfo component is a plus sign, never a space.
                  Net::HTTP.new(
                    uri.hostname, uri.port,
                    proxy_uri.hostname, proxy_uri.port,
-                   proxy_uri.user && URI.decode_www_form_component(proxy_uri.user),
-                   proxy_uri.password && URI.decode_www_form_component(proxy_uri.password)
+                   proxy_uri.user && CGI.unescapeURIComponent(proxy_uri.user),
+                   proxy_uri.password && CGI.unescapeURIComponent(proxy_uri.password)
                  )
         else
                  Net::HTTP.new(uri.hostname, uri.port, nil)

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -387,8 +387,13 @@ module Basecamp
         connect_remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
         raise ReadDeadlineExceeded unless connect_remaining.positive?
 
-        Timeout.timeout(connect_remaining, Net::OpenTimeout) { http.start }
         begin
+          # start INSIDE the cleanup region: Timeout.timeout's asynchronous
+          # Net::OpenTimeout can land after do_start marked the session
+          # started but before the next statement — outside the ensure, that
+          # window leaked a live connection until GC (the outer ensure can
+          # kill the watchdog before it ever closes).
+          Timeout.timeout(connect_remaining, Net::OpenTimeout) { http.start }
           # Re-check the deadline the moment the session is up: if setup
           # consumed the whole budget, fail now rather than granting the
           # request a fresh header wait.

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -110,18 +110,22 @@ module Basecamp
         end
       end
 
-      # Raised internally to abort a streaming read once the cap is exceeded.
-      # Never escapes this module — it is mapped to an OauthError.
+      # Raised to abort a streaming read once the cap is exceeded. Crosses the
+      # module boundary by design: {stream_http} lets it propagate raw, and each
+      # caller (fetch_json here, the device flow's post paths) maps it to its
+      # own typed cap fault.
       class BodyTooLarge < StandardError; end
 
-      # Raised internally when a streaming read exceeds its wall-clock deadline.
-      # Never escapes this module — it is mapped to a retryable +network+ OauthError.
+      # Raised when a streaming read exceeds its wall-clock deadline. Crosses
+      # the module boundary like {BodyTooLarge}: callers map it to a retryable
+      # +network+ fault (fetch_json) or a Faraday timeout (the device flow).
       class ReadDeadlineExceeded < StandardError; end
 
       # Raised from +on_data+ to STOP reading a response whose body the caller does
       # not use (a non-2xx device-auth, a 3xx token redirect). Draining such a slow
       # body would otherwise time out and be misclassified as a transport failure.
-      # Carries the response status so the caller can classify by it. Never escapes.
+      # Carries the response status so the caller can classify by it; like the
+      # markers above it crosses the module boundary raw and is mapped there.
       class SkipBody < StandardError
         attr_reader :status
 

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -342,6 +342,18 @@ module Basecamp
 
         deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
         deadline_fired = false
+        # Net::HTTP#request implicitly re-starts a finished session, and that
+        # restart runs OUTSIDE the connect Timeout.timeout below — an
+        # ENV-proxied CONNECT could drip unbounded there (started? stays
+        # false, so the watchdog cannot close it). The only path to a
+        # finished session is the watchdog, which fires only after the
+        # deadline: guarding EVERY start on deadline_fired closes every
+        # implicit-reconnect path deterministically.
+        http.define_singleton_method(:start) do |&blk|
+          raise Net::OpenTimeout, "total deadline exceeded before (re)connect" if deadline_fired
+
+          super(&blk)
+        end
         watchdog = Thread.new do
           remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
           sleep(remaining) if remaining.positive?

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -605,17 +605,26 @@ module Basecamp
 
         body =
           if chunks.empty?
-            # A buffered adapter (Faraday's test adapter above all) never
-            # invokes on_data: the streamed chunks are empty while the body
-            # sits on the response. Fall back to it under the same cap so an
-            # injected buffered client gets the document instead of a bogus
-            # empty-body parse failure — mirroring post_form's fallback.
-            # +dup+: a frozen response body (test adapters return literals)
-            # cannot take force_encoding below.
-            raw = response.body.to_s.dup
-            raise BodyTooLarge if raw.bytesize > max_body_bytes
+            if (200..299).cover?(response.status)
+              # A buffered adapter (Faraday's test adapter above all) never
+              # invokes on_data: the streamed chunks are empty while the body
+              # sits on the response. Fall back to it under the same cap so an
+              # injected buffered client gets the document instead of a bogus
+              # empty-body parse failure — mirroring post_form's fallback.
+              # +dup+: a frozen response body (test adapters return literals)
+              # cannot take force_encoding below.
+              raw = response.body.to_s.dup
+              raise BodyTooLarge if raw.bytesize > max_body_bytes
 
-            raw
+              raw
+            else
+              # fetch_json discards non-2xx bodies (status dominates, SPEC.md):
+              # return status-only rather than dup-and-size-checking a body
+              # nobody reads, so an oversized buffered error body surfaces as
+              # the status fault — not a size-cap one — and is never copied.
+              # +"" — the frozen literal cannot take force_encoding below.
+              +""
+            end
           else
             chunks.join
           end

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -625,9 +625,11 @@ module Basecamp
               # sits on the response. Fall back to it under the same cap so an
               # injected buffered client gets the document instead of a bogus
               # empty-body parse failure — mirroring post_form's fallback.
-              # +dup+: a frozen response body (test adapters return literals)
-              # cannot take force_encoding below.
-              raw = response.body.to_s.dup
+              # dup ONLY a frozen body (test adapters return literals, which
+              # cannot take force_encoding below): copying every large
+              # buffered 2xx unconditionally would double peak memory.
+              raw = response.body.to_s
+              raw = raw.dup if raw.frozen?
               raise BodyTooLarge if raw.bytesize > max_body_bytes
 
               raw

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -297,6 +297,12 @@ module Basecamp
       # @param skip_status [Proc, nil] statuses whose body is never read
       # @return [Array(Integer, String)] status and (possibly empty) body
       def self.stream_http(method, url, headers: {}, form: nil, timeout:, max_body_bytes: DEFAULT_MAX_BODY_BYTES, skip_status: nil)
+        # Response state first, before ANY call the def-level rescues could
+        # catch, so every rescue path sees it assigned (the completed_at guard
+        # means it is only READ once genuinely populated).
+        status = nil
+        chunks = []
+        total = 0
         uri = begin
           URI.parse(url)
         rescue URI::InvalidURIError
@@ -351,12 +357,6 @@ module Basecamp
         deadline = monotonic_now + timeout
         deadline_fired = false
         completed_at = nil
-        # Response state, initialized before ANY raising step so the rescue
-        # branches below can reference it on every path (the completed_at
-        # guard means it is only READ once genuinely populated).
-        status = nil
-        chunks = []
-        total = 0
         proxy_uri = Timeout.timeout(timeout, Net::OpenTimeout) { uri.find_proxy }
         http = if proxy_uri
                  proxy_tls = proxy_uri.scheme == "https"

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -2,7 +2,10 @@
 
 require "faraday"
 require "json"
-require "cgi/escape"
+# Full cgi, not cgi/escape: on Ruby 3.2-3.4 (the gem floor is 3.2) the
+# escape-only require leaves CGI.unescapeURIComponent broken with an
+# uninitialized @@accept_charset NameError.
+require "cgi"
 require "net/http"
 require "openssl"
 require "timeout"

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -358,17 +358,23 @@ module Basecamp
           raise ReadDeadlineExceeded if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
 
           http.request(request) do |response|
+            status = response.code.to_i
+            # Status-first: a skipped status's body is NEVER read — the raise
+            # unwinds to the ensure below, which closes the socket undrained.
+            # This outranks the deadline-race check below (SPEC §16): a
+            # completed response's KNOWN status must classify as its api_error
+            # even when the deadline fired while the headers were in flight —
+            # a discovery 500 or token redirect must never soften into a
+            # retryable timeout.
+            raise SkipBody.new(status) if skip_status&.call(status)
+
             # Net::HTTP#request implicitly re-starts a finished session: if the
             # watchdog's close landed between the deadline re-check above and
             # the request write, this round trip rode a fresh post-deadline
             # connection. The watchdog loop closes such a connection within a
-            # tick; this classifies a round trip that beat the next tick.
+            # tick; this classifies a non-skipped round trip that beat the
+            # next tick, BEFORE its body is read.
             raise ReadDeadlineExceeded if deadline_fired
-
-            status = response.code.to_i
-            # Status-first: a skipped status's body is NEVER read — the raise
-            # unwinds to the ensure below, which closes the socket undrained.
-            raise SkipBody.new(status) if skip_status&.call(status)
 
             response.read_body do |chunk|
               raise ReadDeadlineExceeded if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -687,7 +687,7 @@ module Basecamp
         # Wall-clock deadline over the WHOLE read: req.options.timeout below bounds
         # only each socket read and resets on every chunk, so a slow-drip peer could
         # otherwise hang the fetch indefinitely while staying under max_body_bytes.
-        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+        deadline = monotonic_now + timeout
         # Streaming adapters (Faraday >= 2.5 pass +env+ to on_data) classify a
         # non-2xx at HEADER time like the default path — fetch_json discards
         # non-2xx bodies, so draining one is pure waste. Buffered adapters
@@ -702,7 +702,13 @@ module Basecamp
         # otherwise hold the request open indefinitely — on_data (a body
         # callback) never runs during the header phase, leaving nothing else
         # to enforce the wall clock on an injected client.
-        response = Timeout.timeout(timeout, Faraday::TimeoutError) do
+        # The window is the REMAINING budget, not a fresh +timeout+: time
+        # spent before dispatch (descheduling included) already counts
+        # against the deadline, so the request can never run past it.
+        remaining = deadline - monotonic_now
+        raise Faraday::TimeoutError, "request budget exhausted before dispatch" if remaining <= 0
+
+        response = Timeout.timeout(remaining, Faraday::TimeoutError) do
           http_client.get(url) do |req|
             req.headers["Accept"] = "application/json"
             # Bounded streaming read: abort the moment the cap is exceeded so an
@@ -714,6 +720,14 @@ module Basecamp
             req.options.open_timeout = timeout
           end
         end
+
+        # Timeout.timeout's interrupt can be delivered late: a 2xx whose block
+        # returns just after the deadline would otherwise be accepted past the
+        # wall clock. A completed non-2xx stays status-classified (status
+        # outranks the deadline race, matching the default path); only a late
+        # 2xx is refused as the same transport-shaped timeout.
+        raise Faraday::TimeoutError, "response completed after the deadline" \
+          if (200..299).cover?(response.status) && monotonic_now > deadline
 
         body =
           if chunks.empty?

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -320,7 +320,12 @@ module Basecamp
           # thread the moment the request completes, so the loop cannot outlive
           # the call.
           loop do
-            begin
+            # The ensure's kill must never land INSIDE finish: interrupted
+            # after do_finish clears started? but before the socket close,
+            # BOTH closers skip — the request-side ensure sees started? false
+            # and this thread is dead — leaking the socket until GC. Defer the
+            # kill across each close attempt; it lands at the sleep below.
+            Thread.handle_interrupt(Object => :never) do
               http.finish
             rescue IOError
               # Not started: still connecting, or between implicit reopens.

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -432,6 +432,13 @@ module Basecamp
       # enforced even under the injected adapter's defaults, and the wall-clock
       # deadline bounds the whole body read.
       #
+      # Known residual (injected connections only): unlike the default
+      # {stream_http} path — which skips unusable bodies by status at header
+      # time — Faraday exposes no headers-time seam, so a non-2xx body is
+      # drained here under the same cap + deadline before the status error
+      # surfaces. Bounded, never followed; callers who inject a connection
+      # keep their transport's semantics by design.
+      #
       # @return [Array(Integer, String)] status and body
       def self.faraday_fetch(http_client, url, timeout:, max_body_bytes:)
         # Wall-clock deadline over the WHOLE read: req.options.timeout below bounds

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -281,6 +281,17 @@ module Basecamp
           raise OauthError.new("validation", "OAuth endpoint URL has no host: #{url.inspect}")
         end
 
+        # Fail closed on an un-normalized timeout (the operation entry points
+        # normalize; this guards direct callers): a non-finite, non-positive,
+        # or beyond-ceiling value would leave the socket timeouts and the
+        # watchdog's sleep unbounded, defeating the total-request bound this
+        # primitive exists to guarantee — mirroring the Python transport's
+        # fail-fast guard.
+        unless valid_timeout?(timeout)
+          raise OauthError.new("validation", \
+            "stream_http timeout must be a positive number of seconds no greater than #{MAX_REQUEST_TIMEOUT}")
+        end
+
         # URI#hostname strips IPv6 brackets ("[::1]" -> "::1"), which is the form
         # Net::HTTP.new expects. ENV proxy handling matches faraday-net_http.
         http = Net::HTTP.new(uri.hostname, uri.port)

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -396,6 +396,7 @@ module Basecamp
 
         deadline = monotonic_now + timeout
         deadline_fired = false
+        completed_at = nil
         # Net::HTTP#request implicitly re-starts a finished session, and that
         # restart runs OUTSIDE the connect Timeout.timeout below — an
         # ENV-proxied CONNECT could drip unbounded there (started? stays
@@ -498,6 +499,10 @@ module Basecamp
 
               chunks << chunk
             end
+            # Stamp completion INSIDE the request block: Net::HTTP's own
+            # end_transport runs before http.request returns, and the
+            # watchdog racing that cleanup must not erase a completed body.
+            completed_at = monotonic_now
           end
           # Final monotonic re-check AFTER the response completes: a peer can
           # deliver the last body chunk just before the deadline and the
@@ -545,6 +550,20 @@ module Basecamp
         # a post-deadline peer reset classifies as ConnectionFailed and the
         # device poll terminates instead of applying its transient backoff.
         raise classify_stream_error(e, deadline_fired || monotonic_now > deadline)
+      rescue NoMethodError => e
+        # The watchdog's cross-thread finish can nil @socket between the body
+        # completing and Net::HTTP's own end_transport, whose @socket.closed?
+        # then raises NoMethodError on the request thread. An in-deadline
+        # COMPLETED response dominates that cleanup race (mirroring the
+        # Python transport's outcome preservation); otherwise, past the
+        # deadline, it is the timeout the cleanup raced. A genuine
+        # NoMethodError (a bug) re-raises untouched.
+        if completed_at && completed_at <= deadline
+          return [ status, chunks.join.force_encoding(Encoding::UTF_8) ]
+        end
+        raise classify_stream_error(e, true) if deadline_fired || monotonic_now > deadline
+
+        raise
       rescue OpenSSL::SSL::SSLError => e
         # The watchdog's forced close surfaces mid-handshake/mid-read as an
         # SSLError: past the deadline it is the timeout it raced, same clock
@@ -651,15 +670,22 @@ module Basecamp
           skip_status: ->(s) { !(200..299).cover?(s) }
         )
 
-        response = http_client.get(url) do |req|
-          req.headers["Accept"] = "application/json"
-          # Bounded streaming read: abort the moment the cap is exceeded so an
-          # oversized body is never fully buffered.
-          req.options.on_data = on_data
-          # Apply the request timeout on every request — even an injected client —
-          # so a stalled socket can't hang discovery under the adapter default.
-          req.options.timeout = timeout
-          req.options.open_timeout = timeout
+        # Timeout.timeout wraps the WHOLE call: the per-read timeout resets on
+        # every socket read, so a peer dripping HEADER bytes under it would
+        # otherwise hold the request open indefinitely — on_data (a body
+        # callback) never runs during the header phase, leaving nothing else
+        # to enforce the wall clock on an injected client.
+        response = Timeout.timeout(timeout, Faraday::TimeoutError) do
+          http_client.get(url) do |req|
+            req.headers["Accept"] = "application/json"
+            # Bounded streaming read: abort the moment the cap is exceeded so an
+            # oversized body is never fully buffered.
+            req.options.on_data = on_data
+            # Apply the request timeout on every request — even an injected client —
+            # so a stalled socket can't hang discovery under the adapter default.
+            req.options.timeout = timeout
+            req.options.open_timeout = timeout
+          end
         end
 
         body =

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -306,16 +306,23 @@ module Basecamp
           remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
           sleep(remaining) if remaining.positive?
           deadline_fired = true
-          # Retry until the session exists to close: the deadline can fire while
-          # the session is still CONNECTING (finish then raises IOError), and a
-          # one-shot close would leave the subsequent header read unbounded. The
-          # ensure below kills this thread the moment the request completes, so
-          # the loop cannot outlive the call.
-          begin
-            http.finish
-          rescue IOError
+          # Close the session and KEEP closing until the ensure below kills this
+          # thread. A one-shot close is wrong twice over: finish raises IOError
+          # while the session is still CONNECTING (a single failed attempt would
+          # leave the subsequent header read unbounded), and Net::HTTP#request
+          # implicitly RE-STARTS a finished session — a close that landed
+          # between the post-connect deadline re-check and the request write
+          # would hand the reopened connection a fresh, unwatched header wait.
+          # Looping bounds any such reopen to one tick. The ensure kills this
+          # thread the moment the request completes, so the loop cannot outlive
+          # the call.
+          loop do
+            begin
+              http.finish
+            rescue IOError
+              # Not started: still connecting, or between implicit reopens.
+            end
             sleep(0.05)
-            retry
           end
         end
 
@@ -335,6 +342,13 @@ module Basecamp
           raise ReadDeadlineExceeded if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
 
           session.request(request) do |response|
+            # Net::HTTP#request implicitly re-starts a finished session: if the
+            # watchdog's close landed between the deadline re-check above and
+            # the request write, this round trip rode a fresh post-deadline
+            # connection. The watchdog loop closes such a connection within a
+            # tick; this classifies a round trip that beat the next tick.
+            raise ReadDeadlineExceeded if deadline_fired
+
             status = response.code.to_i
             # Status-first: a skipped status's body is NEVER read — the raise
             # unwinds through start, whose ensure closes the socket undrained.

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -512,9 +512,15 @@ module Basecamp
         # device poll terminates instead of applying its transient backoff.
         raise classify_stream_error(e, deadline_fired || monotonic_now > deadline)
       rescue OpenSSL::SSL::SSLError => e
-        # TLS failures (an unverifiable peer certificate above all) map to
-        # Faraday::SSLError exactly as faraday-net_http maps them, so the
+        # The watchdog's forced close surfaces mid-handshake/mid-read as an
+        # SSLError: past the deadline it is the timeout it raced, same clock
+        # rule as the wire-error branch above. A genuine pre-deadline TLS
+        # failure (an unverifiable peer certificate above all) still maps to
+        # Faraday::SSLError exactly as faraday-net_http maps it, so the
         # default and injected paths classify certificate rejection alike.
+        raise Faraday::TimeoutError, "OAuth request timed out: TLS interrupted past the deadline" \
+          if deadline_fired || monotonic_now > deadline
+
         raise Faraday::SSLError, e.message
       ensure
         watchdog&.kill

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -90,6 +90,25 @@ module Basecamp
         value.is_a?(Integer) && value >= 0
       end
 
+      # Classifies a wire fault from {stream_http}'s read into the Faraday error
+      # the caller rescues. Once the watchdog DEADLINE has fired, the forced
+      # close can surface in the blocked reader as IOError, a SystemCallError
+      # (ECONNRESET/EBADF and friends), or SocketError depending on platform
+      # and read phase — ALL of them are the timeout then, or the device poll
+      # would terminate as transport instead of applying its transient backoff.
+      # Before the deadline they are genuine wire faults: a peer closing
+      # mid-headers, a malformed status line/header (the Net parse errors are
+      # direct StandardError subclasses, not IOError, so they must be mapped
+      # explicitly or they leak raw), or malformed compressed bytes from
+      # Net::HTTP's automatic Content-Encoding decode (Zlib::Error).
+      def self.classify_stream_error(error, deadline_fired)
+        if deadline_fired
+          Faraday::TimeoutError.new("OAuth request exceeded the timeout deadline")
+        else
+          Faraday::ConnectionFailed.new(error.message)
+        end
+      end
+
       # Raised internally to abort a streaming read once the cap is exceeded.
       # Never escapes this module — it is mapped to an OauthError.
       class BodyTooLarge < StandardError; end
@@ -342,27 +361,14 @@ module Basecamp
         # rescues — or the device poll would terminate instead of applying its
         # transient backoff.
         raise Faraday::TimeoutError, "OAuth request timed out: #{e.message}"
-      rescue IOError => e
-        # The watchdog's close raises IOError in the blocked reader; only map it
-        # to a timeout when the deadline actually fired — any other IOError (a
-        # peer closing mid-headers, for example) is a connection failure.
-        raise Faraday::TimeoutError, "OAuth request exceeded the timeout deadline" if deadline_fired
-
-        raise Faraday::ConnectionFailed, e.message
+      rescue IOError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError,
+             SystemCallError, SocketError, Zlib::Error => e
+        raise classify_stream_error(e, deadline_fired)
       rescue OpenSSL::SSL::SSLError => e
         # TLS failures (an unverifiable peer certificate above all) map to
         # Faraday::SSLError exactly as faraday-net_http maps them, so the
         # default and injected paths classify certificate rejection alike.
         raise Faraday::SSLError, e.message
-      rescue Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError,
-             SystemCallError, SocketError, Zlib::Error => e
-        # The parse errors are direct StandardError subclasses (not IOError), so
-        # a malformed status line / header must be mapped here explicitly or it
-        # would leak raw from the public discovery/device APIs. Zlib::Error
-        # covers Net::HTTP's automatic Content-Encoding decode: a 2xx carrying
-        # malformed gzip/deflate bytes raises Zlib::DataError mid-read_body —
-        # a corrupt transport payload, mapped like every other wire fault.
-        raise Faraday::ConnectionFailed, e.message
       ensure
         watchdog&.kill
         watchdog&.join

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -351,6 +351,12 @@ module Basecamp
         deadline = monotonic_now + timeout
         deadline_fired = false
         completed_at = nil
+        # Response state, initialized before ANY raising step so the rescue
+        # branches below can reference it on every path (the completed_at
+        # guard means it is only READ once genuinely populated).
+        status = nil
+        chunks = []
+        total = 0
         proxy_uri = Timeout.timeout(timeout, Net::OpenTimeout) { uri.find_proxy }
         http = if proxy_uri
                  proxy_tls = proxy_uri.scheme == "https"
@@ -465,9 +471,6 @@ module Basecamp
           end
         end
 
-        status = nil
-        chunks = []
-        total = 0
         # The connection phases (TCP connect, proxy CONNECT, TLS handshake) run
         # before Net::HTTP marks the session started, so the watchdog cannot
         # interrupt them (finish raises IOError until then) — and only TCP

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -280,6 +280,11 @@ module Basecamp
         if uri.nil? || uri.hostname.nil? || uri.hostname.empty?
           raise OauthError.new("validation", "OAuth endpoint URL has no host: #{url.inspect}")
         end
+        # Fail closed on a non-HTTP(S) scheme: callers TLS-guard upstream, but
+        # the primitive must not run an HTTP conversation against ftp:// etc.
+        unless %w[http https].include?(uri.scheme)
+          raise OauthError.new("validation", "OAuth endpoint URL must be http(s): #{url.inspect}")
+        end
 
         # Fail closed on an un-normalized timeout (the operation entry points
         # normalize; this guards direct callers): a non-finite, non-positive,
@@ -300,6 +305,10 @@ module Basecamp
         http.read_timeout = timeout
         http.write_timeout = timeout
         http.max_retries = 0
+
+        # A form body is only meaningful on POST — a GET-with-body masks a
+        # call-site mistake and contradicts this method's own contract.
+        raise ArgumentError, "stream_http: form is only valid with :post" if form && method != :post
 
         request =
           case method
@@ -452,7 +461,7 @@ module Basecamp
       # @param http_client [Faraday::Connection, nil] injected connection, or
       #   nil for the default headers-first transport
       # @param url [String] fully-qualified well-known URL to fetch
-      # @param timeout [Integer] per-request timeout in seconds
+      # @param timeout [Numeric] per-request timeout in seconds (fractional accepted)
       # @param max_body_bytes [Integer] bounded read cap in bytes
       # @return [Hash] the parsed JSON document
       # @raise [OauthError] +api_error+ on non-2xx, oversized body, non-object
@@ -519,7 +528,14 @@ module Basecamp
         # only each socket read and resets on every chunk, so a slow-drip peer could
         # otherwise hang the fetch indefinitely while staying under max_body_bytes.
         deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
-        chunks, on_data = bounded_reader(max_body_bytes, deadline: deadline)
+        # Streaming adapters (Faraday >= 2.5 pass +env+ to on_data) classify a
+        # non-2xx at HEADER time like the default path — fetch_json discards
+        # non-2xx bodies, so draining one is pure waste. Buffered adapters
+        # remain the documented drain-then-classify residual.
+        chunks, on_data = bounded_reader(
+          max_body_bytes, deadline: deadline,
+          skip_status: ->(s) { !(200..299).cover?(s) }
+        )
 
         response = http_client.get(url) do |req|
           req.headers["Accept"] = "application/json"
@@ -532,7 +548,25 @@ module Basecamp
           req.options.open_timeout = timeout
         end
 
-        [ response.status, chunks.join.force_encoding(Encoding::UTF_8) ]
+        body =
+          if chunks.empty?
+            # A buffered adapter (Faraday's test adapter above all) never
+            # invokes on_data: the streamed chunks are empty while the body
+            # sits on the response. Fall back to it under the same cap so an
+            # injected buffered client gets the document instead of a bogus
+            # empty-body parse failure — mirroring post_form's fallback.
+            # +dup+: a frozen response body (test adapters return literals)
+            # cannot take force_encoding below.
+            raw = response.body.to_s.dup
+            raise BodyTooLarge if raw.bytesize > max_body_bytes
+
+            raw
+          else
+            chunks.join
+          end
+        [ response.status, body.force_encoding(Encoding::UTF_8) ]
+      rescue SkipBody => e
+        [ e.status, "" ]
       end
     end
   end

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -259,7 +259,12 @@ module Basecamp
         http.read_timeout = timeout
         http.max_retries = 0
 
-        request = method == :post ? Net::HTTP::Post.new(uri) : Net::HTTP::Get.new(uri)
+        request =
+          case method
+          when :post then Net::HTTP::Post.new(uri)
+          when :get then Net::HTTP::Get.new(uri)
+          else raise ArgumentError, "stream_http supports :get and :post, got #{method.inspect}"
+          end
         headers.each { |name, value| request[name] = value }
         if form
           request.body = URI.encode_www_form(form)

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -345,11 +345,16 @@ module Basecamp
                  # sent verbatim in Proxy-Authorization and fail authentication.
                  # unescapeURIComponent, NOT form decoding: a literal + in a
                  # userinfo component is a plus sign, never a space.
+                 # p_no_proxy nil (find_proxy already honored no_proxy);
+                 # p_use_ssl from the proxy URL's scheme — an https:// proxy
+                 # expects TLS on its own connection, and omitting it would
+                 # send plaintext to a TLS-only proxy and fail before CONNECT.
                  Net::HTTP.new(
                    uri.hostname, uri.port,
                    proxy_uri.hostname, proxy_uri.port,
                    proxy_uri.user && CGI.unescapeURIComponent(proxy_uri.user),
-                   proxy_uri.password && CGI.unescapeURIComponent(proxy_uri.password)
+                   proxy_uri.password && CGI.unescapeURIComponent(proxy_uri.password),
+                   nil, proxy_uri.scheme == "https"
                  )
         else
                  Net::HTTP.new(uri.hostname, uri.port, nil)

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -297,10 +297,12 @@ module Basecamp
             "stream_http timeout must be a positive number of seconds no greater than #{MAX_REQUEST_TIMEOUT}")
         end
         # The body cap gets the same fail-closed discipline: nil, a Float
-        # (Infinity included), or a non-positive value would disable or crash
-        # the streaming bound.
-        unless max_body_bytes.is_a?(Integer) && max_body_bytes.positive?
-          raise OauthError.new("validation", "stream_http max_body_bytes must be a positive Integer")
+        # (Infinity included), or a negative value would disable or crash the
+        # streaming bound. Same predicate as {normalize_body_cap} so the
+        # transport can never reject a cap the public entry points accept —
+        # zero is a legitimate strict cap (any non-empty body trips it).
+        unless valid_body_cap?(max_body_bytes)
+          raise OauthError.new("validation", "stream_http max_body_bytes must be a non-negative Integer")
         end
 
         # URI#hostname strips IPv6 brackets ("[::1]" -> "::1"), which is the form

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -4,6 +4,7 @@ require "faraday"
 require "json"
 require "net/http"
 require "openssl"
+require "timeout"
 require "uri"
 require "zlib"
 
@@ -237,10 +238,12 @@ module Basecamp
       #    Scope: the watchdog governs from session-start on. The CONNECTION
       #    phases (TCP connect, proxy CONNECT, TLS handshake) are not
       #    watchdog-interruptible — Net::HTTP marks the session started only
-      #    after they complete — but each is natively bounded by open_timeout,
-      #    and a post-connect deadline re-check refuses the request when setup
-      #    consumed the budget. Total wall clock is a small multiple of the
-      #    timeout, never unbounded.
+      #    after they complete — so connection setup runs under its own
+      #    whole-phase Timeout.timeout bound (a proxy's CONNECT response is
+      #    parsed under the per-read timeout, which a byte-dripping proxy
+      #    resets forever), and a post-connect deadline re-check refuses the
+      #    request when setup consumed the budget. Total wall clock is
+      #    ~timeout, never unbounded.
       #
       # The body streams under the same cap + deadline as the Faraday path, and
       # redirects are structurally never followed (+Net::HTTP#request+ has no
@@ -329,19 +332,27 @@ module Basecamp
         status = nil
         chunks = []
         total = 0
-        http.start do |session|
-          # The connection phases (TCP connect, proxy CONNECT, TLS handshake)
-          # are each natively bounded by open_timeout — the watchdog cannot
-          # interrupt them because Net::HTTP only marks the session started
-          # once they complete (finish raises IOError until then). Re-check the
-          # deadline the moment the session is up: if setup consumed the whole
-          # budget, fail now rather than granting the request a fresh header
-          # wait. Worst-case wall clock is a small multiple of the timeout
-          # (per-phase native bounds + watchdog from headers on), never
-          # unbounded.
+        # The connection phases (TCP connect, proxy CONNECT, TLS handshake) run
+        # before Net::HTTP marks the session started, so the watchdog cannot
+        # interrupt them (finish raises IOError until then) — and only TCP
+        # connect and the TLS handshake carry native open_timeout bounds. A
+        # proxy's CONNECT response is parsed under the PER-READ timeout, which
+        # resets on every dripped byte: without a whole-phase bound, an
+        # ENV-proxied HTTPS request could sit in connection setup indefinitely.
+        # Timeout.timeout's async raise is safe here precisely because the
+        # guarded region is ONLY connection setup: no response state exists
+        # yet, and Net::HTTP's connect rescue closes both sockets on any raise.
+        connect_remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        raise ReadDeadlineExceeded unless connect_remaining.positive?
+
+        Timeout.timeout(connect_remaining, Net::OpenTimeout) { http.start }
+        begin
+          # Re-check the deadline the moment the session is up: if setup
+          # consumed the whole budget, fail now rather than granting the
+          # request a fresh header wait.
           raise ReadDeadlineExceeded if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
 
-          session.request(request) do |response|
+          http.request(request) do |response|
             # Net::HTTP#request implicitly re-starts a finished session: if the
             # watchdog's close landed between the deadline re-check above and
             # the request write, this round trip rode a fresh post-deadline
@@ -351,7 +362,7 @@ module Basecamp
 
             status = response.code.to_i
             # Status-first: a skipped status's body is NEVER read — the raise
-            # unwinds through start, whose ensure closes the socket undrained.
+            # unwinds to the ensure below, which closes the socket undrained.
             raise SkipBody.new(status) if skip_status&.call(status)
 
             response.read_body do |chunk|
@@ -362,6 +373,15 @@ module Basecamp
 
               chunks << chunk
             end
+          end
+        ensure
+          # Block-form start would close the session itself; with the explicit
+          # start (needed so ONLY connection setup sits under Timeout.timeout)
+          # close it here.
+          begin
+            http.finish if http.started?
+          rescue IOError
+            # Already closed by the watchdog.
           end
         end
         [ status, chunks.join.force_encoding(Encoding::UTF_8) ]

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -5,6 +5,7 @@ require "json"
 require "net/http"
 require "openssl"
 require "uri"
+require "zlib"
 
 module Basecamp
   module Oauth
@@ -354,10 +355,13 @@ module Basecamp
         # default and injected paths classify certificate rejection alike.
         raise Faraday::SSLError, e.message
       rescue Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError,
-             SystemCallError, SocketError => e
+             SystemCallError, SocketError, Zlib::Error => e
         # The parse errors are direct StandardError subclasses (not IOError), so
         # a malformed status line / header must be mapped here explicitly or it
-        # would leak raw from the public discovery/device APIs.
+        # would leak raw from the public discovery/device APIs. Zlib::Error
+        # covers Net::HTTP's automatic Content-Encoding decode: a 2xx carrying
+        # malformed gzip/deflate bytes raises Zlib::DataError mid-read_body —
+        # a corrupt transport payload, mapped like every other wire fault.
         raise Faraday::ConnectionFailed, e.message
       ensure
         watchdog&.kill

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -246,7 +246,11 @@ module Basecamp
 
         request = method == :post ? Net::HTTP::Post.new(uri) : Net::HTTP::Get.new(uri)
         headers.each { |name, value| request[name] = value }
-        request.body = URI.encode_www_form(form) if form
+        if form
+          request.body = URI.encode_www_form(form)
+          # A form body implies the form content type; explicit headers win.
+          request["Content-Type"] ||= "application/x-www-form-urlencoded"
+        end
 
         deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
         deadline_fired = false
@@ -290,7 +294,10 @@ module Basecamp
         [ status, chunks.join.force_encoding(Encoding::UTF_8) ]
       rescue SkipBody => e
         [ e.status, "" ]
-      rescue Net::OpenTimeout, Net::ReadTimeout => e
+      rescue Net::OpenTimeout, Net::ReadTimeout, Errno::ETIMEDOUT => e
+        # Errno::ETIMEDOUT is a SystemCallError, but it is a TIMEOUT: it must map
+        # with the other timeouts (as faraday-net_http maps it) or the device
+        # poll would terminate instead of applying its transient backoff.
         raise Faraday::TimeoutError, "OAuth request timed out: #{e.message}"
       rescue IOError => e
         # The watchdog's close raises IOError in the blocked reader; only map it
@@ -353,12 +360,13 @@ module Basecamp
           end
 
         unless (200..299).cover?(status)
-          # The default path skips the non-2xx body (empty here); the injected
-          # Faraday path still carries it — append it only when present.
-          detail = body.empty? ? "" : ": #{Basecamp::Security.truncate(body)}"
+          # Status-only, on BOTH paths: the error category, retryability, and
+          # http_status are the observable contract; embedding response body
+          # text would put attacker-influenced content in exception messages
+          # and diverge from the (body-less) default transport and Python.
           raise OauthError.new(
             "api_error",
-            "OAuth discovery failed with status #{status}#{detail}",
+            "OAuth discovery failed with status #{status}",
             http_status: status
           )
         end

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -310,10 +310,19 @@ module Basecamp
         # call-site mistake and contradicts this method's own contract.
         raise ArgumentError, "stream_http: form is only valid with :post" if form && method != :post
 
+        # Identity encoding IN THE INITHEADER: Net::HTTP inflates gzip/deflate
+        # BEFORE read_body yields, so the per-chunk cap would measure DECODED
+        # bytes — a small compressed body could balloon far past max_body_bytes
+        # in memory (compression bomb). A caller-supplied Accept-Encoding at
+        # construction time is the supported way to switch decode_content off
+        # (assigning the header later does not); a server compressing anyway
+        # hands us raw bytes bounded by the cap, which then fail
+        # classification upstream instead of exhausting memory.
+        identity = { "Accept-Encoding" => "identity" }
         request =
           case method
-          when :post then Net::HTTP::Post.new(uri)
-          when :get then Net::HTTP::Get.new(uri)
+          when :post then Net::HTTP::Post.new(uri, identity)
+          when :get then Net::HTTP::Get.new(uri, identity)
           else raise ArgumentError, "stream_http supports :get and :post, got #{method.inspect}"
           end
         headers.each { |name, value| request[name] = value }

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -77,6 +77,12 @@ module Basecamp
       # Process.clock_gettime — so tests can stub Fetcher's own notion of
       # "now" without touching the process-wide clock that Net::HTTP, the
       # watchdog sleeps, and the test server all rely on.
+      # net-http >= 0.5 (Ruby 3.4+) added Net::HTTP.new's eighth p_use_ssl
+      # parameter; the gem floor is Ruby 3.2, whose bundled net-http lacks it.
+      def self.proxy_tls_capable?
+        Net::HTTP.method(:new).parameters.length >= 8
+      end
+
       def self.monotonic_now
         Process.clock_gettime(Process::CLOCK_MONOTONIC)
       end
@@ -337,25 +343,44 @@ module Basecamp
         # wrongly govern TLS requests). Resolve the proxy against the REAL
         # scheme — matching faraday-net_http's per-scheme resolution — and
         # pass it explicitly; a nil p_addr disables the broken built-in.
-        proxy_uri = uri.find_proxy
+        # The total deadline starts BEFORE proxy resolution: find_proxy
+        # resolves the target hostname (IPSocket.getaddress) to evaluate its
+        # loopback rule — a blocking DNS call that must sit inside the
+        # advertised bound like every other network step. Net::OpenTimeout
+        # maps through the Timeout::Error rescue to the transport timeout.
+        deadline = monotonic_now + timeout
+        deadline_fired = false
+        completed_at = nil
+        proxy_uri = Timeout.timeout(timeout, Net::OpenTimeout) { uri.find_proxy }
         http = if proxy_uri
+                 proxy_tls = proxy_uri.scheme == "https"
+                 # An https:// proxy needs TLS on its own connection via the
+                 # p_use_ssl argument, which exists only in net-http >= 0.5
+                 # (Ruby 3.4+). On the older bundled net-http (Ruby 3.2/3.3)
+                 # the 8-arg call would raise ArgumentError — refuse with an
+                 # actionable error instead of plaintext-to-a-TLS-proxy.
+                 if proxy_tls && !proxy_tls_capable?
+                   raise OauthError.new(
+                     "validation",
+                     "https:// proxies need net-http >= 0.5 (Ruby 3.4+, or add the net-http gem)"
+                   )
+                 end
+
                  # Percent-decode the credentials: URI#user/#password return the
                  # encoded forms, and the explicit-proxy Net::HTTP.new does NOT
                  # unescape them the way its :ENV mode does — p%40ss would be
                  # sent verbatim in Proxy-Authorization and fail authentication.
                  # unescapeURIComponent, NOT form decoding: a literal + in a
                  # userinfo component is a plus sign, never a space.
-                 # p_no_proxy nil (find_proxy already honored no_proxy);
-                 # p_use_ssl from the proxy URL's scheme — an https:// proxy
-                 # expects TLS on its own connection, and omitting it would
-                 # send plaintext to a TLS-only proxy and fail before CONNECT.
-                 Net::HTTP.new(
+                 # p_no_proxy nil (find_proxy already honored no_proxy).
+                 args = [
                    uri.hostname, uri.port,
                    proxy_uri.hostname, proxy_uri.port,
                    proxy_uri.user && CGI.unescapeURIComponent(proxy_uri.user),
-                   proxy_uri.password && CGI.unescapeURIComponent(proxy_uri.password),
-                   nil, proxy_uri.scheme == "https"
-                 )
+                   proxy_uri.password && CGI.unescapeURIComponent(proxy_uri.password)
+                 ]
+                 args += [ nil, true ] if proxy_tls
+                 Net::HTTP.new(*args)
         else
                  Net::HTTP.new(uri.hostname, uri.port, nil)
         end
@@ -399,9 +424,6 @@ module Basecamp
           request["Content-Type"] ||= "application/x-www-form-urlencoded"
         end
 
-        deadline = monotonic_now + timeout
-        deadline_fired = false
-        completed_at = nil
         # Net::HTTP#request implicitly re-starts a finished session, and that
         # restart runs OUTSIDE the connect Timeout.timeout below — an
         # ENV-proxied CONNECT could drip unbounded there (started? stays

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -505,7 +505,12 @@ module Basecamp
         raise Faraday::TimeoutError, "OAuth request timed out: #{e.message}"
       rescue IOError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError,
              SystemCallError, SocketError, Zlib::Error => e
-        raise classify_stream_error(e, deadline_fired)
+        # The clock outranks the watchdog FLAG: a wire fault observed past the
+        # monotonic deadline is the timeout it raced, even when the watchdog
+        # thread has not yet been scheduled to flip deadline_fired — otherwise
+        # a post-deadline peer reset classifies as ConnectionFailed and the
+        # device poll terminates instead of applying its transient backoff.
+        raise classify_stream_error(e, deadline_fired || monotonic_now > deadline)
       rescue OpenSSL::SSL::SSLError => e
         # TLS failures (an unverifiable peer certificate above all) map to
         # Faraday::SSLError exactly as faraday-net_http maps them, so the

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -325,7 +325,15 @@ module Basecamp
           when :get then Net::HTTP::Get.new(uri, identity)
           else raise ArgumentError, "stream_http supports :get and :post, got #{method.inspect}"
           end
-        headers.each { |name, value| request[name] = value }
+        headers.each do |name, value|
+          # The identity Accept-Encoding above is load-bearing (compression
+          # bomb bound): a caller-supplied override would reintroduce
+          # transparent inflation, so it is dropped — matching the Python
+          # transport, which forcibly overwrites the header.
+          next if name.to_s.casecmp("accept-encoding").zero?
+
+          request[name] = value
+        end
         if form
           request.body = URI.encode_www_form(form)
           # A form body implies the form content type; explicit headers win.

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -179,11 +179,15 @@ module Basecamp
           # callback, so the one unreachable case — headers arrive, then the body
           # stalls past the read timeout — surfaces as a bounded transport timeout
           # instead (never followed, never unbounded; see +post_form+).
-          raise SkipBody.new(env.status) if skip_status && env && skip_status.call(env.status)
-
-          if deadline && Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+          # Deadline FIRST: a first chunk that becomes runnable past the total
+          # bound means the status was not known in time — the timeout wins,
+          # matching the default transport's header-time gate. (The resetting
+          # per-read timeout alone would admit it.)
+          if deadline && monotonic_now > deadline
             raise ReadDeadlineExceeded
           end
+
+          raise SkipBody.new(env.status) if skip_status && env && skip_status.call(env.status)
 
           total += chunk.bytesize
           raise BodyTooLarge if total > max_body_bytes

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -114,7 +114,10 @@ module Basecamp
         if deadline_fired
           Faraday::TimeoutError.new("OAuth request exceeded the timeout deadline")
         else
-          Faraday::ConnectionFailed.new(error.message)
+          # Wrap the exception itself (the conventional Faraday pattern), not
+          # just its message: the original class and backtrace survive for
+          # debugging while callers' rescues see the same Faraday class.
+          Faraday::ConnectionFailed.new(error)
         end
       end
 

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -257,6 +257,7 @@ module Basecamp
         http.use_ssl = uri.scheme == "https"
         http.open_timeout = timeout
         http.read_timeout = timeout
+        http.write_timeout = timeout
         http.max_retries = 0
 
         request =
@@ -314,10 +315,13 @@ module Basecamp
         [ status, chunks.join.force_encoding(Encoding::UTF_8) ]
       rescue SkipBody => e
         [ e.status, "" ]
-      rescue Net::OpenTimeout, Net::ReadTimeout, Errno::ETIMEDOUT => e
-        # Errno::ETIMEDOUT is a SystemCallError, but it is a TIMEOUT: it must map
-        # with the other timeouts (as faraday-net_http maps it) or the device
-        # poll would terminate instead of applying its transient backoff.
+      rescue Timeout::Error, Errno::ETIMEDOUT => e
+        # Timeout::Error covers Net::OpenTimeout/ReadTimeout/WriteTimeout alike
+        # (a peer that accepts the connection but stops READING trips the write
+        # timeout). Errno::ETIMEDOUT is a SystemCallError, but it is a TIMEOUT:
+        # both must map with the timeouts — the exact pair faraday-net_http
+        # rescues — or the device poll would terminate instead of applying its
+        # transient backoff.
         raise Faraday::TimeoutError, "OAuth request timed out: #{e.message}"
       rescue IOError => e
         # The watchdog's close raises IOError in the blocked reader; only map it

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -69,6 +69,14 @@ module Basecamp
       # +real?+ gates out Complex before +finite?+/+positive?+ (which Complex does
       # not define — calling them would raise NoMethodError). Integer, Float, and
       # Rational are all real and answer both.
+      # Monotonic clock read (seconds). A module seam — rather than inline
+      # Process.clock_gettime — so tests can stub Fetcher's own notion of
+      # "now" without touching the process-wide clock that Net::HTTP, the
+      # watchdog sleeps, and the test server all rely on.
+      def self.monotonic_now
+        Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      end
+
       def self.valid_timeout?(value)
         value.is_a?(Numeric) && value.real? && value.finite? && value.positive? \
           && value <= MAX_REQUEST_TIMEOUT
@@ -352,7 +360,7 @@ module Basecamp
           request["Content-Type"] ||= "application/x-www-form-urlencoded"
         end
 
-        deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+        deadline = monotonic_now + timeout
         deadline_fired = false
         # Net::HTTP#request implicitly re-starts a finished session, and that
         # restart runs OUTSIDE the connect Timeout.timeout below — an
@@ -367,7 +375,7 @@ module Basecamp
           super(&blk)
         end
         watchdog = Thread.new do
-          remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          remaining = deadline - monotonic_now
           sleep(remaining) if remaining.positive?
           deadline_fired = true
           # Close the session and KEEP closing until the ensure below kills this
@@ -408,7 +416,7 @@ module Basecamp
         # Timeout.timeout's async raise is safe here precisely because the
         # guarded region is ONLY connection setup: no response state exists
         # yet, and Net::HTTP's connect rescue closes both sockets on any raise.
-        connect_remaining = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        connect_remaining = deadline - monotonic_now
         raise ReadDeadlineExceeded unless connect_remaining.positive?
 
         begin
@@ -421,18 +429,24 @@ module Basecamp
           # Re-check the deadline the moment the session is up: if setup
           # consumed the whole budget, fail now rather than granting the
           # request a fresh header wait.
-          raise ReadDeadlineExceeded if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+          raise ReadDeadlineExceeded if monotonic_now > deadline
 
           http.request(request) do |response|
             status = response.code.to_i
-            # Status-first: a skipped status's body is NEVER read — the raise
-            # unwinds to the ensure below, which closes the socket undrained.
-            # This outranks the deadline-race check below (SPEC §16): a
-            # completed response's KNOWN status must classify as its api_error
-            # even when the deadline fired while the headers were in flight —
-            # a discovery 500 or token redirect must never soften into a
-            # retryable timeout.
-            raise SkipBody.new(status) if skip_status&.call(status)
+            if skip_status&.call(status)
+              # Deadline first for a status NOT known in time: headers that
+              # become runnable past the monotonic deadline (but before the
+              # watchdog flips deadline_fired) are a timeout, not a
+              # classification — matching the Python transport. A status
+              # known IN time is still raised before any body read: the
+              # SkipBody unwinds to the ensure below, which closes the
+              # socket undrained, so a skipped status's body is NEVER
+              # drained and a discovery 500 or token redirect known before
+              # the deadline never softens into a retryable timeout.
+              raise ReadDeadlineExceeded if monotonic_now > deadline
+
+              raise SkipBody.new(status)
+            end
 
             # Net::HTTP#request implicitly re-starts a finished session: if the
             # watchdog's close landed between the deadline re-check above and
@@ -443,7 +457,7 @@ module Basecamp
             raise ReadDeadlineExceeded if deadline_fired
 
             response.read_body do |chunk|
-              raise ReadDeadlineExceeded if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+              raise ReadDeadlineExceeded if monotonic_now > deadline
 
               total += chunk.bytesize
               raise BodyTooLarge if total > max_body_bytes
@@ -458,7 +472,7 @@ module Basecamp
           # the watchdog sets deadline_fired. A completed response is never
           # accepted past the advertised total-request bound. (Skipped statuses
           # keep status-first classification — SkipBody unwinds before this.)
-          raise ReadDeadlineExceeded if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+          raise ReadDeadlineExceeded if monotonic_now > deadline
         ensure
           # Block-form start would close the session itself; with the explicit
           # start (needed so ONLY connection setup sits under Timeout.timeout)

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -299,6 +299,11 @@ module Basecamp
         raise Faraday::TimeoutError, "OAuth request exceeded the timeout deadline" if deadline_fired
 
         raise Faraday::ConnectionFailed, e.message
+      rescue OpenSSL::SSL::SSLError => e
+        # TLS failures (an unverifiable peer certificate above all) map to
+        # Faraday::SSLError exactly as faraday-net_http maps them, so the
+        # default and injected paths classify certificate rejection alike.
+        raise Faraday::SSLError, e.message
       rescue Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError,
              SystemCallError, SocketError => e
         # The parse errors are direct StandardError subclasses (not IOError), so
@@ -335,16 +340,25 @@ module Basecamp
             stream_http(
               :get, url,
               headers: { "Accept" => "application/json" },
-              timeout: timeout, max_body_bytes: max_body_bytes
+              timeout: timeout, max_body_bytes: max_body_bytes,
+              # STATUS DOMINATES THE BODY (SPEC.md: non-2xx on either hop →
+              # api_error, never network): skip draining a non-2xx body so a
+              # stalled/dripped error body cannot convert the required api_error
+              # into a network timeout. The body text was only optional
+              # diagnostics — the other SDKs read it best-effort at most.
+              skip_status: ->(response_status) { !(200..299).cover?(response_status) }
             )
           else
             faraday_fetch(http_client, url, timeout: timeout, max_body_bytes: max_body_bytes)
           end
 
         unless (200..299).cover?(status)
+          # The default path skips the non-2xx body (empty here); the injected
+          # Faraday path still carries it — append it only when present.
+          detail = body.empty? ? "" : ": #{Basecamp::Security.truncate(body)}"
           raise OauthError.new(
             "api_error",
-            "OAuth discovery failed with status #{status}: #{Basecamp::Security.truncate(body)}",
+            "OAuth discovery failed with status #{status}#{detail}",
             http_status: status
           )
         end

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -235,7 +235,19 @@ module Basecamp
       # @param skip_status [Proc, nil] statuses whose body is never read
       # @return [Array(Integer, String)] status and (possibly empty) body
       def self.stream_http(method, url, headers: {}, form: nil, timeout:, max_body_bytes: DEFAULT_MAX_BODY_BYTES, skip_status: nil)
-        uri = URI.parse(url)
+        uri = begin
+          URI.parse(url)
+        rescue URI::InvalidURIError
+          nil
+        end
+        # Fail closed on an unparsable or hostless URL ("https:foo" parses with a
+        # nil hostname): require_https checks only the scheme, and a nil host
+        # would otherwise surface as a raw ArgumentError from inside Net::HTTP —
+        # outside the transport's Faraday-error contract.
+        if uri.nil? || uri.hostname.nil? || uri.hostname.empty?
+          raise OauthError.new("validation", "OAuth endpoint URL has no host: #{url.inspect}")
+        end
+
         # URI#hostname strips IPv6 brackets ("[::1]" -> "::1"), which is the form
         # Net::HTTP.new expects. ENV proxy handling matches faraday-net_http.
         http = Net::HTTP.new(uri.hostname, uri.port)

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -214,6 +214,13 @@ module Basecamp
       #    raises IOError in the blocked reader — verified on a live socket).
       #    +max_retries = 0+ is load-bearing: Net::HTTP's idempotent-retry would
       #    otherwise silently REOPEN the connection the watchdog just closed.
+      #    Scope: the watchdog governs from session-start on. The CONNECTION
+      #    phases (TCP connect, proxy CONNECT, TLS handshake) are not
+      #    watchdog-interruptible — Net::HTTP marks the session started only
+      #    after they complete — but each is natively bounded by open_timeout,
+      #    and a post-connect deadline re-check refuses the request when setup
+      #    consumed the budget. Total wall clock is a small multiple of the
+      #    timeout, never unbounded.
       #
       # The body streams under the same cap + deadline as the Faraday path, and
       # redirects are structurally never followed (+Net::HTTP#request+ has no
@@ -296,6 +303,17 @@ module Basecamp
         chunks = []
         total = 0
         http.start do |session|
+          # The connection phases (TCP connect, proxy CONNECT, TLS handshake)
+          # are each natively bounded by open_timeout — the watchdog cannot
+          # interrupt them because Net::HTTP only marks the session started
+          # once they complete (finish raises IOError until then). Re-check the
+          # deadline the moment the session is up: if setup consumed the whole
+          # budget, fail now rather than granting the request a fresh header
+          # wait. Worst-case wall clock is a small multiple of the timeout
+          # (per-phase native bounds + watchdog from headers on), never
+          # unbounded.
+          raise ReadDeadlineExceeded if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+
           session.request(request) do |response|
             status = response.code.to_i
             # Status-first: a skipped status's body is NEVER read — the raise

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -154,29 +154,16 @@ module Basecamp
         [ chunks, reader ]
       end
 
-      # Builds the default SSRF-hardened Faraday connection. No redirect
-      # middleware is registered, so redirects are not followed.
-      #
-      # @param timeout [Integer] request + connect timeout in seconds
-      # @return [Faraday::Connection]
-      def self.build_client(timeout)
-        Faraday.new do |conn|
-          conn.options.timeout = timeout
-          conn.options.open_timeout = timeout
-          conn.adapter Faraday.default_adapter
-        end
-      end
-
       # Rejects an INJECTED connection whose middleware stack we cannot verify to
       # be redirect-free. Redirect suppression is a load-bearing SSRF control (RFC
       # 9728 §7.7): a caller-supplied client that follows redirects would silently
       # chase an attacker-controlled +Location+. A class-NAME heuristic (matching
       # +/redirect/+) is bypassable by a follower whose class name does not contain
       # "redirect", so we enforce a POLICY instead of guessing by name: an injected
-      # connection may carry ONLY adapter handlers. The default {build_client}
-      # connection (adapter only) and a test's mock adapter qualify; ANY request/
-      # response middleware — which could follow redirects under any name, or
-      # otherwise rewrite the request — is refused rather than trusted.
+      # connection may carry ONLY adapter handlers (an adapter-only connection or
+      # a test's mock adapter qualifies); ANY request/response middleware — which
+      # could follow redirects under any name, or otherwise rewrite the request —
+      # is refused rather than trusted.
       #
       # @param client [Faraday::Connection]
       # @raise [OauthError] +validation+ when non-adapter middleware is present
@@ -228,17 +215,22 @@ module Basecamp
       # The body streams under the same cap + deadline as the Faraday path, and
       # redirects are structurally never followed (+Net::HTTP#request+ has no
       # follow logic). Transport failures surface as Faraday errors
-      # (+TimeoutError+ for timeout/deadline, +ConnectionFailed+ otherwise) so
-      # both transport paths classify through the same caller rescues.
+      # (+TimeoutError+ for timeouts, +ConnectionFailed+ for connection and
+      # protocol-parse failures) so both transport paths classify through the
+      # same caller rescues. Bounded-read violations keep raising the shared
+      # {BodyTooLarge} / {ReadDeadlineExceeded} markers — deliberately NOT
+      # Faraday errors, so each caller maps them to its own operation-specific
+      # error message, exactly as on the Faraday path.
       #
       # @param method [Symbol] +:get+ or +:post+
       # @param url [String] fully-qualified URL (already origin-validated)
       # @param headers [Hash] request headers
       # @param form [Hash, nil] form params; www-form-encoded into the POST body
       # @param timeout [Numeric] total request bound in seconds (already
-      #   normalized by the caller); connect is separately bounded by the same
-      #   value, so the absolute worst case is ~2x timeout when the deadline
-      #   fires mid-connect
+      #   normalized by the caller). The deadline is anchored BEFORE connect and
+      #   open_timeout carries the same value, so the total wall time is
+      #   ~timeout regardless of which phase stalls (the watchdog closes the
+      #   session the moment it exists if the deadline fired mid-connect)
       # @param max_body_bytes [Integer] bounded read cap in bytes
       # @param skip_status [Proc, nil] statuses whose body is never read
       # @return [Array(Integer, String)] status and (possibly empty) body
@@ -307,7 +299,11 @@ module Basecamp
         raise Faraday::TimeoutError, "OAuth request exceeded the timeout deadline" if deadline_fired
 
         raise Faraday::ConnectionFailed, e.message
-      rescue SystemCallError, SocketError => e
+      rescue Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError,
+             SystemCallError, SocketError => e
+        # The parse errors are direct StandardError subclasses (not IOError), so
+        # a malformed status line / header must be mapped here explicitly or it
+        # would leak raw from the public discovery/device APIs.
         raise Faraday::ConnectionFailed, e.message
       ensure
         watchdog&.kill

--- a/ruby/lib/basecamp/oauth/resource.rb
+++ b/ruby/lib/basecamp/oauth/resource.rb
@@ -14,7 +14,10 @@ module Basecamp
         # wall-clock deadline: a non-finite/non-positive timeout must not disable
         # either bound (see Fetcher.normalize_timeout).
         @timeout = Fetcher.normalize_timeout(timeout)
-        @http_client = http_client || Fetcher.build_client(@timeout)
+        # nil selects the headers-first {Fetcher.stream_http} transport (total
+        # wall-clock bound incl. the header phase); an injected connection keeps
+        # the Faraday path, verified redirect-free above.
+        @http_client = http_client
         # Normalize the public cap to a finite non-negative Integer: a nil, float,
         # or Float::INFINITY would otherwise disable the streaming memory bound
         # (an infinite/undefined cap never trips), reintroducing an SSRF/OOM risk.

--- a/ruby/lib/basecamp/oauth/resource.rb
+++ b/ruby/lib/basecamp/oauth/resource.rb
@@ -10,7 +10,8 @@ module Basecamp
       # @param max_body_bytes [Integer] bounded read cap in bytes
       def initialize(http_client: nil, timeout: 10, max_body_bytes: Fetcher::DEFAULT_MAX_BODY_BYTES)
         Fetcher.ensure_redirects_suppressed!(http_client) if http_client
-        # Normalize before building the client and before the fetch computes its
+        # Normalize before storing (nil selects the headers-first Net::HTTP
+        # transport; an injected client is kept) and before the fetch computes its
         # wall-clock deadline: a non-finite/non-positive timeout must not disable
         # either bound (see Fetcher.normalize_timeout).
         @timeout = Fetcher.normalize_timeout(timeout)

--- a/ruby/lib/basecamp/oauth/resource.rb
+++ b/ruby/lib/basecamp/oauth/resource.rb
@@ -5,8 +5,11 @@ module Basecamp
     # Fetches RFC 9728 protected-resource metadata (hop 1 of resource-first
     # discovery) and binds the returned +resource+ to the requested origin.
     class Resource
-      # @param http_client [Faraday::Connection, nil] HTTP client (SSRF-hardened default if nil)
-      # @param timeout [Integer] request timeout in seconds (default: 10)
+      # @param http_client [Faraday::Connection, nil] injected Faraday client
+      #   (kept, verified redirect-free); nil selects the default headers-first
+      #   Net::HTTP transport ({Fetcher.stream_http})
+      # @param timeout [Numeric] request timeout in seconds (default: 10); an
+      #   invalid value falls back via {Fetcher.normalize_timeout}
       # @param max_body_bytes [Integer] bounded read cap in bytes
       def initialize(http_client: nil, timeout: 10, max_body_bytes: Fetcher::DEFAULT_MAX_BODY_BYTES)
         Fetcher.ensure_redirects_suppressed!(http_client) if http_client

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -92,6 +92,26 @@ class OAuthDeviceTest < Minitest::Test
 
   # --- request_device_authorization -----------------------------------------
 
+  def test_request_maps_an_oversized_default_transport_body_to_api_error
+    # The nil-client path early-returns Fetcher.stream_http, whose raw
+    # BodyTooLarge marker is still mapped by post_form's def-level rescues —
+    # a raise inside `return expr` does not bypass a method-level rescue.
+    stub_request(:post, DEVICE_ENDPOINT).to_return(
+      status: 200, headers: { "Content-Type" => "application/json" },
+      body: "x" * 2048
+    )
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth::DeviceFlow.request_device_authorization(
+        device_authorization_endpoint: DEVICE_ENDPOINT, client_id: "basecamp-cli",
+        max_body_bytes: 1024
+      )
+    end
+
+    assert_equal "api_error", error.type
+    assert_match(/size cap/i, error.message)
+  end
+
   def test_request_omits_scope_when_unset_and_validates_response
     stub_request(:post, DEVICE_ENDPOINT).to_return(json(device_auth_response))
 

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -49,7 +49,7 @@ class OAuthTransportTest < Minitest::Test
         @conns << conn
         while (line = conn.gets) && line != "\r\n"; end
         handler.call(conn)
-      rescue IOError, Errno::EBADF
+      rescue IOError, SystemCallError
         break # server closed in teardown
       end
     end
@@ -124,7 +124,7 @@ class OAuthTransportTest < Minitest::Test
       begin
         1_000.times { conn.write("x" * 10_000); sleep 0.005 }
         server_saw_close << false
-      rescue Errno::EPIPE, IOError, Errno::ECONNRESET
+      rescue IOError, SystemCallError
         server_saw_close << true
       end
     end
@@ -166,7 +166,7 @@ class OAuthTransportTest < Minitest::Test
       "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n".each_char do |char|
         begin
           conn.write(char)
-        rescue IOError, Errno::EPIPE
+        rescue IOError, SystemCallError
           break
         end
         sleep 0.1
@@ -216,7 +216,7 @@ class OAuthTransportTest < Minitest::Test
       loop do
         conn.write("x")
         sleep 0.1
-      rescue IOError, Errno::EPIPE
+      rescue IOError, SystemCallError
         break
       end
     end
@@ -238,7 +238,7 @@ class OAuthTransportTest < Minitest::Test
       conn.write("HTTP/1.1 200 OK\r\nContent-Length: 300000\r\n\r\n")
       begin
         30.times { conn.write("x" * 10_000) }
-      rescue IOError, Errno::EPIPE
+      rescue IOError, SystemCallError
         nil
       end
     end
@@ -282,7 +282,7 @@ class OAuthTransportTest < Minitest::Test
       loop do
         @conns << ssl_server.accept
         handshakes_completed += 1
-      rescue OpenSSL::SSL::SSLError, IOError, Errno::EBADF, Errno::ECONNRESET
+      rescue OpenSSL::SSL::SSLError, IOError, SystemCallError
         # The client rejecting the cert aborts the handshake server-side —
         # keep accepting until teardown closes the listener.
         break if tcp.closed?

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -298,6 +298,13 @@ class OAuthTransportTest < Minitest::Test
     assert_equal 0, handshakes_completed, "the client must abort the handshake, not complete it"
   end
 
+  def test_unsupported_method_fails_fast
+    # A typo'd verb must not silently become a GET.
+    assert_raises(ArgumentError) do
+      Basecamp::Oauth::Fetcher.stream_http(:put, "https://issuer.example/x", timeout: TIMEOUT)
+    end
+  end
+
   def test_hostless_url_fails_closed_as_validation_error
     # "https:foo" passes the scheme-only HTTPS guard but parses with a nil
     # hostname; without the explicit check it surfaced as a raw ArgumentError

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -298,6 +298,19 @@ class OAuthTransportTest < Minitest::Test
     assert_equal 0, handshakes_completed, "the client must abort the handshake, not complete it"
   end
 
+  def test_hostless_url_fails_closed_as_validation_error
+    # "https:foo" passes the scheme-only HTTPS guard but parses with a nil
+    # hostname; without the explicit check it surfaced as a raw ArgumentError
+    # from inside Net::HTTP — outside the transport's error contract.
+    [ "https:foo", "https://", "http:" ].each do |url|
+      error = assert_raises(Basecamp::Oauth::OauthError, url) do
+        Basecamp::Oauth::Fetcher.stream_http(:post, url, form: { "a" => "b" }, timeout: TIMEOUT)
+      end
+      assert_equal "validation", error.type, url
+      assert_match(/no host/i, error.message)
+    end
+  end
+
   def test_malformed_http_response_maps_to_transport_error
     # A non-HTTP peer (garbage status line) raises Net::HTTPBadResponse — a bare
     # StandardError subclass that must be mapped, or it leaks raw from the

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "openssl"
 require "socket"
 
 # Acceptance tests for the headers-first default transport

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -17,9 +17,17 @@ class OAuthTransportTest < Minitest::Test
     # header-time semantics these tests exist to prove.
     WebMock.disable!
     @servers = []
+    @conns = []
+    @server_threads = []
   end
 
   def teardown
+    # Stop the server threads FIRST (they append to @conns), then close every
+    # accepted socket and listener — the stall handlers sleep for tens of
+    # seconds, so without the kill+join each test would leak a live thread and
+    # its socket well past the test's end.
+    @server_threads.each(&:kill).each(&:join)
+    @conns.each { |conn| conn.close rescue nil }
     @servers.each { |server| server.close rescue nil }
     WebMock.enable!
     WebMock.disable_net_connect!
@@ -27,15 +35,17 @@ class OAuthTransportTest < Minitest::Test
 
   # Starts a real TCP server; the handler receives each accepted socket after
   # the request headers have been consumed. Returns [endpoint, accepts] where
-  # +accepts+ counts connections — the zero-retry assertions read it.
+  # +accepts+ counts connections — the zero-retry assertions read it. Accepted
+  # sockets and the accept thread are tracked for teardown.
   def start_server(&handler)
     server = TCPServer.new("127.0.0.1", 0)
     @servers << server
     accepts = []
-    Thread.new do
+    @server_threads << Thread.new do
       loop do
         conn = server.accept
         accepts << conn
+        @conns << conn
         while (line = conn.gets) && line != "\r\n"; end
         handler.call(conn)
       rescue IOError, Errno::EBADF
@@ -177,6 +187,26 @@ class OAuthTransportTest < Minitest::Test
     assert_operator seconds, :<, TIMEOUT * 3, "a dripped header phase must be bounded by the watchdog"
   end
 
+  def test_discovery_non_2xx_with_stalled_body_is_immediate_api_error
+    # SPEC.md: non-2xx on either discovery hop → api_error, never network —
+    # status dominates even when the error body stalls forever.
+    endpoint, = start_server do |conn|
+      conn.write("HTTP/1.1 500 Internal Server Error\r\nContent-Length: 1000\r\n\r\n")
+      sleep 30
+    end
+
+    error = nil
+    seconds = elapsed do
+      error = assert_raises(Basecamp::Oauth::OauthError) do
+        Basecamp::Oauth::Fetcher.fetch_json(nil, "#{endpoint}/doc", timeout: TIMEOUT)
+      end
+    end
+
+    assert_equal "api_error", error.type
+    assert_equal 500, error.http_status
+    assert_operator seconds, :<, TIMEOUT, "status must classify at header time"
+  end
+
   def test_body_slow_drip_is_bounded_for_discovery
     # A wanted (2xx) body dripped forever: the read-loop deadline bounds it and
     # discovery surfaces its retryable network timeout.
@@ -220,6 +250,52 @@ class OAuthTransportTest < Minitest::Test
 
     assert_equal "api_error", error.type
     assert_match(/size cap/i, error.message)
+  end
+
+  def test_self_signed_tls_certificate_is_rejected_and_mapped
+    # The default transport moved from Faraday to direct Net::HTTP — prove peer
+    # verification survived the move: a self-signed certificate must fail the
+    # handshake and map to the same Faraday::SSLError → network classification
+    # faraday-net_http produced, never a raw OpenSSL exception (and never a
+    # completed request).
+    key = OpenSSL::PKey::RSA.new(2048)
+    name = OpenSSL::X509::Name.parse("/CN=127.0.0.1")
+    cert = OpenSSL::X509::Certificate.new
+    cert.version = 2
+    cert.serial = 1
+    cert.subject = name
+    cert.issuer = name
+    cert.public_key = key.public_key
+    cert.not_before = Time.now - 60
+    cert.not_after = Time.now + 3600
+    cert.sign(key, OpenSSL::Digest.new("SHA256"))
+
+    ssl_context = OpenSSL::SSL::SSLContext.new
+    ssl_context.cert = cert
+    ssl_context.key = key
+    tcp = TCPServer.new("127.0.0.1", 0)
+    @servers << tcp
+    ssl_server = OpenSSL::SSL::SSLServer.new(tcp, ssl_context)
+    handshakes_completed = 0
+    @server_threads << Thread.new do
+      loop do
+        @conns << ssl_server.accept
+        handshakes_completed += 1
+      rescue OpenSSL::SSL::SSLError, IOError, Errno::EBADF, Errno::ECONNRESET
+        # The client rejecting the cert aborts the handshake server-side —
+        # keep accepting until teardown closes the listener.
+        break if tcp.closed?
+      end
+    end
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth::Fetcher.fetch_json(nil, "https://127.0.0.1:#{tcp.addr[1]}/doc", timeout: TIMEOUT)
+    end
+
+    assert_equal "network", error.type
+    assert error.retryable
+    assert_match(/certificate|SSL/i, error.message)
+    assert_equal 0, handshakes_completed, "the client must abort the handshake, not complete it"
   end
 
   def test_malformed_http_response_maps_to_transport_error

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -222,6 +222,23 @@ class OAuthTransportTest < Minitest::Test
     assert_match(/size cap/i, error.message)
   end
 
+  def test_malformed_http_response_maps_to_transport_error
+    # A non-HTTP peer (garbage status line) raises Net::HTTPBadResponse — a bare
+    # StandardError subclass that must be mapped, or it leaks raw from the
+    # public discovery/device APIs instead of the documented network error.
+    endpoint, = start_server do |conn|
+      conn.write("NOT-HTTP GARBAGE\r\n\r\n")
+      conn.close
+    end
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth::Fetcher.fetch_json(nil, "#{endpoint}/doc", timeout: TIMEOUT)
+    end
+
+    assert_equal "network", error.type
+    assert error.retryable
+  end
+
   def test_watchdog_threads_do_not_leak
     endpoint, = start_server do |conn|
       conn.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}")

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -1,0 +1,238 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "socket"
+
+# Acceptance tests for the headers-first default transport
+# ({Basecamp::Oauth::Fetcher.stream_http}) against REAL sockets — the response
+# shapes these prove (a stalled or byte-dripped header phase, a body that never
+# arrives after headers) cannot be produced by WebMock stubs or Faraday test
+# adapters, and are exactly the shapes the primitive exists to bound.
+class OAuthTransportTest < Minitest::Test
+  TIMEOUT = 0.6
+
+  def setup
+    # Fully unpatch Net::HTTP (not merely allow_localhost): WebMock's patched
+    # Net::HTTP buffers even allowed real requests, which destroys the
+    # header-time semantics these tests exist to prove.
+    WebMock.disable!
+    @servers = []
+  end
+
+  def teardown
+    @servers.each { |server| server.close rescue nil }
+    WebMock.enable!
+    WebMock.disable_net_connect!
+  end
+
+  # Starts a real TCP server; the handler receives each accepted socket after
+  # the request headers have been consumed. Returns [endpoint, accepts] where
+  # +accepts+ counts connections — the zero-retry assertions read it.
+  def start_server(&handler)
+    server = TCPServer.new("127.0.0.1", 0)
+    @servers << server
+    accepts = []
+    Thread.new do
+      loop do
+        conn = server.accept
+        accepts << conn
+        while (line = conn.gets) && line != "\r\n"; end
+        handler.call(conn)
+      rescue IOError, Errno::EBADF
+        break # server closed in teardown
+      end
+    end
+    [ "http://127.0.0.1:#{server.addr[1]}", accepts ]
+  end
+
+  def elapsed
+    start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    yield
+    Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+  end
+
+  # --- status-first: a skipped status classifies at HEADER time -------------
+
+  def test_device_auth_non_2xx_with_stalled_body_is_immediate_api_error
+    # 500 headers, then NOT ONE body byte: the old body-callback transport could
+    # only time this out as :transport; headers-first classifies it instantly.
+    endpoint, = start_server do |conn|
+      conn.write("HTTP/1.1 500 Internal Server Error\r\nContent-Length: 1000\r\n\r\n")
+      sleep 30
+    end
+
+    error = nil
+    seconds = elapsed do
+      error = assert_raises(Basecamp::Oauth::OauthError) do
+        Basecamp::Oauth::DeviceFlow.request_device_authorization(
+          device_authorization_endpoint: "#{endpoint}/device",
+          client_id: "basecamp-cli", timeout: TIMEOUT
+        )
+      end
+    end
+
+    assert_equal "api_error", error.type
+    assert_equal 500, error.http_status
+    assert_operator seconds, :<, TIMEOUT, "status must classify at header time, not after a body timeout"
+  end
+
+  def test_token_poll_302_with_stalled_body_is_immediate_api_error_with_zero_retries
+    # The SPEC §16 contract this transport closes: a token 3xx whose body stalls
+    # must surface the redirect api_error immediately — one request, no
+    # transport-backoff retries toward code expiry.
+    endpoint, accepts = start_server do |conn|
+      conn.write("HTTP/1.1 302 Found\r\nLocation: https://attacker.example/\r\nContent-Length: 1000\r\n\r\n")
+      sleep 30
+    end
+
+    error = nil
+    seconds = elapsed do
+      error = assert_raises(Basecamp::Oauth::OauthError) do
+        Basecamp::Oauth::DeviceFlow.poll_device_token(
+          token_endpoint: "#{endpoint}/token", client_id: "basecamp-cli",
+          device_code: "d", interval: 5, expires_in: 900,
+          timeout: TIMEOUT, sleeper: ->(_seconds) { }
+        )
+      end
+    end
+
+    assert_equal "api_error", error.type
+    assert_equal 302, error.http_status
+    assert_match(/redirect/i, error.message)
+    assert_equal 1, accepts.length, "a header-classified redirect must never be retried"
+    assert_operator seconds, :<, TIMEOUT
+  end
+
+  def test_skipped_response_closes_the_connection_undrained
+    # Releasing the connection matters as much as classifying it: the server
+    # must observe the socket close (EPIPE/RST) instead of feeding a body to a
+    # client that will never read it.
+    server_saw_close = Queue.new
+    endpoint, = start_server do |conn|
+      conn.write("HTTP/1.1 302 Found\r\nLocation: https://x/\r\nContent-Length: 10000000\r\n\r\n")
+      begin
+        1_000.times { conn.write("x" * 10_000); sleep 0.005 }
+        server_saw_close << false
+      rescue Errno::EPIPE, IOError, Errno::ECONNRESET
+        server_saw_close << true
+      end
+    end
+
+    status, body = Basecamp::Oauth::Fetcher.stream_http(
+      :post, "#{endpoint}/token", form: { "a" => "b" },
+      timeout: TIMEOUT, skip_status: ->(s) { (300..399).cover?(s) }
+    )
+
+    assert_equal 302, status
+    assert_equal "", body
+    assert_equal true, server_saw_close.pop, "the abandoned body's socket must be torn down"
+  end
+
+  # --- total wall-clock bound, including the header phase -------------------
+
+  def test_header_phase_stall_is_bounded_transport_error
+    endpoint, = start_server { |_conn| sleep 30 } # headers never arrive
+
+    error = nil
+    seconds = elapsed do
+      error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+        Basecamp::Oauth::DeviceFlow.request_device_authorization(
+          device_authorization_endpoint: "#{endpoint}/device",
+          client_id: "basecamp-cli", timeout: TIMEOUT
+        )
+      end
+    end
+
+    assert_equal :transport, error.reason
+    assert_operator seconds, :<, TIMEOUT * 3, "a header stall must be bounded by the watchdog"
+  end
+
+  def test_header_phase_drip_is_bounded_transport_error
+    # One header byte per 0.1s: every read succeeds inside the per-read timeout,
+    # so only the watchdog's monotonic deadline can bound this — the case that
+    # is structurally impossible to bound through Faraday's on_data.
+    endpoint, = start_server do |conn|
+      "HTTP/1.1 200 OK\r\nContent-Length: 2\r\n".each_char do |char|
+        begin
+          conn.write(char)
+        rescue IOError, Errno::EPIPE
+          break
+        end
+        sleep 0.1
+      end
+      sleep 30
+    end
+
+    error = nil
+    seconds = elapsed do
+      error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+        Basecamp::Oauth::DeviceFlow.request_device_authorization(
+          device_authorization_endpoint: "#{endpoint}/device",
+          client_id: "basecamp-cli", timeout: TIMEOUT
+        )
+      end
+    end
+
+    assert_equal :transport, error.reason
+    assert_operator seconds, :<, TIMEOUT * 3, "a dripped header phase must be bounded by the watchdog"
+  end
+
+  def test_body_slow_drip_is_bounded_for_discovery
+    # A wanted (2xx) body dripped forever: the read-loop deadline bounds it and
+    # discovery surfaces its retryable network timeout.
+    endpoint, = start_server do |conn|
+      conn.write("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n")
+      loop do
+        conn.write("x")
+        sleep 0.1
+      rescue IOError, Errno::EPIPE
+        break
+      end
+    end
+
+    error = nil
+    seconds = elapsed do
+      error = assert_raises(Basecamp::Oauth::OauthError) do
+        Basecamp::Oauth::Fetcher.fetch_json(nil, "#{endpoint}/.well-known/oauth-authorization-server", timeout: TIMEOUT)
+      end
+    end
+
+    assert_equal "network", error.type
+    assert error.retryable
+    assert_operator seconds, :<, TIMEOUT * 3
+  end
+
+  def test_oversized_body_aborts_streaming_read
+    endpoint, = start_server do |conn|
+      conn.write("HTTP/1.1 200 OK\r\nContent-Length: 300000\r\n\r\n")
+      begin
+        30.times { conn.write("x" * 10_000) }
+      rescue IOError, Errno::EPIPE
+        nil
+      end
+    end
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth::Fetcher.fetch_json(
+        nil, "#{endpoint}/doc", timeout: TIMEOUT, max_body_bytes: 8 * 1024
+      )
+    end
+
+    assert_equal "api_error", error.type
+    assert_match(/size cap/i, error.message)
+  end
+
+  def test_watchdog_threads_do_not_leak
+    endpoint, = start_server do |conn|
+      conn.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}")
+    end
+
+    baseline = Thread.list.length
+    5.times do
+      Basecamp::Oauth::Fetcher.stream_http(:get, "#{endpoint}/doc", timeout: TIMEOUT)
+    end
+    # The watchdog is killed and JOINED in the primitive's ensure, so no request
+    # leaves a thread behind.
+    assert_operator Thread.list.length, :<=, baseline
+  end
+end

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -345,6 +345,7 @@ class OAuthTransportTest < Minitest::Test
     # Net::HTTP derives Host from the bracket-stripped connect address,
     # emitting the invalid "Host: ::1:PORT" — the transport must send the
     # RFC 3986 authority form for bracketed IPv6 endpoints.
+    server = nil
     begin
       server = TCPServer.new("::1", 0)
     rescue Errno::EADDRNOTAVAIL, Errno::EAFNOSUPPORT

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -675,12 +675,14 @@ class OAuthTransportTest < Minitest::Test
       end
     end
 
-    # Net::HTTP's :ENV proxy detection builds an http:// URI for the target
-    # and calls find_proxy on it, so it reads http_proxy even for TLS requests.
+    # The transport resolves the ENV proxy against the REAL scheme (https →
+    # https_proxy), unlike Net::HTTP's broken built-in :ENV detection which
+    # reads http_proxy even for TLS requests — so this ALSO pins that an
+    # https_proxy-only environment routes HTTPS requests through its proxy.
     proxy_env = %w[http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY]
     saved = ENV.to_h.slice(*proxy_env)
     proxy_env.each { |k| ENV.delete(k) }
-    ENV["http_proxy"] = "http://127.0.0.1:#{proxy.addr[1]}"
+    ENV["https_proxy"] = "http://127.0.0.1:#{proxy.addr[1]}"
     begin
       took = elapsed do
         assert_raises(Faraday::TimeoutError) do

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -613,6 +613,60 @@ class OAuthTransportTest < Minitest::Test
     WebMock.disable!
   end
 
+  def test_injected_dispatch_refused_when_budget_already_spent
+    # The wall-clock wrap must grant the REMAINING budget, not a fresh full
+    # timeout: when the deadline has already passed by dispatch time (thread
+    # descheduled after the deadline was captured), the GET must be refused
+    # rather than handed a whole new request window. The stubbed clock jumps
+    # after the deadline capture, so the remaining budget is negative at
+    # dispatch.
+    calls = 0
+    real = Basecamp::Oauth::Fetcher.method(:monotonic_now)
+    Basecamp::Oauth::Fetcher.singleton_class.send(:define_method, :monotonic_now) do
+      calls += 1
+      calls == 1 ? real.call : real.call + 10
+    end
+    dispatched = false
+    client = Object.new
+    client.define_singleton_method(:get) { |_url| dispatched = true }
+
+    assert_raises(Faraday::TimeoutError) do
+      Basecamp::Oauth::Fetcher.faraday_fetch(
+        client, "https://example.test/doc", timeout: 1, max_body_bytes: 1024
+      )
+    end
+    assert_equal false, dispatched, "GET must not dispatch on an exhausted budget"
+  ensure
+    Basecamp::Oauth::Fetcher.singleton_class.send(:define_method, :monotonic_now) { real.call }
+  end
+
+  def test_injected_2xx_completing_past_the_deadline_is_refused
+    # Timeout.timeout's interrupt can be delivered late: simulate that race
+    # with a client that completes a 200 while the stubbed clock has moved
+    # past the deadline. The post-return monotonic re-check must refuse the
+    # late 2xx as a transport-shaped timeout — a completed non-2xx stays
+    # status-classified (status outranks the deadline race).
+    state = { late: false }
+    real = Basecamp::Oauth::Fetcher.method(:monotonic_now)
+    Basecamp::Oauth::Fetcher.singleton_class.send(:define_method, :monotonic_now) do
+      state[:late] ? real.call + 10 : real.call
+    end
+    response = Struct.new(:status, :body).new(200, +"{}")
+    client = Object.new
+    client.define_singleton_method(:get) do |_url|
+      state[:late] = true
+      response
+    end
+
+    assert_raises(Faraday::TimeoutError) do
+      Basecamp::Oauth::Fetcher.faraday_fetch(
+        client, "https://example.test/doc", timeout: 1, max_body_bytes: 1024
+      )
+    end
+  ensure
+    Basecamp::Oauth::Fetcher.singleton_class.send(:define_method, :monotonic_now) { real.call }
+  end
+
   def test_unsupported_method_fails_fast
     # A typo'd verb must not silently become a GET.
     assert_raises(ArgumentError) do

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -461,6 +461,33 @@ class OAuthTransportTest < Minitest::Test
     Basecamp::Oauth::Fetcher.singleton_class.send(:define_method, :monotonic_now) { real.call }
   end
 
+  def test_wire_error_past_the_deadline_classifies_as_timeout
+    # A peer reset observed past the monotonic deadline — before the watchdog
+    # thread is scheduled to flip deadline_fired — is the timeout it raced:
+    # the device poll retries only Faraday::TimeoutError, so classifying it
+    # as ConnectionFailed would terminate polling. The handler flips
+    # Fetcher's stubbed clock before resetting, so the classification read
+    # sees a past-deadline now while the watchdog flag is still false.
+    state = { past_deadline: false }
+    real = Basecamp::Oauth::Fetcher.method(:monotonic_now)
+    Basecamp::Oauth::Fetcher.singleton_class.send(:define_method, :monotonic_now) do
+      state[:past_deadline] ? 1e12 : real.call
+    end
+
+    endpoint, = start_server do |conn|
+      state[:past_deadline] = true
+      # An abrupt RST mid-request surfaces as a wire error, never a timeout.
+      conn.setsockopt(Socket::SOL_SOCKET, Socket::SO_LINGER, [ 1, 0 ].pack("ii"))
+      conn.close
+    end
+
+    assert_raises(Faraday::TimeoutError) do
+      Basecamp::Oauth::Fetcher.stream_http(:get, "#{endpoint}/doc", timeout: 5)
+    end
+  ensure
+    Basecamp::Oauth::Fetcher.singleton_class.send(:define_method, :monotonic_now) { real.call }
+  end
+
   def test_fetch_json_buffered_oversized_error_body_is_the_status_fault
     # fetch_json discards non-2xx bodies (status dominates): a buffered adapter
     # whose oversized ERROR body is already in memory must surface the status

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -544,6 +544,49 @@ class OAuthTransportTest < Minitest::Test
     end
   end
 
+  def test_completed_response_is_never_accepted_past_the_deadline
+    # The narrow race the watchdog cannot cover: the last body chunk lands
+    # just before the deadline and the completion lands just after it, with
+    # the request thread processing completion before the watchdog sets
+    # deadline_fired. The instrumented request tail-sleep makes the ordering
+    # deterministic: the response completes cleanly, then the deadline passes
+    # before stream_http can return — the final monotonic re-check must
+    # refuse the completed response.
+    server = TCPServer.new("127.0.0.1", 0)
+    @servers << server
+    @server_threads << Thread.new do
+      loop do
+        conn = server.accept
+        @conns << conn
+        while (line = conn.gets) && line != "\r\n"; end
+        conn.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}")
+      rescue IOError, SystemCallError
+        break
+      end
+    end
+    endpoint = "http://127.0.0.1:#{server.addr[1]}"
+
+    instrumented = Class.new(Net::HTTP) do
+      def request(req, body = nil, &block)
+        result = super
+        sleep(0.4) # completion processed; deadline passes before returning
+        result
+      end
+    end
+
+    uri = URI.parse(endpoint)
+    http = instrumented.new(uri.hostname, uri.port)
+    original_new = Net::HTTP.method(:new)
+    Net::HTTP.define_singleton_method(:new) { |*| http }
+    begin
+      assert_raises(Basecamp::Oauth::Fetcher::ReadDeadlineExceeded) do
+        Basecamp::Oauth::Fetcher.stream_http(:get, "#{endpoint}/token", timeout: 0.2)
+      end
+    ensure
+      Net::HTTP.define_singleton_method(:new, original_new)
+    end
+  end
+
   def test_watchdog_kill_cannot_leak_a_half_closed_socket
     # Completion racing the deadline: the watchdog can be INSIDE http.finish —
     # after do_finish clears started? but before the socket close — when the
@@ -593,8 +636,12 @@ class OAuthTransportTest < Minitest::Test
     original_new = Net::HTTP.method(:new)
     Net::HTTP.define_singleton_method(:new) { |*| http }
     begin
-      status, = Basecamp::Oauth::Fetcher.stream_http(:get, "#{endpoint}/token", timeout: 0.1)
-      assert_equal 204, status
+      # The final post-request deadline re-check now refuses the completed
+      # 204 (it finished past the wall clock); the leak property under test
+      # is unchanged — the watchdog's close must still complete.
+      assert_raises(Basecamp::Oauth::Fetcher::ReadDeadlineExceeded) do
+        Basecamp::Oauth::Fetcher.stream_http(:get, "#{endpoint}/token", timeout: 0.1)
+      end
     ensure
       Net::HTTP.define_singleton_method(:new, original_new)
     end

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -311,15 +311,31 @@ class OAuthTransportTest < Minitest::Test
 
   def test_invalid_max_body_bytes_fails_closed_as_validation_error
     # The cap IS the streaming bound this transport exists to provide — nil,
-    # a float, a bool, or a non-positive value would disable or crash it, so
+    # a float, a bool, or a negative value would disable or crash it, so
     # misuse rejects before any connection.
-    [ nil, 0, -1, 1.5, true, Float::INFINITY ].each do |cap|
+    [ nil, -1, 1.5, true, Float::INFINITY ].each do |cap|
       error = assert_raises(Basecamp::Oauth::OauthError, "cap=#{cap.inspect}") do
         Basecamp::Oauth::Fetcher.stream_http(:get, "http://127.0.0.1:9/doc", timeout: TIMEOUT, max_body_bytes: cap)
       end
       assert_equal "validation", error.type, "cap=#{cap.inspect}"
-      assert_match(/max_body_bytes must be a positive Integer/, error.message)
+      assert_match(/max_body_bytes must be a non-negative Integer/, error.message)
     end
+  end
+
+  def test_zero_max_body_bytes_is_a_strict_cap_not_a_validation_error
+    # normalize_body_cap accepts zero as a legitimate strict cap, so the
+    # transport must too: the request goes out and any non-empty body trips
+    # the bound, surfacing as the documented cap fault — never "validation".
+    endpoint, = start_server do |conn|
+      conn.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nhi")
+    end
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth::Fetcher.fetch_json(nil, "#{endpoint}/doc", timeout: TIMEOUT, max_body_bytes: 0)
+    end
+
+    assert_equal "api_error", error.type
+    assert_match(/size cap/i, error.message)
   end
 
   def test_bracketed_ipv6_host_header_keeps_its_brackets

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -341,6 +341,15 @@ class OAuthTransportTest < Minitest::Test
       conn.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}")
     end
 
+    # Warm-up request BEFORE the baseline: the process's first Net::HTTP
+    # connect can lazily spawn Ruby's persistent Timeout worker thread (one
+    # per process, never reaped). Whether that already happened depends on
+    # randomized suite order, so counting it after the baseline made this
+    # assertion flake by exactly +1 on the orderings where this test ran
+    # first. The warm-up folds any lazily-created runtime threads into the
+    # baseline; the assertion then counts only threads OUR primitive leaks.
+    Basecamp::Oauth::Fetcher.stream_http(:get, "#{endpoint}/doc", timeout: TIMEOUT)
+
     baseline = Thread.list.length
     5.times do
       Basecamp::Oauth::Fetcher.stream_http(:get, "#{endpoint}/doc", timeout: TIMEOUT)

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -650,6 +650,41 @@ class OAuthTransportTest < Minitest::Test
     end
   end
 
+  def test_proxy_credentials_are_percent_decoded
+    # URI#user/#password return the percent-encoded forms, and the
+    # explicit-proxy Net::HTTP.new does not unescape them the way its :ENV
+    # mode does — the CONNECT's Proxy-Authorization must carry the DECODED
+    # credentials or authenticated proxies reject the request.
+    proxy = TCPServer.new("127.0.0.1", 0)
+    @servers << proxy
+    captured = +""
+    @server_threads << Thread.new do
+      conn = proxy.accept
+      @conns << conn
+      while (line = conn.gets) && line != "\r\n"
+        captured << line
+      end
+      conn.close
+    rescue IOError, SystemCallError
+      nil
+    end
+
+    proxy_env = %w[http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY]
+    saved = ENV.to_h.slice(*proxy_env)
+    proxy_env.each { |k| ENV.delete(k) }
+    ENV["https_proxy"] = "http://user:p%40ss@127.0.0.1:#{proxy.addr[1]}"
+    begin
+      assert_raises(Faraday::Error) do
+        Basecamp::Oauth::Fetcher.stream_http(:get, "https://proxy-auth.test/token", timeout: 1)
+      end
+      expected = [ "user:p@ss" ].pack("m0")
+      assert_includes captured, "Proxy-Authorization: Basic #{expected}"
+    ensure
+      proxy_env.each { |k| ENV.delete(k) }
+      saved.each { |k, v| ENV[k] = v }
+    end
+  end
+
   def test_proxy_connect_drip_is_bounded_by_the_deadline
     # With an ENV-configured proxy and an HTTPS endpoint, Net::HTTP parses the
     # proxy's CONNECT response BEFORE it marks the session started: the

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -461,6 +461,30 @@ class OAuthTransportTest < Minitest::Test
     Basecamp::Oauth::Fetcher.singleton_class.send(:define_method, :monotonic_now) { real.call }
   end
 
+  def test_completed_response_survives_the_watchdog_finish_race
+    # The watchdog's cross-thread finish can nil @socket while the request
+    # thread is inside Net::HTTP's own end_transport, whose @socket.closed?
+    # then raises NoMethodError. An in-deadline COMPLETED response must
+    # dominate that cleanup race (mirroring the Python transport), never
+    # leak the raw NoMethodError. end_transport is delayed past the 0.5s
+    # watchdog to land in the race window deterministically.
+    real = Net::HTTP.instance_method(:end_transport)
+    Net::HTTP.send(:define_method, :end_transport) do |*args|
+      sleep(0.9)
+      real.bind_call(self, *args)
+    end
+
+    endpoint, = start_server do |conn|
+      conn.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nhi")
+    end
+
+    status, body = Basecamp::Oauth::Fetcher.stream_http(:get, "#{endpoint}/doc", timeout: 0.5)
+    assert_equal 200, status
+    assert_equal "hi", body
+  ensure
+    Net::HTTP.send(:define_method, :end_transport, real)
+  end
+
   def test_tls_failure_past_the_deadline_classifies_as_timeout
     # The watchdog's forced close during a TLS operation surfaces as an
     # SSLError, not a timeout — past the monotonic deadline it must classify

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -386,20 +386,34 @@ class OAuthTransportTest < Minitest::Test
     assert error.retryable
   end
 
-  def test_malformed_gzip_body_is_a_transport_failure
-    # Net::HTTP auto-decodes Content-Encoding; malformed gzip bytes raise
-    # Zlib::DataError mid-read_body, which must map through the documented
-    # transport classification (Faraday::ConnectionFailed → the public
-    # network OauthError) — never leak Zlib::DataError raw.
+  def test_compressed_bodies_are_never_inflated_by_the_transport
+    # Transparent decompression would let a compression bomb balloon past the
+    # byte cap BEFORE the per-chunk check ran (Net::HTTP inflates before
+    # read_body yields). The transport requests identity and disables
+    # decoding: a server compressing anyway hands over raw bytes bounded by
+    # the cap, and classification (here: a JSON parse failure) happens on the
+    # small compressed payload — memory never exceeds the advertised bound.
+    require "stringio"
+    gz = StringIO.new
+    writer = Zlib::GzipWriter.new(gz)
+    writer.write("x" * 10_000_000) # ~10 MB decoded
+    writer.close
+    compressed = gz.string
+    assert_operator compressed.bytesize, :<, 20_000, "bomb premise: tiny on the wire"
+
     endpoint, = start_server do |conn|
-      body = "not gzip at all"
-      conn.write("HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}")
+      conn.write("HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: #{compressed.bytesize}\r\n\r\n#{compressed}")
     end
 
     error = assert_raises(Basecamp::Oauth::OauthError) do
       Basecamp::Oauth.discover(endpoint)
     end
-    assert_equal "network", error.type
+    # The RAW bytes flowed through under the cap and failed JSON parsing —
+    # never a BodyTooLarge/decoded blow-up (both would be api_error, but the
+    # parse failure proves no inflation happened).
+    assert_equal "api_error", error.type
+    # scrub: the parse-failure message can embed raw compressed bytes.
+    assert_match(/parse|JSON/i, error.message.scrub)
   end
 
   def test_classify_stream_error_maps_every_forced_close_shape_after_deadline

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -703,12 +703,14 @@ class OAuthTransportTest < Minitest::Test
     proxy_env = %w[http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY]
     saved = ENV.to_h.slice(*proxy_env)
     proxy_env.each { |k| ENV.delete(k) }
-    ENV["https_proxy"] = "http://user:p%40ss@127.0.0.1:#{proxy.addr[1]}"
+    # p%40s+s: the %40 percent-decodes to @, while the literal + must stay a
+    # plus (userinfo is percent-decoded, never form-decoded).
+    ENV["https_proxy"] = "http://user:p%40s+s@127.0.0.1:#{proxy.addr[1]}"
     begin
       assert_raises(Faraday::Error) do
         Basecamp::Oauth::Fetcher.stream_http(:get, "https://proxy-auth.test/token", timeout: 1)
       end
-      expected = [ "user:p@ss" ].pack("m0")
+      expected = [ "user:p@s+s" ].pack("m0")
       assert_includes captured, "Proxy-Authorization: Basic #{expected}"
     ensure
       proxy_env.each { |k| ENV.delete(k) }

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -309,6 +309,39 @@ class OAuthTransportTest < Minitest::Test
     assert_equal "validation", error.type
   end
 
+  def test_bracketed_ipv6_host_header_keeps_its_brackets
+    # Net::HTTP derives Host from the bracket-stripped connect address,
+    # emitting the invalid "Host: ::1:PORT" — the transport must send the
+    # RFC 3986 authority form for bracketed IPv6 endpoints.
+    begin
+      server = TCPServer.new("::1", 0)
+    rescue Errno::EADDRNOTAVAIL, Errno::EAFNOSUPPORT
+      skip "IPv6 loopback unavailable"
+    end
+    @servers << server
+    seen = Queue.new
+    @server_threads << Thread.new do
+      loop do
+        conn = server.accept
+        @conns << conn
+        lines = []
+        while (line = conn.gets) && line != "\r\n"
+          lines << line
+        end
+        seen << lines.join
+        conn.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}")
+      rescue IOError, SystemCallError
+        break
+      end
+    end
+    port = server.addr[1]
+
+    status, = Basecamp::Oauth::Fetcher.stream_http(:get, "http://[::1]:#{port}/doc", timeout: TIMEOUT)
+    assert_equal 200, status
+    request_headers = seen.pop
+    assert_match(/^Host: \[::1\]:#{port}\r?$/i, request_headers)
+  end
+
   def test_caller_headers_cannot_override_identity_encoding
     # The identity Accept-Encoding is the compression-bomb bound — a caller
     # override must be dropped, matching the Python transport.

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -603,6 +603,32 @@ class OAuthTransportTest < Minitest::Test
     assert sockets.all?(&:closed?), "the deadline-racing close must complete: no socket may leak"
   end
 
+  def test_unnormalized_timeout_fails_closed_before_any_request
+    # The operation entry points normalize; the primitive still fails closed
+    # for direct callers — a non-finite, non-positive, or beyond-ceiling
+    # timeout would leave the socket timeouts and watchdog sleep unbounded.
+    server = TCPServer.new("127.0.0.1", 0)
+    @servers << server
+    accepted = []
+    @server_threads << Thread.new do
+      loop do
+        accepted << server.accept
+        @conns << accepted.last
+      rescue IOError, SystemCallError
+        break
+      end
+    end
+    endpoint = "http://127.0.0.1:#{server.addr[1]}"
+
+    [ Float::INFINITY, Float::NAN, 0, -1, 3601, nil, "30" ].each do |timeout|
+      error = assert_raises(Basecamp::Oauth::OauthError) do
+        Basecamp::Oauth::Fetcher.stream_http(:get, "#{endpoint}/token", timeout: timeout)
+      end
+      assert_equal "validation", error.type, "timeout=#{timeout.inspect}"
+    end
+    assert_empty accepted, "the guard must reject before any connection"
+  end
+
   def test_watchdog_threads_do_not_leak
     endpoint, = start_server do |conn|
       conn.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}")

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -558,6 +558,37 @@ class OAuthTransportTest < Minitest::Test
     WebMock.disable!
   end
 
+  def test_injected_skip_status_past_the_deadline_classifies_as_timeout
+    # The injected-Faraday bounded_reader gates the SkipBody fast-path on the
+    # monotonic deadline: a first chunk that becomes runnable past the total
+    # bound means the status was not known in time — the timeout must win,
+    # matching the default transport's header-time gate. The stubbed clock
+    # jumps once WebMock is serving, so the on_data callback observes a
+    # past-deadline now while the per-read timeout would have admitted it.
+    state = { past_deadline: false }
+    real = Basecamp::Oauth::Fetcher.method(:monotonic_now)
+    Basecamp::Oauth::Fetcher.singleton_class.send(:define_method, :monotonic_now) do
+      state[:past_deadline] ? 1e12 : real.call
+    end
+
+    WebMock.enable!
+    WebMock.disable_net_connect!
+    stub_request(:get, "https://example.test/doc").to_return do
+      state[:past_deadline] = true
+      { status: 500, body: "x" * 1000 }
+    end
+    connection = Faraday.new
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth::Fetcher.fetch_json(connection, "https://example.test/doc", timeout: 1)
+    end
+    assert_equal "network", error.type
+    assert error.retryable
+  ensure
+    Basecamp::Oauth::Fetcher.singleton_class.send(:define_method, :monotonic_now) { real.call }
+    WebMock.disable!
+  end
+
   def test_unsupported_method_fails_fast
     # A typo'd verb must not silently become a GET.
     assert_raises(ArgumentError) do

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -486,6 +486,65 @@ class OAuthTransportTest < Minitest::Test
     end
   end
 
+  def test_watchdog_kill_cannot_leak_a_half_closed_socket
+    # Completion racing the deadline: the watchdog can be INSIDE http.finish —
+    # after do_finish clears started? but before the socket close — when the
+    # ensure's kill fires. Un-fixed, the thread dies mid-close and the request
+    # side skips its own close (started? is already false): the socket leaks
+    # until GC. The instrumented subclass widens that window so the kill lands
+    # inside it deterministically; the deferred-interrupt fix must still
+    # complete the close before the thread dies.
+    # The shape needs a KEEP-ALIVE response that completes cleanly (any raise
+    # inside the response block makes Net::HTTP's own transport rescue close
+    # the socket) with the deadline firing between the response block and the
+    # request-side ensure — the instrumented request tail-sleep pins the main
+    # thread there while the deadline fires.
+    server = TCPServer.new("127.0.0.1", 0)
+    @servers << server
+    @server_threads << Thread.new do
+      loop do
+        conn = server.accept
+        @conns << conn
+        while (line = conn.gets) && line != "\r\n"; end
+        conn.write("HTTP/1.1 204 No Content\r\n\r\n") # keep-alive: socket survives the request
+      rescue IOError, SystemCallError
+        break
+      end
+    end
+    endpoint = "http://127.0.0.1:#{server.addr[1]}"
+
+    sockets = []
+    instrumented = Class.new(Net::HTTP) do
+      define_method(:do_finish) do
+        @started = false
+        sockets << @socket if @socket
+        sleep(0.5) # widened started?-cleared -> socket-close window
+        @socket&.close
+        @socket = nil
+      end
+
+      define_method(:request) do |req, body = nil, &block|
+        result = super(req, body, &block)
+        sleep(0.2) # let the deadline fire before the request-side ensure runs
+        result
+      end
+    end
+
+    uri = URI.parse(endpoint)
+    http = instrumented.new(uri.hostname, uri.port)
+    original_new = Net::HTTP.method(:new)
+    Net::HTTP.define_singleton_method(:new) { |*| http }
+    begin
+      status, = Basecamp::Oauth::Fetcher.stream_http(:get, "#{endpoint}/token", timeout: 0.1)
+      assert_equal 204, status
+    ensure
+      Net::HTTP.define_singleton_method(:new, original_new)
+    end
+
+    assert_not_empty sockets, "watchdog never entered the close window"
+    assert sockets.all?(&:closed?), "the deadline-racing close must complete: no socket may leak"
+  end
+
   def test_watchdog_threads_do_not_leak
     endpoint, = start_server do |conn|
       conn.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}")

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -742,6 +742,58 @@ class OAuthTransportTest < Minitest::Test
     end
   end
 
+  def test_proxy_resolution_dns_is_inside_the_deadline
+    # find_proxy resolves the target hostname (IPSocket.getaddress) to
+    # evaluate its loopback rule — a stalled resolver must be cut by the
+    # advertised bound, not hold the request open before any deadline exists.
+    real = IPSocket.method(:getaddress)
+    IPSocket.define_singleton_method(:getaddress) do |host|
+      sleep(5)
+      real.call(host)
+    end
+
+    proxy_env = %w[http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY]
+    saved = ENV.to_h.slice(*proxy_env)
+    proxy_env.each { |k| ENV.delete(k) }
+    ENV["https_proxy"] = "http://127.0.0.1:9"
+    begin
+      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      assert_raises(Faraday::TimeoutError) do
+        Basecamp::Oauth::Fetcher.stream_http(:get, "https://dns-stall.test/token", timeout: 0.5)
+      end
+      took = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
+      assert_operator took, :<, 2.0, "proxy-resolution DNS must be cut by the deadline, took #{took.round(2)}s"
+    ensure
+      proxy_env.each { |k| ENV.delete(k) }
+      saved.each { |k, v| ENV[k] = v }
+      IPSocket.define_singleton_method(:getaddress) { |host| real.call(host) }
+    end
+  end
+
+  def test_https_proxy_refused_without_p_use_ssl_support
+    # On Ruby 3.2/3.3 the bundled net-http lacks Net::HTTP.new's eighth
+    # p_use_ssl parameter — an https:// proxy must refuse with an actionable
+    # validation error, never plaintext-to-a-TLS-proxy or an ArgumentError.
+    real = Basecamp::Oauth::Fetcher.method(:proxy_tls_capable?)
+    Basecamp::Oauth::Fetcher.singleton_class.send(:define_method, :proxy_tls_capable?) { false }
+
+    proxy_env = %w[http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY]
+    saved = ENV.to_h.slice(*proxy_env)
+    proxy_env.each { |k| ENV.delete(k) }
+    ENV["https_proxy"] = "https://127.0.0.1:9"
+    begin
+      error = assert_raises(Basecamp::Oauth::OauthError) do
+        Basecamp::Oauth::Fetcher.stream_http(:get, "https://old-net-http.test/token", timeout: 1)
+      end
+      assert_equal "validation", error.type
+      assert_match(/net-http >= 0\.5/, error.message)
+    ensure
+      proxy_env.each { |k| ENV.delete(k) }
+      saved.each { |k, v| ENV[k] = v }
+      Basecamp::Oauth::Fetcher.singleton_class.send(:define_method, :proxy_tls_capable?) { real.call }
+    end
+  end
+
   def test_https_proxy_scheme_gets_tls_on_the_proxy_connection
     # An https:// proxy URL means TLS on the PROXY connection itself:
     # Net::HTTP.new's p_use_ssl must be passed through or the transport

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "faraday"
 require "openssl"
 require "socket"
 
@@ -374,6 +375,51 @@ class OAuthTransportTest < Minitest::Test
 
       before = Basecamp::Oauth::Fetcher.classify_stream_error(shape, false)
       assert_kind_of Faraday::ConnectionFailed, before, "pre-deadline #{shape.class} must be a connection failure"
+    end
+  end
+
+  def test_proxy_connect_drip_is_bounded_by_the_deadline
+    # With an ENV-configured proxy and an HTTPS endpoint, Net::HTTP parses the
+    # proxy's CONNECT response BEFORE it marks the session started: the
+    # watchdog cannot close the connecting socket (finish raises IOError), and
+    # the per-read timeout resets on every dripped byte. A proxy dripping the
+    # CONNECT response below read_timeout must be cut by the whole-phase
+    # deadline bound, not left to per-read timeouts that never fire.
+    proxy = TCPServer.new("127.0.0.1", 0)
+    @servers << proxy
+    @server_threads << Thread.new do
+      loop do
+        conn = proxy.accept
+        @conns << conn
+        while (line = conn.gets) && line != "\r\n"; end
+        # Drip the CONNECT response one byte at a time, each gap well below
+        # the 0.5s per-read timeout, for ~7.6s — far past the 0.5s deadline.
+        "HTTP/1.1 200 Connection Established\r\n\r\n".each_char do |ch|
+          conn.write(ch)
+          sleep(0.2)
+        end
+      rescue IOError, SystemCallError
+        break
+      end
+    end
+
+    # Net::HTTP's :ENV proxy detection builds an http:// URI for the target
+    # and calls find_proxy on it, so it reads http_proxy even for TLS requests.
+    proxy_env = %w[http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY]
+    saved = ENV.to_h.slice(*proxy_env)
+    proxy_env.each { |k| ENV.delete(k) }
+    ENV["http_proxy"] = "http://127.0.0.1:#{proxy.addr[1]}"
+    begin
+      took = elapsed do
+        assert_raises(Faraday::TimeoutError) do
+          Basecamp::Oauth::Fetcher.stream_http(:get, "https://proxy-drip.test/token", timeout: 0.5)
+        end
+      end
+      assert_operator took, :<, 2.0, \
+        "CONNECT parsing must be cut at the ~0.5s deadline; per-read timeouts alone let the drip run ~8s"
+    ensure
+      proxy_env.each { |k| ENV.delete(k) }
+      saved.each { |k, v| ENV[k] = v }
     end
   end
 

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -309,6 +309,19 @@ class OAuthTransportTest < Minitest::Test
     assert_equal "validation", error.type
   end
 
+  def test_invalid_max_body_bytes_fails_closed_as_validation_error
+    # The cap IS the streaming bound this transport exists to provide — nil,
+    # a float, a bool, or a non-positive value would disable or crash it, so
+    # misuse rejects before any connection.
+    [ nil, 0, -1, 1.5, true, Float::INFINITY ].each do |cap|
+      error = assert_raises(Basecamp::Oauth::OauthError, "cap=#{cap.inspect}") do
+        Basecamp::Oauth::Fetcher.stream_http(:get, "http://127.0.0.1:9/doc", timeout: TIMEOUT, max_body_bytes: cap)
+      end
+      assert_equal "validation", error.type, "cap=#{cap.inspect}"
+      assert_match(/max_body_bytes must be a positive Integer/, error.message)
+    end
+  end
+
   def test_bracketed_ipv6_host_header_keeps_its_brackets
     # Net::HTTP derives Host from the bracket-stripped connect address,
     # emitting the invalid "Host: ::1:PORT" — the transport must send the

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -2,8 +2,10 @@
 
 require "test_helper"
 require "faraday"
+require "net/http"
 require "openssl"
 require "socket"
+require "zlib"
 
 # Acceptance tests for the headers-first default transport
 # ({Basecamp::Oauth::Fetcher.stream_http}) against REAL sockets — the response
@@ -298,6 +300,53 @@ class OAuthTransportTest < Minitest::Test
     assert error.retryable
     assert_match(/certificate|SSL/i, error.message)
     assert_equal 0, handshakes_completed, "the client must abort the handshake, not complete it"
+  end
+
+  def test_non_http_scheme_fails_closed_as_validation_error
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth::Fetcher.stream_http(:get, "ftp://127.0.0.1/doc", timeout: TIMEOUT)
+    end
+    assert_equal "validation", error.type
+  end
+
+  def test_form_with_get_fails_fast
+    # A GET-with-body contradicts the method contract and masks call-site
+    # mistakes — reject before any connection.
+    error = assert_raises(ArgumentError) do
+      Basecamp::Oauth::Fetcher.stream_http(:get, "http://127.0.0.1:9/doc", form: { "a" => "b" }, timeout: TIMEOUT)
+    end
+    assert_match(/form is only valid with :post/, error.message)
+  end
+
+  def test_fetch_json_buffered_injected_adapter_still_yields_the_body
+    # Faraday's test adapter BUFFERS and never invokes on_data: the streamed
+    # chunks are empty while the body sits on the response. The fallback must
+    # hand the document to the parser instead of a bogus empty-body failure.
+    stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.get("/doc") { [ 200, { "Content-Type" => "application/json" }, '{"ok":true}' ] }
+    end
+    connection = Faraday.new { |f| f.adapter :test, stubs }
+
+    doc = Basecamp::Oauth::Fetcher.fetch_json(connection, "https://example.test/doc", timeout: 1)
+    assert_equal({ "ok" => true }, doc)
+  end
+
+  def test_fetch_json_injected_streaming_non_2xx_is_status_first_api_error
+    # A streaming injected adapter (net_http via WebMock) classifies a non-2xx
+    # at header time through the SkipBody seam; the observable stays the
+    # status-only api_error.
+    WebMock.enable!
+    WebMock.disable_net_connect!
+    stub_request(:get, "https://example.test/doc").to_return(status: 500, body: "x" * 1000)
+    connection = Faraday.new
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth::Fetcher.fetch_json(connection, "https://example.test/doc", timeout: 1)
+    end
+    assert_equal "api_error", error.type
+    assert_equal 500, error.http_status
+  ensure
+    WebMock.disable!
   end
 
   def test_unsupported_method_fails_fast

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -377,6 +377,69 @@ class OAuthTransportTest < Minitest::Test
     end
   end
 
+  def test_watchdog_close_racing_the_request_cannot_reopen_past_the_deadline
+    # Net::HTTP#request implicitly re-starts a finished session. If the
+    # watchdog's close lands between stream_http's post-connect deadline
+    # re-check and the request write, the request would ride a fresh
+    # post-deadline connection — and a bodyless response would surface as
+    # SUCCESS after the wall clock expired. Lose the race deterministically:
+    # hold the request until the watchdog has finished the session, exactly
+    # the window the race occupies. Not start_server: its accept loop dies on
+    # the watchdog-closed first connection, and the reopened connection must
+    # get a real, instant response for the un-fixed code to "succeed".
+    server = TCPServer.new("127.0.0.1", 0)
+    @servers << server
+    @server_threads << Thread.new do
+      loop do
+        conn = server.accept
+        @conns << conn
+        begin
+          while (line = conn.gets) && line != "\r\n"; end
+          conn.write("HTTP/1.1 204 No Content\r\nConnection: close\r\n\r\n")
+          conn.close
+        rescue IOError, SystemCallError
+          # Connection #1 dies under the watchdog's close; keep accepting.
+        end
+      rescue IOError, SystemCallError
+        break # listener closed in teardown
+      end
+    end
+    endpoint = "http://127.0.0.1:#{server.addr[1]}"
+
+    instrumented = Class.new(Net::HTTP) do
+      def hold_next_request!
+        @hold_next_request = true
+      end
+
+      def request(req, body = nil, &block)
+        if @hold_next_request
+          @hold_next_request = false
+          sleep(0.005) while started?
+        end
+        super
+      end
+    end
+
+    uri = URI.parse(endpoint)
+    http = instrumented.new(uri.hostname, uri.port)
+    http.hold_next_request!
+
+    # Hand the instrumented instance to stream_http (minitest 6 dropped
+    # minitest/mock, so restore the singleton by hand).
+    original_new = Net::HTTP.method(:new)
+    Net::HTTP.define_singleton_method(:new) { |*| http }
+    begin
+      # Either deadline classification is correct: the response-block re-check
+      # raises the bounded-read marker, and the persistent watchdog loop may
+      # close the reopened connection mid-flight first (surfacing as timeout).
+      assert_raises(Basecamp::Oauth::Fetcher::ReadDeadlineExceeded, Faraday::TimeoutError) do
+        Basecamp::Oauth::Fetcher.stream_http(:get, "#{endpoint}/token", timeout: 0.3)
+      end
+    ensure
+      Net::HTTP.define_singleton_method(:new, original_new)
+    end
+  end
+
   def test_watchdog_threads_do_not_leak
     endpoint, = start_server do |conn|
       conn.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}")

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -352,6 +352,31 @@ class OAuthTransportTest < Minitest::Test
     assert_equal "network", error.type
   end
 
+  def test_classify_stream_error_maps_every_forced_close_shape_after_deadline
+    # Deterministic exception-shape matrix: once the watchdog deadline fired,
+    # the forced close can surface as IOError, SystemCallError, or SocketError
+    # depending on platform/read phase — every shape must classify as the
+    # timeout (the poll's transient-backoff signal), and as a connection
+    # failure before the deadline. The live-socket test exercises only the
+    # common IOError path.
+    shapes = [
+      IOError.new("closed stream"),
+      Errno::ECONNRESET.new,
+      Errno::EBADF.new,
+      SocketError.new("socket closed"),
+      Net::HTTPBadResponse.new("wrong status line"),
+      Zlib::DataError.new("invalid stored block lengths")
+    ]
+
+    shapes.each do |shape|
+      after = Basecamp::Oauth::Fetcher.classify_stream_error(shape, true)
+      assert_kind_of Faraday::TimeoutError, after, "post-deadline #{shape.class} must be a timeout"
+
+      before = Basecamp::Oauth::Fetcher.classify_stream_error(shape, false)
+      assert_kind_of Faraday::ConnectionFailed, before, "pre-deadline #{shape.class} must be a connection failure"
+    end
+  end
+
   def test_watchdog_threads_do_not_leak
     endpoint, = start_server do |conn|
       conn.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}")

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -336,6 +336,22 @@ class OAuthTransportTest < Minitest::Test
     assert error.retryable
   end
 
+  def test_malformed_gzip_body_is_a_transport_failure
+    # Net::HTTP auto-decodes Content-Encoding; malformed gzip bytes raise
+    # Zlib::DataError mid-read_body, which must map through the documented
+    # transport classification (Faraday::ConnectionFailed → the public
+    # network OauthError) — never leak Zlib::DataError raw.
+    endpoint, = start_server do |conn|
+      body = "not gzip at all"
+      conn.write("HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: #{body.bytesize}\r\n\r\n#{body}")
+    end
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth.discover(endpoint)
+    end
+    assert_equal "network", error.type
+  end
+
   def test_watchdog_threads_do_not_leak
     endpoint, = start_server do |conn|
       conn.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}")

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -427,6 +427,37 @@ class OAuthTransportTest < Minitest::Test
     assert_equal({ "ok" => true }, doc)
   end
 
+  def test_skip_status_headers_past_the_deadline_classify_as_timeout
+    # Headers that become runnable past the monotonic deadline — but before
+    # the watchdog flips deadline_fired — mean the status was NOT known in
+    # time: the skip fast-path must surface the timeout, never race into a
+    # status classification (matching the Python transport). The skip
+    # callable itself flips Fetcher's stubbed clock, so exactly the reads
+    # AFTER header arrival see a past-deadline "now".
+    served = false
+    real = Basecamp::Oauth::Fetcher.method(:monotonic_now)
+    skip = lambda do |status|
+      served = true
+      !(200..299).cover?(status)
+    end
+
+    # The suite does not load minitest/mock — swap the singleton by hand and
+    # restore it in ensure (the established idiom in this file).
+    Basecamp::Oauth::Fetcher.singleton_class.send(:define_method, :monotonic_now) do
+      served ? 1e12 : real.call
+    end
+
+    endpoint, = start_server do |conn|
+      conn.write("HTTP/1.1 500 Nope\r\nContent-Length: 2\r\nConnection: close\r\n\r\nno")
+    end
+
+    assert_raises(Basecamp::Oauth::Fetcher::ReadDeadlineExceeded) do
+      Basecamp::Oauth::Fetcher.stream_http(:get, "#{endpoint}/doc", timeout: 5, skip_status: skip)
+    end
+  ensure
+    Basecamp::Oauth::Fetcher.singleton_class.send(:define_method, :monotonic_now) { real.call }
+  end
+
   def test_fetch_json_buffered_oversized_error_body_is_the_status_fault
     # fetch_json discards non-2xx bodies (status dominates): a buffered adapter
     # whose oversized ERROR body is already in memory must surface the status

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -742,6 +742,42 @@ class OAuthTransportTest < Minitest::Test
     end
   end
 
+  def test_https_proxy_scheme_gets_tls_on_the_proxy_connection
+    # An https:// proxy URL means TLS on the PROXY connection itself:
+    # Net::HTTP.new's p_use_ssl must be passed through or the transport
+    # sends plaintext CONNECT to a TLS-only proxy. The plain TCP listener
+    # distinguishes the two by the first bytes: a TLS ClientHello record
+    # (0x16 0x03...) with the fix, a plaintext "CONNECT ..." without.
+    first_bytes = nil
+    server = TCPServer.new("127.0.0.1", 0)
+    port = server.addr[1]
+    thread = Thread.new do
+      conn = server.accept
+      first_bytes = conn.readpartial(5)
+      conn.close
+    rescue IOError, SystemCallError
+      nil
+    end
+
+    proxy_env = %w[http_proxy HTTP_PROXY https_proxy HTTPS_PROXY no_proxy NO_PROXY]
+    saved = ENV.to_h.slice(*proxy_env)
+    proxy_env.each { |k| ENV.delete(k) }
+    ENV["https_proxy"] = "https://127.0.0.1:#{port}"
+    begin
+      assert_raises(Faraday::Error) do
+        Basecamp::Oauth::Fetcher.stream_http(:get, "https://tls-proxy.test/token", timeout: 1)
+      end
+      thread.join(2)
+      assert_equal 0x16, first_bytes&.bytes&.first,
+        "expected a TLS ClientHello to the https:// proxy, got #{first_bytes.inspect}"
+    ensure
+      proxy_env.each { |k| ENV.delete(k) }
+      saved.each { |k, v| ENV[k] = v }
+      thread&.kill&.join
+      server&.close
+    end
+  end
+
   def test_proxy_connect_drip_is_bounded_by_the_deadline
     # With an ENV-configured proxy and an HTTPS endpoint, Net::HTTP parses the
     # proxy's CONNECT response BEFORE it marks the session started: the

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -423,6 +423,64 @@ class OAuthTransportTest < Minitest::Test
     end
   end
 
+  def test_skipped_status_outranks_the_deadline_race
+    # Status-first survives the deadline race (SPEC §16): when a SKIPPED
+    # status (here a token 302) completes while deadline_fired is already
+    # true, the known status must classify as its api_error path — never
+    # soften into ReadDeadlineExceeded/timeout, which the poll would back off
+    # and retry. Same deterministic harness as the reopen test: hold the
+    # request until the watchdog has finished the session.
+    server = TCPServer.new("127.0.0.1", 0)
+    @servers << server
+    @server_threads << Thread.new do
+      loop do
+        conn = server.accept
+        @conns << conn
+        begin
+          while (line = conn.gets) && line != "\r\n"; end
+          conn.write("HTTP/1.1 302 Found\r\nLocation: https://x/\r\nConnection: close\r\n\r\n")
+          conn.close
+        rescue IOError, SystemCallError
+          # Connection #1 dies under the watchdog's close; keep accepting.
+        end
+      rescue IOError, SystemCallError
+        break # listener closed in teardown
+      end
+    end
+    endpoint = "http://127.0.0.1:#{server.addr[1]}"
+
+    instrumented = Class.new(Net::HTTP) do
+      def hold_next_request!
+        @hold_next_request = true
+      end
+
+      def request(req, body = nil, &block)
+        if @hold_next_request
+          @hold_next_request = false
+          sleep(0.005) while started?
+        end
+        super
+      end
+    end
+
+    uri = URI.parse(endpoint)
+    http = instrumented.new(uri.hostname, uri.port)
+    http.hold_next_request!
+
+    original_new = Net::HTTP.method(:new)
+    Net::HTTP.define_singleton_method(:new) { |*| http }
+    begin
+      status, body = Basecamp::Oauth::Fetcher.stream_http(
+        :get, "#{endpoint}/token", timeout: 0.3,
+        skip_status: ->(s) { (300..399).cover?(s) }
+      )
+      assert_equal 302, status
+      assert_equal "", body
+    ensure
+      Net::HTTP.define_singleton_method(:new, original_new)
+    end
+  end
+
   def test_watchdog_close_racing_the_request_cannot_reopen_past_the_deadline
     # Net::HTTP#request implicitly re-starts a finished session. If the
     # watchdog's close lands between stream_http's post-connect deadline

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -520,18 +520,19 @@ class OAuthTransportTest < Minitest::Test
     end
   end
 
-  def test_skipped_status_outranks_the_deadline_race
-    # Status-first survives the deadline race (SPEC §16): when a SKIPPED
-    # status (here a token 302) completes while deadline_fired is already
-    # true, the known status must classify as its api_error path — never
-    # soften into ReadDeadlineExceeded/timeout, which the poll would back off
-    # and retry. Same deterministic harness as the reopen test: hold the
-    # request until the watchdog has finished the session.
+  def test_watchdog_close_cannot_mint_a_second_connection
+    # Once the watchdog closes the session post-deadline, Net::HTTP#request's
+    # implicit re-start must be refused outright (the restart runs outside the
+    # connect Timeout.timeout, where an ENV-proxied CONNECT could drip
+    # unbounded). Same deterministic hold harness as the reopen test — but the
+    # guarded start now raises, and CRITICALLY no second connection is minted.
+    accepts = []
     server = TCPServer.new("127.0.0.1", 0)
     @servers << server
     @server_threads << Thread.new do
       loop do
         conn = server.accept
+        accepts << conn
         @conns << conn
         begin
           while (line = conn.gets) && line != "\r\n"; end
@@ -567,15 +568,16 @@ class OAuthTransportTest < Minitest::Test
     original_new = Net::HTTP.method(:new)
     Net::HTTP.define_singleton_method(:new) { |*| http }
     begin
-      status, body = Basecamp::Oauth::Fetcher.stream_http(
-        :get, "#{endpoint}/token", timeout: 0.3,
-        skip_status: ->(s) { (300..399).cover?(s) }
-      )
-      assert_equal 302, status
-      assert_equal "", body
+      assert_raises(Faraday::TimeoutError) do
+        Basecamp::Oauth::Fetcher.stream_http(
+          :get, "#{endpoint}/token", timeout: 0.3,
+          skip_status: ->(s) { (300..399).cover?(s) }
+        )
+      end
     ensure
       Net::HTTP.define_singleton_method(:new, original_new)
     end
+    assert_equal 1, accepts.length, "the post-deadline implicit re-start must never mint a second connection"
   end
 
   def test_watchdog_close_racing_the_request_cannot_reopen_past_the_deadline

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -427,6 +427,24 @@ class OAuthTransportTest < Minitest::Test
     assert_equal({ "ok" => true }, doc)
   end
 
+  def test_fetch_json_buffered_oversized_error_body_is_the_status_fault
+    # fetch_json discards non-2xx bodies (status dominates): a buffered adapter
+    # whose oversized ERROR body is already in memory must surface the status
+    # api_error, not a size-cap fault — the body is never read or copied.
+    stubs = Faraday::Adapter::Test::Stubs.new do |stub|
+      stub.get("/doc") { [ 500, { "Content-Type" => "text/html" }, "x" * 2048 ] }
+    end
+    connection = Faraday.new { |f| f.adapter :test, stubs }
+
+    error = assert_raises(Basecamp::Oauth::OauthError) do
+      Basecamp::Oauth::Fetcher.fetch_json(connection, "https://example.test/doc", timeout: 1, max_body_bytes: 1024)
+    end
+
+    assert_equal "api_error", error.type
+    assert_equal 500, error.http_status
+    assert_match(/status 500/, error.message)
+  end
+
   def test_fetch_json_injected_streaming_non_2xx_is_status_first_api_error
     # A streaming injected adapter (net_http via WebMock) classifies a non-2xx
     # at header time through the SkipBody seam; the observable stays the

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -461,6 +461,40 @@ class OAuthTransportTest < Minitest::Test
     Basecamp::Oauth::Fetcher.singleton_class.send(:define_method, :monotonic_now) { real.call }
   end
 
+  def test_tls_failure_past_the_deadline_classifies_as_timeout
+    # The watchdog's forced close during a TLS operation surfaces as an
+    # SSLError, not a timeout — past the monotonic deadline it must classify
+    # as the timeout it raced, or the device poll terminates instead of
+    # backing off. The handler flips Fetcher's stubbed clock before feeding
+    # the handshake garbage, so the SSLError is observed strictly after it.
+    state = { past_deadline: false }
+    real = Basecamp::Oauth::Fetcher.method(:monotonic_now)
+    Basecamp::Oauth::Fetcher.singleton_class.send(:define_method, :monotonic_now) do
+      state[:past_deadline] ? 1e12 : real.call
+    end
+
+    tcp = TCPServer.new("127.0.0.1", 0)
+    port = tcp.addr[1]
+    thread = Thread.new do
+      conn = tcp.accept
+      state[:past_deadline] = true
+      # Non-TLS bytes during the handshake surface client-side as an
+      # OpenSSL::SSL::SSLError ("wrong version number"), never a timeout.
+      conn.write("HTTP/1.1 200 OK\r\n\r\n")
+      conn.close
+    rescue IOError
+      nil
+    end
+
+    assert_raises(Faraday::TimeoutError) do
+      Basecamp::Oauth::Fetcher.stream_http(:get, "https://127.0.0.1:#{port}/doc", timeout: 5)
+    end
+  ensure
+    Basecamp::Oauth::Fetcher.singleton_class.send(:define_method, :monotonic_now) { real.call }
+    thread&.kill&.join
+    tcp&.close
+  end
+
   def test_wire_error_past_the_deadline_classifies_as_timeout
     # A peer reset observed past the monotonic deadline — before the watchdog
     # thread is scheduled to flip deadline_fired — is the timeout it raced:

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -309,6 +309,40 @@ class OAuthTransportTest < Minitest::Test
     assert_equal "validation", error.type
   end
 
+  def test_caller_headers_cannot_override_identity_encoding
+    # The identity Accept-Encoding is the compression-bomb bound — a caller
+    # override must be dropped, matching the Python transport.
+    seen = Queue.new
+    server = TCPServer.new("127.0.0.1", 0)
+    @servers << server
+    @server_threads << Thread.new do
+      loop do
+        conn = server.accept
+        @conns << conn
+        lines = []
+        while (line = conn.gets) && line != "\r\n"
+          lines << line
+        end
+        seen << lines.join
+        conn.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}")
+      rescue IOError, SystemCallError
+        break
+      end
+    end
+    endpoint = "http://127.0.0.1:#{server.addr[1]}"
+
+    Basecamp::Oauth::Fetcher.stream_http(
+      :get, "#{endpoint}/doc",
+      headers: { "Accept-Encoding" => "gzip", "X-Custom" => "kept" },
+      timeout: TIMEOUT
+    )
+
+    request_headers = seen.pop
+    assert_match(/^Accept-Encoding: identity\r?$/i, request_headers)
+    assert_no_match(/gzip/i, request_headers)
+    assert_match(/^X-Custom: kept\r?$/i, request_headers)
+  end
+
   def test_form_with_get_fails_fast
     # A GET-with-body contradicts the method contract and masks call-site
     # mistakes — reject before any connection.

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -29,10 +29,13 @@ class OAuthTransportTest < Minitest::Test
     # Stop the server threads FIRST (they append to @conns), then close every
     # accepted socket and listener — the stall handlers sleep for tens of
     # seconds, so without the kill+join each test would leak a live thread and
-    # its socket well past the test's end.
+    # its socket well past the test's end. Close the LISTENERS first: a
+    # thread blocked in accept is unblocked deterministically by the close,
+    # where Thread#kill alone can hang the join mid-syscall on some
+    # platforms/builds.
+    @servers.each { |server| server.close rescue nil }
     @server_threads.each(&:kill).each(&:join)
     @conns.each { |conn| conn.close rescue nil }
-    @servers.each { |server| server.close rescue nil }
     WebMock.enable!
     WebMock.disable_net_connect!
   end


### PR DESCRIPTION
## Why

The BC5 OAuth work (#369 discovery, #370 device flow) hardened every fetch with redirect suppression, streaming body caps, and per-request timeouts. Review of #370 surfaced two response shapes that per-read timeouts and body-callback streaming **cannot** classify or bound, in the two SDKs whose HTTP stacks lack a total-request bound:

1. **Headers arrive, body stalls.** Ruby's Faraday exposes no headers-time callback (`on_data` fires per body chunk), so a 3xx/non-2xx whose body never arrives was classified as a transport timeout and retried — where SPEC.md §16 requires an immediate `api_error`. Bounded and redirect-safe, but a contract deviation, documented in-code during #370 review.
2. **The header phase itself stalls or drips.** A per-read timeout resets on every byte, so a peer dripping one byte per interval holds the request open indefinitely. Sync httpx additionally cannot be interrupted by closing the client from a watchdog (verified). Python's device flow already solved this with an `asyncio.wait_for`-cancelled worker; Python's *discovery* — which handles the SSRF-exposed URLs — did not.

This PR closes both, before BC5 go-live, so every SDK-built OAuth fetch has exact status-first classification and a true total-request bound. Go, TypeScript, and Kotlin already have both properties natively (response-at-headers APIs + context/abort/plugin deadlines) and are untouched.

## What

**Ruby — `Fetcher.stream_http`, one headers-first primitive for discovery + device flow.** Net::HTTP's block form yields at header time: `skip_status` classifies before any body read, and raising out of the block closes the socket undrained. A watchdog thread closes the connection at a monotonic deadline, interrupting even a blocked or byte-dripped *header* read (`max_retries = 0` is load-bearing — the idempotent-retry default silently reopens the connection the watchdog just closed). Redirects are structurally never followed. Injected Faraday connections keep the previous verified path; the stall residual is now scoped to injection only.

**Python — `_transport.request_bounded`, the device flow's bounded worker shared with discovery.** The `asyncio.wait_for`-cancelled, worker-thread-hosted core moves to `_transport.py`; `_post_form_bounded` delegates unchanged and discovery's between-chunks deadline loop (which never bounded the header phase) is replaced by the same total bound.

## Verification

Real-socket acceptance tests in both languages (mock layers cannot stall or drip — WebMock's patched Net::HTTP buffers even allowed requests, and respx serves instantly):

- header stall and header **drip** → bounded transport timeout at ~timeout
- stalled-body 302 on the token endpoint → immediate `api_error`, **exactly one request, zero retries**
- stalled-body non-2xx on device authorization → immediate `api_error` by status
- body drip → bounded; oversized body → streaming-cap abort
- skipped responses: server observes the socket close (no undrained body feeding)
- no leaked watchdog/worker threads

Full suites green: Ruby 750 runs / rubocop clean; Python 177 tests / mypy / ruff.

## Sequencing

Stacked on #370 (device flow, converged and merge-held). Intended to land immediately after #370, with no SDK release between them, so the transport contract is uniform from the first device-flow release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes headers-first, totally bounded HTTP transport the default for OAuth discovery, resource, and device flow in Ruby, and shares the same bounded worker transport across Python discovery and device. Adds identity-encoded raw‑wire reads, strict time/size validation, scheme‑correct proxy/TLS handling, and deadline‑first classification to prevent stalls, compression bombs, leaks, and misclassification.

- **New Features**
  - Ruby default transport on Net::HTTP: headers‑first status classification; total wall‑clock bound across open/read/write; identity encoding with raw‑wire body caps.
  - Python shared `request_bounded` for discovery/device using async `httpx` under a worker: enforces `MAX_REQUEST_TIMEOUT`, budgets from the caller’s remaining deadline with a 1s cleanup grace, caps concurrent workers to 8, streams raw bytes.
  - Proxies: per‑scheme ENV resolution, percent‑decoded credentials, and TLS to `https://` proxies (feature‑detected; older Rubies fail closed with a clear error).
  - Injected clients: documented fidelity tier in SPEC; injected paths run under the remaining budget, refuse late 2xx; buffered adapters return real bodies for 2xx and status‑only for non‑2xx.
  - Validation: fail fast on invalid methods, non‑HTTP/hostless URLs, GET‑with‑body, and invalid timeouts/body caps (zero cap allowed).

- **Bug Fixes**
  - Deadlines: late headers/bodies and post‑deadline reconnects classify as timeouts; completed outcomes and size‑cap faults survive cleanup; nothing is accepted past the deadline; watchdog keeps closing and teardown races are handled.
  - Fault mapping: protocol/TLS/Zlib/wire errors map uniformly and by capture time vs deadline (post‑deadline → timeout); `ETIMEDOUT` maps to timeout; write phase is bounded and classified.
  - Proxy/TLS: proxy DNS and CONNECT parsing run inside the deadline; sockets orphaned between connect/start are closed; TLS is used on proxy connections; bracketed IPv6 Host preserved.
  - Discovery: non‑2xx status dominates (no body drain on the default path); errors are status‑only to match other SDKs.
  - Compression‑safety: force identity `Accept-Encoding` and drop caller overrides; the cap applies to raw wire bytes to defeat compression bombs.
  - Initialization: response state is initialized at method start to satisfy static analysis and avoid use‑before‑init paths (no behavior change).

<sup>Written for commit e3f0af2481ebc23fb0c6ca6e0059d3ba2e0c7b95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

