### PR TITLE
Record upload new-version API gap; guard upload update contract

### DIFF
--- a/API-GAP-404.md
+++ b/API-GAP-404.md
@@ -1,0 +1,136 @@
+# API gap: uploading a new version of an existing file
+
+Addresses basecamp/basecamp-cli#404.
+
+## Question
+
+basecamp-cli#404 asks the SDK to support uploading a **new version** of an
+existing uploaded file. The issue hypothesizes that `PUT /uploads/{id}.json`
+with a fresh `attachable_sgid` replaces the file and creates a version event,
+the way the read-only [Get upload versions][versions] endpoint
+(`GET /uploads/{id}/versions.json`, "each version event represents a file
+replacement") implies file replacement is a real server-side concept.
+
+The plumbing would be small: add `AttachableSGID` to `UpdateUploadRequest`
+(`go/pkg/basecamp/vaults.go`) and map it into the request body in
+`UploadsService.Update`. Before shipping that, the server behavior had to be
+verified, because a mapping that the server silently drops is worse than no
+method at all — it would look like it worked.
+
+## Finding: the API ignores `attachable_sgid` on update
+
+**Verified against the BC3 source pinned in `spec/api-provenance.json`
+(`basecamp/bc3` @ `ba105ba7d7e48bd97afdc98305e9fb8a63a88beb`).** This is a
+static source read of the pinned revision, not a live-account request — see
+*Verification status* below.
+
+`PUT /uploads/{id}.json` is served by `UploadsController#update`. The update
+path never reads `attachable_sgid`:
+
+```ruby
+# app/controllers/uploads_controller.rb @ ba105ba7
+class UploadsController < ApplicationController
+  wrap_parameters :upload, include: %i[ base_name description ]
+
+  before_action :set_new_upload, only: :create      # <- attachable_sgid consumed here, create only
+
+  def update
+    @recording.update! recordable: @upload.changing(upload_params), status: status_param
+    # ...
+  end
+
+  private
+    def upload_params
+      params[:upload]&.permit(:base_name, :description) || {}   # <- only these two
+    end
+
+    def uploadable_params
+      params.permit(:attachable_sgid, :file)                    # <- used only by set_new_upload (create)
+    end
+end
+```
+
+Three independent reasons the `attachable_sgid` sent to `update` is a no-op:
+
+1. **`wrap_parameters :upload, include: %i[base_name description]`** — only
+   `base_name` and `description` are wrapped into the `:upload` params the
+   update reads. `attachable_sgid` is not among them.
+2. **`upload_params` permits only `:base_name, :description`.** The update
+   calls `@upload.changing(upload_params)`; `attachable_sgid` is never passed
+   in.
+3. **`uploadable_params` (which does permit `:attachable_sgid`) is consumed
+   solely by `set_new_upload`**, a `before_action` scoped `only: :create`. The
+   update action never calls it.
+
+Even the version-event machinery cannot fire on an API update. `Upload#changing`
+re-attaches the *existing* blob:
+
+```ruby
+# app/models/upload.rb @ ba105ba7
+def changing(attributes)
+  super.tap { |copy| copy.attach(blob) }    # re-attaches the SAME blob
+end
+
+def track_blob_change(recording)
+  if previous_recordable = recording.last_version_event&.recordable
+    if previous_recordable.blob != blob            # never true on a metadata-only update
+      recording.track_event :blob_changed, recordable_previous: previous_recordable
+    end
+  end
+end
+```
+
+Because the blob is unchanged, `previous_recordable.blob != blob` is false and
+no `blob_changed` version event is created.
+
+The route table confirms there is no API write path for versions at all:
+
+```ruby
+# config/routes.rb @ ba105ba7  (API namespace)
+resources :uploads, only: %i[ show edit update destroy ] do
+  resources :versions, only: %i[ index ], controller: "uploads/versions"   # read-only
+end
+```
+
+The documentation matches the code. `doc/api/sections/uploads.md` documents
+**Update an upload** as changing `description` and `base_name` only, and
+**Get upload versions** as read-only. File replacement in the product happens
+through a web-only path, not the JSON API.
+
+## Conclusion
+
+`PUT /uploads/{id}.json` accepts a new `attachable_sgid` on the wire (Rails
+strong-params silently discard the unpermitted key) but **does not act on it**:
+the file is not replaced and no version is created. Only `description` and
+`base_name` are mutable through the JSON API. The basecamp-cli#404 hypothesis
+is **not supported** by the current server.
+
+Per the SDK's hard rule against shipping a wire method the server silently
+drops, `AttachableSGID` was **not** added to `UpdateUploadRequest`. Doing so
+would present a working "upload new version" affordance that never replaces
+anything.
+
+## Verification status
+
+- **Source-verified** against `basecamp/bc3` @ `ba105ba7` (the revision
+  `spec/api-provenance.json` pins). Controller, model, routes, and published
+  API docs all agree.
+- **Not** verified against a live account. A live confirmation is not required
+  to reject the change — the source is unambiguous that the update path drops
+  the key — but if the API team later adds a version-write contract, absorption
+  should be confirmed end-to-end before the CLI exposes a user-facing command.
+
+## Recommendation
+
+1. Do not add `attachable_sgid` to the upload-update SDK surface while the
+   server ignores it.
+2. Raise the capability with the API team via the tracked registry entry
+   [`spec/api-gaps/upload-new-version.md`](spec/api-gaps/upload-new-version.md).
+   The read side (versions list) is already modeled and absorbed
+   (`UploadsService.ListVersions`); only the **write** side (replace file /
+   create version) is missing a JSON contract.
+3. If and when BC3 ships a version-write contract, absorb it through the
+   Smithy spec + regeneration and confirm against a live account before the
+   CLI exposes "upload new version."
+
+[versions]: https://github.com/basecamp/bc3-api/blob/master/sections/uploads.md

--- a/API-GAP-404.md
+++ b/API-GAP-404.md
@@ -101,9 +101,12 @@ through a web-only path, not the JSON API.
 
 `PUT /uploads/{id}.json` accepts a new `attachable_sgid` on the wire (Rails
 strong-params silently discard the unpermitted key) but **does not act on it**:
-the file is not replaced and no version is created. Only `description` and
-`base_name` are mutable through the JSON API. The basecamp-cli#404 hypothesis
-is **not supported** by the current server.
+the file is not replaced and no version is created. The upload payload permits
+only `description` and `base_name`, and no file/blob replacement parameter is
+accepted through the JSON API. (The update also applies a top-level `status`
+param, but that changes the recording's status, not the file — it is unrelated
+to versioning.) The basecamp-cli#404 hypothesis is **not supported** by the
+current server.
 
 Per the SDK's hard rule against shipping a wire method the server silently
 drops, `AttachableSGID` was **not** added to `UpdateUploadRequest`. Doing so

--- a/go/pkg/basecamp/vaults_test.go
+++ b/go/pkg/basecamp/vaults_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -598,14 +599,33 @@ func TestUpdateUploadRequest_Marshal(t *testing.T) {
 	}
 }
 
-// TestUploadsService_Update_IgnoresAttachableSGID guards the confirmed server
-// contract: PUT /uploads/{id}.json mutates only description and base_name. The
-// bc3 update action drops attachable_sgid entirely (verified against
-// basecamp/bc3 @ ba105ba7 — see /API-GAP-404.md), so the SDK must never send it
-// on an upload update. If a future change adds an attachable_sgid field to
-// UpdateUploadRequest and maps it here without a verified server contract, this
-// test fails at the wire.
-func TestUploadsService_Update_IgnoresAttachableSGID(t *testing.T) {
+// TestUpdateUploadRequest_HasNoFileReplacementField guards the confirmed server
+// contract: PUT /uploads/{id}.json accepts no file/blob replacement parameter.
+// The bc3 update action drops attachable_sgid entirely (verified against
+// basecamp/bc3 @ ba105ba7 — see /API-GAP-404.md), so the SDK must not offer it
+// as an upload-update field.
+//
+// This is asserted over the request type, not the wire: an omitempty field left
+// unset is simply absent from the body, so a wire-body check could not catch a
+// newly added field. Adding an attachable_sgid field to UpdateUploadRequest
+// without a verified server contract fails here.
+func TestUpdateUploadRequest_HasNoFileReplacementField(t *testing.T) {
+	typ := reflect.TypeOf(UpdateUploadRequest{})
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		jsonName := strings.Split(field.Tag.Get("json"), ",")[0]
+		if jsonName == "attachable_sgid" || jsonName == "file" ||
+			strings.Contains(strings.ToLower(field.Name), "attachable") {
+			t.Errorf("UpdateUploadRequest carries file-replacement field %q (json %q); "+
+				"the server ignores attachable_sgid on update — see /API-GAP-404.md",
+				field.Name, jsonName)
+		}
+	}
+}
+
+// TestUploadsService_Update_SendsDocumentedFields verifies the update maps the
+// two documented mutable payload fields onto a PUT.
+func TestUploadsService_Update_SendsDocumentedFields(t *testing.T) {
 	var receivedMethod string
 	var receivedBody []byte
 
@@ -642,9 +662,6 @@ func TestUploadsService_Update_IgnoresAttachableSGID(t *testing.T) {
 	var body map[string]any
 	if err := json.Unmarshal(receivedBody, &body); err != nil {
 		t.Fatalf("failed to parse request body: %v", err)
-	}
-	if _, present := body["attachable_sgid"]; present {
-		t.Errorf("attachable_sgid must not be sent on upload update (server ignores it); body: %s", receivedBody)
 	}
 	if body["description"] != "Updated description" {
 		t.Errorf("expected description to be sent, got %v", body["description"])

--- a/go/pkg/basecamp/vaults_test.go
+++ b/go/pkg/basecamp/vaults_test.go
@@ -628,11 +628,13 @@ func TestUpdateUploadRequest_HasNoFileReplacementField(t *testing.T) {
 func TestUploadsService_Update_SendsDocumentedFields(t *testing.T) {
 	var receivedMethod string
 	var receivedPath string
+	var receivedAuth string
 	var receivedBody []byte
 
 	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedMethod = r.Method
 		receivedPath = r.URL.Path
+		receivedAuth = r.Header.Get("Authorization")
 		receivedBody, _ = io.ReadAll(r.Body)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -662,6 +664,9 @@ func TestUploadsService_Update_SendsDocumentedFields(t *testing.T) {
 	}
 	if receivedPath != "/12345/uploads/1069479400" {
 		t.Errorf("expected path /12345/uploads/1069479400, got %s", receivedPath)
+	}
+	if receivedAuth != "Bearer test-token" {
+		t.Errorf("expected Authorization 'Bearer test-token', got %s", receivedAuth)
 	}
 
 	var body map[string]any

--- a/go/pkg/basecamp/vaults_test.go
+++ b/go/pkg/basecamp/vaults_test.go
@@ -614,7 +614,11 @@ func TestUpdateUploadRequest_HasNoFileReplacementField(t *testing.T) {
 	for i := 0; i < typ.NumField(); i++ {
 		field := typ.Field(i)
 		jsonName := strings.Split(field.Tag.Get("json"), ",")[0]
+		// Match on the Go field name too, not just the json tag: a File []byte
+		// with no json tag serializes under its Go name and would otherwise slip
+		// the tag-only checks.
 		if jsonName == "attachable_sgid" || jsonName == "file" ||
+			strings.EqualFold(field.Name, "file") ||
 			strings.Contains(strings.ToLower(field.Name), "attachable") {
 			t.Errorf("UpdateUploadRequest carries file-replacement field %q (json %q); "+
 				"the server ignores attachable_sgid on update — see /API-GAP-404.md",

--- a/go/pkg/basecamp/vaults_test.go
+++ b/go/pkg/basecamp/vaults_test.go
@@ -679,6 +679,16 @@ func TestUploadsService_Update_SendsDocumentedFields(t *testing.T) {
 	if body["base_name"] != "renamed" {
 		t.Errorf("expected base_name to be sent, got %v", body["base_name"])
 	}
+	// Only the two documented mutable fields may reach the wire. In particular
+	// attachable_sgid/file must never appear: the server ignores them on update
+	// (see /API-GAP-404.md), and TestUpdateUploadRequest_HasNoFileReplacementField
+	// guards the request type. This closes the loop on the wire itself.
+	documented := map[string]bool{"description": true, "base_name": true}
+	for key := range body {
+		if !documented[key] {
+			t.Errorf("update sent undocumented field %q; only description and base_name are documented mutable fields", key)
+		}
+	}
 }
 
 // TestCreateUploadRequest_Subscriptions tests that Subscriptions

--- a/go/pkg/basecamp/vaults_test.go
+++ b/go/pkg/basecamp/vaults_test.go
@@ -600,7 +600,7 @@ func TestUpdateUploadRequest_Marshal(t *testing.T) {
 }
 
 // TestUpdateUploadRequest_HasNoFileReplacementField guards the confirmed server
-// contract: PUT /uploads/{id}.json accepts no file/blob replacement parameter.
+// contract: PUT /uploads/{id}(.json) accepts no file/blob replacement parameter.
 // The bc3 update action drops attachable_sgid entirely (verified against
 // basecamp/bc3 @ ba105ba7 — see /API-GAP-404.md), so the SDK must not offer it
 // as an upload-update field.

--- a/go/pkg/basecamp/vaults_test.go
+++ b/go/pkg/basecamp/vaults_test.go
@@ -598,6 +598,62 @@ func TestUpdateUploadRequest_Marshal(t *testing.T) {
 	}
 }
 
+// TestUploadsService_Update_IgnoresAttachableSGID guards the confirmed server
+// contract: PUT /uploads/{id}.json mutates only description and base_name. The
+// bc3 update action drops attachable_sgid entirely (verified against
+// basecamp/bc3 @ ba105ba7 — see /API-GAP-404.md), so the SDK must never send it
+// on an upload update. If a future change adds an attachable_sgid field to
+// UpdateUploadRequest and maps it here without a verified server contract, this
+// test fails at the wire.
+func TestUploadsService_Update_IgnoresAttachableSGID(t *testing.T) {
+	var receivedMethod string
+	var receivedBody []byte
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedMethod = r.Method
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       1069479400,
+			"title":    "logo.png",
+			"filename": "logo.png",
+		})
+	}))
+	defer apiServer.Close()
+
+	cfg := DefaultConfig()
+	cfg.BaseURL = apiServer.URL
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+	ac := client.ForAccount("12345")
+
+	_, err := ac.Uploads().Update(context.Background(), 1069479400, &UpdateUploadRequest{
+		Description: "Updated description",
+		BaseName:    "renamed",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedMethod != http.MethodPut {
+		t.Errorf("expected PUT, got %s", receivedMethod)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal(receivedBody, &body); err != nil {
+		t.Fatalf("failed to parse request body: %v", err)
+	}
+	if _, present := body["attachable_sgid"]; present {
+		t.Errorf("attachable_sgid must not be sent on upload update (server ignores it); body: %s", receivedBody)
+	}
+	if body["description"] != "Updated description" {
+		t.Errorf("expected description to be sent, got %v", body["description"])
+	}
+	if body["base_name"] != "renamed" {
+		t.Errorf("expected base_name to be sent, got %v", body["base_name"])
+	}
+}
+
 // TestCreateUploadRequest_Subscriptions tests that Subscriptions
 // field serializes correctly with specific person IDs.
 func TestCreateUploadRequest_Subscriptions(t *testing.T) {

--- a/go/pkg/basecamp/vaults_test.go
+++ b/go/pkg/basecamp/vaults_test.go
@@ -627,10 +627,12 @@ func TestUpdateUploadRequest_HasNoFileReplacementField(t *testing.T) {
 // two documented mutable payload fields onto a PUT.
 func TestUploadsService_Update_SendsDocumentedFields(t *testing.T) {
 	var receivedMethod string
+	var receivedPath string
 	var receivedBody []byte
 
 	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedMethod = r.Method
+		receivedPath = r.URL.Path
 		receivedBody, _ = io.ReadAll(r.Body)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -657,6 +659,9 @@ func TestUploadsService_Update_SendsDocumentedFields(t *testing.T) {
 
 	if receivedMethod != http.MethodPut {
 		t.Errorf("expected PUT, got %s", receivedMethod)
+	}
+	if receivedPath != "/12345/uploads/1069479400" {
+		t.Errorf("expected path /12345/uploads/1069479400, got %s", receivedPath)
 	}
 
 	var body map[string]any

--- a/spec/api-gaps/README.md
+++ b/spec/api-gaps/README.md
@@ -52,6 +52,7 @@ making the absorption journey publicly auditable.
 | [todoset-direct-todo-create](todoset-direct-todo-create.md) | addressed-in-bc3-pr-12359 | post-train | medium |
 | [schedule-recurrence-writes](schedule-recurrence-writes.md) | addressed-in-bc3-pr-12359 | post-train | medium |
 | [dock-tool-create-contract](dock-tool-create-contract.md) | absorbed-in-sdk | launch | medium |
+| [upload-new-version](upload-new-version.md) | no-json-contract | post-train | medium |
 
 > Statuses reflect how BC3's **BC5 API train** actually shipped (8 PRs merged
 > to `master`, 2026-07-18..21); BC3 #10947 closed unmerged, superseded by the

--- a/spec/api-gaps/upload-new-version.md
+++ b/spec/api-gaps/upload-new-version.md
@@ -1,0 +1,101 @@
+---
+gap: upload-new-version
+status: no-json-contract
+detected: 2026-07-22
+sdk_demand: medium
+bc3_refs:
+  routes:
+    - PUT /:account_id/uploads/:id.json
+    - GET /:account_id/uploads/:id/versions.json
+  controllers:
+    - app/controllers/uploads_controller.rb
+    - app/models/upload.rb
+  related_existing_api:
+    - UpdateUpload
+    - ListUploadVersions
+---
+
+# Upload a new version of an existing file (write side)
+
+## What's missing
+
+There is no JSON API to **replace an existing upload's file** (create a new
+version). The read side is fully covered — `GET /uploads/{id}/versions.json`
+lists version events and is already modeled as `ListUploadVersions` / absorbed
+as `UploadsService.ListVersions` — but nothing writes a version.
+
+basecamp-cli#404 hypothesized that `PUT /uploads/{id}.json` with a fresh
+`attachable_sgid` would replace the file and create a version. Verified against
+`basecamp/bc3` @ `ba105ba7` (the revision `spec/api-provenance.json` pins), it
+does not:
+
+- `UploadsController#update` reads `upload_params`, which permits only
+  `:base_name` and `:description`. `attachable_sgid` lives in
+  `uploadable_params`, consumed exclusively by `set_new_upload` — a
+  `before_action` scoped `only: :create`.
+- `wrap_parameters :upload, include: %i[base_name description]` never wraps
+  `attachable_sgid` into the params the update reads.
+- `Upload#changing` re-attaches the **existing** blob, so
+  `track_blob_change` sees an unchanged blob and never records a
+  `blob_changed` version event.
+- The API route table exposes `versions` as `only: %i[index]` (read-only);
+  there is no version-write route.
+
+`PUT /uploads/{id}.json` accepts the key on the wire (strong-params silently
+drop it) but takes no action on it. Only `description` and `base_name` are
+mutable through the JSON API. Full controller-level evidence:
+[`/API-GAP-404.md`](../../API-GAP-404.md).
+
+## Why it matters
+
+Replacing a file in place — keeping the same upload record, its comments, its
+URL, and its position, while pushing a new revision — is a common integration
+need: synced documents, generated exports refreshed on a schedule, design
+iterations. The version *history* is already exposed through the API, which
+makes the absence of a version *write* especially visible: a consumer can read
+that an upload has five versions but cannot create the sixth. Today the only
+way to revise a file through the API is to create a brand-new upload, which
+breaks the record's identity, comment thread, and version lineage.
+
+## Suggested API shape
+
+A write contract for file replacement, either:
+
+- **Extend `PUT /uploads/{id}.json`** to honor `attachable_sgid` (and
+  optionally `file`), replacing the blob and recording a `blob_changed`
+  version event; or
+- **Add a dedicated version-create route**, e.g.
+  `POST /uploads/{id}/versions.json` accepting `attachable_sgid`, mirroring the
+  create-upload contract and returning the updated upload (or the new version
+  event).
+
+Either way the request carries an `attachable_sgid` obtained from the Create
+Attachment endpoint, exactly as create-upload does, and the response should
+reflect the new blob (`byte_size`, `content_type`, `filename`, `download_url`).
+
+## Implementation notes for BC3
+
+- Decide the surface: widen `update`'s permitted params to include
+  `attachable_sgid`/`file` and thread them through `@upload.changing`, or add a
+  version-create action. A metadata-only update must remain a no-op on the
+  blob so it does not spuriously create versions.
+- Ensure the replacement path drives `track_blob_change` so a new
+  `blob_changed` event is recorded and surfaces in
+  `GET /uploads/{id}/versions.json`.
+- Document the chosen route in `doc/api/sections/uploads.md`, including whether
+  `description`/`base_name` may accompany the replacement.
+
+## SDK absorption plan when this lands
+
+- Model the write operation in `spec/basecamp.smithy` (extend
+  `UpdateUploadInput` with `attachable_sgid`, or add a `CreateUploadVersion`
+  operation), then `make smithy-build` and regenerate.
+- Map the new field/operation in `UploadsService` (`go/pkg/basecamp/vaults.go`)
+  and the peer SDKs; add `AttachableSGID` to `UpdateUploadRequest` only once the
+  server honors it.
+- Add a canary fixture exercising a real file replacement and confirm the
+  version list grows, against a live account, before the CLI (basecamp-cli#404)
+  exposes an "upload new version" command.
+- Replace the contract-guard test
+  (`TestUploadsService_Update_IgnoresAttachableSGID`) with a positive
+  assertion that the field is now sent.

--- a/spec/api-gaps/upload-new-version.md
+++ b/spec/api-gaps/upload-new-version.md
@@ -97,6 +97,6 @@ reflect the new blob (`byte_size`, `content_type`, `filename`, `download_url`).
 - Add a canary fixture exercising a real file replacement and confirm the
   version list grows, against a live account, before the CLI (basecamp-cli#404)
   exposes an "upload new version" command.
-- Replace the contract-guard test
-  (`TestUploadsService_Update_IgnoresAttachableSGID`) with a positive
+- Replace the reflection guard
+  (`TestUpdateUploadRequest_HasNoFileReplacementField`) with a positive
   assertion that the field is now sent.

--- a/spec/api-gaps/upload-new-version.md
+++ b/spec/api-gaps/upload-new-version.md
@@ -9,7 +9,6 @@ bc3_refs:
     - GET /:account_id/uploads/:id/versions.json
   controllers:
     - app/controllers/uploads_controller.rb
-    - app/models/upload.rb
   related_existing_api:
     - UpdateUpload
     - ListUploadVersions
@@ -42,8 +41,10 @@ does not:
   there is no version-write route.
 
 `PUT /uploads/{id}.json` accepts the key on the wire (strong-params silently
-drop it) but takes no action on it. Only `description` and `base_name` are
-mutable through the JSON API. Full controller-level evidence:
+drop it) but takes no action on it. The upload payload permits only
+`description` and `base_name`, and no file/blob replacement parameter is
+accepted (the update's top-level `status` param changes the recording status,
+not the file). Full controller-level evidence:
 [`/API-GAP-404.md`](../../API-GAP-404.md).
 
 ## Why it matters


### PR DESCRIPTION
Addresses basecamp/basecamp-cli#404.

## Summary

basecamp-cli#404 asked the SDK to support uploading a **new version** of an
existing uploaded file, hypothesizing that `PUT /uploads/{id}.json` with a
fresh `attachable_sgid` replaces the file and creates a version event — the way
the read-only `GET /uploads/{id}/versions.json` endpoint ("each version event
represents a file replacement") implies file replacement is a real server-side
concept.

I verified the server behavior before touching the SDK surface, because a
mapping the server silently drops is worse than no method — it would look like
it worked. **The hypothesis does not hold: the JSON API ignores
`attachable_sgid` on update.** No `AttachableSGID` field was added to
`UpdateUploadRequest`. This PR is a **draft** documenting the gap so it can be
raised with the API team.

## Verification

Source-verified against `basecamp/bc3` @ `ba105ba7d7e48bd97afdc98305e9fb8a63a88beb`
— the revision `spec/api-provenance.json` pins. `UploadsController#update`:

- reads `upload_params`, which permits only `:base_name` and `:description`;
- `attachable_sgid` lives in `uploadable_params`, consumed exclusively by
  `set_new_upload`, a `before_action` scoped `only: :create`;
- `wrap_parameters :upload, include: %i[base_name description]` never wraps
  `attachable_sgid` into the params the update reads;
- `Upload#changing` re-attaches the **existing** blob, so `track_blob_change`
  sees an unchanged blob and never records a `blob_changed` version event;
- the API route table exposes `versions` as `only: %i[index]` (read-only);
  there is no version-write route.

The update also applies a top-level `status` param, but that changes the
recording's status, not the file — it is unrelated to versioning. The upload
payload permits only `description` and `base_name`; no file/blob replacement
parameter is accepted. `doc/api/sections/uploads.md` matches the code. File
replacement in the product happens through a web-only path, not the JSON API.

**Verification status:** source-verified against the pinned bc3 revision; the
source is unambiguous. Not exercised against a live account. A live confirmation
is not required to reject the change, but if the API team later adds a
version-write contract, absorption should be confirmed end-to-end before the CLI
exposes a user-facing "upload new version" command.

## Changes

- **`API-GAP-404.md`** — controller-level evidence and recommendation.
- **`spec/api-gaps/upload-new-version.md`** — registry entry tracking the
  missing version-**write** contract for BC3 coordination. The read side
  (versions list) is already modeled and absorbed as
  `UploadsService.ListVersions`; only the write side is missing.
- **`spec/api-gaps/README.md`** — registry table row.
- **`go/pkg/basecamp/vaults_test.go`** — a reflection guard asserting
  `UpdateUploadRequest` carries no file-replacement field, plus a positive test
  that the update maps `description`/`base_name` onto a PUT.

No Smithy or generated code changed — there is no server contract to absorb yet,
so no SDK regeneration is required.

## Recommendation

Kept as a draft. If BC3 ships a version-write contract (extend `UpdateUpload`
to honor `attachable_sgid`, or add `POST /uploads/{id}/versions.json`), absorb
it through the Smithy spec + regeneration and confirm against a live account
before the CLI exposes "upload new version."

## Checks

`make check` (Go) green; `make validate-api-gaps` clean.
