### PR TITLE
Fix TypeScript SDK Content-Type on GET requests

### DIFF
--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -426,8 +426,10 @@ function createAuthMiddleware(authStrategy: AuthStrategy, userAgent: string, req
       requireSameOrigin(request.url, baseUrl);
       await authStrategy.authenticate(request.headers);
       request.headers.set("User-Agent", userAgent);
-      // Only set Content-Type if not already set (preserves binary uploads, etc.)
-      if (!request.headers.has("Content-Type")) {
+      // Content-Type describes a request body, so set the JSON default only when a
+      // body is present and not already typed (preserves binary uploads, etc.).
+      // bc3 silently discards query params on GET requests that carry a Content-Type.
+      if (request.body != null && !request.headers.has("Content-Type")) {
         request.headers.set("Content-Type", "application/json");
       }
       request.headers.set("Accept", "application/json");

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -429,7 +429,7 @@ function createAuthMiddleware(authStrategy: AuthStrategy, userAgent: string, req
       // Content-Type describes a request body, so set the JSON default only when a
       // body is present and not already typed (preserves binary uploads, etc.).
       // bc3 silently discards query params on GET requests that carry a Content-Type.
-      if (request.body != null && !request.headers.has("Content-Type")) {
+      if (request.body !== null && !request.headers.has("Content-Type")) {
         request.headers.set("Content-Type", "application/json");
       }
       request.headers.set("Accept", "application/json");

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -63,6 +63,80 @@ describe("BasecampClient", () => {
     });
   });
 
+  describe("content type", () => {
+    it("should not set Content-Type on bodyless GET requests", async () => {
+      // bc3 silently discards query params on GET requests that carry a
+      // Content-Type header, so bodyless requests must not send one.
+      let capturedRequest: Request | null = null;
+
+      server.use(
+        http.get(`${BASE_URL}/projects.json`, ({ request }) => {
+          capturedRequest = request;
+          return HttpResponse.json([]);
+        })
+      );
+
+      const client = createBasecampClient({
+        accountId: "12345",
+        accessToken: "test-token",
+      });
+
+      await client.GET("/projects.json");
+
+      expect(capturedRequest?.headers.get("Content-Type")).toBeNull();
+      expect(capturedRequest?.headers.get("Accept")).toBe("application/json");
+    });
+
+    it("should set Content-Type to application/json for JSON bodies", async () => {
+      let capturedRequest: Request | null = null;
+
+      server.use(
+        http.post(`${BASE_URL}/todolists/456/todos.json`, ({ request }) => {
+          capturedRequest = request;
+          return HttpResponse.json({ id: 1, content: "Test todo" }, { status: 201 });
+        })
+      );
+
+      const client = createBasecampClient({
+        accountId: "12345",
+        accessToken: "test-token",
+      });
+
+      await client.POST("/todolists/{todolistId}/todos.json", {
+        params: { path: { todolistId: 456 } },
+        body: { content: "Test todo" },
+      });
+
+      expect(capturedRequest?.headers.get("Content-Type")).toBe("application/json");
+    });
+
+    it("should preserve an explicitly set Content-Type on requests with a body", async () => {
+      let capturedRequest: Request | null = null;
+
+      server.use(
+        http.post(`${BASE_URL}/todolists/456/todos.json`, ({ request }) => {
+          capturedRequest = request;
+          return HttpResponse.json({ id: 1, content: "Test todo" }, { status: 201 });
+        })
+      );
+
+      const client = createBasecampClient({
+        accountId: "12345",
+        accessToken: "test-token",
+      });
+
+      await client.POST("/todolists/{todolistId}/todos.json", {
+        params: { path: { todolistId: 456 } },
+        body: { content: "Test todo" },
+        headers: { "Content-Type": "application/json; charset=utf-8" },
+      });
+
+      expect(capturedRequest?.headers.get("Content-Type")).toBe(
+        "application/json; charset=utf-8"
+      );
+    });
+  });
+
   describe("retry behavior", () => {
     it("should retry on 429 with Retry-After header", async () => {
       let attempts = 0;


### PR DESCRIPTION
## Problem

bc3 silently discards search query params and filters on GET requests that carry a `Content-Type: application/json` header. The TypeScript SDK's auth middleware set that header unconditionally on every request — guarded only by "not already set" — so every bodyless GET advertised a JSON body it did not have. Consumers saw this as search returning unfiltered results: basecamp-cli #546 and #470.

## Fix

Mirrors the Go SDK fix (#334): gate the JSON default on the request actually having a body, rather than on the HTTP method. In `createAuthMiddleware`, the header is now set only when `request.body != null` and no Content-Type is already present, preserving explicitly typed body-bearing requests (e.g. binary uploads via attachments).

openapi-fetch itself already only sets a default Content-Type when a serialized body exists, so the middleware was the sole source of the stray header on GETs.

## Tests

Client-level MSW tests covering all three directions:
- bodyless GET carries no Content-Type header (and still sends `Accept: application/json`)
- POST with a JSON body carries `Content-Type: application/json`
- an explicitly set Content-Type on a body-bearing request is preserved

Conformance fixtures are deliberately omitted here to avoid overlapping the in-flight bc5-readiness stack; wire-level coverage can land there once that stack settles.

## Note on releases

The released Go SDK v0.7.2 predates #334 and still carries the Go-side bug, so a post-merge release is what actually ships these fixes to consumers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the TypeScript SDK so bodyless GETs no longer send `Content-Type`, preventing bc3 from dropping query params and returning unfiltered results. The auth middleware now sets `Content-Type: application/json` only when `request.body !== null` (strict null check) and no header exists, still sends `Accept: application/json`, with tests covering GET, JSON POST, and preserving explicit types.

<sup>Written for commit 89fe05f4da51a6f708f06fc3df1db5f2bda1113b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

