### PR TITLE
Complete rich-text `*_attachments` coverage across all decode paths

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -667,8 +667,12 @@ All integer IDs must use at least 64 bits of precision (e.g., Go `int64`, Kotlin
 
 ### Nullable Numeric Dimensions (rich-text attachment width/height)
 
-Rich-text `*_attachments` elements (e.g. `Todo.description_attachments`, per the
-`RichTextAttachment` schema) always emit `width` and `height` keys, but the
+Rich-text `*_attachments` elements — the companion array the API pairs with
+every rich-text attribute, spanning 18 modeled emitters (`Todo`, 14 concrete
+resources, `GaugeNeedle`, and the polymorphic `SearchResult`/`Recording`
+projections; three are optional — `Gauge`, `SearchResult`, `Recording` — the
+rest `@required`), all sharing the `RichTextAttachment` schema — always emit
+`width` and `height` keys, but the
 **value is `null` for non-image blobs**, and the BC3 API may serialize a present
 dimension **float-spelled** (`1024.0`). These two members are deliberately
 optional/nullable in the schema (not `@required`, and marked `nullable: true` in

--- a/go/pkg/basecamp/cards.go
+++ b/go/pkg/basecamp/cards.go
@@ -71,37 +71,42 @@ type CardColumnOnHold struct {
 
 // Card represents a card in a card table column.
 type Card struct {
-	ID                    int64      `json:"id"`
-	Status                string     `json:"status"`
-	VisibleToClients      bool       `json:"visible_to_clients"`
-	CreatedAt             time.Time  `json:"created_at"`
-	UpdatedAt             time.Time  `json:"updated_at"`
-	Title                 string     `json:"title"`
-	InheritsStatus        bool       `json:"inherits_status"`
-	Type                  string     `json:"type"`
-	URL                   string     `json:"url"`
-	AppURL                string     `json:"app_url"`
-	BookmarkURL           string     `json:"bookmark_url"`
-	SubscriptionURL       string     `json:"subscription_url,omitempty"`
-	Position              int        `json:"position"`
-	Content               string     `json:"content,omitempty"`
-	Description           string     `json:"description,omitempty"`
-	DueOn                 string     `json:"due_on,omitempty"`
-	Completed             bool       `json:"completed"`
-	CompletedAt           *time.Time `json:"completed_at,omitempty"`
-	CommentsCount         int        `json:"comments_count"`
-	BoostsCount           int        `json:"boosts_count"`
-	BoostsURL             string     `json:"boosts_url,omitempty"`
-	CommentsURL           string     `json:"comments_url,omitempty"`
-	CommentCount          int        `json:"comment_count"`
-	CompletionURL         string     `json:"completion_url,omitempty"`
-	Parent                *Parent    `json:"parent,omitempty"`
-	Bucket                *Bucket    `json:"bucket,omitempty"`
-	Creator               *Person    `json:"creator,omitempty"`
-	Completer             *Person    `json:"completer,omitempty"`
-	Assignees             []Person   `json:"assignees,omitempty"`
-	CompletionSubscribers []Person   `json:"completion_subscribers,omitempty"`
-	Steps                 []CardStep `json:"steps,omitempty"`
+	ID               int64     `json:"id"`
+	Status           string    `json:"status"`
+	VisibleToClients bool      `json:"visible_to_clients"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+	Title            string    `json:"title"`
+	InheritsStatus   bool      `json:"inherits_status"`
+	Type             string    `json:"type"`
+	URL              string    `json:"url"`
+	AppURL           string    `json:"app_url"`
+	BookmarkURL      string    `json:"bookmark_url"`
+	SubscriptionURL  string    `json:"subscription_url,omitempty"`
+	Position         int       `json:"position"`
+	Content          string    `json:"content,omitempty"`
+	Description      string    `json:"description,omitempty"`
+	// DescriptionAttachments holds structured metadata for the downloadable
+	// files embedded in the rich text Description. Always sent by the API
+	// (empty when none); not omitempty so absent (nil) vs empty ([]) survives
+	// re-encoding. See RichTextAttachment.
+	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`
+	DueOn                  string               `json:"due_on,omitempty"`
+	Completed              bool                 `json:"completed"`
+	CompletedAt            *time.Time           `json:"completed_at,omitempty"`
+	CommentsCount          int                  `json:"comments_count"`
+	BoostsCount            int                  `json:"boosts_count"`
+	BoostsURL              string               `json:"boosts_url,omitempty"`
+	CommentsURL            string               `json:"comments_url,omitempty"`
+	CommentCount           int                  `json:"comment_count"`
+	CompletionURL          string               `json:"completion_url,omitempty"`
+	Parent                 *Parent              `json:"parent,omitempty"`
+	Bucket                 *Bucket              `json:"bucket,omitempty"`
+	Creator                *Person              `json:"creator,omitempty"`
+	Completer              *Person              `json:"completer,omitempty"`
+	Assignees              []Person             `json:"assignees,omitempty"`
+	CompletionSubscribers  []Person             `json:"completion_subscribers,omitempty"`
+	Steps                  []CardStep           `json:"steps,omitempty"`
 }
 
 // CardStep represents a step (checklist item) on a card.
@@ -1390,6 +1395,8 @@ func cardFromGenerated(gc generated.Card) Card {
 			c.Steps = append(c.Steps, cardStepFromGenerated(gs))
 		}
 	}
+
+	c.DescriptionAttachments = richTextAttachmentsFromGenerated(gc.DescriptionAttachments)
 
 	return c
 }

--- a/go/pkg/basecamp/cards.go
+++ b/go/pkg/basecamp/cards.go
@@ -86,10 +86,13 @@ type Card struct {
 	Position         int       `json:"position"`
 	Content          string    `json:"content,omitempty"`
 	Description      string    `json:"description,omitempty"`
-	// DescriptionAttachments holds structured metadata for the downloadable
-	// files embedded in the rich text Description. Always sent by the API
-	// (empty when none); not omitempty so absent (nil) vs empty ([]) survives
-	// re-encoding. See RichTextAttachment.
+	// DescriptionAttachments holds structured metadata for the downloadable files
+	// embedded in the rich text Description. @required — the API always sends this
+	// array (empty when the description has no inline files). No omitempty, so on
+	// marshal a non-nil slice emits its elements ([] when empty) and a nil
+	// slice (only from manual construction) emits null; the key is never
+	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
+	// RichTextAttachment.
 	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`
 	DueOn                  string               `json:"due_on,omitempty"`
 	Completed              bool                 `json:"completed"`

--- a/go/pkg/basecamp/cards.go
+++ b/go/pkg/basecamp/cards.go
@@ -90,7 +90,7 @@ type Card struct {
 	// embedded in the rich text Description. @required — the API always sends this
 	// array (empty when the description has no inline files). No omitempty, so on
 	// marshal a non-nil slice emits its elements ([] when empty) and a nil
-	// slice (only from manual construction) emits null; the key is never
+	// slice emits null; the key is never
 	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
 	// RichTextAttachment.
 	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`

--- a/go/pkg/basecamp/checkins.go
+++ b/go/pkg/basecamp/checkins.go
@@ -114,9 +114,12 @@ type QuestionAnswer struct {
 	CommentsURL      string    `json:"comments_url"`
 	Content          string    `json:"content"`
 	// ContentAttachments holds structured metadata for the downloadable files
-	// embedded in the rich text Content. Always sent by the API (empty when
-	// none); not omitempty so absent (nil) vs empty ([]) survives re-encoding.
-	// See RichTextAttachment.
+	// embedded in the rich text Content. @required — the API always sends this
+	// array (empty when the content has no inline files). No omitempty, so on
+	// marshal a non-nil slice emits its elements ([] when empty) and a nil
+	// slice (only from manual construction) emits null; the key is never
+	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
+	// RichTextAttachment.
 	ContentAttachments []RichTextAttachment `json:"content_attachments"`
 	GroupOn            string               `json:"group_on"`
 	Parent             *Parent              `json:"parent,omitempty"`

--- a/go/pkg/basecamp/checkins.go
+++ b/go/pkg/basecamp/checkins.go
@@ -117,7 +117,7 @@ type QuestionAnswer struct {
 	// embedded in the rich text Content. @required — the API always sends this
 	// array (empty when the content has no inline files). No omitempty, so on
 	// marshal a non-nil slice emits its elements ([] when empty) and a nil
-	// slice (only from manual construction) emits null; the key is never
+	// slice emits null; the key is never
 	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
 	// RichTextAttachment.
 	ContentAttachments []RichTextAttachment `json:"content_attachments"`

--- a/go/pkg/basecamp/checkins.go
+++ b/go/pkg/basecamp/checkins.go
@@ -113,10 +113,15 @@ type QuestionAnswer struct {
 	CommentsCount    int       `json:"comments_count"`
 	CommentsURL      string    `json:"comments_url"`
 	Content          string    `json:"content"`
-	GroupOn          string    `json:"group_on"`
-	Parent           *Parent   `json:"parent,omitempty"`
-	Bucket           *Bucket   `json:"bucket,omitempty"`
-	Creator          *Person   `json:"creator,omitempty"`
+	// ContentAttachments holds structured metadata for the downloadable files
+	// embedded in the rich text Content. Always sent by the API (empty when
+	// none); not omitempty so absent (nil) vs empty ([]) survives re-encoding.
+	// See RichTextAttachment.
+	ContentAttachments []RichTextAttachment `json:"content_attachments"`
+	GroupOn            string               `json:"group_on"`
+	Parent             *Parent              `json:"parent,omitempty"`
+	Bucket             *Bucket              `json:"bucket,omitempty"`
+	Creator            *Person              `json:"creator,omitempty"`
 }
 
 // CreateQuestionRequest specifies the parameters for creating a question.
@@ -892,6 +897,8 @@ func questionAnswerFromGenerated(ga generated.QuestionAnswer) QuestionAnswer {
 		creator := personFromGenerated(ga.Creator)
 		a.Creator = &creator
 	}
+
+	a.ContentAttachments = richTextAttachmentsFromGenerated(ga.ContentAttachments)
 
 	return a
 }

--- a/go/pkg/basecamp/client_approvals.go
+++ b/go/pkg/basecamp/client_approvals.go
@@ -27,29 +27,34 @@ type ClientApprovalListOptions struct {
 
 // ClientApproval represents a Basecamp client approval request.
 type ClientApproval struct {
-	ID               int64                    `json:"id"`
-	Status           string                   `json:"status"`
-	VisibleToClients bool                     `json:"visible_to_clients"`
-	CreatedAt        time.Time                `json:"created_at"`
-	UpdatedAt        time.Time                `json:"updated_at"`
-	Title            string                   `json:"title"`
-	InheritsStatus   bool                     `json:"inherits_status"`
-	Type             string                   `json:"type"`
-	URL              string                   `json:"url"`
-	AppURL           string                   `json:"app_url"`
-	BookmarkURL      string                   `json:"bookmark_url"`
-	SubscriptionURL  string                   `json:"subscription_url"`
-	Parent           *Parent                  `json:"parent,omitempty"`
-	Bucket           *Bucket                  `json:"bucket,omitempty"`
-	Creator          *Person                  `json:"creator,omitempty"`
-	Content          string                   `json:"content"`
-	Subject          string                   `json:"subject"`
-	DueOn            *string                  `json:"due_on,omitempty"`
-	RepliesCount     int                      `json:"replies_count"`
-	RepliesURL       string                   `json:"replies_url"`
-	ApprovalStatus   string                   `json:"approval_status"`
-	Approver         *Person                  `json:"approver,omitempty"`
-	Responses        []ClientApprovalResponse `json:"responses,omitempty"`
+	ID               int64     `json:"id"`
+	Status           string    `json:"status"`
+	VisibleToClients bool      `json:"visible_to_clients"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+	Title            string    `json:"title"`
+	InheritsStatus   bool      `json:"inherits_status"`
+	Type             string    `json:"type"`
+	URL              string    `json:"url"`
+	AppURL           string    `json:"app_url"`
+	BookmarkURL      string    `json:"bookmark_url"`
+	SubscriptionURL  string    `json:"subscription_url"`
+	Parent           *Parent   `json:"parent,omitempty"`
+	Bucket           *Bucket   `json:"bucket,omitempty"`
+	Creator          *Person   `json:"creator,omitempty"`
+	Content          string    `json:"content"`
+	// ContentAttachments holds structured metadata for the downloadable files
+	// embedded in the rich text Content. Always sent by the API (empty when
+	// none); not omitempty so absent (nil) vs empty ([]) survives re-encoding.
+	// See RichTextAttachment.
+	ContentAttachments []RichTextAttachment     `json:"content_attachments"`
+	Subject            string                   `json:"subject"`
+	DueOn              *string                  `json:"due_on,omitempty"`
+	RepliesCount       int                      `json:"replies_count"`
+	RepliesURL         string                   `json:"replies_url"`
+	ApprovalStatus     string                   `json:"approval_status"`
+	Approver           *Person                  `json:"approver,omitempty"`
+	Responses          []ClientApprovalResponse `json:"responses,omitempty"`
 }
 
 // ClientApprovalResponse represents a response to a client approval.
@@ -308,6 +313,8 @@ func clientApprovalFromGenerated(ga generated.ClientApproval) ClientApproval {
 			a.Responses = append(a.Responses, resp)
 		}
 	}
+
+	a.ContentAttachments = richTextAttachmentsFromGenerated(ga.ContentAttachments)
 
 	return a
 }

--- a/go/pkg/basecamp/client_approvals.go
+++ b/go/pkg/basecamp/client_approvals.go
@@ -47,7 +47,7 @@ type ClientApproval struct {
 	// embedded in the rich text Content. @required — the API always sends this
 	// array (empty when the content has no inline files). No omitempty, so on
 	// marshal a non-nil slice emits its elements ([] when empty) and a nil
-	// slice (only from manual construction) emits null; the key is never
+	// slice emits null; the key is never
 	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
 	// RichTextAttachment.
 	ContentAttachments []RichTextAttachment     `json:"content_attachments"`

--- a/go/pkg/basecamp/client_approvals.go
+++ b/go/pkg/basecamp/client_approvals.go
@@ -44,9 +44,12 @@ type ClientApproval struct {
 	Creator          *Person   `json:"creator,omitempty"`
 	Content          string    `json:"content"`
 	// ContentAttachments holds structured metadata for the downloadable files
-	// embedded in the rich text Content. Always sent by the API (empty when
-	// none); not omitempty so absent (nil) vs empty ([]) survives re-encoding.
-	// See RichTextAttachment.
+	// embedded in the rich text Content. @required — the API always sends this
+	// array (empty when the content has no inline files). No omitempty, so on
+	// marshal a non-nil slice emits its elements ([] when empty) and a nil
+	// slice (only from manual construction) emits null; the key is never
+	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
+	// RichTextAttachment.
 	ContentAttachments []RichTextAttachment     `json:"content_attachments"`
 	Subject            string                   `json:"subject"`
 	DueOn              *string                  `json:"due_on,omitempty"`

--- a/go/pkg/basecamp/client_correspondences.go
+++ b/go/pkg/basecamp/client_correspondences.go
@@ -43,9 +43,14 @@ type ClientCorrespondence struct {
 	Bucket           *Bucket   `json:"bucket,omitempty"`
 	Creator          *Person   `json:"creator,omitempty"`
 	Content          string    `json:"content"`
-	Subject          string    `json:"subject"`
-	RepliesCount     int       `json:"replies_count"`
-	RepliesURL       string    `json:"replies_url"`
+	// ContentAttachments holds structured metadata for the downloadable files
+	// embedded in the rich text Content. Always sent by the API (empty when
+	// none); not omitempty so absent (nil) vs empty ([]) survives re-encoding.
+	// See RichTextAttachment.
+	ContentAttachments []RichTextAttachment `json:"content_attachments"`
+	Subject            string               `json:"subject"`
+	RepliesCount       int                  `json:"replies_count"`
+	RepliesURL         string               `json:"replies_url"`
 }
 
 // ClientCorrespondenceListResult contains the results from listing client correspondences.
@@ -230,6 +235,8 @@ func clientCorrespondenceFromGenerated(gc generated.ClientCorrespondence) Client
 		creator := personFromGenerated(gc.Creator)
 		c.Creator = &creator
 	}
+
+	c.ContentAttachments = richTextAttachmentsFromGenerated(gc.ContentAttachments)
 
 	return c
 }

--- a/go/pkg/basecamp/client_correspondences.go
+++ b/go/pkg/basecamp/client_correspondences.go
@@ -47,7 +47,7 @@ type ClientCorrespondence struct {
 	// embedded in the rich text Content. @required — the API always sends this
 	// array (empty when the content has no inline files). No omitempty, so on
 	// marshal a non-nil slice emits its elements ([] when empty) and a nil
-	// slice (only from manual construction) emits null; the key is never
+	// slice emits null; the key is never
 	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
 	// RichTextAttachment.
 	ContentAttachments []RichTextAttachment `json:"content_attachments"`

--- a/go/pkg/basecamp/client_correspondences.go
+++ b/go/pkg/basecamp/client_correspondences.go
@@ -44,9 +44,12 @@ type ClientCorrespondence struct {
 	Creator          *Person   `json:"creator,omitempty"`
 	Content          string    `json:"content"`
 	// ContentAttachments holds structured metadata for the downloadable files
-	// embedded in the rich text Content. Always sent by the API (empty when
-	// none); not omitempty so absent (nil) vs empty ([]) survives re-encoding.
-	// See RichTextAttachment.
+	// embedded in the rich text Content. @required — the API always sends this
+	// array (empty when the content has no inline files). No omitempty, so on
+	// marshal a non-nil slice emits its elements ([] when empty) and a nil
+	// slice (only from manual construction) emits null; the key is never
+	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
+	// RichTextAttachment.
 	ContentAttachments []RichTextAttachment `json:"content_attachments"`
 	Subject            string               `json:"subject"`
 	RepliesCount       int                  `json:"replies_count"`

--- a/go/pkg/basecamp/client_replies.go
+++ b/go/pkg/basecamp/client_replies.go
@@ -36,6 +36,11 @@ type ClientReply struct {
 	Bucket           *Bucket   `json:"bucket,omitempty"`
 	Creator          *Person   `json:"creator,omitempty"`
 	Content          string    `json:"content"`
+	// ContentAttachments holds structured metadata for the downloadable files
+	// embedded in the rich text Content. Always sent by the API (empty when
+	// none); not omitempty so absent (nil) vs empty ([]) survives re-encoding.
+	// See RichTextAttachment.
+	ContentAttachments []RichTextAttachment `json:"content_attachments"`
 }
 
 // ClientReplyListResult contains the results from listing client replies.
@@ -210,6 +215,8 @@ func clientReplyFromGenerated(gr generated.ClientReply) ClientReply {
 		creator := personFromGenerated(gr.Creator)
 		r.Creator = &creator
 	}
+
+	r.ContentAttachments = richTextAttachmentsFromGenerated(gr.ContentAttachments)
 
 	return r
 }

--- a/go/pkg/basecamp/client_replies.go
+++ b/go/pkg/basecamp/client_replies.go
@@ -37,9 +37,12 @@ type ClientReply struct {
 	Creator          *Person   `json:"creator,omitempty"`
 	Content          string    `json:"content"`
 	// ContentAttachments holds structured metadata for the downloadable files
-	// embedded in the rich text Content. Always sent by the API (empty when
-	// none); not omitempty so absent (nil) vs empty ([]) survives re-encoding.
-	// See RichTextAttachment.
+	// embedded in the rich text Content. @required — the API always sends this
+	// array (empty when the content has no inline files). No omitempty, so on
+	// marshal a non-nil slice emits its elements ([] when empty) and a nil
+	// slice (only from manual construction) emits null; the key is never
+	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
+	// RichTextAttachment.
 	ContentAttachments []RichTextAttachment `json:"content_attachments"`
 }
 

--- a/go/pkg/basecamp/client_replies.go
+++ b/go/pkg/basecamp/client_replies.go
@@ -40,7 +40,7 @@ type ClientReply struct {
 	// embedded in the rich text Content. @required — the API always sends this
 	// array (empty when the content has no inline files). No omitempty, so on
 	// marshal a non-nil slice emits its elements ([] when empty) and a nil
-	// slice (only from manual construction) emits null; the key is never
+	// slice emits null; the key is never
 	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
 	// RichTextAttachment.
 	ContentAttachments []RichTextAttachment `json:"content_attachments"`

--- a/go/pkg/basecamp/comments.go
+++ b/go/pkg/basecamp/comments.go
@@ -22,15 +22,20 @@ type Comment struct {
 	Title            string    `json:"title,omitempty"`
 	InheritsStatus   bool      `json:"inherits_status"`
 	Content          string    `json:"content"`
-	Type             string    `json:"type"`
-	URL              string    `json:"url"`
-	AppURL           string    `json:"app_url"`
-	BookmarkURL      string    `json:"bookmark_url,omitempty"`
-	BoostsCount      int       `json:"boosts_count,omitempty"`
-	BoostsURL        string    `json:"boosts_url,omitempty"`
-	Parent           *Parent   `json:"parent,omitempty"`
-	Bucket           *Bucket   `json:"bucket,omitempty"`
-	Creator          *Person   `json:"creator,omitempty"`
+	// ContentAttachments holds structured metadata for the downloadable files
+	// embedded in the rich text Content. Always sent by the API (empty when
+	// none); not omitempty so a nil (absent) vs empty ([]) distinction
+	// survives re-encoding. See RichTextAttachment.
+	ContentAttachments []RichTextAttachment `json:"content_attachments"`
+	Type               string               `json:"type"`
+	URL                string               `json:"url"`
+	AppURL             string               `json:"app_url"`
+	BookmarkURL        string               `json:"bookmark_url,omitempty"`
+	BoostsCount        int                  `json:"boosts_count,omitempty"`
+	BoostsURL          string               `json:"boosts_url,omitempty"`
+	Parent             *Parent              `json:"parent,omitempty"`
+	Bucket             *Bucket              `json:"bucket,omitempty"`
+	Creator            *Person              `json:"creator,omitempty"`
 }
 
 // CreateCommentRequest specifies the parameters for creating a comment.
@@ -346,6 +351,8 @@ func commentFromGenerated(gc generated.Comment) Comment {
 		creator := personFromGenerated(gc.Creator)
 		c.Creator = &creator
 	}
+
+	c.ContentAttachments = richTextAttachmentsFromGenerated(gc.ContentAttachments)
 
 	return c
 }

--- a/go/pkg/basecamp/comments.go
+++ b/go/pkg/basecamp/comments.go
@@ -26,7 +26,7 @@ type Comment struct {
 	// embedded in the rich text Content. @required — the API always sends this
 	// array (empty when the content has no inline files). No omitempty, so on
 	// marshal a non-nil slice emits its elements ([] when empty) and a nil
-	// slice (only from manual construction) emits null; the key is never
+	// slice emits null; the key is never
 	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
 	// RichTextAttachment.
 	ContentAttachments []RichTextAttachment `json:"content_attachments"`

--- a/go/pkg/basecamp/comments.go
+++ b/go/pkg/basecamp/comments.go
@@ -23,9 +23,12 @@ type Comment struct {
 	InheritsStatus   bool      `json:"inherits_status"`
 	Content          string    `json:"content"`
 	// ContentAttachments holds structured metadata for the downloadable files
-	// embedded in the rich text Content. Always sent by the API (empty when
-	// none); not omitempty so a nil (absent) vs empty ([]) distinction
-	// survives re-encoding. See RichTextAttachment.
+	// embedded in the rich text Content. @required — the API always sends this
+	// array (empty when the content has no inline files). No omitempty, so on
+	// marshal a non-nil slice emits its elements ([] when empty) and a nil
+	// slice (only from manual construction) emits null; the key is never
+	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
+	// RichTextAttachment.
 	ContentAttachments []RichTextAttachment `json:"content_attachments"`
 	Type               string               `json:"type"`
 	URL                string               `json:"url"`

--- a/go/pkg/basecamp/comments_test.go
+++ b/go/pkg/basecamp/comments_test.go
@@ -162,6 +162,40 @@ func TestComment_UnmarshalGet(t *testing.T) {
 	if !comment.Creator.Employee {
 		t.Error("expected Creator.Employee to be true")
 	}
+
+	// ContentAttachments: the two-entry representative decodes directly into
+	// the public Comment, so RichTextAttachment.UnmarshalJSON runs per element.
+	// The image carries a float-spelled dimension (1024.0 -> 1024) and a plain
+	// int height; the non-image blob carries null dimensions (-> nil).
+	if len(comment.ContentAttachments) != 2 {
+		t.Fatalf("expected 2 content attachments, got %d", len(comment.ContentAttachments))
+	}
+	img := comment.ContentAttachments[0]
+	if img.ID != 1069480010 {
+		t.Errorf("expected image attachment ID 1069480010, got %d", img.ID)
+	}
+	if img.Filename != "celebration.png" || img.ContentType != "image/png" {
+		t.Errorf("unexpected image attachment: %+v", img)
+	}
+	if img.Width == nil || *img.Width != 1024 {
+		t.Errorf("expected image Width 1024 (float-spelled 1024.0), got %v", img.Width)
+	}
+	if img.Height == nil || *img.Height != 768 {
+		t.Errorf("expected image Height 768, got %v", img.Height)
+	}
+	if !img.Previewable {
+		t.Error("expected image attachment to be previewable")
+	}
+	blob := comment.ContentAttachments[1]
+	if blob.ID != 1069480011 || blob.ContentType != "application/pdf" {
+		t.Errorf("unexpected blob attachment: %+v", blob)
+	}
+	if blob.Width != nil || blob.Height != nil {
+		t.Errorf("expected nil dimensions for non-image blob, got width=%v height=%v", blob.Width, blob.Height)
+	}
+	if blob.Previewable {
+		t.Error("expected non-image blob to not be previewable")
+	}
 }
 
 func TestCreateCommentRequest_Marshal(t *testing.T) {

--- a/go/pkg/basecamp/forwards.go
+++ b/go/pkg/basecamp/forwards.go
@@ -86,17 +86,22 @@ type Forward struct {
 	InheritsStatus   bool      `json:"inherits_status"`
 	Subject          string    `json:"subject"`
 	Content          string    `json:"content"`
-	From             string    `json:"from"`
-	Type             string    `json:"type"`
-	URL              string    `json:"url"`
-	AppURL           string    `json:"app_url"`
-	BookmarkURL      string    `json:"bookmark_url,omitempty"`
-	SubscriptionURL  string    `json:"subscription_url,omitempty"`
-	RepliesCount     int       `json:"replies_count,omitempty"`
-	RepliesURL       string    `json:"replies_url,omitempty"`
-	Parent           *Parent   `json:"parent,omitempty"`
-	Bucket           *Bucket   `json:"bucket,omitempty"`
-	Creator          *Person   `json:"creator,omitempty"`
+	// ContentAttachments holds structured metadata for the downloadable files
+	// embedded in the rich text Content. Always sent by the API (empty when
+	// none); not omitempty so absent (nil) vs empty ([]) survives re-encoding.
+	// See RichTextAttachment.
+	ContentAttachments []RichTextAttachment `json:"content_attachments"`
+	From               string               `json:"from"`
+	Type               string               `json:"type"`
+	URL                string               `json:"url"`
+	AppURL             string               `json:"app_url"`
+	BookmarkURL        string               `json:"bookmark_url,omitempty"`
+	SubscriptionURL    string               `json:"subscription_url,omitempty"`
+	RepliesCount       int                  `json:"replies_count,omitempty"`
+	RepliesURL         string               `json:"replies_url,omitempty"`
+	Parent             *Parent              `json:"parent,omitempty"`
+	Bucket             *Bucket              `json:"bucket,omitempty"`
+	Creator            *Person              `json:"creator,omitempty"`
 }
 
 // ForwardReply represents a reply to a forwarded email.
@@ -109,15 +114,20 @@ type ForwardReply struct {
 	Title            string    `json:"title,omitempty"`
 	InheritsStatus   bool      `json:"inherits_status"`
 	Content          string    `json:"content"`
-	Type             string    `json:"type"`
-	URL              string    `json:"url"`
-	AppURL           string    `json:"app_url"`
-	BookmarkURL      string    `json:"bookmark_url,omitempty"`
-	BoostsCount      int       `json:"boosts_count,omitempty"`
-	BoostsURL        string    `json:"boosts_url,omitempty"`
-	Parent           *Parent   `json:"parent,omitempty"`
-	Bucket           *Bucket   `json:"bucket,omitempty"`
-	Creator          *Person   `json:"creator,omitempty"`
+	// ContentAttachments holds structured metadata for the downloadable files
+	// embedded in the rich text Content. Always sent by the API (empty when
+	// none); not omitempty so absent (nil) vs empty ([]) survives re-encoding.
+	// See RichTextAttachment.
+	ContentAttachments []RichTextAttachment `json:"content_attachments"`
+	Type               string               `json:"type"`
+	URL                string               `json:"url"`
+	AppURL             string               `json:"app_url"`
+	BookmarkURL        string               `json:"bookmark_url,omitempty"`
+	BoostsCount        int                  `json:"boosts_count,omitempty"`
+	BoostsURL          string               `json:"boosts_url,omitempty"`
+	Parent             *Parent              `json:"parent,omitempty"`
+	Bucket             *Bucket              `json:"bucket,omitempty"`
+	Creator            *Person              `json:"creator,omitempty"`
 }
 
 // CreateForwardReplyRequest specifies the parameters for creating a reply to a forward.
@@ -525,6 +535,8 @@ func forwardFromGenerated(gf generated.Forward) Forward {
 		f.Creator = &creator
 	}
 
+	f.ContentAttachments = richTextAttachmentsFromGenerated(gf.ContentAttachments)
+
 	return f
 }
 
@@ -572,6 +584,8 @@ func forwardReplyFromGenerated(gr generated.ForwardReply) ForwardReply {
 		creator := personFromGenerated(gr.Creator)
 		r.Creator = &creator
 	}
+
+	r.ContentAttachments = richTextAttachmentsFromGenerated(gr.ContentAttachments)
 
 	return r
 }

--- a/go/pkg/basecamp/forwards.go
+++ b/go/pkg/basecamp/forwards.go
@@ -90,7 +90,7 @@ type Forward struct {
 	// embedded in the rich text Content. @required — the API always sends this
 	// array (empty when the content has no inline files). No omitempty, so on
 	// marshal a non-nil slice emits its elements ([] when empty) and a nil
-	// slice (only from manual construction) emits null; the key is never
+	// slice emits null; the key is never
 	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
 	// RichTextAttachment.
 	ContentAttachments []RichTextAttachment `json:"content_attachments"`
@@ -121,7 +121,7 @@ type ForwardReply struct {
 	// embedded in the rich text Content. @required — the API always sends this
 	// array (empty when the content has no inline files). No omitempty, so on
 	// marshal a non-nil slice emits its elements ([] when empty) and a nil
-	// slice (only from manual construction) emits null; the key is never
+	// slice emits null; the key is never
 	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
 	// RichTextAttachment.
 	ContentAttachments []RichTextAttachment `json:"content_attachments"`

--- a/go/pkg/basecamp/forwards.go
+++ b/go/pkg/basecamp/forwards.go
@@ -87,9 +87,12 @@ type Forward struct {
 	Subject          string    `json:"subject"`
 	Content          string    `json:"content"`
 	// ContentAttachments holds structured metadata for the downloadable files
-	// embedded in the rich text Content. Always sent by the API (empty when
-	// none); not omitempty so absent (nil) vs empty ([]) survives re-encoding.
-	// See RichTextAttachment.
+	// embedded in the rich text Content. @required — the API always sends this
+	// array (empty when the content has no inline files). No omitempty, so on
+	// marshal a non-nil slice emits its elements ([] when empty) and a nil
+	// slice (only from manual construction) emits null; the key is never
+	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
+	// RichTextAttachment.
 	ContentAttachments []RichTextAttachment `json:"content_attachments"`
 	From               string               `json:"from"`
 	Type               string               `json:"type"`
@@ -115,9 +118,12 @@ type ForwardReply struct {
 	InheritsStatus   bool      `json:"inherits_status"`
 	Content          string    `json:"content"`
 	// ContentAttachments holds structured metadata for the downloadable files
-	// embedded in the rich text Content. Always sent by the API (empty when
-	// none); not omitempty so absent (nil) vs empty ([]) survives re-encoding.
-	// See RichTextAttachment.
+	// embedded in the rich text Content. @required — the API always sends this
+	// array (empty when the content has no inline files). No omitempty, so on
+	// marshal a non-nil slice emits its elements ([] when empty) and a nil
+	// slice (only from manual construction) emits null; the key is never
+	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
+	// RichTextAttachment.
 	ContentAttachments []RichTextAttachment `json:"content_attachments"`
 	Type               string               `json:"type"`
 	URL                string               `json:"url"`

--- a/go/pkg/basecamp/gauges.go
+++ b/go/pkg/basecamp/gauges.go
@@ -11,50 +11,64 @@ import (
 
 // Gauge represents a gauge (progress indicator) on a project.
 type Gauge struct {
-	ID                     int64     `json:"id"`
-	Title                  string    `json:"title,omitempty"`
-	Description            string    `json:"description,omitempty"`
-	Enabled                bool      `json:"enabled,omitempty"`
-	Status                 string    `json:"status,omitempty"`
-	LastNeedleColor        string    `json:"last_needle_color,omitempty"`
-	LastNeedlePosition     int32     `json:"last_needle_position,omitempty"`
-	PreviousNeedlePosition int32     `json:"previous_needle_position,omitempty"`
-	InheritsStatus         bool      `json:"inherits_status,omitempty"`
-	VisibleToClients       bool      `json:"visible_to_clients,omitempty"`
-	Type                   string    `json:"type,omitempty"`
-	URL                    string    `json:"url,omitempty"`
-	AppURL                 string    `json:"app_url,omitempty"`
-	BookmarkURL            string    `json:"bookmark_url,omitempty"`
-	Creator                *Person   `json:"creator,omitempty"`
-	Bucket                 *Bucket   `json:"bucket,omitempty"`
-	CreatedAt              time.Time `json:"created_at"`
-	UpdatedAt              time.Time `json:"updated_at"`
+	ID          int64  `json:"id"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	// DescriptionAttachments holds structured metadata for the downloadable
+	// files embedded in the rich text Description. Optional: the API renders
+	// this array only when the gauge has needles, so it is absent (nil) for a
+	// needle-less gauge. omitempty matches the codebase optional-array
+	// convention (Assignees, Steps) and, since the member is non-nullable,
+	// never emits an invalid "description_attachments": null. Decodes directly
+	// (RichTextAttachment.UnmarshalJSON runs per element). See RichTextAttachment.
+	DescriptionAttachments []RichTextAttachment `json:"description_attachments,omitempty"`
+	Enabled                bool                 `json:"enabled,omitempty"`
+	Status                 string               `json:"status,omitempty"`
+	LastNeedleColor        string               `json:"last_needle_color,omitempty"`
+	LastNeedlePosition     int32                `json:"last_needle_position,omitempty"`
+	PreviousNeedlePosition int32                `json:"previous_needle_position,omitempty"`
+	InheritsStatus         bool                 `json:"inherits_status,omitempty"`
+	VisibleToClients       bool                 `json:"visible_to_clients,omitempty"`
+	Type                   string               `json:"type,omitempty"`
+	URL                    string               `json:"url,omitempty"`
+	AppURL                 string               `json:"app_url,omitempty"`
+	BookmarkURL            string               `json:"bookmark_url,omitempty"`
+	Creator                *Person              `json:"creator,omitempty"`
+	Bucket                 *Bucket              `json:"bucket,omitempty"`
+	CreatedAt              time.Time            `json:"created_at"`
+	UpdatedAt              time.Time            `json:"updated_at"`
 }
 
 // GaugeNeedle represents a single needle (progress update) on a gauge.
 type GaugeNeedle struct {
-	ID               int64     `json:"id"`
-	Title            string    `json:"title,omitempty"`
-	Description      string    `json:"description,omitempty"`
-	Position         int32     `json:"position,omitempty"`
-	Color            string    `json:"color,omitempty"`
-	Status           string    `json:"status,omitempty"`
-	InheritsStatus   bool      `json:"inherits_status,omitempty"`
-	VisibleToClients bool      `json:"visible_to_clients,omitempty"`
-	CommentsCount    int32     `json:"comments_count,omitempty"`
-	BoostsCount      int32     `json:"boosts_count,omitempty"`
-	Type             string    `json:"type,omitempty"`
-	URL              string    `json:"url,omitempty"`
-	AppURL           string    `json:"app_url,omitempty"`
-	BookmarkURL      string    `json:"bookmark_url,omitempty"`
-	CommentsURL      string    `json:"comments_url,omitempty"`
-	BoostsURL        string    `json:"boosts_url,omitempty"`
-	SubscriptionURL  string    `json:"subscription_url,omitempty"`
-	Creator          *Person   `json:"creator,omitempty"`
-	Bucket           *Bucket   `json:"bucket,omitempty"`
-	Parent           *Parent   `json:"parent,omitempty"`
-	CreatedAt        time.Time `json:"created_at"`
-	UpdatedAt        time.Time `json:"updated_at"`
+	ID          int64  `json:"id"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	// DescriptionAttachments holds structured metadata for the downloadable
+	// files embedded in the rich text Description. Always sent by the API
+	// (empty when none); not omitempty so absent (nil) vs empty ([]) survives
+	// re-encoding. Decodes directly (RichTextAttachment.UnmarshalJSON runs per
+	// element). See RichTextAttachment.
+	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`
+	Position               int32                `json:"position,omitempty"`
+	Color                  string               `json:"color,omitempty"`
+	Status                 string               `json:"status,omitempty"`
+	InheritsStatus         bool                 `json:"inherits_status,omitempty"`
+	VisibleToClients       bool                 `json:"visible_to_clients,omitempty"`
+	CommentsCount          int32                `json:"comments_count,omitempty"`
+	BoostsCount            int32                `json:"boosts_count,omitempty"`
+	Type                   string               `json:"type,omitempty"`
+	URL                    string               `json:"url,omitempty"`
+	AppURL                 string               `json:"app_url,omitempty"`
+	BookmarkURL            string               `json:"bookmark_url,omitempty"`
+	CommentsURL            string               `json:"comments_url,omitempty"`
+	BoostsURL              string               `json:"boosts_url,omitempty"`
+	SubscriptionURL        string               `json:"subscription_url,omitempty"`
+	Creator                *Person              `json:"creator,omitempty"`
+	Bucket                 *Bucket              `json:"bucket,omitempty"`
+	Parent                 *Parent              `json:"parent,omitempty"`
+	CreatedAt              time.Time            `json:"created_at"`
+	UpdatedAt              time.Time            `json:"updated_at"`
 }
 
 // CreateGaugeNeedleRequest specifies parameters for creating a gauge needle.

--- a/go/pkg/basecamp/gauges.go
+++ b/go/pkg/basecamp/gauges.go
@@ -45,11 +45,13 @@ type GaugeNeedle struct {
 	ID          int64  `json:"id"`
 	Title       string `json:"title,omitempty"`
 	Description string `json:"description,omitempty"`
-	// DescriptionAttachments holds structured metadata for the downloadable
-	// files embedded in the rich text Description. Always sent by the API
-	// (empty when none); not omitempty so absent (nil) vs empty ([]) survives
-	// re-encoding. Decodes directly (RichTextAttachment.UnmarshalJSON runs per
-	// element). See RichTextAttachment.
+	// DescriptionAttachments holds structured metadata for the downloadable files
+	// embedded in the rich text Description. @required — the API always sends this
+	// array (empty when the description has no inline files). No omitempty, so on
+	// marshal a non-nil slice emits its elements ([] when empty) and a nil
+	// slice (only from manual construction) emits null; the key is never
+	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
+	// RichTextAttachment.
 	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`
 	Position               int32                `json:"position,omitempty"`
 	Color                  string               `json:"color,omitempty"`

--- a/go/pkg/basecamp/gauges.go
+++ b/go/pkg/basecamp/gauges.go
@@ -16,27 +16,28 @@ type Gauge struct {
 	Description string `json:"description,omitempty"`
 	// DescriptionAttachments holds structured metadata for the downloadable
 	// files embedded in the rich text Description. Optional: the API renders
-	// this array only when the gauge has needles, so it is absent (nil) for a
-	// needle-less gauge. omitempty matches the codebase optional-array
-	// convention (Assignees, Steps) and, since the member is non-nullable,
-	// never emits an invalid "description_attachments": null. Decodes directly
+	// this array only when the gauge has needles, so it is absent for a
+	// needle-less gauge. Optional and non-nullable; modeled as a pointer to a
+	// slice with omitempty so all three wire states round-trip faithfully — nil
+	// pointer (absent) is omitted, a non-nil pointer to an empty slice
+	// re-encodes as [], and a populated one as the list. Decodes directly
 	// (RichTextAttachment.UnmarshalJSON runs per element). See RichTextAttachment.
-	DescriptionAttachments []RichTextAttachment `json:"description_attachments,omitempty"`
-	Enabled                bool                 `json:"enabled,omitempty"`
-	Status                 string               `json:"status,omitempty"`
-	LastNeedleColor        string               `json:"last_needle_color,omitempty"`
-	LastNeedlePosition     int32                `json:"last_needle_position,omitempty"`
-	PreviousNeedlePosition int32                `json:"previous_needle_position,omitempty"`
-	InheritsStatus         bool                 `json:"inherits_status,omitempty"`
-	VisibleToClients       bool                 `json:"visible_to_clients,omitempty"`
-	Type                   string               `json:"type,omitempty"`
-	URL                    string               `json:"url,omitempty"`
-	AppURL                 string               `json:"app_url,omitempty"`
-	BookmarkURL            string               `json:"bookmark_url,omitempty"`
-	Creator                *Person              `json:"creator,omitempty"`
-	Bucket                 *Bucket              `json:"bucket,omitempty"`
-	CreatedAt              time.Time            `json:"created_at"`
-	UpdatedAt              time.Time            `json:"updated_at"`
+	DescriptionAttachments *[]RichTextAttachment `json:"description_attachments,omitempty"`
+	Enabled                bool                  `json:"enabled,omitempty"`
+	Status                 string                `json:"status,omitempty"`
+	LastNeedleColor        string                `json:"last_needle_color,omitempty"`
+	LastNeedlePosition     int32                 `json:"last_needle_position,omitempty"`
+	PreviousNeedlePosition int32                 `json:"previous_needle_position,omitempty"`
+	InheritsStatus         bool                  `json:"inherits_status,omitempty"`
+	VisibleToClients       bool                  `json:"visible_to_clients,omitempty"`
+	Type                   string                `json:"type,omitempty"`
+	URL                    string                `json:"url,omitempty"`
+	AppURL                 string                `json:"app_url,omitempty"`
+	BookmarkURL            string                `json:"bookmark_url,omitempty"`
+	Creator                *Person               `json:"creator,omitempty"`
+	Bucket                 *Bucket               `json:"bucket,omitempty"`
+	CreatedAt              time.Time             `json:"created_at"`
+	UpdatedAt              time.Time             `json:"updated_at"`
 }
 
 // GaugeNeedle represents a single needle (progress update) on a gauge.

--- a/go/pkg/basecamp/gauges.go
+++ b/go/pkg/basecamp/gauges.go
@@ -49,7 +49,7 @@ type GaugeNeedle struct {
 	// embedded in the rich text Description. @required — the API always sends this
 	// array (empty when the description has no inline files). No omitempty, so on
 	// marshal a non-nil slice emits its elements ([] when empty) and a nil
-	// slice (only from manual construction) emits null; the key is never
+	// slice emits null; the key is never
 	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
 	// RichTextAttachment.
 	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`

--- a/go/pkg/basecamp/gauges_test.go
+++ b/go/pkg/basecamp/gauges_test.go
@@ -1,0 +1,116 @@
+package basecamp
+
+// Gauge and GaugeNeedle decode directly into their public structs (no
+// generated converter), so their rich text description_attachments arrays
+// decode by invoking RichTextAttachment.UnmarshalJSON per element. These tests
+// pin that decode path plus the two structures' differing presence contracts:
+// GaugeNeedle's array is @required (nil-vs-empty preserved), while Gauge's is
+// optional (omitempty) because the API renders it only when the gauge has
+// needles.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestGaugeNeedle_DecodesDescriptionAttachments proves the direct-decode path:
+// a GaugeNeedle body with a populated description_attachments array decodes,
+// invoking RichTextAttachment.UnmarshalJSON on each element so a float-spelled
+// dimension (1024.0 -> 1024) and a null dimension (-> nil) decode faithfully.
+func TestGaugeNeedle_DecodesDescriptionAttachments(t *testing.T) {
+	body := []byte(`{
+		"id": 42,
+		"type": "Gauge::Needle",
+		"description": "<div>Progress update with files</div>",
+		"description_attachments": [
+			{
+				"id": 1069480030,
+				"sgid": "BAh7needle1",
+				"filename": "chart.png",
+				"content_type": "image/png",
+				"byte_size": 40960,
+				"download_url": "https://example.com/download/chart.png",
+				"width": 1024.0,
+				"height": 768,
+				"previewable": true,
+				"preview_url": "https://example.com/preview/chart.png",
+				"thumbnail_url": "https://example.com/thumb/chart.png"
+			},
+			{
+				"id": 1069480031,
+				"sgid": "BAh7needle2",
+				"filename": "notes.pdf",
+				"content_type": "application/pdf",
+				"byte_size": 81920,
+				"download_url": "https://example.com/download/notes.pdf",
+				"width": null,
+				"height": null,
+				"previewable": false,
+				"preview_url": "https://example.com/preview/notes.pdf",
+				"thumbnail_url": "https://example.com/thumb/notes.pdf"
+			}
+		]
+	}`)
+
+	var needle GaugeNeedle
+	if err := json.Unmarshal(body, &needle); err != nil {
+		t.Fatalf("failed to unmarshal GaugeNeedle: %v", err)
+	}
+	if len(needle.DescriptionAttachments) != 2 {
+		t.Fatalf("expected 2 description attachments, got %d", len(needle.DescriptionAttachments))
+	}
+	img := needle.DescriptionAttachments[0]
+	if img.ID != 1069480030 || img.Filename != "chart.png" || img.ContentType != "image/png" {
+		t.Errorf("unexpected image attachment: %+v", img)
+	}
+	if img.Width == nil || *img.Width != 1024 {
+		t.Errorf("expected image Width 1024 (float-spelled 1024.0), got %v", img.Width)
+	}
+	if img.Height == nil || *img.Height != 768 {
+		t.Errorf("expected image Height 768, got %v", img.Height)
+	}
+	blob := needle.DescriptionAttachments[1]
+	if blob.ID != 1069480031 || blob.Width != nil || blob.Height != nil {
+		t.Errorf("expected non-image blob with nil dimensions, got %+v", blob)
+	}
+}
+
+// TestGauge_DescriptionAttachments_PresenceContract pins Gauge's optional
+// array: an absent key stays nil, a server-sent [] decodes to a non-nil
+// zero-length slice.
+func TestGauge_DescriptionAttachments_PresenceContract(t *testing.T) {
+	// Absent key -> nil.
+	var absent Gauge
+	if err := json.Unmarshal([]byte(`{"id": 7, "type": "Gauge"}`), &absent); err != nil {
+		t.Fatalf("failed to unmarshal needle-less gauge: %v", err)
+	}
+	if absent.DescriptionAttachments != nil {
+		t.Errorf("expected nil DescriptionAttachments for absent key, got %v", absent.DescriptionAttachments)
+	}
+
+	// Present but empty -> non-nil zero-length slice.
+	var empty Gauge
+	if err := json.Unmarshal([]byte(`{"id": 7, "type": "Gauge", "description_attachments": []}`), &empty); err != nil {
+		t.Fatalf("failed to unmarshal gauge with empty array: %v", err)
+	}
+	if empty.DescriptionAttachments == nil {
+		t.Error("expected non-nil DescriptionAttachments for server-sent []")
+	}
+	if len(empty.DescriptionAttachments) != 0 {
+		t.Errorf("expected 0 attachments, got %d", len(empty.DescriptionAttachments))
+	}
+}
+
+// TestGauge_MarshalOmitsAbsentAttachments pins the omitempty choice on Gauge's
+// optional, non-nullable array: a nil array must be omitted on re-encode, never
+// emitted as an invalid "description_attachments": null.
+func TestGauge_MarshalOmitsAbsentAttachments(t *testing.T) {
+	data, err := json.Marshal(Gauge{ID: 7})
+	if err != nil {
+		t.Fatalf("failed to marshal gauge: %v", err)
+	}
+	if strings.Contains(string(data), "description_attachments") {
+		t.Errorf("expected absent (nil) description_attachments to be omitted, got %s", data)
+	}
+}

--- a/go/pkg/basecamp/gauges_test.go
+++ b/go/pkg/basecamp/gauges_test.go
@@ -89,28 +89,40 @@ func TestGauge_DescriptionAttachments_PresenceContract(t *testing.T) {
 		t.Errorf("expected nil DescriptionAttachments for absent key, got %v", absent.DescriptionAttachments)
 	}
 
-	// Present but empty -> non-nil zero-length slice.
+	// Present but empty -> non-nil pointer to a zero-length slice.
 	var empty Gauge
 	if err := json.Unmarshal([]byte(`{"id": 7, "type": "Gauge", "description_attachments": []}`), &empty); err != nil {
 		t.Fatalf("failed to unmarshal gauge with empty array: %v", err)
 	}
 	if empty.DescriptionAttachments == nil {
-		t.Error("expected non-nil DescriptionAttachments for server-sent []")
+		t.Fatal("expected non-nil DescriptionAttachments pointer for server-sent []")
 	}
-	if len(empty.DescriptionAttachments) != 0 {
-		t.Errorf("expected 0 attachments, got %d", len(empty.DescriptionAttachments))
+	if len(*empty.DescriptionAttachments) != 0 {
+		t.Errorf("expected 0 attachments, got %d", len(*empty.DescriptionAttachments))
 	}
 }
 
-// TestGauge_MarshalOmitsAbsentAttachments pins the omitempty choice on Gauge's
-// optional, non-nullable array: a nil array must be omitted on re-encode, never
-// emitted as an invalid "description_attachments": null.
-func TestGauge_MarshalOmitsAbsentAttachments(t *testing.T) {
+// TestGauge_MarshalRoundTripsPresence pins the *[]RichTextAttachment choice on
+// Gauge's optional, non-nullable array: an absent (nil-pointer) array is omitted
+// on re-encode — never an invalid "description_attachments": null — while a
+// present-but-empty array re-encodes as [], staying distinct from absent.
+func TestGauge_MarshalRoundTripsPresence(t *testing.T) {
+	// Absent (nil pointer): key omitted entirely.
 	data, err := json.Marshal(Gauge{ID: 7})
 	if err != nil {
-		t.Fatalf("failed to marshal gauge: %v", err)
+		t.Fatalf("failed to marshal needle-less gauge: %v", err)
 	}
 	if strings.Contains(string(data), "description_attachments") {
-		t.Errorf("expected absent (nil) description_attachments to be omitted, got %s", data)
+		t.Errorf("expected absent description_attachments to be omitted, got %s", data)
+	}
+
+	// Present but empty (non-nil pointer to empty slice): encodes as [].
+	empty := []RichTextAttachment{}
+	data, err = json.Marshal(Gauge{ID: 7, DescriptionAttachments: &empty})
+	if err != nil {
+		t.Fatalf("failed to marshal gauge with empty attachments: %v", err)
+	}
+	if !strings.Contains(string(data), `"description_attachments":[]`) {
+		t.Errorf("expected present-empty description_attachments to encode as [], got %s", data)
 	}
 }

--- a/go/pkg/basecamp/messages.go
+++ b/go/pkg/basecamp/messages.go
@@ -20,9 +20,12 @@ type Message struct {
 	Subject          string `json:"subject"`
 	Content          string `json:"content"`
 	// ContentAttachments holds structured metadata for the downloadable files
-	// embedded in the rich text Content. Always sent by the API (empty when
-	// none); not omitempty so absent (nil) vs empty ([]) survives re-encoding.
-	// See RichTextAttachment.
+	// embedded in the rich text Content. @required — the API always sends this
+	// array (empty when the content has no inline files). No omitempty, so on
+	// marshal a non-nil slice emits its elements ([] when empty) and a nil
+	// slice (only from manual construction) emits null; the key is never
+	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
+	// RichTextAttachment.
 	ContentAttachments []RichTextAttachment `json:"content_attachments"`
 	CreatedAt          time.Time            `json:"created_at"`
 	UpdatedAt          time.Time            `json:"updated_at"`

--- a/go/pkg/basecamp/messages.go
+++ b/go/pkg/basecamp/messages.go
@@ -23,7 +23,7 @@ type Message struct {
 	// embedded in the rich text Content. @required — the API always sends this
 	// array (empty when the content has no inline files). No omitempty, so on
 	// marshal a non-nil slice emits its elements ([] when empty) and a nil
-	// slice (only from manual construction) emits null; the key is never
+	// slice emits null; the key is never
 	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
 	// RichTextAttachment.
 	ContentAttachments []RichTextAttachment `json:"content_attachments"`

--- a/go/pkg/basecamp/messages.go
+++ b/go/pkg/basecamp/messages.go
@@ -14,28 +14,33 @@ const DefaultMessageLimit = 100
 
 // Message represents a Basecamp message on a message board.
 type Message struct {
-	ID               int64        `json:"id"`
-	Status           string       `json:"status"`
-	VisibleToClients bool         `json:"visible_to_clients"`
-	Subject          string       `json:"subject"`
-	Content          string       `json:"content"`
-	CreatedAt        time.Time    `json:"created_at"`
-	UpdatedAt        time.Time    `json:"updated_at"`
-	Title            string       `json:"title,omitempty"`
-	InheritsStatus   bool         `json:"inherits_status"`
-	Type             string       `json:"type"`
-	URL              string       `json:"url"`
-	AppURL           string       `json:"app_url"`
-	BookmarkURL      string       `json:"bookmark_url,omitempty"`
-	BoostsCount      int          `json:"boosts_count,omitempty"`
-	BoostsURL        string       `json:"boosts_url,omitempty"`
-	CommentsCount    int          `json:"comments_count,omitempty"`
-	CommentsURL      string       `json:"comments_url,omitempty"`
-	SubscriptionURL  string       `json:"subscription_url,omitempty"`
-	Parent           *Parent      `json:"parent,omitempty"`
-	Bucket           *Bucket      `json:"bucket,omitempty"`
-	Creator          *Person      `json:"creator,omitempty"`
-	Category         *MessageType `json:"category,omitempty"`
+	ID               int64  `json:"id"`
+	Status           string `json:"status"`
+	VisibleToClients bool   `json:"visible_to_clients"`
+	Subject          string `json:"subject"`
+	Content          string `json:"content"`
+	// ContentAttachments holds structured metadata for the downloadable files
+	// embedded in the rich text Content. Always sent by the API (empty when
+	// none); not omitempty so absent (nil) vs empty ([]) survives re-encoding.
+	// See RichTextAttachment.
+	ContentAttachments []RichTextAttachment `json:"content_attachments"`
+	CreatedAt          time.Time            `json:"created_at"`
+	UpdatedAt          time.Time            `json:"updated_at"`
+	Title              string               `json:"title,omitempty"`
+	InheritsStatus     bool                 `json:"inherits_status"`
+	Type               string               `json:"type"`
+	URL                string               `json:"url"`
+	AppURL             string               `json:"app_url"`
+	BookmarkURL        string               `json:"bookmark_url,omitempty"`
+	BoostsCount        int                  `json:"boosts_count,omitempty"`
+	BoostsURL          string               `json:"boosts_url,omitempty"`
+	CommentsCount      int                  `json:"comments_count,omitempty"`
+	CommentsURL        string               `json:"comments_url,omitempty"`
+	SubscriptionURL    string               `json:"subscription_url,omitempty"`
+	Parent             *Parent              `json:"parent,omitempty"`
+	Bucket             *Bucket              `json:"bucket,omitempty"`
+	Creator            *Person              `json:"creator,omitempty"`
+	Category           *MessageType         `json:"category,omitempty"`
 }
 
 // CreateMessageRequest specifies the parameters for creating a message.
@@ -510,6 +515,8 @@ func messageFromGenerated(gm generated.Message) Message {
 			UpdatedAt: gm.Category.UpdatedAt,
 		}
 	}
+
+	m.ContentAttachments = richTextAttachmentsFromGenerated(gm.ContentAttachments)
 
 	return m
 }

--- a/go/pkg/basecamp/recordings.go
+++ b/go/pkg/basecamp/recordings.go
@@ -44,12 +44,21 @@ type Recording struct {
 	AppURL           string    `json:"app_url"`
 	BookmarkURL      string    `json:"bookmark_url"`
 	Content          string    `json:"content,omitempty"`
-	CommentsCount    int       `json:"comments_count,omitempty"`
-	CommentsURL      string    `json:"comments_url,omitempty"`
-	SubscriptionURL  string    `json:"subscription_url,omitempty"`
-	Parent           *Parent   `json:"parent,omitempty"`
-	Bucket           *Bucket   `json:"bucket,omitempty"`
-	Creator          *Person   `json:"creator,omitempty"`
+	// ContentAttachments and DescriptionAttachments are the rich text companion
+	// arrays carried through the generic recording projection. A given recording
+	// is one type, so it carries only the array matching its rich text attribute
+	// (ContentAttachments for a Comment/Message, DescriptionAttachments for a
+	// Todo/Card); a webhook-sourced recording carries neither. Optional, so
+	// omitempty matches the non-nullable member (never emits an invalid null).
+	// See RichTextAttachment.
+	ContentAttachments     []RichTextAttachment `json:"content_attachments,omitempty"`
+	DescriptionAttachments []RichTextAttachment `json:"description_attachments,omitempty"`
+	CommentsCount          int                  `json:"comments_count,omitempty"`
+	CommentsURL            string               `json:"comments_url,omitempty"`
+	SubscriptionURL        string               `json:"subscription_url,omitempty"`
+	Parent                 *Parent              `json:"parent,omitempty"`
+	Bucket                 *Bucket              `json:"bucket,omitempty"`
+	Creator                *Person              `json:"creator,omitempty"`
 }
 
 // DefaultRecordingLimit is the default number of recordings to return when no limit is specified.
@@ -407,6 +416,9 @@ func recordingFromGenerated(gr generated.Recording) Recording {
 		creator := personFromGenerated(gr.Creator)
 		r.Creator = &creator
 	}
+
+	r.ContentAttachments = richTextAttachmentsFromGenerated(gr.ContentAttachments)
+	r.DescriptionAttachments = richTextAttachmentsFromGenerated(gr.DescriptionAttachments)
 
 	return r
 }

--- a/go/pkg/basecamp/recordings.go
+++ b/go/pkg/basecamp/recordings.go
@@ -48,17 +48,22 @@ type Recording struct {
 	// arrays carried through the generic recording projection. A given recording
 	// is one type, so it carries only the array matching its rich text attribute
 	// (ContentAttachments for a Comment/Message, DescriptionAttachments for a
-	// Todo/Card); a webhook-sourced recording carries neither. Optional, so
-	// omitempty matches the non-nullable member (never emits an invalid null).
-	// See RichTextAttachment.
-	ContentAttachments     []RichTextAttachment `json:"content_attachments,omitempty"`
-	DescriptionAttachments []RichTextAttachment `json:"description_attachments,omitempty"`
-	CommentsCount          int                  `json:"comments_count,omitempty"`
-	CommentsURL            string               `json:"comments_url,omitempty"`
-	SubscriptionURL        string               `json:"subscription_url,omitempty"`
-	Parent                 *Parent              `json:"parent,omitempty"`
-	Bucket                 *Bucket              `json:"bucket,omitempty"`
-	Creator                *Person              `json:"creator,omitempty"`
+	// Todo/Card); a webhook-sourced recording carries neither. These are
+	// optional and non-nullable, and their absent-vs-present-empty distinction
+	// is meaningful (a matching type with no inline files serves an empty [],
+	// while a non-matching/webhook recording omits the key). Modeled as a
+	// pointer to a slice with omitempty so all three wire states round-trip
+	// faithfully: nil pointer (absent) is omitted, a non-nil pointer to an
+	// empty slice re-encodes as [], and a populated one as the list — matching
+	// the nullable/optional modeling in every other SDK. See RichTextAttachment.
+	ContentAttachments     *[]RichTextAttachment `json:"content_attachments,omitempty"`
+	DescriptionAttachments *[]RichTextAttachment `json:"description_attachments,omitempty"`
+	CommentsCount          int                   `json:"comments_count,omitempty"`
+	CommentsURL            string                `json:"comments_url,omitempty"`
+	SubscriptionURL        string                `json:"subscription_url,omitempty"`
+	Parent                 *Parent               `json:"parent,omitempty"`
+	Bucket                 *Bucket               `json:"bucket,omitempty"`
+	Creator                *Person               `json:"creator,omitempty"`
 }
 
 // DefaultRecordingLimit is the default number of recordings to return when no limit is specified.
@@ -417,8 +422,8 @@ func recordingFromGenerated(gr generated.Recording) Recording {
 		r.Creator = &creator
 	}
 
-	r.ContentAttachments = richTextAttachmentsFromGenerated(gr.ContentAttachments)
-	r.DescriptionAttachments = richTextAttachmentsFromGenerated(gr.DescriptionAttachments)
+	r.ContentAttachments = richTextAttachmentsPtrFromGenerated(gr.ContentAttachments)
+	r.DescriptionAttachments = richTextAttachmentsPtrFromGenerated(gr.DescriptionAttachments)
 
 	return r
 }

--- a/go/pkg/basecamp/recordings_test.go
+++ b/go/pkg/basecamp/recordings_test.go
@@ -113,6 +113,13 @@ func TestRecording_UnmarshalList(t *testing.T) {
 	if r2.Creator.Name != "Annie Bryan" {
 		t.Errorf("expected Creator.Name 'Annie Bryan', got %q", r2.Creator.Name)
 	}
+
+	// End-to-end projection proof: each Message recording carries its
+	// content_attachments companion array through the wire.
+	if len(r1.ContentAttachments) == 0 || len(r2.ContentAttachments) == 0 {
+		t.Errorf("expected both recordings to carry ContentAttachments, got %d and %d",
+			len(r1.ContentAttachments), len(r2.ContentAttachments))
+	}
 }
 
 func TestRecording_UnmarshalGet(t *testing.T) {
@@ -165,6 +172,21 @@ func TestRecording_UnmarshalGet(t *testing.T) {
 	}
 	if !recording.Creator.Owner {
 		t.Error("expected Creator.Owner to be true")
+	}
+
+	// End-to-end projection proof: the generic recording projection carries the
+	// recording's rich text companion array through the wire. This Message
+	// carries content_attachments (its content attribute) and no
+	// description_attachments.
+	if len(recording.ContentAttachments) == 0 {
+		t.Error("expected non-empty ContentAttachments for the Message recording")
+	}
+	if recording.DescriptionAttachments != nil {
+		t.Errorf("expected no DescriptionAttachments, got %v", recording.DescriptionAttachments)
+	}
+	att := recording.ContentAttachments[0]
+	if att.ContentType != "image/png" || att.Width == nil || *att.Width != 1024 {
+		t.Errorf("unexpected content attachment (float-spelled width should narrow to 1024): %+v", att)
 	}
 }
 

--- a/go/pkg/basecamp/recordings_test.go
+++ b/go/pkg/basecamp/recordings_test.go
@@ -179,7 +179,7 @@ func TestRecording_UnmarshalGet(t *testing.T) {
 	// carries content_attachments (its content attribute) and no
 	// description_attachments.
 	if len(recording.ContentAttachments) == 0 {
-		t.Error("expected non-empty ContentAttachments for the Message recording")
+		t.Fatal("expected non-empty ContentAttachments for the Message recording")
 	}
 	if recording.DescriptionAttachments != nil {
 		t.Errorf("expected no DescriptionAttachments, got %v", recording.DescriptionAttachments)

--- a/go/pkg/basecamp/recordings_test.go
+++ b/go/pkg/basecamp/recordings_test.go
@@ -115,10 +115,14 @@ func TestRecording_UnmarshalList(t *testing.T) {
 	}
 
 	// End-to-end projection proof: each Message recording carries its
-	// content_attachments companion array through the wire.
-	if len(r1.ContentAttachments) == 0 || len(r2.ContentAttachments) == 0 {
-		t.Errorf("expected both recordings to carry ContentAttachments, got %d and %d",
-			len(r1.ContentAttachments), len(r2.ContentAttachments))
+	// content_attachments companion array through the wire (a non-nil pointer).
+	if r1.ContentAttachments == nil || r2.ContentAttachments == nil {
+		t.Fatalf("expected both recordings to carry ContentAttachments, got %v and %v",
+			r1.ContentAttachments, r2.ContentAttachments)
+	}
+	if len(*r1.ContentAttachments) == 0 || len(*r2.ContentAttachments) == 0 {
+		t.Errorf("expected both recordings' ContentAttachments to be populated, got %d and %d",
+			len(*r1.ContentAttachments), len(*r2.ContentAttachments))
 	}
 }
 
@@ -175,16 +179,19 @@ func TestRecording_UnmarshalGet(t *testing.T) {
 	}
 
 	// End-to-end projection proof: the generic recording projection carries the
-	// recording's rich text companion array through the wire. This Message
-	// carries content_attachments (its content attribute) and no
-	// description_attachments.
-	if len(recording.ContentAttachments) == 0 {
+	// recording's rich text companion array through the wire (a non-nil pointer).
+	// This Message carries content_attachments (its content attribute) and no
+	// description_attachments (a nil pointer, absent).
+	if recording.ContentAttachments == nil {
+		t.Fatal("expected non-nil ContentAttachments for the Message recording")
+	}
+	if len(*recording.ContentAttachments) == 0 {
 		t.Fatal("expected non-empty ContentAttachments for the Message recording")
 	}
 	if recording.DescriptionAttachments != nil {
-		t.Errorf("expected no DescriptionAttachments, got %v", recording.DescriptionAttachments)
+		t.Errorf("expected nil (absent) DescriptionAttachments, got %v", recording.DescriptionAttachments)
 	}
-	att := recording.ContentAttachments[0]
+	att := (*recording.ContentAttachments)[0]
 	if att.ContentType != "image/png" || att.Width == nil || *att.Width != 1024 {
 		t.Errorf("unexpected content attachment (float-spelled width should narrow to 1024): %+v", att)
 	}

--- a/go/pkg/basecamp/rich_text_attachments_test.go
+++ b/go/pkg/basecamp/rich_text_attachments_test.go
@@ -1,0 +1,139 @@
+package basecamp
+
+// Wiring proof for the rich text *_attachments coverage sweep (#405): every
+// resource that pairs a rich text attribute with a companion attachments array
+// must carry that array through its hand-written converter. The table below
+// runs one populated generated fixture through each converter and asserts the
+// relevant array(s) convert, exercising the shared
+// richTextAttachmentsFromGenerated helper for all 15 converter structures (13
+// concrete + the two polymorphic projections, each of which carries both a
+// content and a description array). Gauge and GaugeNeedle decode directly (no
+// converter) and are covered in gauges_test.go.
+
+import (
+	"testing"
+
+	"github.com/basecamp/basecamp-sdk/go/pkg/generated"
+	"github.com/basecamp/basecamp-sdk/go/pkg/types"
+)
+
+// richTextAttachmentsFixture returns a two-element generated attachment slice
+// exercising both dimension forms: an image with a pixel width and a non-image
+// blob with nil (JSON null) dimensions.
+func richTextAttachmentsFixture() []generated.RichTextAttachment {
+	w := types.FlexInt(1024)
+	h := types.FlexInt(768)
+	return []generated.RichTextAttachment{
+		{
+			Id:           987,
+			Sgid:         "BAh7img",
+			Filename:     "diagram.png",
+			ContentType:  "image/png",
+			ByteSize:     20480,
+			DownloadUrl:  "https://example.com/download/diagram.png",
+			Width:        &w,
+			Height:       &h,
+			Previewable:  true,
+			PreviewUrl:   "https://example.com/preview/diagram.png",
+			ThumbnailUrl: "https://example.com/thumb/diagram.png",
+		},
+		{
+			Id:           988,
+			Sgid:         "BAh7pdf",
+			Filename:     "spec.pdf",
+			ContentType:  "application/pdf",
+			ByteSize:     51200,
+			DownloadUrl:  "https://example.com/download/spec.pdf",
+			Width:        nil,
+			Height:       nil,
+			Previewable:  false,
+			PreviewUrl:   "https://example.com/preview/spec.pdf",
+			ThumbnailUrl: "https://example.com/thumb/spec.pdf",
+		},
+	}
+}
+
+// assertRichTextAttachmentsConverted verifies the shared fixture converted to
+// the public type with the always-emitted fields carried through and both
+// dimension forms narrowed faithfully (present -> *int32, null -> nil).
+func assertRichTextAttachmentsConverted(t *testing.T, got []RichTextAttachment) {
+	t.Helper()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 attachments, got %d", len(got))
+	}
+	img := got[0]
+	if img.ID != 987 || img.SGID != "BAh7img" || img.Filename != "diagram.png" || img.ContentType != "image/png" {
+		t.Errorf("image attachment fields not propagated: %+v", img)
+	}
+	if img.ByteSize != 20480 || img.DownloadURL != "https://example.com/download/diagram.png" {
+		t.Errorf("image attachment byte_size/download_url not propagated: %+v", img)
+	}
+	if img.Width == nil || *img.Width != 1024 {
+		t.Errorf("image Width: got %v, want 1024", img.Width)
+	}
+	if img.Height == nil || *img.Height != 768 {
+		t.Errorf("image Height: got %v, want 768", img.Height)
+	}
+	if !img.Previewable {
+		t.Error("image Previewable: got false, want true")
+	}
+	blob := got[1]
+	if blob.ID != 988 || blob.ContentType != "application/pdf" {
+		t.Errorf("blob attachment fields not propagated: %+v", blob)
+	}
+	if blob.Width != nil || blob.Height != nil {
+		t.Errorf("blob dimensions: got width=%v height=%v, want nil/nil", blob.Width, blob.Height)
+	}
+}
+
+func TestRichTextAttachments_ConverterPropagation(t *testing.T) {
+	fix := richTextAttachmentsFixture()
+	cases := []struct {
+		name string
+		got  []RichTextAttachment
+	}{
+		{"Todolist", todolistFromGenerated(generated.Todolist{DescriptionAttachments: fix}).DescriptionAttachments},
+		{"Comment", commentFromGenerated(generated.Comment{ContentAttachments: fix}).ContentAttachments},
+		{"Message", messageFromGenerated(generated.Message{ContentAttachments: fix}).ContentAttachments},
+		{"Document", documentFromGenerated(generated.Document{ContentAttachments: fix}).ContentAttachments},
+		{"Upload", uploadFromGenerated(generated.Upload{DescriptionAttachments: fix}).DescriptionAttachments},
+		{"ScheduleEntry", scheduleEntryFromGenerated(generated.ScheduleEntry{DescriptionAttachments: fix}).DescriptionAttachments},
+		{"Forward", forwardFromGenerated(generated.Forward{ContentAttachments: fix}).ContentAttachments},
+		{"ForwardReply", forwardReplyFromGenerated(generated.ForwardReply{ContentAttachments: fix}).ContentAttachments},
+		{"Card", cardFromGenerated(generated.Card{DescriptionAttachments: fix}).DescriptionAttachments},
+		{"ClientApproval", clientApprovalFromGenerated(generated.ClientApproval{ContentAttachments: fix}).ContentAttachments},
+		{"ClientCorrespondence", clientCorrespondenceFromGenerated(generated.ClientCorrespondence{ContentAttachments: fix}).ContentAttachments},
+		{"ClientReply", clientReplyFromGenerated(generated.ClientReply{ContentAttachments: fix}).ContentAttachments},
+		{"QuestionAnswer", questionAnswerFromGenerated(generated.QuestionAnswer{ContentAttachments: fix}).ContentAttachments},
+		{"SearchResult.content", searchResultFromGenerated(generated.SearchResult{ContentAttachments: fix}).ContentAttachments},
+		{"SearchResult.description", searchResultFromGenerated(generated.SearchResult{DescriptionAttachments: fix}).DescriptionAttachments},
+		{"Recording.content", recordingFromGenerated(generated.Recording{ContentAttachments: fix}).ContentAttachments},
+		{"Recording.description", recordingFromGenerated(generated.Recording{DescriptionAttachments: fix}).DescriptionAttachments},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertRichTextAttachmentsConverted(t, tc.got)
+		})
+	}
+}
+
+// TestRichTextAttachments_NilVsEmpty pins the nil-vs-empty contract the shared
+// helper preserves: a server-sent [] becomes a non-nil zero-length slice, an
+// absent property stays nil. Representative of every converter structure since
+// they all route through richTextAttachmentsFromGenerated.
+func TestRichTextAttachments_NilVsEmpty(t *testing.T) {
+	// Present but empty -> non-nil zero-length slice.
+	c := commentFromGenerated(generated.Comment{ContentAttachments: []generated.RichTextAttachment{}})
+	if c.ContentAttachments == nil {
+		t.Error("expected non-nil ContentAttachments for server-sent []")
+	}
+	if len(c.ContentAttachments) != 0 {
+		t.Errorf("expected 0 attachments, got %d", len(c.ContentAttachments))
+	}
+
+	// Absent -> nil.
+	c = commentFromGenerated(generated.Comment{})
+	if c.ContentAttachments != nil {
+		t.Errorf("expected nil ContentAttachments for absent property, got %v", c.ContentAttachments)
+	}
+}

--- a/go/pkg/basecamp/rich_text_attachments_test.go
+++ b/go/pkg/basecamp/rich_text_attachments_test.go
@@ -53,6 +53,15 @@ func richTextAttachmentsFixture() []generated.RichTextAttachment {
 	}
 }
 
+// derefAttachments dereferences an optional projection array pointer for the
+// converter table; the fixture always produces a non-nil pointer.
+func derefAttachments(p *[]RichTextAttachment) []RichTextAttachment {
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
 // assertRichTextAttachmentsConverted verifies the shared fixture converted to
 // the public type with the always-emitted fields carried through and both
 // dimension forms narrowed faithfully (present -> *int32, null -> nil).
@@ -105,10 +114,15 @@ func TestRichTextAttachments_ConverterPropagation(t *testing.T) {
 		{"ClientCorrespondence", clientCorrespondenceFromGenerated(generated.ClientCorrespondence{ContentAttachments: fix}).ContentAttachments},
 		{"ClientReply", clientReplyFromGenerated(generated.ClientReply{ContentAttachments: fix}).ContentAttachments},
 		{"QuestionAnswer", questionAnswerFromGenerated(generated.QuestionAnswer{ContentAttachments: fix}).ContentAttachments},
-		{"SearchResult.content", searchResultFromGenerated(generated.SearchResult{ContentAttachments: fix}).ContentAttachments},
-		{"SearchResult.description", searchResultFromGenerated(generated.SearchResult{DescriptionAttachments: fix}).DescriptionAttachments},
-		{"Recording.content", recordingFromGenerated(generated.Recording{ContentAttachments: fix}).ContentAttachments},
-		{"Recording.description", recordingFromGenerated(generated.Recording{DescriptionAttachments: fix}).DescriptionAttachments},
+		// The projection arrays are optional and modeled as *[]RichTextAttachment;
+		// the fixture is non-nil so the converter yields a non-nil pointer, safe
+		// to dereference. The pointer's nil-vs-non-nil presence contract is
+		// covered separately (Recording in recordings_test.go, Gauge in
+		// gauges_test.go).
+		{"SearchResult.content", derefAttachments(searchResultFromGenerated(generated.SearchResult{ContentAttachments: fix}).ContentAttachments)},
+		{"SearchResult.description", derefAttachments(searchResultFromGenerated(generated.SearchResult{DescriptionAttachments: fix}).DescriptionAttachments)},
+		{"Recording.content", derefAttachments(recordingFromGenerated(generated.Recording{ContentAttachments: fix}).ContentAttachments)},
+		{"Recording.description", derefAttachments(recordingFromGenerated(generated.Recording{DescriptionAttachments: fix}).DescriptionAttachments)},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -136,4 +150,34 @@ func TestRichTextAttachments_NilVsEmpty(t *testing.T) {
 	if c.ContentAttachments != nil {
 		t.Errorf("expected nil ContentAttachments for absent property, got %v", c.ContentAttachments)
 	}
+}
+
+// TestRichTextAttachments_OptionalPointerPresence pins the *[]RichTextAttachment
+// presence contract for the optional projection arrays (via the shared pointer
+// helper on the Recording converter): absent stays a nil pointer, present-empty
+// becomes a non-nil pointer to a zero-length slice, and populated a non-nil
+// pointer to the converted slice — so all three wire states stay distinguishable
+// in both directions (see the marshal round-trip in gauges_test.go).
+func TestRichTextAttachments_OptionalPointerPresence(t *testing.T) {
+	// Absent -> nil pointer.
+	absent := recordingFromGenerated(generated.Recording{})
+	if absent.ContentAttachments != nil {
+		t.Errorf("expected nil ContentAttachments pointer for absent property, got %v", absent.ContentAttachments)
+	}
+
+	// Present but empty -> non-nil pointer to a zero-length slice.
+	empty := recordingFromGenerated(generated.Recording{ContentAttachments: []generated.RichTextAttachment{}})
+	if empty.ContentAttachments == nil {
+		t.Fatal("expected non-nil ContentAttachments pointer for server-sent []")
+	}
+	if len(*empty.ContentAttachments) != 0 {
+		t.Errorf("expected 0 attachments, got %d", len(*empty.ContentAttachments))
+	}
+
+	// Populated -> non-nil pointer to the converted slice.
+	populated := recordingFromGenerated(generated.Recording{ContentAttachments: richTextAttachmentsFixture()})
+	if populated.ContentAttachments == nil {
+		t.Fatal("expected non-nil ContentAttachments pointer for populated array")
+	}
+	assertRichTextAttachmentsConverted(t, *populated.ContentAttachments)
 }

--- a/go/pkg/basecamp/schedules.go
+++ b/go/pkg/basecamp/schedules.go
@@ -70,10 +70,15 @@ type ScheduleEntry struct {
 	EndsAt           types.FlexibleTime `json:"ends_at"`
 	AllDay           bool               `json:"all_day"`
 	Description      string             `json:"description"`
-	Parent           *Parent            `json:"parent,omitempty"`
-	Bucket           *Bucket            `json:"bucket,omitempty"`
-	Creator          *Person            `json:"creator,omitempty"`
-	Participants     []Person           `json:"participants,omitempty"`
+	// DescriptionAttachments holds structured metadata for the downloadable
+	// files embedded in the rich text Description. Always sent by the API
+	// (empty when none); not omitempty so absent (nil) vs empty ([]) survives
+	// re-encoding. See RichTextAttachment.
+	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`
+	Parent                 *Parent              `json:"parent,omitempty"`
+	Bucket                 *Bucket              `json:"bucket,omitempty"`
+	Creator                *Person              `json:"creator,omitempty"`
+	Participants           []Person             `json:"participants,omitempty"`
 }
 
 // CreateScheduleEntryRequest specifies the parameters for creating a schedule entry.
@@ -653,6 +658,8 @@ func scheduleEntryFromGenerated(ge generated.ScheduleEntry) ScheduleEntry {
 			e.Participants = append(e.Participants, personFromGenerated(gp))
 		}
 	}
+
+	e.DescriptionAttachments = richTextAttachmentsFromGenerated(ge.DescriptionAttachments)
 
 	return e
 }

--- a/go/pkg/basecamp/schedules.go
+++ b/go/pkg/basecamp/schedules.go
@@ -74,7 +74,7 @@ type ScheduleEntry struct {
 	// embedded in the rich text Description. @required — the API always sends this
 	// array (empty when the description has no inline files). No omitempty, so on
 	// marshal a non-nil slice emits its elements ([] when empty) and a nil
-	// slice (only from manual construction) emits null; the key is never
+	// slice emits null; the key is never
 	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
 	// RichTextAttachment.
 	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`

--- a/go/pkg/basecamp/schedules.go
+++ b/go/pkg/basecamp/schedules.go
@@ -70,10 +70,13 @@ type ScheduleEntry struct {
 	EndsAt           types.FlexibleTime `json:"ends_at"`
 	AllDay           bool               `json:"all_day"`
 	Description      string             `json:"description"`
-	// DescriptionAttachments holds structured metadata for the downloadable
-	// files embedded in the rich text Description. Always sent by the API
-	// (empty when none); not omitempty so absent (nil) vs empty ([]) survives
-	// re-encoding. See RichTextAttachment.
+	// DescriptionAttachments holds structured metadata for the downloadable files
+	// embedded in the rich text Description. @required — the API always sends this
+	// array (empty when the description has no inline files). No omitempty, so on
+	// marshal a non-nil slice emits its elements ([] when empty) and a nil
+	// slice (only from manual construction) emits null; the key is never
+	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
+	// RichTextAttachment.
 	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`
 	Parent                 *Parent              `json:"parent,omitempty"`
 	Bucket                 *Bucket              `json:"bucket,omitempty"`

--- a/go/pkg/basecamp/search.go
+++ b/go/pkg/basecamp/search.go
@@ -27,7 +27,16 @@ type SearchResult struct {
 	Creator          *Person   `json:"creator,omitempty"`
 	Content          string    `json:"content,omitempty"`
 	Description      string    `json:"description,omitempty"`
-	Subject          string    `json:"subject,omitempty"`
+	// ContentAttachments and DescriptionAttachments are the rich text companion
+	// arrays carried through the polymorphic search projection. A given result
+	// is one recording type, so it carries only the array matching its rich text
+	// attribute (ContentAttachments for a Comment/Message, DescriptionAttachments
+	// for a Todo); a webhook-sourced result carries neither. Optional, so
+	// omitempty matches the non-nullable member (never emits an invalid null).
+	// See RichTextAttachment.
+	ContentAttachments     []RichTextAttachment `json:"content_attachments,omitempty"`
+	DescriptionAttachments []RichTextAttachment `json:"description_attachments,omitempty"`
+	Subject                string               `json:"subject,omitempty"`
 }
 
 // SearchMetadata represents the available search filter options returned by
@@ -347,6 +356,9 @@ func searchResultFromGenerated(gsr generated.SearchResult) SearchResult {
 		creator := personFromGenerated(gsr.Creator)
 		sr.Creator = &creator
 	}
+
+	sr.ContentAttachments = richTextAttachmentsFromGenerated(gsr.ContentAttachments)
+	sr.DescriptionAttachments = richTextAttachmentsFromGenerated(gsr.DescriptionAttachments)
 
 	return sr
 }

--- a/go/pkg/basecamp/search.go
+++ b/go/pkg/basecamp/search.go
@@ -31,12 +31,14 @@ type SearchResult struct {
 	// arrays carried through the polymorphic search projection. A given result
 	// is one recording type, so it carries only the array matching its rich text
 	// attribute (ContentAttachments for a Comment/Message, DescriptionAttachments
-	// for a Todo); a webhook-sourced result carries neither. Optional, so
-	// omitempty matches the non-nullable member (never emits an invalid null).
-	// See RichTextAttachment.
-	ContentAttachments     []RichTextAttachment `json:"content_attachments,omitempty"`
-	DescriptionAttachments []RichTextAttachment `json:"description_attachments,omitempty"`
-	Subject                string               `json:"subject,omitempty"`
+	// for a Todo); a webhook-sourced result carries neither. Optional and
+	// non-nullable; modeled as a pointer to a slice with omitempty so all three
+	// wire states round-trip faithfully — nil pointer (absent) is omitted, a
+	// non-nil pointer to an empty slice re-encodes as [], and a populated one as
+	// the list. See Recording for the same contract and RichTextAttachment.
+	ContentAttachments     *[]RichTextAttachment `json:"content_attachments,omitempty"`
+	DescriptionAttachments *[]RichTextAttachment `json:"description_attachments,omitempty"`
+	Subject                string                `json:"subject,omitempty"`
 }
 
 // SearchMetadata represents the available search filter options returned by
@@ -357,8 +359,8 @@ func searchResultFromGenerated(gsr generated.SearchResult) SearchResult {
 		sr.Creator = &creator
 	}
 
-	sr.ContentAttachments = richTextAttachmentsFromGenerated(gsr.ContentAttachments)
-	sr.DescriptionAttachments = richTextAttachmentsFromGenerated(gsr.DescriptionAttachments)
+	sr.ContentAttachments = richTextAttachmentsPtrFromGenerated(gsr.ContentAttachments)
+	sr.DescriptionAttachments = richTextAttachmentsPtrFromGenerated(gsr.DescriptionAttachments)
 
 	return sr
 }

--- a/go/pkg/basecamp/search_test.go
+++ b/go/pkg/basecamp/search_test.go
@@ -457,6 +457,29 @@ func TestSearchService_Search_BestMatchSort(t *testing.T) {
 	if len(result.Results) != 3 {
 		t.Errorf("expected 3 results, got %d", len(result.Results))
 	}
+
+	// End-to-end projection proof: the polymorphic search projection carries a
+	// result's rich text companion array through the wire and searchResultFromGenerated.
+	// A given result carries only the array matching its type — content_attachments
+	// for a Comment/Message, description_attachments for a Todo.
+	for _, r := range result.Results {
+		switch r.Type {
+		case "Comment", "Message":
+			if len(r.ContentAttachments) == 0 {
+				t.Errorf("%s result: expected non-empty ContentAttachments", r.Type)
+			}
+			if r.DescriptionAttachments != nil {
+				t.Errorf("%s result: expected no DescriptionAttachments, got %v", r.Type, r.DescriptionAttachments)
+			}
+		case "Todo":
+			if len(r.DescriptionAttachments) == 0 {
+				t.Errorf("Todo result: expected non-empty DescriptionAttachments")
+			}
+			if r.ContentAttachments != nil {
+				t.Errorf("Todo result: expected no ContentAttachments, got %v", r.ContentAttachments)
+			}
+		}
+	}
 }
 
 func TestSearchService_Search_NoSort(t *testing.T) {

--- a/go/pkg/basecamp/search_test.go
+++ b/go/pkg/basecamp/search_test.go
@@ -463,20 +463,22 @@ func TestSearchService_Search_BestMatchSort(t *testing.T) {
 	// A given result carries only the array matching its type — content_attachments
 	// for a Comment/Message, description_attachments for a Todo.
 	for _, r := range result.Results {
+		// The arrays are optional projection members (*[]RichTextAttachment): the
+		// matching type carries a non-nil pointer, the other stays nil (absent).
 		switch r.Type {
 		case "Comment", "Message":
-			if len(r.ContentAttachments) == 0 {
+			if r.ContentAttachments == nil || len(*r.ContentAttachments) == 0 {
 				t.Errorf("%s result: expected non-empty ContentAttachments", r.Type)
 			}
 			if r.DescriptionAttachments != nil {
-				t.Errorf("%s result: expected no DescriptionAttachments, got %v", r.Type, r.DescriptionAttachments)
+				t.Errorf("%s result: expected nil DescriptionAttachments, got %v", r.Type, r.DescriptionAttachments)
 			}
 		case "Todo":
-			if len(r.DescriptionAttachments) == 0 {
+			if r.DescriptionAttachments == nil || len(*r.DescriptionAttachments) == 0 {
 				t.Errorf("Todo result: expected non-empty DescriptionAttachments")
 			}
 			if r.ContentAttachments != nil {
-				t.Errorf("Todo result: expected no ContentAttachments, got %v", r.ContentAttachments)
+				t.Errorf("Todo result: expected nil ContentAttachments, got %v", r.ContentAttachments)
 			}
 		}
 	}

--- a/go/pkg/basecamp/todolists.go
+++ b/go/pkg/basecamp/todolists.go
@@ -36,11 +36,13 @@ type Todolist struct {
 	Bucket           *Bucket   `json:"bucket,omitempty"`
 	Creator          *Person   `json:"creator,omitempty"`
 	Description      string    `json:"description"`
-	// DescriptionAttachments holds structured metadata for the downloadable
-	// files embedded in the rich text Description. The API always sends this
-	// array (empty when the description has no inline files), so a non-nil
-	// zero-length slice means an empty list and nil means absent. Not
-	// omitempty so re-encoding keeps it visible (nil→null, empty→[]).
+	// DescriptionAttachments holds structured metadata for the downloadable files
+	// embedded in the rich text Description. @required — the API always sends this
+	// array (empty when the description has no inline files). No omitempty, so on
+	// marshal a non-nil slice emits its elements ([] when empty) and a nil
+	// slice (only from manual construction) emits null; the key is never
+	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
+	// RichTextAttachment.
 	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`
 	Completed              bool                 `json:"completed"`
 	CompletedRatio         string               `json:"completed_ratio"`

--- a/go/pkg/basecamp/todolists.go
+++ b/go/pkg/basecamp/todolists.go
@@ -40,7 +40,7 @@ type Todolist struct {
 	// embedded in the rich text Description. @required — the API always sends this
 	// array (empty when the description has no inline files). No omitempty, so on
 	// marshal a non-nil slice emits its elements ([] when empty) and a nil
-	// slice (only from manual construction) emits null; the key is never
+	// slice emits null; the key is never
 	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
 	// RichTextAttachment.
 	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`

--- a/go/pkg/basecamp/todolists.go
+++ b/go/pkg/basecamp/todolists.go
@@ -36,12 +36,18 @@ type Todolist struct {
 	Bucket           *Bucket   `json:"bucket,omitempty"`
 	Creator          *Person   `json:"creator,omitempty"`
 	Description      string    `json:"description"`
-	Completed        bool      `json:"completed"`
-	CompletedRatio   string    `json:"completed_ratio"`
-	Name             string    `json:"name"`
-	TodosURL         string    `json:"todos_url"`
-	GroupsURL        string    `json:"groups_url"`
-	AppTodosURL      string    `json:"app_todos_url"`
+	// DescriptionAttachments holds structured metadata for the downloadable
+	// files embedded in the rich text Description. The API always sends this
+	// array (empty when the description has no inline files), so a non-nil
+	// zero-length slice means an empty list and nil means absent. Not
+	// omitempty so re-encoding keeps it visible (nil→null, empty→[]).
+	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`
+	Completed              bool                 `json:"completed"`
+	CompletedRatio         string               `json:"completed_ratio"`
+	Name                   string               `json:"name"`
+	TodosURL               string               `json:"todos_url"`
+	GroupsURL              string               `json:"groups_url"`
+	AppTodosURL            string               `json:"app_todos_url"`
 }
 
 // TodolistListOptions specifies options for listing todolists.
@@ -433,6 +439,8 @@ func todolistFromGenerated(gtl generated.Todolist) Todolist {
 		creator := personFromGenerated(gtl.Creator)
 		tl.Creator = &creator
 	}
+
+	tl.DescriptionAttachments = richTextAttachmentsFromGenerated(gtl.DescriptionAttachments)
 
 	return tl
 }

--- a/go/pkg/basecamp/todos.go
+++ b/go/pkg/basecamp/todos.go
@@ -904,12 +904,7 @@ func todoFromGenerated(gt generated.Todo) Todo {
 	// distinction the same way as CompletionSubscribers: the API always
 	// sends the array, so a server-sent [] becomes a non-nil zero-length
 	// slice and an absent property stays nil.
-	if gt.DescriptionAttachments != nil {
-		t.DescriptionAttachments = make([]RichTextAttachment, 0, len(gt.DescriptionAttachments))
-		for _, ga := range gt.DescriptionAttachments {
-			t.DescriptionAttachments = append(t.DescriptionAttachments, richTextAttachmentFromGenerated(ga))
-		}
-	}
+	t.DescriptionAttachments = richTextAttachmentsFromGenerated(gt.DescriptionAttachments)
 
 	// BC5: convert embedded steps
 	if len(gt.Steps) > 0 {
@@ -948,4 +943,21 @@ func richTextAttachmentFromGenerated(ga generated.RichTextAttachment) RichTextAt
 		a.Height = &h
 	}
 	return a
+}
+
+// richTextAttachmentsFromGenerated converts a slice of generated
+// RichTextAttachment to the public type, preserving the nil-vs-empty
+// distinction the API relies on: a nil input (the property was absent) stays
+// nil, and a non-nil input (server-sent, possibly empty) becomes a non-nil
+// slice of the same length. Shared by every resource that pairs a rich text
+// attribute with a companion attachments array.
+func richTextAttachmentsFromGenerated(gas []generated.RichTextAttachment) []RichTextAttachment {
+	if gas == nil {
+		return nil
+	}
+	attachments := make([]RichTextAttachment, 0, len(gas))
+	for _, ga := range gas {
+		attachments = append(attachments, richTextAttachmentFromGenerated(ga))
+	}
+	return attachments
 }

--- a/go/pkg/basecamp/todos.go
+++ b/go/pkg/basecamp/todos.go
@@ -37,7 +37,7 @@ type Todo struct {
 	// embedded in the rich text Description. @required — the API always sends this
 	// array (empty when the description has no inline files). No omitempty, so on
 	// marshal a non-nil slice emits its elements ([] when empty) and a nil
-	// slice (only from manual construction) emits null; the key is never
+	// slice emits null; the key is never
 	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
 	// RichTextAttachment.
 	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`

--- a/go/pkg/basecamp/todos.go
+++ b/go/pkg/basecamp/todos.go
@@ -33,14 +33,13 @@ type Todo struct {
 	Creator          *Person   `json:"creator,omitempty"`
 	Content          string    `json:"content"`
 	Description      string    `json:"description"`
-	// DescriptionAttachments holds structured metadata for the
-	// downloadable files embedded in the rich text Description. Like
-	// CompletionSubscribers it distinguishes present-but-empty from
-	// absent: the API always sends this array (empty when the description
-	// has no inline files), so a non-nil zero-length slice means an empty
-	// list and nil means the property was absent. Deliberately not
-	// omitempty so re-encoding keeps the field visible either way (nil
-	// marshals as null, empty as []) instead of dropping it.
+	// DescriptionAttachments holds structured metadata for the downloadable files
+	// embedded in the rich text Description. @required — the API always sends this
+	// array (empty when the description has no inline files). No omitempty, so on
+	// marshal a non-nil slice emits its elements ([] when empty) and a nil
+	// slice (only from manual construction) emits null; the key is never
+	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
+	// RichTextAttachment.
 	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`
 	StartsOn               string               `json:"starts_on,omitempty"`
 	DueOn                  string               `json:"due_on,omitempty"`

--- a/go/pkg/basecamp/todos.go
+++ b/go/pkg/basecamp/todos.go
@@ -961,3 +961,18 @@ func richTextAttachmentsFromGenerated(gas []generated.RichTextAttachment) []Rich
 	}
 	return attachments
 }
+
+// richTextAttachmentsPtrFromGenerated is the pointer-to-slice variant used by
+// the optional rich text companion arrays on the polymorphic projections
+// (SearchResult, Recording). A nil input (the property was absent) yields a nil
+// pointer so re-encoding omits the key; a non-nil input (server-sent, possibly
+// empty) yields a non-nil pointer so a present-but-empty array re-encodes as []
+// rather than collapsing into absence. This keeps all three wire states —
+// absent, present-empty, populated — distinguishable in both directions.
+func richTextAttachmentsPtrFromGenerated(gas []generated.RichTextAttachment) *[]RichTextAttachment {
+	if gas == nil {
+		return nil
+	}
+	attachments := richTextAttachmentsFromGenerated(gas)
+	return &attachments
+}

--- a/go/pkg/basecamp/vaults.go
+++ b/go/pkg/basecamp/vaults.go
@@ -118,6 +118,11 @@ type Document struct {
 	Bucket           *Bucket   `json:"bucket,omitempty"`
 	Creator          *Person   `json:"creator,omitempty"`
 	Content          string    `json:"content"`
+	// ContentAttachments holds structured metadata for the downloadable files
+	// embedded in the rich text Content. Always sent by the API (empty when
+	// none); not omitempty so absent (nil) vs empty ([]) survives re-encoding.
+	// See RichTextAttachment.
+	ContentAttachments []RichTextAttachment `json:"content_attachments"`
 }
 
 // Upload represents a Basecamp uploaded file in a vault.
@@ -143,12 +148,17 @@ type Upload struct {
 	Bucket           *Bucket   `json:"bucket,omitempty"`
 	Creator          *Person   `json:"creator,omitempty"`
 	Description      string    `json:"description"`
-	ContentType      string    `json:"content_type"`
-	ByteSize         int64     `json:"byte_size"`
-	Width            int       `json:"width,omitempty"`
-	Height           int       `json:"height,omitempty"`
-	DownloadURL      string    `json:"download_url"`
-	Filename         string    `json:"filename"`
+	// DescriptionAttachments holds structured metadata for the downloadable
+	// files embedded in the rich text Description. Always sent by the API
+	// (empty when none); not omitempty so absent (nil) vs empty ([]) survives
+	// re-encoding. See RichTextAttachment.
+	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`
+	ContentType            string               `json:"content_type"`
+	ByteSize               int64                `json:"byte_size"`
+	Width                  int                  `json:"width,omitempty"`
+	Height                 int                  `json:"height,omitempty"`
+	DownloadURL            string               `json:"download_url"`
+	Filename               string               `json:"filename"`
 }
 
 // UnmarshalJSON decodes an Upload from JSON, handling the BC3 API's
@@ -1163,6 +1173,8 @@ func documentFromGenerated(gd generated.Document) Document {
 		d.Creator = &creator
 	}
 
+	d.ContentAttachments = richTextAttachmentsFromGenerated(gd.ContentAttachments)
+
 	return d
 }
 
@@ -1220,6 +1232,8 @@ func uploadFromGenerated(gu generated.Upload) Upload {
 		creator := personFromGenerated(gu.Creator)
 		u.Creator = &creator
 	}
+
+	u.DescriptionAttachments = richTextAttachmentsFromGenerated(gu.DescriptionAttachments)
 
 	return u
 }

--- a/go/pkg/basecamp/vaults.go
+++ b/go/pkg/basecamp/vaults.go
@@ -119,9 +119,12 @@ type Document struct {
 	Creator          *Person   `json:"creator,omitempty"`
 	Content          string    `json:"content"`
 	// ContentAttachments holds structured metadata for the downloadable files
-	// embedded in the rich text Content. Always sent by the API (empty when
-	// none); not omitempty so absent (nil) vs empty ([]) survives re-encoding.
-	// See RichTextAttachment.
+	// embedded in the rich text Content. @required — the API always sends this
+	// array (empty when the content has no inline files). No omitempty, so on
+	// marshal a non-nil slice emits its elements ([] when empty) and a nil
+	// slice (only from manual construction) emits null; the key is never
+	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
+	// RichTextAttachment.
 	ContentAttachments []RichTextAttachment `json:"content_attachments"`
 }
 
@@ -148,10 +151,13 @@ type Upload struct {
 	Bucket           *Bucket   `json:"bucket,omitempty"`
 	Creator          *Person   `json:"creator,omitempty"`
 	Description      string    `json:"description"`
-	// DescriptionAttachments holds structured metadata for the downloadable
-	// files embedded in the rich text Description. Always sent by the API
-	// (empty when none); not omitempty so absent (nil) vs empty ([]) survives
-	// re-encoding. See RichTextAttachment.
+	// DescriptionAttachments holds structured metadata for the downloadable files
+	// embedded in the rich text Description. @required — the API always sends this
+	// array (empty when the description has no inline files). No omitempty, so on
+	// marshal a non-nil slice emits its elements ([] when empty) and a nil
+	// slice (only from manual construction) emits null; the key is never
+	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
+	// RichTextAttachment.
 	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`
 	ContentType            string               `json:"content_type"`
 	ByteSize               int64                `json:"byte_size"`

--- a/go/pkg/basecamp/vaults.go
+++ b/go/pkg/basecamp/vaults.go
@@ -122,7 +122,7 @@ type Document struct {
 	// embedded in the rich text Content. @required — the API always sends this
 	// array (empty when the content has no inline files). No omitempty, so on
 	// marshal a non-nil slice emits its elements ([] when empty) and a nil
-	// slice (only from manual construction) emits null; the key is never
+	// slice emits null; the key is never
 	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
 	// RichTextAttachment.
 	ContentAttachments []RichTextAttachment `json:"content_attachments"`
@@ -155,7 +155,7 @@ type Upload struct {
 	// embedded in the rich text Description. @required — the API always sends this
 	// array (empty when the description has no inline files). No omitempty, so on
 	// marshal a non-nil slice emits its elements ([] when empty) and a nil
-	// slice (only from manual construction) emits null; the key is never
+	// slice emits null; the key is never
 	// dropped. Decode distinguishes a server-sent [] (non-nil) from nil. See
 	// RichTextAttachment.
 	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`

--- a/go/pkg/basecamp/vaults_test.go
+++ b/go/pkg/basecamp/vaults_test.go
@@ -517,6 +517,35 @@ func TestUpload_UnmarshalGet(t *testing.T) {
 	if upload.Creator.Name != "Victor Cooper" {
 		t.Errorf("expected Creator.Name 'Victor Cooper', got %q", upload.Creator.Name)
 	}
+
+	// DescriptionAttachments: the two-entry representative decodes through
+	// Upload's custom UnmarshalJSON (which delegates to uploadFromGenerated),
+	// so the generated FlexInt dimensions narrow into *int32. The image carries
+	// a float-spelled dimension (1024.0 -> 1024); the non-image blob carries
+	// null dimensions (-> nil).
+	if len(upload.DescriptionAttachments) != 2 {
+		t.Fatalf("expected 2 description attachments, got %d", len(upload.DescriptionAttachments))
+	}
+	img := upload.DescriptionAttachments[0]
+	if img.ID != 1069480020 {
+		t.Errorf("expected image attachment ID 1069480020, got %d", img.ID)
+	}
+	if img.Filename != "brand-guide.png" || img.ContentType != "image/png" {
+		t.Errorf("unexpected image attachment: %+v", img)
+	}
+	if img.Width == nil || *img.Width != 1024 {
+		t.Errorf("expected image Width 1024 (float-spelled 1024.0), got %v", img.Width)
+	}
+	if img.Height == nil || *img.Height != 768 {
+		t.Errorf("expected image Height 768, got %v", img.Height)
+	}
+	blob := upload.DescriptionAttachments[1]
+	if blob.ID != 1069480021 || blob.ContentType != "application/pdf" {
+		t.Errorf("unexpected blob attachment: %+v", blob)
+	}
+	if blob.Width != nil || blob.Height != nil {
+		t.Errorf("expected nil dimensions for non-image blob, got width=%v height=%v", blob.Width, blob.Height)
+	}
 }
 
 func TestUpload_UnmarshalList(t *testing.T) {

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -193,36 +193,37 @@ type CampfireLineAttachment struct {
 
 // Card defines model for Card.
 type Card struct {
-	AppUrl                string          `json:"app_url"`
-	Assignees             []Person        `json:"assignees,omitempty"`
-	BookmarkUrl           string          `json:"bookmark_url,omitempty"`
-	BoostsCount           int32           `json:"boosts_count,omitempty"`
-	BoostsUrl             string          `json:"boosts_url,omitempty"`
-	Bucket                TodoBucket      `json:"bucket"`
-	CommentsCount         int32           `json:"comments_count,omitempty"`
-	CommentsUrl           string          `json:"comments_url,omitempty"`
-	Completed             bool            `json:"completed,omitempty"`
-	CompletedAt           time.Time       `json:"completed_at,omitempty"`
-	Completer             Person          `json:"completer,omitempty"`
-	CompletionSubscribers []Person        `json:"completion_subscribers,omitempty"`
-	CompletionUrl         string          `json:"completion_url,omitempty"`
-	Content               string          `json:"content,omitempty"`
-	CreatedAt             time.Time       `json:"created_at"`
-	Creator               Person          `json:"creator"`
-	Description           string          `json:"description,omitempty"`
-	DueOn                 types.Date      `json:"due_on,omitempty"`
-	Id                    int64           `json:"id"`
-	InheritsStatus        bool            `json:"inherits_status"`
-	Parent                RecordingParent `json:"parent"`
-	Position              int32           `json:"position,omitempty"`
-	Status                string          `json:"status"`
-	Steps                 []CardStep      `json:"steps,omitempty"`
-	SubscriptionUrl       string          `json:"subscription_url,omitempty"`
-	Title                 string          `json:"title"`
-	Type                  string          `json:"type"`
-	UpdatedAt             time.Time       `json:"updated_at"`
-	Url                   string          `json:"url"`
-	VisibleToClients      bool            `json:"visible_to_clients"`
+	AppUrl                 string               `json:"app_url"`
+	Assignees              []Person             `json:"assignees,omitempty"`
+	BookmarkUrl            string               `json:"bookmark_url,omitempty"`
+	BoostsCount            int32                `json:"boosts_count,omitempty"`
+	BoostsUrl              string               `json:"boosts_url,omitempty"`
+	Bucket                 TodoBucket           `json:"bucket"`
+	CommentsCount          int32                `json:"comments_count,omitempty"`
+	CommentsUrl            string               `json:"comments_url,omitempty"`
+	Completed              bool                 `json:"completed,omitempty"`
+	CompletedAt            time.Time            `json:"completed_at,omitempty"`
+	Completer              Person               `json:"completer,omitempty"`
+	CompletionSubscribers  []Person             `json:"completion_subscribers,omitempty"`
+	CompletionUrl          string               `json:"completion_url,omitempty"`
+	Content                string               `json:"content,omitempty"`
+	CreatedAt              time.Time            `json:"created_at"`
+	Creator                Person               `json:"creator"`
+	Description            string               `json:"description,omitempty"`
+	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`
+	DueOn                  types.Date           `json:"due_on,omitempty"`
+	Id                     int64                `json:"id"`
+	InheritsStatus         bool                 `json:"inherits_status"`
+	Parent                 RecordingParent      `json:"parent"`
+	Position               int32                `json:"position,omitempty"`
+	Status                 string               `json:"status"`
+	Steps                  []CardStep           `json:"steps,omitempty"`
+	SubscriptionUrl        string               `json:"subscription_url,omitempty"`
+	Title                  string               `json:"title"`
+	Type                   string               `json:"type"`
+	UpdatedAt              time.Time            `json:"updated_at"`
+	Url                    string               `json:"url"`
+	VisibleToClients       bool                 `json:"visible_to_clients"`
 }
 
 // CardColumn defines model for CardColumn.
@@ -322,29 +323,30 @@ type Chatbot struct {
 
 // ClientApproval defines model for ClientApproval.
 type ClientApproval struct {
-	AppUrl           string                   `json:"app_url"`
-	ApprovalStatus   string                   `json:"approval_status,omitempty"`
-	Approver         Person                   `json:"approver,omitempty"`
-	BookmarkUrl      string                   `json:"bookmark_url,omitempty"`
-	Bucket           RecordingBucket          `json:"bucket"`
-	Content          string                   `json:"content,omitempty"`
-	CreatedAt        time.Time                `json:"created_at"`
-	Creator          Person                   `json:"creator"`
-	DueOn            types.Date               `json:"due_on,omitempty"`
-	Id               int64                    `json:"id"`
-	InheritsStatus   bool                     `json:"inherits_status"`
-	Parent           RecordingParent          `json:"parent"`
-	RepliesCount     int32                    `json:"replies_count,omitempty"`
-	RepliesUrl       string                   `json:"replies_url,omitempty"`
-	Responses        []ClientApprovalResponse `json:"responses,omitempty"`
-	Status           string                   `json:"status"`
-	Subject          string                   `json:"subject,omitempty"`
-	SubscriptionUrl  string                   `json:"subscription_url,omitempty"`
-	Title            string                   `json:"title"`
-	Type             string                   `json:"type"`
-	UpdatedAt        time.Time                `json:"updated_at"`
-	Url              string                   `json:"url"`
-	VisibleToClients bool                     `json:"visible_to_clients"`
+	AppUrl             string                   `json:"app_url"`
+	ApprovalStatus     string                   `json:"approval_status,omitempty"`
+	Approver           Person                   `json:"approver,omitempty"`
+	BookmarkUrl        string                   `json:"bookmark_url,omitempty"`
+	Bucket             RecordingBucket          `json:"bucket"`
+	Content            string                   `json:"content,omitempty"`
+	ContentAttachments []RichTextAttachment     `json:"content_attachments"`
+	CreatedAt          time.Time                `json:"created_at"`
+	Creator            Person                   `json:"creator"`
+	DueOn              types.Date               `json:"due_on,omitempty"`
+	Id                 int64                    `json:"id"`
+	InheritsStatus     bool                     `json:"inherits_status"`
+	Parent             RecordingParent          `json:"parent"`
+	RepliesCount       int32                    `json:"replies_count,omitempty"`
+	RepliesUrl         string                   `json:"replies_url,omitempty"`
+	Responses          []ClientApprovalResponse `json:"responses,omitempty"`
+	Status             string                   `json:"status"`
+	Subject            string                   `json:"subject,omitempty"`
+	SubscriptionUrl    string                   `json:"subscription_url,omitempty"`
+	Title              string                   `json:"title"`
+	Type               string                   `json:"type"`
+	UpdatedAt          time.Time                `json:"updated_at"`
+	Url                string                   `json:"url"`
+	VisibleToClients   bool                     `json:"visible_to_clients"`
 }
 
 // ClientApprovalResponse defines model for ClientApprovalResponse.
@@ -374,44 +376,46 @@ type ClientCompany struct {
 
 // ClientCorrespondence defines model for ClientCorrespondence.
 type ClientCorrespondence struct {
-	AppUrl           string          `json:"app_url"`
-	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	Bucket           RecordingBucket `json:"bucket"`
-	Content          string          `json:"content,omitempty"`
-	CreatedAt        time.Time       `json:"created_at"`
-	Creator          Person          `json:"creator"`
-	Id               int64           `json:"id"`
-	InheritsStatus   bool            `json:"inherits_status"`
-	Parent           RecordingParent `json:"parent"`
-	RepliesCount     int32           `json:"replies_count,omitempty"`
-	RepliesUrl       string          `json:"replies_url,omitempty"`
-	Status           string          `json:"status"`
-	Subject          string          `json:"subject"`
-	SubscriptionUrl  string          `json:"subscription_url,omitempty"`
-	Title            string          `json:"title"`
-	Type             string          `json:"type"`
-	UpdatedAt        time.Time       `json:"updated_at"`
-	Url              string          `json:"url"`
-	VisibleToClients bool            `json:"visible_to_clients"`
+	AppUrl             string               `json:"app_url"`
+	BookmarkUrl        string               `json:"bookmark_url,omitempty"`
+	Bucket             RecordingBucket      `json:"bucket"`
+	Content            string               `json:"content,omitempty"`
+	ContentAttachments []RichTextAttachment `json:"content_attachments"`
+	CreatedAt          time.Time            `json:"created_at"`
+	Creator            Person               `json:"creator"`
+	Id                 int64                `json:"id"`
+	InheritsStatus     bool                 `json:"inherits_status"`
+	Parent             RecordingParent      `json:"parent"`
+	RepliesCount       int32                `json:"replies_count,omitempty"`
+	RepliesUrl         string               `json:"replies_url,omitempty"`
+	Status             string               `json:"status"`
+	Subject            string               `json:"subject"`
+	SubscriptionUrl    string               `json:"subscription_url,omitempty"`
+	Title              string               `json:"title"`
+	Type               string               `json:"type"`
+	UpdatedAt          time.Time            `json:"updated_at"`
+	Url                string               `json:"url"`
+	VisibleToClients   bool                 `json:"visible_to_clients"`
 }
 
 // ClientReply defines model for ClientReply.
 type ClientReply struct {
-	AppUrl           string          `json:"app_url"`
-	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	Bucket           RecordingBucket `json:"bucket"`
-	Content          string          `json:"content"`
-	CreatedAt        time.Time       `json:"created_at"`
-	Creator          Person          `json:"creator"`
-	Id               int64           `json:"id"`
-	InheritsStatus   bool            `json:"inherits_status"`
-	Parent           RecordingParent `json:"parent"`
-	Status           string          `json:"status"`
-	Title            string          `json:"title"`
-	Type             string          `json:"type"`
-	UpdatedAt        time.Time       `json:"updated_at"`
-	Url              string          `json:"url"`
-	VisibleToClients bool            `json:"visible_to_clients"`
+	AppUrl             string               `json:"app_url"`
+	BookmarkUrl        string               `json:"bookmark_url,omitempty"`
+	Bucket             RecordingBucket      `json:"bucket"`
+	Content            string               `json:"content"`
+	ContentAttachments []RichTextAttachment `json:"content_attachments"`
+	CreatedAt          time.Time            `json:"created_at"`
+	Creator            Person               `json:"creator"`
+	Id                 int64                `json:"id"`
+	InheritsStatus     bool                 `json:"inherits_status"`
+	Parent             RecordingParent      `json:"parent"`
+	Status             string               `json:"status"`
+	Title              string               `json:"title"`
+	Type               string               `json:"type"`
+	UpdatedAt          time.Time            `json:"updated_at"`
+	Url                string               `json:"url"`
+	VisibleToClients   bool                 `json:"visible_to_clients"`
 }
 
 // ClientSide This shape is deprecated since 2024-01: Use Client Visibility feature instead
@@ -422,23 +426,24 @@ type ClientSide struct {
 
 // Comment defines model for Comment.
 type Comment struct {
-	AppUrl           string          `json:"app_url"`
-	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	BoostsCount      int32           `json:"boosts_count,omitempty"`
-	BoostsUrl        string          `json:"boosts_url,omitempty"`
-	Bucket           TodoBucket      `json:"bucket"`
-	Content          string          `json:"content"`
-	CreatedAt        time.Time       `json:"created_at"`
-	Creator          Person          `json:"creator"`
-	Id               int64           `json:"id"`
-	InheritsStatus   bool            `json:"inherits_status"`
-	Parent           RecordingParent `json:"parent"`
-	Status           string          `json:"status"`
-	Title            string          `json:"title"`
-	Type             string          `json:"type"`
-	UpdatedAt        time.Time       `json:"updated_at"`
-	Url              string          `json:"url"`
-	VisibleToClients bool            `json:"visible_to_clients"`
+	AppUrl             string               `json:"app_url"`
+	BookmarkUrl        string               `json:"bookmark_url,omitempty"`
+	BoostsCount        int32                `json:"boosts_count,omitempty"`
+	BoostsUrl          string               `json:"boosts_url,omitempty"`
+	Bucket             TodoBucket           `json:"bucket"`
+	Content            string               `json:"content"`
+	ContentAttachments []RichTextAttachment `json:"content_attachments"`
+	CreatedAt          time.Time            `json:"created_at"`
+	Creator            Person               `json:"creator"`
+	Id                 int64                `json:"id"`
+	InheritsStatus     bool                 `json:"inherits_status"`
+	Parent             RecordingParent      `json:"parent"`
+	Status             string               `json:"status"`
+	Title              string               `json:"title"`
+	Type               string               `json:"type"`
+	UpdatedAt          time.Time            `json:"updated_at"`
+	Url                string               `json:"url"`
+	VisibleToClients   bool                 `json:"visible_to_clients"`
 }
 
 // CreateAnswerResponseContent defines model for CreateAnswerResponseContent.
@@ -758,27 +763,28 @@ type DockItem struct {
 
 // Document defines model for Document.
 type Document struct {
-	AppUrl           string          `json:"app_url"`
-	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	BoostsCount      int32           `json:"boosts_count,omitempty"`
-	BoostsUrl        string          `json:"boosts_url,omitempty"`
-	Bucket           TodoBucket      `json:"bucket"`
-	CommentsCount    int32           `json:"comments_count,omitempty"`
-	CommentsUrl      string          `json:"comments_url,omitempty"`
-	Content          string          `json:"content,omitempty"`
-	CreatedAt        time.Time       `json:"created_at"`
-	Creator          Person          `json:"creator"`
-	Id               int64           `json:"id"`
-	InheritsStatus   bool            `json:"inherits_status"`
-	Parent           RecordingParent `json:"parent"`
-	Position         int32           `json:"position,omitempty"`
-	Status           string          `json:"status"`
-	SubscriptionUrl  string          `json:"subscription_url,omitempty"`
-	Title            string          `json:"title"`
-	Type             string          `json:"type"`
-	UpdatedAt        time.Time       `json:"updated_at"`
-	Url              string          `json:"url"`
-	VisibleToClients bool            `json:"visible_to_clients"`
+	AppUrl             string               `json:"app_url"`
+	BookmarkUrl        string               `json:"bookmark_url,omitempty"`
+	BoostsCount        int32                `json:"boosts_count,omitempty"`
+	BoostsUrl          string               `json:"boosts_url,omitempty"`
+	Bucket             TodoBucket           `json:"bucket"`
+	CommentsCount      int32                `json:"comments_count,omitempty"`
+	CommentsUrl        string               `json:"comments_url,omitempty"`
+	Content            string               `json:"content,omitempty"`
+	ContentAttachments []RichTextAttachment `json:"content_attachments"`
+	CreatedAt          time.Time            `json:"created_at"`
+	Creator            Person               `json:"creator"`
+	Id                 int64                `json:"id"`
+	InheritsStatus     bool                 `json:"inherits_status"`
+	Parent             RecordingParent      `json:"parent"`
+	Position           int32                `json:"position,omitempty"`
+	Status             string               `json:"status"`
+	SubscriptionUrl    string               `json:"subscription_url,omitempty"`
+	Title              string               `json:"title"`
+	Type               string               `json:"type"`
+	UpdatedAt          time.Time            `json:"updated_at"`
+	Url                string               `json:"url"`
+	VisibleToClients   bool                 `json:"visible_to_clients"`
 }
 
 // EnableCardColumnOnHoldResponseContent defines model for EnableCardColumnOnHoldResponseContent.
@@ -823,95 +829,104 @@ type ForbiddenErrorResponseContent struct {
 
 // Forward defines model for Forward.
 type Forward struct {
-	AppUrl           string          `json:"app_url"`
-	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	Bucket           TodoBucket      `json:"bucket"`
-	Content          string          `json:"content,omitempty"`
-	CreatedAt        time.Time       `json:"created_at"`
-	Creator          Person          `json:"creator"`
-	From             string          `json:"from,omitempty"`
-	Id               int64           `json:"id"`
-	InheritsStatus   bool            `json:"inherits_status"`
-	Parent           RecordingParent `json:"parent"`
-	RepliesCount     int32           `json:"replies_count,omitempty"`
-	RepliesUrl       string          `json:"replies_url,omitempty"`
-	Status           string          `json:"status"`
-	Subject          string          `json:"subject"`
-	SubscriptionUrl  string          `json:"subscription_url,omitempty"`
-	Title            string          `json:"title"`
-	Type             string          `json:"type"`
-	UpdatedAt        time.Time       `json:"updated_at"`
-	Url              string          `json:"url"`
-	VisibleToClients bool            `json:"visible_to_clients"`
+	AppUrl             string               `json:"app_url"`
+	BookmarkUrl        string               `json:"bookmark_url,omitempty"`
+	Bucket             TodoBucket           `json:"bucket"`
+	Content            string               `json:"content,omitempty"`
+	ContentAttachments []RichTextAttachment `json:"content_attachments"`
+	CreatedAt          time.Time            `json:"created_at"`
+	Creator            Person               `json:"creator"`
+	From               string               `json:"from,omitempty"`
+	Id                 int64                `json:"id"`
+	InheritsStatus     bool                 `json:"inherits_status"`
+	Parent             RecordingParent      `json:"parent"`
+	RepliesCount       int32                `json:"replies_count,omitempty"`
+	RepliesUrl         string               `json:"replies_url,omitempty"`
+	Status             string               `json:"status"`
+	Subject            string               `json:"subject"`
+	SubscriptionUrl    string               `json:"subscription_url,omitempty"`
+	Title              string               `json:"title"`
+	Type               string               `json:"type"`
+	UpdatedAt          time.Time            `json:"updated_at"`
+	Url                string               `json:"url"`
+	VisibleToClients   bool                 `json:"visible_to_clients"`
 }
 
 // ForwardReply defines model for ForwardReply.
 type ForwardReply struct {
-	AppUrl           string          `json:"app_url"`
-	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	BoostsCount      int32           `json:"boosts_count,omitempty"`
-	BoostsUrl        string          `json:"boosts_url,omitempty"`
-	Bucket           TodoBucket      `json:"bucket"`
-	Content          string          `json:"content"`
-	CreatedAt        time.Time       `json:"created_at"`
-	Creator          Person          `json:"creator"`
-	Id               int64           `json:"id"`
-	InheritsStatus   bool            `json:"inherits_status"`
-	Parent           RecordingParent `json:"parent"`
-	Status           string          `json:"status"`
-	Title            string          `json:"title"`
-	Type             string          `json:"type"`
-	UpdatedAt        time.Time       `json:"updated_at"`
-	Url              string          `json:"url"`
-	VisibleToClients bool            `json:"visible_to_clients"`
+	AppUrl             string               `json:"app_url"`
+	BookmarkUrl        string               `json:"bookmark_url,omitempty"`
+	BoostsCount        int32                `json:"boosts_count,omitempty"`
+	BoostsUrl          string               `json:"boosts_url,omitempty"`
+	Bucket             TodoBucket           `json:"bucket"`
+	Content            string               `json:"content"`
+	ContentAttachments []RichTextAttachment `json:"content_attachments"`
+	CreatedAt          time.Time            `json:"created_at"`
+	Creator            Person               `json:"creator"`
+	Id                 int64                `json:"id"`
+	InheritsStatus     bool                 `json:"inherits_status"`
+	Parent             RecordingParent      `json:"parent"`
+	Status             string               `json:"status"`
+	Title              string               `json:"title"`
+	Type               string               `json:"type"`
+	UpdatedAt          time.Time            `json:"updated_at"`
+	Url                string               `json:"url"`
+	VisibleToClients   bool                 `json:"visible_to_clients"`
 }
 
 // Gauge defines model for Gauge.
 type Gauge struct {
-	AppUrl                 string          `json:"app_url,omitempty"`
-	BookmarkUrl            string          `json:"bookmark_url,omitempty"`
-	Bucket                 RecordingBucket `json:"bucket,omitempty"`
-	CreatedAt              time.Time       `json:"created_at"`
-	Creator                Person          `json:"creator,omitempty"`
-	Description            string          `json:"description,omitempty"`
-	Enabled                bool            `json:"enabled,omitempty"`
-	Id                     int64           `json:"id"`
-	InheritsStatus         bool            `json:"inherits_status,omitempty"`
-	LastNeedleColor        string          `json:"last_needle_color,omitempty"`
-	LastNeedlePosition     int32           `json:"last_needle_position,omitempty"`
-	PreviousNeedlePosition int32           `json:"previous_needle_position,omitempty"`
-	Status                 string          `json:"status,omitempty"`
-	Title                  string          `json:"title,omitempty"`
-	Type                   string          `json:"type,omitempty"`
-	UpdatedAt              time.Time       `json:"updated_at"`
-	Url                    string          `json:"url,omitempty"`
-	VisibleToClients       bool            `json:"visible_to_clients,omitempty"`
+	AppUrl      string          `json:"app_url,omitempty"`
+	BookmarkUrl string          `json:"bookmark_url,omitempty"`
+	Bucket      RecordingBucket `json:"bucket,omitempty"`
+	CreatedAt   time.Time       `json:"created_at"`
+	Creator     Person          `json:"creator,omitempty"`
+	Description string          `json:"description,omitempty"`
+
+	// DescriptionAttachments Optional (no `@required`): the type-specific partial renders the
+	// companion array only when the gauge has needles (bc3 `if
+	// gauge.any_needles?`), so a needle-less gauge omits the key entirely.
+	// Non-nullable — never served as JSON `null`.
+	DescriptionAttachments []RichTextAttachment `json:"description_attachments,omitempty"`
+	Enabled                bool                 `json:"enabled,omitempty"`
+	Id                     int64                `json:"id"`
+	InheritsStatus         bool                 `json:"inherits_status,omitempty"`
+	LastNeedleColor        string               `json:"last_needle_color,omitempty"`
+	LastNeedlePosition     int32                `json:"last_needle_position,omitempty"`
+	PreviousNeedlePosition int32                `json:"previous_needle_position,omitempty"`
+	Status                 string               `json:"status,omitempty"`
+	Title                  string               `json:"title,omitempty"`
+	Type                   string               `json:"type,omitempty"`
+	UpdatedAt              time.Time            `json:"updated_at"`
+	Url                    string               `json:"url,omitempty"`
+	VisibleToClients       bool                 `json:"visible_to_clients,omitempty"`
 }
 
 // GaugeNeedle defines model for GaugeNeedle.
 type GaugeNeedle struct {
-	AppUrl           string          `json:"app_url,omitempty"`
-	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	BoostsCount      int32           `json:"boosts_count,omitempty"`
-	BoostsUrl        string          `json:"boosts_url,omitempty"`
-	Bucket           RecordingBucket `json:"bucket,omitempty"`
-	Color            string          `json:"color,omitempty"`
-	CommentsCount    int32           `json:"comments_count,omitempty"`
-	CommentsUrl      string          `json:"comments_url,omitempty"`
-	CreatedAt        time.Time       `json:"created_at"`
-	Creator          Person          `json:"creator,omitempty"`
-	Description      string          `json:"description,omitempty"`
-	Id               int64           `json:"id"`
-	InheritsStatus   bool            `json:"inherits_status,omitempty"`
-	Parent           RecordingParent `json:"parent,omitempty"`
-	Position         int32           `json:"position,omitempty"`
-	Status           string          `json:"status,omitempty"`
-	SubscriptionUrl  string          `json:"subscription_url,omitempty"`
-	Title            string          `json:"title,omitempty"`
-	Type             string          `json:"type,omitempty"`
-	UpdatedAt        time.Time       `json:"updated_at"`
-	Url              string          `json:"url,omitempty"`
-	VisibleToClients bool            `json:"visible_to_clients,omitempty"`
+	AppUrl                 string               `json:"app_url,omitempty"`
+	BookmarkUrl            string               `json:"bookmark_url,omitempty"`
+	BoostsCount            int32                `json:"boosts_count,omitempty"`
+	BoostsUrl              string               `json:"boosts_url,omitempty"`
+	Bucket                 RecordingBucket      `json:"bucket,omitempty"`
+	Color                  string               `json:"color,omitempty"`
+	CommentsCount          int32                `json:"comments_count,omitempty"`
+	CommentsUrl            string               `json:"comments_url,omitempty"`
+	CreatedAt              time.Time            `json:"created_at"`
+	Creator                Person               `json:"creator,omitempty"`
+	Description            string               `json:"description,omitempty"`
+	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`
+	Id                     int64                `json:"id"`
+	InheritsStatus         bool                 `json:"inherits_status,omitempty"`
+	Parent                 RecordingParent      `json:"parent,omitempty"`
+	Position               int32                `json:"position,omitempty"`
+	Status                 string               `json:"status,omitempty"`
+	SubscriptionUrl        string               `json:"subscription_url,omitempty"`
+	Title                  string               `json:"title,omitempty"`
+	Type                   string               `json:"type,omitempty"`
+	UpdatedAt              time.Time            `json:"updated_at"`
+	Url                    string               `json:"url,omitempty"`
+	VisibleToClients       bool                 `json:"visible_to_clients,omitempty"`
 }
 
 // GaugeNeedlePayload defines model for GaugeNeedlePayload.
@@ -1336,28 +1351,29 @@ type MarkAsReadRequestContent struct {
 
 // Message defines model for Message.
 type Message struct {
-	AppUrl           string          `json:"app_url"`
-	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	BoostsCount      int32           `json:"boosts_count,omitempty"`
-	BoostsUrl        string          `json:"boosts_url,omitempty"`
-	Bucket           TodoBucket      `json:"bucket"`
-	Category         MessageType     `json:"category,omitempty"`
-	CommentsCount    int32           `json:"comments_count,omitempty"`
-	CommentsUrl      string          `json:"comments_url,omitempty"`
-	Content          string          `json:"content"`
-	CreatedAt        time.Time       `json:"created_at"`
-	Creator          Person          `json:"creator"`
-	Id               int64           `json:"id"`
-	InheritsStatus   bool            `json:"inherits_status"`
-	Parent           RecordingParent `json:"parent"`
-	Status           string          `json:"status"`
-	Subject          string          `json:"subject"`
-	SubscriptionUrl  string          `json:"subscription_url,omitempty"`
-	Title            string          `json:"title"`
-	Type             string          `json:"type"`
-	UpdatedAt        time.Time       `json:"updated_at"`
-	Url              string          `json:"url"`
-	VisibleToClients bool            `json:"visible_to_clients"`
+	AppUrl             string               `json:"app_url"`
+	BookmarkUrl        string               `json:"bookmark_url,omitempty"`
+	BoostsCount        int32                `json:"boosts_count,omitempty"`
+	BoostsUrl          string               `json:"boosts_url,omitempty"`
+	Bucket             TodoBucket           `json:"bucket"`
+	Category           MessageType          `json:"category,omitempty"`
+	CommentsCount      int32                `json:"comments_count,omitempty"`
+	CommentsUrl        string               `json:"comments_url,omitempty"`
+	Content            string               `json:"content"`
+	ContentAttachments []RichTextAttachment `json:"content_attachments"`
+	CreatedAt          time.Time            `json:"created_at"`
+	Creator            Person               `json:"creator"`
+	Id                 int64                `json:"id"`
+	InheritsStatus     bool                 `json:"inherits_status"`
+	Parent             RecordingParent      `json:"parent"`
+	Status             string               `json:"status"`
+	Subject            string               `json:"subject"`
+	SubscriptionUrl    string               `json:"subscription_url,omitempty"`
+	Title              string               `json:"title"`
+	Type               string               `json:"type"`
+	UpdatedAt          time.Time            `json:"updated_at"`
+	Url                string               `json:"url"`
+	VisibleToClients   bool                 `json:"visible_to_clients"`
 }
 
 // MessageBoard defines model for MessageBoard.
@@ -1676,27 +1692,28 @@ type Question struct {
 
 // QuestionAnswer defines model for QuestionAnswer.
 type QuestionAnswer struct {
-	AppUrl           string          `json:"app_url"`
-	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	BoostsCount      int32           `json:"boosts_count,omitempty"`
-	BoostsUrl        string          `json:"boosts_url,omitempty"`
-	Bucket           RecordingBucket `json:"bucket"`
-	CommentsCount    int32           `json:"comments_count,omitempty"`
-	CommentsUrl      string          `json:"comments_url,omitempty"`
-	Content          string          `json:"content"`
-	CreatedAt        time.Time       `json:"created_at"`
-	Creator          Person          `json:"creator"`
-	GroupOn          types.Date      `json:"group_on,omitempty"`
-	Id               int64           `json:"id"`
-	InheritsStatus   bool            `json:"inherits_status"`
-	Parent           RecordingParent `json:"parent"`
-	Status           string          `json:"status"`
-	SubscriptionUrl  string          `json:"subscription_url,omitempty"`
-	Title            string          `json:"title"`
-	Type             string          `json:"type"`
-	UpdatedAt        time.Time       `json:"updated_at"`
-	Url              string          `json:"url"`
-	VisibleToClients bool            `json:"visible_to_clients"`
+	AppUrl             string               `json:"app_url"`
+	BookmarkUrl        string               `json:"bookmark_url,omitempty"`
+	BoostsCount        int32                `json:"boosts_count,omitempty"`
+	BoostsUrl          string               `json:"boosts_url,omitempty"`
+	Bucket             RecordingBucket      `json:"bucket"`
+	CommentsCount      int32                `json:"comments_count,omitempty"`
+	CommentsUrl        string               `json:"comments_url,omitempty"`
+	Content            string               `json:"content"`
+	ContentAttachments []RichTextAttachment `json:"content_attachments"`
+	CreatedAt          time.Time            `json:"created_at"`
+	Creator            Person               `json:"creator"`
+	GroupOn            types.Date           `json:"group_on,omitempty"`
+	Id                 int64                `json:"id"`
+	InheritsStatus     bool                 `json:"inherits_status"`
+	Parent             RecordingParent      `json:"parent"`
+	Status             string               `json:"status"`
+	SubscriptionUrl    string               `json:"subscription_url,omitempty"`
+	Title              string               `json:"title"`
+	Type               string               `json:"type"`
+	UpdatedAt          time.Time            `json:"updated_at"`
+	Url                string               `json:"url"`
+	VisibleToClients   bool                 `json:"visible_to_clients"`
 }
 
 // QuestionAnswerPayload defines model for QuestionAnswerPayload.
@@ -1761,24 +1778,36 @@ type RateLimitErrorResponseContent struct {
 
 // Recording defines model for Recording.
 type Recording struct {
-	AppUrl           string          `json:"app_url"`
-	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	Bucket           RecordingBucket `json:"bucket"`
-	CommentsCount    int32           `json:"comments_count,omitempty"`
-	CommentsUrl      string          `json:"comments_url,omitempty"`
-	Content          string          `json:"content,omitempty"`
-	CreatedAt        time.Time       `json:"created_at"`
-	Creator          Person          `json:"creator"`
-	Id               int64           `json:"id"`
-	InheritsStatus   bool            `json:"inherits_status"`
-	Parent           RecordingParent `json:"parent"`
-	Status           string          `json:"status"`
-	SubscriptionUrl  string          `json:"subscription_url,omitempty"`
-	Title            string          `json:"title"`
-	Type             string          `json:"type"`
-	UpdatedAt        time.Time       `json:"updated_at"`
-	Url              string          `json:"url"`
-	VisibleToClients bool            `json:"visible_to_clients"`
+	AppUrl        string          `json:"app_url"`
+	BookmarkUrl   string          `json:"bookmark_url,omitempty"`
+	Bucket        RecordingBucket `json:"bucket"`
+	CommentsCount int32           `json:"comments_count,omitempty"`
+	CommentsUrl   string          `json:"comments_url,omitempty"`
+	Content       string          `json:"content,omitempty"`
+
+	// ContentAttachments Rich-text companion arrays carried through the generic recording
+	// projection (`to_recordable_partial_path` renders the full type-specific
+	// partial). A given recording is one type, so it carries only the array
+	// matching its rich-text attribute (`content_attachments` for a
+	// Comment/Message, `description_attachments` for a Todo/Card); a
+	// webhook-sourced recording (base partial) carries neither. Optional (no
+	// `@required`), non-nullable.
+	ContentAttachments []RichTextAttachment `json:"content_attachments,omitempty"`
+	CreatedAt          time.Time            `json:"created_at"`
+	Creator            Person               `json:"creator"`
+
+	// DescriptionAttachments See `content_attachments` — the description-attribute companion array.
+	DescriptionAttachments []RichTextAttachment `json:"description_attachments,omitempty"`
+	Id                     int64                `json:"id"`
+	InheritsStatus         bool                 `json:"inherits_status"`
+	Parent                 RecordingParent      `json:"parent"`
+	Status                 string               `json:"status"`
+	SubscriptionUrl        string               `json:"subscription_url,omitempty"`
+	Title                  string               `json:"title"`
+	Type                   string               `json:"type"`
+	UpdatedAt              time.Time            `json:"updated_at"`
+	Url                    string               `json:"url"`
+	VisibleToClients       bool                 `json:"visible_to_clients"`
 }
 
 // RecordingBucket defines model for RecordingBucket.
@@ -1905,31 +1934,32 @@ type ScheduleAttributes struct {
 
 // ScheduleEntry defines model for ScheduleEntry.
 type ScheduleEntry struct {
-	AllDay           bool               `json:"all_day,omitempty"`
-	AppUrl           string             `json:"app_url"`
-	BookmarkUrl      string             `json:"bookmark_url,omitempty"`
-	BoostsCount      int32              `json:"boosts_count,omitempty"`
-	BoostsUrl        string             `json:"boosts_url,omitempty"`
-	Bucket           TodoBucket         `json:"bucket"`
-	CommentsCount    int32              `json:"comments_count,omitempty"`
-	CommentsUrl      string             `json:"comments_url,omitempty"`
-	CreatedAt        time.Time          `json:"created_at"`
-	Creator          Person             `json:"creator"`
-	Description      string             `json:"description,omitempty"`
-	EndsAt           types.FlexibleTime `json:"ends_at,omitempty"`
-	Id               int64              `json:"id"`
-	InheritsStatus   bool               `json:"inherits_status"`
-	Parent           RecordingParent    `json:"parent"`
-	Participants     []Person           `json:"participants,omitempty"`
-	StartsAt         types.FlexibleTime `json:"starts_at,omitempty"`
-	Status           string             `json:"status"`
-	SubscriptionUrl  string             `json:"subscription_url,omitempty"`
-	Summary          string             `json:"summary"`
-	Title            string             `json:"title"`
-	Type             string             `json:"type"`
-	UpdatedAt        time.Time          `json:"updated_at"`
-	Url              string             `json:"url"`
-	VisibleToClients bool               `json:"visible_to_clients"`
+	AllDay                 bool                 `json:"all_day,omitempty"`
+	AppUrl                 string               `json:"app_url"`
+	BookmarkUrl            string               `json:"bookmark_url,omitempty"`
+	BoostsCount            int32                `json:"boosts_count,omitempty"`
+	BoostsUrl              string               `json:"boosts_url,omitempty"`
+	Bucket                 TodoBucket           `json:"bucket"`
+	CommentsCount          int32                `json:"comments_count,omitempty"`
+	CommentsUrl            string               `json:"comments_url,omitempty"`
+	CreatedAt              time.Time            `json:"created_at"`
+	Creator                Person               `json:"creator"`
+	Description            string               `json:"description,omitempty"`
+	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`
+	EndsAt                 types.FlexibleTime   `json:"ends_at,omitempty"`
+	Id                     int64                `json:"id"`
+	InheritsStatus         bool                 `json:"inherits_status"`
+	Parent                 RecordingParent      `json:"parent"`
+	Participants           []Person             `json:"participants,omitempty"`
+	StartsAt               types.FlexibleTime   `json:"starts_at,omitempty"`
+	Status                 string               `json:"status"`
+	SubscriptionUrl        string               `json:"subscription_url,omitempty"`
+	Summary                string               `json:"summary"`
+	Title                  string               `json:"title"`
+	Type                   string               `json:"type"`
+	UpdatedAt              time.Time            `json:"updated_at"`
+	Url                    string               `json:"url"`
+	VisibleToClients       bool                 `json:"visible_to_clients"`
 }
 
 // SearchMetadata defines model for SearchMetadata.
@@ -1948,23 +1978,35 @@ type SearchResponseContent = []SearchResult
 
 // SearchResult defines model for SearchResult.
 type SearchResult struct {
-	AppUrl           string          `json:"app_url"`
-	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	Bucket           RecordingBucket `json:"bucket,omitempty"`
-	Content          string          `json:"content,omitempty"`
-	CreatedAt        time.Time       `json:"created_at,omitempty"`
-	Creator          Person          `json:"creator,omitempty"`
-	Description      string          `json:"description,omitempty"`
-	Id               int64           `json:"id"`
-	InheritsStatus   bool            `json:"inherits_status,omitempty"`
-	Parent           RecordingParent `json:"parent,omitempty"`
-	Status           string          `json:"status,omitempty"`
-	Subject          string          `json:"subject,omitempty"`
-	Title            string          `json:"title"`
-	Type             string          `json:"type"`
-	UpdatedAt        time.Time       `json:"updated_at,omitempty"`
-	Url              string          `json:"url"`
-	VisibleToClients bool            `json:"visible_to_clients,omitempty"`
+	AppUrl      string          `json:"app_url"`
+	BookmarkUrl string          `json:"bookmark_url,omitempty"`
+	Bucket      RecordingBucket `json:"bucket,omitempty"`
+	Content     string          `json:"content,omitempty"`
+
+	// ContentAttachments Rich-text companion arrays carried through the polymorphic search
+	// projection. A given result is one recording type, so it carries only
+	// the array matching its rich-text attribute (`content_attachments` for a
+	// Comment/Message, `description_attachments` for a Todo); a webhook-sourced
+	// result carries neither. Optional (no `@required`), non-nullable. Distinct
+	// from the generic `attachments` key (the recording's aggregate downloadable
+	// files), which is a separate projection concern and not modeled here.
+	ContentAttachments []RichTextAttachment `json:"content_attachments,omitempty"`
+	CreatedAt          time.Time            `json:"created_at,omitempty"`
+	Creator            Person               `json:"creator,omitempty"`
+	Description        string               `json:"description,omitempty"`
+
+	// DescriptionAttachments See `content_attachments` — the description-attribute companion array.
+	DescriptionAttachments []RichTextAttachment `json:"description_attachments,omitempty"`
+	Id                     int64                `json:"id"`
+	InheritsStatus         bool                 `json:"inherits_status,omitempty"`
+	Parent                 RecordingParent      `json:"parent,omitempty"`
+	Status                 string               `json:"status,omitempty"`
+	Subject                string               `json:"subject,omitempty"`
+	Title                  string               `json:"title"`
+	Type                   string               `json:"type"`
+	UpdatedAt              time.Time            `json:"updated_at,omitempty"`
+	Url                    string               `json:"url"`
+	VisibleToClients       bool                 `json:"visible_to_clients,omitempty"`
 }
 
 // SearchType A selectable search filter option. `key` is the value passed back as a
@@ -2125,25 +2167,26 @@ type TodoParent struct {
 
 // Todolist defines model for Todolist.
 type Todolist struct {
-	AppTodosUrl    string     `json:"app_todos_url,omitempty"`
-	AppUrl         string     `json:"app_url"`
-	BookmarkUrl    string     `json:"bookmark_url,omitempty"`
-	BoostsCount    int32      `json:"boosts_count,omitempty"`
-	BoostsUrl      string     `json:"boosts_url,omitempty"`
-	Bucket         TodoBucket `json:"bucket"`
-	CommentsCount  int32      `json:"comments_count,omitempty"`
-	CommentsUrl    string     `json:"comments_url,omitempty"`
-	Completed      bool       `json:"completed,omitempty"`
-	CompletedRatio string     `json:"completed_ratio,omitempty"`
-	CreatedAt      time.Time  `json:"created_at"`
-	Creator        Person     `json:"creator"`
-	Description    string     `json:"description,omitempty"`
-	GroupsUrl      string     `json:"groups_url,omitempty"`
-	Id             int64      `json:"id"`
-	InheritsStatus bool       `json:"inherits_status"`
-	Name           string     `json:"name"`
-	Parent         TodoParent `json:"parent"`
-	Position       int32      `json:"position,omitempty"`
+	AppTodosUrl            string               `json:"app_todos_url,omitempty"`
+	AppUrl                 string               `json:"app_url"`
+	BookmarkUrl            string               `json:"bookmark_url,omitempty"`
+	BoostsCount            int32                `json:"boosts_count,omitempty"`
+	BoostsUrl              string               `json:"boosts_url,omitempty"`
+	Bucket                 TodoBucket           `json:"bucket"`
+	CommentsCount          int32                `json:"comments_count,omitempty"`
+	CommentsUrl            string               `json:"comments_url,omitempty"`
+	Completed              bool                 `json:"completed,omitempty"`
+	CompletedRatio         string               `json:"completed_ratio,omitempty"`
+	CreatedAt              time.Time            `json:"created_at"`
+	Creator                Person               `json:"creator"`
+	Description            string               `json:"description,omitempty"`
+	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`
+	GroupsUrl              string               `json:"groups_url,omitempty"`
+	Id                     int64                `json:"id"`
+	InheritsStatus         bool                 `json:"inherits_status"`
+	Name                   string               `json:"name"`
+	Parent                 TodoParent           `json:"parent"`
+	Position               int32                `json:"position,omitempty"`
 
 	// Status active|archived|trashed
 	Status           string    `json:"status"`
@@ -2542,33 +2585,34 @@ type UpdateWebhookResponseContent = Webhook
 
 // Upload defines model for Upload.
 type Upload struct {
-	AppUrl           string          `json:"app_url"`
-	BookmarkUrl      string          `json:"bookmark_url,omitempty"`
-	BoostsCount      int32           `json:"boosts_count,omitempty"`
-	BoostsUrl        string          `json:"boosts_url,omitempty"`
-	Bucket           TodoBucket      `json:"bucket"`
-	ByteSize         int64           `json:"byte_size,omitempty"`
-	CommentsCount    int32           `json:"comments_count,omitempty"`
-	CommentsUrl      string          `json:"comments_url,omitempty"`
-	ContentType      string          `json:"content_type,omitempty"`
-	CreatedAt        time.Time       `json:"created_at"`
-	Creator          Person          `json:"creator"`
-	Description      string          `json:"description,omitempty"`
-	DownloadUrl      string          `json:"download_url,omitempty"`
-	Filename         string          `json:"filename,omitempty"`
-	Height           types.FlexInt   `json:"height,omitempty"`
-	Id               int64           `json:"id"`
-	InheritsStatus   bool            `json:"inherits_status"`
-	Parent           RecordingParent `json:"parent"`
-	Position         int32           `json:"position,omitempty"`
-	Status           string          `json:"status"`
-	SubscriptionUrl  string          `json:"subscription_url,omitempty"`
-	Title            string          `json:"title"`
-	Type             string          `json:"type"`
-	UpdatedAt        time.Time       `json:"updated_at"`
-	Url              string          `json:"url"`
-	VisibleToClients bool            `json:"visible_to_clients"`
-	Width            types.FlexInt   `json:"width,omitempty"`
+	AppUrl                 string               `json:"app_url"`
+	BookmarkUrl            string               `json:"bookmark_url,omitempty"`
+	BoostsCount            int32                `json:"boosts_count,omitempty"`
+	BoostsUrl              string               `json:"boosts_url,omitempty"`
+	Bucket                 TodoBucket           `json:"bucket"`
+	ByteSize               int64                `json:"byte_size,omitempty"`
+	CommentsCount          int32                `json:"comments_count,omitempty"`
+	CommentsUrl            string               `json:"comments_url,omitempty"`
+	ContentType            string               `json:"content_type,omitempty"`
+	CreatedAt              time.Time            `json:"created_at"`
+	Creator                Person               `json:"creator"`
+	Description            string               `json:"description,omitempty"`
+	DescriptionAttachments []RichTextAttachment `json:"description_attachments"`
+	DownloadUrl            string               `json:"download_url,omitempty"`
+	Filename               string               `json:"filename,omitempty"`
+	Height                 types.FlexInt        `json:"height,omitempty"`
+	Id                     int64                `json:"id"`
+	InheritsStatus         bool                 `json:"inherits_status"`
+	Parent                 RecordingParent      `json:"parent"`
+	Position               int32                `json:"position,omitempty"`
+	Status                 string               `json:"status"`
+	SubscriptionUrl        string               `json:"subscription_url,omitempty"`
+	Title                  string               `json:"title"`
+	Type                   string               `json:"type"`
+	UpdatedAt              time.Time            `json:"updated_at"`
+	Url                    string               `json:"url"`
+	VisibleToClients       bool                 `json:"visible_to_clients"`
+	Width                  types.FlexInt        `json:"width,omitempty"`
 }
 
 // ValidationErrorResponseContent defines model for ValidationErrorResponseContent.

--- a/kotlin/generator/src/main/kotlin/com/basecamp/sdk/generator/ModelEmitter.kt
+++ b/kotlin/generator/src/main/kotlin/com/basecamp/sdk/generator/ModelEmitter.kt
@@ -149,7 +149,17 @@ class ModelEmitter(private val api: OpenApiParser) {
             "string" -> if (isRequired) "String" else "String?"
             "array" -> {
                 val itemType = resolveArrayItemType(schema["items"]?.jsonObject)
-                "List<$itemType>"
+                // Rich-text companion arrays (RichTextAttachmentList) carry a
+                // documented cross-SDK presence contract (SPEC.md §10): an
+                // OPTIONAL one must stay nullable so an absent array (a
+                // non-matching projection type or a webhook-sourced item) is
+                // distinct from a present-but-empty one, matching how Go (nil),
+                // Swift/TypeScript (optional), Python (NotRequired), and Ruby
+                // (nil) already decode it. A bare `List<X> = emptyList()` would
+                // be a sentinel for absence, which SPEC.md's Optional Fields
+                // rule forbids. Other optional arrays keep the empty-list
+                // convention (no such presence contract).
+                if (!isRequired && itemType == "RichTextAttachment") "List<$itemType>?" else "List<$itemType>"
             }
             "object" -> if (isRequired) "JsonObject" else "JsonObject?"
             else -> if (isRequired) "JsonElement" else "JsonElement?"
@@ -188,12 +198,14 @@ class ModelEmitter(private val api: OpenApiParser) {
         schema["x-go-type"]?.jsonPrimitive?.content?.contains("FlexInt") == true
 
     private fun defaultValue(type: String): String = when {
+        // Nullable types (incl. a nullable List<X>?) default to null, so this
+        // must precede the List branch below.
+        type.endsWith("?") -> "null"
         type == "Boolean" -> "false"
         type == "Int" -> "0"
         type == "Long" -> "0L"
         type == "Double" -> "0.0"
         type.startsWith("List<") -> "emptyList()"
-        type.endsWith("?") -> "null"
         else -> "null"
     }
 }

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Answer.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Answer.kt
@@ -23,6 +23,7 @@ data class Answer(
     val url: String,
     @SerialName("app_url") val appUrl: String,
     val content: String,
+    @SerialName("content_attachments") val contentAttachments: List<RichTextAttachment>,
     val parent: RecordingParent,
     val bucket: RecordingBucket,
     val creator: Person,

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Card.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Card.kt
@@ -22,6 +22,7 @@ data class Card(
     val type: String,
     val url: String,
     @SerialName("app_url") val appUrl: String,
+    @SerialName("description_attachments") val descriptionAttachments: List<RichTextAttachment>,
     val parent: RecordingParent,
     val bucket: TodoBucket,
     val creator: Person,

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/ClientApproval.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/ClientApproval.kt
@@ -25,6 +25,7 @@ data class ClientApproval(
     val parent: RecordingParent,
     val bucket: RecordingBucket,
     val creator: Person,
+    @SerialName("content_attachments") val contentAttachments: List<RichTextAttachment>,
     @SerialName("bookmark_url") val bookmarkUrl: String? = null,
     @SerialName("subscription_url") val subscriptionUrl: String? = null,
     val content: String? = null,

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/ClientCorrespondence.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/ClientCorrespondence.kt
@@ -25,6 +25,7 @@ data class ClientCorrespondence(
     val parent: RecordingParent,
     val bucket: RecordingBucket,
     val creator: Person,
+    @SerialName("content_attachments") val contentAttachments: List<RichTextAttachment>,
     val subject: String,
     @SerialName("bookmark_url") val bookmarkUrl: String? = null,
     @SerialName("subscription_url") val subscriptionUrl: String? = null,

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/ClientReply.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/ClientReply.kt
@@ -26,5 +26,6 @@ data class ClientReply(
     val bucket: RecordingBucket,
     val creator: Person,
     val content: String,
+    @SerialName("content_attachments") val contentAttachments: List<RichTextAttachment>,
     @SerialName("bookmark_url") val bookmarkUrl: String? = null
 )

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Comment.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Comment.kt
@@ -26,6 +26,7 @@ data class Comment(
     val bucket: TodoBucket,
     val creator: Person,
     val content: String,
+    @SerialName("content_attachments") val contentAttachments: List<RichTextAttachment>,
     @SerialName("bookmark_url") val bookmarkUrl: String? = null,
     @SerialName("boosts_count") val boostsCount: Int = 0,
     @SerialName("boosts_url") val boostsUrl: String? = null

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Document.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Document.kt
@@ -25,6 +25,7 @@ data class Document(
     val parent: RecordingParent,
     val bucket: TodoBucket,
     val creator: Person,
+    @SerialName("content_attachments") val contentAttachments: List<RichTextAttachment>,
     @SerialName("bookmark_url") val bookmarkUrl: String? = null,
     @SerialName("subscription_url") val subscriptionUrl: String? = null,
     @SerialName("comments_count") val commentsCount: Int = 0,

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Forward.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Forward.kt
@@ -25,6 +25,7 @@ data class Forward(
     val parent: RecordingParent,
     val bucket: TodoBucket,
     val creator: Person,
+    @SerialName("content_attachments") val contentAttachments: List<RichTextAttachment>,
     val subject: String,
     @SerialName("bookmark_url") val bookmarkUrl: String? = null,
     @SerialName("subscription_url") val subscriptionUrl: String? = null,

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/ForwardReply.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/ForwardReply.kt
@@ -26,6 +26,7 @@ data class ForwardReply(
     val bucket: TodoBucket,
     val creator: Person,
     val content: String,
+    @SerialName("content_attachments") val contentAttachments: List<RichTextAttachment>,
     @SerialName("bookmark_url") val bookmarkUrl: String? = null,
     @SerialName("boosts_count") val boostsCount: Int = 0,
     @SerialName("boosts_url") val boostsUrl: String? = null

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Message.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Message.kt
@@ -27,6 +27,7 @@ data class Message(
     val creator: Person,
     val subject: String,
     val content: String,
+    @SerialName("content_attachments") val contentAttachments: List<RichTextAttachment>,
     @SerialName("bookmark_url") val bookmarkUrl: String? = null,
     @SerialName("subscription_url") val subscriptionUrl: String? = null,
     @SerialName("comments_count") val commentsCount: Int = 0,

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Recording.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Recording.kt
@@ -27,6 +27,8 @@ data class Recording(
     val creator: Person,
     @SerialName("bookmark_url") val bookmarkUrl: String? = null,
     val content: String? = null,
+    @SerialName("content_attachments") val contentAttachments: List<RichTextAttachment> = emptyList(),
+    @SerialName("description_attachments") val descriptionAttachments: List<RichTextAttachment> = emptyList(),
     @SerialName("comments_count") val commentsCount: Int = 0,
     @SerialName("comments_url") val commentsUrl: String? = null,
     @SerialName("subscription_url") val subscriptionUrl: String? = null

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Recording.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Recording.kt
@@ -27,8 +27,8 @@ data class Recording(
     val creator: Person,
     @SerialName("bookmark_url") val bookmarkUrl: String? = null,
     val content: String? = null,
-    @SerialName("content_attachments") val contentAttachments: List<RichTextAttachment> = emptyList(),
-    @SerialName("description_attachments") val descriptionAttachments: List<RichTextAttachment> = emptyList(),
+    @SerialName("content_attachments") val contentAttachments: List<RichTextAttachment>? = null,
+    @SerialName("description_attachments") val descriptionAttachments: List<RichTextAttachment>? = null,
     @SerialName("comments_count") val commentsCount: Int = 0,
     @SerialName("comments_url") val commentsUrl: String? = null,
     @SerialName("subscription_url") val subscriptionUrl: String? = null

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/ScheduleEntry.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/ScheduleEntry.kt
@@ -26,6 +26,7 @@ data class ScheduleEntry(
     val bucket: TodoBucket,
     val creator: Person,
     val summary: String,
+    @SerialName("description_attachments") val descriptionAttachments: List<RichTextAttachment>,
     @SerialName("bookmark_url") val bookmarkUrl: String? = null,
     @SerialName("subscription_url") val subscriptionUrl: String? = null,
     @SerialName("comments_count") val commentsCount: Int = 0,

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Todolist.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Todolist.kt
@@ -25,6 +25,7 @@ data class Todolist(
     val parent: TodoParent,
     val bucket: TodoBucket,
     val creator: Person,
+    @SerialName("description_attachments") val descriptionAttachments: List<RichTextAttachment>,
     val name: String,
     @SerialName("bookmark_url") val bookmarkUrl: String? = null,
     @SerialName("subscription_url") val subscriptionUrl: String? = null,

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Upload.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Upload.kt
@@ -26,6 +26,7 @@ data class Upload(
     val parent: RecordingParent,
     val bucket: TodoBucket,
     val creator: Person,
+    @SerialName("description_attachments") val descriptionAttachments: List<RichTextAttachment>,
     @SerialName("bookmark_url") val bookmarkUrl: String? = null,
     @SerialName("subscription_url") val subscriptionUrl: String? = null,
     @SerialName("comments_count") val commentsCount: Int = 0,

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/CommentsServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/CommentsServiceTest.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class CommentsServiceTest {
@@ -25,7 +26,7 @@ class CommentsServiceTest {
         }
     }
 
-    private fun commentJson(id: Long, content: String) = """{
+    private fun commentJson(id: Long, content: String, attachments: String = "[]") = """{
         "id": $id,
         "status": "active",
         "visible_to_clients": false,
@@ -37,6 +38,7 @@ class CommentsServiceTest {
         "url": "https://3.basecampapi.com/12345/buckets/1/comments/$id.json",
         "app_url": "https://3.basecamp.com/12345/buckets/1/comments/$id",
         "content": "$content",
+        "content_attachments": $attachments,
         "parent": {"id": 100, "title": "Parent", "type": "Todo", "url": "https://3.basecampapi.com/12345/buckets/1/todos/100.json", "app_url": "https://3.basecamp.com/12345/buckets/1/todos/100"},
         "bucket": {"id": 1, "name": "Project", "type": "Project"},
         "creator": {"id": 1, "name": "Test User", "created_at": "2025-01-01T00:00:00Z", "updated_at": "2025-01-01T00:00:00Z"}
@@ -233,6 +235,49 @@ class CommentsServiceTest {
         } catch (e: BasecampException.Auth) {
             assertEquals("Authentication required", e.message)
         }
+
+        client.close()
+    }
+
+    // -- Attachment dimension decode (SPEC.md §10 Type Fidelity) --
+    //
+    // A Comment's rich-text content is paired with a content_attachments array
+    // whose pixel dimensions arrive float-spelled (1024.0) for images and null
+    // for non-image blobs. The generated RichTextAttachment gives width/height a
+    // nullable `Int?` decoded through FlexibleIntSerializer, so Kotlin decodes
+    // both faithfully — matching Go/Swift/Ruby: a served null stays null (not a
+    // sentinel 0), and a float-spelled 1024.0 becomes 1024.
+
+    private fun attachmentJson(id: Long, filename: String, contentType: String, width: String, height: String) = """{
+        "id": $id, "sgid": "BAh-$id", "filename": "$filename",
+        "content_type": "$contentType", "byte_size": 284111,
+        "download_url": "https://3.basecampapi.com/12345/buckets/1/blobs/$id/download/$filename",
+        "width": $width, "height": $height, "previewable": true,
+        "preview_url": "https://3.basecampapi.com/12345/buckets/1/blobs/$id/previews/$filename",
+        "thumbnail_url": "https://3.basecampapi.com/12345/buckets/1/blobs/$id/thumbnails/$filename"
+    }"""
+
+    @Test
+    fun contentAttachmentDimensionsDecodeFaithfully() = runTest {
+        val image = attachmentJson(1069480010, "celebration.png", "image/png", "1024.0", "768")
+        val blob = attachmentJson(1069480011, "notes.pdf", "application/pdf", "null", "null")
+        val client = mockClient { _ ->
+            respond(
+                content = commentJson(77, "Great work!", attachments = "[$image, $blob]"),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+
+        val comment = client.forAccount("12345").comments.get(commentId = 77)
+        assertEquals(2, comment.contentAttachments.size)
+
+        // The BC3 API's float-spelled 1024.0 decodes to the integer 1024.
+        assertEquals(1024, comment.contentAttachments[0].width)
+        assertEquals(768, comment.contentAttachments[0].height)
+        // A non-image blob's null dimensions decode to null, not a sentinel 0.
+        assertNull(comment.contentAttachments[1].width)
+        assertNull(comment.contentAttachments[1].height)
 
         client.close()
     }

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/MessagesServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/MessagesServiceTest.kt
@@ -29,7 +29,7 @@ class MessagesServiceTest {
         "title": "Hello", "inherits_status": true, "type": "Message",
         "url": "https://3.basecampapi.com/1/buckets/1/messages/$id.json",
         "app_url": "https://3.basecamp.com/1/buckets/1/messages/$id",
-        "subject": "Hello", "content": "<p>Body</p>",
+        "subject": "Hello", "content": "<p>Body</p>", "content_attachments": [],
         "creator": {"id": 1, "name": "Test", "created_at": "2025-01-01T00:00:00Z", "updated_at": "2025-01-01T00:00:00Z"},
         "bucket": {"id": 1, "name": "Project", "type": "Project"},
         "parent": {"id": 2, "title": "Board", "type": "Message::Board", "url": "https://3.basecampapi.com/1/buckets/1/message_boards/2.json", "app_url": "https://3.basecamp.com/1/buckets/1/message_boards/2"}

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/RecordingsServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/RecordingsServiceTest.kt
@@ -1,0 +1,107 @@
+package com.basecamp.sdk
+
+import com.basecamp.sdk.generated.recordings
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class RecordingsServiceTest {
+
+    private fun mockClient(handler: MockRequestHandler): BasecampClient {
+        val engine = MockEngine(handler)
+        return testBasecampClient {
+            accessToken("test-token")
+            this.engine = engine
+        }
+    }
+
+    // The generic Recording is a polymorphic projection: it carries only the
+    // rich-text companion array matching its type, and a webhook-sourced
+    // recording (rendered from the base partial) carries neither. Those arrays
+    // are therefore OPTIONAL — modeled as a nullable `List<RichTextAttachment>?`
+    // rather than the empty-list default used for other optional arrays — so an
+    // absent array stays distinct from a present-but-empty one, matching Go,
+    // Swift, TypeScript, Python, and Ruby. See SPEC.md §10 / the
+    // rich-text-attachments-coverage api-gap entry.
+    private fun recordingJson(id: Long, attachments: String) = """{
+        "id": $id,
+        "status": "active",
+        "visible_to_clients": false,
+        "created_at": "2025-01-01T00:00:00Z",
+        "updated_at": "2025-01-01T00:00:00Z",
+        "title": "We won Leto!",
+        "inherits_status": true,
+        "type": "Message",
+        "url": "https://3.basecampapi.com/12345/buckets/1/messages/$id.json",
+        "app_url": "https://3.basecamp.com/12345/buckets/1/messages/$id",
+        "content": "<div>Big news</div>"$attachments,
+        "parent": {"id": 100, "title": "Message Board", "type": "Message::Board", "url": "https://3.basecampapi.com/12345/buckets/1/message_boards/100.json", "app_url": "https://3.basecamp.com/12345/buckets/1/message_boards/100"},
+        "bucket": {"id": 1, "name": "Project", "type": "Project"},
+        "creator": {"id": 1, "name": "Test User", "created_at": "2025-01-01T00:00:00Z", "updated_at": "2025-01-01T00:00:00Z"}
+    }"""
+
+    @Test
+    fun absentCompanionArrayDecodesToNull() = runTest {
+        // A webhook-sourced recording omits the companion arrays entirely.
+        val client = mockClient { _ ->
+            respond(
+                content = recordingJson(1, ""),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val recording = client.forAccount("12345").recordings.get(recordingId = 1)
+        assertNull(recording.contentAttachments, "absent content_attachments should decode to null")
+        assertNull(recording.descriptionAttachments, "absent description_attachments should decode to null")
+        client.close()
+    }
+
+    @Test
+    fun presentEmptyCompanionArrayDecodesToEmptyList() = runTest {
+        // A Message recording with no inline files: present, but empty. This must
+        // stay distinct from absent — a non-null empty list, not null.
+        val client = mockClient { _ ->
+            respond(
+                content = recordingJson(2, ""","content_attachments": []"""),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val recording = client.forAccount("12345").recordings.get(recordingId = 2)
+        val attachments = assertNotNull(recording.contentAttachments, "present-empty content_attachments must not be null")
+        assertEquals(0, attachments.size)
+        client.close()
+    }
+
+    @Test
+    fun populatedCompanionArrayDecodesFaithfully() = runTest {
+        val attachment = """{
+            "id": 1069480040, "sgid": "BAh-img", "filename": "diagram.png",
+            "content_type": "image/png", "byte_size": 204800,
+            "download_url": "https://3.basecampapi.com/12345/buckets/1/blobs/img/download/diagram.png",
+            "width": 1024.0, "height": 768, "previewable": true,
+            "preview_url": "https://3.basecampapi.com/12345/buckets/1/blobs/img/previews/diagram.png",
+            "thumbnail_url": "https://3.basecampapi.com/12345/buckets/1/blobs/img/thumbnails/diagram.png"
+        }"""
+        val client = mockClient { _ ->
+            respond(
+                content = recordingJson(3, ""","content_attachments": [$attachment]"""),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val recording = client.forAccount("12345").recordings.get(recordingId = 3)
+        val attachments = assertNotNull(recording.contentAttachments)
+        assertEquals(1, attachments.size)
+        // Float-spelled 1024.0 decodes to the integer 1024 via FlexibleIntSerializer.
+        assertEquals(1024, attachments[0].width)
+        assertEquals(768, attachments[0].height)
+        // The matching-type recording carries only its own array; the other stays null.
+        assertNull(recording.descriptionAttachments)
+        client.close()
+    }
+}

--- a/openapi.json
+++ b/openapi.json
@@ -17760,6 +17760,7 @@
                           "title": "Launch Tasks",
                           "inherits_status": true,
                           "type": "Todolist",
+                          "description_attachments": [],
                           "url": "https://3.basecampapi.com/999/buckets/12345678/todolists/987654.json",
                           "app_url": "https://3.basecamp.com/999/buckets/12345678/todolists/987654",
                           "creator": {
@@ -21555,6 +21556,12 @@
           "description": {
             "type": "string"
           },
+          "description_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "due_on": {
             "type": "string",
             "x-go-type": "types.Date",
@@ -21627,6 +21634,7 @@
           "bucket",
           "created_at",
           "creator",
+          "description_attachments",
           "id",
           "inherits_status",
           "parent",
@@ -22098,6 +22106,12 @@
           "content": {
             "type": "string"
           },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "subject": {
             "type": "string"
           },
@@ -22132,6 +22146,7 @@
         "required": [
           "app_url",
           "bucket",
+          "content_attachments",
           "created_at",
           "creator",
           "id",
@@ -22287,6 +22302,12 @@
           "content": {
             "type": "string"
           },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "subject": {
             "type": "string"
           },
@@ -22301,6 +22322,7 @@
         "required": [
           "app_url",
           "bucket",
+          "content_attachments",
           "created_at",
           "creator",
           "id",
@@ -22374,12 +22396,19 @@
           },
           "content": {
             "type": "string"
+          },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
           }
         },
         "required": [
           "app_url",
           "bucket",
           "content",
+          "content_attachments",
           "created_at",
           "creator",
           "id",
@@ -22466,6 +22495,12 @@
           "content": {
             "type": "string"
           },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "boosts_count": {
             "type": "integer",
             "format": "int32"
@@ -22478,6 +22513,7 @@
           "app_url",
           "bucket",
           "content",
+          "content_attachments",
           "created_at",
           "creator",
           "id",
@@ -23285,6 +23321,12 @@
           "content": {
             "type": "string"
           },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "boosts_count": {
             "type": "integer",
             "format": "int32"
@@ -23296,6 +23338,7 @@
         "required": [
           "app_url",
           "bucket",
+          "content_attachments",
           "created_at",
           "creator",
           "id",
@@ -23487,6 +23530,12 @@
           "content": {
             "type": "string"
           },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "subject": {
             "type": "string"
           },
@@ -23504,6 +23553,7 @@
         "required": [
           "app_url",
           "bucket",
+          "content_attachments",
           "created_at",
           "creator",
           "id",
@@ -23578,6 +23628,12 @@
           "content": {
             "type": "string"
           },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "boosts_count": {
             "type": "integer",
             "format": "int32"
@@ -23590,6 +23646,7 @@
           "app_url",
           "bucket",
           "content",
+          "content_attachments",
           "created_at",
           "creator",
           "id",
@@ -23659,6 +23716,13 @@
           },
           "description": {
             "type": "string"
+          },
+          "description_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            },
+            "description": "Optional (no `@required`): the type-specific partial renders the\ncompanion array only when the gauge has needles (bc3 `if\ngauge.any_needles?`), so a needle-less gauge omits the key entirely.\nNon-nullable — never served as JSON `null`."
           },
           "enabled": {
             "type": "boolean"
@@ -23758,6 +23822,12 @@
           "description": {
             "type": "string"
           },
+          "description_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "color": {
             "type": "string"
           },
@@ -23768,6 +23838,7 @@
         },
         "required": [
           "created_at",
+          "description_attachments",
           "id",
           "updated_at"
         ]
@@ -24660,6 +24731,12 @@
           "content": {
             "type": "string"
           },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "category": {
             "$ref": "#/components/schemas/MessageType"
           },
@@ -24675,6 +24752,7 @@
           "app_url",
           "bucket",
           "content",
+          "content_attachments",
           "created_at",
           "creator",
           "id",
@@ -25704,6 +25782,12 @@
           "content": {
             "type": "string"
           },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "group_on": {
             "type": "string",
             "x-go-type": "types.Date",
@@ -25733,6 +25817,7 @@
           "app_url",
           "bucket",
           "content",
+          "content_attachments",
           "created_at",
           "creator",
           "id",
@@ -26003,6 +26088,20 @@
           },
           "content": {
             "type": "string"
+          },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            },
+            "description": "Rich-text companion arrays carried through the generic recording\nprojection (`to_recordable_partial_path` renders the full type-specific\npartial). A given recording is one type, so it carries only the array\nmatching its rich-text attribute (`content_attachments` for a\nComment/Message, `description_attachments` for a Todo/Card); a\nwebhook-sourced recording (base partial) carries neither. Optional (no\n`@required`), non-nullable."
+          },
+          "description_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            },
+            "description": "See `content_attachments` — the description-attribute companion array."
           },
           "comments_count": {
             "type": "integer",
@@ -26460,6 +26559,12 @@
           "description": {
             "type": "string"
           },
+          "description_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "all_day": {
             "type": "boolean"
           },
@@ -26498,6 +26603,7 @@
           "bucket",
           "created_at",
           "creator",
+          "description_attachments",
           "id",
           "inherits_status",
           "parent",
@@ -26619,6 +26725,20 @@
           },
           "description": {
             "type": "string"
+          },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            },
+            "description": "Rich-text companion arrays carried through the polymorphic search\nprojection. A given result is one recording type, so it carries only\nthe array matching its rich-text attribute (`content_attachments` for a\nComment/Message, `description_attachments` for a Todo); a webhook-sourced\nresult carries neither. Optional (no `@required`), non-nullable. Distinct\nfrom the generic `attachments` key (the recording's aggregate downloadable\nfiles), which is a separate projection concern and not modeled here."
+          },
+          "description_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            },
+            "description": "See `content_attachments` — the description-attribute companion array."
           },
           "subject": {
             "type": "string"
@@ -27191,6 +27311,12 @@
           "description": {
             "type": "string"
           },
+          "description_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "completed": {
             "type": "boolean"
           },
@@ -27222,6 +27348,7 @@
           "bucket",
           "created_at",
           "creator",
+          "description_attachments",
           "id",
           "inherits_status",
           "name",
@@ -28199,6 +28326,12 @@
           "description": {
             "type": "string"
           },
+          "description_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "content_type": {
             "type": "string"
           },
@@ -28244,6 +28377,7 @@
           "bucket",
           "created_at",
           "creator",
+          "description_attachments",
           "id",
           "inherits_status",
           "parent",

--- a/python/src/basecamp/generated/types.py
+++ b/python/src/basecamp/generated/types.py
@@ -147,6 +147,7 @@ class Card(TypedDict):
     created_at: str
     creator: Person
     description: NotRequired[str]
+    description_attachments: list[RichTextAttachment]
     due_on: NotRequired[str]
     id: int
     inherits_status: bool
@@ -259,6 +260,7 @@ class ClientApproval(TypedDict):
     bookmark_url: NotRequired[str]
     bucket: RecordingBucket
     content: NotRequired[str]
+    content_attachments: list[RichTextAttachment]
     created_at: str
     creator: Person
     due_on: NotRequired[str]
@@ -306,6 +308,7 @@ class ClientCorrespondence(TypedDict):
     bookmark_url: NotRequired[str]
     bucket: RecordingBucket
     content: NotRequired[str]
+    content_attachments: list[RichTextAttachment]
     created_at: str
     creator: Person
     id: int
@@ -328,6 +331,7 @@ class ClientReply(TypedDict):
     bookmark_url: NotRequired[str]
     bucket: RecordingBucket
     content: str
+    content_attachments: list[RichTextAttachment]
     created_at: str
     creator: Person
     id: int
@@ -353,6 +357,7 @@ class Comment(TypedDict):
     boosts_url: NotRequired[str]
     bucket: TodoBucket
     content: str
+    content_attachments: list[RichTextAttachment]
     created_at: str
     creator: Person
     id: int
@@ -555,6 +560,7 @@ class Document(TypedDict):
     comments_count: NotRequired[int]
     comments_url: NotRequired[str]
     content: NotRequired[str]
+    content_attachments: list[RichTextAttachment]
     created_at: str
     creator: Person
     id: int
@@ -601,6 +607,7 @@ class Forward(TypedDict):
     bookmark_url: NotRequired[str]
     bucket: TodoBucket
     content: NotRequired[str]
+    content_attachments: list[RichTextAttachment]
     created_at: str
     creator: Person
     from_: NotRequired[str]
@@ -626,6 +633,7 @@ class ForwardReply(TypedDict):
     boosts_url: NotRequired[str]
     bucket: TodoBucket
     content: str
+    content_attachments: list[RichTextAttachment]
     created_at: str
     creator: Person
     id: int
@@ -646,6 +654,7 @@ class Gauge(TypedDict):
     created_at: str
     creator: NotRequired[Person]
     description: NotRequired[str]
+    description_attachments: NotRequired[list[RichTextAttachment]]
     enabled: NotRequired[bool]
     id: int
     inherits_status: NotRequired[bool]
@@ -672,6 +681,7 @@ class GaugeNeedle(TypedDict):
     created_at: str
     creator: NotRequired[Person]
     description: NotRequired[str]
+    description_attachments: list[RichTextAttachment]
     id: int
     inherits_status: NotRequired[bool]
     parent: NotRequired[RecordingParent]
@@ -800,6 +810,7 @@ class Message(TypedDict):
     comments_count: NotRequired[int]
     comments_url: NotRequired[str]
     content: str
+    content_attachments: list[RichTextAttachment]
     created_at: str
     creator: Person
     id: int
@@ -1072,6 +1083,7 @@ class QuestionAnswer(TypedDict):
     comments_count: NotRequired[int]
     comments_url: NotRequired[str]
     content: str
+    content_attachments: list[RichTextAttachment]
     created_at: str
     creator: Person
     group_on: NotRequired[str]
@@ -1148,8 +1160,10 @@ class Recording(TypedDict):
     comments_count: NotRequired[int]
     comments_url: NotRequired[str]
     content: NotRequired[str]
+    content_attachments: NotRequired[list[RichTextAttachment]]
     created_at: str
     creator: Person
+    description_attachments: NotRequired[list[RichTextAttachment]]
     id: int
     inherits_status: bool
     parent: RecordingParent
@@ -1263,6 +1277,7 @@ class ScheduleEntry(TypedDict):
     created_at: str
     creator: Person
     description: NotRequired[str]
+    description_attachments: list[RichTextAttachment]
     ends_at: NotRequired[str]
     id: int
     inherits_status: bool
@@ -1294,9 +1309,11 @@ class SearchResult(TypedDict):
     bookmark_url: NotRequired[str]
     bucket: NotRequired[RecordingBucket]
     content: NotRequired[str]
+    content_attachments: NotRequired[list[RichTextAttachment]]
     created_at: NotRequired[str]
     creator: NotRequired[Person]
     description: NotRequired[str]
+    description_attachments: NotRequired[list[RichTextAttachment]]
     id: int
     inherits_status: NotRequired[bool]
     parent: NotRequired[RecordingParent]
@@ -1442,6 +1459,7 @@ class Todolist(TypedDict):
     created_at: str
     creator: Person
     description: NotRequired[str]
+    description_attachments: list[RichTextAttachment]
     groups_url: NotRequired[str]
     id: int
     inherits_status: bool
@@ -1712,6 +1730,7 @@ class Upload(TypedDict):
     created_at: str
     creator: Person
     description: NotRequired[str]
+    description_attachments: list[RichTextAttachment]
     download_url: NotRequired[str]
     filename: NotRequired[str]
     height: NotRequired[int | float]

--- a/python/tests/services/test_uploads.py
+++ b/python/tests/services/test_uploads.py
@@ -201,6 +201,7 @@ class TestDescriptionAttachments:
         assert attachments[0]["width"] == 1024
         assert isinstance(attachments[0]["width"], float)
         assert attachments[0]["height"] == 768
-        # None is preserved verbatim despite the TypedDict's declared width type.
+        # None is preserved verbatim, matching the TypedDict's
+        # NotRequired[Optional[int | float]] width/height type.
         assert attachments[1]["width"] is None
         assert attachments[1]["height"] is None

--- a/python/tests/services/test_uploads.py
+++ b/python/tests/services/test_uploads.py
@@ -140,3 +140,67 @@ class TestAsyncDownload:
             assert "download_url" in str(exc_info.value)
             assert metadata_route.call_count == 1
             assert len(router.calls) == 1
+
+
+class TestDescriptionAttachments:
+    @respx.mock
+    def test_get_preserves_dimension_float_and_none(self):
+        """An Upload's rich-text description is paired with a
+        description_attachments array. Pixel dimensions arrive float-spelled
+        (1024.0) for images and null for non-image blobs. The service returns the
+        parsed response dict, so httpx/json preserves both the float and None
+        verbatim — Python performs no int coercion. The generated TypedDict types
+        these honestly as ``NotRequired[Optional[int | float]]`` (the schema is
+        nullable and the FlexInt dimension may arrive as a float), so both the
+        float value and None below are within the declared type. See SPEC.md §10
+        Type Fidelity.
+        """
+        upload = {
+            "id": 77,
+            "filename": "logo.png",
+            "description": "Company logo",
+            "download_url": "https://3.basecampapi.com/12345/blobs/abc/download/logo.png",
+            "description_attachments": [
+                {
+                    "id": 1069480020,
+                    "sgid": "BAh-img",
+                    "filename": "brand-guide.png",
+                    "content_type": "image/png",
+                    "byte_size": 512000,
+                    "download_url": "https://3.basecampapi.com/12345/buckets/1/blobs/img/download/brand-guide.png",
+                    "width": 1024.0,
+                    "height": 768,
+                    "previewable": True,
+                    "preview_url": "https://3.basecampapi.com/12345/buckets/1/blobs/img/previews/brand-guide.png",
+                    "thumbnail_url": "https://3.basecampapi.com/12345/buckets/1/blobs/img/thumbnails/brand-guide.png",
+                },
+                {
+                    "id": 1069480021,
+                    "sgid": "BAh-pdf",
+                    "filename": "specs.pdf",
+                    "content_type": "application/pdf",
+                    "byte_size": 2097152,
+                    "download_url": "https://3.basecampapi.com/12345/buckets/1/blobs/pdf/download/specs.pdf",
+                    "width": None,
+                    "height": None,
+                    "previewable": False,
+                    "preview_url": "https://3.basecampapi.com/12345/buckets/1/blobs/pdf/previews/specs.pdf",
+                    "thumbnail_url": "https://3.basecampapi.com/12345/buckets/1/blobs/pdf/thumbnails/specs.pdf",
+                },
+            ],
+        }
+        respx.get("https://3.basecampapi.com/12345/uploads/77").mock(return_value=httpx.Response(200, json=upload))
+
+        c = Client(access_token="test-token")
+        result = c.for_account("12345").uploads.get(upload_id=77)
+        attachments = result["description_attachments"]
+        assert len(attachments) == 2
+
+        # Float-spelled 1024.0 is preserved verbatim, as a Python float — the
+        # runtime performs no integer coercion (unlike Go's FlexInt).
+        assert attachments[0]["width"] == 1024
+        assert isinstance(attachments[0]["width"], float)
+        assert attachments[0]["height"] == 768
+        # None is preserved verbatim despite the TypedDict's declared width type.
+        assert attachments[1]["width"] is None
+        assert attachments[1]["height"] is None

--- a/python/tests/services/test_uploads.py
+++ b/python/tests/services/test_uploads.py
@@ -16,6 +16,7 @@ def _metadata(upload_id: int = 1069479400, *, download_url, filename="report.pdf
         "id": upload_id,
         "filename": filename,
         "download_url": download_url,
+        "description_attachments": [],
     }
 
 

--- a/ruby/lib/basecamp/generated/metadata.json
+++ b/ruby/lib/basecamp/generated/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-07-24T05:18:10Z",
+  "generated": "2026-07-24T20:00:38Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Auto-generated from OpenAPI spec. Do not edit manually.
-# Generated: 2026-07-24T05:18:10Z
+# Generated: 2026-07-24T20:00:38Z
 
 require "json"
 require "time"
@@ -439,11 +439,11 @@ module Basecamp
     # Card
     class Card
       include TypeHelpers
-      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :assignees, :bookmark_url, :boosts_count, :boosts_url, :comments_count, :comments_url, :completed, :completed_at, :completer, :completion_subscribers, :completion_url, :content, :description, :due_on, :position, :steps, :subscription_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :description_attachments, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :assignees, :bookmark_url, :boosts_count, :boosts_url, :comments_count, :comments_url, :completed, :completed_at, :completer, :completion_subscribers, :completion_url, :content, :description, :due_on, :position, :steps, :subscription_url
 
       # @return [Array<Symbol>]
       def self.required_fields
-        %i[app_url bucket created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+        %i[app_url bucket created_at creator description_attachments id inherits_status parent status title type updated_at url visible_to_clients].freeze
       end
 
       def initialize(data = {})
@@ -451,6 +451,7 @@ module Basecamp
         @bucket = parse_type(data["bucket"], "TodoBucket")
         @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
+        @description_attachments = parse_array(data["description_attachments"], "RichTextAttachment")
         @id = parse_integer(data["id"])
         @inherits_status = parse_boolean(data["inherits_status"])
         @parent = parse_type(data["parent"], "RecordingParent")
@@ -485,6 +486,7 @@ module Basecamp
           "bucket" => @bucket,
           "created_at" => @created_at,
           "creator" => @creator,
+          "description_attachments" => @description_attachments,
           "id" => @id,
           "inherits_status" => @inherits_status,
           "parent" => @parent,
@@ -787,16 +789,17 @@ module Basecamp
     # ClientApproval
     class ClientApproval
       include TypeHelpers
-      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :approval_status, :approver, :bookmark_url, :content, :due_on, :replies_count, :replies_url, :responses, :subject, :subscription_url
+      attr_accessor :app_url, :bucket, :content_attachments, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :approval_status, :approver, :bookmark_url, :content, :due_on, :replies_count, :replies_url, :responses, :subject, :subscription_url
 
       # @return [Array<Symbol>]
       def self.required_fields
-        %i[app_url bucket created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+        %i[app_url bucket content_attachments created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
       end
 
       def initialize(data = {})
         @app_url = data["app_url"]
         @bucket = parse_type(data["bucket"], "RecordingBucket")
+        @content_attachments = parse_array(data["content_attachments"], "RichTextAttachment")
         @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
         @id = parse_integer(data["id"])
@@ -824,6 +827,7 @@ module Basecamp
         {
           "app_url" => @app_url,
           "bucket" => @bucket,
+          "content_attachments" => @content_attachments,
           "created_at" => @created_at,
           "creator" => @creator,
           "id" => @id,
@@ -931,16 +935,17 @@ module Basecamp
     # ClientCorrespondence
     class ClientCorrespondence
       include TypeHelpers
-      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :subject, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :content, :replies_count, :replies_url, :subscription_url
+      attr_accessor :app_url, :bucket, :content_attachments, :created_at, :creator, :id, :inherits_status, :parent, :status, :subject, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :content, :replies_count, :replies_url, :subscription_url
 
       # @return [Array<Symbol>]
       def self.required_fields
-        %i[app_url bucket created_at creator id inherits_status parent status subject title type updated_at url visible_to_clients].freeze
+        %i[app_url bucket content_attachments created_at creator id inherits_status parent status subject title type updated_at url visible_to_clients].freeze
       end
 
       def initialize(data = {})
         @app_url = data["app_url"]
         @bucket = parse_type(data["bucket"], "RecordingBucket")
+        @content_attachments = parse_array(data["content_attachments"], "RichTextAttachment")
         @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
         @id = parse_integer(data["id"])
@@ -964,6 +969,7 @@ module Basecamp
         {
           "app_url" => @app_url,
           "bucket" => @bucket,
+          "content_attachments" => @content_attachments,
           "created_at" => @created_at,
           "creator" => @creator,
           "id" => @id,
@@ -992,17 +998,18 @@ module Basecamp
     # ClientReply
     class ClientReply
       include TypeHelpers
-      attr_accessor :app_url, :bucket, :content, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url
+      attr_accessor :app_url, :bucket, :content, :content_attachments, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url
 
       # @return [Array<Symbol>]
       def self.required_fields
-        %i[app_url bucket content created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+        %i[app_url bucket content content_attachments created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
       end
 
       def initialize(data = {})
         @app_url = data["app_url"]
         @bucket = parse_type(data["bucket"], "RecordingBucket")
         @content = data["content"]
+        @content_attachments = parse_array(data["content_attachments"], "RichTextAttachment")
         @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
         @id = parse_integer(data["id"])
@@ -1022,6 +1029,7 @@ module Basecamp
           "app_url" => @app_url,
           "bucket" => @bucket,
           "content" => @content,
+          "content_attachments" => @content_attachments,
           "created_at" => @created_at,
           "creator" => @creator,
           "id" => @id,
@@ -1067,17 +1075,18 @@ module Basecamp
     # Comment
     class Comment
       include TypeHelpers
-      attr_accessor :app_url, :bucket, :content, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :boosts_count, :boosts_url
+      attr_accessor :app_url, :bucket, :content, :content_attachments, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :boosts_count, :boosts_url
 
       # @return [Array<Symbol>]
       def self.required_fields
-        %i[app_url bucket content created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+        %i[app_url bucket content content_attachments created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
       end
 
       def initialize(data = {})
         @app_url = data["app_url"]
         @bucket = parse_type(data["bucket"], "TodoBucket")
         @content = data["content"]
+        @content_attachments = parse_array(data["content_attachments"], "RichTextAttachment")
         @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
         @id = parse_integer(data["id"])
@@ -1099,6 +1108,7 @@ module Basecamp
           "app_url" => @app_url,
           "bucket" => @bucket,
           "content" => @content,
+          "content_attachments" => @content_attachments,
           "created_at" => @created_at,
           "creator" => @creator,
           "id" => @id,
@@ -1192,16 +1202,17 @@ module Basecamp
     # Document
     class Document
       include TypeHelpers
-      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :boosts_count, :boosts_url, :comments_count, :comments_url, :content, :position, :subscription_url
+      attr_accessor :app_url, :bucket, :content_attachments, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :boosts_count, :boosts_url, :comments_count, :comments_url, :content, :position, :subscription_url
 
       # @return [Array<Symbol>]
       def self.required_fields
-        %i[app_url bucket created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+        %i[app_url bucket content_attachments created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
       end
 
       def initialize(data = {})
         @app_url = data["app_url"]
         @bucket = parse_type(data["bucket"], "TodoBucket")
+        @content_attachments = parse_array(data["content_attachments"], "RichTextAttachment")
         @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
         @id = parse_integer(data["id"])
@@ -1227,6 +1238,7 @@ module Basecamp
         {
           "app_url" => @app_url,
           "bucket" => @bucket,
+          "content_attachments" => @content_attachments,
           "created_at" => @created_at,
           "creator" => @creator,
           "id" => @id,
@@ -1320,16 +1332,17 @@ module Basecamp
     # Forward
     class Forward
       include TypeHelpers
-      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :subject, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :content, :from, :replies_count, :replies_url, :subscription_url
+      attr_accessor :app_url, :bucket, :content_attachments, :created_at, :creator, :id, :inherits_status, :parent, :status, :subject, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :content, :from, :replies_count, :replies_url, :subscription_url
 
       # @return [Array<Symbol>]
       def self.required_fields
-        %i[app_url bucket created_at creator id inherits_status parent status subject title type updated_at url visible_to_clients].freeze
+        %i[app_url bucket content_attachments created_at creator id inherits_status parent status subject title type updated_at url visible_to_clients].freeze
       end
 
       def initialize(data = {})
         @app_url = data["app_url"]
         @bucket = parse_type(data["bucket"], "TodoBucket")
+        @content_attachments = parse_array(data["content_attachments"], "RichTextAttachment")
         @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
         @id = parse_integer(data["id"])
@@ -1354,6 +1367,7 @@ module Basecamp
         {
           "app_url" => @app_url,
           "bucket" => @bucket,
+          "content_attachments" => @content_attachments,
           "created_at" => @created_at,
           "creator" => @creator,
           "id" => @id,
@@ -1383,17 +1397,18 @@ module Basecamp
     # ForwardReply
     class ForwardReply
       include TypeHelpers
-      attr_accessor :app_url, :bucket, :content, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :boosts_count, :boosts_url
+      attr_accessor :app_url, :bucket, :content, :content_attachments, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :boosts_count, :boosts_url
 
       # @return [Array<Symbol>]
       def self.required_fields
-        %i[app_url bucket content created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+        %i[app_url bucket content content_attachments created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
       end
 
       def initialize(data = {})
         @app_url = data["app_url"]
         @bucket = parse_type(data["bucket"], "TodoBucket")
         @content = data["content"]
+        @content_attachments = parse_array(data["content_attachments"], "RichTextAttachment")
         @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
         @id = parse_integer(data["id"])
@@ -1415,6 +1430,7 @@ module Basecamp
           "app_url" => @app_url,
           "bucket" => @bucket,
           "content" => @content,
+          "content_attachments" => @content_attachments,
           "created_at" => @created_at,
           "creator" => @creator,
           "id" => @id,
@@ -1440,7 +1456,7 @@ module Basecamp
     # Gauge
     class Gauge
       include TypeHelpers
-      attr_accessor :created_at, :id, :updated_at, :app_url, :bookmark_url, :bucket, :creator, :description, :enabled, :inherits_status, :last_needle_color, :last_needle_position, :previous_needle_position, :status, :title, :type, :url, :visible_to_clients
+      attr_accessor :created_at, :id, :updated_at, :app_url, :bookmark_url, :bucket, :creator, :description, :description_attachments, :enabled, :inherits_status, :last_needle_color, :last_needle_position, :previous_needle_position, :status, :title, :type, :url, :visible_to_clients
 
       # @return [Array<Symbol>]
       def self.required_fields
@@ -1456,6 +1472,7 @@ module Basecamp
         @bucket = parse_type(data["bucket"], "RecordingBucket")
         @creator = parse_type(data["creator"], "Person")
         @description = data["description"]
+        @description_attachments = parse_array(data["description_attachments"], "RichTextAttachment")
         @enabled = parse_boolean(data["enabled"])
         @inherits_status = parse_boolean(data["inherits_status"])
         @last_needle_color = data["last_needle_color"]
@@ -1478,6 +1495,7 @@ module Basecamp
           "bucket" => @bucket,
           "creator" => @creator,
           "description" => @description,
+          "description_attachments" => @description_attachments,
           "enabled" => @enabled,
           "inherits_status" => @inherits_status,
           "last_needle_color" => @last_needle_color,
@@ -1499,15 +1517,16 @@ module Basecamp
     # GaugeNeedle
     class GaugeNeedle
       include TypeHelpers
-      attr_accessor :created_at, :id, :updated_at, :app_url, :bookmark_url, :boosts_count, :boosts_url, :bucket, :color, :comments_count, :comments_url, :creator, :description, :inherits_status, :parent, :position, :status, :subscription_url, :title, :type, :url, :visible_to_clients
+      attr_accessor :created_at, :description_attachments, :id, :updated_at, :app_url, :bookmark_url, :boosts_count, :boosts_url, :bucket, :color, :comments_count, :comments_url, :creator, :description, :inherits_status, :parent, :position, :status, :subscription_url, :title, :type, :url, :visible_to_clients
 
       # @return [Array<Symbol>]
       def self.required_fields
-        %i[created_at id updated_at].freeze
+        %i[created_at description_attachments id updated_at].freeze
       end
 
       def initialize(data = {})
         @created_at = parse_datetime(data["created_at"])
+        @description_attachments = parse_array(data["description_attachments"], "RichTextAttachment")
         @id = parse_integer(data["id"])
         @updated_at = parse_datetime(data["updated_at"])
         @app_url = data["app_url"]
@@ -1534,6 +1553,7 @@ module Basecamp
       def to_h
         {
           "created_at" => @created_at,
+          "description_attachments" => @description_attachments,
           "id" => @id,
           "updated_at" => @updated_at,
           "app_url" => @app_url,
@@ -1798,17 +1818,18 @@ module Basecamp
     # Message
     class Message
       include TypeHelpers
-      attr_accessor :app_url, :bucket, :content, :created_at, :creator, :id, :inherits_status, :parent, :status, :subject, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :boosts_count, :boosts_url, :category, :comments_count, :comments_url, :subscription_url
+      attr_accessor :app_url, :bucket, :content, :content_attachments, :created_at, :creator, :id, :inherits_status, :parent, :status, :subject, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :boosts_count, :boosts_url, :category, :comments_count, :comments_url, :subscription_url
 
       # @return [Array<Symbol>]
       def self.required_fields
-        %i[app_url bucket content created_at creator id inherits_status parent status subject title type updated_at url visible_to_clients].freeze
+        %i[app_url bucket content content_attachments created_at creator id inherits_status parent status subject title type updated_at url visible_to_clients].freeze
       end
 
       def initialize(data = {})
         @app_url = data["app_url"]
         @bucket = parse_type(data["bucket"], "TodoBucket")
         @content = data["content"]
+        @content_attachments = parse_array(data["content_attachments"], "RichTextAttachment")
         @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
         @id = parse_integer(data["id"])
@@ -1835,6 +1856,7 @@ module Basecamp
           "app_url" => @app_url,
           "bucket" => @bucket,
           "content" => @content,
+          "content_attachments" => @content_attachments,
           "created_at" => @created_at,
           "creator" => @creator,
           "id" => @id,
@@ -2635,17 +2657,18 @@ module Basecamp
     # QuestionAnswer
     class QuestionAnswer
       include TypeHelpers
-      attr_accessor :app_url, :bucket, :content, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :boosts_count, :boosts_url, :comments_count, :comments_url, :group_on, :subscription_url
+      attr_accessor :app_url, :bucket, :content, :content_attachments, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :boosts_count, :boosts_url, :comments_count, :comments_url, :group_on, :subscription_url
 
       # @return [Array<Symbol>]
       def self.required_fields
-        %i[app_url bucket content created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+        %i[app_url bucket content content_attachments created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
       end
 
       def initialize(data = {})
         @app_url = data["app_url"]
         @bucket = parse_type(data["bucket"], "RecordingBucket")
         @content = data["content"]
+        @content_attachments = parse_array(data["content_attachments"], "RichTextAttachment")
         @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
         @id = parse_integer(data["id"])
@@ -2671,6 +2694,7 @@ module Basecamp
           "app_url" => @app_url,
           "bucket" => @bucket,
           "content" => @content,
+          "content_attachments" => @content_attachments,
           "created_at" => @created_at,
           "creator" => @creator,
           "id" => @id,
@@ -2871,7 +2895,7 @@ module Basecamp
     # Recording
     class Recording
       include TypeHelpers
-      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :comments_count, :comments_url, :content, :subscription_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :comments_count, :comments_url, :content, :content_attachments, :description_attachments, :subscription_url
 
       # @return [Array<Symbol>]
       def self.required_fields
@@ -2896,6 +2920,8 @@ module Basecamp
         @comments_count = parse_integer(data["comments_count"])
         @comments_url = data["comments_url"]
         @content = data["content"]
+        @content_attachments = parse_array(data["content_attachments"], "RichTextAttachment")
+        @description_attachments = parse_array(data["description_attachments"], "RichTextAttachment")
         @subscription_url = data["subscription_url"]
       end
 
@@ -2918,6 +2944,8 @@ module Basecamp
           "comments_count" => @comments_count,
           "comments_url" => @comments_url,
           "content" => @content,
+          "content_attachments" => @content_attachments,
+          "description_attachments" => @description_attachments,
           "subscription_url" => @subscription_url,
         }.compact
       end
@@ -3116,11 +3144,11 @@ module Basecamp
     # ScheduleEntry
     class ScheduleEntry
       include TypeHelpers
-      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :summary, :title, :type, :updated_at, :url, :visible_to_clients, :all_day, :bookmark_url, :boosts_count, :boosts_url, :comments_count, :comments_url, :description, :ends_at, :participants, :starts_at, :subscription_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :description_attachments, :id, :inherits_status, :parent, :status, :summary, :title, :type, :updated_at, :url, :visible_to_clients, :all_day, :bookmark_url, :boosts_count, :boosts_url, :comments_count, :comments_url, :description, :ends_at, :participants, :starts_at, :subscription_url
 
       # @return [Array<Symbol>]
       def self.required_fields
-        %i[app_url bucket created_at creator id inherits_status parent status summary title type updated_at url visible_to_clients].freeze
+        %i[app_url bucket created_at creator description_attachments id inherits_status parent status summary title type updated_at url visible_to_clients].freeze
       end
 
       def initialize(data = {})
@@ -3128,6 +3156,7 @@ module Basecamp
         @bucket = parse_type(data["bucket"], "TodoBucket")
         @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
+        @description_attachments = parse_array(data["description_attachments"], "RichTextAttachment")
         @id = parse_integer(data["id"])
         @inherits_status = parse_boolean(data["inherits_status"])
         @parent = parse_type(data["parent"], "RecordingParent")
@@ -3157,6 +3186,7 @@ module Basecamp
           "bucket" => @bucket,
           "created_at" => @created_at,
           "creator" => @creator,
+          "description_attachments" => @description_attachments,
           "id" => @id,
           "inherits_status" => @inherits_status,
           "parent" => @parent,
@@ -3226,7 +3256,7 @@ module Basecamp
     # SearchResult
     class SearchResult
       include TypeHelpers
-      attr_accessor :app_url, :id, :title, :type, :url, :bookmark_url, :bucket, :content, :created_at, :creator, :description, :inherits_status, :parent, :status, :subject, :updated_at, :visible_to_clients
+      attr_accessor :app_url, :id, :title, :type, :url, :bookmark_url, :bucket, :content, :content_attachments, :created_at, :creator, :description, :description_attachments, :inherits_status, :parent, :status, :subject, :updated_at, :visible_to_clients
 
       # @return [Array<Symbol>]
       def self.required_fields
@@ -3242,9 +3272,11 @@ module Basecamp
         @bookmark_url = data["bookmark_url"]
         @bucket = parse_type(data["bucket"], "RecordingBucket")
         @content = data["content"]
+        @content_attachments = parse_array(data["content_attachments"], "RichTextAttachment")
         @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
         @description = data["description"]
+        @description_attachments = parse_array(data["description_attachments"], "RichTextAttachment")
         @inherits_status = parse_boolean(data["inherits_status"])
         @parent = parse_type(data["parent"], "RecordingParent")
         @status = data["status"]
@@ -3263,9 +3295,11 @@ module Basecamp
           "bookmark_url" => @bookmark_url,
           "bucket" => @bucket,
           "content" => @content,
+          "content_attachments" => @content_attachments,
           "created_at" => @created_at,
           "creator" => @creator,
           "description" => @description,
+          "description_attachments" => @description_attachments,
           "inherits_status" => @inherits_status,
           "parent" => @parent,
           "status" => @status,
@@ -3628,11 +3662,11 @@ module Basecamp
     # Todolist
     class Todolist
       include TypeHelpers
-      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :name, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :app_todos_url, :bookmark_url, :boosts_count, :boosts_url, :comments_count, :comments_url, :completed, :completed_ratio, :description, :groups_url, :position, :subscription_url, :todos_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :description_attachments, :id, :inherits_status, :name, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :app_todos_url, :bookmark_url, :boosts_count, :boosts_url, :comments_count, :comments_url, :completed, :completed_ratio, :description, :groups_url, :position, :subscription_url, :todos_url
 
       # @return [Array<Symbol>]
       def self.required_fields
-        %i[app_url bucket created_at creator id inherits_status name parent status title type updated_at url visible_to_clients].freeze
+        %i[app_url bucket created_at creator description_attachments id inherits_status name parent status title type updated_at url visible_to_clients].freeze
       end
 
       def initialize(data = {})
@@ -3640,6 +3674,7 @@ module Basecamp
         @bucket = parse_type(data["bucket"], "TodoBucket")
         @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
+        @description_attachments = parse_array(data["description_attachments"], "RichTextAttachment")
         @id = parse_integer(data["id"])
         @inherits_status = parse_boolean(data["inherits_status"])
         @name = data["name"]
@@ -3671,6 +3706,7 @@ module Basecamp
           "bucket" => @bucket,
           "created_at" => @created_at,
           "creator" => @creator,
+          "description_attachments" => @description_attachments,
           "id" => @id,
           "inherits_status" => @inherits_status,
           "name" => @name,
@@ -3890,11 +3926,11 @@ module Basecamp
     # Upload
     class Upload
       include TypeHelpers
-      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :boosts_count, :boosts_url, :byte_size, :comments_count, :comments_url, :content_type, :description, :download_url, :filename, :height, :position, :subscription_url, :width
+      attr_accessor :app_url, :bucket, :created_at, :creator, :description_attachments, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :boosts_count, :boosts_url, :byte_size, :comments_count, :comments_url, :content_type, :description, :download_url, :filename, :height, :position, :subscription_url, :width
 
       # @return [Array<Symbol>]
       def self.required_fields
-        %i[app_url bucket created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+        %i[app_url bucket created_at creator description_attachments id inherits_status parent status title type updated_at url visible_to_clients].freeze
       end
 
       def initialize(data = {})
@@ -3902,6 +3938,7 @@ module Basecamp
         @bucket = parse_type(data["bucket"], "TodoBucket")
         @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
+        @description_attachments = parse_array(data["description_attachments"], "RichTextAttachment")
         @id = parse_integer(data["id"])
         @inherits_status = parse_boolean(data["inherits_status"])
         @parent = parse_type(data["parent"], "RecordingParent")
@@ -3933,6 +3970,7 @@ module Basecamp
           "bucket" => @bucket,
           "created_at" => @created_at,
           "creator" => @creator,
+          "description_attachments" => @description_attachments,
           "id" => @id,
           "inherits_status" => @inherits_status,
           "parent" => @parent,

--- a/ruby/test/basecamp/services/cards_service_test.rb
+++ b/ruby/test/basecamp/services/cards_service_test.rb
@@ -19,6 +19,7 @@ class CardsServiceTest < Minitest::Test
       "id" => id,
       "title" => title,
       "content" => "<p>Card description</p>",
+      "description_attachments" => [],
       "due_on" => "2024-12-31",
       "completed" => false,
       "assignees" => []

--- a/ruby/test/basecamp/services/checkins_service_test.rb
+++ b/ruby/test/basecamp/services/checkins_service_test.rb
@@ -36,6 +36,7 @@ class CheckinsServiceTest < Minitest::Test
     {
       "id" => id,
       "content" => content,
+      "content_attachments" => [],
       "creator" => { "id" => 1, "name" => "Test User" },
       "created_at" => "2024-01-01T00:00:00Z"
     }

--- a/ruby/test/basecamp/services/client_approvals_service_test.rb
+++ b/ruby/test/basecamp/services/client_approvals_service_test.rb
@@ -20,6 +20,7 @@ class ClientApprovalsServiceTest < Minitest::Test
       "subject" => subject,
       "approval_status" => "pending",
       "content" => "<p>Please review the attached designs.</p>",
+      "content_attachments" => [],
       "created_at" => "2024-01-01T00:00:00Z"
     }
   end

--- a/ruby/test/basecamp/services/client_correspondences_service_test.rb
+++ b/ruby/test/basecamp/services/client_correspondences_service_test.rb
@@ -19,6 +19,7 @@ class ClientCorrespondencesServiceTest < Minitest::Test
       "id" => id,
       "subject" => subject,
       "content" => "<p>Here is the latest update on the project.</p>",
+      "content_attachments" => [],
       "replies_count" => 3,
       "created_at" => "2024-01-01T00:00:00Z"
     }

--- a/ruby/test/basecamp/services/client_replies_service_test.rb
+++ b/ruby/test/basecamp/services/client_replies_service_test.rb
@@ -18,6 +18,7 @@ class ClientRepliesServiceTest < Minitest::Test
     {
       "id" => id,
       "content" => content,
+      "content_attachments" => [],
       "creator" => { "id" => 1, "name" => "Client User" },
       "created_at" => "2024-01-01T00:00:00Z"
     }

--- a/ruby/test/basecamp/services/comments_service_test.rb
+++ b/ruby/test/basecamp/services/comments_service_test.rb
@@ -70,4 +70,47 @@ class CommentsServiceTest < Minitest::Test
 
     assert_equal "<p>Updated comment</p>", comment["content"]
   end
+
+  # The typed decode (Basecamp::Types::Comment → RichTextAttachment) carries the
+  # rich-text content's inline files. Pixel dimensions arrive float-spelled
+  # (1024.0) for images and null for non-image blobs; parse_integer decodes
+  # both faithfully — 1024.0 → 1024 (to_i) and null → nil. This is a
+  # decode-only assertion: re-encoding a nil dimension is out of scope here,
+  # since to_h calls .compact and drops the nil key (an SDK-wide encoder
+  # behavior documented in SPEC.md §10 Type Fidelity).
+  def test_content_attachment_dimensions_decode
+    comment = Basecamp::Types::Comment.new(
+      "id" => 456,
+      "content" => "<p>Great work!</p>",
+      "content_attachments" => [
+        {
+          "id" => 1_069_480_010, "sgid" => "BAh-img", "filename" => "celebration.png",
+          "content_type" => "image/png", "byte_size" => 284_111,
+          "download_url" => "https://3.basecampapi.com/12345/buckets/1/blobs/img/download/celebration.png",
+          "width" => 1024.0, "height" => 768, "previewable" => true,
+          "preview_url" => "https://3.basecampapi.com/12345/buckets/1/blobs/img/previews/celebration.png",
+          "thumbnail_url" => "https://3.basecampapi.com/12345/buckets/1/blobs/img/thumbnails/celebration.png"
+        },
+        {
+          "id" => 1_069_480_011, "sgid" => "BAh-pdf", "filename" => "notes.pdf",
+          "content_type" => "application/pdf", "byte_size" => 1_048_576,
+          "download_url" => "https://3.basecampapi.com/12345/buckets/1/blobs/pdf/download/notes.pdf",
+          "width" => nil, "height" => nil, "previewable" => false,
+          "preview_url" => "https://3.basecampapi.com/12345/buckets/1/blobs/pdf/previews/notes.pdf",
+          "thumbnail_url" => "https://3.basecampapi.com/12345/buckets/1/blobs/pdf/thumbnails/notes.pdf"
+        }
+      ]
+    )
+
+    image, pdf = comment.content_attachments
+
+    # Float-spelled 1024.0 decodes to the integer 1024.
+    assert_equal 1024, image.width
+    assert_equal 768, image.height
+    assert_equal "image/png", image.content_type
+
+    # null dimensions decode to nil (not a sentinel 0).
+    assert_nil pdf.width
+    assert_nil pdf.height
+  end
 end

--- a/ruby/test/basecamp/services/comments_service_test.rb
+++ b/ruby/test/basecamp/services/comments_service_test.rb
@@ -19,6 +19,7 @@ class CommentsServiceTest < Minitest::Test
     {
       "id" => id,
       "content" => content,
+      "content_attachments" => [],
       "creator" => { "id" => 1, "name" => "Test User" },
       "created_at" => "2024-01-01T00:00:00Z"
     }

--- a/ruby/test/basecamp/services/documents_service_test.rb
+++ b/ruby/test/basecamp/services/documents_service_test.rb
@@ -19,6 +19,7 @@ class DocumentsServiceTest < Minitest::Test
       "id" => id,
       "title" => title,
       "content" => "<p>Notes from today's meeting...</p>",
+      "content_attachments" => [],
       "status" => "active",
       "comments_count" => 2,
       "created_at" => "2024-01-01T00:00:00Z"

--- a/ruby/test/basecamp/services/forwards_service_test.rb
+++ b/ruby/test/basecamp/services/forwards_service_test.rb
@@ -28,6 +28,7 @@ class ForwardsServiceTest < Minitest::Test
       "subject" => subject,
       "from" => "client@example.com",
       "content" => "<p>I have a question about the project.</p>",
+      "content_attachments" => [],
       "created_at" => "2024-01-01T00:00:00Z"
     }
   end
@@ -36,6 +37,7 @@ class ForwardsServiceTest < Minitest::Test
     {
       "id" => id,
       "content" => content,
+      "content_attachments" => [],
       "creator" => { "id" => 1, "name" => "Test User" },
       "created_at" => "2024-01-01T00:00:00Z"
     }

--- a/ruby/test/basecamp/services/messages_service_test.rb
+++ b/ruby/test/basecamp/services/messages_service_test.rb
@@ -21,6 +21,7 @@ class MessagesServiceTest < Minitest::Test
       "id" => id,
       "subject" => subject,
       "content" => "<p>Message content</p>",
+      "content_attachments" => [],
       "status" => "active",
       "created_at" => "2024-01-01T00:00:00Z",
       "creator" => { "id" => 1, "name" => "Test User" }

--- a/ruby/test/basecamp/services/recordings_service_test.rb
+++ b/ruby/test/basecamp/services/recordings_service_test.rb
@@ -25,6 +25,9 @@ class RecordingsServiceTest < Minitest::Test
       "title" => title,
       "status" => "active",
       "type" => "Todo",
+      # The generic recording projection carries the matching type's rich-text
+      # companion array; a Todo recording surfaces description_attachments.
+      "description_attachments" => [],
       "created_at" => "2024-01-01T00:00:00Z"
     }
   end
@@ -61,6 +64,8 @@ class RecordingsServiceTest < Minitest::Test
 
     assert_equal 456, result["id"]
     assert_equal "Test Recording", result["title"]
+    # The optional projection array surfaces on the matching-type recording.
+    assert_equal [], result["description_attachments"]
   end
 
   def test_archive

--- a/ruby/test/basecamp/services/schedules_service_test.rb
+++ b/ruby/test/basecamp/services/schedules_service_test.rb
@@ -28,6 +28,7 @@ class SchedulesServiceTest < Minitest::Test
     {
       "id" => id,
       "summary" => summary,
+      "description_attachments" => [],
       "starts_at" => "2024-12-15T09:00:00Z",
       "ends_at" => "2024-12-15T10:00:00Z",
       "all_day" => false

--- a/ruby/test/basecamp/services/search_service_test.rb
+++ b/ruby/test/basecamp/services/search_service_test.rb
@@ -24,8 +24,9 @@ class SearchServiceTest < Minitest::Test
 
     assert_equal 2, result.length
     assert_equal "Quarterly Report", result[0]["title"]
-    # The optional projection array surfaces on the matching-type result.
+    # The optional projection array surfaces on each matching-type result.
     assert_equal [], result[0]["content_attachments"]
+    assert_equal [], result[1]["content_attachments"]
   end
 
   def test_search_with_sort

--- a/ruby/test/basecamp/services/search_service_test.rb
+++ b/ruby/test/basecamp/services/search_service_test.rb
@@ -11,8 +11,10 @@ class SearchServiceTest < Minitest::Test
 
   def test_search
     results = [
-      { "id" => 1, "title" => "Quarterly Report", "type" => "Message" },
-      { "id" => 2, "title" => "Q1 Report Draft", "type" => "Document" }
+      # The search projection carries the matching type's rich-text companion
+      # array; a Message result surfaces content_attachments.
+      { "id" => 1, "title" => "Quarterly Report", "type" => "Message", "content_attachments" => [] },
+      { "id" => 2, "title" => "Q1 Report Draft", "type" => "Document", "content_attachments" => [] }
     ]
     stub_request(:get, "https://3.basecampapi.com/12345/search.json")
       .with(query: { q: "quarterly report" })
@@ -22,6 +24,8 @@ class SearchServiceTest < Minitest::Test
 
     assert_equal 2, result.length
     assert_equal "Quarterly Report", result[0]["title"]
+    # The optional projection array surfaces on the matching-type result.
+    assert_equal [], result[0]["content_attachments"]
   end
 
   def test_search_with_sort

--- a/ruby/test/basecamp/services/todolists_service_test.rb
+++ b/ruby/test/basecamp/services/todolists_service_test.rb
@@ -16,7 +16,7 @@ class TodolistsServiceTest < Minitest::Test
   end
 
   def test_list
-    response = [ { "id" => 1, "name" => "Sprint Tasks", "completed_ratio" => "3/10" } ]
+    response = [ { "id" => 1, "name" => "Sprint Tasks", "completed_ratio" => "3/10", "description_attachments" => [] } ]
 
     stub_request(:get, %r{https://3\.basecampapi\.com/12345/todosets/\d+/todolists\.json})
       .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
@@ -27,7 +27,7 @@ class TodolistsServiceTest < Minitest::Test
   end
 
   def test_list_with_status
-    response = [ { "id" => 1, "name" => "Archived List", "status" => "archived" } ]
+    response = [ { "id" => 1, "name" => "Archived List", "status" => "archived", "description_attachments" => [] } ]
 
     stub_request(:get, %r{https://3\.basecampapi\.com/12345/todosets/\d+/todolists\.json\?status=archived})
       .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
@@ -37,7 +37,7 @@ class TodolistsServiceTest < Minitest::Test
   end
 
   def test_get
-    response = { "id" => 2, "name" => "Sprint Tasks" }
+    response = { "id" => 2, "name" => "Sprint Tasks", "description_attachments" => [] }
 
     # Generated service uses /todolists/{id} without .json
     stub_request(:get, %r{https://3\.basecampapi\.com/12345/todolists/\d+$})
@@ -48,7 +48,7 @@ class TodolistsServiceTest < Minitest::Test
   end
 
   def test_create
-    response = { "id" => 1, "name" => "New List" }
+    response = { "id" => 1, "name" => "New List", "description_attachments" => [] }
 
     stub_request(:post, %r{https://3\.basecampapi\.com/12345/todosets/\d+/todolists\.json})
       .to_return(status: 201, body: response.to_json, headers: { "Content-Type" => "application/json" })
@@ -58,7 +58,7 @@ class TodolistsServiceTest < Minitest::Test
   end
 
   def test_update
-    response = { "id" => 2, "name" => "Updated List" }
+    response = { "id" => 2, "name" => "Updated List", "description_attachments" => [] }
 
     # Generated service uses /todolists/{id} without .json
     stub_request(:put, %r{https://3\.basecampapi\.com/12345/todolists/\d+$})

--- a/ruby/test/basecamp/services/uploads_service_test.rb
+++ b/ruby/test/basecamp/services/uploads_service_test.rb
@@ -10,7 +10,7 @@ class UploadsServiceTest < Minitest::Test
   end
 
   def test_list
-    response = [ { "id" => 1, "filename" => "report.pdf", "byte_size" => 1024 } ]
+    response = [ { "id" => 1, "filename" => "report.pdf", "byte_size" => 1024, "description_attachments" => [] } ]
 
     stub_request(:get, %r{https://3\.basecampapi\.com/12345/vaults/\d+/uploads\.json})
       .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
@@ -21,7 +21,7 @@ class UploadsServiceTest < Minitest::Test
   end
 
   def test_get
-    response = { "id" => 1, "filename" => "report.pdf" }
+    response = { "id" => 1, "filename" => "report.pdf", "description_attachments" => [] }
 
     stub_request(:get, %r{https://3\.basecampapi\.com/12345/uploads/\d+})
       .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
@@ -31,7 +31,7 @@ class UploadsServiceTest < Minitest::Test
   end
 
   def test_create
-    response = { "id" => 1, "filename" => "new-report.pdf" }
+    response = { "id" => 1, "filename" => "new-report.pdf", "description_attachments" => [] }
 
     stub_request(:post, %r{https://3\.basecampapi\.com/12345/vaults/\d+/uploads\.json})
       .to_return(status: 201, body: response.to_json, headers: { "Content-Type" => "application/json" })
@@ -44,7 +44,7 @@ class UploadsServiceTest < Minitest::Test
   end
 
   def test_create_with_subscriptions
-    response = { "id" => 2, "filename" => "report.pdf" }
+    response = { "id" => 2, "filename" => "report.pdf", "description_attachments" => [] }
 
     stub_request(:post, %r{https://3\.basecampapi\.com/12345/vaults/\d+/uploads\.json})
       .to_return(status: 201, body: response.to_json, headers: { "Content-Type" => "application/json" })
@@ -60,7 +60,7 @@ class UploadsServiceTest < Minitest::Test
   end
 
   def test_update
-    response = { "id" => 1, "description" => "Updated description" }
+    response = { "id" => 1, "description" => "Updated description", "description_attachments" => [] }
 
     stub_request(:put, %r{https://3\.basecampapi\.com/12345/uploads/\d+})
       .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
@@ -70,7 +70,7 @@ class UploadsServiceTest < Minitest::Test
   end
 
   def test_list_versions
-    response = [ { "id" => 1, "version" => 1 }, { "id" => 2, "version" => 2 } ]
+    response = [ { "id" => 1, "version" => 1, "description_attachments" => [] }, { "id" => 2, "version" => 2, "description_attachments" => [] } ]
 
     stub_request(:get, %r{https://3\.basecampapi\.com/12345/uploads/\d+/versions\.json})
       .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })

--- a/spec/api-gaps/README.md
+++ b/spec/api-gaps/README.md
@@ -54,7 +54,7 @@ making the absorption journey publicly auditable.
 | [dock-tool-create-contract](dock-tool-create-contract.md) | absorbed-in-sdk | launch | medium |
 | [upload-new-version](upload-new-version.md) | no-json-contract | post-train | medium |
 | [todolist-reposition](todolist-reposition.md) | absorbed-in-sdk | pre-BC5 | medium |
-| [rich-text-attachments-coverage](rich-text-attachments-coverage.md) | addressed-in-bc3-pr-9980 | n/a | medium |
+| [rich-text-attachments-coverage](rich-text-attachments-coverage.md) | absorbed-in-sdk | n/a | medium |
 | [visible-to-clients-on-creates](visible-to-clients-on-creates.md) | absorbed-in-sdk | post-train | medium |
 | [external-links-doors](external-links-doors.md) | addressed-in-bc3-pr-12375 | post-train | low |
 | [dock-tool-visible-to-clients](dock-tool-visible-to-clients.md) | addressed-in-bc3-pr-12386 | post-train | low |

--- a/spec/api-gaps/rich-text-attachments-coverage.md
+++ b/spec/api-gaps/rich-text-attachments-coverage.md
@@ -1,9 +1,32 @@
 ---
 gap: rich-text-attachments-coverage
-status: addressed-in-bc3-pr-9980
+status: absorbed-in-sdk
 detected: 2026-07-22
 sdk_demand: medium
 bc3_pr: 9980
+smithy_refs:
+  - "RichTextAttachment (spec/basecamp.smithy:1309)"
+  - "RichTextAttachmentList (spec/basecamp.smithy:1299)"
+  - "Todo$description_attachments (spec/basecamp.smithy:1284)"
+  - "Todolist$description_attachments (spec/basecamp.smithy:1523)"
+  - "Comment$content_attachments (spec/basecamp.smithy:2898)"
+  - "Message$content_attachments (spec/basecamp.smithy:2966)"
+  - "Document$content_attachments (spec/basecamp.smithy:3110)"
+  - "Upload$description_attachments (spec/basecamp.smithy:3161)"
+  - "ScheduleEntry$description_attachments (spec/basecamp.smithy:3254)"
+  - "Forward$content_attachments (spec/basecamp.smithy:4101)"
+  - "ForwardReply$content_attachments (spec/basecamp.smithy:4144)"
+  - "Card$description_attachments (spec/basecamp.smithy:4854)"
+  - "ClientApproval$content_attachments (spec/basecamp.smithy:5471)"
+  - "ClientCorrespondence$content_attachments (spec/basecamp.smithy:5538)"
+  - "ClientReply$content_attachments (spec/basecamp.smithy:5580)"
+  - "Recording$content_attachments (spec/basecamp.smithy:6097)"
+  - "Recording$description_attachments (spec/basecamp.smithy:6099)"
+  - "QuestionAnswer$content_attachments (spec/basecamp.smithy:6697)"
+  - "SearchResult$content_attachments (spec/basecamp.smithy:7551)"
+  - "SearchResult$description_attachments (spec/basecamp.smithy:7553)"
+  - "Gauge$description_attachments (spec/basecamp.smithy:8252)"
+  - "GaugeNeedle$description_attachments (spec/basecamp.smithy:8284)"
 bc3_refs:
   introduced_in: three
   routes:
@@ -14,81 +37,112 @@ bc3_refs:
     - app/views/api/blobs/_blob.json.jbuilder
   related_existing_api:
     - GetTodo
+    - GetComment
+    - GetMessage
+    - Search
+    - ListRecordings
 ---
 
-# Rich-text `*_attachments` arrays are only partially modeled
+# Rich-text `*_attachments` arrays are now fully modeled
 
 > **Not an additive BC5 gap.** Every rich-text attribute in a BC3/BC4/BC5 API
 > response has *always* been paired with a `*_attachments` array of structured
 > file metadata (documented in upstream `doc/api/sections/rich_text.md`,
-> addressed by bc3 #9980). The gap is SDK-side: the SDK modeled the rich-text
-> *strings* but not their companion attachment arrays. This entry records the
-> first slice of coverage (`Todo.description_attachments`) and the residual.
+> addressed by bc3 #9980). The gap was SDK-side: the SDK modeled the rich-text
+> *strings* but not their companion attachment arrays. #400 shipped the first
+> slice (`Todo.description_attachments`); **#405 completes coverage across every
+> modeled rich-text decode path** and flips this entry to `absorbed-in-sdk`.
+> This is absorption, not a provenance sync — the contract was already within
+> the current pin, so no repin.
 
 ## What's missing
 
-Per `doc/api/sections/rich_text.md`, a resource's rich-text attribute
-(`content`, `description`, …) is accompanied by a `*_attachments` array named
-after it — the structured metadata (`id, sgid, filename, content_type,
-byte_size, download_url, previewable, preview_url, thumbnail_url`, plus
-nullable `width`/`height`) for the downloadable files embedded in that rich
-text. The array is always present (empty when the rich text has no inline
-files). The element shape comes from the jbuilder chain
-`api/recordings/_rich_text` → `attachments/_attachment` → `blobs/_blob`.
+Nothing outstanding on the modeled decode paths. Per
+`doc/api/sections/rich_text.md`, a resource's rich-text attribute (`content`,
+`description`, …) is accompanied by a `*_attachments` array named after it —
+the structured metadata (`id, sgid, filename, content_type, byte_size,
+download_url, previewable, preview_url, thumbnail_url`, plus nullable
+`width`/`height`) for the downloadable files embedded in that rich text. The
+element shape comes from the jbuilder chain `api/recordings/_rich_text` →
+`attachments/_attachment` → `blobs/_blob`.
 
-**Absorbed by this PR:** `Todo.description_attachments` (the field
-`basecamp/basecamp-cli#449` observed missing from `todos show --json`), modeled
-as `RichTextAttachment` + `RichTextAttachmentList`.
+**Absorbed (18 modeled emitters, 20 members):** every rich-text attribute the
+SDK decodes now carries its companion array, reusing `RichTextAttachment` +
+`RichTextAttachmentList`:
 
-**Residual — still unmodeled:** the companion `content_attachments` /
-`description_attachments` arrays on the other ten rich-text resources, all
-confirmed lacking a modeled array today:
+- **Todo** — `description_attachments` (#400).
+- **14 concrete resources, `@required` (always emitted, empty when no inline
+  files):** Todolist, Comment, Message, Document, Upload, ScheduleEntry,
+  Forward, ForwardReply, Card (`description_attachments`), ClientApproval,
+  ClientCorrespondence, ClientReply, QuestionAnswer, and **GaugeNeedle**.
+- **Gauge — optional, non-nullable:** the type-specific partial renders the
+  companion array only when the gauge has needles (`if gauge.any_needles?`), so
+  a needle-less gauge omits the key.
+- **2 polymorphic projections — optional, non-nullable, both arrays each:**
+  **SearchResult** (`searches/show.json.jbuilder` renders the full type-specific
+  partial via `api_search_result_template_path`, nulls the strings but keeps the
+  arrays) and the generic **Recording** (`projects/recordings/index` renders
+  `to_recordable_partial_path`). A given item carries only the array matching its
+  type; a webhook-sourced item carries neither.
 
-- Comment (`content_attachments`)
-- ClientApproval, ClientCorrespondence, ClientReply (`content_attachments`)
-- Document (`content_attachments`)
-- Message (`content_attachments`)
-- QuestionAnswer (`content_attachments`)
-- ScheduleEntry (`description_attachments` — its rich-text attribute is `description`)
-- Todolist (`description_attachments`)
-- Upload (`description_attachments`)
+**Explicitly out of scope (not "absorbed" — accurate status per item):**
+
+- **Generic `attachments` key on SearchResult** (`searches/show:25`): the
+  recording's aggregate downloadable files, a *different* projection concern, not
+  a rich-text companion array. Not modeled; tracked separately if demanded.
+- **everything/aggregates endpoints** (`everything/*`, which also render full
+  partials): **unmodeled in the SDK** — no decode path exists to carry an array
+  into. Covered by the separate `everything-aggregates.md` gap
+  (`addressed-in-bc3-pr-11627`); the companion arrays arrive for free when those
+  endpoints are absorbed.
+- **Webhook-sourced generic Recording** (`webhooks/event.jbuilder:5` renders the
+  **base** `recordings/recording` partial, which emits **no** arrays): handled by
+  the optional Recording arrays being absent — not a gap.
+- **JournalEntry:** undocumented / out of API scope. Not modeled.
+- **google_documents, cloud_files:** unmodeled bc3 resources with their own gap
+  entries; their rich-text arrays are covered when those resources are absorbed.
+- **clients/forwards, clients/introductions:** `Client::Correspondence`
+  sub-forms, not standalone modeled decode paths. Not modeled here.
 
 ## Why it matters
 
 Consumers enumerating the files embedded in a recording's rich text (to list,
-download, or preview them) can do so for a Todo's `description` but not for any
-other rich-text resource. The arrays are emitted by the API on every read, so
-the gap is purely in the SDK's typed surface — a read-path completeness gap,
-invisible to per-resource schema validation because each resource validates
-fine without the (additive) array.
+download, or preview them) can now do so for every modeled rich-text resource,
+not just a Todo's `description`. The arrays are emitted by the API on every
+read, so the gap was purely in the SDK's typed surface — a read-path
+completeness gap, invisible to per-resource schema validation because each
+resource validates fine without the (additive) array.
 
 ## Suggested API shape
 
-None new — the contract already exists and is stable. Each residual resource
-gains a `*_attachments: RichTextAttachmentList` member (`@required`, always
-emitted, empty when no inline files) reusing the `RichTextAttachment` structure
-introduced here. `width`/`height` stay optional/nullable with the cross-SDK
+None new — the contract already exists and is stable. Each resource gained a
+`*_attachments: RichTextAttachmentList` member reusing the `RichTextAttachment`
+structure: `@required` for the 14 concrete always-emitting resources, optional
+(no `@required`) for Gauge and the two projections whose partials render the
+array conditionally. `width`/`height` stay optional/nullable with the cross-SDK
 decode caveat recorded in SPEC.md §10 Type Fidelity.
 
 ## Implementation notes for BC3
 
 None. The JSON contract is documented (`doc/api/sections/rich_text.md`, bc3
 #9980) and shipping in production across BC3/BC4/BC5. This is SDK absorption
-work only; no upstream change is required.
+work only; no upstream change is required, and no provenance repin — the
+contract already sits within the current pin.
 
 ## SDK absorption plan when this lands
 
-Incremental, resource by resource, reusing `RichTextAttachment`:
+Complete. Shipped in two increments, both reusing `RichTextAttachment`:
 
-1. **Done (this PR):** `Todo.description_attachments` — the `RichTextAttachment`
-   structure + `RichTextAttachmentList` (`spec/basecamp.smithy`), faithful
-   decode across all six SDKs (float-spelled `1024.0` → `1024`,
-   `null` → nil/null), Go round-trip (`null` → `"width": null`), and per-SDK
-   decode tests. The nullable float-tolerant dimension representation shipped
-   here — Go `types.FlexInt`, Kotlin `FlexibleIntSerializer` on a nullable
-   `Int?`, Swift `Int32?` — is documented in SPEC.md §10 Type Fidelity.
-2. **Follow-up:** add `content_attachments` / `description_attachments` to the
-   ten residual resources above, each `@required RichTextAttachmentList`,
-   reusing `RichTextAttachment` and the same per-SDK decode assertions. No new
-   dimension-fidelity work is needed — the representation from step 1 already
-   decodes faithfully everywhere.
+1. **#400:** `Todo.description_attachments` — the `RichTextAttachment` structure
+   + `RichTextAttachmentList` (`spec/basecamp.smithy`), faithful decode across
+   all six SDKs (float-spelled `1024.0` → `1024`, `null` → nil/null), Go
+   round-trip (`null` → `"width": null`), and per-SDK decode tests. The nullable
+   float-tolerant dimension representation — Go `types.FlexInt`, Kotlin
+   `FlexibleIntSerializer` on a nullable `Int?`, Swift `Int32?`, Python
+   `int | float`, Ruby nilable — is documented in SPEC.md §10 Type Fidelity.
+2. **#405 (this PR):** `content_attachments` / `description_attachments` on the
+   remaining 17 structures (19 members) — 14 concrete `@required`, Gauge and the
+   two polymorphic projections (SearchResult, Recording) optional/non-nullable —
+   reusing `RichTextAttachment` and the same per-SDK decode assertions unchanged.
+   No new dimension-fidelity work was needed. The out-of-scope items above are
+   documented rather than absorbed.

--- a/spec/api-gaps/rich-text-attachments-coverage.md
+++ b/spec/api-gaps/rich-text-attachments-coverage.md
@@ -122,6 +122,18 @@ structure: `@required` for the 14 concrete always-emitting resources, optional
 array conditionally. `width`/`height` stay optional/nullable with the cross-SDK
 decode caveat recorded in SPEC.md §10 Type Fidelity.
 
+**Optional-array presence contract.** For the three optional members (Gauge and
+the SearchResult/Recording projections) an *absent* array and a *present-but-empty*
+one are distinct wire states — absent means the item is not that rich-text type
+(a non-matching projection type, or a webhook-sourced item rendered from the base
+partial), while present-empty means the matching type carries no inline files. Per
+SPEC.md's Optional Fields rule (a sentinel is not a substitute for absence), every
+SDK decodes this faithfully: Go `[]RichTextAttachment` (nil vs non-nil empty),
+Swift `[RichTextAttachment]?`, TypeScript `?: …[]`, Python `NotRequired[…]`, Ruby
+nil-vs-`[]` (`parse_array`), and Kotlin `List<RichTextAttachment>? = null` (the
+model generator emits a nullable list for optional `RichTextAttachmentList`
+members rather than the empty-list default it uses for other optional arrays).
+
 ## Implementation notes for BC3
 
 None. The JSON contract is documented (`doc/api/sections/rich_text.md`, bc3

--- a/spec/api-gaps/rich-text-attachments-coverage.md
+++ b/spec/api-gaps/rich-text-attachments-coverage.md
@@ -4,29 +4,31 @@ status: absorbed-in-sdk
 detected: 2026-07-22
 sdk_demand: medium
 bc3_pr: 9980
+# Referenced by shape/member name (grep-navigable in spec/basecamp.smithy)
+# rather than line number, which drifts as the spec grows.
 smithy_refs:
-  - "RichTextAttachment (spec/basecamp.smithy:1309)"
-  - "RichTextAttachmentList (spec/basecamp.smithy:1299)"
-  - "Todo$description_attachments (spec/basecamp.smithy:1284)"
-  - "Todolist$description_attachments (spec/basecamp.smithy:1523)"
-  - "Comment$content_attachments (spec/basecamp.smithy:2898)"
-  - "Message$content_attachments (spec/basecamp.smithy:2966)"
-  - "Document$content_attachments (spec/basecamp.smithy:3110)"
-  - "Upload$description_attachments (spec/basecamp.smithy:3161)"
-  - "ScheduleEntry$description_attachments (spec/basecamp.smithy:3254)"
-  - "Forward$content_attachments (spec/basecamp.smithy:4101)"
-  - "ForwardReply$content_attachments (spec/basecamp.smithy:4144)"
-  - "Card$description_attachments (spec/basecamp.smithy:4854)"
-  - "ClientApproval$content_attachments (spec/basecamp.smithy:5471)"
-  - "ClientCorrespondence$content_attachments (spec/basecamp.smithy:5538)"
-  - "ClientReply$content_attachments (spec/basecamp.smithy:5580)"
-  - "Recording$content_attachments (spec/basecamp.smithy:6097)"
-  - "Recording$description_attachments (spec/basecamp.smithy:6099)"
-  - "QuestionAnswer$content_attachments (spec/basecamp.smithy:6697)"
-  - "SearchResult$content_attachments (spec/basecamp.smithy:7551)"
-  - "SearchResult$description_attachments (spec/basecamp.smithy:7553)"
-  - "Gauge$description_attachments (spec/basecamp.smithy:8252)"
-  - "GaugeNeedle$description_attachments (spec/basecamp.smithy:8284)"
+  - "RichTextAttachment (spec/basecamp.smithy)"
+  - "RichTextAttachmentList (spec/basecamp.smithy)"
+  - "Todo$description_attachments (spec/basecamp.smithy)"
+  - "Todolist$description_attachments (spec/basecamp.smithy)"
+  - "Comment$content_attachments (spec/basecamp.smithy)"
+  - "Message$content_attachments (spec/basecamp.smithy)"
+  - "Document$content_attachments (spec/basecamp.smithy)"
+  - "Upload$description_attachments (spec/basecamp.smithy)"
+  - "ScheduleEntry$description_attachments (spec/basecamp.smithy)"
+  - "Forward$content_attachments (spec/basecamp.smithy)"
+  - "ForwardReply$content_attachments (spec/basecamp.smithy)"
+  - "Card$description_attachments (spec/basecamp.smithy)"
+  - "ClientApproval$content_attachments (spec/basecamp.smithy)"
+  - "ClientCorrespondence$content_attachments (spec/basecamp.smithy)"
+  - "ClientReply$content_attachments (spec/basecamp.smithy)"
+  - "Recording$content_attachments (spec/basecamp.smithy)"
+  - "Recording$description_attachments (spec/basecamp.smithy)"
+  - "QuestionAnswer$content_attachments (spec/basecamp.smithy)"
+  - "SearchResult$content_attachments (spec/basecamp.smithy)"
+  - "SearchResult$description_attachments (spec/basecamp.smithy)"
+  - "Gauge$description_attachments (spec/basecamp.smithy)"
+  - "GaugeNeedle$description_attachments (spec/basecamp.smithy)"
 bc3_refs:
   introduced_in: three
   routes:
@@ -128,11 +130,15 @@ one are distinct wire states — absent means the item is not that rich-text typ
 (a non-matching projection type, or a webhook-sourced item rendered from the base
 partial), while present-empty means the matching type carries no inline files. Per
 SPEC.md's Optional Fields rule (a sentinel is not a substitute for absence), every
-SDK decodes this faithfully: Go `[]RichTextAttachment` (nil vs non-nil empty),
-Swift `[RichTextAttachment]?`, TypeScript `?: …[]`, Python `NotRequired[…]`, Ruby
-nil-vs-`[]` (`parse_array`), and Kotlin `List<RichTextAttachment>? = null` (the
-model generator emits a nullable list for optional `RichTextAttachmentList`
-members rather than the empty-list default it uses for other optional arrays).
+SDK models these as nullable/optional so all three wire states — absent,
+present-empty, populated — round-trip faithfully in both directions: Go
+`*[]RichTextAttachment` (nil pointer omitted, non-nil pointer to `[]` re-encodes as
+`[]`), Swift `[RichTextAttachment]?`, TypeScript `?: …[]`, Python `NotRequired[…]`,
+Ruby nil-vs-`[]` (`parse_array`), and Kotlin `List<RichTextAttachment>? = null`
+(the model generator emits a nullable list for optional `RichTextAttachmentList`
+members rather than the empty-list default it uses for other optional arrays). The
+14 concrete `@required` members are always present, so they stay a plain
+non-optional list in each SDK.
 
 ## Implementation notes for BC3
 

--- a/spec/basecamp.smithy
+++ b/spec/basecamp.smithy
@@ -1521,6 +1521,8 @@ structure Todolist {
   @required
   creator: Person
   description: TodolistDescription
+  @required
+  description_attachments: RichTextAttachmentList
   completed: Boolean
   completed_ratio: String
   @required
@@ -2902,6 +2904,8 @@ structure Comment {
   creator: Person
   @required
   content: CommentContent
+  @required
+  content_attachments: RichTextAttachmentList
   boosts_count: Integer
   boosts_url: String
 }
@@ -2968,6 +2972,8 @@ structure Message {
   subject: MessageSubject
   @required
   content: MessageContent
+  @required
+  content_attachments: RichTextAttachmentList
   category: MessageType
   boosts_count: Integer
   boosts_url: String
@@ -3110,6 +3116,8 @@ structure Document {
   @required
   creator: Person
   content: DocumentContent
+  @required
+  content_attachments: RichTextAttachmentList
   boosts_count: Integer
   boosts_url: String
 }
@@ -3159,6 +3167,8 @@ structure Upload {
   @required
   creator: Person
   description: UploadDescription
+  @required
+  description_attachments: RichTextAttachmentList
   content_type: String
   byte_size: Long
   width: Integer
@@ -3250,6 +3260,8 @@ structure ScheduleEntry {
   @required
   summary: ScheduleEntrySummary
   description: ScheduleEntryDescription
+  @required
+  description_attachments: RichTextAttachmentList
   all_day: Boolean
   starts_at: ISO8601Timestamp
   ends_at: ISO8601Timestamp
@@ -4096,6 +4108,8 @@ structure Forward {
   creator: Person
   content: String
   @required
+  content_attachments: RichTextAttachmentList
+  @required
   subject: String
   from: String
   replies_count: Integer
@@ -4136,6 +4150,8 @@ structure ForwardReply {
   creator: Person
   @required
   content: String
+  @required
+  content_attachments: RichTextAttachmentList
   boosts_count: Integer
   boosts_url: String
 }
@@ -4844,6 +4860,8 @@ structure Card {
   position: Integer
   content: String
   description: String
+  @required
+  description_attachments: RichTextAttachmentList
   due_on: ISO8601Date
   completed: Boolean
   completed_at: ISO8601Timestamp
@@ -5459,6 +5477,8 @@ structure ClientApproval {
   @required
   creator: Person
   content: String
+  @required
+  content_attachments: RichTextAttachmentList
   subject: String
   due_on: ISO8601Date
   replies_count: Integer
@@ -5525,6 +5545,8 @@ structure ClientCorrespondence {
   creator: Person
   content: String
   @required
+  content_attachments: RichTextAttachmentList
+  @required
   subject: String
   replies_count: Integer
   replies_url: String
@@ -5564,6 +5586,8 @@ structure ClientReply {
   creator: Person
   @required
   content: String
+  @required
+  content_attachments: RichTextAttachmentList
 }
 
 structure RecordingBucket {
@@ -6073,6 +6097,16 @@ structure Recording {
   app_url: String
   bookmark_url: String
   content: String
+  /// Rich-text companion arrays carried through the generic recording
+  /// projection (`to_recordable_partial_path` renders the full type-specific
+  /// partial). A given recording is one type, so it carries only the array
+  /// matching its rich-text attribute (`content_attachments` for a
+  /// Comment/Message, `description_attachments` for a Todo/Card); a
+  /// webhook-sourced recording (base partial) carries neither. Optional (no
+  /// `@required`), non-nullable.
+  content_attachments: RichTextAttachmentList
+  /// See `content_attachments` — the description-attribute companion array.
+  description_attachments: RichTextAttachmentList
   comments_count: Integer
   comments_url: String
   subscription_url: String
@@ -6671,6 +6705,8 @@ structure QuestionAnswer {
   comments_url: String
   @required
   content: String
+  @required
+  content_attachments: RichTextAttachmentList
   group_on: ISO8601Date
   @required
   parent: RecordingParent
@@ -7517,6 +7553,16 @@ structure SearchResult {
   creator: Person
   content: String
   description: String
+  /// Rich-text companion arrays carried through the polymorphic search
+  /// projection. A given result is one recording type, so it carries only
+  /// the array matching its rich-text attribute (`content_attachments` for a
+  /// Comment/Message, `description_attachments` for a Todo); a webhook-sourced
+  /// result carries neither. Optional (no `@required`), non-nullable. Distinct
+  /// from the generic `attachments` key (the recording's aggregate downloadable
+  /// files), which is a separate projection concern and not modeled here.
+  content_attachments: RichTextAttachmentList
+  /// See `content_attachments` — the description-attribute companion array.
+  description_attachments: RichTextAttachmentList
   subject: String
 }
 
@@ -8211,6 +8257,11 @@ structure Gauge {
   bucket: RecordingBucket
   creator: Person
   description: String
+  /// Optional (no `@required`): the type-specific partial renders the
+  /// companion array only when the gauge has needles (bc3 `if
+  /// gauge.any_needles?`), so a needle-less gauge omits the key entirely.
+  /// Non-nullable — never served as JSON `null`.
+  description_attachments: RichTextAttachmentList
   enabled: Boolean
   last_needle_color: String
   last_needle_position: Integer
@@ -8241,6 +8292,8 @@ structure GaugeNeedle {
   bucket: RecordingBucket
   creator: Person
   description: String
+  @required
+  description_attachments: RichTextAttachmentList
   color: String
   position: Integer
 }

--- a/spec/fixtures/cards/get.json
+++ b/spec/fixtures/cards/get.json
@@ -140,5 +140,6 @@
       },
       "assignees": []
     }
-  ]
+  ],
+  "description_attachments": []
 }

--- a/spec/fixtures/cards/list.json
+++ b/spec/fixtures/cards/list.json
@@ -114,7 +114,8 @@
         },
         "assignees": []
       }
-    ]
+    ],
+    "description_attachments": []
   },
   {
     "id": 1069479351,
@@ -155,6 +156,7 @@
     },
     "assignees": [],
     "completion_subscribers": [],
-    "steps": []
+    "steps": [],
+    "description_attachments": []
   }
 ]

--- a/spec/fixtures/checkins/answer.json
+++ b/spec/fixtures/checkins/answer.json
@@ -46,5 +46,6 @@
     "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
     "can_manage_projects": true,
     "can_manage_people": true
-  }
+  },
+  "content_attachments": []
 }

--- a/spec/fixtures/checkins/answers_by_person.json
+++ b/spec/fixtures/checkins/answers_by_person.json
@@ -47,6 +47,7 @@
       "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
       "can_manage_projects": true,
       "can_manage_people": true
-    }
+    },
+    "content_attachments": []
   }
 ]

--- a/spec/fixtures/checkins/answers_list.json
+++ b/spec/fixtures/checkins/answers_list.json
@@ -47,7 +47,8 @@
       "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
       "can_manage_projects": true,
       "can_manage_people": true
-    }
+    },
+    "content_attachments": []
   },
   {
     "id": 1069479460,
@@ -101,6 +102,7 @@
       },
       "can_manage_projects": true,
       "can_manage_people": false
-    }
+    },
+    "content_attachments": []
   }
 ]

--- a/spec/fixtures/client_approvals/get.json
+++ b/spec/fixtures/client_approvals/get.json
@@ -128,5 +128,6 @@
       "content": "<div>Looks great! Thanks for all your hard work on this.</div>",
       "approved": true
     }
-  ]
+  ],
+  "content_attachments": []
 }

--- a/spec/fixtures/client_approvals/list.json
+++ b/spec/fixtures/client_approvals/list.json
@@ -77,6 +77,7 @@
       },
       "can_manage_projects": false,
       "can_manage_people": false
-    }
+    },
+    "content_attachments": []
   }
 ]

--- a/spec/fixtures/client_correspondences/get.json
+++ b/spec/fixtures/client_correspondences/get.json
@@ -46,5 +46,6 @@
   "content": "<div>Hi everyone! Welcome to the Basecamp that we'll be using to collaborate and manage the Leto Locator project.</div>",
   "subject": "Project kickoff!",
   "replies_count": 5,
-  "replies_url": "https://3.basecampapi.com/195539477/buckets/2085958500/client/recordings/1069479566/replies.json"
+  "replies_url": "https://3.basecampapi.com/195539477/buckets/2085958500/client/recordings/1069479566/replies.json",
+  "content_attachments": []
 }

--- a/spec/fixtures/client_correspondences/list.json
+++ b/spec/fixtures/client_correspondences/list.json
@@ -51,6 +51,7 @@
     "content": "<div>Hey everyone - we're in the home stretch!</div>",
     "subject": "Final deliverables and launch are right around the corner",
     "replies_count": 5,
-    "replies_url": "https://3.basecampapi.com/195539477/buckets/2085958500/client/recordings/1069479645/replies.json"
+    "replies_url": "https://3.basecampapi.com/195539477/buckets/2085958500/client/recordings/1069479645/replies.json",
+    "content_attachments": []
   }
 ]

--- a/spec/fixtures/client_replies/get.json
+++ b/spec/fixtures/client_replies/get.json
@@ -46,5 +46,6 @@
     "can_manage_projects": true,
     "can_manage_people": true
   },
-  "content": "<div>Hi Leto team, this it's Annie. I'll be your day to day contact for the project, so keep me on your speed dial (or speed email, perhaps more accurately!) Feel free to reach out to me with any questions at all, and I'll be posting up some outlines, timelines, etc. very shortly.</div>"
+  "content": "<div>Hi Leto team, this it's Annie. I'll be your day to day contact for the project, so keep me on your speed dial (or speed email, perhaps more accurately!) Feel free to reach out to me with any questions at all, and I'll be posting up some outlines, timelines, etc. very shortly.</div>",
+  "content_attachments": []
 }

--- a/spec/fixtures/client_replies/list.json
+++ b/spec/fixtures/client_replies/list.json
@@ -47,6 +47,7 @@
       "can_manage_projects": false,
       "can_manage_people": false
     },
-    "content": "<div>Hi all - we're excited to get started too.</div>"
+    "content": "<div>Hi all - we're excited to get started too.</div>",
+    "content_attachments": []
   }
 ]

--- a/spec/fixtures/comments/create.json
+++ b/spec/fixtures/comments/create.json
@@ -46,5 +46,6 @@
     "can_manage_projects": true,
     "can_manage_people": true
   },
-  "content": "<div><em>Wow!</em> That is cool.</div>"
+  "content": "<div><em>Wow!</em> That is cool.</div>",
+  "content_attachments": []
 }

--- a/spec/fixtures/comments/get.json
+++ b/spec/fixtures/comments/get.json
@@ -46,5 +46,33 @@
     "can_manage_projects": true,
     "can_manage_people": true
   },
-  "content": "<div>I just want to echo what just about everyone already said. This is a big one for us, and I can't wait to get going. I'll be spinning up the project shortly!</div>"
+  "content": "<div>I just want to echo what just about everyone already said. This is a big one for us, and I can't wait to get going. I'll be spinning up the project shortly!</div>",
+  "content_attachments": [
+    {
+      "id": 1069480010,
+      "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDAxMAY6BkVU--c0mm3nt1",
+      "filename": "celebration.png",
+      "content_type": "image/png",
+      "byte_size": 284111,
+      "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDAxMAY6BkVU--c0mm3nt1/download/celebration.png",
+      "width": 1024.0,
+      "height": 768,
+      "previewable": true,
+      "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDAxMAY6BkVU--c0mm3nt1/previews/celebration.png",
+      "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDAxMAY6BkVU--c0mm3nt1/thumbnails/celebration.png"
+    },
+    {
+      "id": 1069480011,
+      "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDAxMQY6BkVU--c0mm3nt2",
+      "filename": "notes.pdf",
+      "content_type": "application/pdf",
+      "byte_size": 1048576,
+      "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDAxMQY6BkVU--c0mm3nt2/download/notes.pdf",
+      "width": null,
+      "height": null,
+      "previewable": false,
+      "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDAxMQY6BkVU--c0mm3nt2/previews/notes.pdf",
+      "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDAxMQY6BkVU--c0mm3nt2/thumbnails/notes.pdf"
+    }
+  ]
 }

--- a/spec/fixtures/comments/list.json
+++ b/spec/fixtures/comments/list.json
@@ -43,7 +43,8 @@
       "can_manage_projects": true,
       "can_manage_people": true
     },
-    "content": "<div>Yeah! Great job everyone! Super excited to get going!</div>"
+    "content": "<div>Yeah! Great job everyone! Super excited to get going!</div>",
+    "content_attachments": []
   },
   {
     "id": 1069479361,
@@ -93,6 +94,7 @@
       "can_manage_projects": true,
       "can_manage_people": true
     },
-    "content": "<div>I just want to echo what just about everyone already said. This is a big one for us, and I can't wait to get going. I'll be spinning up the project shortly!</div>"
+    "content": "<div>I just want to echo what just about everyone already said. This is a big one for us, and I can't wait to get going. I'll be spinning up the project shortly!</div>",
+    "content_attachments": []
   }
 ]

--- a/spec/fixtures/documents/get.json
+++ b/spec/fixtures/documents/get.json
@@ -46,5 +46,6 @@
     "can_manage_projects": true,
     "can_manage_people": true
   },
-  "content": "<div>This document contains the project overview and key milestones.</div>"
+  "content": "<div>This document contains the project overview and key milestones.</div>",
+  "content_attachments": []
 }

--- a/spec/fixtures/documents/list.json
+++ b/spec/fixtures/documents/list.json
@@ -47,7 +47,8 @@
       "can_manage_projects": true,
       "can_manage_people": true
     },
-    "content": "<div>This document contains the project overview and key milestones.</div>"
+    "content": "<div>This document contains the project overview and key milestones.</div>",
+    "content_attachments": []
   },
   {
     "id": 1069479301,
@@ -97,6 +98,7 @@
       "can_manage_projects": true,
       "can_manage_people": true
     },
-    "content": "<div>Notes from the kickoff meeting.</div>"
+    "content": "<div>Notes from the kickoff meeting.</div>",
+    "content_attachments": []
   }
 ]

--- a/spec/fixtures/forwards/get.json
+++ b/spec/fixtures/forwards/get.json
@@ -38,5 +38,6 @@
     "employee": true,
     "time_zone": "America/Chicago",
     "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--e9c67c17e3fc5c36ae1eaeefe7cc2a3ba1b7f05a/avatar?v=1"
-  }
+  },
+  "content_attachments": []
 }

--- a/spec/fixtures/forwards/list.json
+++ b/spec/fixtures/forwards/list.json
@@ -31,7 +31,8 @@
       "title": "Chief Strategist",
       "admin": true,
       "owner": true
-    }
+    },
+    "content_attachments": []
   },
   {
     "id": 1069479390,
@@ -69,6 +70,7 @@
         "id": 1033447817,
         "name": "Honcho Design"
       }
-    }
+    },
+    "content_attachments": []
   }
 ]

--- a/spec/fixtures/forwards/replies_list.json
+++ b/spec/fixtures/forwards/replies_list.json
@@ -29,7 +29,8 @@
       "title": "Project Manager",
       "admin": false,
       "owner": false
-    }
+    },
+    "content_attachments": []
   },
   {
     "id": 1069479410,
@@ -61,6 +62,7 @@
       "title": "Chief Strategist",
       "admin": true,
       "owner": true
-    }
+    },
+    "content_attachments": []
   }
 ]

--- a/spec/fixtures/forwards/reply_get.json
+++ b/spec/fixtures/forwards/reply_get.json
@@ -40,5 +40,6 @@
       "id": 1033447817,
       "name": "Honcho Design"
     }
-  }
+  },
+  "content_attachments": []
 }

--- a/spec/fixtures/messages/get.json
+++ b/spec/fixtures/messages/get.json
@@ -56,5 +56,6 @@
     "icon": "📢",
     "created_at": "2022-10-28T15:00:00.000Z",
     "updated_at": "2022-10-28T15:00:00.000Z"
-  }
+  },
+  "content_attachments": []
 }

--- a/spec/fixtures/messages/list.json
+++ b/spec/fixtures/messages/list.json
@@ -51,7 +51,8 @@
       "icon": "📢",
       "created_at": "2022-10-28T15:00:00.000Z",
       "updated_at": "2022-10-28T15:00:00.000Z"
-    }
+    },
+    "content_attachments": []
   },
   {
     "id": 1069479360,
@@ -102,6 +103,7 @@
       },
       "can_manage_projects": true,
       "can_manage_people": true
-    }
+    },
+    "content_attachments": []
   }
 ]

--- a/spec/fixtures/recordings/get.json
+++ b/spec/fixtures/recordings/get.json
@@ -45,5 +45,20 @@
     },
     "can_manage_projects": true,
     "can_manage_people": true
-  }
+  },
+  "content_attachments": [
+    {
+      "id": 1069481040,
+      "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA40--pr0j0040",
+      "filename": "diagram-40.png",
+      "content_type": "image/png",
+      "byte_size": 204800,
+      "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA40--pr0j0040/download/diagram-40.png",
+      "width": 1024.0,
+      "height": 768,
+      "previewable": true,
+      "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA40--pr0j0040/previews/diagram-40.png",
+      "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA40--pr0j0040/thumbnails/diagram-40.png"
+    }
+  ]
 }

--- a/spec/fixtures/recordings/list.json
+++ b/spec/fixtures/recordings/list.json
@@ -46,7 +46,22 @@
       },
       "can_manage_projects": true,
       "can_manage_people": true
-    }
+    },
+    "content_attachments": [
+      {
+        "id": 1069481050,
+        "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA50--pr0j0050",
+        "filename": "diagram-50.png",
+        "content_type": "image/png",
+        "byte_size": 204800,
+        "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA50--pr0j0050/download/diagram-50.png",
+        "width": 1024.0,
+        "height": 768,
+        "previewable": true,
+        "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA50--pr0j0050/previews/diagram-50.png",
+        "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA50--pr0j0050/thumbnails/diagram-50.png"
+      }
+    ]
   },
   {
     "id": 1069479400,
@@ -91,6 +106,21 @@
         "id": 1033447817,
         "name": "Honcho Design"
       }
-    }
+    },
+    "content_attachments": [
+      {
+        "id": 1069481051,
+        "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA51--pr0j0051",
+        "filename": "diagram-51.png",
+        "content_type": "image/png",
+        "byte_size": 204800,
+        "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA51--pr0j0051/download/diagram-51.png",
+        "width": 1024.0,
+        "height": 768,
+        "previewable": true,
+        "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA51--pr0j0051/previews/diagram-51.png",
+        "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA51--pr0j0051/thumbnails/diagram-51.png"
+      }
+    ]
   }
 ]

--- a/spec/fixtures/schedules/entries_list.json
+++ b/spec/fixtures/schedules/entries_list.json
@@ -92,7 +92,8 @@
         "can_manage_projects": true,
         "can_manage_people": true
       }
-    ]
+    ],
+    "description_attachments": []
   },
   {
     "id": 1069479410,
@@ -146,6 +147,7 @@
       "can_manage_projects": true,
       "can_manage_people": true
     },
-    "participants": []
+    "participants": [],
+    "description_attachments": []
   }
 ]

--- a/spec/fixtures/schedules/entry_get.json
+++ b/spec/fixtures/schedules/entry_get.json
@@ -91,5 +91,6 @@
       "can_manage_projects": true,
       "can_manage_people": true
     }
-  ]
+  ],
+  "description_attachments": []
 }

--- a/spec/fixtures/search/results.json
+++ b/spec/fixtures/search/results.json
@@ -44,7 +44,22 @@
       "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
       "can_manage_projects": true,
       "can_manage_people": true
-    }
+    },
+    "content_attachments": [
+      {
+        "id": 1069481030,
+        "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA30--pr0j0030",
+        "filename": "diagram-30.png",
+        "content_type": "image/png",
+        "byte_size": 204800,
+        "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA30--pr0j0030/download/diagram-30.png",
+        "width": 1024.0,
+        "height": 768,
+        "previewable": true,
+        "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA30--pr0j0030/previews/diagram-30.png",
+        "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA30--pr0j0030/thumbnails/diagram-30.png"
+      }
+    ]
   },
   {
     "id": 1069479400,
@@ -90,7 +105,22 @@
       "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMtkkT4=--avatar",
       "can_manage_projects": true,
       "can_manage_people": true
-    }
+    },
+    "description_attachments": [
+      {
+        "id": 1069481031,
+        "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA31--pr0j0031",
+        "filename": "diagram-31.png",
+        "content_type": "image/png",
+        "byte_size": 204800,
+        "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA31--pr0j0031/download/diagram-31.png",
+        "width": 1024.0,
+        "height": 768,
+        "previewable": true,
+        "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA31--pr0j0031/previews/diagram-31.png",
+        "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA31--pr0j0031/thumbnails/diagram-31.png"
+      }
+    ]
   },
   {
     "id": 1069479450,
@@ -136,6 +166,21 @@
       "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
       "can_manage_projects": true,
       "can_manage_people": true
-    }
+    },
+    "content_attachments": [
+      {
+        "id": 1069481032,
+        "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA32--pr0j0032",
+        "filename": "diagram-32.png",
+        "content_type": "image/png",
+        "byte_size": 204800,
+        "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA32--pr0j0032/download/diagram-32.png",
+        "width": 1024.0,
+        "height": 768,
+        "previewable": true,
+        "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA32--pr0j0032/previews/diagram-32.png",
+        "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA32--pr0j0032/thumbnails/diagram-32.png"
+      }
+    ]
   }
 ]

--- a/spec/fixtures/todolists/get.json
+++ b/spec/fixtures/todolists/get.json
@@ -56,5 +56,6 @@
   "name": "Hardware",
   "todos_url": "https://3.basecampapi.com/195539477/buckets/2085958500/todolists/1069479519/todos.json",
   "groups_url": "https://3.basecampapi.com/195539477/buckets/2085958500/todolists/1069479519/groups.json",
-  "app_todos_url": "https://3.basecamp.com/195539477/buckets/2085958500/todolists/1069479519/todos"
+  "app_todos_url": "https://3.basecamp.com/195539477/buckets/2085958500/todolists/1069479519/todos",
+  "description_attachments": []
 }

--- a/spec/fixtures/todolists/list.json
+++ b/spec/fixtures/todolists/list.json
@@ -57,7 +57,8 @@
     "name": "Hardware",
     "todos_url": "https://3.basecampapi.com/195539477/buckets/2085958500/todolists/1069479519/todos.json",
     "groups_url": "https://3.basecampapi.com/195539477/buckets/2085958500/todolists/1069479519/groups.json",
-    "app_todos_url": "https://3.basecamp.com/195539477/buckets/2085958500/todolists/1069479519/todos"
+    "app_todos_url": "https://3.basecamp.com/195539477/buckets/2085958500/todolists/1069479519/todos",
+    "description_attachments": []
   },
   {
     "id": 1069479522,
@@ -117,6 +118,7 @@
     "name": "Software",
     "todos_url": "https://3.basecampapi.com/195539477/buckets/2085958500/todolists/1069479522/todos.json",
     "groups_url": "https://3.basecampapi.com/195539477/buckets/2085958500/todolists/1069479522/groups.json",
-    "app_todos_url": "https://3.basecamp.com/195539477/buckets/2085958500/todolists/1069479522/todos"
+    "app_todos_url": "https://3.basecamp.com/195539477/buckets/2085958500/todolists/1069479522/todos",
+    "description_attachments": []
   }
 ]

--- a/spec/fixtures/uploads/get.json
+++ b/spec/fixtures/uploads/get.json
@@ -52,5 +52,33 @@
   "width": 1024.0,
   "height": 768.0,
   "download_url": "https://3.basecampapi.com/999999999/blobs/abcd1234/download/logo.png",
-  "filename": "logo.png"
+  "filename": "logo.png",
+  "description_attachments": [
+    {
+      "id": 1069480020,
+      "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDAyMAY6BkVU--upl0ad01",
+      "filename": "brand-guide.png",
+      "content_type": "image/png",
+      "byte_size": 512000,
+      "download_url": "https://3.basecampapi.com/999999999/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDAyMAY6BkVU--upl0ad01/download/brand-guide.png",
+      "width": 1024.0,
+      "height": 768,
+      "previewable": true,
+      "preview_url": "https://3.basecampapi.com/999999999/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDAyMAY6BkVU--upl0ad01/previews/brand-guide.png",
+      "thumbnail_url": "https://3.basecampapi.com/999999999/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDAyMAY6BkVU--upl0ad01/thumbnails/brand-guide.png"
+    },
+    {
+      "id": 1069480021,
+      "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDAyMQY6BkVU--upl0ad02",
+      "filename": "specs.pdf",
+      "content_type": "application/pdf",
+      "byte_size": 2097152,
+      "download_url": "https://3.basecampapi.com/999999999/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDAyMQY6BkVU--upl0ad02/download/specs.pdf",
+      "width": null,
+      "height": null,
+      "previewable": false,
+      "preview_url": "https://3.basecampapi.com/999999999/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDAyMQY6BkVU--upl0ad02/previews/specs.pdf",
+      "thumbnail_url": "https://3.basecampapi.com/999999999/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDAyMQY6BkVU--upl0ad02/thumbnails/specs.pdf"
+    }
+  ]
 }

--- a/spec/fixtures/uploads/list.json
+++ b/spec/fixtures/uploads/list.json
@@ -53,7 +53,8 @@
     "width": 1024.0,
     "height": 768.0,
     "download_url": "https://3.basecampapi.com/999999999/blobs/abcd1234/download/logo.png",
-    "filename": "logo.png"
+    "filename": "logo.png",
+    "description_attachments": []
   },
   {
     "id": 1069479401,
@@ -107,6 +108,7 @@
     "content_type": "application/pdf",
     "byte_size": 1048576,
     "download_url": "https://3.basecampapi.com/999999999/blobs/efgh5678/download/proposal.pdf",
-    "filename": "proposal.pdf"
+    "filename": "proposal.pdf",
+    "description_attachments": []
   }
 ]

--- a/spec/overlays/examples.smithy
+++ b/spec/overlays/examples.smithy
@@ -12,7 +12,7 @@ apply GetTodolistOrGroup @examples([
     output: { result: { todolist: {
       id: 987654, status: "active", name: "Launch Tasks",
       visible_to_clients: false, created_at: "2025-01-01T00:00:00Z", updated_at: "2025-01-01T00:00:00Z",
-      title: "Launch Tasks", inherits_status: true, type: "Todolist",
+      title: "Launch Tasks", inherits_status: true, type: "Todolist", description_attachments: [],
       url: "https://3.basecampapi.com/999/buckets/12345678/todolists/987654.json",
       app_url: "https://3.basecamp.com/999/buckets/12345678/todolists/987654",
       creator: { id: 1, name: "Someone", created_at: "2025-01-01T00:00:00Z", updated_at: "2025-01-01T00:00:00Z" },

--- a/swift/Sources/Basecamp/Generated/Models/Answer.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Answer.swift
@@ -5,6 +5,7 @@ public struct Answer: Codable, Sendable {
     public let appUrl: String
     public let bucket: RecordingBucket
     public let content: String
+    public let contentAttachments: [RichTextAttachment]
     public let createdAt: String
     public let creator: Person
     public let id: Int
@@ -28,6 +29,7 @@ public struct Answer: Codable, Sendable {
         appUrl: String,
         bucket: RecordingBucket,
         content: String,
+        contentAttachments: [RichTextAttachment],
         createdAt: String,
         creator: Person,
         id: Int,
@@ -50,6 +52,7 @@ public struct Answer: Codable, Sendable {
         self.appUrl = appUrl
         self.bucket = bucket
         self.content = content
+        self.contentAttachments = contentAttachments
         self.createdAt = createdAt
         self.creator = creator
         self.id = id

--- a/swift/Sources/Basecamp/Generated/Models/Card.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Card.swift
@@ -6,6 +6,7 @@ public struct Card: Codable, Sendable {
     public let bucket: TodoBucket
     public let createdAt: String
     public let creator: Person
+    public let descriptionAttachments: [RichTextAttachment]
     public let id: Int
     public let inheritsStatus: Bool
     public let parent: RecordingParent
@@ -38,6 +39,7 @@ public struct Card: Codable, Sendable {
         bucket: TodoBucket,
         createdAt: String,
         creator: Person,
+        descriptionAttachments: [RichTextAttachment],
         id: Int,
         inheritsStatus: Bool,
         parent: RecordingParent,
@@ -69,6 +71,7 @@ public struct Card: Codable, Sendable {
         self.bucket = bucket
         self.createdAt = createdAt
         self.creator = creator
+        self.descriptionAttachments = descriptionAttachments
         self.id = id
         self.inheritsStatus = inheritsStatus
         self.parent = parent

--- a/swift/Sources/Basecamp/Generated/Models/ClientApproval.swift
+++ b/swift/Sources/Basecamp/Generated/Models/ClientApproval.swift
@@ -4,6 +4,7 @@ import Foundation
 public struct ClientApproval: Codable, Sendable {
     public let appUrl: String
     public let bucket: RecordingBucket
+    public let contentAttachments: [RichTextAttachment]
     public let createdAt: String
     public let creator: Person
     public let id: Int
@@ -29,6 +30,7 @@ public struct ClientApproval: Codable, Sendable {
     public init(
         appUrl: String,
         bucket: RecordingBucket,
+        contentAttachments: [RichTextAttachment],
         createdAt: String,
         creator: Person,
         id: Int,
@@ -53,6 +55,7 @@ public struct ClientApproval: Codable, Sendable {
     ) {
         self.appUrl = appUrl
         self.bucket = bucket
+        self.contentAttachments = contentAttachments
         self.createdAt = createdAt
         self.creator = creator
         self.id = id

--- a/swift/Sources/Basecamp/Generated/Models/ClientCorrespondence.swift
+++ b/swift/Sources/Basecamp/Generated/Models/ClientCorrespondence.swift
@@ -4,6 +4,7 @@ import Foundation
 public struct ClientCorrespondence: Codable, Sendable {
     public let appUrl: String
     public let bucket: RecordingBucket
+    public let contentAttachments: [RichTextAttachment]
     public let createdAt: String
     public let creator: Person
     public let id: Int
@@ -25,6 +26,7 @@ public struct ClientCorrespondence: Codable, Sendable {
     public init(
         appUrl: String,
         bucket: RecordingBucket,
+        contentAttachments: [RichTextAttachment],
         createdAt: String,
         creator: Person,
         id: Int,
@@ -45,6 +47,7 @@ public struct ClientCorrespondence: Codable, Sendable {
     ) {
         self.appUrl = appUrl
         self.bucket = bucket
+        self.contentAttachments = contentAttachments
         self.createdAt = createdAt
         self.creator = creator
         self.id = id

--- a/swift/Sources/Basecamp/Generated/Models/ClientReply.swift
+++ b/swift/Sources/Basecamp/Generated/Models/ClientReply.swift
@@ -5,6 +5,7 @@ public struct ClientReply: Codable, Sendable {
     public let appUrl: String
     public let bucket: RecordingBucket
     public let content: String
+    public let contentAttachments: [RichTextAttachment]
     public let createdAt: String
     public let creator: Person
     public let id: Int
@@ -22,6 +23,7 @@ public struct ClientReply: Codable, Sendable {
         appUrl: String,
         bucket: RecordingBucket,
         content: String,
+        contentAttachments: [RichTextAttachment],
         createdAt: String,
         creator: Person,
         id: Int,
@@ -38,6 +40,7 @@ public struct ClientReply: Codable, Sendable {
         self.appUrl = appUrl
         self.bucket = bucket
         self.content = content
+        self.contentAttachments = contentAttachments
         self.createdAt = createdAt
         self.creator = creator
         self.id = id

--- a/swift/Sources/Basecamp/Generated/Models/Comment.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Comment.swift
@@ -5,6 +5,7 @@ public struct Comment: Codable, Sendable {
     public let appUrl: String
     public let bucket: TodoBucket
     public let content: String
+    public let contentAttachments: [RichTextAttachment]
     public let createdAt: String
     public let creator: Person
     public let id: Int
@@ -24,6 +25,7 @@ public struct Comment: Codable, Sendable {
         appUrl: String,
         bucket: TodoBucket,
         content: String,
+        contentAttachments: [RichTextAttachment],
         createdAt: String,
         creator: Person,
         id: Int,
@@ -42,6 +44,7 @@ public struct Comment: Codable, Sendable {
         self.appUrl = appUrl
         self.bucket = bucket
         self.content = content
+        self.contentAttachments = contentAttachments
         self.createdAt = createdAt
         self.creator = creator
         self.id = id

--- a/swift/Sources/Basecamp/Generated/Models/Document.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Document.swift
@@ -4,6 +4,7 @@ import Foundation
 public struct Document: Codable, Sendable {
     public let appUrl: String
     public let bucket: TodoBucket
+    public let contentAttachments: [RichTextAttachment]
     public let createdAt: String
     public let creator: Person
     public let id: Int
@@ -27,6 +28,7 @@ public struct Document: Codable, Sendable {
     public init(
         appUrl: String,
         bucket: TodoBucket,
+        contentAttachments: [RichTextAttachment],
         createdAt: String,
         creator: Person,
         id: Int,
@@ -49,6 +51,7 @@ public struct Document: Codable, Sendable {
     ) {
         self.appUrl = appUrl
         self.bucket = bucket
+        self.contentAttachments = contentAttachments
         self.createdAt = createdAt
         self.creator = creator
         self.id = id

--- a/swift/Sources/Basecamp/Generated/Models/Forward.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Forward.swift
@@ -4,6 +4,7 @@ import Foundation
 public struct Forward: Codable, Sendable {
     public let appUrl: String
     public let bucket: TodoBucket
+    public let contentAttachments: [RichTextAttachment]
     public let createdAt: String
     public let creator: Person
     public let id: Int
@@ -26,6 +27,7 @@ public struct Forward: Codable, Sendable {
     public init(
         appUrl: String,
         bucket: TodoBucket,
+        contentAttachments: [RichTextAttachment],
         createdAt: String,
         creator: Person,
         id: Int,
@@ -47,6 +49,7 @@ public struct Forward: Codable, Sendable {
     ) {
         self.appUrl = appUrl
         self.bucket = bucket
+        self.contentAttachments = contentAttachments
         self.createdAt = createdAt
         self.creator = creator
         self.id = id

--- a/swift/Sources/Basecamp/Generated/Models/ForwardReply.swift
+++ b/swift/Sources/Basecamp/Generated/Models/ForwardReply.swift
@@ -5,6 +5,7 @@ public struct ForwardReply: Codable, Sendable {
     public let appUrl: String
     public let bucket: TodoBucket
     public let content: String
+    public let contentAttachments: [RichTextAttachment]
     public let createdAt: String
     public let creator: Person
     public let id: Int
@@ -24,6 +25,7 @@ public struct ForwardReply: Codable, Sendable {
         appUrl: String,
         bucket: TodoBucket,
         content: String,
+        contentAttachments: [RichTextAttachment],
         createdAt: String,
         creator: Person,
         id: Int,
@@ -42,6 +44,7 @@ public struct ForwardReply: Codable, Sendable {
         self.appUrl = appUrl
         self.bucket = bucket
         self.content = content
+        self.contentAttachments = contentAttachments
         self.createdAt = createdAt
         self.creator = creator
         self.id = id

--- a/swift/Sources/Basecamp/Generated/Models/Gauge.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Gauge.swift
@@ -10,6 +10,7 @@ public struct Gauge: Codable, Sendable {
     public var bucket: RecordingBucket?
     public var creator: Person?
     public var description: String?
+    public var descriptionAttachments: [RichTextAttachment]?
     public var enabled: Bool?
     public var inheritsStatus: Bool?
     public var lastNeedleColor: String?
@@ -30,6 +31,7 @@ public struct Gauge: Codable, Sendable {
         bucket: RecordingBucket? = nil,
         creator: Person? = nil,
         description: String? = nil,
+        descriptionAttachments: [RichTextAttachment]? = nil,
         enabled: Bool? = nil,
         inheritsStatus: Bool? = nil,
         lastNeedleColor: String? = nil,
@@ -49,6 +51,7 @@ public struct Gauge: Codable, Sendable {
         self.bucket = bucket
         self.creator = creator
         self.description = description
+        self.descriptionAttachments = descriptionAttachments
         self.enabled = enabled
         self.inheritsStatus = inheritsStatus
         self.lastNeedleColor = lastNeedleColor

--- a/swift/Sources/Basecamp/Generated/Models/GaugeNeedle.swift
+++ b/swift/Sources/Basecamp/Generated/Models/GaugeNeedle.swift
@@ -3,6 +3,7 @@ import Foundation
 
 public struct GaugeNeedle: Codable, Sendable {
     public let createdAt: String
+    public let descriptionAttachments: [RichTextAttachment]
     public let id: Int
     public let updatedAt: String
     public var appUrl: String?
@@ -27,6 +28,7 @@ public struct GaugeNeedle: Codable, Sendable {
 
     public init(
         createdAt: String,
+        descriptionAttachments: [RichTextAttachment],
         id: Int,
         updatedAt: String,
         appUrl: String? = nil,
@@ -50,6 +52,7 @@ public struct GaugeNeedle: Codable, Sendable {
         visibleToClients: Bool? = nil
     ) {
         self.createdAt = createdAt
+        self.descriptionAttachments = descriptionAttachments
         self.id = id
         self.updatedAt = updatedAt
         self.appUrl = appUrl

--- a/swift/Sources/Basecamp/Generated/Models/Message.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Message.swift
@@ -5,6 +5,7 @@ public struct Message: Codable, Sendable {
     public let appUrl: String
     public let bucket: TodoBucket
     public let content: String
+    public let contentAttachments: [RichTextAttachment]
     public let createdAt: String
     public let creator: Person
     public let id: Int
@@ -29,6 +30,7 @@ public struct Message: Codable, Sendable {
         appUrl: String,
         bucket: TodoBucket,
         content: String,
+        contentAttachments: [RichTextAttachment],
         createdAt: String,
         creator: Person,
         id: Int,
@@ -52,6 +54,7 @@ public struct Message: Codable, Sendable {
         self.appUrl = appUrl
         self.bucket = bucket
         self.content = content
+        self.contentAttachments = contentAttachments
         self.createdAt = createdAt
         self.creator = creator
         self.id = id

--- a/swift/Sources/Basecamp/Generated/Models/Recording.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Recording.swift
@@ -19,6 +19,8 @@ public struct Recording: Codable, Sendable {
     public var commentsCount: Int32?
     public var commentsUrl: String?
     public var content: String?
+    public var contentAttachments: [RichTextAttachment]?
+    public var descriptionAttachments: [RichTextAttachment]?
     public var subscriptionUrl: String?
 
     public init(
@@ -39,6 +41,8 @@ public struct Recording: Codable, Sendable {
         commentsCount: Int32? = nil,
         commentsUrl: String? = nil,
         content: String? = nil,
+        contentAttachments: [RichTextAttachment]? = nil,
+        descriptionAttachments: [RichTextAttachment]? = nil,
         subscriptionUrl: String? = nil
     ) {
         self.appUrl = appUrl
@@ -58,6 +62,8 @@ public struct Recording: Codable, Sendable {
         self.commentsCount = commentsCount
         self.commentsUrl = commentsUrl
         self.content = content
+        self.contentAttachments = contentAttachments
+        self.descriptionAttachments = descriptionAttachments
         self.subscriptionUrl = subscriptionUrl
     }
 }

--- a/swift/Sources/Basecamp/Generated/Models/ScheduleEntry.swift
+++ b/swift/Sources/Basecamp/Generated/Models/ScheduleEntry.swift
@@ -6,6 +6,7 @@ public struct ScheduleEntry: Codable, Sendable {
     public let bucket: TodoBucket
     public let createdAt: String
     public let creator: Person
+    public let descriptionAttachments: [RichTextAttachment]
     public let id: Int
     public let inheritsStatus: Bool
     public let parent: RecordingParent
@@ -33,6 +34,7 @@ public struct ScheduleEntry: Codable, Sendable {
         bucket: TodoBucket,
         createdAt: String,
         creator: Person,
+        descriptionAttachments: [RichTextAttachment],
         id: Int,
         inheritsStatus: Bool,
         parent: RecordingParent,
@@ -59,6 +61,7 @@ public struct ScheduleEntry: Codable, Sendable {
         self.bucket = bucket
         self.createdAt = createdAt
         self.creator = creator
+        self.descriptionAttachments = descriptionAttachments
         self.id = id
         self.inheritsStatus = inheritsStatus
         self.parent = parent

--- a/swift/Sources/Basecamp/Generated/Models/SearchResult.swift
+++ b/swift/Sources/Basecamp/Generated/Models/SearchResult.swift
@@ -10,9 +10,11 @@ public struct SearchResult: Codable, Sendable {
     public var bookmarkUrl: String?
     public var bucket: RecordingBucket?
     public var content: String?
+    public var contentAttachments: [RichTextAttachment]?
     public var createdAt: String?
     public var creator: Person?
     public var description: String?
+    public var descriptionAttachments: [RichTextAttachment]?
     public var inheritsStatus: Bool?
     public var parent: RecordingParent?
     public var status: String?
@@ -29,9 +31,11 @@ public struct SearchResult: Codable, Sendable {
         bookmarkUrl: String? = nil,
         bucket: RecordingBucket? = nil,
         content: String? = nil,
+        contentAttachments: [RichTextAttachment]? = nil,
         createdAt: String? = nil,
         creator: Person? = nil,
         description: String? = nil,
+        descriptionAttachments: [RichTextAttachment]? = nil,
         inheritsStatus: Bool? = nil,
         parent: RecordingParent? = nil,
         status: String? = nil,
@@ -47,9 +51,11 @@ public struct SearchResult: Codable, Sendable {
         self.bookmarkUrl = bookmarkUrl
         self.bucket = bucket
         self.content = content
+        self.contentAttachments = contentAttachments
         self.createdAt = createdAt
         self.creator = creator
         self.description = description
+        self.descriptionAttachments = descriptionAttachments
         self.inheritsStatus = inheritsStatus
         self.parent = parent
         self.status = status

--- a/swift/Sources/Basecamp/Generated/Models/Todolist.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Todolist.swift
@@ -6,6 +6,7 @@ public struct Todolist: Codable, Sendable {
     public let bucket: TodoBucket
     public let createdAt: String
     public let creator: Person
+    public let descriptionAttachments: [RichTextAttachment]
     public let id: Int
     public let inheritsStatus: Bool
     public let name: String
@@ -35,6 +36,7 @@ public struct Todolist: Codable, Sendable {
         bucket: TodoBucket,
         createdAt: String,
         creator: Person,
+        descriptionAttachments: [RichTextAttachment],
         id: Int,
         inheritsStatus: Bool,
         name: String,
@@ -63,6 +65,7 @@ public struct Todolist: Codable, Sendable {
         self.bucket = bucket
         self.createdAt = createdAt
         self.creator = creator
+        self.descriptionAttachments = descriptionAttachments
         self.id = id
         self.inheritsStatus = inheritsStatus
         self.name = name

--- a/swift/Sources/Basecamp/Generated/Models/Upload.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Upload.swift
@@ -6,6 +6,7 @@ public struct Upload: Codable, Sendable {
     public let bucket: TodoBucket
     public let createdAt: String
     public let creator: Person
+    public let descriptionAttachments: [RichTextAttachment]
     public let id: Int
     public let inheritsStatus: Bool
     public let parent: RecordingParent
@@ -35,6 +36,7 @@ public struct Upload: Codable, Sendable {
         bucket: TodoBucket,
         createdAt: String,
         creator: Person,
+        descriptionAttachments: [RichTextAttachment],
         id: Int,
         inheritsStatus: Bool,
         parent: RecordingParent,
@@ -63,6 +65,7 @@ public struct Upload: Codable, Sendable {
         self.bucket = bucket
         self.createdAt = createdAt
         self.creator = creator
+        self.descriptionAttachments = descriptionAttachments
         self.id = id
         self.inheritsStatus = inheritsStatus
         self.parent = parent

--- a/swift/Tests/BasecampTests/GeneratedServiceTests.swift
+++ b/swift/Tests/BasecampTests/GeneratedServiceTests.swift
@@ -203,7 +203,7 @@ final class GeneratedServiceTests: XCTestCase {
 
     func testUpdateCommentSendsPUT() async throws {
         let responseJSON: [String: Any] = [
-            "id": 10, "content": "Updated comment",
+            "id": 10, "content": "Updated comment", "content_attachments": [],
             "app_url": "https://3.basecamp.com/1/buckets/1/comments/10",
             "url": "https://3.basecampapi.com/1/buckets/1/comments/10.json",
             "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
@@ -337,7 +337,7 @@ final class GeneratedServiceTests: XCTestCase {
 
     func testCommentsServiceGet() async throws {
         let responseJSON: [String: Any] = [
-            "id": 7, "content": "Great idea!",
+            "id": 7, "content": "Great idea!", "content_attachments": [],
             "app_url": "https://3.basecamp.com/1/buckets/1/comments/7",
             "url": "https://3.basecampapi.com/1/buckets/1/comments/7.json",
             "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
@@ -360,7 +360,7 @@ final class GeneratedServiceTests: XCTestCase {
 
     func testMessagesServiceGet() async throws {
         let responseJSON: [String: Any] = [
-            "id": 3, "subject": "Weekly Update", "content": "Here's what happened...",
+            "id": 3, "subject": "Weekly Update", "content": "Here's what happened...", "content_attachments": [],
             "app_url": "https://3.basecamp.com/1/buckets/1/messages/3",
             "url": "https://3.basecampapi.com/1/buckets/1/messages/3.json",
             "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",

--- a/swift/Tests/BasecampTests/GeneratedServiceTests.swift
+++ b/swift/Tests/BasecampTests/GeneratedServiceTests.swift
@@ -702,7 +702,7 @@ final class GeneratedServiceTests: XCTestCase {
     // coverage stands in for the other five ops.
     private func messageResponseData() throws -> Data {
         let responseJSON: [String: Any] = [
-            "id": 99, "subject": "Hello", "content": "<p>Body</p>",
+            "id": 99, "subject": "Hello", "content": "<p>Body</p>", "content_attachments": [],
             "app_url": "https://3.basecamp.com/1/buckets/1/messages/99",
             "url": "https://3.basecampapi.com/1/buckets/1/messages/99.json",
             "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",

--- a/swift/Tests/BasecampTests/UploadsServiceExtensionsTests.swift
+++ b/swift/Tests/BasecampTests/UploadsServiceExtensionsTests.swift
@@ -36,6 +36,7 @@ private func uploadMetadataJSON(
         "type": "Upload",
         "inherits_status": false,
         "visible_to_clients": false,
+        "description_attachments": [],
         "bucket": ["id": 1, "name": "Project", "type": "Project"] as [String: Any],
         "creator": ["id": 1, "name": "Test User"] as [String: Any],
         "parent": [

--- a/typescript/src/generated/metadata.ts
+++ b/typescript/src/generated/metadata.ts
@@ -37,7 +37,7 @@ export interface MetadataOutput {
 const metadata: MetadataOutput = {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-07-24T05:18:09.347Z",
+  "generated": "2026-07-24T20:00:38.180Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/typescript/src/generated/openapi-stripped.json
+++ b/typescript/src/generated/openapi-stripped.json
@@ -15756,6 +15756,7 @@
                           "title": "Launch Tasks",
                           "inherits_status": true,
                           "type": "Todolist",
+                          "description_attachments": [],
                           "url": "https://3.basecampapi.com/999/buckets/12345678/todolists/987654.json",
                           "app_url": "https://3.basecamp.com/999/buckets/12345678/todolists/987654",
                           "creator": {
@@ -19210,6 +19211,12 @@
           "description": {
             "type": "string"
           },
+          "description_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "due_on": {
             "type": "string",
             "x-go-type": "types.Date",
@@ -19282,6 +19289,7 @@
           "bucket",
           "created_at",
           "creator",
+          "description_attachments",
           "id",
           "inherits_status",
           "parent",
@@ -19753,6 +19761,12 @@
           "content": {
             "type": "string"
           },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "subject": {
             "type": "string"
           },
@@ -19787,6 +19801,7 @@
         "required": [
           "app_url",
           "bucket",
+          "content_attachments",
           "created_at",
           "creator",
           "id",
@@ -19942,6 +19957,12 @@
           "content": {
             "type": "string"
           },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "subject": {
             "type": "string"
           },
@@ -19956,6 +19977,7 @@
         "required": [
           "app_url",
           "bucket",
+          "content_attachments",
           "created_at",
           "creator",
           "id",
@@ -20029,12 +20051,19 @@
           },
           "content": {
             "type": "string"
+          },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
           }
         },
         "required": [
           "app_url",
           "bucket",
           "content",
+          "content_attachments",
           "created_at",
           "creator",
           "id",
@@ -20121,6 +20150,12 @@
           "content": {
             "type": "string"
           },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "boosts_count": {
             "type": "integer",
             "format": "int32"
@@ -20133,6 +20168,7 @@
           "app_url",
           "bucket",
           "content",
+          "content_attachments",
           "created_at",
           "creator",
           "id",
@@ -20940,6 +20976,12 @@
           "content": {
             "type": "string"
           },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "boosts_count": {
             "type": "integer",
             "format": "int32"
@@ -20951,6 +20993,7 @@
         "required": [
           "app_url",
           "bucket",
+          "content_attachments",
           "created_at",
           "creator",
           "id",
@@ -21142,6 +21185,12 @@
           "content": {
             "type": "string"
           },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "subject": {
             "type": "string"
           },
@@ -21159,6 +21208,7 @@
         "required": [
           "app_url",
           "bucket",
+          "content_attachments",
           "created_at",
           "creator",
           "id",
@@ -21233,6 +21283,12 @@
           "content": {
             "type": "string"
           },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "boosts_count": {
             "type": "integer",
             "format": "int32"
@@ -21245,6 +21301,7 @@
           "app_url",
           "bucket",
           "content",
+          "content_attachments",
           "created_at",
           "creator",
           "id",
@@ -21314,6 +21371,13 @@
           },
           "description": {
             "type": "string"
+          },
+          "description_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            },
+            "description": "Optional (no `@required`): the type-specific partial renders the\ncompanion array only when the gauge has needles (bc3 `if\ngauge.any_needles?`), so a needle-less gauge omits the key entirely.\nNon-nullable — never served as JSON `null`."
           },
           "enabled": {
             "type": "boolean"
@@ -21413,6 +21477,12 @@
           "description": {
             "type": "string"
           },
+          "description_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "color": {
             "type": "string"
           },
@@ -21423,6 +21493,7 @@
         },
         "required": [
           "created_at",
+          "description_attachments",
           "id",
           "updated_at"
         ]
@@ -22315,6 +22386,12 @@
           "content": {
             "type": "string"
           },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "category": {
             "$ref": "#/components/schemas/MessageType"
           },
@@ -22330,6 +22407,7 @@
           "app_url",
           "bucket",
           "content",
+          "content_attachments",
           "created_at",
           "creator",
           "id",
@@ -23359,6 +23437,12 @@
           "content": {
             "type": "string"
           },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "group_on": {
             "type": "string",
             "x-go-type": "types.Date",
@@ -23388,6 +23472,7 @@
           "app_url",
           "bucket",
           "content",
+          "content_attachments",
           "created_at",
           "creator",
           "id",
@@ -23658,6 +23743,20 @@
           },
           "content": {
             "type": "string"
+          },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            },
+            "description": "Rich-text companion arrays carried through the generic recording\nprojection (`to_recordable_partial_path` renders the full type-specific\npartial). A given recording is one type, so it carries only the array\nmatching its rich-text attribute (`content_attachments` for a\nComment/Message, `description_attachments` for a Todo/Card); a\nwebhook-sourced recording (base partial) carries neither. Optional (no\n`@required`), non-nullable."
+          },
+          "description_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            },
+            "description": "See `content_attachments` — the description-attribute companion array."
           },
           "comments_count": {
             "type": "integer",
@@ -24115,6 +24214,12 @@
           "description": {
             "type": "string"
           },
+          "description_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "all_day": {
             "type": "boolean"
           },
@@ -24153,6 +24258,7 @@
           "bucket",
           "created_at",
           "creator",
+          "description_attachments",
           "id",
           "inherits_status",
           "parent",
@@ -24274,6 +24380,20 @@
           },
           "description": {
             "type": "string"
+          },
+          "content_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            },
+            "description": "Rich-text companion arrays carried through the polymorphic search\nprojection. A given result is one recording type, so it carries only\nthe array matching its rich-text attribute (`content_attachments` for a\nComment/Message, `description_attachments` for a Todo); a webhook-sourced\nresult carries neither. Optional (no `@required`), non-nullable. Distinct\nfrom the generic `attachments` key (the recording's aggregate downloadable\nfiles), which is a separate projection concern and not modeled here."
+          },
+          "description_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            },
+            "description": "See `content_attachments` — the description-attribute companion array."
           },
           "subject": {
             "type": "string"
@@ -24846,6 +24966,12 @@
           "description": {
             "type": "string"
           },
+          "description_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "completed": {
             "type": "boolean"
           },
@@ -24877,6 +25003,7 @@
           "bucket",
           "created_at",
           "creator",
+          "description_attachments",
           "id",
           "inherits_status",
           "name",
@@ -25854,6 +25981,12 @@
           "description": {
             "type": "string"
           },
+          "description_attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RichTextAttachment"
+            }
+          },
           "content_type": {
             "type": "string"
           },
@@ -25899,6 +26032,7 @@
           "bucket",
           "created_at",
           "creator",
+          "description_attachments",
           "id",
           "inherits_status",
           "parent",

--- a/typescript/src/generated/schema.d.ts
+++ b/typescript/src/generated/schema.d.ts
@@ -2701,6 +2701,7 @@ export interface components {
             position?: number;
             content?: string;
             description?: string;
+            description_attachments: components["schemas"]["RichTextAttachment"][];
             due_on?: string;
             completed?: boolean;
             completed_at?: string;
@@ -2832,6 +2833,7 @@ export interface components {
             bucket: components["schemas"]["RecordingBucket"];
             creator: components["schemas"]["Person"];
             content?: string;
+            content_attachments: components["schemas"]["RichTextAttachment"][];
             subject?: string;
             due_on?: string;
             /** Format: int32 */
@@ -2882,6 +2884,7 @@ export interface components {
             bucket: components["schemas"]["RecordingBucket"];
             creator: components["schemas"]["Person"];
             content?: string;
+            content_attachments: components["schemas"]["RichTextAttachment"][];
             subject: string;
             /** Format: int32 */
             replies_count?: number;
@@ -2904,6 +2907,7 @@ export interface components {
             bucket: components["schemas"]["RecordingBucket"];
             creator: components["schemas"]["Person"];
             content: string;
+            content_attachments: components["schemas"]["RichTextAttachment"][];
         };
         /**
          * @deprecated
@@ -2930,6 +2934,7 @@ export interface components {
             bucket: components["schemas"]["TodoBucket"];
             creator: components["schemas"]["Person"];
             content: string;
+            content_attachments: components["schemas"]["RichTextAttachment"][];
             /** Format: int32 */
             boosts_count?: number;
             boosts_url?: string;
@@ -3156,6 +3161,7 @@ export interface components {
             bucket: components["schemas"]["TodoBucket"];
             creator: components["schemas"]["Person"];
             content?: string;
+            content_attachments: components["schemas"]["RichTextAttachment"][];
             /** Format: int32 */
             boosts_count?: number;
             boosts_url?: string;
@@ -3207,6 +3213,7 @@ export interface components {
             bucket: components["schemas"]["TodoBucket"];
             creator: components["schemas"]["Person"];
             content?: string;
+            content_attachments: components["schemas"]["RichTextAttachment"][];
             subject: string;
             from?: string;
             /** Format: int32 */
@@ -3230,6 +3237,7 @@ export interface components {
             bucket: components["schemas"]["TodoBucket"];
             creator: components["schemas"]["Person"];
             content: string;
+            content_attachments: components["schemas"]["RichTextAttachment"][];
             /** Format: int32 */
             boosts_count?: number;
             boosts_url?: string;
@@ -3250,6 +3258,13 @@ export interface components {
             bucket?: components["schemas"]["RecordingBucket"];
             creator?: components["schemas"]["Person"];
             description?: string;
+            /**
+             * @description Optional (no `@required`): the type-specific partial renders the
+             *     companion array only when the gauge has needles (bc3 `if
+             *     gauge.any_needles?`), so a needle-less gauge omits the key entirely.
+             *     Non-nullable — never served as JSON `null`.
+             */
+            description_attachments?: components["schemas"]["RichTextAttachment"][];
             enabled?: boolean;
             last_needle_color?: string;
             /** Format: int32 */
@@ -3281,6 +3296,7 @@ export interface components {
             bucket?: components["schemas"]["RecordingBucket"];
             creator?: components["schemas"]["Person"];
             description?: string;
+            description_attachments: components["schemas"]["RichTextAttachment"][];
             color?: string;
             /** Format: int32 */
             position?: number;
@@ -3519,6 +3535,7 @@ export interface components {
             creator: components["schemas"]["Person"];
             subject: string;
             content: string;
+            content_attachments: components["schemas"]["RichTextAttachment"][];
             category?: components["schemas"]["MessageType"];
             /** Format: int32 */
             boosts_count?: number;
@@ -3853,6 +3870,7 @@ export interface components {
             comments_count?: number;
             comments_url?: string;
             content: string;
+            content_attachments: components["schemas"]["RichTextAttachment"][];
             group_on?: string;
             parent: components["schemas"]["RecordingParent"];
             bucket: components["schemas"]["RecordingBucket"];
@@ -3932,6 +3950,18 @@ export interface components {
             app_url: string;
             bookmark_url?: string;
             content?: string;
+            /**
+             * @description Rich-text companion arrays carried through the generic recording
+             *     projection (`to_recordable_partial_path` renders the full type-specific
+             *     partial). A given recording is one type, so it carries only the array
+             *     matching its rich-text attribute (`content_attachments` for a
+             *     Comment/Message, `description_attachments` for a Todo/Card); a
+             *     webhook-sourced recording (base partial) carries neither. Optional (no
+             *     `@required`), non-nullable.
+             */
+            content_attachments?: components["schemas"]["RichTextAttachment"][];
+            /** @description See `content_attachments` — the description-attribute companion array. */
+            description_attachments?: components["schemas"]["RichTextAttachment"][];
             /** Format: int32 */
             comments_count?: number;
             comments_url?: string;
@@ -4083,6 +4113,7 @@ export interface components {
             creator: components["schemas"]["Person"];
             summary: string;
             description?: string;
+            description_attachments: components["schemas"]["RichTextAttachment"][];
             all_day?: boolean;
             starts_at?: string;
             ends_at?: string;
@@ -4119,6 +4150,18 @@ export interface components {
             creator?: components["schemas"]["Person"];
             content?: string;
             description?: string;
+            /**
+             * @description Rich-text companion arrays carried through the polymorphic search
+             *     projection. A given result is one recording type, so it carries only
+             *     the array matching its rich-text attribute (`content_attachments` for a
+             *     Comment/Message, `description_attachments` for a Todo); a webhook-sourced
+             *     result carries neither. Optional (no `@required`), non-nullable. Distinct
+             *     from the generic `attachments` key (the recording's aggregate downloadable
+             *     files), which is a separate projection concern and not modeled here.
+             */
+            content_attachments?: components["schemas"]["RichTextAttachment"][];
+            /** @description See `content_attachments` — the description-attribute companion array. */
+            description_attachments?: components["schemas"]["RichTextAttachment"][];
             subject?: string;
         };
         /**
@@ -4287,6 +4330,7 @@ export interface components {
             bucket: components["schemas"]["TodoBucket"];
             creator: components["schemas"]["Person"];
             description?: string;
+            description_attachments: components["schemas"]["RichTextAttachment"][];
             completed?: boolean;
             completed_ratio?: string;
             name: string;
@@ -4590,6 +4634,7 @@ export interface components {
             bucket: components["schemas"]["TodoBucket"];
             creator: components["schemas"]["Person"];
             description?: string;
+            description_attachments: components["schemas"]["RichTextAttachment"][];
             content_type?: string;
             /** Format: int64 */
             byte_size?: number;

--- a/typescript/tests/services/cards.test.ts
+++ b/typescript/tests/services/cards.test.ts
@@ -14,6 +14,7 @@ const sampleCard = (id = 1) => ({
   id,
   title: "Design mockups",
   content: "<p>Create initial designs</p>",
+  description_attachments: [],
   due_on: "2024-03-01",
   created_at: "2024-01-15T10:00:00Z",
   updated_at: "2024-01-15T10:00:00Z",

--- a/typescript/tests/services/checkins.test.ts
+++ b/typescript/tests/services/checkins.test.ts
@@ -46,7 +46,7 @@ describe("CheckinsService", () => {
       server.use(
         http.get(`${BASE_URL}/questionnaires/100`, () => {
           return HttpResponse.json(mockQuestionnaire);
-        })
+        }),
       );
 
       const questionnaire = await client.checkins.getQuestionnaire(100);
@@ -71,7 +71,8 @@ describe("CheckinsService", () => {
           type: "Question",
           url: "https://3.basecampapi.com/12345/questions/1.json",
           app_url: "https://3.basecamp.com/12345/questions/1",
-          bookmark_url: "https://3.basecampapi.com/12345/my/bookmarks/BAh7.json",
+          bookmark_url:
+            "https://3.basecampapi.com/12345/my/bookmarks/BAh7.json",
           subscription_url:
             "https://3.basecampapi.com/12345/recordings/1/subscription.json",
           paused: false,
@@ -90,7 +91,7 @@ describe("CheckinsService", () => {
       server.use(
         http.get(`${BASE_URL}/questionnaires/100/questions.json`, () => {
           return HttpResponse.json(mockQuestions);
-        })
+        }),
       );
 
       const questions = await client.checkins.listQuestions(100);
@@ -126,14 +127,13 @@ describe("CheckinsService", () => {
           minute: 0,
         },
         answers_count: 10,
-        answers_url:
-          "https://3.basecampapi.com/12345/questions/1/answers.json",
+        answers_url: "https://3.basecampapi.com/12345/questions/1/answers.json",
       };
 
       server.use(
         http.get(`${BASE_URL}/questions/1`, () => {
           return HttpResponse.json(mockQuestion);
-        })
+        }),
       );
 
       const question = await client.checkins.getQuestion(1);
@@ -167,8 +167,7 @@ describe("CheckinsService", () => {
           minute: 0,
         },
         answers_count: 0,
-        answers_url:
-          "https://3.basecampapi.com/12345/questions/2/answers.json",
+        answers_url: "https://3.basecampapi.com/12345/questions/2/answers.json",
       };
 
       server.use(
@@ -178,8 +177,8 @@ describe("CheckinsService", () => {
             const body = (await request.json()) as { title: string };
             expect(body.title).toBe("What are your blockers?");
             return HttpResponse.json(mockQuestion);
-          }
-        )
+          },
+        ),
       );
 
       const question = await client.checkins.createQuestion(100, {
@@ -223,14 +222,13 @@ describe("CheckinsService", () => {
           minute: 0,
         },
         answers_count: 10,
-        answers_url:
-          "https://3.basecampapi.com/12345/questions/1/answers.json",
+        answers_url: "https://3.basecampapi.com/12345/questions/1/answers.json",
       };
 
       server.use(
         http.put(`${BASE_URL}/questions/1`, () => {
           return HttpResponse.json(mockQuestion);
-        })
+        }),
       );
 
       const question = await client.checkins.updateQuestion(1, {
@@ -255,13 +253,15 @@ describe("CheckinsService", () => {
           type: "Question::Answer",
           url: "https://3.basecampapi.com/12345/question_answers/50.json",
           app_url: "https://3.basecamp.com/12345/question_answers/50",
-          bookmark_url: "https://3.basecampapi.com/12345/my/bookmarks/BAh7.json",
+          bookmark_url:
+            "https://3.basecampapi.com/12345/my/bookmarks/BAh7.json",
           subscription_url:
             "https://3.basecampapi.com/12345/recordings/50/subscription.json",
           comments_count: 0,
           comments_url:
             "https://3.basecampapi.com/12345/recordings/50/comments.json",
           content: "<p>Worked on the new feature</p>",
+          content_attachments: [],
           group_on: "2024-01-01",
           creator: { id: 999, name: "Test User" },
         },
@@ -270,7 +270,7 @@ describe("CheckinsService", () => {
       server.use(
         http.get(`${BASE_URL}/questions/1/answers.json`, () => {
           return HttpResponse.json(mockAnswers);
-        })
+        }),
       );
 
       const answers = await client.checkins.listAnswers(1);
@@ -301,13 +301,14 @@ describe("CheckinsService", () => {
         comments_url:
           "https://3.basecampapi.com/12345/recordings/50/comments.json",
         content: "<p>Worked on the new feature</p>",
+        content_attachments: [],
         group_on: "2024-01-01",
       };
 
       server.use(
         http.get(`${BASE_URL}/question_answers/50`, () => {
           return HttpResponse.json(mockAnswer);
-        })
+        }),
       );
 
       const answer = await client.checkins.getAnswer(50);
@@ -337,6 +338,7 @@ describe("CheckinsService", () => {
         comments_url:
           "https://3.basecampapi.com/12345/recordings/51/comments.json",
         content: "<p>Finished the feature!</p>",
+        content_attachments: [],
         group_on: "2024-01-02",
       };
 
@@ -347,8 +349,8 @@ describe("CheckinsService", () => {
             const body = (await request.json()) as { content: string };
             expect(body.content).toBe("<p>Finished the feature!</p>");
             return HttpResponse.json(mockAnswer);
-          }
-        )
+          },
+        ),
       );
 
       const answer = await client.checkins.createAnswer(1, {
@@ -367,7 +369,7 @@ describe("CheckinsService", () => {
       server.use(
         http.put(`${BASE_URL}/question_answers/50`, () => {
           return new HttpResponse(null, { status: 204 });
-        })
+        }),
       );
 
       // Should not throw
@@ -383,7 +385,7 @@ describe("CheckinsService", () => {
         http.put(`${BASE_URL}/question_answers/50`, async ({ request }) => {
           receivedBody = (await request.json()) as Record<string, unknown>;
           return new HttpResponse(null, { status: 204 });
-        })
+        }),
       );
 
       await client.checkins.updateAnswer(50, {

--- a/typescript/tests/services/client-approvals.test.ts
+++ b/typescript/tests/services/client-approvals.test.ts
@@ -33,13 +33,17 @@ describe("ClientApprovalsService", () => {
           type: "Client::Approval",
           url: "https://3.basecampapi.com/12345/client/approvals/1.json",
           app_url: "https://3.basecamp.com/12345/client/approvals/1",
-          bookmark_url: "https://3.basecampapi.com/12345/my/bookmarks/BAh7.json",
-          subscription_url: "https://3.basecampapi.com/12345/recordings/1/subscription.json",
+          bookmark_url:
+            "https://3.basecampapi.com/12345/my/bookmarks/BAh7.json",
+          subscription_url:
+            "https://3.basecampapi.com/12345/recordings/1/subscription.json",
           content: "<p>Please review the attached designs</p>",
+          content_attachments: [],
           subject: "Design Review",
           due_on: "2024-01-15",
           replies_count: 2,
-          replies_url: "https://3.basecampapi.com/12345/client/recordings/1/replies.json",
+          replies_url:
+            "https://3.basecampapi.com/12345/client/recordings/1/replies.json",
           approval_status: "pending",
           bucket: { id: 1, name: "Test Project", type: "Project" },
           creator: { id: 999, name: "Test User" },
@@ -49,7 +53,7 @@ describe("ClientApprovalsService", () => {
       server.use(
         http.get(`${BASE_URL}/client/approvals.json`, () => {
           return HttpResponse.json(mockApprovals);
-        })
+        }),
       );
 
       const approvals = await client.clientApprovals.list(1);
@@ -64,7 +68,7 @@ describe("ClientApprovalsService", () => {
       server.use(
         http.get(`${BASE_URL}/client/approvals.json`, () => {
           return HttpResponse.json([]);
-        })
+        }),
       );
 
       const approvals = await client.clientApprovals.list(1);
@@ -86,12 +90,15 @@ describe("ClientApprovalsService", () => {
         url: "https://3.basecampapi.com/12345/client/approvals/1.json",
         app_url: "https://3.basecamp.com/12345/client/approvals/1",
         bookmark_url: "https://3.basecampapi.com/12345/my/bookmarks/BAh7.json",
-        subscription_url: "https://3.basecampapi.com/12345/recordings/1/subscription.json",
+        subscription_url:
+          "https://3.basecampapi.com/12345/recordings/1/subscription.json",
         content: "<p>Please review the attached designs</p>",
+        content_attachments: [],
         subject: "Design Review",
         due_on: "2024-01-15",
         replies_count: 2,
-        replies_url: "https://3.basecampapi.com/12345/client/recordings/1/replies.json",
+        replies_url:
+          "https://3.basecampapi.com/12345/client/recordings/1/replies.json",
         approval_status: "approved",
         bucket: { id: 1, name: "Test Project", type: "Project" },
         creator: { id: 999, name: "Test User" },
@@ -106,9 +113,12 @@ describe("ClientApprovalsService", () => {
             title: "",
             inherits_status: true,
             type: "Client::Approval::Response",
-            app_url: "https://3.basecamp.com/12345/client/approvals/1/responses/10",
-            bookmark_url: "https://3.basecampapi.com/12345/my/bookmarks/BAh7.json",
+            app_url:
+              "https://3.basecamp.com/12345/client/approvals/1/responses/10",
+            bookmark_url:
+              "https://3.basecampapi.com/12345/my/bookmarks/BAh7.json",
             content: "<p>Looks great!</p>",
+            content_attachments: [],
             approved: true,
             creator: { id: 888, name: "Client User" },
           },
@@ -118,7 +128,7 @@ describe("ClientApprovalsService", () => {
       server.use(
         http.get(`${BASE_URL}/client/approvals/1`, () => {
           return HttpResponse.json(mockApproval);
-        })
+        }),
       );
 
       const approval = await client.clientApprovals.get(1);
@@ -135,7 +145,7 @@ describe("ClientApprovalsService", () => {
       server.use(
         http.get(`${BASE_URL}/client/approvals/999`, () => {
           return HttpResponse.json({ error: "Not found" }, { status: 404 });
-        })
+        }),
       );
 
       try {

--- a/typescript/tests/services/client-approvals.test.ts
+++ b/typescript/tests/services/client-approvals.test.ts
@@ -118,7 +118,6 @@ describe("ClientApprovalsService", () => {
             bookmark_url:
               "https://3.basecampapi.com/12345/my/bookmarks/BAh7.json",
             content: "<p>Looks great!</p>",
-            content_attachments: [],
             approved: true,
             creator: { id: 888, name: "Client User" },
           },

--- a/typescript/tests/services/client-correspondences.test.ts
+++ b/typescript/tests/services/client-correspondences.test.ts
@@ -33,12 +33,16 @@ describe("ClientCorrespondencesService", () => {
           type: "Client::Correspondence",
           url: "https://3.basecampapi.com/12345/client/correspondences/1.json",
           app_url: "https://3.basecamp.com/12345/client/correspondences/1",
-          bookmark_url: "https://3.basecampapi.com/12345/my/bookmarks/BAh7.json",
-          subscription_url: "https://3.basecampapi.com/12345/recordings/1/subscription.json",
+          bookmark_url:
+            "https://3.basecampapi.com/12345/my/bookmarks/BAh7.json",
+          subscription_url:
+            "https://3.basecampapi.com/12345/recordings/1/subscription.json",
           content: "<p>Welcome to the project!</p>",
+          content_attachments: [],
           subject: "Project Kickoff",
           replies_count: 3,
-          replies_url: "https://3.basecampapi.com/12345/client/recordings/1/replies.json",
+          replies_url:
+            "https://3.basecampapi.com/12345/client/recordings/1/replies.json",
           bucket: { id: 1, name: "Test Project", type: "Project" },
           creator: { id: 999, name: "Test User" },
         },
@@ -53,12 +57,16 @@ describe("ClientCorrespondencesService", () => {
           type: "Client::Correspondence",
           url: "https://3.basecampapi.com/12345/client/correspondences/2.json",
           app_url: "https://3.basecamp.com/12345/client/correspondences/2",
-          bookmark_url: "https://3.basecampapi.com/12345/my/bookmarks/BAh7.json",
-          subscription_url: "https://3.basecampapi.com/12345/recordings/2/subscription.json",
+          bookmark_url:
+            "https://3.basecampapi.com/12345/my/bookmarks/BAh7.json",
+          subscription_url:
+            "https://3.basecampapi.com/12345/recordings/2/subscription.json",
           content: "<p>Here's the weekly progress update</p>",
+          content_attachments: [],
           subject: "Weekly Update",
           replies_count: 1,
-          replies_url: "https://3.basecampapi.com/12345/client/recordings/2/replies.json",
+          replies_url:
+            "https://3.basecampapi.com/12345/client/recordings/2/replies.json",
           bucket: { id: 1, name: "Test Project", type: "Project" },
           creator: { id: 999, name: "Test User" },
         },
@@ -67,7 +75,7 @@ describe("ClientCorrespondencesService", () => {
       server.use(
         http.get(`${BASE_URL}/client/correspondences.json`, () => {
           return HttpResponse.json(mockCorrespondences);
-        })
+        }),
       );
 
       const correspondences = await client.clientCorrespondences.list(1);
@@ -82,7 +90,7 @@ describe("ClientCorrespondencesService", () => {
       server.use(
         http.get(`${BASE_URL}/client/correspondences.json`, () => {
           return HttpResponse.json([]);
-        })
+        }),
       );
 
       const correspondences = await client.clientCorrespondences.list(1);
@@ -104,19 +112,26 @@ describe("ClientCorrespondencesService", () => {
         url: "https://3.basecampapi.com/12345/client/correspondences/1.json",
         app_url: "https://3.basecamp.com/12345/client/correspondences/1",
         bookmark_url: "https://3.basecampapi.com/12345/my/bookmarks/BAh7.json",
-        subscription_url: "https://3.basecampapi.com/12345/recordings/1/subscription.json",
+        subscription_url:
+          "https://3.basecampapi.com/12345/recordings/1/subscription.json",
         content: "<p>Welcome to the project! We're excited to get started.</p>",
+        content_attachments: [],
         subject: "Project Kickoff",
         replies_count: 3,
-        replies_url: "https://3.basecampapi.com/12345/client/recordings/1/replies.json",
+        replies_url:
+          "https://3.basecampapi.com/12345/client/recordings/1/replies.json",
         bucket: { id: 1, name: "Test Project", type: "Project" },
-        creator: { id: 999, name: "Test User", email_address: "test@example.com" },
+        creator: {
+          id: 999,
+          name: "Test User",
+          email_address: "test@example.com",
+        },
       };
 
       server.use(
         http.get(`${BASE_URL}/client/correspondences/1`, () => {
           return HttpResponse.json(mockCorrespondence);
-        })
+        }),
       );
 
       const correspondence = await client.clientCorrespondences.get(1);
@@ -131,7 +146,7 @@ describe("ClientCorrespondencesService", () => {
       server.use(
         http.get(`${BASE_URL}/client/correspondences/999`, () => {
           return HttpResponse.json({ error: "Not found" }, { status: 404 });
-        })
+        }),
       );
 
       try {

--- a/typescript/tests/services/client-replies.test.ts
+++ b/typescript/tests/services/client-replies.test.ts
@@ -33,8 +33,10 @@ describe("ClientRepliesService", () => {
           type: "Client::Reply",
           url: "https://3.basecampapi.com/12345/client/replies/10.json",
           app_url: "https://3.basecamp.com/12345/client/replies/10",
-          bookmark_url: "https://3.basecampapi.com/12345/my/bookmarks/BAh7.json",
+          bookmark_url:
+            "https://3.basecampapi.com/12345/my/bookmarks/BAh7.json",
           content: "<p>Thanks for the update!</p>",
+          content_attachments: [],
           bucket: { id: 1, name: "Test Project", type: "Project" },
           creator: { id: 888, name: "Client User" },
         },
@@ -49,8 +51,10 @@ describe("ClientRepliesService", () => {
           type: "Client::Reply",
           url: "https://3.basecampapi.com/12345/client/replies/11.json",
           app_url: "https://3.basecamp.com/12345/client/replies/11",
-          bookmark_url: "https://3.basecampapi.com/12345/my/bookmarks/BAh7.json",
+          bookmark_url:
+            "https://3.basecampapi.com/12345/my/bookmarks/BAh7.json",
           content: "<p>Looking forward to the next milestone.</p>",
+          content_attachments: [],
           bucket: { id: 1, name: "Test Project", type: "Project" },
           creator: { id: 888, name: "Client User" },
         },
@@ -59,7 +63,7 @@ describe("ClientRepliesService", () => {
       server.use(
         http.get(`${BASE_URL}/client/recordings/100/replies.json`, () => {
           return HttpResponse.json(mockReplies);
-        })
+        }),
       );
 
       const replies = await client.clientReplies.list(100);
@@ -67,14 +71,16 @@ describe("ClientRepliesService", () => {
       expect(replies).toHaveLength(2);
       expect(replies[0].content).toBe("<p>Thanks for the update!</p>");
       expect(replies[0].creator?.name).toBe("Client User");
-      expect(replies[1].content).toBe("<p>Looking forward to the next milestone.</p>");
+      expect(replies[1].content).toBe(
+        "<p>Looking forward to the next milestone.</p>",
+      );
     });
 
     it("should return empty array when no replies exist", async () => {
       server.use(
         http.get(`${BASE_URL}/client/recordings/100/replies.json`, () => {
           return HttpResponse.json([]);
-        })
+        }),
       );
 
       const replies = await client.clientReplies.list(100);
@@ -97,6 +103,7 @@ describe("ClientRepliesService", () => {
         app_url: "https://3.basecamp.com/12345/client/replies/10",
         bookmark_url: "https://3.basecampapi.com/12345/my/bookmarks/BAh7.json",
         content: "<p>Thanks for the update! This looks great.</p>",
+        content_attachments: [],
         parent: {
           id: 100,
           title: "Project Kickoff",
@@ -105,19 +112,25 @@ describe("ClientRepliesService", () => {
           app_url: "https://3.basecamp.com/12345/client/correspondences/100",
         },
         bucket: { id: 1, name: "Test Project", type: "Project" },
-        creator: { id: 888, name: "Client User", email_address: "client@example.com" },
+        creator: {
+          id: 888,
+          name: "Client User",
+          email_address: "client@example.com",
+        },
       };
 
       server.use(
         http.get(`${BASE_URL}/client/recordings/100/replies/10`, () => {
           return HttpResponse.json(mockReply);
-        })
+        }),
       );
 
       const reply = await client.clientReplies.get(100, 10);
 
       expect(reply.id).toBe(10);
-      expect(reply.content).toBe("<p>Thanks for the update! This looks great.</p>");
+      expect(reply.content).toBe(
+        "<p>Thanks for the update! This looks great.</p>",
+      );
       expect(reply.parent?.title).toBe("Project Kickoff");
       expect(reply.creator?.name).toBe("Client User");
     });
@@ -126,7 +139,7 @@ describe("ClientRepliesService", () => {
       server.use(
         http.get(`${BASE_URL}/client/recordings/100/replies/999`, () => {
           return HttpResponse.json({ error: "Not found" }, { status: 404 });
-        })
+        }),
       );
 
       try {

--- a/typescript/tests/services/comments.test.ts
+++ b/typescript/tests/services/comments.test.ts
@@ -44,6 +44,63 @@ describe("CommentsService", () => {
       expect(comment.content).toBe("<p>Great work!</p>");
     });
 
+    it("preserves float-spelled and null attachment dimensions at runtime", async () => {
+      // A Comment's rich-text content is paired with a content_attachments
+      // array. Pixel dimensions arrive float-spelled (1024.0) for images and
+      // null for non-image blobs. The schema is nullable, so the generated
+      // static type is `width?: number | null` — the present null is captured.
+      // (In JS there is no int/float distinction, so 1024.0 is simply the
+      // number 1024.) openapi-fetch performs no runtime validation; the values
+      // below survive verbatim on the parsed object.
+      const commentId = 77;
+      server.use(
+        http.get(`${BASE_URL}/comments/${commentId}`, () => {
+          return HttpResponse.json({
+            ...sampleComment(commentId),
+            content_attachments: [
+              {
+                id: 1069480010,
+                sgid: "BAh-img",
+                filename: "celebration.png",
+                content_type: "image/png",
+                byte_size: 284111,
+                download_url: `${BASE_URL}/buckets/1/blobs/img/download/celebration.png`,
+                width: 1024.0,
+                height: 768,
+                previewable: true,
+                preview_url: `${BASE_URL}/buckets/1/blobs/img/previews/celebration.png`,
+                thumbnail_url: `${BASE_URL}/buckets/1/blobs/img/thumbnails/celebration.png`,
+              },
+              {
+                id: 1069480011,
+                sgid: "BAh-pdf",
+                filename: "notes.pdf",
+                content_type: "application/pdf",
+                byte_size: 1048576,
+                download_url: `${BASE_URL}/buckets/1/blobs/pdf/download/notes.pdf`,
+                width: null,
+                height: null,
+                previewable: false,
+                preview_url: `${BASE_URL}/buckets/1/blobs/pdf/previews/notes.pdf`,
+                thumbnail_url: `${BASE_URL}/buckets/1/blobs/pdf/thumbnails/notes.pdf`,
+              },
+            ],
+          });
+        })
+      );
+
+      const comment = await client.comments.get(commentId);
+      const attachments = comment.content_attachments;
+      expect(attachments).toHaveLength(2);
+
+      // Float-spelled 1024.0 is preserved as the number 1024.
+      expect(attachments[0]!.width).toBe(1024);
+      expect(attachments[0]!.height).toBe(768);
+      // null is preserved verbatim despite the static `width?: number` type.
+      expect(attachments[1]!.width).toBeNull();
+      expect(attachments[1]!.height).toBeNull();
+    });
+
     it("should throw not_found for missing comment", async () => {
       server.use(
         http.get(`${BASE_URL}/comments/999`, () => {

--- a/typescript/tests/services/comments.test.ts
+++ b/typescript/tests/services/comments.test.ts
@@ -96,7 +96,7 @@ describe("CommentsService", () => {
       // Float-spelled 1024.0 is preserved as the number 1024.
       expect(attachments[0]!.width).toBe(1024);
       expect(attachments[0]!.height).toBe(768);
-      // null is preserved verbatim despite the static `width?: number` type.
+      // null is preserved verbatim, matching the static `width?: number | null`.
       expect(attachments[1]!.width).toBeNull();
       expect(attachments[1]!.height).toBeNull();
     });

--- a/typescript/tests/services/comments.test.ts
+++ b/typescript/tests/services/comments.test.ts
@@ -13,6 +13,7 @@ const BASE_URL = "https://3.basecampapi.com/12345";
 const sampleComment = (id = 1) => ({
   id,
   content: "<p>Great work!</p>",
+  content_attachments: [],
   created_at: "2024-01-15T10:00:00Z",
   updated_at: "2024-01-15T10:00:00Z",
   creator: { id: 100, name: "Jane Doe" },

--- a/typescript/tests/services/documents.test.ts
+++ b/typescript/tests/services/documents.test.ts
@@ -32,6 +32,7 @@ describe("DocumentsService", () => {
         id: 5001,
         title: "Meeting Notes",
         content: "<p>Notes from the meeting...</p>",
+        content_attachments: [],
         status: "active",
         comments_count: 3,
       };
@@ -39,7 +40,7 @@ describe("DocumentsService", () => {
       server.use(
         http.get(`${BASE_URL}/documents/5001`, () => {
           return HttpResponse.json(document);
-        })
+        }),
       );
 
       const result = await service.get(5001);
@@ -53,7 +54,7 @@ describe("DocumentsService", () => {
       server.use(
         http.get(`${BASE_URL}/documents/9999`, () => {
           return HttpResponse.json({ error: "Not found" }, { status: 404 });
-        })
+        }),
       );
 
       await expect(service.get(9999)).rejects.toThrow(BasecampError);
@@ -76,7 +77,7 @@ describe("DocumentsService", () => {
       server.use(
         http.get(`${BASE_URL}/vaults/1001/documents.json`, () => {
           return HttpResponse.json(documents);
-        })
+        }),
       );
 
       const result = await service.list(1001);
@@ -90,7 +91,7 @@ describe("DocumentsService", () => {
       server.use(
         http.get(`${BASE_URL}/vaults/1001/documents.json`, () => {
           return HttpResponse.json([]);
-        })
+        }),
       );
 
       const result = await service.list(1001);
@@ -105,13 +106,14 @@ describe("DocumentsService", () => {
         id: 6001,
         title: "New Document",
         content: "<p>Content here</p>",
+        content_attachments: [],
         status: "active",
       };
 
       server.use(
         http.post(`${BASE_URL}/vaults/1001/documents.json`, () => {
           return HttpResponse.json(newDocument);
-        })
+        }),
       );
 
       const result = await service.create(1001, {
@@ -125,11 +127,14 @@ describe("DocumentsService", () => {
 
     it("should pass subscriptions in request body", async () => {
       server.use(
-        http.post(`${BASE_URL}/vaults/1001/documents.json`, async ({ request }) => {
-          const body = (await request.json()) as Record<string, unknown>;
-          expect(body.subscriptions).toEqual([111, 222]);
-          return HttpResponse.json({ id: 6002, title: "Test" });
-        })
+        http.post(
+          `${BASE_URL}/vaults/1001/documents.json`,
+          async ({ request }) => {
+            const body = (await request.json()) as Record<string, unknown>;
+            expect(body.subscriptions).toEqual([111, 222]);
+            return HttpResponse.json({ id: 6002, title: "Test" });
+          },
+        ),
       );
 
       const result = await service.create(1001, {
@@ -140,13 +145,24 @@ describe("DocumentsService", () => {
     });
 
     it("should send all fields in request body", async () => {
-      let capturedBody: { title?: string; content?: string; status?: string } | null = null;
+      let capturedBody: {
+        title?: string;
+        content?: string;
+        status?: string;
+      } | null = null;
 
       server.use(
-        http.post(`${BASE_URL}/vaults/1001/documents.json`, async ({ request }) => {
-          capturedBody = (await request.json()) as { title?: string; content?: string; status?: string };
-          return HttpResponse.json({ id: 1, title: "Test" });
-        })
+        http.post(
+          `${BASE_URL}/vaults/1001/documents.json`,
+          async ({ request }) => {
+            capturedBody = (await request.json()) as {
+              title?: string;
+              content?: string;
+              status?: string;
+            };
+            return HttpResponse.json({ id: 1, title: "Test" });
+          },
+        ),
       );
 
       await service.create(1001, {
@@ -169,13 +185,14 @@ describe("DocumentsService", () => {
         id: 5001,
         title: "Updated Title",
         content: "<p>Updated content</p>",
+        content_attachments: [],
         status: "active",
       };
 
       server.use(
         http.put(`${BASE_URL}/documents/5001`, () => {
           return HttpResponse.json(updatedDocument);
-        })
+        }),
       );
 
       const result = await service.update(5001, {
@@ -192,9 +209,12 @@ describe("DocumentsService", () => {
 
       server.use(
         http.put(`${BASE_URL}/documents/5001`, async ({ request }) => {
-          capturedBody = (await request.json()) as { title?: string; content?: string };
+          capturedBody = (await request.json()) as {
+            title?: string;
+            content?: string;
+          };
           return HttpResponse.json({ id: 5001, title: "Updated" });
-        })
+        }),
       );
 
       await service.update(5001, { title: "New Title" });

--- a/typescript/tests/services/forwards.test.ts
+++ b/typescript/tests/services/forwards.test.ts
@@ -39,7 +39,7 @@ describe("ForwardsService", () => {
       server.use(
         http.get(`${BASE_URL}/inboxes/100`, () => {
           return HttpResponse.json(mockInbox);
-        })
+        }),
       );
 
       const inbox = await client.forwards.getInbox(100);
@@ -60,6 +60,7 @@ describe("ForwardsService", () => {
           updated_at: "2024-01-01T00:00:00Z",
           subject: "Re: Project Update",
           content: "<p>Email content here</p>",
+          content_attachments: [],
           from: "sender@example.com",
           type: "Inbox::Forward",
           url: "https://3.basecampapi.com/12345/inbox_forwards/1.json",
@@ -72,6 +73,7 @@ describe("ForwardsService", () => {
           updated_at: "2024-01-02T00:00:00Z",
           subject: "Meeting Notes",
           content: "<p>Another email</p>",
+          content_attachments: [],
           from: "other@example.com",
           type: "Inbox::Forward",
           url: "https://3.basecampapi.com/12345/inbox_forwards/2.json",
@@ -82,7 +84,7 @@ describe("ForwardsService", () => {
       server.use(
         http.get(`${BASE_URL}/inboxes/100/forwards.json`, () => {
           return HttpResponse.json(mockForwards);
-        })
+        }),
       );
 
       const forwards = await client.forwards.list(100);
@@ -103,6 +105,7 @@ describe("ForwardsService", () => {
         updated_at: "2024-01-01T00:00:00Z",
         subject: "Re: Project Update",
         content: "<p>Email content here</p>",
+        content_attachments: [],
         from: "sender@example.com",
         type: "Inbox::Forward",
         url: "https://3.basecampapi.com/12345/inbox_forwards/1.json",
@@ -112,7 +115,7 @@ describe("ForwardsService", () => {
       server.use(
         http.get(`${BASE_URL}/inbox_forwards/1`, () => {
           return HttpResponse.json(mockForward);
-        })
+        }),
       );
 
       const forward = await client.forwards.get(1);
@@ -132,6 +135,7 @@ describe("ForwardsService", () => {
           created_at: "2024-01-01T00:00:00Z",
           updated_at: "2024-01-01T00:00:00Z",
           content: "<p>Thanks for the update!</p>",
+          content_attachments: [],
           type: "Inbox::Reply",
           url: "https://3.basecampapi.com/12345/inbox_replies/10.json",
           app_url: "https://3.basecamp.com/12345/inbox_replies/10",
@@ -141,7 +145,7 @@ describe("ForwardsService", () => {
       server.use(
         http.get(`${BASE_URL}/inbox_forwards/1/replies.json`, () => {
           return HttpResponse.json(mockReplies);
-        })
+        }),
       );
 
       const replies = await client.forwards.listReplies(1);
@@ -159,6 +163,7 @@ describe("ForwardsService", () => {
         created_at: "2024-01-01T00:00:00Z",
         updated_at: "2024-01-01T00:00:00Z",
         content: "<p>Thanks for the update!</p>",
+        content_attachments: [],
         type: "Inbox::Reply",
         url: "https://3.basecampapi.com/12345/inbox_replies/10.json",
         app_url: "https://3.basecamp.com/12345/inbox_replies/10",
@@ -167,7 +172,7 @@ describe("ForwardsService", () => {
       server.use(
         http.get(`${BASE_URL}/inbox_forwards/1/replies/10`, () => {
           return HttpResponse.json(mockReply);
-        })
+        }),
       );
 
       const reply = await client.forwards.getReply(1, 10);
@@ -185,17 +190,21 @@ describe("ForwardsService", () => {
         created_at: "2024-01-01T00:00:00Z",
         updated_at: "2024-01-01T00:00:00Z",
         content: "<p>New reply content</p>",
+        content_attachments: [],
         type: "Inbox::Reply",
         url: "https://3.basecampapi.com/12345/inbox_replies/11.json",
         app_url: "https://3.basecamp.com/12345/inbox_replies/11",
       };
 
       server.use(
-        http.post(`${BASE_URL}/inbox_forwards/1/replies.json`, async ({ request }) => {
-          const body = await request.json() as { content: string };
-          expect(body.content).toBe("<p>New reply content</p>");
-          return HttpResponse.json(mockReply);
-        })
+        http.post(
+          `${BASE_URL}/inbox_forwards/1/replies.json`,
+          async ({ request }) => {
+            const body = (await request.json()) as { content: string };
+            expect(body.content).toBe("<p>New reply content</p>");
+            return HttpResponse.json(mockReply);
+          },
+        ),
       );
 
       const reply = await client.forwards.createReply(1, {

--- a/typescript/tests/services/messages.test.ts
+++ b/typescript/tests/services/messages.test.ts
@@ -14,6 +14,7 @@ const sampleMessage = (id = 1) => ({
   id,
   subject: "Weekly Update",
   content: "<p>Here is the update</p>",
+  content_attachments: [],
   status: "active",
   created_at: "2024-01-15T10:00:00Z",
   updated_at: "2024-01-15T10:00:00Z",

--- a/typescript/tests/services/recordings.test.ts
+++ b/typescript/tests/services/recordings.test.ts
@@ -29,7 +29,16 @@ describe("RecordingsService", () => {
   describe("list", () => {
     it("should list recordings by type and return ListResult", async () => {
       const recordings = [
-        { id: 1001, type: "Todo", title: "Task 1", status: "active" },
+        {
+          id: 1001,
+          type: "Todo",
+          title: "Task 1",
+          status: "active",
+          // The generic recording projection carries the matching type's
+          // rich-text companion array; a Todo recording surfaces
+          // description_attachments (empty here — the Todo has no inline files).
+          description_attachments: [],
+        },
         { id: 1002, type: "Todo", title: "Task 2", status: "active" },
       ];
 
@@ -40,7 +49,7 @@ describe("RecordingsService", () => {
           return HttpResponse.json(recordings, {
             headers: { "X-Total-Count": "2" },
           });
-        })
+        }),
       );
 
       const result = await service.list("Todo");
@@ -48,6 +57,8 @@ describe("RecordingsService", () => {
       expect(result).toBeInstanceOf(ListResult);
       expect(result).toHaveLength(2);
       expect(result[0].type).toBe("Todo");
+      // The optional projection array surfaces on the matching-type recording.
+      expect(result[0].description_attachments).toEqual([]);
       expect(result.meta.totalCount).toBe(2);
     });
 
@@ -58,7 +69,7 @@ describe("RecordingsService", () => {
         http.get(`${BASE_URL}/projects/recordings.json`, ({ request }) => {
           capturedUrl = new URL(request.url);
           return HttpResponse.json([]);
-        })
+        }),
       );
 
       // bucket is number[] → joined as CSV string in the query
@@ -83,7 +94,7 @@ describe("RecordingsService", () => {
         http.get(`${BASE_URL}/projects/recordings.json`, ({ request }) => {
           capturedUrl = new URL(request.url);
           return HttpResponse.json([]);
-        })
+        }),
       );
 
       await service.list("Todo", { bucket: [1, 2, 3] });
@@ -97,7 +108,7 @@ describe("RecordingsService", () => {
           return HttpResponse.json([], {
             headers: { "X-Total-Count": "0" },
           });
-        })
+        }),
       );
 
       const result = await service.list("Todo");
@@ -121,7 +132,7 @@ describe("RecordingsService", () => {
       server.use(
         http.get(`${BASE_URL}/recordings/3001`, () => {
           return HttpResponse.json(recording);
-        })
+        }),
       );
 
       const result = await service.get(3001);
@@ -135,7 +146,7 @@ describe("RecordingsService", () => {
       server.use(
         http.get(`${BASE_URL}/recordings/9999`, () => {
           return HttpResponse.json({ error: "Not found" }, { status: 404 });
-        })
+        }),
       );
 
       await expect(service.get(9999)).rejects.toThrow(BasecampError);
@@ -153,7 +164,7 @@ describe("RecordingsService", () => {
       server.use(
         http.put(`${BASE_URL}/recordings/3001/status/trashed.json`, () => {
           return new HttpResponse(null, { status: 204 });
-        })
+        }),
       );
 
       await expect(service.trash(3001)).resolves.toBeUndefined();
@@ -163,7 +174,7 @@ describe("RecordingsService", () => {
       server.use(
         http.put(`${BASE_URL}/recordings/9999/status/trashed.json`, () => {
           return HttpResponse.json({ error: "Not found" }, { status: 404 });
-        })
+        }),
       );
 
       await expect(service.trash(9999)).rejects.toThrow(BasecampError);
@@ -175,7 +186,7 @@ describe("RecordingsService", () => {
       server.use(
         http.put(`${BASE_URL}/recordings/3001/status/archived.json`, () => {
           return new HttpResponse(null, { status: 204 });
-        })
+        }),
       );
 
       await expect(service.archive(3001)).resolves.toBeUndefined();
@@ -185,7 +196,7 @@ describe("RecordingsService", () => {
       server.use(
         http.put(`${BASE_URL}/recordings/9999/status/archived.json`, () => {
           return HttpResponse.json({ error: "Not found" }, { status: 404 });
-        })
+        }),
       );
 
       await expect(service.archive(9999)).rejects.toThrow(BasecampError);
@@ -197,7 +208,7 @@ describe("RecordingsService", () => {
       server.use(
         http.put(`${BASE_URL}/recordings/3001/status/active.json`, () => {
           return new HttpResponse(null, { status: 204 });
-        })
+        }),
       );
 
       await expect(service.unarchive(3001)).resolves.toBeUndefined();
@@ -207,7 +218,7 @@ describe("RecordingsService", () => {
       server.use(
         http.put(`${BASE_URL}/recordings/9999/status/active.json`, () => {
           return HttpResponse.json({ error: "Not found" }, { status: 404 });
-        })
+        }),
       );
 
       await expect(service.unarchive(9999)).rejects.toThrow(BasecampError);

--- a/typescript/tests/services/schedules.test.ts
+++ b/typescript/tests/services/schedules.test.ts
@@ -73,11 +73,13 @@ describe("SchedulesService", () => {
           id: 4101,
           summary: "Team Meeting",
           starts_at: "2024-12-15T09:00:00Z",
+          description_attachments: [],
         },
         {
           id: 4102,
           summary: "Project Review",
           starts_at: "2024-12-16T14:00:00Z",
+          description_attachments: [],
         },
       ];
 

--- a/typescript/tests/services/schedules.test.ts
+++ b/typescript/tests/services/schedules.test.ts
@@ -39,7 +39,7 @@ describe("SchedulesService", () => {
       server.use(
         http.get(`${BASE_URL}/schedules/4001`, () => {
           return HttpResponse.json(schedule);
-        })
+        }),
       );
 
       const result = await service.get(4001);
@@ -53,7 +53,7 @@ describe("SchedulesService", () => {
       server.use(
         http.get(`${BASE_URL}/schedules/9999`, () => {
           return HttpResponse.json({ error: "Not found" }, { status: 404 });
-        })
+        }),
       );
 
       await expect(service.get(9999)).rejects.toThrow(BasecampError);
@@ -69,14 +69,22 @@ describe("SchedulesService", () => {
   describe("listEntries", () => {
     it("should return schedule entries", async () => {
       const entries = [
-        { id: 4101, summary: "Team Meeting", starts_at: "2024-12-15T09:00:00Z" },
-        { id: 4102, summary: "Project Review", starts_at: "2024-12-16T14:00:00Z" },
+        {
+          id: 4101,
+          summary: "Team Meeting",
+          starts_at: "2024-12-15T09:00:00Z",
+        },
+        {
+          id: 4102,
+          summary: "Project Review",
+          starts_at: "2024-12-16T14:00:00Z",
+        },
       ];
 
       server.use(
         http.get(`${BASE_URL}/schedules/4001/entries.json`, () => {
           return HttpResponse.json(entries);
-        })
+        }),
       );
 
       const result = await service.listEntries(4001);
@@ -90,7 +98,7 @@ describe("SchedulesService", () => {
       server.use(
         http.get(`${BASE_URL}/schedules/4001/entries.json`, () => {
           return HttpResponse.json([]);
-        })
+        }),
       );
 
       const result = await service.listEntries(4001);
@@ -105,6 +113,7 @@ describe("SchedulesService", () => {
         id: 4101,
         summary: "Team Meeting",
         description: "<p>Weekly sync</p>",
+        description_attachments: [],
         starts_at: "2024-12-15T09:00:00Z",
         ends_at: "2024-12-15T10:00:00Z",
         all_day: false,
@@ -113,7 +122,7 @@ describe("SchedulesService", () => {
       server.use(
         http.get(`${BASE_URL}/schedule_entries/4101`, () => {
           return HttpResponse.json(entry);
-        })
+        }),
       );
 
       const result = await service.getEntry(4101);
@@ -137,7 +146,7 @@ describe("SchedulesService", () => {
       server.use(
         http.post(`${BASE_URL}/schedules/4001/entries.json`, () => {
           return HttpResponse.json(newEntry);
-        })
+        }),
       );
 
       const result = await service.createEntry(4001, {
@@ -152,11 +161,14 @@ describe("SchedulesService", () => {
 
     it("should pass subscriptions in request body", async () => {
       server.use(
-        http.post(`${BASE_URL}/schedules/4001/entries.json`, async ({ request }) => {
-          const body = (await request.json()) as Record<string, unknown>;
-          expect(body.subscriptions).toEqual([111, 222]);
-          return HttpResponse.json({ id: 4202, summary: "Test" });
-        })
+        http.post(
+          `${BASE_URL}/schedules/4001/entries.json`,
+          async ({ request }) => {
+            const body = (await request.json()) as Record<string, unknown>;
+            expect(body.subscriptions).toEqual([111, 222]);
+            return HttpResponse.json({ id: 4202, summary: "Test" });
+          },
+        ),
       );
 
       const result = await service.createEntry(4001, {
@@ -172,10 +184,13 @@ describe("SchedulesService", () => {
       let capturedBody: Record<string, unknown> | null = null;
 
       server.use(
-        http.post(`${BASE_URL}/schedules/4001/entries.json`, async ({ request }) => {
-          capturedBody = (await request.json()) as Record<string, unknown>;
-          return HttpResponse.json({ id: 1, summary: "Test" });
-        })
+        http.post(
+          `${BASE_URL}/schedules/4001/entries.json`,
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json({ id: 1, summary: "Test" });
+          },
+        ),
       );
 
       await service.createEntry(4001, {
@@ -212,7 +227,7 @@ describe("SchedulesService", () => {
       server.use(
         http.put(`${BASE_URL}/schedule_entries/4101`, () => {
           return HttpResponse.json(updatedEntry);
-        })
+        }),
       );
 
       const result = await service.updateEntry(4101, {
@@ -237,9 +252,12 @@ describe("SchedulesService", () => {
       };
 
       server.use(
-        http.get(`${BASE_URL}/schedule_entries/4101/occurrences/2024-12-22`, () => {
-          return HttpResponse.json(entry);
-        })
+        http.get(
+          `${BASE_URL}/schedule_entries/4101/occurrences/2024-12-22`,
+          () => {
+            return HttpResponse.json(entry);
+          },
+        ),
       );
 
       const result = await service.getEntryOccurrence(4101, "2024-12-22");
@@ -261,7 +279,7 @@ describe("SchedulesService", () => {
       server.use(
         http.put(`${BASE_URL}/schedules/4001`, () => {
           return HttpResponse.json(schedule);
-        })
+        }),
       );
 
       const result = await service.updateSettings(4001, {
@@ -276,9 +294,11 @@ describe("SchedulesService", () => {
 
       server.use(
         http.put(`${BASE_URL}/schedules/4001`, async ({ request }) => {
-          capturedBody = (await request.json()) as { include_due_assignments?: boolean };
+          capturedBody = (await request.json()) as {
+            include_due_assignments?: boolean;
+          };
           return HttpResponse.json({ id: 4001, title: "Schedule" });
-        })
+        }),
       );
 
       await service.updateSettings(4001, { includeDueAssignments: true });

--- a/typescript/tests/services/schedules.test.ts
+++ b/typescript/tests/services/schedules.test.ts
@@ -94,6 +94,8 @@ describe("SchedulesService", () => {
       expect(result).toHaveLength(2);
       expect(result[0].summary).toBe("Team Meeting");
       expect(result[1].summary).toBe("Project Review");
+      // The required description_attachments array round-trips through the list.
+      expect(result[0].description_attachments).toEqual([]);
     });
 
     it("should return empty array when no entries", async () => {

--- a/typescript/tests/services/search.test.ts
+++ b/typescript/tests/services/search.test.ts
@@ -42,6 +42,25 @@ describe("SearchService", () => {
           status: "active",
           url: "https://example.com/2",
           app_url: "https://basecamp.com/2",
+          // The search projection carries the matching type's rich-text
+          // companion array; a Message result surfaces content_attachments.
+          content_attachments: [
+            {
+              id: 900,
+              sgid: "BAh-img",
+              filename: "diagram.png",
+              content_type: "image/png",
+              byte_size: 2048,
+              download_url:
+                "https://example.com/blobs/img/download/diagram.png",
+              width: 1024.0,
+              height: 768,
+              previewable: true,
+              preview_url: "https://example.com/blobs/img/previews/diagram.png",
+              thumbnail_url:
+                "https://example.com/blobs/img/thumbnails/diagram.png",
+            },
+          ],
         },
       ];
 
@@ -50,11 +69,14 @@ describe("SearchService", () => {
           const url = new URL(request.url);
           expect(url.searchParams.get("q")).toBe("project");
           return HttpResponse.json(mockResults);
-        })
+        }),
       );
 
       const results = await client.search.search("project");
       expect(results).toHaveLength(2);
+      // The optional projection array surfaces on the matching-type result.
+      expect(results[1]!.content_attachments).toHaveLength(1);
+      expect(results[1]!.content_attachments![0]!.width).toBe(1024);
       expect(results[0]!.title).toBe("Project Plan");
       expect(results[1]!.type).toBe("Message");
     });
@@ -66,10 +88,12 @@ describe("SearchService", () => {
           expect(url.searchParams.get("q")).toBe("test");
           expect(url.searchParams.get("sort")).toBe("best_match");
           return HttpResponse.json([]);
-        })
+        }),
       );
 
-      const results = await client.search.search("test", { sort: "best_match" });
+      const results = await client.search.search("test", {
+        sort: "best_match",
+      });
       expect(results).toHaveLength(0);
     });
 
@@ -89,7 +113,7 @@ describe("SearchService", () => {
           expect(url.searchParams.has("bucket_ids")).toBe(false);
           expect(url.searchParams.has("bucket_ids[][]")).toBe(false);
           return HttpResponse.json([]);
-        })
+        }),
       );
 
       const results = await client.search.search("hello", {
@@ -117,7 +141,7 @@ describe("SearchService", () => {
           expect(p.get("bucket_id")).toBe("9");
           expect(p.get("creator_id")).toBe("3");
           return HttpResponse.json([]);
-        })
+        }),
       );
 
       await client.search.search("hello", {
@@ -140,7 +164,7 @@ describe("SearchService", () => {
       server.use(
         http.get(`${BASE_URL}/search.json`, () => {
           return HttpResponse.json([]);
-        })
+        }),
       );
 
       const results = await client.search.search("nonexistent");
@@ -169,7 +193,7 @@ describe("SearchService", () => {
       server.use(
         http.get(`${BASE_URL}/searches/metadata.json`, () => {
           return HttpResponse.json(mockMetadata);
-        })
+        }),
       );
 
       const metadata = await client.search.metadata();

--- a/typescript/tests/services/todolists.test.ts
+++ b/typescript/tests/services/todolists.test.ts
@@ -14,6 +14,7 @@ const sampleTodolist = (id = 1) => ({
   id,
   name: "Launch list",
   description: "<p>Things to do before launch</p>",
+  description_attachments: [],
   completed: false,
   completed_ratio: "0/5",
   created_at: "2024-01-15T10:00:00Z",

--- a/typescript/tests/services/uploads.test.ts
+++ b/typescript/tests/services/uploads.test.ts
@@ -37,14 +37,15 @@ describe("UploadsService", () => {
         filename: "report.pdf",
         content_type: "application/pdf",
         byte_size: 1024000,
-        download_url: "https://3.basecampapi.com/12345/blobs/abcd/download/report.pdf",
+        download_url:
+          "https://3.basecampapi.com/12345/blobs/abcd/download/report.pdf",
         status: "active",
       };
 
       server.use(
         http.get(`${BASE_URL}/uploads/7001`, () => {
           return HttpResponse.json(upload);
-        })
+        }),
       );
 
       const result = await service.get(7001);
@@ -58,7 +59,7 @@ describe("UploadsService", () => {
       server.use(
         http.get(`${BASE_URL}/uploads/9999`, () => {
           return HttpResponse.json({ error: "Not found" }, { status: 404 });
-        })
+        }),
       );
 
       await expect(service.get(9999)).rejects.toThrow(BasecampError);
@@ -81,7 +82,7 @@ describe("UploadsService", () => {
       server.use(
         http.get(`${BASE_URL}/vaults/1001/uploads.json`, () => {
           return HttpResponse.json(uploads);
-        })
+        }),
       );
 
       const result = await service.list(1001);
@@ -95,7 +96,7 @@ describe("UploadsService", () => {
       server.use(
         http.get(`${BASE_URL}/vaults/1001/uploads.json`, () => {
           return HttpResponse.json([]);
-        })
+        }),
       );
 
       const result = await service.list(1001);
@@ -111,13 +112,14 @@ describe("UploadsService", () => {
         title: "presentation.pptx",
         filename: "presentation.pptx",
         description: "Q4 Presentation",
+        description_attachments: [],
         status: "active",
       };
 
       server.use(
         http.post(`${BASE_URL}/vaults/1001/uploads.json`, () => {
           return HttpResponse.json(newUpload);
-        })
+        }),
       );
 
       const result = await service.create(1001, {
@@ -131,11 +133,14 @@ describe("UploadsService", () => {
 
     it("should pass subscriptions in request body", async () => {
       server.use(
-        http.post(`${BASE_URL}/vaults/1001/uploads.json`, async ({ request }) => {
-          const body = (await request.json()) as Record<string, unknown>;
-          expect(body.subscriptions).toEqual([111, 222]);
-          return HttpResponse.json({ id: 8002, title: "Test" });
-        })
+        http.post(
+          `${BASE_URL}/vaults/1001/uploads.json`,
+          async ({ request }) => {
+            const body = (await request.json()) as Record<string, unknown>;
+            expect(body.subscriptions).toEqual([111, 222]);
+            return HttpResponse.json({ id: 8002, title: "Test" });
+          },
+        ),
       );
 
       const result = await service.create(1001, {
@@ -146,13 +151,24 @@ describe("UploadsService", () => {
     });
 
     it("should send all fields in request body", async () => {
-      let capturedBody: { attachable_sgid?: string; description?: string; base_name?: string } | null = null;
+      let capturedBody: {
+        attachable_sgid?: string;
+        description?: string;
+        base_name?: string;
+      } | null = null;
 
       server.use(
-        http.post(`${BASE_URL}/vaults/1001/uploads.json`, async ({ request }) => {
-          capturedBody = (await request.json()) as { attachable_sgid?: string; description?: string; base_name?: string };
-          return HttpResponse.json({ id: 1, title: "Test" });
-        })
+        http.post(
+          `${BASE_URL}/vaults/1001/uploads.json`,
+          async ({ request }) => {
+            capturedBody = (await request.json()) as {
+              attachable_sgid?: string;
+              description?: string;
+              base_name?: string;
+            };
+            return HttpResponse.json({ id: 1, title: "Test" });
+          },
+        ),
       );
 
       await service.create(1001, {
@@ -175,13 +191,14 @@ describe("UploadsService", () => {
         id: 7001,
         title: "new-name.pdf",
         description: "Updated description",
+        description_attachments: [],
         status: "active",
       };
 
       server.use(
         http.put(`${BASE_URL}/uploads/7001`, () => {
           return HttpResponse.json(updatedUpload);
-        })
+        }),
       );
 
       const result = await service.update(7001, {
@@ -193,13 +210,17 @@ describe("UploadsService", () => {
     });
 
     it("should send updated fields in request body", async () => {
-      let capturedBody: { description?: string; base_name?: string } | null = null;
+      let capturedBody: { description?: string; base_name?: string } | null =
+        null;
 
       server.use(
         http.put(`${BASE_URL}/uploads/7001`, async ({ request }) => {
-          capturedBody = (await request.json()) as { description?: string; base_name?: string };
+          capturedBody = (await request.json()) as {
+            description?: string;
+            base_name?: string;
+          };
           return HttpResponse.json({ id: 7001, title: "Test" });
-        })
+        }),
       );
 
       await service.update(7001, {
@@ -215,15 +236,27 @@ describe("UploadsService", () => {
   describe("listVersions", () => {
     it("should return upload versions", async () => {
       const uploads = [
-        { id: 7001, filename: "file_v3.pdf", created_at: "2024-03-15T10:00:00Z" },
-        { id: 7001, filename: "file_v2.pdf", created_at: "2024-02-10T10:00:00Z" },
-        { id: 7001, filename: "file_v1.pdf", created_at: "2024-01-05T10:00:00Z" },
+        {
+          id: 7001,
+          filename: "file_v3.pdf",
+          created_at: "2024-03-15T10:00:00Z",
+        },
+        {
+          id: 7001,
+          filename: "file_v2.pdf",
+          created_at: "2024-02-10T10:00:00Z",
+        },
+        {
+          id: 7001,
+          filename: "file_v1.pdf",
+          created_at: "2024-01-05T10:00:00Z",
+        },
       ];
 
       server.use(
         http.get(`${BASE_URL}/uploads/7001/versions.json`, () => {
           return HttpResponse.json(uploads);
-        })
+        }),
       );
 
       const result = await service.listVersions(7001);
@@ -235,7 +268,7 @@ describe("UploadsService", () => {
       server.use(
         http.get(`${BASE_URL}/uploads/7001/versions.json`, () => {
           return HttpResponse.json([]);
-        })
+        }),
       );
 
       const result = await service.listVersions(7001);
@@ -261,17 +294,21 @@ describe("UploadsService", () => {
           return HttpResponse.json({
             id: 1069479400,
             filename: "logo.png",
-            download_url: "https://storage.3.basecamp.com/12345/blobs/abc/download/logo.png",
+            download_url:
+              "https://storage.3.basecamp.com/12345/blobs/abc/download/logo.png",
           });
         }),
         // Hop 1: origin-rewritten to API_ORIGIN
-        http.get(`${API_ORIGIN}/12345/blobs/abc/download/logo.png`, ({ request }) => {
-          authorizationHeaders.push(request.headers.get("authorization"));
-          return new HttpResponse(null, {
-            status: 302,
-            headers: { Location: SIGNED_URL },
-          });
-        }),
+        http.get(
+          `${API_ORIGIN}/12345/blobs/abc/download/logo.png`,
+          ({ request }) => {
+            authorizationHeaders.push(request.headers.get("authorization"));
+            return new HttpResponse(null, {
+              status: 302,
+              headers: { Location: SIGNED_URL },
+            });
+          },
+        ),
         // Hop 2: signed URL (no auth)
         http.get(SIGNED_URL, ({ request }) => {
           authorizationHeaders.push(request.headers.get("authorization"));
@@ -328,4 +365,3 @@ describe("UploadsService", () => {
     });
   });
 });
-

--- a/typescript/tests/services/uploads.test.ts
+++ b/typescript/tests/services/uploads.test.ts
@@ -314,6 +314,7 @@ describe("UploadsService", () => {
             filename: "logo.png",
             download_url:
               "https://storage.3.basecamp.com/12345/blobs/abc/download/logo.png",
+            description_attachments: [],
           });
         }),
         // Hop 1: origin-rewritten to API_ORIGIN
@@ -363,6 +364,7 @@ describe("UploadsService", () => {
             id: 1069479400,
             filename: "logo.png",
             download_url: null,
+            description_attachments: [],
           });
         }),
         // No download hop should fire — this handler would record it if so

--- a/typescript/tests/services/uploads.test.ts
+++ b/typescript/tests/services/uploads.test.ts
@@ -40,6 +40,7 @@ describe("UploadsService", () => {
         download_url:
           "https://3.basecampapi.com/12345/blobs/abcd/download/report.pdf",
         status: "active",
+        description_attachments: [],
       };
 
       server.use(
@@ -75,8 +76,18 @@ describe("UploadsService", () => {
   describe("list", () => {
     it("should return uploads in a vault", async () => {
       const uploads = [
-        { id: 7001, filename: "file1.pdf", status: "active" },
-        { id: 7002, filename: "file2.xlsx", status: "active" },
+        {
+          id: 7001,
+          filename: "file1.pdf",
+          status: "active",
+          description_attachments: [],
+        },
+        {
+          id: 7002,
+          filename: "file2.xlsx",
+          status: "active",
+          description_attachments: [],
+        },
       ];
 
       server.use(
@@ -219,7 +230,11 @@ describe("UploadsService", () => {
             description?: string;
             base_name?: string;
           };
-          return HttpResponse.json({ id: 7001, title: "Test" });
+          return HttpResponse.json({
+            id: 7001,
+            title: "Test",
+            description_attachments: [],
+          });
         }),
       );
 
@@ -240,16 +255,19 @@ describe("UploadsService", () => {
           id: 7001,
           filename: "file_v3.pdf",
           created_at: "2024-03-15T10:00:00Z",
+          description_attachments: [],
         },
         {
           id: 7001,
           filename: "file_v2.pdf",
           created_at: "2024-02-10T10:00:00Z",
+          description_attachments: [],
         },
         {
           id: 7001,
           filename: "file_v1.pdf",
           created_at: "2024-01-05T10:00:00Z",
+          description_attachments: [],
         },
       ];
 


### PR DESCRIPTION
Completes rich-text attachment coverage across every modeled decode path. PR #400 added `Todo.description_attachments` and the reusable `RichTextAttachment` + `RichTextAttachmentList`; this wires up the remaining 17 structures (19 members), so every rich-text attribute the SDK decodes now carries its companion `*_attachments` array of structured file metadata (bc3 `recordings/_rich_text.json.jbuilder`).

## What ships (18 modeled emitters incl. Todo, 20 members)

- **14 concrete resources — `@required`** (always emitted, empty when no inline files): Todolist, Comment, Message, Document, Upload, ScheduleEntry, Forward, ForwardReply, Card (`description`), ClientApproval, ClientCorrespondence, ClientReply, QuestionAnswer, GaugeNeedle.
- **Gauge — optional, non-nullable**: its partial renders the array only when the gauge has needles (`if gauge.any_needles?`), so a needle-less gauge omits the key.
- **SearchResult + generic Recording — optional, non-nullable, both arrays each**: these polymorphic projections render the full type-specific partial, so the companion arrays survive; a given item carries only the array matching its type, a webhook-sourced item neither.

Reuses #400's `RichTextAttachment` and all its nullable/float-spelled dimension machinery unchanged.

## Implementation

- **Go**: every converter routes through a shared `richTextAttachmentsFromGenerated` helper preserving the nil-vs-empty distinction; Gauge/GaugeNeedle decode directly. Gauge and the two projections use `omitempty` (optional/non-nullable — never emits an invalid `null` on re-encode).
- **Tests**: Go wiring proof for all 15 converter structures + `gauges_test.go` (GaugeNeedle decode, Gauge presence contract, omitempty marshal); end-to-end projection assertions in the Search and Recordings tests; one populated two-entry representative per SDK (Comment for Go/Swift/Kotlin/Ruby/TS, Upload for Python) exercising float-spelled `1024.0` and `null`.

## Notes

- **No provenance repin** — the bc3 #9980 contract already sits within the current pin; this is absorption, not a sync.
- Flips `spec/api-gaps/rich-text-attachments-coverage.md` to `absorbed-in-sdk`, recording the out-of-scope items accurately (the generic `attachments` key, everything-aggregates, JournalEntry, google_documents/cloud_files, clients sub-forms).
- `make check` → `All checks passed`.

Closes #405

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full rich‑text `*_attachments` coverage across all decode paths. Every rich‑text field now carries its companion attachments array with correct nil vs empty handling and nullable, float‑spelled dimensions.

- **New Features**
  - Added `*_attachments` to 14 concrete resources (always present, empty when none) and optional arrays for `Gauge`, `Recording`, and `SearchResult`; reused `RichTextAttachment`, updated Smithy/OpenAPI, fixtures, and generated models/tests across Go/Swift/Kotlin/Python/Ruby/TypeScript.

- **Bug Fixes**
  - Go: optional projection arrays (`Gauge`, `Recording`, `SearchResult`) use `*[]RichTextAttachment` with `omitempty` to round‑trip absent vs empty vs populated; added pointer helper/tests; clarified marshal behavior in `@required` array comments.
  - Kotlin: optional rich‑text arrays in polymorphic `Recording`/`SearchResult` are nullable (`List<RichTextAttachment>?`) to preserve absent vs empty; added `RecordingsServiceTest`.
  - Fixtures/stubs/tests/docs: added required `content_attachments`/`description_attachments` to remaining stubs (Python upload `_metadata()`, TypeScript schedule entries and upload download‑flow metadata); Ruby service stubs updated; added TS/Ruby tests exercising optional projection arrays and ScheduleEntry round‑trip; api‑gaps entry switched to grep‑able `smithy_refs` and documents the optional‑array presence contract; Ruby search test now asserts both Message and Document results surface `content_attachments`; Go comment wording tightened.
  - TypeScript: removed erroneous `content_attachments` from `ClientApprovalResponse` test stub (non‑emitter); only `ClientApproval` includes the companion array.

Closes #405

<sup>Written for commit a1862927b7dfee2963b3a4254404f382149868fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

