### PR TITLE
Propagate @deprecated to all six SDKs per a signal-class matrix (#406)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -743,13 +743,23 @@ tools:
 # Spec-shape lints
 #------------------------------------------------------------------------------
 
-.PHONY: check-bucket-flat-parity validate-api-gaps
+.PHONY: check-bucket-flat-parity validate-api-gaps check-deprecation-parity
 
 # Verify every bucket-scoped GET list operation has a flat-path counterpart
 # (or is justified in spec/bucket-scoped-allowlist.txt). Cross-project SDK
 # consumers shouldn't need to enumerate projects to reach account-wide data.
 check-bucket-flat-parity:
 	@./scripts/check-bucket-flat-parity.sh
+
+# Verify @deprecated propagates to all six SDKs in the right signal class
+# (compiler=Kotlin; editor=TS/Go; doc-only=Ruby/Python/Swift), that the clean
+# controls stay unmarked, and that no doubled "Deprecated: Deprecated:" slips in.
+# Depends on rb-build: the Ruby YARD-registry sub-check runs `bundle exec`, so
+# the gems (YARD) must be installed first — otherwise a direct invocation or a
+# parallel `make -j check` that schedules this before rb-check would fail on a
+# clean checkout.
+check-deprecation-parity: rb-build
+	@./scripts/check-deprecation-parity
 
 # Validate spec/api-gaps/ entry frontmatter, required body sections, and allowlist.
 validate-api-gaps:
@@ -777,7 +787,7 @@ generate:
 	@echo "==> Generation complete"
 
 # Run all checks (Smithy + Go + TypeScript + Ruby + Kotlin + Swift + Python + Behavior Model + Conformance + Provenance + Actions lint)
-check: lint-actions sync-spec-version-check smithy-check behavior-model-check provenance-check sync-api-version-check go-check-drift go-check-wrapper-drift auth-routable-check kt-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps
+check: lint-actions sync-spec-version-check smithy-check behavior-model-check provenance-check sync-api-version-check go-check-drift go-check-wrapper-drift auth-routable-check kt-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity
 	@echo "==> All checks passed"
 
 # Clean all build artifacts

--- a/go/generate.go
+++ b/go/generate.go
@@ -3,4 +3,5 @@
 // Run `go generate ./...` from the go directory to regenerate the client code.
 //
 //go:generate go tool oapi-codegen -config oapi-codegen.yaml ../openapi.json
+//go:generate ../scripts/normalize-go-deprecation-godoc.sh pkg/generated/client.gen.go
 package generate

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -420,7 +420,7 @@ type ClientReply struct {
 
 // ClientSide This shape is deprecated since 2024-01: Use Client Visibility feature instead
 //
-// Deprecated: this type has been marked as deprecated upstream, but no `x-deprecated-reason` was set
+// Deprecated: This shape is deprecated since 2024-01: Use Client Visibility feature instead
 type ClientSide struct {
 	AppUrl string `json:"app_url,omitempty"`
 	Url    string `json:"url,omitempty"`
@@ -1632,7 +1632,8 @@ type Project struct {
 	ClientsEnabled bool          `json:"clients_enabled,omitempty"`
 
 	// Clientside This shape is deprecated since 2024-01: Use Client Visibility feature instead
-	// Deprecated: this property has been marked as deprecated upstream, but no `x-deprecated-reason` was set
+	//
+	// Deprecated: This shape is deprecated since 2024-01: Use Client Visibility feature instead
 	Clientside  ClientSide `json:"clientside,omitempty"`
 	CreatedAt   time.Time  `json:"created_at"`
 	Description string     `json:"description,omitempty"`
@@ -2925,12 +2926,18 @@ type SearchParams struct {
 	Sort string `form:"sort,omitempty" json:"sort,omitempty"`
 
 	// Type Deprecated: prefer type_names[].
+	//
+	// Deprecated: prefer type_names[].
 	Type string `form:"type,omitempty" json:"type,omitempty"`
 
 	// BucketId Deprecated: prefer bucket_ids[].
+	//
+	// Deprecated: prefer bucket_ids[].
 	BucketId int64 `form:"bucket_id,omitempty" json:"bucket_id,omitempty"`
 
 	// CreatorId Deprecated: prefer creator_ids[].
+	//
+	// Deprecated: prefer creator_ids[].
 	CreatorId int64 `form:"creator_id,omitempty" json:"creator_id,omitempty"`
 }
 

--- a/kotlin/generator/src/main/kotlin/com/basecamp/sdk/generator/ModelEmitter.kt
+++ b/kotlin/generator/src/main/kotlin/com/basecamp/sdk/generator/ModelEmitter.kt
@@ -56,6 +56,21 @@ class ModelEmitter(private val api: OpenApiParser) {
         lines += " *"
         lines += " * @generated from OpenAPI spec — do not edit directly"
         lines += " */"
+        // A model that references a deprecated component type warns merely by
+        // declaring the field — annotating the property does NOT suppress the
+        // deprecated-TYPE-reference warning — so suppress at the type level.
+        // Conditional on actually referencing a deprecated component, not keyed
+        // on any specific model, to hold the zero-generator-warning invariant.
+        // See #406.
+        val referencesDeprecatedType = properties.any { (_, ps) -> referencesDeprecatedComponent(ps.jsonObject) }
+        if (referencesDeprecatedType) {
+            lines += "@Suppress(\"DEPRECATION\")"
+        }
+        // A wholly deprecated type gets a class-level @Deprecated (compiler
+        // warning at use sites).
+        if (schema["deprecated"]?.jsonPrimitive?.booleanOrNull == true) {
+            lines += "@Deprecated(${kotlinStringLiteral(schema["x-deprecated-reason"]?.jsonPrimitive?.content ?: "deprecated")})"
+        }
         lines += "@Serializable"
         lines += "data class $typeName("
 
@@ -80,6 +95,12 @@ class ModelEmitter(private val api: OpenApiParser) {
             val isFlexibleInt = isFlexInt(propObj)
 
             val propLine = buildString {
+                // Compiler-level deprecation on the property (see #406). The
+                // class-level @Suppress above absorbs the deprecated-type-
+                // reference warning; this marks the property for consumers.
+                if (propObj["deprecated"]?.jsonPrimitive?.booleanOrNull == true) {
+                    append("    @Deprecated(${kotlinStringLiteral(propObj["x-deprecated-reason"]?.jsonPrimitive?.content ?: "deprecated")})\n")
+                }
                 if (isFlexible) {
                     append("    @Serializable(with = FlexibleLongSerializer::class)\n")
                 }
@@ -164,6 +185,24 @@ class ModelEmitter(private val api: OpenApiParser) {
             "object" -> if (isRequired) "JsonObject" else "JsonObject?"
             else -> if (isRequired) "JsonElement" else "JsonElement?"
         }
+    }
+
+    /** True when a property's type resolves to a component schema marked
+     *  `deprecated: true` (directly or as an array element). Declaring a field of
+     *  such a type warns at the declaration site regardless of any @Deprecated on
+     *  the property, so the owning data class needs a type-level @Suppress. */
+    private fun referencesDeprecatedComponent(propObj: JsonObject): Boolean {
+        val refName = componentRefName(propObj) ?: return false
+        val refSchema = api.getSchema(refName) ?: return false
+        return refSchema["deprecated"]?.jsonPrimitive?.booleanOrNull == true
+    }
+
+    /** The referenced component name for a property that is a `$ref` or an array
+     *  of `$ref`, else null. */
+    private fun componentRefName(propObj: JsonObject): String? {
+        propObj["\$ref"]?.jsonPrimitive?.content?.let { return api.resolveRef(it) }
+        propObj["items"]?.jsonObject?.get("\$ref")?.jsonPrimitive?.content?.let { return api.resolveRef(it) }
+        return null
     }
 
     private fun resolveArrayItemType(items: JsonObject?): String {

--- a/kotlin/generator/src/main/kotlin/com/basecamp/sdk/generator/OperationParser.kt
+++ b/kotlin/generator/src/main/kotlin/com/basecamp/sdk/generator/OperationParser.kt
@@ -28,7 +28,14 @@ data class ParsedOperation(
 )
 
 data class PathParam(val name: String, val type: String, val description: String?)
-data class QueryParam(val name: String, val type: String, val required: Boolean, val description: String?)
+data class QueryParam(
+    val name: String,
+    val type: String,
+    val required: Boolean,
+    val description: String?,
+    val deprecated: Boolean = false,
+    val deprecationReason: String? = null,
+)
 data class BodyProperty(val name: String, val type: String, val required: Boolean, val description: String?, val formatHint: String?)
 
 data class ServiceDefinition(
@@ -113,11 +120,17 @@ class OperationParser(private val api: OpenApiParser) {
                     }
                     else -> "String"
                 }
+                val deprecated = (param["deprecated"]?.jsonPrimitive?.booleanOrNull ?: false) ||
+                    (schema["deprecated"]?.jsonPrimitive?.booleanOrNull ?: false)
+                val deprecationReason = param["x-deprecated-reason"]?.jsonPrimitive?.content
+                    ?: schema["x-deprecated-reason"]?.jsonPrimitive?.content
                 QueryParam(
                     name,
                     type,
                     param["required"]?.jsonPrimitive?.boolean ?: false,
                     param["description"]?.jsonPrimitive?.content,
+                    deprecated,
+                    deprecationReason,
                 )
             }
 
@@ -324,3 +337,16 @@ fun String.snakeToCamelCase(): String =
 
 fun String.capitalize(): String =
     replaceFirstChar { it.uppercase() }
+
+/** Render a string as a Kotlin double-quoted literal, escaping the characters
+ *  that would otherwise break the literal. Used for @Deprecated("...") reasons. */
+fun kotlinStringLiteral(value: String): String {
+    val escaped = value
+        .replace("\\", "\\\\")
+        .replace("\"", "\\\"")
+        .replace("$", "\\$")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    return "\"$escaped\""
+}

--- a/kotlin/generator/src/main/kotlin/com/basecamp/sdk/generator/ServiceEmitter.kt
+++ b/kotlin/generator/src/main/kotlin/com/basecamp/sdk/generator/ServiceEmitter.kt
@@ -92,6 +92,16 @@ class ServiceEmitter(private val api: OpenApiParser) {
         }
         sb.appendLine("     */")
 
+        // A function that reads a deprecated query param (e.g. search reads
+        // options?.type/bucketId/creatorId) would itself emit DEPRECATION
+        // warnings on the generated SDK's own code. Suppress at the function
+        // level, keyed on "operation has >=1 deprecated param" rather than the
+        // literal operation name, to hold the zero-generator-warning invariant.
+        // See #406.
+        if (op.queryParams.any { it.deprecated }) {
+            sb.appendLine("    @Suppress(\"DEPRECATION\")")
+        }
+
         // Method signature
         sb.appendLine("    suspend fun ${op.methodName}($params): $returnType {")
 

--- a/kotlin/generator/src/main/kotlin/com/basecamp/sdk/generator/TypeEmitter.kt
+++ b/kotlin/generator/src/main/kotlin/com/basecamp/sdk/generator/TypeEmitter.kt
@@ -92,7 +92,12 @@ class TypeEmitter {
         val lines = mutableListOf<String>()
         for (q in optionalParams) {
             val camelName = q.name.snakeToCamelCase()
-            lines += "    val $camelName: ${q.type}? = null"
+            // Compiler-level deprecation (see #406): @Deprecated on the property
+            // warns at read sites. It binds to the property (it cannot target a
+            // VALUE_PARAMETER), so the named-constructor-arg call site stays
+            // unflagged — documented as unsupported, parallel to Swift.
+            val annotation = if (q.deprecated) "    @Deprecated(${kotlinStringLiteral(q.deprecationReason ?: "deprecated")})\n" else ""
+            lines += "$annotation    val $camelName: ${q.type}? = null"
         }
         if (hasPagination) {
             lines += "    val maxItems: Int? = null"

--- a/kotlin/sdk/build.gradle.kts
+++ b/kotlin/sdk/build.gradle.kts
@@ -8,7 +8,21 @@ group = "com.basecamp"
 version = "0.8.0"
 
 kotlin {
-    jvm()
+    jvm {
+        // Enforce the zero-generator-origin-deprecation-warning invariant (#406):
+        // the generated common+jvm main sources compile with all warnings
+        // (including DEPRECATION) promoted to errors. The generic
+        // ModelEmitter/ServiceEmitter @Suppress("DEPRECATION") annotations must
+        // hold for this to pass; a regression (e.g. a new deprecated-type
+        // reference without suppression) then fails the build.
+        compilations.named("main") {
+            compileTaskProvider.configure {
+                compilerOptions {
+                    allWarningsAsErrors.set(true)
+                }
+            }
+        }
+    }
 
     sourceSets {
         commonMain.dependencies {
@@ -28,6 +42,10 @@ kotlin {
         }
         jvmTest.dependencies {
             implementation(libs.junit.jupiter)
+            // Drives the deprecation diagnostic fixture (#406): compiles source
+            // snippets against the SDK classpath at test time and asserts the
+            // compiler's diagnostics, rather than just "it compiles".
+            implementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:${libs.versions.kotlin.get()}")
         }
     }
 }

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/ClientSide.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/ClientSide.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.json.JsonObject
  *
  * @generated from OpenAPI spec — do not edit directly
  */
+@Deprecated("This shape is deprecated since 2024-01: Use Client Visibility feature instead")
 @Serializable
 data class ClientSide(
     val url: String? = null,

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Project.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Project.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.json.JsonObject
  *
  * @generated from OpenAPI spec — do not edit directly
  */
+@Suppress("DEPRECATION")
 @Serializable
 data class Project(
     val id: Long,
@@ -28,5 +29,6 @@ data class Project(
     val dock: List<DockItem> = emptyList(),
     val bookmarked: Boolean = false,
     @SerialName("client_company") val clientCompany: ClientCompany? = null,
+    @Deprecated("This shape is deprecated since 2024-01: Use Client Visibility feature instead")
     val clientside: ClientSide? = null
 )

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/Types.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/Types.kt
@@ -451,8 +451,11 @@ data class SearchOptions(
     val excludeChat: Boolean? = null,
     val since: String? = null,
     val sort: String? = null,
+    @Deprecated("prefer type_names[].")
     val type: String? = null,
+    @Deprecated("prefer bucket_ids[].")
     val bucketId: Long? = null,
+    @Deprecated("prefer creator_ids[].")
     val creatorId: Long? = null,
     val maxItems: Int? = null
 ) {

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/search.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/search.kt
@@ -17,6 +17,7 @@ class SearchService(client: AccountClient) : BaseService(client) {
      * @param q q
      * @param options Optional query parameters and pagination control
      */
+    @Suppress("DEPRECATION")
     suspend fun search(q: String, options: SearchOptions? = null): ListResult<JsonElement> {
         val info = OperationInfo(
             service = "Search",

--- a/kotlin/sdk/src/jvmTest/kotlin/com/basecamp/sdk/DeprecationDiagnosticsTest.kt
+++ b/kotlin/sdk/src/jvmTest/kotlin/com/basecamp/sdk/DeprecationDiagnosticsTest.kt
@@ -1,0 +1,111 @@
+package com.basecamp.sdk
+
+import org.jetbrains.kotlin.cli.common.ExitCode
+import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
+import org.jetbrains.kotlin.config.Services
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Diagnostic fixture for the deprecation-propagation work (#406).
+ *
+ * Kotlin is the one compiler-warning language in the matrix, so its behavior is
+ * asserted at the level of actual compiler diagnostics — not "it compiles". Each
+ * snippet is compiled at test time by the embedded Kotlin compiler against this
+ * test's own classpath (which includes the built SDK), with all warnings
+ * promoted to errors, so a deprecation warning becomes a hard compile failure we
+ * can assert on. The snippets are compiled by the embedded compiler, never by
+ * the ordinary SDK test compilation, so they don't perturb the normal build.
+ *
+ * The outer gate is the two @Test methods together (jvmTest is red unless BOTH
+ * hold): reading a deprecated property must fail with the deprecation reason,
+ * and the named-constructor-argument call site must stay clean — recording that
+ * `@Deprecated` cannot target a `VALUE_PARAMETER`, so that site is unsupported.
+ */
+class DeprecationDiagnosticsTest {
+
+    private data class CompileResult(val exitCode: ExitCode, val messages: List<String>)
+
+    private fun compile(source: String): CompileResult {
+        val tmpDir = File.createTempFile("dep-fixture", "").apply {
+            delete()
+            mkdirs()
+        }
+        try {
+            val srcFile = File(tmpDir, "Fixture.kt").apply { writeText(source) }
+            val outDir = File(tmpDir, "out").apply { mkdirs() }
+            val messages = mutableListOf<String>()
+            val collector = object : MessageCollector {
+                private var errors = false
+                override fun clear() {
+                    errors = false
+                }
+                override fun hasErrors() = errors
+                override fun report(
+                    severity: CompilerMessageSeverity,
+                    message: String,
+                    location: CompilerMessageSourceLocation?,
+                ) {
+                    if (severity.isError) errors = true
+                    messages += "$severity: $message"
+                }
+            }
+            val args = K2JVMCompilerArguments().apply {
+                freeArgs = listOf(srcFile.absolutePath)
+                classpath = System.getProperty("java.class.path")
+                destination = outDir.absolutePath
+                // Deprecation is a warning by default; promote so it becomes an
+                // asserting failure the fixture can observe.
+                allWarningsAsErrors = true
+                // stdlib is already on the test classpath.
+                noStdlib = true
+                noReflect = true
+            }
+            val exitCode = K2JVMCompiler().exec(collector, Services.EMPTY, args)
+            return CompileResult(exitCode, messages)
+        } finally {
+            tmpDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun readingDeprecatedPropertyFailsWithReason() {
+        val result = compile(
+            """
+            import com.basecamp.sdk.generated.services.SearchOptions
+            fun probe(o: SearchOptions): String? = o.type
+            """.trimIndent(),
+        )
+        assertTrue(
+            result.exitCode == ExitCode.COMPILATION_ERROR,
+            "reading a deprecated property should fail under deprecation-as-error; " +
+                "got ${result.exitCode}\n${result.messages.joinToString("\n")}",
+        )
+        assertTrue(
+            result.messages.any { it.contains("prefer type_names[].") },
+            "the diagnostic should carry the resolved deprecation reason; " +
+                "got:\n${result.messages.joinToString("\n")}",
+        )
+    }
+
+    @Test
+    fun namedConstructorArgumentIsUnflagged() {
+        val result = compile(
+            """
+            import com.basecamp.sdk.generated.services.SearchOptions
+            fun probe(): SearchOptions = SearchOptions(type = "x")
+            """.trimIndent(),
+        )
+        assertTrue(
+            result.exitCode == ExitCode.OK,
+            "constructing via the named argument should compile clean — @Deprecated " +
+                "binds to the property, not the VALUE_PARAMETER, so this call site is " +
+                "unsupported/unflagged; got ${result.exitCode}\n${result.messages.joinToString("\n")}",
+        )
+    }
+}

--- a/openapi.json
+++ b/openapi.json
@@ -16494,7 +16494,9 @@
               "type": "string",
               "deprecated": true,
               "description": "Deprecated: prefer type_names[].\nThis shape is deprecated since 2026-07: Use typeNames (type_names[]) instead"
-            }
+            },
+            "deprecated": true,
+            "x-deprecated-reason": "prefer type_names[]."
           },
           {
             "name": "bucket_id",
@@ -16505,7 +16507,9 @@
               "deprecated": true,
               "description": "Deprecated: prefer bucket_ids[].\nThis shape is deprecated since 2026-07: Use bucketIds (bucket_ids[]) instead",
               "format": "int64"
-            }
+            },
+            "deprecated": true,
+            "x-deprecated-reason": "prefer bucket_ids[]."
           },
           {
             "name": "creator_id",
@@ -16516,7 +16520,9 @@
               "deprecated": true,
               "description": "Deprecated: prefer creator_ids[].\nThis shape is deprecated since 2026-07: Use creatorIds (creator_ids[]) instead",
               "format": "int64"
-            }
+            },
+            "deprecated": true,
+            "x-deprecated-reason": "prefer creator_ids[]."
           }
         ],
         "responses": {
@@ -22433,7 +22439,8 @@
           "app_url": {
             "type": "string"
           }
-        }
+        },
+        "x-deprecated-reason": "This shape is deprecated since 2024-01: Use Client Visibility feature instead"
       },
       "Comment": {
         "type": "object",
@@ -25564,7 +25571,8 @@
           },
           "clientside": {
             "$ref": "#/components/schemas/ClientSide",
-            "deprecated": true
+            "deprecated": true,
+            "x-deprecated-reason": "This shape is deprecated since 2024-01: Use Client Visibility feature instead"
           }
         },
         "required": [

--- a/python/scripts/gen_common.py
+++ b/python/scripts/gen_common.py
@@ -1,0 +1,24 @@
+"""Shared helpers for the Python code generators (generate_services.py,
+generate_types.py)."""
+
+from __future__ import annotations
+
+
+def escape_py_string(value: str) -> str:
+    """Escape arbitrary text for safe interpolation into a Python string or
+    docstring literal.
+
+    Escapes backslashes, double-quotes (so the text can't close a triple-quoted
+    docstring), and the control characters that would otherwise split the
+    emitted source line or form an invalid escape (e.g. a lone ``\\u``). The
+    result stays on one line and is syntactically valid for any input, so a
+    deprecation reason sourced from a multi-line OpenAPI description can't break
+    the generated module.
+    """
+    return (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )

--- a/python/scripts/generate_services.py
+++ b/python/scripts/generate_services.py
@@ -16,6 +16,11 @@ import re
 import sys
 from pathlib import Path
 
+# Make the shared generator helper importable whether this file is run as a
+# script (its dir is already sys.path[0]) or loaded via importlib in tests.
+sys.path.insert(0, str(Path(__file__).parent))
+from gen_common import escape_py_string  # noqa: E402
+
 METHODS = ("get", "post", "put", "patch", "delete")
 
 # Tag to service name mapping overrides
@@ -417,11 +422,14 @@ def parse_operation(
             # `bucket_ids%5B%5D=…`), but strip it for the public `python_name`
             # kwarg identifier (`bucket_ids[]` is not a valid identifier).
             snake = to_snake_case(re.sub(r"\[\]$", "", p["name"]))
+            schema = p.get("schema") or {}
             query_params.append({
                 "name": p["name"],
                 "python_name": safe_python_name(snake),
                 "type": schema_to_python_type(p.get("schema")),
                 "required": p.get("required", False),
+                "deprecated": bool(p.get("deprecated") or schema.get("deprecated")),
+                "deprecation_reason": p.get("x-deprecated-reason") or schema.get("x-deprecated-reason"),
             })
 
     # Body params
@@ -506,6 +514,26 @@ def python_type_hint(param_type: str) -> str:
         "str": "str",
         "dict": "dict",
     }.get(param_type, "str")
+
+
+def deprecation_docstring(op: dict) -> list[str]:
+    """Emit a method docstring flagging deprecated query params.
+
+    Documentation-only (see #406): a TypedDict/kwarg has no per-parameter
+    deprecation directive, and an RST ``.. deprecated::`` inside a ``:param:``
+    is malformed, so this is a real prose docstring listing each deprecated
+    parameter and its replacement. Emitted only when the operation has at least
+    one deprecated param, keyed on that flag rather than a specific method name.
+    """
+    deprecated = [q for q in op["query_params"] if q.get("deprecated")]
+    if not deprecated:
+        return []
+    lines = ['        """Deprecated parameters (prefer the replacement):', ""]
+    for q in deprecated:
+        reason = escape_py_string(q.get("deprecation_reason") or "deprecated")
+        lines.append(f"        - {q['name']}: {reason}")
+    lines.append('        """')
+    return lines
 
 
 def build_params(op: dict) -> list[str]:
@@ -717,6 +745,7 @@ def generate_service_file(service: dict) -> str:
         ret = return_type(op)
         sig_params = ", ".join(["self"] + ([f"*, {', '.join(params)}"] if params else []))
         lines.append(f"    def {op['method_name']}({sig_params}) -> {ret}:")
+        lines.extend(deprecation_docstring(op))
         body = generate_method_body(op, name, is_async=False)
         lines.extend(body)
 
@@ -730,6 +759,7 @@ def generate_service_file(service: dict) -> str:
         ret = return_type(op)
         sig_params = ", ".join(["self"] + ([f"*, {', '.join(params)}"] if params else []))
         lines.append(f"    async def {op['method_name']}({sig_params}) -> {ret}:")
+        lines.extend(deprecation_docstring(op))
         body = generate_method_body(op, name, is_async=True)
         lines.extend(body)
 

--- a/python/scripts/generate_types.py
+++ b/python/scripts/generate_types.py
@@ -10,6 +10,11 @@ import keyword
 import sys
 from pathlib import Path
 
+# Make the shared generator helper importable whether this file is run as a
+# script (its dir is already sys.path[0]) or loaded via importlib in tests.
+sys.path.insert(0, str(Path(__file__).parent))
+from gen_common import escape_py_string  # noqa: E402
+
 # Python keywords that can't be used as field names in TypedDicts
 PYTHON_KEYWORDS = set(keyword.kwlist)
 
@@ -111,6 +116,13 @@ def main() -> None:
 
         lines.append("")
         lines.append(f"class {name}(TypedDict):")
+        # Documentation-only deprecation (see #406): a real class docstring for a
+        # wholly deprecated TypedDict. TypedDicts have no runtime docstring hook
+        # for individual fields, so per-field deprecation is a source-only comment
+        # below.
+        if schema.get("deprecated"):
+            reason = escape_py_string(schema.get("x-deprecated-reason") or "deprecated")
+            lines.append(f'    """Deprecated: {reason}"""')
 
         for prop_name in sorted(props):
             prop = props[prop_name]
@@ -118,6 +130,13 @@ def main() -> None:
             py_type = schema_to_type(prop, schemas, optional=is_optional)
             # Escape Python keywords by appending underscore
             field_name = f"{prop_name}_" if prop_name in PYTHON_KEYWORDS else prop_name
+            # TypedDict fields carry no directive; label deprecation honestly as a
+            # source-only comment (see #406).
+            if prop.get("deprecated"):
+                # escape_py_string collapses control chars to escapes, so a
+                # multi-line reason stays a single `#` comment line.
+                reason = escape_py_string(prop.get("x-deprecated-reason") or "deprecated")
+                lines.append(f"    # deprecated (source-only): {reason}")
             lines.append(f"    {field_name}: {py_type}")
             # Add system_label field after id for flexible integer fields
             # (system actors like LocalPerson have non-numeric labels as id)

--- a/python/src/basecamp/generated/services/search.py
+++ b/python/src/basecamp/generated/services/search.py
@@ -26,6 +26,12 @@ class SearchService(BaseService):
         bucket_id: int | None = None,
         creator_id: int | None = None,
     ) -> ListResult:
+        """Deprecated parameters (prefer the replacement):
+
+        - type: prefer type_names[].
+        - bucket_id: prefer bucket_ids[].
+        - creator_id: prefer creator_ids[].
+        """
         return self._request_paginated(
             OperationInfo(service="search", operation="search", is_mutation=False),
             "/search.json",
@@ -70,6 +76,12 @@ class AsyncSearchService(AsyncBaseService):
         bucket_id: int | None = None,
         creator_id: int | None = None,
     ) -> ListResult:
+        """Deprecated parameters (prefer the replacement):
+
+        - type: prefer type_names[].
+        - bucket_id: prefer bucket_ids[].
+        - creator_id: prefer creator_ids[].
+        """
         return await self._request_paginated(
             OperationInfo(service="search", operation="search", is_mutation=False),
             "/search.json",

--- a/python/src/basecamp/generated/types.py
+++ b/python/src/basecamp/generated/types.py
@@ -346,6 +346,8 @@ class ClientReply(TypedDict):
 
 
 class ClientSide(TypedDict):
+    """Deprecated: This shape is deprecated since 2024-01: Use Client Visibility feature instead"""
+
     app_url: NotRequired[str]
     url: NotRequired[str]
 
@@ -1021,6 +1023,7 @@ class Project(TypedDict):
     bookmarked: NotRequired[bool]
     client_company: NotRequired[ClientCompany]
     clients_enabled: NotRequired[bool]
+    # deprecated (source-only): This shape is deprecated since 2024-01: Use Client Visibility feature instead
     clientside: NotRequired[ClientSide]
     created_at: str
     description: NotRequired[str]

--- a/python/tests/test_generate_deprecation.py
+++ b/python/tests/test_generate_deprecation.py
@@ -1,0 +1,52 @@
+"""Fixture for the deprecation-reason escaping shared by the Python generators
+(#406). A deprecation reason can, in principle, be sourced from a multi-line
+OpenAPI description containing quotes and backslashes; escape_py_string must keep
+such text valid when interpolated into a docstring or a source comment.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from gen_common import escape_py_string  # noqa: E402
+
+# Triple quotes (would close a docstring), a backslash + `u` (would be an invalid
+# unicode escape), and an embedded newline (would split the source line).
+NASTY = 'has """ triple, back\\slash \\u not-unicode, and\na newline'
+
+
+def test_escaped_reason_stays_single_line_and_quote_safe():
+    escaped = escape_py_string(NASTY)
+    assert "\n" not in escaped
+    assert "\r" not in escaped
+    assert '"""' not in escaped
+
+
+def test_escaped_reason_compiles_in_docstring_and_comment():
+    reason = escape_py_string(NASTY)
+    module_src = (
+        "class Foo:\n"
+        f'    """Deprecated: {reason}"""\n'
+        f"    # deprecated (source-only): {reason}\n"
+        "    x: int = 0\n"
+        "\n"
+        "def bar():\n"
+        f'    """Deprecated parameters (prefer the replacement):\n\n    - type: {reason}\n    """\n'
+        "    return 1\n"
+    )
+    # Both the class/def docstrings and the field comment must remain valid
+    # Python for an arbitrary reason.
+    compile(module_src, "<generated-deprecation-fixture>", "exec")
+
+
+def test_raw_reason_would_break_without_escaping():
+    # Guard: the fixture input really is hostile — the unescaped form does not
+    # compile, so the escaping above is doing real work.
+    module_src = f'x = """Deprecated: {NASTY}"""\n'
+    try:
+        compile(module_src, "<raw>", "exec")
+    except (SyntaxError, ValueError):
+        return
+    raise AssertionError("expected the raw reason to break compilation")

--- a/ruby/lib/basecamp/generated/metadata.json
+++ b/ruby/lib/basecamp/generated/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-07-24T20:00:38Z",
+  "generated": "2026-07-25T03:15:23Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Auto-generated from OpenAPI spec. Do not edit manually.
-# Generated: 2026-07-24T20:00:38Z
+# Generated: 2026-07-25T03:15:23Z
 
 require "json"
 require "time"
@@ -1051,6 +1051,7 @@ module Basecamp
     end
 
     # ClientSide
+    # @deprecated This shape is deprecated since 2024-01: Use Client Visibility feature instead
     class ClientSide
       include TypeHelpers
       attr_accessor :app_url, :url
@@ -2459,6 +2460,8 @@ module Basecamp
     # Project
     class Project
       include TypeHelpers
+      # @!attribute [rw] clientside
+      #   @deprecated This shape is deprecated since 2024-01: Use Client Visibility feature instead
       attr_accessor :app_url, :created_at, :id, :name, :status, :updated_at, :url, :bookmark_url, :bookmarked, :client_company, :clients_enabled, :clientside, :description, :dock, :end_date, :purpose, :start_date
 
       # @return [Array<Symbol>]

--- a/ruby/scripts/generate-types.rb
+++ b/ruby/scripts/generate-types.rb
@@ -124,6 +124,12 @@ if __FILE__ == $PROGRAM_NAME
 
     puts ''
     puts "    # #{name}"
+    # Documentation-only deprecation (see #406): YARD marks a whole class/method,
+    # not individual params, so a class-level @deprecated tag documents a wholly
+    # deprecated type.
+    if schema['deprecated']
+      puts "    # @deprecated #{schema['x-deprecated-reason'] || 'deprecated'}"
+    end
     puts "    class #{name}"
     puts '      include TypeHelpers'
 
@@ -131,6 +137,19 @@ if __FILE__ == $PROGRAM_NAME
     # Add system_label for schemas with flexible integer fields
     has_flexible = ordered_props.any? { |k| properties[k]['x-go-type']&.include?('FlexibleInt64') }
     attr_names << 'system_label' if has_flexible
+
+    # Per-attribute deprecation. The accessors are declared in one grouped
+    # attr_accessor, so a bare comment would wrongly document every attribute;
+    # a YARD @!attribute directive scopes the @deprecated tag to just this one.
+    ordered_props.each do |k|
+      ps = properties[k]
+      next unless ps['deprecated']
+
+      ruby_name = k.gsub(/([A-Z])/, '_\1').downcase.gsub(/^_/, '')
+      puts "      # @!attribute [rw] #{ruby_name}"
+      puts "      #   @deprecated #{ps['x-deprecated-reason'] || 'deprecated'}"
+    end
+
     puts "      attr_accessor #{attr_names.map { |n| ":#{n}" }.join(", ")}"
 
     unless required_props.empty?

--- a/scripts/check-deprecation-parity
+++ b/scripts/check-deprecation-parity
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+#
+# check-deprecation-parity — assert @deprecated propagation across all six SDKs.
+#
+# The five deprecated source sites (see #406) must each carry the
+# language-appropriate marker, in the right signal class:
+#   * Kotlin   — compiler warning  (@Deprecated at property read sites)
+#   * TS / Go  — editor / static   (@deprecated JSDoc / // Deprecated: godoc)
+#   * Swift/Ruby/Python — documentation only (/// , YARD, docstring/comment)
+#
+# It also pins the negative space: the clean controls (the `search` method, the
+# plural replacements typeNames/bucketIds/creatorIds, and an unrelated field)
+# must stay unmarked, and no emitter may produce a doubled "Deprecated:
+# Deprecated:" marker.
+#
+# Exit non-zero on any violation. Wired into `make check`.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+fail=0
+pass=0
+
+# assert_contains <file> <fixed-string> <description>
+assert_contains() {
+    if grep -Fq -- "$2" "$1" 2>/dev/null; then
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $3"
+        echo "        expected to find in $1:"
+        echo "          $2"
+        fail=$((fail + 1))
+    fi
+}
+
+# assert_absent <file> <fixed-string> <description>
+assert_absent() {
+    if grep -Fq -- "$2" "$1" 2>/dev/null; then
+        echo "  FAIL: $3"
+        echo "        unexpected string present in $1:"
+        echo "          $2"
+        fail=$((fail + 1))
+    else
+        pass=$((pass + 1))
+    fi
+}
+
+# assert_count <file> <extended-regex> <expected-n> <description>
+assert_count() {
+    local n
+    n=$(grep -Ec -- "$2" "$1" 2>/dev/null || true)
+    if [[ "$n" == "$3" ]]; then
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $4 (expected $3 match(es) of /$2/ in $1, got $n)"
+        fail=$((fail + 1))
+    fi
+}
+
+echo "==> Checking deprecation parity across six SDKs"
+
+# ---- Go (editor/static: // Deprecated: godoc) --------------------------------
+GO=go/pkg/generated/client.gen.go
+assert_contains "$GO" "// Deprecated: prefer type_names[]." "Go: search 'type' param marker"
+assert_contains "$GO" "// Deprecated: prefer bucket_ids[]." "Go: search 'bucket_id' param marker"
+assert_contains "$GO" "// Deprecated: prefer creator_ids[]." "Go: search 'creator_id' param marker"
+assert_contains "$GO" "// Deprecated: This shape is deprecated since 2024-01: Use Client Visibility feature instead" "Go: ClientSide type + clientside property marker"
+# Exactly 5: 3 params + ClientSide type + clientside property. A control field
+# gaining a marker would bump this count.
+assert_count "$GO" "^[[:space:]]*// Deprecated:" 5 "Go: exactly five deprecation markers (controls clean)"
+
+# ---- TypeScript (editor/static: @deprecated JSDoc) ---------------------------
+TS_SVC=typescript/src/generated/services/search.ts
+assert_contains "$TS_SVC" "@deprecated prefer type_names[]." "TS: search 'type' option marker"
+assert_contains "$TS_SVC" "@deprecated prefer bucket_ids[]." "TS: search 'bucketId' option marker"
+assert_contains "$TS_SVC" "@deprecated prefer creator_ids[]." "TS: search 'creatorId' option marker"
+assert_count "$TS_SVC" "@deprecated" 3 "TS: exactly three option markers (controls clean)"
+# openapi-typescript output (schema.d.ts): ClientSide type + clientside property
+# (from the component/property `deprecated`), plus the 3 search params in the
+# paths section (from the param-level `deprecated: true` hoisted for Go). Five.
+assert_count typescript/src/generated/schema.d.ts "@deprecated" 5 "TS: ClientSide + property + 3 param markers (openapi-typescript)"
+assert_contains typescript/src/generated/schema.d.ts "This shape is deprecated since 2024-01: Use Client Visibility feature instead" "TS: ClientSide type reason (openapi-typescript)"
+
+# ---- Swift (documentation only: /// doc comment, no @available) --------------
+SW_SVC=swift/Sources/Basecamp/Generated/Services/SearchService.swift
+assert_contains "$SW_SVC" "/// Deprecated: prefer type_names[]." "Swift: search 'type' option marker"
+assert_contains "$SW_SVC" "/// Deprecated: prefer bucket_ids[]." "Swift: search 'bucketId' option marker"
+assert_contains "$SW_SVC" "/// Deprecated: prefer creator_ids[]." "Swift: search 'creatorId' option marker"
+assert_count "$SW_SVC" "/// Deprecated:" 3 "Swift: exactly three option markers (controls clean)"
+assert_contains swift/Sources/Basecamp/Generated/Models/ClientSide.swift "/// Deprecated: This shape is deprecated since 2024-01: Use Client Visibility feature instead" "Swift: ClientSide struct marker"
+assert_contains swift/Sources/Basecamp/Generated/Models/Project.swift "/// Deprecated: This shape is deprecated since 2024-01: Use Client Visibility feature instead" "Swift: clientside property marker"
+# Documentation only — no availability attribute anywhere in generated Swift.
+assert_absent "$SW_SVC" "@available(*, deprecated" "Swift: no @available (doc-only signal class)"
+
+# ---- Kotlin (compiler warning: @Deprecated) ----------------------------------
+KT_TYPES=kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/Types.kt
+assert_contains "$KT_TYPES" '@Deprecated("prefer type_names[].")' "Kotlin: search 'type' option marker"
+assert_contains "$KT_TYPES" '@Deprecated("prefer bucket_ids[].")' "Kotlin: search 'bucketId' option marker"
+assert_contains "$KT_TYPES" '@Deprecated("prefer creator_ids[].")' "Kotlin: search 'creatorId' option marker"
+assert_count "$KT_TYPES" "@Deprecated\(" 3 "Kotlin: exactly three option markers (controls clean)"
+assert_contains kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/ClientSide.kt '@Deprecated("This shape is deprecated since 2024-01: Use Client Visibility feature instead")' "Kotlin: ClientSide class marker"
+assert_contains kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Project.kt '@Deprecated("This shape is deprecated since 2024-01: Use Client Visibility feature instead")' "Kotlin: clientside property marker"
+# Zero-generator-warning suppressions (generic, conditional).
+assert_contains kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Project.kt '@Suppress("DEPRECATION")' "Kotlin: model @Suppress for deprecated-type reference"
+assert_contains kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/search.kt '@Suppress("DEPRECATION")' "Kotlin: search service @Suppress for deprecated-param reads"
+# Control: the search function itself is not deprecated (only suppressed).
+assert_absent kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/search.kt "@Deprecated(" "Kotlin: search function is not itself deprecated"
+
+# ---- Ruby (documentation only: YARD) -----------------------------------------
+RB_SVC=ruby/lib/basecamp/generated/services/search_service.rb
+assert_contains "$RB_SVC" "@param type [String, nil] Deprecated: prefer type_names[]." "Ruby: search 'type' param doc"
+assert_contains "$RB_SVC" "@param bucket_id [Integer, nil] Deprecated: prefer bucket_ids[]." "Ruby: search 'bucket_id' param doc"
+assert_contains "$RB_SVC" "@param creator_id [Integer, nil] Deprecated: prefer creator_ids[]." "Ruby: search 'creator_id' param doc"
+
+# ---- Python (documentation only: docstrings / source comment) ----------------
+PY_SVC=python/src/basecamp/generated/services/search.py
+# Present on both the sync and async search methods.
+assert_count "$PY_SVC" "^ +- type: prefer type_names\[\]\." 2 "Python: search docstring (sync + async)"
+assert_contains python/src/basecamp/generated/types.py '"""Deprecated: This shape is deprecated since 2024-01: Use Client Visibility feature instead"""' "Python: ClientSide TypedDict docstring"
+assert_contains python/src/basecamp/generated/types.py "# deprecated (source-only): This shape is deprecated since 2024-01: Use Client Visibility feature instead" "Python: clientside source-only comment"
+
+# ---- Control: the plural replacements and search method stay clean -----------
+# The exact-count assertions above already prove no field beyond the three
+# deprecated singulars is marked (a marked plural would bump the count). These
+# add positive controls: the replacement fields are present as plain
+# declarations, and the search method itself is not deprecated.
+#
+# assert_field_undeprecated <file> <field-decl-regex> <description>: the line
+# declaring the field must exist and must not be immediately preceded by a
+# deprecation marker.
+assert_field_undeprecated() {
+    if awk -v pat="$2" '
+        /(@[Dd]eprecated|\/\/\/? Deprecated:)/ { marker = NR; next }
+        $0 ~ pat {
+            found = 1
+            if (marker == NR - 1) { bad = 1 }
+        }
+        END { exit (found && !bad) ? 0 : 1 }
+    ' "$1" 2>/dev/null; then
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: $3 (field missing, or marked deprecated, in $1)"
+        fail=$((fail + 1))
+    fi
+}
+assert_field_undeprecated "$KT_TYPES" "val typeNames:" "Kotlin control: typeNames replacement is present and unmarked"
+assert_field_undeprecated "$KT_TYPES" "val bucketIds:" "Kotlin control: bucketIds replacement is present and unmarked"
+assert_field_undeprecated "$KT_TYPES" "val creatorIds:" "Kotlin control: creatorIds replacement is present and unmarked"
+assert_field_undeprecated "$KT_TYPES" "val fileType:" "Kotlin control: unrelated field (fileType) is unmarked"
+assert_field_undeprecated "$SW_SVC" "public var typeNames:" "Swift control: typeNames replacement is present and unmarked"
+
+# ---- No doubled markers ------------------------------------------------------
+# Capture into a variable rather than piping grep into `grep -q`: under
+# `set -o pipefail`, `grep -q` closing the pipe early can SIGPIPE the recursive
+# grep, and the pipeline's non-zero status would mask a real match into the
+# "clean" branch. Testing the captured output avoids that.
+doubled=$(grep -rIn "Deprecated: Deprecated:" \
+        go/pkg/generated typescript/src/generated swift/Sources/Basecamp/Generated \
+        ruby/lib/basecamp/generated python/src/basecamp/generated kotlin/sdk/src/commonMain \
+        2>/dev/null || true)
+if [[ -n "$doubled" ]]; then
+    echo "  FAIL: doubled 'Deprecated: Deprecated:' marker found:"
+    echo "$doubled"
+    fail=$((fail + 1))
+else
+    pass=$((pass + 1))
+fi
+
+# ---- Ruby YARD registry: docstrings actually attach --------------------------
+# Parse the generated types with YARD and assert the deprecation attaches to the
+# clientside attribute and the ClientSide class (a text grep can't prove the
+# grouped-attr_accessor @!attribute directive bound correctly).
+if command -v ruby >/dev/null 2>&1; then
+    if (cd ruby && bundle exec ruby "$ROOT/scripts/check-ruby-deprecation-yard.rb"); then
+        pass=$((pass + 1))
+    else
+        echo "  FAIL: Ruby YARD registry check"
+        fail=$((fail + 1))
+    fi
+else
+    echo "  WARN: ruby not found; skipping YARD registry check"
+fi
+
+echo ""
+if [[ "$fail" -eq 0 ]]; then
+    echo "==> Deprecation parity clean ($pass checks passed)"
+    exit 0
+else
+    echo "==> Deprecation parity FAILED ($fail failure(s), $pass passed)"
+    exit 1
+fi

--- a/scripts/check-ruby-deprecation-yard.rb
+++ b/scripts/check-ruby-deprecation-yard.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Assert, via the YARD registry, that the generated Ruby deprecation docs attach
+# to the right objects. Run from the ruby/ directory (see check-deprecation-parity).
+#
+# A text grep cannot prove this: the models declare all accessors in one grouped
+# `attr_accessor`, so the `@!attribute [rw] clientside` directive is the only
+# thing that scopes the @deprecated tag to `clientside` rather than the whole
+# class. This parses the file and checks the actual registry objects.
+
+require 'yard'
+
+TYPES = File.expand_path('lib/basecamp/generated/types.rb', Dir.pwd)
+
+YARD::Registry.clear
+YARD.parse(TYPES)
+
+failures = []
+
+# The resolved reason for both clientside sites (see the shared resolver in
+# scripts/enhance-openapi-go-types.sh). Asserting the tag *text* — not just its
+# presence — makes the Ruby check enforce the same reason guarantee as the
+# other SDK checks.
+EXPECTED_REASON = 'This shape is deprecated since 2024-01: Use Client Visibility feature instead'
+
+def check_deprecated_reason(obj, name, failures)
+  if obj.nil?
+    failures << "#{name} not found in registry"
+    return
+  end
+  tag = obj.tag(:deprecated)
+  if tag.nil?
+    failures << "#{name} is missing a @deprecated tag"
+  elsif tag.text.to_s.strip != EXPECTED_REASON
+    failures << "#{name} @deprecated reason mismatch: #{tag.text.inspect}"
+  end
+end
+
+check_deprecated_reason(YARD::Registry.at('Basecamp::Types::ClientSide'), 'Basecamp::Types::ClientSide', failures)
+check_deprecated_reason(YARD::Registry.at('Basecamp::Types::Project#clientside'), 'Basecamp::Types::Project#clientside', failures)
+
+# Control: a sibling attribute on the same grouped accessor must NOT be
+# deprecated — proves the @!attribute directive scoped the tag correctly.
+sibling = YARD::Registry.at('Basecamp::Types::Project#name')
+if sibling && !sibling.tag(:deprecated).nil?
+  failures << 'control violated: Basecamp::Types::Project#name is unexpectedly @deprecated'
+end
+
+if failures.empty?
+  puts '  Ruby YARD registry: clientside/ClientSide deprecation attached; controls clean'
+  exit 0
+else
+  failures.each { |f| warn "    #{f}" }
+  exit 1
+end

--- a/scripts/enhance-openapi-go-types.sh
+++ b/scripts/enhance-openapi-go-types.sh
@@ -26,6 +26,25 @@ if [[ ! -f "$INPUT_FILE" ]]; then
 fi
 
 jq '
+# normalize_deprecation_reason strips exactly one leading "Deprecated:"
+# (case-insensitive) plus following whitespace and trims, so oapi-codegen can
+# prepend its own "// Deprecated: " once instead of producing a doubled
+# "// Deprecated: Deprecated: ..." marker. Mirrors the resolver rule shared by
+# every SDK generator (see scripts/check-deprecation-parity).
+def normalize_deprecation_reason:
+  (. // "")
+  | sub("^\\s*Deprecated:\\s*"; ""; "i")
+  | sub("^\\s+"; "")
+  | sub("\\s+$"; "");
+
+# mark_deprecated_query_param hoists deprecated + normalized x-deprecated-reason
+# onto a single query parameter object (a no-op for non-deprecated params).
+def mark_deprecated_query_param:
+  if (.in == "query") and ((.deprecated == true) or (.schema.deprecated == true)) then
+    .deprecated = true
+    | .["x-deprecated-reason"] = ((.description // .schema.description // "deprecated") | normalize_deprecation_reason)
+  else . end;
+
 # First pass: add x-go-type extensions for timestamps, dates, and ids
 walk(
   if type == "object" then
@@ -191,6 +210,50 @@ walk(
       )
     else . end
   )
+)
+|
+# Ninth pass: hoist normalized x-deprecated-reason so oapi-codegen (v2.8.0) emits
+# a precise "// Deprecated: <reason>" godoc instead of its generic fallback. Data-
+# driven, not keyed on specific names:
+#   * query params — any deprecated query param (deprecated on the param or its
+#     schema). Reason priority: param.description -> schema.description -> generic.
+#   * component schemas — any deprecated component. Reason: its own description.
+#   * $ref-sibling deprecated properties — reason resolves to the referenced
+#     component description (the property carries no local description).
+# See scripts/check-deprecation-parity for the shared cross-SDK contract.
+( .components.schemas ) as $schemas
+|
+.paths |= map_values(
+  # Path-item-level (shared) parameters — inherited by every method on the path.
+  ( if (.parameters | type == "array") then
+      .parameters |= map(mark_deprecated_query_param)
+    else . end )
+  |
+  # Operation-level parameters (the .parameters array is skipped here since it is
+  # not an object, so it is not double-processed).
+  map_values(
+    if (type == "object") and (.parameters | type == "array") then
+      .parameters |= map(mark_deprecated_query_param)
+    else . end
+  )
+)
+|
+.components.schemas |= map_values(
+  ( if .deprecated == true then
+      .["x-deprecated-reason"] = ((.description // "deprecated") | normalize_deprecation_reason)
+    else . end )
+  |
+  ( if (.properties? // {} | length) > 0 then
+      .properties |= map_values(
+        if .deprecated == true then
+          .["x-deprecated-reason"] = (
+            ( .description
+              // ( if has("$ref") then ($schemas[(.["$ref"] | sub(".*/"; ""))].description) else null end )
+              // "deprecated"
+            ) | normalize_deprecation_reason )
+        else . end
+      )
+    else . end )
 )
 ' "$INPUT_FILE" > "${OUTPUT_FILE}.tmp"
 

--- a/scripts/normalize-go-deprecation-godoc.sh
+++ b/scripts/normalize-go-deprecation-godoc.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# normalize-go-deprecation-godoc.sh — post-process oapi-codegen output so
+# every `// Deprecated:` marker sits in its own doc-comment paragraph.
+#
+# Why: Go's deprecation convention (and the staticcheck/gopls/pkg.go.dev tools
+# that consume it) only recognize a `Deprecated:` marker when it *begins a
+# paragraph* — i.e. is preceded by a blank `//` line. oapi-codegen's typedef
+# path (`.DocComment`) already does this for deprecated *types*, but its
+# struct-field path (schema.go) appends the deprecation line directly after the
+# field's description line with no blank separator. That leaves deprecated
+# fields — the Search params (`type`/`bucket_id`/`creator_id`) and the
+# `Project.clientside` property — with a marker that tools silently ignore.
+#
+# This pass inserts a blank `//` line before any `// Deprecated:` line whose
+# immediately preceding line is a non-blank comment, matching the current
+# indentation. It is a no-op where the paragraph break already exists (the
+# type path), and idempotent. General by construction — keyed on the comment
+# shape, not on any field name.
+#
+# Usage: normalize-go-deprecation-godoc.sh <file.go> [<file.go> ...]
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+    echo "Usage: $0 <file.go> [<file.go> ...]" >&2
+    exit 1
+fi
+
+for file in "$@"; do
+    if [[ ! -f "$file" ]]; then
+        echo "Error: file not found: $file" >&2
+        exit 1
+    fi
+
+    awk '
+    function is_comment(s)       { return s ~ /^[[:space:]]*\/\// }
+    function is_blank_comment(s) { return s ~ /^[[:space:]]*\/\/[[:space:]]*$/ }
+    {
+        if ($0 ~ /^[[:space:]]*\/\/ Deprecated:/ && NR > 1 &&
+            is_comment(prev) && !is_blank_comment(prev)) {
+            match($0, /^[[:space:]]*/)
+            print substr($0, 1, RLENGTH) "//"
+        }
+        print
+        prev = $0
+    }
+    ' "$file" > "${file}.tmp"
+    mv "${file}.tmp" "$file"
+done

--- a/swift/Package.swift
+++ b/swift/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         ),
         .testTarget(
             name: "BasecampTests",
-            dependencies: ["Basecamp"],
+            dependencies: ["Basecamp", "BasecampGenerator"],
             path: "Tests/BasecampTests",
             resources: [
                 .copy("Fixtures"),

--- a/swift/Sources/Basecamp/Generated/Models/ClientSide.swift
+++ b/swift/Sources/Basecamp/Generated/Models/ClientSide.swift
@@ -1,6 +1,7 @@
 // @generated from OpenAPI spec — do not edit directly
 import Foundation
 
+/// Deprecated: This shape is deprecated since 2024-01: Use Client Visibility feature instead
 public struct ClientSide: Codable, Sendable {
     public var appUrl: String?
     public var url: String?

--- a/swift/Sources/Basecamp/Generated/Models/Project.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Project.swift
@@ -13,6 +13,7 @@ public struct Project: Codable, Sendable {
     public var bookmarked: Bool?
     public var clientCompany: ClientCompany?
     public var clientsEnabled: Bool?
+    /// Deprecated: This shape is deprecated since 2024-01: Use Client Visibility feature instead
     public var clientside: ClientSide?
     public var description: String?
     public var dock: [DockItem]?

--- a/swift/Sources/Basecamp/Generated/Services/SearchService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/SearchService.swift
@@ -9,8 +9,11 @@ public struct SearchSearchOptions: Sendable {
     public var excludeChat: Bool?
     public var since: String?
     public var sort: String?
+    /// Deprecated: prefer type_names[].
     public var type: String?
+    /// Deprecated: prefer bucket_ids[].
     public var bucketId: Int?
+    /// Deprecated: prefer creator_ids[].
     public var creatorId: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/BasecampGenerator/ModelEmitter.swift
+++ b/swift/Sources/BasecampGenerator/ModelEmitter.swift
@@ -202,6 +202,12 @@ func emitEntityModel(schemaName: String, schemas: [String: Any]) -> String {
     lines.append("// @generated from OpenAPI spec \u{2014} do not edit directly")
     lines.append("import Foundation")
     lines.append("")
+    // Documentation-only deprecation (see #406): a `///` doc comment on the
+    // whole struct, no `@available`, so the generated code does not warn on its
+    // own references.
+    if schema["deprecated"] as? Bool == true {
+        lines += deprecationDocLines(reason: (schema["x-deprecated-reason"] as? String) ?? "deprecated", indent: "")
+    }
     lines.append("public struct \(typeName): Codable, Sendable {")
 
     // Requiredness and nullability are independent axes:
@@ -222,6 +228,11 @@ func emitEntityModel(schemaName: String, schemas: [String: Any]) -> String {
         let valueOptional = schemaIsNullable(propSchema) || !required
         let propType = baseType + (valueOptional ? "?" : "")
 
+        // Documentation-only deprecation (see #406): `///` doc comment on the
+        // property, no `@available`.
+        if propSchema["deprecated"] as? Bool == true {
+            lines += deprecationDocLines(reason: (propSchema["x-deprecated-reason"] as? String) ?? "deprecated", indent: "    ")
+        }
         // Required members are immutable (`let`, set at init); optional members
         // stay `var` so callers can mutate/omit them.
         lines.append("    public \(required ? "let" : "var") \(camelName): \(propType)")

--- a/swift/Sources/BasecampGenerator/OpenAPIParser.swift
+++ b/swift/Sources/BasecampGenerator/OpenAPIParser.swift
@@ -38,6 +38,9 @@ struct QueryParam {
     let swiftType: String
     let required: Bool
     let description: String?
+    let deprecated: Bool
+    /// Normalized deprecation reason (see scripts/check-deprecation-parity).
+    let deprecationReason: String?
 }
 
 struct BodyProperty {
@@ -131,7 +134,9 @@ func parseOperation(
                 wireName: wireName,
                 swiftType: type,
                 required: param["required"] as? Bool ?? false,
-                description: param["description"] as? String
+                description: param["description"] as? String,
+                deprecated: (param["deprecated"] as? Bool) ?? (schema["deprecated"] as? Bool) ?? false,
+                deprecationReason: (param["x-deprecated-reason"] as? String) ?? (schema["x-deprecated-reason"] as? String)
             )
         }
 

--- a/swift/Sources/BasecampGenerator/ServiceEmitter.swift
+++ b/swift/Sources/BasecampGenerator/ServiceEmitter.swift
@@ -59,6 +59,13 @@ private func emitOptionsStructs(_ service: ServiceDefinition) -> [String] {
 
         for param in optionalQueryParams {
             let camelName = toCamelCase(param.name)
+            // Documentation-only deprecation: `@available(*, deprecated)` would
+            // warn on the generator's own init/service reads and Swift has no
+            // per-line suppression, so this is a `///` doc comment (surfaced in
+            // Xcode QuickHelp), not an availability attribute. See #406.
+            if param.deprecated {
+                lines += deprecationDocLines(reason: param.deprecationReason ?? "deprecated", indent: "    ")
+            }
             lines.append("    public var \(camelName): \(param.swiftType)?")
         }
 
@@ -113,6 +120,19 @@ private func emitMethod(_ op: ParsedOperation, serviceName: String, schemas: [St
     // Build method signature
     let (paramString, hasOptions, hasRequest, _) = buildSignature(op, resourceName: resourceName, serviceName: serviceName)
     let returnType = buildReturnType(op, serviceName: serviceName, schemas: schemas)
+
+    // Required query params are emitted directly in the signature (optional ones
+    // live on the options struct and carry their own /// marker). A deprecated
+    // *required* param therefore needs a method-level `- Parameter` doc note to
+    // preserve the all-query-parameter propagation guarantee (documentation
+    // only — no @available). See #406.
+    for q in op.queryParams where q.required && q.deprecated {
+        lines += deprecationDocLines(
+            reason: q.deprecationReason ?? "deprecated",
+            indent: "    ",
+            leader: "- Parameter \(toCamelCase(q.name)): Deprecated: ",
+        )
+    }
 
     // Method signature
     if returnType == "Void" {

--- a/swift/Sources/BasecampGenerator/Utilities.swift
+++ b/swift/Sources/BasecampGenerator/Utilities.swift
@@ -25,6 +25,26 @@ func queryItemAppendLines(_ q: QueryParam, accessor: String, indent: String) -> 
     return ["\(indent)queryItems.append(URLQueryItem(name: \"\(q.wireName)\", value: \(accessor)))"]
 }
 
+// MARK: - Deprecation Doc Comments
+
+/// Renders a deprecation `reason` as one or more `///` doc-comment lines (#406).
+///
+/// A reason can be sourced from a multi-line OpenAPI description; interpolating
+/// it into a single `///` line would leave any continuation on an un-commented
+/// source line and break compilation. Splitting on line boundaries and
+/// prefixing every line with `///` keeps the emitted Swift valid for any reason.
+/// `leader` precedes the first reason line (e.g. `"Deprecated: "` or
+/// `"- Parameter foo: Deprecated: "`); continuation lines carry no leader.
+func deprecationDocLines(reason: String, indent: String, leader: String = "Deprecated: ") -> [String] {
+    let reasonLines = reason.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    let first = reasonLines.first ?? ""
+    var out = ["\(indent)/// \(leader)\(first)"]
+    for line in reasonLines.dropFirst() {
+        out.append(line.isEmpty ? "\(indent)///" : "\(indent)/// \(line)")
+    }
+    return out
+}
+
 // MARK: - String Utilities
 
 /// Converts a snake_case string to camelCase.

--- a/swift/Tests/BasecampTests/DeprecationDocCommentTests.swift
+++ b/swift/Tests/BasecampTests/DeprecationDocCommentTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+
+@testable import BasecampGenerator
+
+/// Fixture for the deprecation doc-comment rendering shared by the Swift
+/// generator's service and model emitters (#406). A reason sourced from a
+/// multi-line OpenAPI description must never produce an un-commented source
+/// line, on any of the emitted paths (optional/required query params, model
+/// properties, and whole types).
+final class DeprecationDocCommentTests: XCTestCase {
+    private let multiline = "line one\n\nline three with \"quotes\" and a \\ backslash"
+
+    /// Every emitted line must be a doc comment at the requested indent — no
+    /// continuation of a multi-line reason may leak onto a bare source line.
+    private func assertAllDocComment(_ lines: [String], indent: String, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertFalse(lines.isEmpty, file: file, line: line)
+        for l in lines {
+            XCTAssertTrue(
+                l == "\(indent)///" || l.hasPrefix("\(indent)/// "),
+                "line is not a \(indent)/// doc comment: \(l)",
+                file: file,
+                line: line,
+            )
+        }
+    }
+
+    func testOptionalParameterAndPropertyPath() {
+        // Options field / model property: indent "    ", default "Deprecated: " leader.
+        let lines = deprecationDocLines(reason: multiline, indent: "    ")
+        assertAllDocComment(lines, indent: "    ")
+        XCTAssertEqual(lines.first, "    /// Deprecated: line one")
+        XCTAssertTrue(lines.contains("    ///"), "blank interior line should be a bare doc comment")
+    }
+
+    func testRequiredParameterPath() {
+        // Required query param: method-level `- Parameter` leader.
+        let lines = deprecationDocLines(
+            reason: multiline,
+            indent: "    ",
+            leader: "- Parameter typeNames: Deprecated: ",
+        )
+        assertAllDocComment(lines, indent: "    ")
+        XCTAssertEqual(lines.first, "    /// - Parameter typeNames: Deprecated: line one")
+    }
+
+    func testTypePath() {
+        // Whole struct: top-level indent "".
+        let lines = deprecationDocLines(reason: multiline, indent: "")
+        assertAllDocComment(lines, indent: "")
+        XCTAssertEqual(lines.first, "/// Deprecated: line one")
+    }
+
+    func testSingleLineReasonIsOneLine() {
+        let lines = deprecationDocLines(reason: "prefer type_names[].", indent: "    ")
+        XCTAssertEqual(lines, ["    /// Deprecated: prefer type_names[]."])
+    }
+}

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1736,16 +1736,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/chai": {

--- a/typescript/scripts/generate-services.ts
+++ b/typescript/scripts/generate-services.ts
@@ -56,6 +56,8 @@ interface Parameter {
   in: "path" | "query" | "header";
   description?: string;
   required?: boolean;
+  deprecated?: boolean;
+  "x-deprecated-reason"?: string;
   schema: Schema;
 }
 
@@ -84,6 +86,8 @@ interface Schema {
   required?: string[];
   items?: Schema;
   "x-go-type"?: string;
+  deprecated?: boolean;
+  "x-deprecated-reason"?: string;
 }
 
 interface ParsedOperation {
@@ -123,6 +127,9 @@ interface QueryParam {
   type: string;
   required: boolean;
   description?: string;
+  deprecated?: boolean;
+  /** Normalized deprecation reason (see scripts/check-deprecation-parity). */
+  deprecationReason?: string;
 }
 
 interface BodyProperty {
@@ -679,6 +686,8 @@ function parseOperation(
         type: enumUnion || schemaToTsType(p.schema),
         required: p.required || false,
         description: p.description,
+        deprecated: p.deprecated || p.schema.deprecated || false,
+        deprecationReason: p["x-deprecated-reason"] || p.schema["x-deprecated-reason"],
       };
     });
 
@@ -1057,6 +1066,14 @@ function generateRequestInterfaces(service: ServiceDefinition): string[] {
         if (param.name === "bucket" && param.type === "string") {
           lines.push(`  /** Project IDs to filter by */`);
           lines.push(`  ${toCamelCase(param.name)}?: number[];`);
+        } else if (param.deprecated) {
+          // @deprecated is an editor/static-analysis signal (IDE strikethrough +
+          // suggestion diagnostic), not a tsc compile warning. See #406.
+          lines.push(`  /**`);
+          lines.push(`   * ${desc}`);
+          lines.push(`   * @deprecated ${param.deprecationReason || "deprecated"}`);
+          lines.push(`   */`);
+          lines.push(`  ${toCamelCase(param.name)}?: ${param.type};`);
         } else {
           lines.push(`  /** ${desc} */`);
           lines.push(`  ${toCamelCase(param.name)}?: ${param.type};`);

--- a/typescript/src/generated/metadata.ts
+++ b/typescript/src/generated/metadata.ts
@@ -37,7 +37,7 @@ export interface MetadataOutput {
 const metadata: MetadataOutput = {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-07-24T20:00:38.180Z",
+  "generated": "2026-07-25T03:15:22.771Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/typescript/src/generated/openapi-stripped.json
+++ b/typescript/src/generated/openapi-stripped.json
@@ -14636,7 +14636,9 @@
               "type": "string",
               "deprecated": true,
               "description": "Deprecated: prefer type_names[].\nThis shape is deprecated since 2026-07: Use typeNames (type_names[]) instead"
-            }
+            },
+            "deprecated": true,
+            "x-deprecated-reason": "prefer type_names[]."
           },
           {
             "name": "bucket_id",
@@ -14647,7 +14649,9 @@
               "deprecated": true,
               "description": "Deprecated: prefer bucket_ids[].\nThis shape is deprecated since 2026-07: Use bucketIds (bucket_ids[]) instead",
               "format": "int64"
-            }
+            },
+            "deprecated": true,
+            "x-deprecated-reason": "prefer bucket_ids[]."
           },
           {
             "name": "creator_id",
@@ -14658,7 +14662,9 @@
               "deprecated": true,
               "description": "Deprecated: prefer creator_ids[].\nThis shape is deprecated since 2026-07: Use creatorIds (creator_ids[]) instead",
               "format": "int64"
-            }
+            },
+            "deprecated": true,
+            "x-deprecated-reason": "prefer creator_ids[]."
           }
         ],
         "responses": {
@@ -20088,7 +20094,8 @@
           "app_url": {
             "type": "string"
           }
-        }
+        },
+        "x-deprecated-reason": "This shape is deprecated since 2024-01: Use Client Visibility feature instead"
       },
       "Comment": {
         "type": "object",
@@ -23219,7 +23226,8 @@
           },
           "clientside": {
             "$ref": "#/components/schemas/ClientSide",
-            "deprecated": true
+            "deprecated": true,
+            "x-deprecated-reason": "This shape is deprecated since 2024-01: Use Client Visibility feature instead"
           }
         },
         "required": [

--- a/typescript/src/generated/schema.d.ts
+++ b/typescript/src/generated/schema.d.ts
@@ -14944,11 +14944,20 @@ export interface operations {
                 since?: string;
                 /** @description best_match|recency */
                 sort?: string;
-                /** @description Deprecated: prefer type_names[]. */
+                /**
+                 * @deprecated
+                 * @description Deprecated: prefer type_names[].
+                 */
                 type?: string;
-                /** @description Deprecated: prefer bucket_ids[]. */
+                /**
+                 * @deprecated
+                 * @description Deprecated: prefer bucket_ids[].
+                 */
                 bucket_id?: number;
-                /** @description Deprecated: prefer creator_ids[]. */
+                /**
+                 * @deprecated
+                 * @description Deprecated: prefer creator_ids[].
+                 */
                 creator_id?: number;
             };
             header?: never;

--- a/typescript/src/generated/services/search.ts
+++ b/typescript/src/generated/services/search.ts
@@ -34,11 +34,20 @@ endpoint's `file_search_types`. */
   since?: "last_7_days" | "last_30_days" | "last_90_days" | "last_12_months" | "forever";
   /** Filter by sort */
   sort?: "best_match" | "recency";
-  /** Deprecated: prefer type_names[]. */
+  /**
+   * Deprecated: prefer type_names[].
+   * @deprecated prefer type_names[].
+   */
   type?: string;
-  /** Deprecated: prefer bucket_ids[]. */
+  /**
+   * Deprecated: prefer bucket_ids[].
+   * @deprecated prefer bucket_ids[].
+   */
   bucketId?: number;
-  /** Deprecated: prefer creator_ids[]. */
+  /**
+   * Deprecated: prefer creator_ids[].
+   * @deprecated prefer creator_ids[].
+   */
   creatorId?: number;
 }
 


### PR DESCRIPTION
## #406 — propagate `@deprecated` per a per-language signal-class matrix

Closes #406.

> **Third of the three stacked follow-ups.** Base is `fix/407-empty-slice-query-guard` (which bases on the oapi-codegen v2.8.0 precursor #409). Retarget to `main` once #409 → #410 merge. Depends on the precursor for the Go param markers.

**First action taken:** issue #406 retitled/reframed from "compiler-level deprecation" (inaccurate for 5 of 6 languages) to the corrected matrix below.

### The problem
Deprecation is not uniformly a compiler warning, and a naïve annotation makes the *generated* SDK warn on its own code. The five deprecated source sites — the three Search singular query params (`type`/`bucket_id`/`creator_id`), the `Project.clientside` property, and the `ClientSide` type — must each surface in the language-appropriate signal class, under a hard **zero-generator-origin-warning** invariant.

### Signal-class matrix (verified against generated output)
| Lang | Signal class | Marker |
|---|---|---|
| **Kotlin** | compiler warning | `@Deprecated` at property read sites |
| **TS / Go** | editor / static-analysis | `@deprecated` JSDoc / `// Deprecated:` godoc |
| **Swift / Ruby / Python** | documentation only | `///` / YARD / docstring+comment |

### Shared reason resolution
The enhance script hoists **one** normalized `x-deprecated-reason` onto the OpenAPI (priority: `parameter.description` → local property desc → referenced component desc → `schema.description` → generic; then strip one leading `Deprecated:` and trim). Every generator reads that single resolved reason, so parity holds by construction. Resolved: params → `prefer <plural>[].`; clientside/ClientSide → `This shape is deprecated since 2024-01: Use Client Visibility feature instead`. No doubled `Deprecated: Deprecated:`.

### Per language
- **Go** — `enhance-openapi-go-types.sh` hoists the reason so oapi v2.8.0 emits the precise `// Deprecated: <reason>`. A generate-time normalizer (`normalize-go-deprecation-godoc.sh`) inserts the blank-line paragraph break oapi omits for deprecated *fields*, so staticcheck/gopls/pkg.go.dev actually recognize the param + clientside-property markers (**verified with staticcheck SA1019**). General, idempotent, keyed on comment shape.
- **TS** — `@deprecated` JSDoc on the options fields; openapi-typescript already marks the models and now the params too (5 markers in `schema.d.ts`).
- **Swift** — `///` doc comments on the options fields, the `clientside` property, and the `ClientSide` struct. No `@available` (Swift has no per-line suppression).
- **Ruby** — query `@param` docs already carried the text; models get a class-level `@deprecated` and a scoped YARD `@!attribute [rw] clientside` block (the grouped `attr_accessor` means a bare comment would document every attribute). Attachment asserted via the **YARD registry**, not a grep.
- **Python** — real prose docstrings on the sync **and** async `search` methods, a class docstring on the `ClientSide` TypedDict, and an honest `# deprecated (source-only)` comment on the `clientside` field.
- **Kotlin** — `@Deprecated` on the options fields, the `clientside` property, and the `ClientSide` data class. Two **generic, conditional** `@Suppress("DEPRECATION")` hold the invariant: any model referencing a deprecated component type (type-level) and any function reading a deprecated param (function-level). Named-constructor-arg / Swift init-label sites are **unsupported** (`@Deprecated` can't target `VALUE_PARAMETER`) — documented.

### Durable coverage
- **Kotlin diagnostic fixture** (`DeprecationDiagnosticsTest`) drives the embedded compiler on two snippets under deprecation-as-error: reading a deprecated property **must fail** with the reason; the named-constructor-arg site **must compile clean**. Both together are the gate (jvmTest → `make check`).
- The Kotlin main source set compiles with **`allWarningsAsErrors`**, proving zero generator-origin deprecation warnings.
- **`scripts/check-deprecation-parity`** (+ `check-deprecation-parity` make target, wired into `make check`) asserts all five sites carry the right-class marker across all six SDKs, the clean controls (search method, plural replacements, an unrelated field) stay unmarked, no doubled marker, and the Ruby YARD registry attaches correctly. **40 checks.**

### Verify
`make generate` deterministic (modulo the pre-existing metadata regen timestamps); `make check` green — all six SDKs + conformance + `check-deprecation-parity` (40) + the Kotlin diagnostic gate + `allWarningsAsErrors` production compile + the Ruby YARD registry check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates deprecation markers across all six SDKs using a per-language signal-class matrix with zero generator-origin warnings. Implements #406 with one normalized reason shared via OpenAPI, plus hardened rendering and checks to keep markers accurate and docs valid.

- New Features
  - Signal classes: Kotlin compiler (`@Deprecated`), TypeScript/Go editor (`@deprecated`, `// Deprecated:`), Swift/Ruby/Python docs-only (`///`, YARD, docstrings/comments).
  - One normalized reason (`x-deprecated-reason`) hoisted in OpenAPI (incl. path-item–level params) and read by all generators; prevents doubled “Deprecated:” and keeps parity.
  - Zero warnings: generic, conditional Kotlin `@Suppress("DEPRECATION")` (models referencing deprecated types, and functions reading deprecated params) plus `allWarningsAsErrors`; Kotlin diagnostic test enforces compiler behavior.
  - Go godoc recognized: a post-process inserts a blank line before `// Deprecated:` so tools pick up field markers; invoked via `go generate`.
  - TypeScript: services emit `@deprecated` JSDoc on deprecated query options; `openapi-typescript` marks models and params.

- Bug Fixes
  - Reason hoisting/normalization: covers path-item–level shared params; trims leading “Deprecated:” and whitespace.
  - Safe reason rendering: Python shares `escape_py_string` across generators with tests; Swift centralizes `deprecationDocLines` to split multi-line reasons into `///` lines with tests; Kotlin `@Deprecated("…")` reasons escape backslash, quotes, dollar, and control chars.
  - Parity tooling: `check-deprecation-parity` (wired into `make check`) asserts all five sites carry the right-class marker across all six SDKs, clean controls stay unmarked, no doubled marker, and the Ruby YARD registry attaches the exact reason text.
  - Dependencies: bump `brace-expansion` to 5.0.8 to address GHSA-mh99-v99m-4gvg in dev tooling.

<sup>Written for commit 57e37a2f50c500e71cb12d8aaea8ee6c6c391e7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

