### PR TITLE
CI: conformance follow-ups from #387 review

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -254,8 +254,8 @@ jobs:
         if: matrix.python == '3.13'
         working-directory: conformance/runner/python
         run: |
-          uv sync
-          uv run python runner.py
+          uv sync --python ${{ matrix.python }}
+          uv run --python ${{ matrix.python }} python runner.py
 
   test-swift:
     name: Swift Tests
@@ -337,9 +337,11 @@ jobs:
         env:
           RESULTS: ${{ toJSON(needs) }}
         run: |
-          echo "$RESULTS"
-          if echo "$RESULTS" | grep -Eq '"result": *"(failure|cancelled|skipped)"'; then
-            echo "::error::A language test job (which runs its own conformance suite) did not succeed"
+          echo "$RESULTS" | jq .
+          NOT_GREEN=$(echo "$RESULTS" | jq -r 'to_entries[] | select(.value.result != "success") | "\(.key): \(.value.result)"')
+          if [ -n "$NOT_GREEN" ]; then
+            echo "::error::Language test jobs (which run their own conformance suites) did not succeed:"
+            echo "$NOT_GREEN"
             exit 1
           fi
           echo "All per-language conformance suites green"


### PR DESCRIPTION
Two review threads on #387 landed after merge; this addresses both:

1. **Pin the conformance `uv sync` to the matrix Python** — the step is gated to the 3.13 leg but its sync/run weren't pinned, so uv could resolve against a different interpreter than the leg's intent. Both `uv sync` and `uv run` now pass `--python ${{ matrix.python }}`, matching the test steps above.
2. **Parse the fan-in gate's `needs` JSON instead of grepping it** — the gate now jq-parses results, fails on anything `!= success` (same skipped/cancelled semantics), and names exactly which job was not green instead of a bare error.

zizmor clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins Python conformance `uv` steps to the matrix interpreter and switches the fan-in gate to parse `needs` with `jq` for clear, accurate failures. Prevents mismatched Python during conformance and reports exactly which language jobs are not green.

- **Bug Fixes**
  - Pass `--python ${{ matrix.python }}` to `uv sync` and `uv run` in the conformance runner.
  - Parse `needs` JSON with `jq`, fail on any non-`success`, and print the specific job name and result.

<sup>Written for commit 2aebb72e8c559cc9c3f38de3c3189e91635af311. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

