### PR TITLE
CI: fold conformance suites into their language test jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,11 +137,14 @@ jobs:
           echo "$FILES" | grep -q '^typescript/dist/index\.js$'
           echo "$FILES" | grep -q '^typescript/dist/index\.d\.ts$'
 
+      # npx vitest run, not npm test: the runner's pretest script rebuilds
+      # the SDK, which this job just built two steps up. The runner's
+      # dist-freshness globalSetup still fails loudly if dist/ were stale.
       - name: Run TypeScript conformance tests
         working-directory: conformance/runner/typescript
         run: |
           npm ci
-          npm test
+          npx vitest run
 
   test-ruby:
     name: Ruby ${{ matrix.ruby }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,9 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'go/go.mod'
-          cache-dependency-path: 'go/go.sum'
+          cache-dependency-path: |
+            go/go.sum
+            conformance/runner/go/go.sum
 
       - name: Build
         run: go build ./...
@@ -85,6 +87,12 @@ jobs:
             exit 1
           fi
 
+      - name: Run Go conformance tests
+        working-directory: conformance/runner/go
+        run: |
+          go build -o conformance-runner .
+          ./conformance-runner
+
   test-typescript:
     name: TypeScript Tests
     runs-on: ubuntu-latest
@@ -103,7 +111,9 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-          cache-dependency-path: typescript/package-lock.json
+          cache-dependency-path: |
+            typescript/package-lock.json
+            conformance/runner/typescript/package-lock.json
 
       - name: Install dependencies
         run: npm ci
@@ -126,6 +136,12 @@ jobs:
           FILES=$(npm pack --ignore-scripts --json | jq -r '.[0].files[].path')
           echo "$FILES" | grep -q '^typescript/dist/index\.js$'
           echo "$FILES" | grep -q '^typescript/dist/index\.d\.ts$'
+
+      - name: Run TypeScript conformance tests
+        working-directory: conformance/runner/typescript
+        run: |
+          npm ci
+          npm test
 
   test-ruby:
     name: Ruby ${{ matrix.ruby }}
@@ -168,6 +184,13 @@ jobs:
 
       - name: Test
         run: bundle exec rake test
+
+      - name: Run Ruby conformance tests
+        if: matrix.ruby == '3.3'
+        working-directory: conformance/runner/ruby
+        run: |
+          bundle install
+          ruby runner.rb
 
   test-python:
     name: Python ${{ matrix.python }}
@@ -223,6 +246,13 @@ jobs:
 
       - name: Test with coverage
         run: uv run pytest --cov --cov-report=term-missing --cov-fail-under=60
+
+      - name: Run Python conformance tests
+        if: matrix.python == '3.13'
+        working-directory: conformance/runner/python
+        run: |
+          uv sync
+          uv run python runner.py
 
   test-swift:
     name: Swift Tests
@@ -283,85 +313,33 @@ jobs:
           fi
           echo "Generated code is up to date"
 
+      - name: Run Kotlin conformance tests
+        run: ./gradlew :conformance:run
+
   conformance:
+    # Fan-in gate: each language's conformance suite now runs inside its own
+    # test job (warm toolchain, built SDK), which removes the serial
+    # five-toolchain job that used to start only after every test job
+    # finished. This job keeps the required-check name "Conformance Tests"
+    # stable for the main-gate ruleset and fails if any language job —
+    # which includes its conformance step — did not succeed.
     name: Conformance Tests
     runs-on: ubuntu-latest
     needs: [test-go, test-typescript, test-ruby, test-kotlin, test-python]
+    if: always()
     permissions:
       contents: read
-    defaults:
-      run:
-        working-directory: conformance/runner/go
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-
-      - name: Set up Go
-        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
-        with:
-          go-version-file: 'conformance/runner/go/go.mod'
-          cache-dependency-path: 'conformance/runner/go/go.sum'
-
-      - name: Build conformance runner
-        run: go build -o conformance-runner .
-
-      - name: Run Go conformance tests
-        run: ./conformance-runner
-
-      - name: Set up Java
-        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-        with:
-          cache-provider: basic
-
-      - name: Run Kotlin conformance tests
-        working-directory: kotlin
-        run: ./gradlew :conformance:run
-
-      - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: '22'
-          cache: 'npm'
-          cache-dependency-path: conformance/runner/typescript/package-lock.json
-
-      - name: Build TypeScript SDK
-        working-directory: typescript
+      - name: Verify per-language conformance results
+        env:
+          RESULTS: ${{ toJSON(needs) }}
         run: |
-          npm ci
-          npm run build
-
-      - name: Run TypeScript conformance tests
-        working-directory: conformance/runner/typescript
-        run: |
-          npm ci
-          npm test
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
-        with:
-          ruby-version: '3.3'
-          bundler-cache: true
-          working-directory: conformance/runner/ruby
-
-      - name: Run Ruby conformance tests
-        working-directory: conformance/runner/ruby
-        run: ruby runner.rb
-
-      - name: Install uv (Python)
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
-
-      - name: Run Python conformance tests
-        working-directory: conformance/runner/python
-        run: |
-          uv sync
-          uv run python runner.py
+          echo "$RESULTS"
+          if echo "$RESULTS" | grep -Eq '"result": *"(failure|cancelled|skipped)"'; then
+            echo "::error::A language test job (which runs its own conformance suite) did not succeed"
+            exit 1
+          fi
+          echo "All per-language conformance suites green"
 
   lint:
     name: Lint
@@ -377,7 +355,9 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'go/go.mod'
-          cache-dependency-path: 'go/go.sum'
+          cache-dependency-path: |
+            go/go.sum
+            conformance/runner/go/go.sum
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
@@ -403,7 +383,9 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'go/go.mod'
-          cache-dependency-path: 'go/go.sum'
+          cache-dependency-path: |
+            go/go.sum
+            conformance/runner/go/go.sum
 
       - name: Test with race detector
         run: go test -race -v ./...
@@ -427,7 +409,9 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version-file: 'go/go.mod'
-          cache-dependency-path: 'go/go.sum'
+          cache-dependency-path: |
+            go/go.sum
+            conformance/runner/go/go.sum
 
       - name: Cache Go tools
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0


### PR DESCRIPTION
`Conformance Tests` adds ~5 minutes of tail latency to every PR round, twice over:

1. **It's gated behind everything** — `needs: [test-go, test-typescript, test-ruby, test-kotlin, test-python]` means it starts only after the slowest language job finishes.
2. **It's a five-toolchain serial job** — one runner sets up Go, Java/Gradle, Node, Ruby, and uv from cold, re-paying setups the language jobs just paid, then runs the five suites back-to-back.

The mock conformance suites have no cross-language dependencies, so this PR runs each suite inside its own language test job, where the toolchain is warm and the SDK is already built:

- **Go / TypeScript / Kotlin**: appended to their test jobs (TS reuses the freshly built `dist/`; caches extended to cover the runner lockfiles).
- **Ruby / Python**: run on one matrix leg each (3.3 / 3.13), matching how Lint is gated in those matrices.
- **`Conformance Tests`** becomes a seconds-long fan-in gate over the five jobs — the required-check name on the main-gate ruleset stays valid with no ruleset edit, and it fails if any language job (conformance step included) didn't succeed.

Critical path drops from `max(tests) + ~5min serial conformance` to `max(test + own suite)` (each suite adds ~1–2 min to a warm job), and billed minutes go **down** — the five duplicate toolchain setups disappear.

Possible follow-up (not in this PR): per-language path filtering via a detect-changes job so docs-only or single-language PRs skip the unaffected suites.

zizmor (`make lint-actions`) clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Folded each conformance suite into its language test job to remove the serial CI bottleneck and cut PR tail latency by ~5 minutes. The `Conformance Tests` job is now a fast fan-in gate that preserves the required check name.

- **Refactors**
  - Go/TypeScript/Kotlin: run conformance inside existing test jobs; TypeScript reuses built `dist/` and calls `npx vitest run` to avoid a duplicate build while keeping dist freshness checks.
  - Ruby/Python: run conformance on one matrix leg each (3.3 / 3.13).
  - Expanded caches to include conformance runner lockfiles for Go and TypeScript.
  - Replaced the serial conformance run with a gate that verifies all language jobs succeeded (fails on failure/cancel/skip) without changing rulesets.

<sup>Written for commit 9d20ad951a27df35521a950919c159ea2074bff0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

