### PR TITLE
ci: re-enable java-kotlin CodeQL analysis (manual build mode)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,8 @@ jobs:
               - 'ruby/**'
             swift:
               - 'swift/**'
+            kotlin:
+              - 'kotlin/**'
             actions:
               - '.github/**'
             config:
@@ -53,6 +55,7 @@ jobs:
           TS: ${{ steps.filter.outputs.typescript }}
           RUBY: ${{ steps.filter.outputs.ruby }}
           SWIFT: ${{ steps.filter.outputs.swift }}
+          KOTLIN: ${{ steps.filter.outputs.kotlin }}
           ACTIONS: ${{ steps.filter.outputs.actions }}
           CONFIG: ${{ steps.filter.outputs.config }}
         run: |
@@ -64,12 +67,14 @@ jobs:
             add go manual
             add javascript none
             add ruby none
+            add java-kotlin manual
             swift=true
           else
             if [ "$ACTIONS" = "true" ]; then add actions none; fi
             if [ "$GO" = "true" ]; then add go manual; fi
             if [ "$TS" = "true" ]; then add javascript none; fi
             if [ "$RUBY" = "true" ]; then add ruby none; fi
+            if [ "$KOTLIN" = "true" ]; then add java-kotlin manual; fi
             swift=$SWIFT
           fi
 
@@ -107,6 +112,19 @@ jobs:
           go-version-file: 'go/go.mod'
           cache-dependency-path: 'go/go.sum'
 
+      - name: Set up Java
+        if: matrix.language == 'java-kotlin'
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Gradle
+        if: matrix.language == 'java-kotlin'
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        with:
+          cache-provider: basic
+
       # --- CodeQL init ---
 
       - name: Initialize CodeQL
@@ -124,6 +142,16 @@ jobs:
         env:
           CODEQL_EXTRACTOR_GO_BUILD_TRACING: 'on'
         run: go build ./...
+
+      # CodeQL extracts Kotlin by tracing the compiler, so the compile task must
+      # actually run: gradle.properties enables the build cache and setup-gradle
+      # restores it, and an UP-TO-DATE compile emits nothing (empty database).
+      # Scoped to :basecamp-sdk — :generator is in neither codeql-config.yml's
+      # paths-ignore nor the SARIF filter, so building it would leak alerts.
+      - name: Build (Kotlin)
+        if: matrix.language == 'java-kotlin'
+        working-directory: kotlin
+        run: ./gradlew --no-build-cache clean :basecamp-sdk:compileKotlinJvm
 
       # --- Analysis (fails build on real errors) ---
 


### PR DESCRIPTION
> **Hold released — all four acceptance gates passed.** CodeQL CLI **2.26.2** reached the runners on 2026-07-31, and every gate below was verified at the merge head `8c0139fd3` (run `30670929581`: job `91288318048` for gates 1–3, `--debug` job rerun for gate 4's KMP source-archive proof). Full evidence is in the gate-walk comment on this PR. The "Current blocker" section below is retained as the historical record of the hold.

## Summary

Restores `java-kotlin` to the CodeQL matrix with **`build-mode: manual`** plus the Gradle build step that #224 removed, and adds a `kotlin/**` paths filter so PR-scoped runs pick it up.

Refs #198 (kept open — the blocker below is not resolved).

## Why manual, not buildless

An earlier revision of this PR used `build-mode: none`. **That cannot work: buildless is Java-only by design and does not extract Kotlin at all.** This repo has zero `.java` files, so the run built a dependency graph, scanned nothing, and finalized an empty database — exit 32, *"CodeQL could not process any code written in Java/Kotlin"* (run `29944343877`, job `89005856562`). Documented behavior, not a bug.

Manual mode traces the Kotlin compiler instead, which is the only route that gets KMP sources into the database. Two review bots (cubic P1, codex P2) flagged this correctly; both threads are now addressed rather than declined.

## Build step details

Three things that silently break this if missed:

- **Project path is `:basecamp-sdk`, not `:sdk`** — `kotlin/settings.gradle.kts:9-10` remaps its `projectDir` to `sdk/`.
- **`--no-build-cache clean` is load-bearing.** `kotlin/gradle.properties` sets `org.gradle.caching=true` and `setup-gradle` restores a cache. CodeQL extracts by *tracing the compiler*; an `UP-TO-DATE` compile task emits nothing and lands the same empty database this PR is fixing. The pre-#224 command carried these flags for exactly this reason.
- **Scoped to `:basecamp-sdk` only.** The historical command also built `:generator`, which is in neither `codeql-config.yml`'s `paths-ignore` nor the SARIF filter regex — building it would leak generator alerts into the upload. `compileKotlinJvm` compiles `commonMain` + `jvmMain` together, covering the whole hand-written surface (~3.2k lines: oauth, http, webhooks, serialization) plus the generated tree the SARIF filter already strips.

`setup-java` and `setup-gradle` pins are copied from the `Kotlin Tests` job in `test.yml` to keep one source of truth.

**No change to `.github/codeql/codeql-config.yml`** — `kotlin/` is already in `paths`, the generated tree and `kotlin/conformance/` are already in `paths-ignore`, and `codeql.yml`'s SARIF filter already carries `kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/`.

## Current blocker

The CodeQL CLI that **actually runs** requires Kotlin **`< 2.4.10`**. `kotlin/gradle/libs.versions.toml:2` pins exactly `2.4.10`, so the extractor throws `KotlinVersionTooRecentError` and fails the build step. There is no override flag — GitHub's sanctioned outs are pin Kotlin down, drop the language, or set `CODEQL_EXTRACTOR_JAVA_AGENT_DISABLE_KOTLIN=true`. None are acceptable here.

Note the CLI version is **resolved by GitHub at runtime, not declared by the pinned action**: `codeql-action` v4.37.0's `src/defaults.json` says `2.26.0`, while this PR's own job log printed `CODEQL_ACTION_CLI_VERSION_INFO … "version":"2.26.1"`.

**The unblock is external and imminent.** `github/codeql` commit `574ef4d1a` *"Kotlin: Support Kotlin 2.4.10"* merged 2026-07-15 but is **not** in the `codeql-cli/v2.26.1` tag (`compare/574ef4d1a...codeql-cli/v2.26.1` → `status: diverged, behind_by: 39`). Maintainer on github/codeql#22189: *"This will be fixed in CodeQL 2.26.2"*; on #22210 (2026-07-17): *"released either next week or the week after"*.

`gh api repos/github/codeql-action/contents/src/defaults.json` is a **hint only** — as above, GitHub can serve a newer CLI with no action bump. The only authoritative source is the `Setup CodeQL tools` line in a fresh job log, so the unblock check is *rerun the workflow and read the log*.

## Verification so far

Local, on CLI 2.26.1 — **none of this is a passing java-kotlin job**:

- `actionlint .github/workflows/codeql.yml` clean; both new `uses:` are SHA-pinned.
- Matrix builder exercised locally: `java-kotlin` appears with `"build-mode": "manual"` in both the full (`EVENT=push`) and PR-filtered (`EVENT=pull_request KOTLIN=true`) branches.
- `cd kotlin && ./gradlew --no-build-cache clean :basecamp-sdk:compileKotlinJvm` → `BUILD SUCCESSFUL`, with `:basecamp-sdk:compileKotlinJvm` **executed** (not `UP-TO-DATE`). This proves the task name and project path. It does **not** prove CodeQL extraction.

Expected CI outcome while the runners are still on 2.26.1: `Analyze (java-kotlin)` fails with `KotlinVersionTooRecentError` **instead of** exit 32. That is a step forward, not a pass — it confirms the extractor is finally being invoked at all. The other five `Analyze (*)` jobs should be unaffected.

## Acceptance gate — all four required before this leaves draft

1. **Job log `Setup CodeQL tools` reports CLI ≥ 2.26.2.** Not `defaults.json`.
2. **`Build (Kotlin)` succeeds** — no `KotlinVersionTooRecentError`.
3. **`codeql database finalize` succeeds** — no *"CodeQL could not process any code written in Java/Kotlin"*, no exit 32. Finalize is precisely what fails when nothing was extracted, so this is the real non-empty-database signal.
4. **File-level KMP proof — via job rerun, not a workflow edit.** Once items 1–3 pass, rerun that same successful job at the **same SHA** with debug logging:
   ```
   gh run rerun <run-id> --job <job-id> --debug --repo basecamp/basecamp-sdk
   ```
   Then download the uploaded database artifact and confirm the source archive contains hand-written files from **both** source sets. Match entries **by suffix** — the archive is rooted at the checkout root, so the full repo-relative form is `kotlin/sdk/src/…`, not `sdk/src/…`:
   - `kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampClient.kt`
   - `kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/webhooks/WebhookVerification.kt`
   - `kotlin/sdk/src/jvmMain/kotlin/com/basecamp/sdk/webhooks/WebhookVerification.jvm.kt`

   Doing this as a rerun rather than committing `debug: true` and reverting it is deliberate: **the proof must apply to the head that actually merges.** Committing a debug flag, proving extraction, then removing it validates a SHA that is not the merge candidate. `--debug` at the same SHA preserves exact-head provenance and produces the diagnostic artifact with no workflow churn ([GitHub's CodeQL debug-logging guidance](https://docs.github.com/en/enterprise-cloud/code-security/code-scanning/troubleshooting-code-scanning/logs-not-detailed-enough)).

**SARIF alert counts are not evidence of extraction.** The `Filter generated-code alerts from SARIF` step counts *alerts*, not extracted files, and a healthy scan can legitimately report zero — in the very run above, Go (job `89005856663`) and Swift (job `89005856477`) both finalized real databases while reporting `0 findings, filtered 0`.

Item 4 settles the one thing still genuinely unverified: whether CodeQL's tracer intercepts a **Kotlin Multiplatform** `compileKotlinJvm` task. GitHub has published nothing on KMP and no upstream issue exists either way. If the source archive comes back without `commonMain`/`jvmMain` entries on 2.26.2, that is the finding: **keep this PR a draft, report it upstream, and open a researched follow-up.** There is no quick fallback — `compileKotlinJvm` already compiles the KMP project's JVM target, so switching to a different Kotlin plugin would be a separate architectural change, not a swap of the build command.

## Corrections to the earlier revision

- **#224 removed `java-kotlin`** (`9ee4f948d`), not #229 — #229 (`e4f2a5667`) only rewrote the workflow a month later. The pre-#224 config was already `manual` + Gradle; this PR restores that shape.
- The closed upstream issue github/codeql#21484 (Kotlin 2.3.20) is **not** the live blocker. Kotlin 2.4.10 is.
- The earlier bot replies claimed the job would be a *"permanently red **required** check"*. It is not required — the `main-gate` ruleset (`12136410`) lists 12 contexts, none of them CodeQL — and the PR is `MERGEABLE`. The accurate claim is *unsafe to merge*, not *blocked from merging*.

🤖 _Authored with agent assistance by @jeremy._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enables CodeQL `java-kotlin` analysis in manual build mode and compiles the Kotlin SDK so sources are actually extracted; refs #198. Held until runners ship CodeQL 2.26.2.

- **New Features**
  - Add `kotlin/**` to PR path filters and expose `KOTLIN`; add `java-kotlin manual` to the matrix for full and PR-scoped runs.
  - Set up JDK 17 and Gradle; compile only `:basecamp-sdk` via `./gradlew --no-build-cache clean :basecamp-sdk:compileKotlinJvm` to trace the Kotlin compiler.

- **Dependencies**
  - Current runners use CodeQL 2.26.1, which fails on Kotlin 2.4.10 with `KotlinVersionTooRecentError`.
  - Expected to pass once 2.26.2 is available; no further workflow changes planned.

<sup>Written for commit 8c0139fd3c7e0e88197ed11e93df748907f0f078. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


