### PR TITLE
Add create-time visible_to_clients to CreateTool (bc3 #12386)

### DIFF
--- a/go/pkg/basecamp/tools.go
+++ b/go/pkg/basecamp/tools.go
@@ -27,6 +27,13 @@ type Tool struct {
 type CreateToolOptions struct {
 	// Title for the new tool. If empty, Basecamp assigns the next available default title for the tool type.
 	Title string
+	// VisibleToClients sets client visibility at create time (optional, tri-state).
+	// nil omits the field so the server applies its own default visibility rule; a
+	// non-nil value is sent verbatim, and an explicit false reaches the wire (the
+	// pointer distinguishes unset from false). Honored only for tool types that
+	// manage their own client visibility (Chat::Transcript, Kanban::Board); every
+	// other tool type ignores it and inherits the project default.
+	VisibleToClients *bool
 }
 
 // UpdateToolRequest specifies the parameters for updating (renaming) a tool.
@@ -106,8 +113,11 @@ func (s *ToolsService) Create(ctx context.Context, bucketID int64, toolType stri
 	body := generated.CreateToolJSONRequestBody{
 		ToolType: toolType,
 	}
-	if opts != nil && opts.Title != "" {
-		body.Title = opts.Title
+	if opts != nil {
+		if opts.Title != "" {
+			body.Title = opts.Title
+		}
+		body.VisibleToClients = opts.VisibleToClients
 	}
 
 	resp, err := s.client.parent.gen.CreateToolWithResponse(ctx, s.client.accountID, bucketID, body)

--- a/go/pkg/basecamp/tools_test.go
+++ b/go/pkg/basecamp/tools_test.go
@@ -174,6 +174,62 @@ func TestToolsServiceCreateOmitsTitleWhenNotProvided(t *testing.T) {
 	}
 }
 
+// TestToolsServiceCreateVisibleToClients verifies the tri-state
+// visible_to_clients flag reaches the wire correctly on create: nil omits the
+// key, true is sent verbatim, and an explicit false is sent (not dropped).
+func TestToolsServiceCreateVisibleToClients(t *testing.T) {
+	const (
+		accountID = "5245563"
+		bucketID  = int64(33861629)
+		toolType  = "Chat::Transcript"
+	)
+	tru, fls := true, false
+	cases := []struct {
+		name    string
+		value   *bool
+		present bool
+		want    bool
+	}{
+		{"nil omits the field", nil, false, false},
+		{"true is sent", &tru, true, true},
+		{"explicit false is sent, not dropped", &fls, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var receivedBody map[string]any
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				receivedBody = decodeRequestBody(t, r)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusCreated)
+				_, _ = w.Write(loadToolsFixture(t, "create.json"))
+			}))
+			defer server.Close()
+
+			cfg := DefaultConfig()
+			cfg.BaseURL = server.URL
+			client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+			_, err := client.ForAccount(accountID).Tools().Create(
+				context.Background(),
+				bucketID,
+				toolType,
+				&CreateToolOptions{VisibleToClients: tc.value},
+			)
+			if err != nil {
+				t.Fatalf("Create() error = %v", err)
+			}
+
+			val, ok := receivedBody["visible_to_clients"]
+			if ok != tc.present {
+				t.Fatalf("visible_to_clients present=%v, want %v (body=%v)", ok, tc.present, receivedBody)
+			}
+			if tc.present && val != tc.want {
+				t.Errorf("visible_to_clients=%v, want %v", val, tc.want)
+			}
+		})
+	}
+}
+
 func TestToolsServiceCreateEmptyToolType(t *testing.T) {
 	var requestCount int
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -715,6 +715,9 @@ type CreateToolRequestContent struct {
 
 	// ToolType Tool type to add to the project dock. Values: Chat::Transcript|Inbox|Kanban::Board|Message::Board|Questionnaire|Schedule|Todoset|Vault.
 	ToolType string `json:"tool_type"`
+
+	// VisibleToClients Create the tool already visible to clients. Honored only for tool types that manage their own client visibility (Chat::Transcript, Kanban::Board), which otherwise start hidden; every other tool type ignores it and inherits the project default.
+	VisibleToClients *bool `json:"visible_to_clients,omitempty"`
 }
 
 // CreateToolResponseContent defines model for CreateToolResponseContent.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/Types.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/Types.kt
@@ -613,7 +613,8 @@ data class RepositionTodoBody(
 /** Request body for CreateTool. */
 data class CreateToolBody(
     val toolType: String,
-    val title: String? = null
+    val title: String? = null,
+    val visibleToClients: Boolean? = null
 )
 
 /** Request body for UpdateTool. */

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/tools.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/tools.kt
@@ -30,6 +30,7 @@ class ToolsService(client: AccountClient) : BaseService(client) {
             httpPost("/buckets/${bucketId}/dock/tools.json", json.encodeToString(kotlinx.serialization.json.buildJsonObject {
                 put("tool_type", kotlinx.serialization.json.JsonPrimitive(body.toolType))
                 body.title?.let { put("title", kotlinx.serialization.json.JsonPrimitive(it)) }
+                body.visibleToClients?.let { put("visible_to_clients", kotlinx.serialization.json.JsonPrimitive(it)) }
             }), operationName = info.operation)
         }) { body ->
             json.decodeFromString<Tool>(body)

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/ToolsServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/ToolsServiceTest.kt
@@ -94,4 +94,35 @@ class ToolsServiceTest {
 
         client.close()
     }
+
+    // visibleToClients is tri-state: null omits the key, true/false are sent
+    // verbatim. An explicit false must reach the wire. Only Chat::Transcript and
+    // Kanban::Board honor it; all other tool types ignore it.
+    @Test
+    fun createToolSendsVisibleToClientsTriState() = runTest {
+        var capturedBody: String? = null
+        val client = mockClient { request ->
+            capturedBody = request.body.toByteArray().decodeToString()
+            respond(
+                content = toolJson(802, "Campfire"),
+                status = HttpStatusCode.Created,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val account = client.forAccount("12345")
+
+        account.tools.create(bucketId = 456, body = CreateToolBody(toolType = "Chat::Transcript"))
+        assertFalse(json.parseToJsonElement(capturedBody!!).jsonObject.containsKey("visible_to_clients"))
+
+        account.tools.create(bucketId = 456, body = CreateToolBody(toolType = "Chat::Transcript", visibleToClients = true))
+        val trueObj = json.parseToJsonElement(capturedBody!!).jsonObject
+        assertEquals(true, trueObj["visible_to_clients"]!!.jsonPrimitive.content.toBoolean())
+
+        account.tools.create(bucketId = 456, body = CreateToolBody(toolType = "Chat::Transcript", visibleToClients = false))
+        val falseObj = json.parseToJsonElement(capturedBody!!).jsonObject
+        assertTrue(falseObj.containsKey("visible_to_clients"))
+        assertEquals(false, falseObj["visible_to_clients"]!!.jsonPrimitive.content.toBoolean())
+
+        client.close()
+    }
 }

--- a/openapi.json
+++ b/openapi.json
@@ -23490,6 +23490,11 @@
           "title": {
             "type": "string",
             "description": "Title for the new tool. When omitted, Basecamp assigns the next available default title for the tool type."
+          },
+          "visible_to_clients": {
+            "type": "boolean",
+            "description": "Create the tool already visible to clients. Honored only for tool types that manage their own client visibility (Chat::Transcript, Kanban::Board), which otherwise start hidden; every other tool type ignores it and inherits the project default.",
+            "x-go-type-skip-optional-pointer": false
           }
         },
         "required": [

--- a/python/src/basecamp/generated/services/tools.py
+++ b/python/src/basecamp/generated/services/tools.py
@@ -11,12 +11,14 @@ from basecamp.hooks import OperationInfo
 
 
 class ToolsService(BaseService):
-    def create(self, *, bucket_id: int, tool_type: str, title: str | None = None) -> dict[str, Any]:
+    def create(
+        self, *, bucket_id: int, tool_type: str, title: str | None = None, visible_to_clients: bool | None = None
+    ) -> dict[str, Any]:
         return self._request(
             OperationInfo(service="tools", operation="create", is_mutation=True, project_id=bucket_id),
             "POST",
             f"/buckets/{bucket_id}/dock/tools.json",
-            json_body=self._compact(tool_type=tool_type, title=title),
+            json_body=self._compact(tool_type=tool_type, title=title, visible_to_clients=visible_to_clients),
             operation="CreateTool",
         )
 
@@ -71,12 +73,14 @@ class ToolsService(BaseService):
 
 
 class AsyncToolsService(AsyncBaseService):
-    async def create(self, *, bucket_id: int, tool_type: str, title: str | None = None) -> dict[str, Any]:
+    async def create(
+        self, *, bucket_id: int, tool_type: str, title: str | None = None, visible_to_clients: bool | None = None
+    ) -> dict[str, Any]:
         return await self._request(
             OperationInfo(service="tools", operation="create", is_mutation=True, project_id=bucket_id),
             "POST",
             f"/buckets/{bucket_id}/dock/tools.json",
-            json_body=self._compact(tool_type=tool_type, title=title),
+            json_body=self._compact(tool_type=tool_type, title=title, visible_to_clients=visible_to_clients),
             operation="CreateTool",
         )
 

--- a/python/src/basecamp/generated/types.py
+++ b/python/src/basecamp/generated/types.py
@@ -524,6 +524,7 @@ class CreateTodolistRequestContent(TypedDict):
 class CreateToolRequestContent(TypedDict):
     title: NotRequired[str]
     tool_type: str
+    visible_to_clients: NotRequired[bool]
 
 
 class CreateUploadRequestContent(TypedDict):

--- a/python/tests/services/test_tools.py
+++ b/python/tests/services/test_tools.py
@@ -84,6 +84,27 @@ class TestSyncTools:
         assert info.resource_id is None
 
     @respx.mock
+    def test_create_visible_to_clients_tristate(self):
+        # visible_to_clients is tri-state: unset omits the key (_compact drops None),
+        # true/false are sent verbatim. An explicit false must reach the wire. Only
+        # Chat::Transcript and Kanban::Board honor it; all other tool types ignore it.
+        route = respx.post("https://3.basecampapi.com/12345/buckets/456/dock/tools.json").mock(
+            return_value=httpx.Response(201, json=_tool())
+        )
+        account = Client(access_token="test-token").for_account("12345")
+
+        account.tools.create(bucket_id=456, tool_type="Chat::Transcript")
+        assert "visible_to_clients" not in json.loads(route.calls[-1].request.content)
+
+        account.tools.create(bucket_id=456, tool_type="Chat::Transcript", visible_to_clients=True)
+        assert json.loads(route.calls[-1].request.content)["visible_to_clients"] is True
+
+        account.tools.create(bucket_id=456, tool_type="Chat::Transcript", visible_to_clients=False)
+        body = json.loads(route.calls[-1].request.content)
+        assert "visible_to_clients" in body
+        assert body["visible_to_clients"] is False
+
+    @respx.mock
     def test_create_raises_validation_error_on_422(self):
         route = respx.post("https://3.basecampapi.com/12345/buckets/456/dock/tools.json").mock(
             return_value=httpx.Response(422, json={"error": "Tool type is not included in the list"})
@@ -150,6 +171,27 @@ class TestAsyncTools:
         assert info.operation == "create"
         assert info.project_id == 456
         assert info.resource_id is None
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_create_visible_to_clients_tristate(self):
+        # Async counterpart of the sync tri-state test: unset omits the key,
+        # true/false are sent verbatim, and an explicit false reaches the wire.
+        route = respx.post("https://3.basecampapi.com/12345/buckets/456/dock/tools.json").mock(
+            return_value=httpx.Response(201, json=_tool())
+        )
+        account = AsyncClient(access_token="test-token").for_account("12345")
+
+        await account.tools.create(bucket_id=456, tool_type="Chat::Transcript")
+        assert "visible_to_clients" not in json.loads(route.calls[-1].request.content)
+
+        await account.tools.create(bucket_id=456, tool_type="Chat::Transcript", visible_to_clients=True)
+        assert json.loads(route.calls[-1].request.content)["visible_to_clients"] is True
+
+        await account.tools.create(bucket_id=456, tool_type="Chat::Transcript", visible_to_clients=False)
+        body = json.loads(route.calls[-1].request.content)
+        assert "visible_to_clients" in body
+        assert body["visible_to_clients"] is False
 
     @pytest.mark.asyncio
     @respx.mock

--- a/ruby/lib/basecamp/generated/metadata.json
+++ b/ruby/lib/basecamp/generated/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-07-27T05:29:04Z",
+  "generated": "2026-07-26T17:22:47Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/ruby/lib/basecamp/generated/services/tools_service.rb
+++ b/ruby/lib/basecamp/generated/services/tools_service.rb
@@ -11,10 +11,11 @@ module Basecamp
       # @param bucket_id [Integer] bucket id ID
       # @param tool_type [String] Tool type to add to the project dock. Values: Chat::Transcript|Inbox|Kanban::Board|Message::Board|Questionnaire|Schedule|Todoset|Vault.
       # @param title [String, nil] Title for the new tool. When omitted, Basecamp assigns the next available default title for the tool type.
+      # @param visible_to_clients [Boolean, nil] Create the tool already visible to clients. Honored only for tool types that manage their own client visibility (Chat::Transcript, Kanban::Board), which otherwise start hidden; every other tool type ignores it and inherits the project default.
       # @return [Hash] response data
-      def create(bucket_id:, tool_type:, title: nil)
+      def create(bucket_id:, tool_type:, title: nil, visible_to_clients: nil)
         with_operation(service: "tools", operation: "create", is_mutation: true, project_id: bucket_id) do
-          http_post("/buckets/#{bucket_id}/dock/tools.json", body: compact_params(tool_type: tool_type, title: title)).json
+          http_post("/buckets/#{bucket_id}/dock/tools.json", body: compact_params(tool_type: tool_type, title: title, visible_to_clients: visible_to_clients)).json
         end
       end
 

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Auto-generated from OpenAPI spec. Do not edit manually.
-# Generated: 2026-07-27T05:29:05Z
+# Generated: 2026-07-26T17:22:47Z
 
 require "json"
 require "time"

--- a/ruby/test/basecamp/services/tools_service_test.rb
+++ b/ruby/test/basecamp/services/tools_service_test.rb
@@ -42,6 +42,43 @@ class ToolsServiceTest < Minitest::Test
     assert_equal "Message Board", result["name"]
   end
 
+  # visible_to_clients is tri-state: unset omits the key (compact_params drops nil),
+  # true/false are sent verbatim. An explicit false must reach the wire. Only
+  # Chat::Transcript and Kanban::Board honor it; all other tool types ignore it.
+  def test_create_omits_visible_to_clients_when_unset
+    response = { "id" => 3, "name" => "Campfire" }
+    stub_request(:post, %r{https://3\.basecampapi\.com/12345/buckets/456/dock/tools\.json})
+      .to_return(status: 201, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    @account.tools.create(bucket_id: 456, tool_type: "Chat::Transcript")
+
+    assert_requested(:post, "https://3.basecampapi.com/12345/buckets/456/dock/tools.json") do |req|
+      !JSON.parse(req.body).key?("visible_to_clients")
+    end
+  end
+
+  def test_create_sends_visible_to_clients_true
+    response = { "id" => 3, "name" => "Campfire" }
+    stub_request(:post, %r{https://3\.basecampapi\.com/12345/buckets/456/dock/tools\.json})
+      .to_return(status: 201, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    @account.tools.create(bucket_id: 456, tool_type: "Chat::Transcript", visible_to_clients: true)
+
+    assert_requested(:post, "https://3.basecampapi.com/12345/buckets/456/dock/tools.json",
+      body: hash_including("visible_to_clients" => true))
+  end
+
+  def test_create_sends_visible_to_clients_false
+    response = { "id" => 3, "name" => "Campfire" }
+    stub_request(:post, %r{https://3\.basecampapi\.com/12345/buckets/456/dock/tools\.json})
+      .to_return(status: 201, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    @account.tools.create(bucket_id: 456, tool_type: "Chat::Transcript", visible_to_clients: false)
+
+    assert_requested(:post, "https://3.basecampapi.com/12345/buckets/456/dock/tools.json",
+      body: hash_including("visible_to_clients" => false))
+  end
+
   def test_create_raises_validation_error_on_422
     stub_request(:post, %r{https://3\.basecampapi\.com/12345/buckets/456/dock/tools\.json})
       .to_return(

--- a/spec/api-gaps/README.md
+++ b/spec/api-gaps/README.md
@@ -60,7 +60,7 @@ making the absorption journey publicly auditable.
 | [my-bookmarks](my-bookmarks.md) | addressed-in-bc3-pr-12383 | master | medium |
 | [my-drafts](my-drafts.md) | addressed-in-bc3-pr-12381 | master | medium |
 | [my-assignments-priorities](my-assignments-priorities.md) | addressed-in-bc3-pr-12380 | master | medium |
-| [dock-tool-visible-to-clients](dock-tool-visible-to-clients.md) | addressed-in-bc3-pr-12386 | post-train | low |
+| [dock-tool-visible-to-clients](dock-tool-visible-to-clients.md) | absorbed-in-sdk | post-train | low |
 | [card-table-wormholes](card-table-wormholes.md) | absorbed-in-sdk | post-train | medium |
 
 > Statuses reflect how BC3's **BC5 API train** actually shipped (8 PRs merged

--- a/spec/api-gaps/dock-tool-visible-to-clients.md
+++ b/spec/api-gaps/dock-tool-visible-to-clients.md
@@ -1,9 +1,11 @@
 ---
 gap: dock-tool-visible-to-clients
-status: addressed-in-bc3-pr-12386
+status: absorbed-in-sdk
 detected: 2026-07-23
 sdk_demand: low
 bc3_pr: 12386
+smithy_refs:
+  - "CreateToolInput.visible_to_clients member (spec/basecamp.smithy:7227)"
 bc3_refs:
   introduced_in: master
   routes:
@@ -40,13 +42,14 @@ The contract is narrower than the content creates:
   `Recording::VisibleToClientsParam` and gates it on
   `tool.changes_client_visibility?`.
 
-The SDK's `CreateTool` request type does not yet expose `visible_to_clients`, so
-consumers can't set a Chat/Kanban tool's client visibility at create time.
+The SDK's `CreateTool` request type now exposes `visible_to_clients` (added as a
+tri-state optional on `CreateToolInput`), so consumers can set a Chat/Kanban
+tool's client visibility at create time.
 
-This entry **registers** the shipped contract; it does **not** absorb it. It is
-kept separate from the six-content-create absorption on purpose: `CreateTool` is
-a distinct dock-tool operation with a narrower (two-tool-type) honoring rule, so
-folding it in would both widen scope and blur the semantics.
+This absorption is kept separate from the six-content-create absorption on
+purpose: `CreateTool` is a distinct dock-tool operation with a narrower
+(two-tool-type) honoring rule, so folding it in would both widen scope and blur
+the semantics.
 
 ## Why it matters
 
@@ -73,9 +76,11 @@ Nothing further is required of BC3.
 
 ## SDK absorption plan when this lands
 
-Deferred to a follow-up. When absorbed, add optional `visible_to_clients` to the
-Smithy `CreateToolInput`, regenerate, add the Go hand-wrapper field + pass-through
-(CreateTool has a hand-written wrapper like the content creates), and add a
-tri-state transport test asserting explicit `false` reaches the wire — then flip
-this entry to `absorbed-in-sdk` with the Smithy ref. Until then it stays
-`addressed-in-bc3-pr-12386` as a register-only record.
+Absorbed (basecamp-sdk PR-1 of the post-#401 follow-up program). Added optional
+`visible_to_clients: Boolean` to the Smithy `CreateToolInput`, regenerated, added
+the Go hand-wrapper field (`CreateToolOptions.VisibleToClients *bool`) with a
+tri-state pass-through in `ToolsService.Create`, and added a Go tri-state
+transport test plus one body-encoding test in each non-Go SDK
+(TS/Ruby/Python/Kotlin/Swift) asserting an explicit `false` reaches the wire.
+The narrower two-tool-type honoring rule is documented on the Smithy member and
+the Go option field.

--- a/spec/api-gaps/dock-tool-visible-to-clients.md
+++ b/spec/api-gaps/dock-tool-visible-to-clients.md
@@ -26,8 +26,9 @@ boolean at create time in BC3 **#12386** ("Honor create-time visible_to_clients
 on dock tool creates", merged `bee714c74`, 2026-07-23). This is the dock-tool
 sibling of the six content creates absorbed in
 [[visible-to-clients-on-creates]]; it is split into its own entry because the
-honoring rule is narrower and `CreateToolInput` is **not** modeled with the
-field yet.
+honoring rule is narrower. It is now `absorbed-in-sdk`: `CreateToolInput` models
+the optional `visible_to_clients` field and `ToolsService.Create` passes it
+through (see the smithy_refs below).
 
 The contract is narrower than the content creates:
 

--- a/spec/basecamp.smithy
+++ b/spec/basecamp.smithy
@@ -7222,6 +7222,9 @@ structure CreateToolInput {
 
   /// Title for the new tool. When omitted, Basecamp assigns the next available default title for the tool type.
   title: String
+
+  /// Create the tool already visible to clients. Honored only for tool types that manage their own client visibility (Chat::Transcript, Kanban::Board), which otherwise start hidden; every other tool type ignores it and inherits the project default.
+  visible_to_clients: Boolean
 }
 
 structure CreateToolOutput {

--- a/swift/Sources/Basecamp/Generated/Models/CreateToolRequest.swift
+++ b/swift/Sources/Basecamp/Generated/Models/CreateToolRequest.swift
@@ -4,9 +4,11 @@ import Foundation
 public struct CreateToolRequest: Codable, Sendable {
     public var title: String?
     public let toolType: String
+    public var visibleToClients: Bool?
 
-    public init(title: String? = nil, toolType: String) {
+    public init(title: String? = nil, toolType: String, visibleToClients: Bool? = nil) {
         self.title = title
         self.toolType = toolType
+        self.visibleToClients = visibleToClients
     }
 }

--- a/swift/Tests/BasecampTests/GeneratedServiceTests.swift
+++ b/swift/Tests/BasecampTests/GeneratedServiceTests.swift
@@ -513,6 +513,39 @@ final class GeneratedServiceTests: XCTestCase {
         XCTAssertNil(sentJSON["title"])
     }
 
+    // visibleToClients is tri-state: nil omits the key (encodeIfPresent), true/false
+    // are sent verbatim. An explicit false must reach the wire, not be dropped. Only
+    // Chat::Transcript and Kanban::Board honor it; all other tool types ignore it.
+    private func sentToolBody(visibleToClients: Bool?) async throws -> [String: Any] {
+        let responseJSON: [String: Any] = [
+            "id": 802, "name": "chat", "title": "Campfire", "enabled": true,
+            "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+        ]
+        let transport = MockTransport(statusCode: 201, data: try JSONSerialization.data(withJSONObject: responseJSON))
+        let account = makeTestAccountClient(transport: transport)
+        _ = try await account.tools.create(
+            bucketId: 456,
+            req: CreateToolRequest(toolType: "Chat::Transcript", visibleToClients: visibleToClients)
+        )
+        return try JSONSerialization.jsonObject(with: transport.lastRequest!.request.httpBody!) as! [String: Any]
+    }
+
+    func testToolsServiceCreateOmitsVisibleToClientsWhenNil() async throws {
+        let sentJSON = try await sentToolBody(visibleToClients: nil)
+        XCTAssertNil(sentJSON["visible_to_clients"], "nil must omit the key")
+    }
+
+    func testToolsServiceCreateSendsVisibleToClientsTrue() async throws {
+        let sentJSON = try await sentToolBody(visibleToClients: true)
+        XCTAssertEqual(sentJSON["visible_to_clients"] as? Bool, true)
+    }
+
+    func testToolsServiceCreateSendsVisibleToClientsFalse() async throws {
+        let sentJSON = try await sentToolBody(visibleToClients: false)
+        XCTAssertNotNil(sentJSON["visible_to_clients"], "explicit false must be sent, not dropped")
+        XCTAssertEqual(sentJSON["visible_to_clients"] as? Bool, false)
+    }
+
     // MARK: - Campfire line operations
 
     private func campfireLineJSON(id: Int, content: String) -> [String: Any] {

--- a/typescript/src/generated/metadata.ts
+++ b/typescript/src/generated/metadata.ts
@@ -37,7 +37,7 @@ export interface MetadataOutput {
 const metadata: MetadataOutput = {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-07-27T05:29:04.217Z",
+  "generated": "2026-07-26T17:22:47.099Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/typescript/src/generated/openapi-stripped.json
+++ b/typescript/src/generated/openapi-stripped.json
@@ -21112,6 +21112,11 @@
           "title": {
             "type": "string",
             "description": "Title for the new tool. When omitted, Basecamp assigns the next available default title for the tool type."
+          },
+          "visible_to_clients": {
+            "type": "boolean",
+            "description": "Create the tool already visible to clients. Honored only for tool types that manage their own client visibility (Chat::Transcript, Kanban::Board), which otherwise start hidden; every other tool type ignores it and inherits the project default.",
+            "x-go-type-skip-optional-pointer": false
           }
         },
         "required": [

--- a/typescript/src/generated/schema.d.ts
+++ b/typescript/src/generated/schema.d.ts
@@ -3148,6 +3148,8 @@ export interface components {
             tool_type: string;
             /** @description Title for the new tool. When omitted, Basecamp assigns the next available default title for the tool type. */
             title?: string;
+            /** @description Create the tool already visible to clients. Honored only for tool types that manage their own client visibility (Chat::Transcript, Kanban::Board), which otherwise start hidden; every other tool type ignores it and inherits the project default. */
+            visible_to_clients?: boolean;
         };
         CreateToolResponseContent: components["schemas"]["Tool"];
         CreateUploadRequestContent: {

--- a/typescript/src/generated/services/tools.ts
+++ b/typescript/src/generated/services/tools.ts
@@ -23,6 +23,8 @@ export interface CreateToolRequest {
   toolType: string;
   /** Title for the new tool. When omitted, Basecamp assigns the next available default title for the tool type. */
   title?: string;
+  /** Create the tool already visible to clients. Honored only for tool types that manage their own client visibility (Chat::Transcript, Kanban::Board), which otherwise start hidden; every other tool type ignores it and inherits the project default. */
+  visibleToClients?: boolean;
 }
 
 /**
@@ -83,6 +85,7 @@ export class ToolsService extends BaseService {
           body: {
             tool_type: req.toolType,
             title: req.title,
+            visible_to_clients: req.visibleToClients,
           },
         })
     );

--- a/typescript/tests/services/tools.test.ts
+++ b/typescript/tests/services/tools.test.ts
@@ -117,6 +117,36 @@ describe("ToolsService", () => {
     it("requires a tool type", async () => {
       await expect(client.tools.create(456, { toolType: "" })).rejects.toThrow(BasecampError);
     });
+
+    // visibleToClients is tri-state: undefined omits the key, true/false are sent
+    // verbatim. An explicit false must reach the wire (not be dropped). Only
+    // Chat::Transcript and Kanban::Board honor it; all other tool types ignore it.
+    it("should send visible_to_clients tri-state in request body", async () => {
+      const bucketId = 456;
+      const toolType = "Chat::Transcript";
+      const mockTool = { id: 335, name: "chat", title: "Campfire", enabled: true, position: 5 };
+      let capturedBody: Record<string, unknown> = {};
+
+      server.use(
+        http.post(
+          `${BASE_URL}/buckets/${bucketId}/dock/tools.json`,
+          async ({ request }) => {
+            capturedBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(mockTool, { status: 201 });
+          }
+        )
+      );
+
+      await client.tools.create(bucketId, { toolType });
+      expect("visible_to_clients" in capturedBody).toBe(false);
+
+      await client.tools.create(bucketId, { toolType, visibleToClients: true });
+      expect(capturedBody.visible_to_clients).toBe(true);
+
+      await client.tools.create(bucketId, { toolType, visibleToClients: false });
+      expect("visible_to_clients" in capturedBody).toBe(true);
+      expect(capturedBody.visible_to_clients).toBe(false);
+    });
   });
 
   describe("update", () => {


### PR DESCRIPTION
Closes #418. Part of the post-#401 BC3 follow-up absorption program (**PR-1**).

> **Stacked on #416 (PR-0, provenance sync).** Base is `provenance-sync-d7bc88da`; review the PR-1 commit only. Will retarget to `main` once #416 merges.

## Summary

The dock-tool create endpoint gained an optional top-level `visible_to_clients` boolean in bc3 **#12386** (`bee714c74`, merged 2026-07-23). Only tool types that manage their own client visibility — `Chat::Transcript` and `Kanban::Board`, which otherwise start hidden — honor it; every other tool type ignores it and inherits the project default.

Absorbs it as a tri-state optional, mirroring the six content-create inputs from #401.

## Changes

- **Smithy**: `visible_to_clients: Boolean` on `CreateToolInput` (plain `Boolean` → Go `*bool`), documenting the two-tool-type honoring rule on the member.
- **Go**: `CreateToolOptions.VisibleToClients *bool` with a pass-through in `ToolsService.Create` — `nil` omits the field, explicit `false` reaches the wire.
- **Tests**: Go tri-state transport test **plus one body-encoding test in each non-Go SDK** (TS/Ruby/Python/Kotlin/Swift) asserting explicit `false` is sent, not dropped.
- **Registry**: flip `dock-tool-visible-to-clients.md` → `absorbed-in-sdk` with the smithy_ref; update the api-gaps README row.

## Verification

`make generate && make check` — clean (71 conformance passed, 0 failed; api-gaps + deprecation parity clean). Canary `live-my-surface.json` validates statically (live canary dormant pending a safe token mechanism).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds create-time `visible_to_clients` to `CreateTool` so callers can set client visibility when creating dock tools; only `Chat::Transcript` and `Kanban::Board` honor it. Tri-state support (unset omitted; true/false sent) is implemented across Go, TypeScript, Ruby, Python, Kotlin, and Swift.

- **New Features**
  - Smithy/OpenAPI: optional `visible_to_clients` on `CreateToolInput`, with the two-tool honoring rule documented.
  - Go: `CreateToolOptions.VisibleToClients *bool` passthrough in `ToolsService.Create`; tri-state transport test added.
  - TS/Ruby/Python/Kotlin/Swift: request bodies accept `visible_to_clients`/`visibleToClients`; tests in each SDK (incl. Python sync/async) ensure explicit `false` reaches the wire.
  - Docs: `dock-tool-visible-to-clients` gap flipped to `absorbed-in-sdk` with `smithy_ref`; narrative corrected.

<sup>Written for commit 0549e360afd148cd3b07f07cee8be0563f437ee0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/419?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

