### PR TITLE
chore(deps): bump postcss to 8.5.23 (GHSA-r28c-9q8g-f849)

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -2600,9 +2600,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2797,9 +2797,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -2817,7 +2817,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## postcss 8.5.16 → 8.5.23 (npm Audit, high)

Clears **[GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849)** — PostCSS path traversal in source-map auto-loading (`sourceMappingURL`), affecting `<=8.5.17`. A transitive dev/build dependency (not in the shipped SDK runtime).

- Fixed via `npm audit fix` — **lockfile-only** change (`typescript/package-lock.json`), no `package.json` edit.
- `npm audit` now reports **0 vulnerabilities**; TS build + full suite (736 tests) green.

Split out from the combined dep-bump branch so it can land independently of the Go/kin-openapi bump (which reshuffles transitive Go modules and deserves separate review). Opened as a draft.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `postcss` to 8.5.23 to fix GHSA-r28c-9q8g-f849 (path traversal via sourceMappingURL). Lockfile-only change in the TypeScript package; no runtime impact.

- **Dependencies**
  - `postcss` 8.5.16 → 8.5.23 (dev/build only)
  - Transitive `nanoid` → 3.3.16
  - `npm audit` clean; build and tests pass

<sup>Written for commit 4cc7295ab9650a108902feb5b75595fbce167af2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

