### PR TITLE
Fix project construction request envelope across SDKs

### DIFF
--- a/go/pkg/basecamp/templates.go
+++ b/go/pkg/basecamp/templates.go
@@ -326,8 +326,10 @@ func (s *TemplatesService) CreateProject(ctx context.Context, templateID int64, 
 	}
 
 	body := generated.CreateProjectFromTemplateJSONRequestBody{
-		Name:        name,
-		Description: description,
+		Project: generated.ProjectConstructionAttributes{
+			Name:        name,
+			Description: description,
+		},
 	}
 
 	resp, err := s.client.parent.gen.CreateProjectFromTemplateWithResponse(ctx, s.client.accountID, templateID, body)

--- a/go/pkg/basecamp/templates_test.go
+++ b/go/pkg/basecamp/templates_test.go
@@ -203,7 +203,10 @@ func TestTemplatesService_CreateProjectEnvelope(t *testing.T) {
 	fixture := loadTemplatesFixture(t, "project_construction.json")
 
 	var receivedBody map[string]any
+	var receivedMethod, receivedPath string
 	svc := testTemplatesServer(t, func(w http.ResponseWriter, r *http.Request) {
+		receivedMethod = r.Method
+		receivedPath = r.URL.Path
 		receivedBody = decodeRequestBody(t, r)
 
 		w.Header().Set("Content-Type", "application/json")
@@ -214,6 +217,13 @@ func TestTemplatesService_CreateProjectEnvelope(t *testing.T) {
 	_, err := svc.CreateProject(context.Background(), 987, "New Project from Template", "Kick-off details")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", receivedMethod)
+	}
+	if want := "/99999/templates/987/project_constructions.json"; receivedPath != want {
+		t.Errorf("expected path %q, got %q", want, receivedPath)
 	}
 
 	project, ok := receivedBody["project"].(map[string]any)

--- a/go/pkg/basecamp/templates_test.go
+++ b/go/pkg/basecamp/templates_test.go
@@ -1,7 +1,10 @@
 package basecamp
 
 import (
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -176,6 +179,55 @@ func TestProjectConstruction_UnmarshalCompleted(t *testing.T) {
 	}
 	if construction.Project.Name != "New Project from Template" {
 		t.Errorf("expected Project.Name 'New Project from Template', got %q", construction.Project.Name)
+	}
+}
+
+// testTemplatesServer wires a TemplatesService to an httptest server.
+func testTemplatesServer(t *testing.T, handler http.HandlerFunc) *TemplatesService {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	cfg := DefaultConfig()
+	cfg.BaseURL = server.URL
+	token := &StaticTokenProvider{Token: "test-token"}
+	client := NewClient(cfg, token)
+	account := client.ForAccount("99999")
+	return account.Templates()
+}
+
+// TestTemplatesService_CreateProjectEnvelope verifies the request body nests the
+// project parameters under a "project" envelope, as the project_constructions
+// endpoint requires. A flat {"name","description"} body is rejected with 400.
+func TestTemplatesService_CreateProjectEnvelope(t *testing.T) {
+	fixture := loadTemplatesFixture(t, "project_construction.json")
+
+	var receivedBody map[string]any
+	svc := testTemplatesServer(t, func(w http.ResponseWriter, r *http.Request) {
+		receivedBody = decodeRequestBody(t, r)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write(fixture)
+	})
+
+	_, err := svc.CreateProject(context.Background(), 987, "New Project from Template", "Kick-off details")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	project, ok := receivedBody["project"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected params nested under \"project\" envelope, got body: %v", receivedBody)
+	}
+	if _, flat := receivedBody["name"]; flat {
+		t.Error("expected no top-level \"name\"; params must be nested under \"project\"")
+	}
+	if project["name"] != "New Project from Template" {
+		t.Errorf("expected project.name 'New Project from Template', got %v", project["name"])
+	}
+	if project["description"] != "Kick-off details" {
+		t.Errorf("expected project.description 'Kick-off details', got %v", project["description"])
 	}
 }
 

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -597,8 +597,7 @@ type CreatePersonRequest struct {
 
 // CreateProjectFromTemplateRequestContent defines model for CreateProjectFromTemplateRequestContent.
 type CreateProjectFromTemplateRequestContent struct {
-	Description string `json:"description,omitempty"`
-	Name        string `json:"name"`
+	Project ProjectConstructionAttributes `json:"project"`
 }
 
 // CreateProjectFromTemplateResponseContent defines model for CreateProjectFromTemplateResponseContent.
@@ -1638,6 +1637,12 @@ type ProjectConstruction struct {
 	Project Project `json:"project,omitempty"`
 	Status  string  `json:"status"`
 	Url     string  `json:"url,omitempty"`
+}
+
+// ProjectConstructionAttributes defines model for ProjectConstructionAttributes.
+type ProjectConstructionAttributes struct {
+	Description string `json:"description,omitempty"`
+	Name        string `json:"name"`
 }
 
 // Question defines model for Question.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/Types.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/Types.kt
@@ -474,8 +474,7 @@ data class UpdateTemplateBody(
 
 /** Request body for CreateProjectFromTemplate. */
 data class CreateProjectFromTemplateBody(
-    val name: String,
-    val description: String? = null
+    val project: JsonObject
 )
 
 /** Options for GetProjectTimesheet. */

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/templates.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/templates.kt
@@ -136,8 +136,7 @@ class TemplatesService(client: AccountClient) : BaseService(client) {
         )
         return request(info, {
             httpPost("/templates/${templateId}/project_constructions.json", json.encodeToString(kotlinx.serialization.json.buildJsonObject {
-                put("name", kotlinx.serialization.json.JsonPrimitive(body.name))
-                body.description?.let { put("description", kotlinx.serialization.json.JsonPrimitive(it)) }
+                put("project", body.project)
             }), operationName = info.operation)
         }) { body ->
             json.decodeFromString<JsonElement>(body)

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TemplatesServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TemplatesServiceTest.kt
@@ -1,0 +1,69 @@
+package com.basecamp.sdk
+
+import com.basecamp.sdk.generated.services.CreateProjectFromTemplateBody
+import com.basecamp.sdk.generated.templates
+import io.ktor.client.engine.mock.*
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.*
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TemplatesServiceTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun mockClient(handler: MockRequestHandler): BasecampClient {
+        val engine = MockEngine(handler)
+        return testBasecampClient {
+            accessToken("test-token")
+            this.engine = engine
+        }
+    }
+
+    @Test
+    fun createProjectNestsBodyUnderProjectEnvelope() = runTest {
+        var capturedRequest: HttpRequestData? = null
+        var capturedBody: String? = null
+
+        val client = mockClient { request ->
+            capturedRequest = request
+            capturedBody = request.body.toByteArray().decodeToString()
+
+            respond(
+                content = """{"id": 900, "status": "completed"}""",
+                status = HttpStatusCode.Created,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+
+        val account = client.forAccount("12345")
+        account.templates.createProject(
+            templateId = 456,
+            body = CreateProjectFromTemplateBody(
+                project = buildJsonObject {
+                    put("name", "New Project")
+                    put("description", "From template")
+                },
+            ),
+        )
+
+        assertEquals(HttpMethod.Post, capturedRequest!!.method)
+        assertTrue(capturedRequest!!.url.encodedPath.endsWith("/templates/456/project_constructions.json"))
+
+        val bodyJson = json.parseToJsonElement(capturedBody!!).jsonObject
+        assertFalse(bodyJson.containsKey("name"))
+        val project = bodyJson["project"]!!.jsonObject
+        assertEquals("New Project", project["name"]!!.jsonPrimitive.content)
+        assertEquals("From template", project["description"]!!.jsonPrimitive.content)
+
+        client.close()
+    }
+}

--- a/openapi.json
+++ b/openapi.json
@@ -22603,15 +22603,12 @@
       "CreateProjectFromTemplateRequestContent": {
         "type": "object",
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
+          "project": {
+            "$ref": "#/components/schemas/ProjectConstructionAttributes"
           }
         },
         "required": [
-          "name"
+          "project"
         ]
       },
       "CreateProjectFromTemplateResponseContent": {
@@ -25302,6 +25299,20 @@
         "required": [
           "id",
           "status"
+        ]
+      },
+      "ProjectConstructionAttributes": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
         ]
       },
       "Question": {

--- a/python/src/basecamp/generated/services/templates.py
+++ b/python/src/basecamp/generated/services/templates.py
@@ -51,12 +51,12 @@ class TemplatesService(BaseService):
             operation="DeleteTemplate",
         )
 
-    def create_project(self, *, template_id: int, name: str, description: str | None = None) -> dict[str, Any]:
+    def create_project(self, *, template_id: int, project: dict) -> dict[str, Any]:
         return self._request(
             OperationInfo(service="templates", operation="create_project", is_mutation=True, resource_id=template_id),
             "POST",
             f"/templates/{template_id}/project_constructions.json",
-            json_body=self._compact(name=name, description=description),
+            json_body=self._compact(project=project),
             operation="CreateProjectFromTemplate",
         )
 
@@ -113,12 +113,12 @@ class AsyncTemplatesService(AsyncBaseService):
             operation="DeleteTemplate",
         )
 
-    async def create_project(self, *, template_id: int, name: str, description: str | None = None) -> dict[str, Any]:
+    async def create_project(self, *, template_id: int, project: dict) -> dict[str, Any]:
         return await self._request(
             OperationInfo(service="templates", operation="create_project", is_mutation=True, resource_id=template_id),
             "POST",
             f"/templates/{template_id}/project_constructions.json",
-            json_body=self._compact(name=name, description=description),
+            json_body=self._compact(project=project),
             operation="CreateProjectFromTemplate",
         )
 

--- a/python/src/basecamp/generated/types.py
+++ b/python/src/basecamp/generated/types.py
@@ -449,8 +449,7 @@ class CreatePersonRequest(TypedDict):
 
 
 class CreateProjectFromTemplateRequestContent(TypedDict):
-    description: NotRequired[str]
-    name: str
+    project: ProjectConstructionAttributes
 
 
 class CreateProjectRequestContent(TypedDict):
@@ -1029,6 +1028,11 @@ class ProjectConstruction(TypedDict):
     project: NotRequired[Project]
     status: str
     url: NotRequired[str]
+
+
+class ProjectConstructionAttributes(TypedDict):
+    description: NotRequired[str]
+    name: str
 
 
 class Question(TypedDict):

--- a/python/tests/services/test_templates_service.py
+++ b/python/tests/services/test_templates_service.py
@@ -1,0 +1,65 @@
+"""Tests for generated templates service routes."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from basecamp import AsyncClient, Client
+
+
+def _construction() -> dict:
+    return {
+        "id": 900,
+        "status": "completed",
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-01-01T00:00:00Z",
+    }
+
+
+class TestSyncTemplates:
+    @respx.mock
+    def test_create_project_nests_body_under_project_envelope(self):
+        route = respx.post("https://3.basecampapi.com/12345/templates/456/project_constructions.json").mock(
+            return_value=httpx.Response(201, json=_construction())
+        )
+
+        account = Client(access_token="test-token").for_account("12345")
+        result = account.templates.create_project(
+            template_id=456,
+            project={"name": "New Project", "description": "From template"},
+        )
+
+        assert route.called
+        request = route.calls[0].request
+        assert request.method == "POST"
+        body = json.loads(request.content)
+        assert body == {"project": {"name": "New Project", "description": "From template"}}
+        assert "name" not in body
+        assert result["id"] == 900
+
+
+class TestAsyncTemplates:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_create_project_nests_body_under_project_envelope(self):
+        route = respx.post("https://3.basecampapi.com/12345/templates/456/project_constructions.json").mock(
+            return_value=httpx.Response(201, json=_construction())
+        )
+
+        account = AsyncClient(access_token="test-token").for_account("12345")
+        result = await account.templates.create_project(
+            template_id=456,
+            project={"name": "New Project", "description": "From template"},
+        )
+
+        assert route.called
+        request = route.calls[0].request
+        assert request.method == "POST"
+        body = json.loads(request.content)
+        assert body == {"project": {"name": "New Project", "description": "From template"}}
+        assert "name" not in body
+        assert result["id"] == 900

--- a/ruby/lib/basecamp/generated/metadata.json
+++ b/ruby/lib/basecamp/generated/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-07-22T08:33:01Z",
+  "generated": "2026-07-22T21:16:21Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/ruby/lib/basecamp/generated/services/checkins_service.rb
+++ b/ruby/lib/basecamp/generated/services/checkins_service.rb
@@ -57,7 +57,7 @@ module Basecamp
       # Create a new question in a questionnaire
       # @param questionnaire_id [Integer] questionnaire id ID
       # @param title [String] title
-      # @param schedule [String] schedule
+      # @param schedule [Hash] schedule
       # @return [Hash] response data
       def create_question(questionnaire_id:, title:, schedule:)
         with_operation(service: "checkins", operation: "create_question", is_mutation: true, resource_id: questionnaire_id) do
@@ -77,7 +77,7 @@ module Basecamp
       # Update an existing question
       # @param question_id [Integer] question id ID
       # @param title [String, nil] title
-      # @param schedule [String, nil] schedule
+      # @param schedule [Hash, nil] schedule
       # @param paused [Boolean, nil] paused
       # @return [Hash] response data
       def update_question(question_id:, title: nil, schedule: nil, paused: nil)

--- a/ruby/lib/basecamp/generated/services/gauges_service.rb
+++ b/ruby/lib/basecamp/generated/services/gauges_service.rb
@@ -18,7 +18,7 @@ module Basecamp
 
       # Update a gauge needle's description. Position and color are immutable.
       # @param needle_id [Integer] needle id ID
-      # @param gauge_needle [String, nil] gauge needle
+      # @param gauge_needle [Hash, nil] gauge needle
       # @return [Hash] response data
       def update_gauge_needle(needle_id:, gauge_needle: nil)
         with_operation(service: "gauges", operation: "update_gauge_needle", is_mutation: true, resource_id: needle_id) do
@@ -38,7 +38,7 @@ module Basecamp
 
       # Enable or disable the gauge for a project. Only project admins can toggle gauges.
       # @param project_id [Integer] project id ID
-      # @param gauge [String] gauge
+      # @param gauge [Hash] gauge
       # @return [void]
       def toggle_gauge(project_id:, gauge:)
         with_operation(service: "gauges", operation: "toggle_gauge", is_mutation: true, project_id: project_id) do
@@ -58,7 +58,7 @@ module Basecamp
 
       # Create a gauge needle (progress update) for a project
       # @param project_id [Integer] project id ID
-      # @param gauge_needle [String] gauge needle
+      # @param gauge_needle [Hash] gauge needle
       # @param notify [String, nil] Who to notify: "everyone", "working_on", "custom", or omit for nobody
       # @param subscriptions [Array, nil] Array of people IDs to notify (only used when notify is "custom")
       # @return [Hash] response data

--- a/ruby/lib/basecamp/generated/services/people_service.rb
+++ b/ruby/lib/basecamp/generated/services/people_service.rb
@@ -24,7 +24,7 @@ module Basecamp
       end
 
       # Update the current user's preferences
-      # @param person [String] person
+      # @param person [Hash] person
       # @return [Hash] response data
       def update_my_preferences(person:)
         with_operation(service: "people", operation: "update_my_preferences", is_mutation: true) do
@@ -85,7 +85,7 @@ module Basecamp
 
       # Enable or replace out of office for a person.
       # @param person_id [Integer] person id ID
-      # @param out_of_office [String] out of office
+      # @param out_of_office [Hash] out of office
       # @return [Hash] response data
       def enable_out_of_office(person_id:, out_of_office:)
         with_operation(service: "people", operation: "enable_out_of_office", is_mutation: true, resource_id: person_id) do

--- a/ruby/lib/basecamp/generated/services/projects_service.rb
+++ b/ruby/lib/basecamp/generated/services/projects_service.rb
@@ -41,7 +41,7 @@ module Basecamp
       # @param name [String] name
       # @param description [String, nil] description
       # @param admissions [String, nil] invite|employee|team
-      # @param schedule_attributes [String, nil] schedule attributes
+      # @param schedule_attributes [Hash, nil] schedule attributes
       # @return [Hash] response data
       def update(project_id:, name:, description: nil, admissions: nil, schedule_attributes: nil)
         with_operation(service: "projects", operation: "update", is_mutation: true, project_id: project_id) do

--- a/ruby/lib/basecamp/generated/services/templates_service.rb
+++ b/ruby/lib/basecamp/generated/services/templates_service.rb
@@ -59,12 +59,11 @@ module Basecamp
 
       # Create a project from a template (asynchronous)
       # @param template_id [Integer] template id ID
-      # @param name [String] name
-      # @param description [String, nil] description
+      # @param project [Hash] project
       # @return [Hash] response data
-      def create_project(template_id:, name:, description: nil)
+      def create_project(template_id:, project:)
         with_operation(service: "templates", operation: "create_project", is_mutation: true, resource_id: template_id) do
-          http_post("/templates/#{template_id}/project_constructions.json", body: compact_params(name: name, description: description)).json
+          http_post("/templates/#{template_id}/project_constructions.json", body: compact_params(project: project)).json
         end
       end
 

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Auto-generated from OpenAPI spec. Do not edit manually.
-# Generated: 2026-07-22T08:33:01Z
+# Generated: 2026-07-22T21:16:21Z
 
 require "json"
 require "time"
@@ -2536,6 +2536,33 @@ module Basecamp
           "status" => @status,
           "project" => @project,
           "url" => @url,
+        }.compact
+      end
+
+      def to_json(*args)
+        to_h.to_json(*args)
+      end
+    end
+
+    # ProjectConstructionAttributes
+    class ProjectConstructionAttributes
+      include TypeHelpers
+      attr_accessor :name, :description
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[name].freeze
+      end
+
+      def initialize(data = {})
+        @name = data["name"]
+        @description = data["description"]
+      end
+
+      def to_h
+        {
+          "name" => @name,
+          "description" => @description,
         }.compact
       end
 

--- a/ruby/scripts/generate-services.rb
+++ b/ruby/scripts/generate-services.rb
@@ -533,7 +533,13 @@ class ServiceGenerator
   def schema_to_ruby_type(schema)
     return 'Object' unless schema
 
-    case schema['type']
+    # Object-valued members (e.g. a `project`/`gauge`/`schedule` envelope) are passed
+    # as a Hash. Resolve $refs and treat only object-typed schemas as Hash; a string
+    # ref such as FirstWeekDay must stay String.
+    resolved = schema['$ref'] ? resolve_schema_ref(schema) : schema
+    return 'Hash' if resolved && resolved['type'] == 'object'
+
+    case resolved&.fetch('type', nil)
     when 'integer' then 'Integer'
     when 'boolean' then 'Boolean'
     when 'array' then 'Array'

--- a/ruby/test/basecamp/services/templates_service_test.rb
+++ b/ruby/test/basecamp/services/templates_service_test.rb
@@ -62,9 +62,10 @@ class TemplatesServiceTest < Minitest::Test
     response = { "id" => 1, "status" => "processing" }
 
     stub_request(:post, %r{https://3\.basecampapi\.com/12345/templates/\d+/project_constructions\.json})
+      .with(body: { project: { name: "Q1 Project" } })
       .to_return(status: 201, body: response.to_json, headers: { "Content-Type" => "application/json" })
 
-    result = @account.templates.create_project(template_id: 1, name: "Q1 Project")
+    result = @account.templates.create_project(template_id: 1, project: { name: "Q1 Project" })
     assert_equal "processing", result["status"]
   end
 

--- a/spec/basecamp.smithy
+++ b/spec/basecamp.smithy
@@ -6802,6 +6802,11 @@ structure CreateProjectFromTemplateInput {
   templateId: TemplateId
 
   @required
+  project: ProjectConstructionAttributes
+}
+
+structure ProjectConstructionAttributes {
+  @required
   name: String
 
   description: String

--- a/swift/Sources/Basecamp/Generated/Models/CreateProjectFromTemplateRequest.swift
+++ b/swift/Sources/Basecamp/Generated/Models/CreateProjectFromTemplateRequest.swift
@@ -2,11 +2,9 @@
 import Foundation
 
 public struct CreateProjectFromTemplateRequest: Codable, Sendable {
-    public var description: String?
-    public let name: String
+    public let project: ProjectConstructionAttributes
 
-    public init(description: String? = nil, name: String) {
-        self.description = description
-        self.name = name
+    public init(project: ProjectConstructionAttributes) {
+        self.project = project
     }
 }

--- a/swift/Sources/Basecamp/Generated/Models/ProjectConstructionAttributes.swift
+++ b/swift/Sources/Basecamp/Generated/Models/ProjectConstructionAttributes.swift
@@ -1,0 +1,12 @@
+// @generated from OpenAPI spec — do not edit directly
+import Foundation
+
+public struct ProjectConstructionAttributes: Codable, Sendable {
+    public let name: String
+    public var description: String?
+
+    public init(name: String, description: String? = nil) {
+        self.name = name
+        self.description = description
+    }
+}

--- a/swift/Tests/BasecampTests/GeneratedServiceTests.swift
+++ b/swift/Tests/BasecampTests/GeneratedServiceTests.swift
@@ -63,6 +63,31 @@ final class GeneratedServiceTests: XCTestCase {
         XCTAssertEqual(sentJSON["due_on"] as? String, "2026-03-01")
     }
 
+    func testCreateProjectFromTemplateNestsBodyUnderProjectEnvelope() async throws {
+        let responseJSON: [String: Any] = ["id": 900, "status": "completed"]
+        let responseData = try JSONSerialization.data(withJSONObject: responseJSON)
+
+        let transport = MockTransport(statusCode: 201, data: responseData)
+        let account = makeTestAccountClient(transport: transport)
+
+        let req = CreateProjectFromTemplateRequest(
+            project: ProjectConstructionAttributes(name: "New Project", description: "From template")
+        )
+        let construction = try await account.templates.createProject(templateId: 456, req: req)
+        XCTAssertEqual(construction.id, 900)
+
+        let sentURL = transport.lastRequest!.request.url!.absoluteString
+        XCTAssertTrue(sentURL.hasSuffix("/templates/456/project_constructions.json"), "Got \(sentURL)")
+
+        // Body must nest project attributes under a `project` envelope, not flat.
+        let sentBody = transport.lastRequest!.request.httpBody!
+        let sentJSON = try JSONSerialization.jsonObject(with: sentBody) as! [String: Any]
+        XCTAssertNil(sentJSON["name"], "name must not appear at the top level")
+        let project = sentJSON["project"] as! [String: Any]
+        XCTAssertEqual(project["name"] as? String, "New Project")
+        XCTAssertEqual(project["description"] as? String, "From template")
+    }
+
     // MARK: - requestVoid path (DELETE)
 
     func testTrashProjectSendsDelete() async throws {

--- a/typescript/scripts/generate-services.ts
+++ b/typescript/scripts/generate-services.ts
@@ -13,6 +13,7 @@
 
 import * as fs from "fs";
 import * as path from "path";
+import { pathToFileURL } from "url";
 
 // =============================================================================
 // Types
@@ -127,6 +128,7 @@ interface BodyProperty {
   required: boolean;
   description?: string;
   formatHint?: string;
+  schema?: Schema;
 }
 
 interface ServiceDefinition {
@@ -693,6 +695,7 @@ function parseOperation(
           required: required.includes(name),
           description: prop.description,
           formatHint: getFormatHint(prop),
+          schema: prop, // preserve original schema/$ref for example rendering
         };
       });
     }
@@ -1463,9 +1466,42 @@ function buildBodyMapping(op: ParsedOperation): string {
   return `{\n            ${mappings.join(",\n            ")},\n          }`;
 }
 
-function generateExampleValue(name: string, type: string, formatHint?: string): string {
+function generateExampleValue(
+  name: string,
+  type: string,
+  formatHint?: string,
+  schema?: Schema,
+  visited: Set<string> = new Set(),
+): string {
   if (formatHint === "YYYY-MM-DD") return '"2025-06-01"';
   if (formatHint?.includes("RFC3339")) return '"2025-06-01T09:00:00Z"';
+
+  // Object-valued members (e.g. a `project`/`gauge`/`schedule` envelope) render as a
+  // nested object of their required child members, using each child's actual type.
+  // Without this, refs fall through to the '"example"' scalar and emit invalid examples
+  // like `{ project: "example" }`.
+  const resolved = schema?.$ref ? globalSchemas[resolveRef(schema.$ref)] : schema;
+  if (resolved?.type === "object" && resolved.properties) {
+    const refName = schema?.$ref ? resolveRef(schema.$ref) : undefined;
+    if (refName && visited.has(refName)) return "{ }"; // guard against recursive $refs
+    const nextVisited = refName ? new Set(visited).add(refName) : visited;
+    const requiredChildren = resolved.required || [];
+    const fields = Object.entries(resolved.properties)
+      .filter(([childName]) => requiredChildren.includes(childName))
+      .map(([childName, childSchema]) => {
+        const childType = parsePipeEnum(childSchema.description) || schemaToTsType(childSchema, true);
+        const value = generateExampleValue(
+          childName,
+          childType,
+          getFormatHint(childSchema),
+          childSchema,
+          nextVisited,
+        );
+        return `${toCamelCase(childName)}: ${value}`;
+      });
+    return `{ ${fields.join(", ")} }`;
+  }
+
   if (type.includes("[]") || type === "Array") return "[1234]";
   if (type === "boolean") return "true";
   if (type === "number") return "1";
@@ -1496,7 +1532,7 @@ function generateExampleArgs(op: ParsedOperation, hasRequest: boolean): string {
     } else {
       const fields = requiredProps.map((p) => {
         const camelName = toCamelCase(p.name);
-        const value = generateExampleValue(p.name, p.type, p.formatHint);
+        const value = generateExampleValue(p.name, p.type, p.formatHint, p.schema);
         return `${camelName}: ${value}`;
       });
       args.push(`{ ${fields.join(", ")} }`);
@@ -1628,4 +1664,11 @@ function main() {
   } operations total.`);
 }
 
-main();
+// Only run when invoked directly (not when imported by tests).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}
+
+// Exported for generator regression tests.
+export { generateExampleValue, setSchemas };
+export type { Schema };

--- a/typescript/scripts/generate-services.ts
+++ b/typescript/scripts/generate-services.ts
@@ -1497,7 +1497,10 @@ function generateExampleValue(
           childSchema,
           nextVisited,
         );
-        return `${toCamelCase(childName)}: ${value}`;
+        // Nested schema members serialize with their raw (snake_case) keys — the
+        // member is typed as the component schema and forwarded to the wire
+        // unchanged. Only the outer service request interface is camel-cased.
+        return `${childName}: ${value}`;
       });
     return `{ ${fields.join(", ")} }`;
   }

--- a/typescript/src/generated/metadata.ts
+++ b/typescript/src/generated/metadata.ts
@@ -37,7 +37,7 @@ export interface MetadataOutput {
 const metadata: MetadataOutput = {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-07-22T08:32:59.805Z",
+  "generated": "2026-07-22T21:16:20.777Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/typescript/src/generated/openapi-stripped.json
+++ b/typescript/src/generated/openapi-stripped.json
@@ -20269,15 +20269,12 @@
       "CreateProjectFromTemplateRequestContent": {
         "type": "object",
         "properties": {
-          "name": {
-            "type": "string"
-          },
-          "description": {
-            "type": "string"
+          "project": {
+            "$ref": "#/components/schemas/ProjectConstructionAttributes"
           }
         },
         "required": [
-          "name"
+          "project"
         ]
       },
       "CreateProjectFromTemplateResponseContent": {
@@ -22968,6 +22965,20 @@
         "required": [
           "id",
           "status"
+        ]
+      },
+      "ProjectConstructionAttributes": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
         ]
       },
       "Question": {

--- a/typescript/src/generated/schema.d.ts
+++ b/typescript/src/generated/schema.d.ts
@@ -3010,8 +3010,7 @@ export interface components {
             company_name?: string;
         };
         CreateProjectFromTemplateRequestContent: {
-            name: string;
-            description?: string;
+            project: components["schemas"]["ProjectConstructionAttributes"];
         };
         CreateProjectFromTemplateResponseContent: components["schemas"]["ProjectConstruction"];
         CreateProjectRequestContent: {
@@ -3781,6 +3780,10 @@ export interface components {
             status: string;
             url?: string;
             project?: components["schemas"]["Project"];
+        };
+        ProjectConstructionAttributes: {
+            name: string;
+            description?: string;
         };
         Question: {
             /** Format: int64 */

--- a/typescript/src/generated/services/checkins.ts
+++ b/typescript/src/generated/services/checkins.ts
@@ -279,7 +279,7 @@ export class CheckinsService extends BaseService {
    *
    * @example
    * ```ts
-   * const result = await client.checkins.createQuestion(123, { title: "example", schedule: "example" });
+   * const result = await client.checkins.createQuestion(123, { title: "example", schedule: {  } });
    * ```
    */
   async createQuestion(questionnaireId: number, req: CreateQuestionCheckinRequest): Promise<Question> {

--- a/typescript/src/generated/services/gauges.ts
+++ b/typescript/src/generated/services/gauges.ts
@@ -169,7 +169,7 @@ export class GaugesService extends BaseService {
    *
    * @example
    * ```ts
-   * await client.gauges.toggleGauge(123, { gauge: "example" });
+   * await client.gauges.toggleGauge(123, { gauge: { enabled: true } });
    * ```
    */
   async toggleGauge(projectId: number, req: ToggleGaugeGaugeRequest): Promise<void> {
@@ -235,7 +235,7 @@ export class GaugesService extends BaseService {
    *
    * @example
    * ```ts
-   * const result = await client.gauges.createGaugeNeedle(123, { gaugeNeedle: "example" });
+   * const result = await client.gauges.createGaugeNeedle(123, { gaugeNeedle: { position: 1 } });
    * ```
    */
   async createGaugeNeedle(projectId: number, req: CreateGaugeNeedleGaugeRequest): Promise<components["schemas"]["CreateGaugeNeedleResponseContent"]> {

--- a/typescript/src/generated/services/people.ts
+++ b/typescript/src/generated/services/people.ts
@@ -328,7 +328,7 @@ export class PeopleService extends BaseService {
    *
    * @example
    * ```ts
-   * const result = await client.people.enableOutOfOffice(123, { outOfOffice: { startDate: "example", endDate: "example" } });
+   * const result = await client.people.enableOutOfOffice(123, { outOfOffice: { start_date: "example", end_date: "example" } });
    * ```
    */
   async enableOutOfOffice(personId: number, req: EnableOutOfOfficePeopleRequest): Promise<components["schemas"]["EnableOutOfOfficeResponseContent"]> {

--- a/typescript/src/generated/services/people.ts
+++ b/typescript/src/generated/services/people.ts
@@ -152,7 +152,7 @@ export class PeopleService extends BaseService {
    *
    * @example
    * ```ts
-   * const result = await client.people.updateMyPreferences({ person: "example" });
+   * const result = await client.people.updateMyPreferences({ person: {  } });
    * ```
    */
   async updateMyPreferences(req: UpdateMyPreferencesPeopleRequest): Promise<components["schemas"]["UpdateMyPreferencesResponseContent"]> {
@@ -328,7 +328,7 @@ export class PeopleService extends BaseService {
    *
    * @example
    * ```ts
-   * const result = await client.people.enableOutOfOffice(123, { outOfOffice: "example" });
+   * const result = await client.people.enableOutOfOffice(123, { outOfOffice: { startDate: "example", endDate: "example" } });
    * ```
    */
   async enableOutOfOffice(personId: number, req: EnableOutOfOfficePeopleRequest): Promise<components["schemas"]["EnableOutOfOfficeResponseContent"]> {

--- a/typescript/src/generated/services/templates.ts
+++ b/typescript/src/generated/services/templates.ts
@@ -49,10 +49,8 @@ export interface UpdateTemplateRequest {
  * Request parameters for createProject.
  */
 export interface CreateProjectTemplateRequest {
-  /** Display name */
-  name: string;
-  /** Rich text description (HTML) */
-  description?: string;
+  /** Project */
+  project: components["schemas"]["ProjectConstructionAttributes"];
 }
 
 
@@ -232,12 +230,12 @@ export class TemplatesService extends BaseService {
    *
    * @example
    * ```ts
-   * const result = await client.templates.createProject(123, { name: "My example" });
+   * const result = await client.templates.createProject(123, { project: { name: "My example" } });
    * ```
    */
   async createProject(templateId: number, req: CreateProjectTemplateRequest): Promise<components["schemas"]["CreateProjectFromTemplateResponseContent"]> {
-    if (!req.name) {
-      throw Errors.validation("Name is required");
+    if (!req.project) {
+      throw Errors.validation("Project is required");
     }
     const response = await this.request(
       {
@@ -253,8 +251,7 @@ export class TemplatesService extends BaseService {
             path: { templateId },
           },
           body: {
-            name: req.name,
-            description: req.description,
+            project: req.project,
           },
         })
     );

--- a/typescript/tests/generator/example-value.test.ts
+++ b/typescript/tests/generator/example-value.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { generateExampleValue, setSchemas, type Schema } from "../../scripts/generate-services.js";
+
+// Regression coverage for object-valued body members. Before the fix, object refs
+// (e.g. a `project`/`gauge` envelope) fell through to the '"example"' scalar and the
+// generator emitted invalid examples like `{ project: "example" }`.
+describe("generateExampleValue — object-valued body members", () => {
+  const schemas: Record<string, Schema> = {
+    ProjectConstructionAttributes: {
+      type: "object",
+      properties: { name: { type: "string" }, description: { type: "string" } },
+      required: ["name"],
+    },
+    GaugeTogglePayload: {
+      type: "object",
+      properties: { enabled: { type: "boolean" } },
+      required: ["enabled"],
+    },
+    GaugeNeedlePayload: {
+      type: "object",
+      properties: {
+        position: { type: "integer", format: "int32" },
+        color: { type: "string" },
+      },
+      required: ["position"],
+    },
+    FirstWeekDay: {
+      type: "string",
+    },
+  };
+
+  beforeEach(() => {
+    setSchemas(schemas);
+  });
+
+  it("renders a nested object using the member's required children (name)", () => {
+    const value = generateExampleValue("project", 'components["schemas"]["ProjectConstructionAttributes"]', undefined, {
+      $ref: "#/components/schemas/ProjectConstructionAttributes",
+    });
+    expect(value).toBe('{ name: "My example" }');
+  });
+
+  it("renders a non-name object using the child's actual type (enabled: boolean)", () => {
+    const value = generateExampleValue("gauge", 'components["schemas"]["GaugeTogglePayload"]', undefined, {
+      $ref: "#/components/schemas/GaugeTogglePayload",
+    });
+    expect(value).toBe("{ enabled: true }");
+  });
+
+  it("renders integer children as numbers and omits optional members", () => {
+    const value = generateExampleValue("gaugeNeedle", 'components["schemas"]["GaugeNeedlePayload"]', undefined, {
+      $ref: "#/components/schemas/GaugeNeedlePayload",
+    });
+    expect(value).toBe("{ position: 1 }");
+  });
+
+  it("leaves a string ref (FirstWeekDay) as a scalar, not an object", () => {
+    const value = generateExampleValue("firstWeekDay", 'components["schemas"]["FirstWeekDay"]', undefined, {
+      $ref: "#/components/schemas/FirstWeekDay",
+    });
+    expect(value).toBe('"example"');
+  });
+});

--- a/typescript/tests/generator/example-value.test.ts
+++ b/typescript/tests/generator/example-value.test.ts
@@ -24,6 +24,14 @@ describe("generateExampleValue — object-valued body members", () => {
       },
       required: ["position"],
     },
+    OutOfOfficePayload: {
+      type: "object",
+      properties: {
+        start_date: { type: "string" },
+        end_date: { type: "string" },
+      },
+      required: ["start_date", "end_date"],
+    },
     FirstWeekDay: {
       type: "string",
     },
@@ -52,6 +60,15 @@ describe("generateExampleValue — object-valued body members", () => {
       $ref: "#/components/schemas/GaugeNeedlePayload",
     });
     expect(value).toBe("{ position: 1 }");
+  });
+
+  it("keeps nested schema member keys raw (snake_case), not camel-cased", () => {
+    // The nested object is typed as the component schema and forwarded to the wire
+    // unchanged, so its keys must match the schema exactly (start_date, not startDate).
+    const value = generateExampleValue("outOfOffice", 'components["schemas"]["OutOfOfficePayload"]', undefined, {
+      $ref: "#/components/schemas/OutOfOfficePayload",
+    });
+    expect(value).toBe('{ start_date: "example", end_date: "example" }');
   });
 
   it("leaves a string ref (FirstWeekDay) as a scalar, not an object", () => {

--- a/typescript/tests/services/templates.test.ts
+++ b/typescript/tests/services/templates.test.ts
@@ -169,16 +169,16 @@ describe("TemplatesService", () => {
         http.post(
           `${BASE_URL}/templates/${templateId}/project_constructions.json`,
           async ({ request }) => {
-            const body = await request.json() as { name: string; description?: string };
-            expect(body.name).toBe("Q1 Campaign");
+            const body = await request.json() as { project: { name: string; description?: string } };
+            expect(body.project.name).toBe("Q1 Campaign");
+            expect(body.project.description).toBe("Q1 marketing campaign");
             return HttpResponse.json(mockConstruction);
           }
         )
       );
 
       const construction = await client.templates.createProject(templateId, {
-        name: "Q1 Campaign",
-        description: "Q1 marketing campaign",
+        project: { name: "Q1 Campaign", description: "Q1 marketing campaign" },
       });
       expect(construction.id).toBe(789);
       expect(construction.status).toBe("pending");


### PR DESCRIPTION
## Summary

`POST /templates/:id/project_constructions.json` requires its params nested under a `project` envelope (`{"project":{"name":...,"description":...}}`). The SDKs sent the body flat (`{"name":...,"description":...}`), which the API rejected with HTTP 400 — so project construction was 100% broken.

The fix is in the Smithy spec (single source of truth): `CreateProjectFromTemplateInput` now carries a required `project: ProjectConstructionAttributes` member (name required, description optional), modeled exactly like the existing nested-body pattern (`schedule_attributes: ScheduleAttributes`). restJson1 serializes a nested structure member as a nested JSON object keyed by the member name, producing `{"project":{...}}` on the wire. All six SDKs regenerate from the spec.

### Root cause

`Templates::ProjectConstructionsController` reads params via `create_project_params` (`params.expect(project: {})`) plus `project_from_template_params` (`params.require(:project)`). A flat body raises `ActionController::ParameterMissing` → 400. There is no `wrap_parameters`; the `project` namespacing is a shared-family contract (sibling endpoints carry top-level params like `invite_note` outside the envelope). We model the documented shape (name + description) per bc3-api docs.

### Generator fixes

The envelope surfaced two pre-existing generator bugs affecting every object-valued body member (not just templates):

- **TS example renderer** emitted `{ project: "example" }` (and `{ gauge: "example" }`, `{ schedule: "example" }`, …) because object/`$ref` types fell through to the scalar `"example"`. It now resolves the schema and renders required children with their actual types, recursively, guarding cyclic refs. Adds generator regression tests.
- **Ruby doc-type mapper** documented object body params as `[String]`. It now resolves the `$ref` and returns `Hash` only for object-typed schemas; a string ref like `FirstWeekDay` stays `String`.

Regeneration therefore corrects ~5 TS example lines and ~10 Ruby param-doc lines across gauges, check-ins, people, and projects in addition to templates.

## Testing

`make check` green end to end (Smithy, Go, TS, Ruby, Kotlin, Swift, Python, behavior-model, conformance, provenance, actions lint). New behavior tests added for Go, TS, Ruby, Python (sync + async), Kotlin, and Swift asserting the request body nests under `project`.

## Breaking change

Source-breaking for the five generated-only SDKs (TS, Ruby, Python, Kotlin, Swift): the `createProject`/`create_project` signature changes from flat `name`/`description` to a `project` object. Runtime behavior does not regress — the flat call always returned 400 — but callers must update. **Go is non-breaking** (its hand-written wrapper keeps `CreateProject(ctx, id, name, description)`).

### Migration

- **TypeScript**: `createProject(id, { name, description })` → `createProject(id, { project: { name, description } })`
- **Ruby**: `create_project(template_id:, name:, description:)` → `create_project(template_id:, project: { name:, description: })`
- **Python**: `create_project(template_id=, name=, description=)` → `create_project(template_id=, project={ "name": ..., "description": ... })`
- **Kotlin**: `createProject(templateId, CreateProjectFromTemplateBody(project = buildJsonObject { ... }))`
- **Swift**: `createProject(templateId:, req: CreateProjectFromTemplateRequest(project: .init(name:, description:)))`

Fixes #354
Addresses basecamp/basecamp-cli#454
