### PR TITLE
Absorb the Bubble Ups successor surface (bc3 #11628)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 | Component | Status | Details |
 |-----------|--------|---------|
-| **Smithy Spec** | 208 operations | Single source of truth for all APIs |
+| **Smithy Spec** | 209 operations | Single source of truth for all APIs |
 | **Go SDK** | Production-ready | Full generated client + service wrappers |
 | **TypeScript SDK** | Production-ready | 45 generated services, openapi-fetch based |
 | **Ruby SDK** | Production-ready | 45 generated services |
@@ -31,7 +31,7 @@ Smithy Spec → OpenAPI → Generated Client → Service Layer → User
 | **Kotlin** | Ktor via `BaseService` | `sdk/src/commonMain/kotlin/.../generated/services/*.kt` |
 | **Python** | httpx via `HttpClient` | `src/basecamp/generated/services/*.py` |
 
-All 208 operations across the ~45-service per-SDK layer are generated. Hand-written code is limited to infrastructure:
+All 209 operations across the ~45-service per-SDK layer are generated. Hand-written code is limited to infrastructure:
 
 | Purpose | TypeScript | Ruby | Swift | Kotlin | Python |
 |---------|-----------|------|-------|--------|--------|

--- a/SPEC.md
+++ b/SPEC.md
@@ -496,7 +496,7 @@ END
 
 ### behavior-model.json Retry Patterns
 
-All 208 operations in `behavior-model.json` use `retry_on: [429, 503]`. Three `(max, base_delay_ms)` patterns exist:
+All 209 operations in `behavior-model.json` use `retry_on: [429, 503]`. Three `(max, base_delay_ms)` patterns exist:
 - `(2, 1000)` — most create operations
 - `(3, 1000)` — most read/update/delete operations
 - `(3, 2000)` — `CreateAttachment`, `CreateCampfireUpload` (file uploads)
@@ -1548,7 +1548,7 @@ Every operation has a `retry` block, including non-idempotent POSTs. For non-ide
 
 ### Operation Counts
 
-- Total operations: 208
+- Total operations: 209
 - Idempotent: 69 (flagged with `idempotent: true`)
 - Non-idempotent: 139 (no `idempotent` field, or not present)
 - All operations use `retry_on: [429, 503]`

--- a/SPEC.md
+++ b/SPEC.md
@@ -1550,7 +1550,7 @@ Every operation has a `retry` block, including non-idempotent POSTs. For non-ide
 
 - Total operations: 209
 - Idempotent: 69 (flagged with `idempotent: true`)
-- Non-idempotent: 139 (no `idempotent` field, or not present)
+- Non-idempotent: 140 (no `idempotent` field, or not present)
 - All operations use `retry_on: [429, 503]`
 
 ---

--- a/behavior-model.json
+++ b/behavior-model.json
@@ -621,6 +621,22 @@
         ]
       }
     },
+    "GetBubbleUps": {
+      "readonly": true,
+      "pagination": {
+        "style": "link",
+        "maxPageSize": 50
+      },
+      "retry": {
+        "max": 3,
+        "base_delay_ms": 1000,
+        "backoff": "exponential",
+        "retry_on": [
+          429,
+          503
+        ]
+      }
+    },
     "GetCampfire": {
       "readonly": true,
       "retry": {

--- a/conformance/runner/typescript/live-dispatch.ts
+++ b/conformance/runner/typescript/live-dispatch.ts
@@ -81,6 +81,17 @@ export const LIVE_OPERATIONS: Record<string, DispatchSpec> = {
     },
   },
 
+  GetBubbleUps: {
+    fixtures: [],
+    call: async (ctx) => {
+      // maxItems caps pagination: bubble_ups is a paginated feed (50/page), so a
+      // small sample validates the Notification schema without following every
+      // Link page on an active account.
+      const result = await ctx.client.myNotifications.bubbleUps({ maxItems: 5 });
+      return { resolvedIds: {}, result };
+    },
+  },
+
   GetMyProfile: {
     fixtures: [],
     call: async (ctx) => {

--- a/conformance/runner/typescript/schema-validator.test.ts
+++ b/conformance/runner/typescript/schema-validator.test.ts
@@ -69,13 +69,18 @@ describe("validateResponse — ListProjects (array root)", () => {
 // =============================================================================
 
 describe("validateResponse — GetMyNotifications (object root, array fields)", () => {
-  it("validates an empty payload (all arrays absent)", () => {
-    const result = validateResponse("GetMyNotifications", {});
+  // bubble_ups_count / scheduled_bubble_ups_count are @required on the output,
+  // so every valid payload carries them (the arrays remain optional).
+  const counts = { bubble_ups_count: 0, scheduled_bubble_ups_count: 0 };
+
+  it("validates a minimal payload (arrays absent, required counts present)", () => {
+    const result = validateResponse("GetMyNotifications", { ...counts });
     expect(result.ok).toBe(true);
   });
 
   it("validates with empty arrays", () => {
     const result = validateResponse("GetMyNotifications", {
+      ...counts,
       unreads: [],
       reads: [],
       memories: [],
@@ -87,6 +92,7 @@ describe("validateResponse — GetMyNotifications (object root, array fields)", 
 
   it("collects extras at the root", () => {
     const result = validateResponse("GetMyNotifications", {
+      ...counts,
       unreads: [],
       hypothetical_new_top_level: 42,
     });
@@ -101,6 +107,7 @@ describe("validateResponse — GetMyNotifications (object root, array fields)", 
       updated_at: "2026-01-02T00:00:00Z",
     };
     const result = validateResponse("GetMyNotifications", {
+      ...counts,
       unreads: [{ ...minimalNotification, future_envelope_field: "BC5 addition" }],
     });
     expect(result.ok).toBe(true);

--- a/conformance/tests/live-my-surface.json
+++ b/conformance/tests/live-my-surface.json
@@ -14,6 +14,19 @@
   },
   {
     "mode": "live",
+    "name": "GetBubbleUps returns a paginated bubble-ups list and validates against schema",
+    "description": "Exercises the dedicated bubble-ups endpoint (current + scheduled, 50/page) and validates each notification item against the schema. Live-dormant: validates statically until credentials are provisioned.",
+    "operation": "GetBubbleUps",
+    "method": "GET",
+    "path": "/my/readings/bubble_ups.json",
+    "tags": ["live", "read-only"],
+    "liveAssertions": [
+      { "type": "liveCallSucceeds" },
+      { "type": "liveSchemaValidate" }
+    ]
+  },
+  {
+    "mode": "live",
     "name": "ListProjects returns a list and validates against schema",
     "description": "Smoke check + schema validation for the canonical list endpoint. Required fields are enforced per spec; new BC5-only fields surface as extras-observed.",
     "operation": "ListProjects",

--- a/go/pkg/basecamp/my_notifications.go
+++ b/go/pkg/basecamp/my_notifications.go
@@ -197,7 +197,7 @@ func (s *MyNotificationsService) MarkAsRead(ctx context.Context, readables []str
 func (s *MyNotificationsService) BubbleUps(ctx context.Context, page int32) (result *BubbleUpsResult, err error) {
 	op := OperationInfo{
 		Service: "MyNotifications", Operation: "BubbleUps",
-		ResourceType: "notification", IsMutation: false,
+		ResourceType: "bubble_up", IsMutation: false,
 	}
 	if gater, ok := s.client.parent.hooks.(GatingHooks); ok {
 		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {

--- a/go/pkg/basecamp/my_notifications.go
+++ b/go/pkg/basecamp/my_notifications.go
@@ -70,8 +70,26 @@ type NotificationsResult struct {
 	// integrations should prefer BubbleUps.
 	BubbleUps []Notification `json:"bubble_ups,omitempty"`
 	// ScheduledBubbleUps is the BC5-added list of scheduled Bubble Up
-	// notifications (resurface time in the future).
+	// notifications (resurface time in the future). Omitted from the response
+	// entirely when the request sets limit_bubble_ups=true.
 	ScheduledBubbleUps []Notification `json:"scheduled_bubble_ups,omitempty"`
+	// BubbleUpsCount is the total number of current bubble-ups, independent of
+	// the limit_bubble_ups cap on the BubbleUps array.
+	BubbleUpsCount int32 `json:"bubble_ups_count"`
+	// ScheduledBubbleUpsCount is the total number of scheduled bubble-ups,
+	// present even when limit_bubble_ups omits the ScheduledBubbleUps array.
+	ScheduledBubbleUpsCount int32 `json:"scheduled_bubble_ups_count"`
+}
+
+// BubbleUpsResult contains a page-followed list of bubble-up notifications
+// with pagination metadata.
+type BubbleUpsResult struct {
+	// BubbleUps is the combined list of current bubble-ups (first, ordered by
+	// most recently bubbled up) followed by scheduled bubble-ups (ordered by
+	// scheduled time).
+	BubbleUps []Notification
+	// Meta contains pagination metadata (total count, truncation).
+	Meta ListMeta
 }
 
 // MyNotificationsService handles notification operations for the current user.
@@ -84,9 +102,20 @@ func NewMyNotificationsService(client *AccountClient) *MyNotificationsService {
 	return &MyNotificationsService{client: client}
 }
 
+// MyNotificationsGetOption customizes a MyNotifications Get request.
+type MyNotificationsGetOption func(*generated.GetMyNotificationsParams)
+
+// WithLimitBubbleUps caps the bubble_ups array at 2 current bubble-ups and
+// omits the scheduled_bubble_ups array from the response (the counts are still
+// returned). Use the BubbleUps method to page through all bubble-ups.
+func WithLimitBubbleUps() MyNotificationsGetOption {
+	return func(p *generated.GetMyNotificationsParams) { p.LimitBubbleUps = true }
+}
+
 // Get returns notifications for the current user.
-// page is optional; pass 0 to use the default (page 1).
-func (s *MyNotificationsService) Get(ctx context.Context, page int32) (result *NotificationsResult, err error) {
+// page is optional; pass 0 to use the default (page 1). Optional functional
+// options (e.g. WithLimitBubbleUps) tune the request.
+func (s *MyNotificationsService) Get(ctx context.Context, page int32, opts ...MyNotificationsGetOption) (result *NotificationsResult, err error) {
 	op := OperationInfo{
 		Service: "MyNotifications", Operation: "Get",
 		ResourceType: "notification", IsMutation: false,
@@ -100,11 +129,12 @@ func (s *MyNotificationsService) Get(ctx context.Context, page int32) (result *N
 	ctx = s.client.parent.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.parent.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	var params *generated.GetMyNotificationsParams
+	params := &generated.GetMyNotificationsParams{}
 	if page > 0 {
-		params = &generated.GetMyNotificationsParams{
-			Page: page,
-		}
+		params.Page = page
+	}
+	for _, opt := range opts {
+		opt(params)
 	}
 
 	resp, err := s.client.parent.gen.GetMyNotificationsWithResponse(ctx, s.client.accountID, params)
@@ -157,4 +187,93 @@ func (s *MyNotificationsService) MarkAsRead(ctx context.Context, readables []str
 		return err
 	}
 	return checkResponse(resp.HTTPResponse, resp.Body)
+}
+
+// BubbleUps returns the current user's current and scheduled bubble-ups.
+// Current bubble-ups come first (ordered by most recently bubbled up), then
+// scheduled bubble-ups (ordered by scheduled time). The list is paginated at
+// 50 per page; by default this follows the Link header across all pages.
+// Pass a positive page to disable auto-pagination and return only that page.
+func (s *MyNotificationsService) BubbleUps(ctx context.Context, page int32) (result *BubbleUpsResult, err error) {
+	op := OperationInfo{
+		Service: "MyNotifications", Operation: "BubbleUps",
+		ResourceType: "notification", IsMutation: false,
+	}
+	if gater, ok := s.client.parent.hooks.(GatingHooks); ok {
+		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
+			return
+		}
+	}
+	start := time.Now()
+	ctx = s.client.parent.hooks.OnOperationStart(ctx, op)
+	defer func() { s.client.parent.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
+
+	var params *generated.GetBubbleUpsParams
+	if page > 0 {
+		params = &generated.GetBubbleUpsParams{Page: page}
+	}
+
+	resp, err := s.client.parent.gen.GetBubbleUpsWithResponse(ctx, s.client.accountID, params)
+	if err != nil {
+		return nil, err
+	}
+	if err = checkResponse(resp.HTTPResponse, resp.Body); err != nil {
+		return nil, err
+	}
+
+	items, err := decodeBubbleUpPage(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	totalCount := parseTotalCount(resp.HTTPResponse)
+
+	// A positive page disables auto-pagination (single page only).
+	if page > 0 {
+		return &BubbleUpsResult{BubbleUps: items, Meta: ListMeta{TotalCount: totalCount}}, nil
+	}
+
+	rawMore, truncated, err := s.client.parent.followPagination(ctx, resp.HTTPResponse, len(items), 0)
+	if err != nil {
+		return nil, err
+	}
+	for _, raw := range rawMore {
+		n, decErr := decodeNotificationItem(raw)
+		if decErr != nil {
+			return nil, decErr
+		}
+		items = append(items, n)
+	}
+
+	return &BubbleUpsResult{BubbleUps: items, Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
+}
+
+// decodeBubbleUpPage decodes a bubble-ups page (a bare JSON array of
+// notifications) into clean Notification values, applying the embedded-people
+// id normalization the Notification shape relies on.
+func decodeBubbleUpPage(body []byte) ([]Notification, error) {
+	normalized, normErr := normalizeEmbeddedPeopleJSON(body)
+	if normErr != nil {
+		normalized = body // fallback to raw
+	}
+	var items []Notification
+	if err := json.Unmarshal(normalized, &items); err != nil {
+		return nil, fmt.Errorf("failed to parse bubble-ups: %w", err)
+	}
+	return items, nil
+}
+
+// decodeNotificationItem decodes a single notification item (a raw JSON object
+// from a followed pagination page) into a clean Notification, applying the same
+// embedded-people id normalization as the first page.
+func decodeNotificationItem(raw json.RawMessage) (Notification, error) {
+	normalized, normErr := normalizeEmbeddedPeopleJSON(raw)
+	if normErr != nil {
+		normalized = raw // fallback to raw
+	}
+	var n Notification
+	if err := json.Unmarshal(normalized, &n); err != nil {
+		return Notification{}, fmt.Errorf("failed to parse bubble-up notification: %w", err)
+	}
+	return n, nil
 }

--- a/go/pkg/basecamp/my_notifications.go
+++ b/go/pkg/basecamp/my_notifications.go
@@ -113,9 +113,26 @@ func WithLimitBubbleUps() MyNotificationsGetOption {
 }
 
 // Get returns notifications for the current user.
-// page is optional; pass 0 to use the default (page 1). Optional functional
-// options (e.g. WithLimitBubbleUps) tune the request.
-func (s *MyNotificationsService) Get(ctx context.Context, page int32, opts ...MyNotificationsGetOption) (result *NotificationsResult, err error) {
+// page is optional; pass 0 to use the default (page 1).
+//
+// This preserves the original two-argument signature; adding a variadic
+// parameter here would change the method's type and break method values and
+// interface satisfaction for existing callers. Use GetWithOptions to tune the
+// request with functional options.
+func (s *MyNotificationsService) Get(ctx context.Context, page int32) (result *NotificationsResult, err error) {
+	return s.get(ctx, page)
+}
+
+// GetWithOptions returns notifications for the current user, tuned by optional
+// functional options (e.g. WithLimitBubbleUps). page is optional; pass 0 to use
+// the default (page 1).
+func (s *MyNotificationsService) GetWithOptions(ctx context.Context, page int32, opts ...MyNotificationsGetOption) (result *NotificationsResult, err error) {
+	return s.get(ctx, page, opts...)
+}
+
+// get is the shared implementation behind Get and GetWithOptions; both report
+// the same "Get" operation identity to hooks.
+func (s *MyNotificationsService) get(ctx context.Context, page int32, opts ...MyNotificationsGetOption) (result *NotificationsResult, err error) {
 	op := OperationInfo{
 		Service: "MyNotifications", Operation: "Get",
 		ResourceType: "notification", IsMutation: false,
@@ -228,9 +245,13 @@ func (s *MyNotificationsService) BubbleUps(ctx context.Context, page int32) (res
 
 	totalCount := parseTotalCount(resp.HTTPResponse)
 
-	// A positive page disables auto-pagination (single page only).
+	// A positive page disables auto-pagination (single page only). The caller
+	// still needs to know the returned page is a partial view, so report
+	// Truncated when the response carries a rel="next" Link (more pages exist)
+	// even though we deliberately do not follow it here.
 	if page > 0 {
-		return &BubbleUpsResult{BubbleUps: items, Meta: ListMeta{TotalCount: totalCount}}, nil
+		truncated := parseNextLink(resp.HTTPResponse.Header.Get("Link")) != ""
+		return &BubbleUpsResult{BubbleUps: items, Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	rawMore, truncated, err := s.client.parent.followPagination(ctx, resp.HTTPResponse, len(items), 0)

--- a/go/pkg/basecamp/my_notifications_test.go
+++ b/go/pkg/basecamp/my_notifications_test.go
@@ -62,6 +62,131 @@ func TestMyNotificationsService_Get_WithPage(t *testing.T) {
 	}
 }
 
+// TestMyNotificationsService_Get_LimitBubbleUps verifies that
+// WithLimitBubbleUps sends limit_bubble_ups=true and that a response which omits
+// the scheduled_bubble_ups key (per the documented cap) still decodes, with the
+// counts preserved.
+func TestMyNotificationsService_Get_LimitBubbleUps(t *testing.T) {
+	var capturedQuery string
+	svc := testMyNotificationsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		// scheduled_bubble_ups key intentionally omitted; counts still present.
+		w.Write([]byte(`{
+			"unreads": [], "reads": [], "memories": [],
+			"bubble_ups": [{"id": 10, "title": "Bubbled"}, {"id": 11, "title": "Bubbled 2"}],
+			"bubble_ups_count": 5,
+			"scheduled_bubble_ups_count": 3
+		}`))
+	})
+
+	result, err := svc.Get(context.Background(), 0, WithLimitBubbleUps())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedQuery != "limit_bubble_ups=true" {
+		t.Errorf("expected query limit_bubble_ups=true, got %q", capturedQuery)
+	}
+	if len(result.BubbleUps) != 2 {
+		t.Errorf("expected 2 bubble_ups, got %d", len(result.BubbleUps))
+	}
+	if result.ScheduledBubbleUps != nil {
+		t.Errorf("expected scheduled_bubble_ups omitted (nil), got %v", result.ScheduledBubbleUps)
+	}
+	if result.BubbleUpsCount != 5 {
+		t.Errorf("expected bubble_ups_count 5, got %d", result.BubbleUpsCount)
+	}
+	if result.ScheduledBubbleUpsCount != 3 {
+		t.Errorf("expected scheduled_bubble_ups_count 3, got %d", result.ScheduledBubbleUpsCount)
+	}
+}
+
+// TestMyNotificationsService_BubbleUps_MultiPage exercises the dedicated
+// bubble-ups endpoint across multiple pages, verifying Link-header following and
+// generated pagination metadata (X-Total-Count), not just a single-page decode.
+// Current bubble-ups appear first, scheduled bubble-ups follow.
+func TestMyNotificationsService_BubbleUps_MultiPage(t *testing.T) {
+	var serverURL string
+	var page1Hits, page2Hits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/99999/my/readings/bubble_ups.json" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Total-Count", "3")
+		if r.URL.Query().Get("page") == "2" {
+			page2Hits++
+			w.WriteHeader(200)
+			// scheduled bubble-up, ordered after the current ones
+			w.Write([]byte(`[{"id":30,"title":"Scheduled","bubble_up_at":"2026-08-01T00:00:00Z"}]`))
+			return
+		}
+		page1Hits++
+		// page 1: two current bubble-ups, with a Link header to page 2
+		w.Header().Set("Link", fmt.Sprintf(`<%s/99999/my/readings/bubble_ups.json?page=2>; rel="next"`, serverURL))
+		w.WriteHeader(200)
+		w.Write([]byte(`[{"id":10,"title":"Current A"},{"id":11,"title":"Current B"}]`))
+	}))
+	t.Cleanup(server.Close)
+	serverURL = server.URL
+
+	cfg := DefaultConfig()
+	cfg.BaseURL = server.URL
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+	svc := client.ForAccount("99999").MyNotifications()
+
+	result, err := svc.BubbleUps(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if page1Hits != 1 || page2Hits != 1 {
+		t.Fatalf("expected one hit per page, got page1=%d page2=%d", page1Hits, page2Hits)
+	}
+	if len(result.BubbleUps) != 3 {
+		t.Fatalf("expected 3 bubble_ups across pages, got %d", len(result.BubbleUps))
+	}
+	// Ordering: current bubble-ups first, then scheduled.
+	if result.BubbleUps[0].ID != 10 || result.BubbleUps[1].ID != 11 || result.BubbleUps[2].ID != 30 {
+		t.Errorf("unexpected ordering: %d, %d, %d", result.BubbleUps[0].ID, result.BubbleUps[1].ID, result.BubbleUps[2].ID)
+	}
+	if result.BubbleUps[2].BubbleUpAt == nil {
+		t.Errorf("expected scheduled item to carry bubble_up_at")
+	}
+	if result.Meta.TotalCount != 3 {
+		t.Errorf("expected TotalCount 3, got %d", result.Meta.TotalCount)
+	}
+}
+
+// TestMyNotificationsService_BubbleUps_SinglePage verifies that a positive page
+// disables auto-pagination and returns only that page (no Link-following).
+func TestMyNotificationsService_BubbleUps_SinglePage(t *testing.T) {
+	var hits int
+	svc := testMyNotificationsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if r.URL.Query().Get("page") != "2" {
+			t.Errorf("expected page=2, got %q", r.URL.Query().Get("page"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Total-Count", "3")
+		// A Link header is present but must NOT be followed for an explicit page.
+		w.Header().Set("Link", `</99999/my/readings/bubble_ups.json?page=3>; rel="next"`)
+		w.WriteHeader(200)
+		w.Write([]byte(`[{"id":30,"title":"Scheduled"}]`))
+	})
+
+	result, err := svc.BubbleUps(context.Background(), 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hits != 1 {
+		t.Errorf("expected exactly 1 request for explicit page, got %d", hits)
+	}
+	if len(result.BubbleUps) != 1 {
+		t.Errorf("expected 1 bubble_up for single page, got %d", len(result.BubbleUps))
+	}
+}
+
 func TestMyNotificationsService_Get_SentinelCreatorID(t *testing.T) {
 	// The BC3 API returns system-generated notifications with creator.id: "basecamp"
 	// and personable_type: "LocalPerson". The normalize pass walks Person-shaped objects

--- a/go/pkg/basecamp/my_notifications_test.go
+++ b/go/pkg/basecamp/my_notifications_test.go
@@ -31,7 +31,7 @@ func TestMyNotificationsService_Get(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
-		w.Write([]byte(`{"unreads":[{"id":1,"title":"New comment"}],"reads":[],"memories":[]}`))
+		w.Write([]byte(`{"unreads":[{"id":1,"title":"New comment"}],"reads":[],"memories":[],"bubble_ups_count":0,"scheduled_bubble_ups_count":0}`))
 	})
 
 	result, err := svc.Get(context.Background(), 0)
@@ -53,7 +53,7 @@ func TestMyNotificationsService_Get_WithPage(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
-		w.Write([]byte(`{"unreads":[],"reads":[],"memories":[]}`))
+		w.Write([]byte(`{"unreads":[],"reads":[],"memories":[],"bubble_ups_count":0,"scheduled_bubble_ups_count":0}`))
 	})
 
 	_, err := svc.Get(context.Background(), 2)

--- a/go/pkg/basecamp/my_notifications_test.go
+++ b/go/pkg/basecamp/my_notifications_test.go
@@ -31,7 +31,7 @@ func TestMyNotificationsService_Get(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
-		w.Write([]byte(`{"unreads":[{"id":1,"title":"New comment"}],"reads":[],"memories":[],"bubble_ups_count":0,"scheduled_bubble_ups_count":0}`))
+		w.Write([]byte(`{"unreads":[{"id":1,"title":"New comment","created_at":"2026-07-21T00:00:00Z","updated_at":"2026-07-21T00:00:00Z"}],"reads":[],"memories":[],"bubble_ups_count":0,"scheduled_bubble_ups_count":0}`))
 	})
 
 	result, err := svc.Get(context.Background(), 0)
@@ -75,13 +75,13 @@ func TestMyNotificationsService_Get_LimitBubbleUps(t *testing.T) {
 		// scheduled_bubble_ups key intentionally omitted; counts still present.
 		w.Write([]byte(`{
 			"unreads": [], "reads": [], "memories": [],
-			"bubble_ups": [{"id": 10, "title": "Bubbled"}, {"id": 11, "title": "Bubbled 2"}],
+			"bubble_ups": [{"id": 10, "title": "Bubbled", "created_at": "2026-07-21T00:00:00Z", "updated_at": "2026-07-21T00:00:00Z"}, {"id": 11, "title": "Bubbled 2", "created_at": "2026-07-21T00:00:00Z", "updated_at": "2026-07-21T00:00:00Z"}],
 			"bubble_ups_count": 5,
 			"scheduled_bubble_ups_count": 3
 		}`))
 	})
 
-	result, err := svc.Get(context.Background(), 0, WithLimitBubbleUps())
+	result, err := svc.GetWithOptions(context.Background(), 0, WithLimitBubbleUps())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -119,14 +119,14 @@ func TestMyNotificationsService_BubbleUps_MultiPage(t *testing.T) {
 			page2Hits++
 			w.WriteHeader(200)
 			// scheduled bubble-up, ordered after the current ones
-			w.Write([]byte(`[{"id":30,"title":"Scheduled","bubble_up_at":"2026-08-01T00:00:00Z"}]`))
+			w.Write([]byte(`[{"id":30,"title":"Scheduled","bubble_up_at":"2026-08-01T00:00:00Z","created_at":"2026-07-21T00:00:00Z","updated_at":"2026-07-21T00:00:00Z"}]`))
 			return
 		}
 		page1Hits++
 		// page 1: two current bubble-ups, with a Link header to page 2
 		w.Header().Set("Link", fmt.Sprintf(`<%s/99999/my/readings/bubble_ups.json?page=2>; rel="next"`, serverURL))
 		w.WriteHeader(200)
-		w.Write([]byte(`[{"id":10,"title":"Current A"},{"id":11,"title":"Current B"}]`))
+		w.Write([]byte(`[{"id":10,"title":"Current A","created_at":"2026-07-21T00:00:00Z","updated_at":"2026-07-21T00:00:00Z"},{"id":11,"title":"Current B","created_at":"2026-07-21T00:00:00Z","updated_at":"2026-07-21T00:00:00Z"}]`))
 	}))
 	t.Cleanup(server.Close)
 	serverURL = server.URL
@@ -172,7 +172,7 @@ func TestMyNotificationsService_BubbleUps_SinglePage(t *testing.T) {
 		// A Link header is present but must NOT be followed for an explicit page.
 		w.Header().Set("Link", `</99999/my/readings/bubble_ups.json?page=3>; rel="next"`)
 		w.WriteHeader(200)
-		w.Write([]byte(`[{"id":30,"title":"Scheduled"}]`))
+		w.Write([]byte(`[{"id":30,"title":"Scheduled","created_at":"2026-07-21T00:00:00Z","updated_at":"2026-07-21T00:00:00Z"}]`))
 	})
 
 	result, err := svc.BubbleUps(context.Background(), 2)
@@ -184,6 +184,11 @@ func TestMyNotificationsService_BubbleUps_SinglePage(t *testing.T) {
 	}
 	if len(result.BubbleUps) != 1 {
 		t.Errorf("expected 1 bubble_up for single page, got %d", len(result.BubbleUps))
+	}
+	// A next-page Link is present but not followed in explicit-page mode, so the
+	// result must advertise itself as a partial view.
+	if !result.Meta.Truncated {
+		t.Error("expected Meta.Truncated=true when a next-page Link is present in single-page mode")
 	}
 }
 

--- a/go/pkg/basecamp/my_notifications_test.go
+++ b/go/pkg/basecamp/my_notifications_test.go
@@ -214,7 +214,9 @@ func TestMyNotificationsService_Get_SentinelCreatorID(t *testing.T) {
 				}
 			}],
 			"reads": [],
-			"memories": []
+			"memories": [],
+			"bubble_ups_count": 0,
+			"scheduled_bubble_ups_count": 0
 		}`))
 	})
 
@@ -270,7 +272,9 @@ func TestMyNotificationsService_Get_StringCreatorIDWithoutPersonableType(t *test
 				]
 			}],
 			"reads": [],
-			"memories": []
+			"memories": [],
+			"bubble_ups_count": 0,
+			"scheduled_bubble_ups_count": 0
 		}`))
 	})
 

--- a/go/pkg/basecamp/url-routes.json
+++ b/go/pkg/basecamp/url-routes.json
@@ -1021,6 +1021,19 @@
       }
     },
     {
+      "pattern": "/{accountId}/my/readings/bubble_ups",
+      "resource": "MyNotifications",
+      "operations": {
+        "GET": "GetBubbleUps"
+      },
+      "params": {
+        "accountId": {
+          "role": "account",
+          "type": "string"
+        }
+      }
+    },
+    {
       "pattern": "/{accountId}/my/unreads",
       "resource": "MyNotifications",
       "operations": {

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -990,6 +990,9 @@ type GetAssignedTodosResponseContent struct {
 // GetBoostResponseContent defines model for GetBoostResponseContent.
 type GetBoostResponseContent = Boost
 
+// GetBubbleUpsResponseContent defines model for GetBubbleUpsResponseContent.
+type GetBubbleUpsResponseContent = []Notification
+
 // GetCampfireLineResponseContent defines model for GetCampfireLineResponseContent.
 type GetCampfireLineResponseContent = CampfireLine
 
@@ -1069,6 +1072,10 @@ type GetMyNotificationsResponseContent struct {
 	// `scheduled_bubble_ups` for the time-deferred subset.
 	BubbleUps []Notification `json:"bubble_ups,omitempty"`
 
+	// BubbleUpsCount Total number of current bubble-ups, for notification UI counts
+	// (independent of the `limit_bubble_ups` cap on the `bubble_ups` array).
+	BubbleUpsCount int32 `json:"bubble_ups_count"`
+
 	// Memories Legacy "save forever" collection. Permanently `[]` on BC5 by documented
 	// contract (`doc/api/sections/my_notifications.md`, codified by BC3 #11628):
 	// an always-empty placeholder superseded by `bubble_ups`. BC4 (the `four`
@@ -1081,7 +1088,12 @@ type GetMyNotificationsResponseContent struct {
 
 	// ScheduledBubbleUps Bubble Ups scheduled to resurface in the future (BC5 addition).
 	ScheduledBubbleUps []Notification `json:"scheduled_bubble_ups,omitempty"`
-	Unreads            []Notification `json:"unreads,omitempty"`
+
+	// ScheduledBubbleUpsCount Total number of scheduled bubble-ups, for notification UI counts
+	// (present even when `limit_bubble_ups` omits the `scheduled_bubble_ups`
+	// array).
+	ScheduledBubbleUpsCount int32          `json:"scheduled_bubble_ups_count"`
+	Unreads                 []Notification `json:"unreads,omitempty"`
 }
 
 // GetMyPreferencesResponseContent defines model for GetMyPreferencesResponseContent.
@@ -3057,6 +3069,18 @@ type GetMyDueAssignmentsParams struct {
 type GetMyNotificationsParams struct {
 	// Page Page number for paginating through read items. Defaults to 1.
 	Page int32 `form:"page,omitempty" json:"page,omitempty"`
+
+	// LimitBubbleUps Set to true to cap `bubble_ups` at 2 current bubble-ups and omit the
+	// `scheduled_bubble_ups` key entirely. Defaults to false. Use the dedicated
+	// bubble-ups endpoint (GetBubbleUps) to page through all current and
+	// scheduled bubble-ups.
+	LimitBubbleUps bool `form:"limit_bubble_ups,omitempty" json:"limit_bubble_ups,omitempty"`
+}
+
+// GetBubbleUpsParams defines parameters for GetBubbleUps.
+type GetBubbleUpsParams struct {
+	// Page Page number. Defaults to 1.
+	Page int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListProjectsParams defines parameters for ListProjects.
@@ -4048,6 +4072,9 @@ type ClientInterface interface {
 
 	// GetMyNotifications request
 	GetMyNotifications(ctx context.Context, accountId string, params *GetMyNotificationsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// GetBubbleUps request
+	GetBubbleUps(ctx context.Context, accountId string, params *GetBubbleUpsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// MarkAsReadWithBody request with any body
 	MarkAsReadWithBody(ctx context.Context, accountId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -5866,6 +5893,16 @@ func (c *Client) GetMyNotifications(ctx context.Context, accountId string, param
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
 		return NewGetMyNotificationsRequest(c.Server, accountId, params)
 	}, true, "GetMyNotifications", reqEditors...)
+
+}
+
+// GetBubbleUps is marked as idempotent and will be retried on transient failures.
+
+func (c *Client) GetBubbleUps(ctx context.Context, accountId string, params *GetBubbleUpsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+
+	return c.doWithRetry(ctx, func() (*http.Request, error) {
+		return NewGetBubbleUpsRequest(c.Server, accountId, params)
+	}, true, "GetBubbleUps", reqEditors...)
 
 }
 
@@ -12070,6 +12107,78 @@ func NewGetMyNotificationsRequest(server string, accountId string, params *GetMy
 
 		}
 
+		if params.LimitBubbleUps {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "limit_bubble_ups", runtime.ParamLocationQuery, params.LimitBubbleUps); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewGetBubbleUpsRequest generates requests for GetBubbleUps
+func NewGetBubbleUpsRequest(server string, accountId string, params *GetBubbleUpsParams) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "accountId", runtime.ParamLocationPath, accountId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/%s/my/readings/bubble_ups.json", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.Page != 0 {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		queryURL.RawQuery = queryValues.Encode()
 	}
 
@@ -18008,6 +18117,7 @@ var operationMetadata = map[string]OperationMetadata{
 	"UpdateMyProfile":                    {Idempotent: true, HasSensitiveParams: false},
 	"GetQuestionReminders":               {Idempotent: true, HasSensitiveParams: false},
 	"GetMyNotifications":                 {Idempotent: true, HasSensitiveParams: false},
+	"GetBubbleUps":                       {Idempotent: true, HasSensitiveParams: false},
 	"MarkAsRead":                         {Idempotent: true, HasSensitiveParams: false},
 	"ListPeople":                         {Idempotent: true, HasSensitiveParams: false},
 	"GetPerson":                          {Idempotent: true, HasSensitiveParams: false},
@@ -19402,6 +19512,9 @@ type ClientWithResponsesInterface interface {
 
 	// GetMyNotificationsWithResponse request
 	GetMyNotificationsWithResponse(ctx context.Context, accountId string, params *GetMyNotificationsParams, reqEditors ...RequestEditorFn) (*GetMyNotificationsResponse, error)
+
+	// GetBubbleUpsWithResponse request
+	GetBubbleUpsWithResponse(ctx context.Context, accountId string, params *GetBubbleUpsParams, reqEditors ...RequestEditorFn) (*GetBubbleUpsResponse, error)
 
 	// MarkAsReadWithBodyWithResponse request with any body
 	MarkAsReadWithBodyWithResponse(ctx context.Context, accountId string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*MarkAsReadResponse, error)
@@ -23007,6 +23120,40 @@ func (r GetMyNotificationsResponse) StatusCode() int {
 
 // ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
 func (r GetMyNotificationsResponse) ContentType() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Header.Get("Content-Type")
+	}
+	return ""
+}
+
+type GetBubbleUpsResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *GetBubbleUpsResponseContent
+	JSON401      *UnauthorizedErrorResponseContent
+	JSON403      *ForbiddenErrorResponseContent
+	JSON429      *RateLimitErrorResponseContent
+	JSON500      *InternalServerErrorResponseContent
+}
+
+// Status returns HTTPResponse.Status
+func (r GetBubbleUpsResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r GetBubbleUpsResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+// ContentType is a convenience method to retrieve the Content-Type value from the HTTP response headers
+func (r GetBubbleUpsResponse) ContentType() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Header.Get("Content-Type")
 	}
@@ -28055,6 +28202,15 @@ func (c *ClientWithResponses) GetMyNotificationsWithResponse(ctx context.Context
 		return nil, err
 	}
 	return ParseGetMyNotificationsResponse(rsp)
+}
+
+// GetBubbleUpsWithResponse request returning *GetBubbleUpsResponse
+func (c *ClientWithResponses) GetBubbleUpsWithResponse(ctx context.Context, accountId string, params *GetBubbleUpsParams, reqEditors ...RequestEditorFn) (*GetBubbleUpsResponse, error) {
+	rsp, err := c.GetBubbleUps(ctx, accountId, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseGetBubbleUpsResponse(rsp)
 }
 
 // MarkAsReadWithBodyWithResponse request with arbitrary body returning *MarkAsReadResponse
@@ -34626,6 +34782,60 @@ func ParseGetMyNotificationsResponse(rsp *http.Response) (*GetMyNotificationsRes
 			return nil, err
 		}
 		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest InternalServerErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseGetBubbleUpsResponse parses an HTTP response from a GetBubbleUpsWithResponse call
+func ParseGetBubbleUpsResponse(rsp *http.Response) (*GetBubbleUpsResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &GetBubbleUpsResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest GetBubbleUpsResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest UnauthorizedErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 403:
+		var dest ForbiddenErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON403 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 429:
+		var dest RateLimitErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON429 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest InternalServerErrorResponseContent

--- a/kotlin/generator/src/main/kotlin/com/basecamp/sdk/generator/Config.kt
+++ b/kotlin/generator/src/main/kotlin/com/basecamp/sdk/generator/Config.kt
@@ -313,6 +313,7 @@ val TYPE_ALIASES = mapOf(
     "ClientCorrespondence" to "ClientCorrespondence",
     "ClientReply" to "ClientReply",
     "Boost" to "Boost",
+    "Notification" to "Notification",
     "TimelineEvent" to "TimelineEvent",
     "TimesheetEntry" to "TimesheetEntry",
     "HillChart" to "HillChart",

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/Metadata.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/Metadata.kt
@@ -74,6 +74,7 @@ object Metadata {
         "GetAnswersByPerson" to OperationConfig(false, RetryConfig(3, 1000L, "exponential", setOf(429, 503))),
         "GetAssignedTodos" to OperationConfig(false, RetryConfig(3, 1000L, "exponential", setOf(429, 503))),
         "GetBoost" to OperationConfig(false, RetryConfig(3, 1000L, "exponential", setOf(429, 503))),
+        "GetBubbleUps" to OperationConfig(false, RetryConfig(3, 1000L, "exponential", setOf(429, 503))),
         "GetCampfire" to OperationConfig(false, RetryConfig(3, 1000L, "exponential", setOf(429, 503))),
         "GetCampfireLine" to OperationConfig(false, RetryConfig(3, 1000L, "exponential", setOf(429, 503))),
         "GetCard" to OperationConfig(false, RetryConfig(3, 1000L, "exponential", setOf(429, 503))),

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Notification.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Notification.kt
@@ -34,8 +34,8 @@ data class Notification(
     @SerialName("bubble_up_at") val bubbleUpAt: String? = null,
     @SerialName("subscription_url") val subscriptionUrl: String? = null,
     val subscribed: Boolean = false,
-    @SerialName("previewable_attachments") val previewableAttachments: List<PreviewableAttachment> = emptyList(),
-    val participants: List<Person> = emptyList(),
+    @SerialName("previewable_attachments") val previewableAttachments: List<PreviewableAttachment>? = null,
+    val participants: List<Person>? = null,
     val named: Boolean = false,
     @SerialName("image_url") val imageUrl: String? = null
 )

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Notification.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Notification.kt
@@ -1,0 +1,41 @@
+package com.basecamp.sdk.generated.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Notification entity from the Basecamp API.
+ *
+ * @generated from OpenAPI spec — do not edit directly
+ */
+@Serializable
+data class Notification(
+    val id: Long,
+    @SerialName("created_at") val createdAt: String,
+    @SerialName("updated_at") val updatedAt: String,
+    val section: String? = null,
+    @SerialName("unread_count") val unreadCount: Int = 0,
+    @SerialName("unread_at") val unreadAt: String? = null,
+    @SerialName("read_at") val readAt: String? = null,
+    @SerialName("readable_sgid") val readableSgid: String? = null,
+    @SerialName("readable_identifier") val readableIdentifier: String? = null,
+    val title: String? = null,
+    val type: String? = null,
+    @SerialName("bucket_name") val bucketName: String? = null,
+    val creator: Person? = null,
+    @SerialName("content_excerpt") val contentExcerpt: String? = null,
+    @SerialName("app_url") val appUrl: String? = null,
+    @SerialName("unread_url") val unreadUrl: String? = null,
+    @SerialName("bookmark_url") val bookmarkUrl: String? = null,
+    @SerialName("memory_url") val memoryUrl: String? = null,
+    @SerialName("bubble_up_url") val bubbleUpUrl: String? = null,
+    @SerialName("bubble_up_at") val bubbleUpAt: String? = null,
+    @SerialName("subscription_url") val subscriptionUrl: String? = null,
+    val subscribed: Boolean = false,
+    @SerialName("previewable_attachments") val previewableAttachments: List<PreviewableAttachment> = emptyList(),
+    val participants: List<Person> = emptyList(),
+    val named: Boolean = false,
+    @SerialName("image_url") val imageUrl: String? = null
+)

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Notification.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Notification.kt
@@ -16,7 +16,7 @@ data class Notification(
     @SerialName("created_at") val createdAt: String,
     @SerialName("updated_at") val updatedAt: String,
     val section: String? = null,
-    @SerialName("unread_count") val unreadCount: Int = 0,
+    @SerialName("unread_count") val unreadCount: Int? = null,
     @SerialName("unread_at") val unreadAt: String? = null,
     @SerialName("read_at") val readAt: String? = null,
     @SerialName("readable_sgid") val readableSgid: String? = null,
@@ -33,9 +33,9 @@ data class Notification(
     @SerialName("bubble_up_url") val bubbleUpUrl: String? = null,
     @SerialName("bubble_up_at") val bubbleUpAt: String? = null,
     @SerialName("subscription_url") val subscriptionUrl: String? = null,
-    val subscribed: Boolean = false,
+    val subscribed: Boolean? = null,
     @SerialName("previewable_attachments") val previewableAttachments: List<PreviewableAttachment>? = null,
     val participants: List<Person>? = null,
-    val named: Boolean = false,
+    val named: Boolean? = null,
     @SerialName("image_url") val imageUrl: String? = null
 )

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/PreviewableAttachment.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/PreviewableAttachment.kt
@@ -12,12 +12,12 @@ import kotlinx.serialization.json.JsonObject
  */
 @Serializable
 data class PreviewableAttachment(
-    val id: Long = 0L,
+    val id: Long? = null,
     val url: String? = null,
     @SerialName("app_url") val appUrl: String? = null,
     @SerialName("content_type") val contentType: String? = null,
     val filename: String? = null,
-    val filesize: Long = 0L,
-    val width: Int = 0,
-    val height: Int = 0
+    val filesize: Long? = null,
+    val width: Int? = null,
+    val height: Int? = null
 )

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/PreviewableAttachment.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/PreviewableAttachment.kt
@@ -1,0 +1,23 @@
+package com.basecamp.sdk.generated.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * PreviewableAttachment entity from the Basecamp API.
+ *
+ * @generated from OpenAPI spec — do not edit directly
+ */
+@Serializable
+data class PreviewableAttachment(
+    val id: Long = 0L,
+    val url: String? = null,
+    @SerialName("app_url") val appUrl: String? = null,
+    @SerialName("content_type") val contentType: String? = null,
+    val filename: String? = null,
+    val filesize: Long = 0L,
+    val width: Int = 0,
+    val height: Int = 0
+)

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/Types.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/Types.kt
@@ -321,8 +321,17 @@ data class GetMyDueAssignmentsOptions(
 
 /** Options for GetMyNotifications. */
 data class GetMyNotificationsOptions(
-    val page: Long? = null
+    val page: Long? = null,
+    val limitBubbleUps: Boolean? = null
 ) {
+}
+
+/** Options for GetBubbleUps. */
+data class GetBubbleUpsOptions(
+    val page: Long? = null,
+    val maxItems: Int? = null
+) {
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
 }
 
 /** Request body for MarkAsRead. */

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/my-notifications.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/my-notifications.kt
@@ -27,11 +27,35 @@ class MyNotificationsService(client: AccountClient) : BaseService(client) {
         )
         val qs = buildQueryString(
             "page" to options?.page,
+            "limit_bubble_ups" to options?.limitBubbleUps,
         )
         return request(info, {
             httpGet("/my/readings.json" + qs, operationName = info.operation)
         }) { body ->
             json.decodeFromString<JsonElement>(body)
+        }
+    }
+
+    /**
+     * Get the current user's current and scheduled bubble-ups as a paginated
+     * @param options Optional query parameters and pagination control
+     */
+    suspend fun bubbleUps(options: GetBubbleUpsOptions? = null): ListResult<Notification> {
+        val info = OperationInfo(
+            service = "MyNotifications",
+            operation = "GetBubbleUps",
+            resourceType = "bubble_up",
+            isMutation = false,
+            projectId = null,
+            resourceId = null,
+        )
+        val qs = buildQueryString(
+            "page" to options?.page,
+        )
+        return requestPaginated(info, options?.toPaginationOptions(), {
+            httpGet("/my/readings/bubble_ups.json" + qs, operationName = info.operation)
+        }) { body ->
+            json.decodeFromString<List<Notification>>(body)
         }
     }
 

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/my-notifications.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/my-notifications.kt
@@ -37,7 +37,7 @@ class MyNotificationsService(client: AccountClient) : BaseService(client) {
     }
 
     /**
-     * Get the current user's current and scheduled bubble-ups as a paginated
+     * Get the current user's current and scheduled bubble-ups (paginated, 50 per page).
      * @param options Optional query parameters and pagination control
      */
     suspend fun bubbleUps(options: GetBubbleUpsOptions? = null): ListResult<Notification> {

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/BubbleUpsDecodeTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/BubbleUpsDecodeTest.kt
@@ -1,0 +1,54 @@
+package com.basecamp.sdk
+
+import com.basecamp.sdk.generated.models.Notification
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class BubbleUpsDecodeTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val fixtureJson = """
+        [
+          {
+            "id": 2,
+            "created_at": "2026-07-21T00:01:43.009Z",
+            "updated_at": "2026-07-21T00:01:43.031Z",
+            "section": "bubbles",
+            "unread_count": 0,
+            "read_at": "2026-07-21T00:01:43.031Z",
+            "title": "We won Leto!",
+            "type": "Message",
+            "bucket_name": "The Leto Laptop"
+          },
+          {
+            "id": 3,
+            "created_at": "2026-07-21T00:02:00.000Z",
+            "updated_at": "2026-07-21T00:02:00.000Z",
+            "section": "bubbles",
+            "unread_count": 1,
+            "title": "Scheduled follow-up",
+            "type": "Todo",
+            "bubble_up_at": "2026-08-01T00:00:00Z"
+          }
+        ]
+    """.trimIndent()
+
+    @Test
+    fun decodesBubbleUpsNotifications() {
+        val notifications = json.decodeFromString<List<Notification>>(fixtureJson)
+
+        assertEquals(2, notifications.size)
+
+        // Notification 0: current bubble-up (no scheduled bubble_up_at).
+        assertEquals(2L, notifications[0].id)
+        assertEquals("We won Leto!", notifications[0].title)
+        assertEquals("Message", notifications[0].type)
+        assertNull(notifications[0].bubbleUpAt)
+
+        // Notification 1: scheduled bubble-up carries bubble_up_at.
+        assertEquals("2026-08-01T00:00:00Z", notifications[1].bubbleUpAt)
+    }
+}

--- a/openapi.json
+++ b/openapi.json
@@ -9297,6 +9297,15 @@
               "description": "Page number for paginating through read items. Defaults to 1.",
               "format": "int32"
             }
+          },
+          {
+            "name": "limit_bubble_ups",
+            "in": "query",
+            "description": "Set to true to cap `bubble_ups` at 2 current bubble-ups and omit the\n`scheduled_bubble_ups` key entirely. Defaults to false. Use the dedicated\nbubble-ups endpoint (GetBubbleUps) to page through all current and\nscheduled bubble-ups.",
+            "schema": {
+              "type": "boolean",
+              "description": "Set to true to cap `bubble_ups` at 2 current bubble-ups and omit the\n`scheduled_bubble_ups` key entirely. Defaults to false. Use the dedicated\nbubble-ups endpoint (GetBubbleUps) to page through all current and\nscheduled bubble-ups."
+            }
           }
         ],
         "responses": {
@@ -9344,6 +9353,104 @@
         "tags": [
           "MyNotifications"
         ],
+        "x-basecamp-retry": {
+          "maxAttempts": 3,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
+    "/{accountId}/my/readings/bubble_ups.json": {
+      "get": {
+        "description": "Get the current user's current and scheduled bubble-ups as a paginated\nlist (50 per page). Current bubble-ups are returned first, ordered by most\nrecently bubbled up; scheduled bubble-ups follow, ordered by scheduled\nbubble-up time. Each item uses the same notification object shape as\nGetMyNotifications.",
+        "operationId": "GetBubbleUps",
+        "parameters": [
+          {
+            "name": "accountId",
+            "in": "path",
+            "description": "Basecamp account ID (numeric string)",
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]+$",
+              "description": "Basecamp account ID (numeric string)"
+            },
+            "required": true
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number. Defaults to 1.",
+            "schema": {
+              "type": "integer",
+              "description": "Page number. Defaults to 1.",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "GetBubbleUps 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetBubbleUpsResponseContent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "ForbiddenError 403 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenErrorResponseContent"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "RateLimitError 429 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "MyNotifications"
+        ],
+        "x-basecamp-pagination": {
+          "style": "link",
+          "totalCountHeader": "X-Total-Count",
+          "maxPageSize": 50
+        },
         "x-basecamp-retry": {
           "maxAttempts": 3,
           "baseDelayMs": 1000,
@@ -24301,6 +24408,12 @@
       "GetBoostResponseContent": {
         "$ref": "#/components/schemas/Boost"
       },
+      "GetBubbleUpsResponseContent": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Notification"
+        }
+      },
       "GetCampfireLineResponseContent": {
         "$ref": "#/components/schemas/CampfireLine"
       },
@@ -24405,6 +24518,16 @@
               "$ref": "#/components/schemas/Notification"
             }
           },
+          "bubble_ups_count": {
+            "type": "integer",
+            "description": "Total number of current bubble-ups, for notification UI counts\n(independent of the `limit_bubble_ups` cap on the `bubble_ups` array).",
+            "format": "int32"
+          },
+          "scheduled_bubble_ups_count": {
+            "type": "integer",
+            "description": "Total number of scheduled bubble-ups, for notification UI counts\n(present even when `limit_bubble_ups` omits the `scheduled_bubble_ups`\narray).",
+            "format": "int32"
+          },
           "memories": {
             "type": "array",
             "items": {
@@ -24426,7 +24549,11 @@
             },
             "description": "Bubble Ups scheduled to resurface in the future (BC5 addition)."
           }
-        }
+        },
+        "required": [
+          "bubble_ups_count",
+          "scheduled_bubble_ups_count"
+        ]
       },
       "GetMyPreferencesResponseContent": {
         "$ref": "#/components/schemas/Preferences"

--- a/openapi.json
+++ b/openapi.json
@@ -9366,7 +9366,7 @@
     },
     "/{accountId}/my/readings/bubble_ups.json": {
       "get": {
-        "description": "Get the current user's current and scheduled bubble-ups as a paginated\nlist (50 per page). Current bubble-ups are returned first, ordered by most\nrecently bubbled up; scheduled bubble-ups follow, ordered by scheduled\nbubble-up time. Each item uses the same notification object shape as\nGetMyNotifications.",
+        "description": "Get the current user's current and scheduled bubble-ups (paginated, 50 per page).\nCurrent bubble-ups are returned first, ordered by most recently bubbled up;\nscheduled bubble-ups follow, ordered by scheduled bubble-up time. Each item\nuses the same notification object shape as GetMyNotifications.",
         "operationId": "GetBubbleUps",
         "parameters": [
           {

--- a/python/src/basecamp/generated/metadata.json
+++ b/python/src/basecamp/generated/metadata.json
@@ -608,6 +608,17 @@
       ]
     }
   },
+  "GetBubbleUps": {
+    "retry": {
+      "backoff": "exponential",
+      "base_delay_ms": 1000,
+      "max": 3,
+      "retry_on": [
+        429,
+        503
+      ]
+    }
+  },
   "GetCampfire": {
     "retry": {
       "backoff": "exponential",

--- a/python/src/basecamp/generated/services/my_notifications.py
+++ b/python/src/basecamp/generated/services/my_notifications.py
@@ -11,11 +11,18 @@ from basecamp.hooks import OperationInfo
 
 
 class MyNotificationsService(BaseService):
-    def get_my_notifications(self, *, page: int | None = None) -> dict[str, Any]:
+    def get_my_notifications(self, *, page: int | None = None, limit_bubble_ups: bool | None = None) -> dict[str, Any]:
         return self._request(
             OperationInfo(service="mynotifications", operation="get_my_notifications", is_mutation=False),
             "GET",
             "/my/readings.json",
+            params=self._compact(page=page, limit_bubble_ups=limit_bubble_ups),
+        )
+
+    def get_bubble_ups(self, *, page: int | None = None) -> ListResult:
+        return self._request_paginated(
+            OperationInfo(service="mynotifications", operation="get_bubble_ups", is_mutation=False),
+            "/my/readings/bubble_ups.json",
             params=self._compact(page=page),
         )
 
@@ -30,11 +37,20 @@ class MyNotificationsService(BaseService):
 
 
 class AsyncMyNotificationsService(AsyncBaseService):
-    async def get_my_notifications(self, *, page: int | None = None) -> dict[str, Any]:
+    async def get_my_notifications(
+        self, *, page: int | None = None, limit_bubble_ups: bool | None = None
+    ) -> dict[str, Any]:
         return await self._request(
             OperationInfo(service="mynotifications", operation="get_my_notifications", is_mutation=False),
             "GET",
             "/my/readings.json",
+            params=self._compact(page=page, limit_bubble_ups=limit_bubble_ups),
+        )
+
+    async def get_bubble_ups(self, *, page: int | None = None) -> ListResult:
+        return await self._request_paginated(
+            OperationInfo(service="mynotifications", operation="get_bubble_ups", is_mutation=False),
+            "/my/readings/bubble_ups.json",
             params=self._compact(page=page),
         )
 

--- a/python/src/basecamp/generated/types.py
+++ b/python/src/basecamp/generated/types.py
@@ -730,9 +730,11 @@ class GetMyAssignmentsResponseContent(TypedDict):
 
 class GetMyNotificationsResponseContent(TypedDict):
     bubble_ups: NotRequired[list[Notification]]
+    bubble_ups_count: int
     memories: NotRequired[list[Notification]]
     reads: NotRequired[list[Notification]]
     scheduled_bubble_ups: NotRequired[list[Notification]]
+    scheduled_bubble_ups_count: int
     unreads: NotRequired[list[Notification]]
 
 

--- a/python/tests/services/test_my_notifications.py
+++ b/python/tests/services/test_my_notifications.py
@@ -1,0 +1,54 @@
+"""Tests for generated my_notifications service routes."""
+
+from __future__ import annotations
+
+import httpx
+import respx
+
+from basecamp import Client
+
+
+def _bubble_ups() -> list[dict]:
+    return [
+        {
+            "id": 2,
+            "created_at": "2026-07-21T00:01:43.009Z",
+            "updated_at": "2026-07-21T00:01:43.031Z",
+            "section": "bubbles",
+            "unread_count": 0,
+            "read_at": "2026-07-21T00:01:43.031Z",
+            "title": "We won Leto!",
+            "type": "Message",
+            "bucket_name": "The Leto Laptop",
+        },
+        {
+            "id": 3,
+            "created_at": "2026-07-21T00:02:00.000Z",
+            "updated_at": "2026-07-21T00:02:00.000Z",
+            "section": "bubbles",
+            "unread_count": 1,
+            "title": "Scheduled follow-up",
+            "type": "Todo",
+            "bubble_up_at": "2026-08-01T00:00:00Z",
+        },
+    ]
+
+
+class TestSyncMyNotifications:
+    @respx.mock
+    def test_get_bubble_ups_returns_parsed_readings(self):
+        route = respx.get("https://3.basecampapi.com/12345/my/readings/bubble_ups.json").mock(
+            return_value=httpx.Response(200, json=_bubble_ups())
+        )
+
+        from basecamp.generated.services.my_notifications import MyNotificationsService
+
+        account = Client(access_token="test-token").for_account("12345")
+        result = MyNotificationsService(account).get_bubble_ups()
+
+        assert route.called
+        assert len(result) == 2
+        assert result[0]["id"] == 2
+        assert result[0]["title"] == "We won Leto!"
+        assert result[0]["type"] == "Message"
+        assert result[1]["bubble_up_at"] == "2026-08-01T00:00:00Z"

--- a/python/tests/services/test_my_notifications.py
+++ b/python/tests/services/test_my_notifications.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import httpx
+import pytest
 import respx
 
 from basecamp import Client
@@ -52,3 +53,16 @@ class TestSyncMyNotifications:
         assert result[0]["title"] == "We won Leto!"
         assert result[0]["type"] == "Message"
         assert result[1]["bubble_up_at"] == "2026-08-01T00:00:00Z"
+
+    @respx.mock
+    def test_get_bubble_ups_propagates_not_found(self):
+        respx.get("https://3.basecampapi.com/12345/my/readings/bubble_ups.json").mock(
+            return_value=httpx.Response(404, json={"error": "Not found"})
+        )
+
+        from basecamp.errors import NotFoundError
+        from basecamp.generated.services.my_notifications import MyNotificationsService
+
+        account = Client(access_token="test-token").for_account("12345")
+        with pytest.raises(NotFoundError):
+            MyNotificationsService(account).get_bubble_ups()

--- a/python/tests/services/test_notifications.py
+++ b/python/tests/services/test_notifications.py
@@ -36,6 +36,8 @@ class TestSystemActorNormalization:
                     ],
                     "reads": [],
                     "memories": [],
+                    "bubble_ups_count": 0,
+                    "scheduled_bubble_ups_count": 0,
                 },
             )
         )
@@ -72,6 +74,8 @@ class TestSystemActorNormalization:
                     ],
                     "reads": [],
                     "memories": [],
+                    "bubble_ups_count": 0,
+                    "scheduled_bubble_ups_count": 0,
                 },
             )
         )

--- a/ruby/lib/basecamp/generated/metadata.json
+++ b/ruby/lib/basecamp/generated/metadata.json
@@ -1,7 +1,13 @@
 {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-07-27T08:00:45Z",
+<<<<<<< HEAD
+  "generated": "2026-07-27T05:56:36Z",
+||||||| parent of fe0ebcc7 (Absorb the Bubble Ups successor surface (bc3 #11628))
+  "generated": "2026-07-26T17:29:02Z",
+=======
+  "generated": "2026-07-25T07:14:10Z",
+>>>>>>> fe0ebcc7 (Absorb the Bubble Ups successor surface (bc3 #11628))
   "operations": {
     "GetAccount": {
       "retry": {
@@ -1191,6 +1197,22 @@
           429,
           503
         ]
+      }
+    },
+    "GetBubbleUps": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
       }
     },
     "MarkAsRead": {

--- a/ruby/lib/basecamp/generated/metadata.json
+++ b/ruby/lib/basecamp/generated/metadata.json
@@ -1,13 +1,7 @@
 {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-<<<<<<< HEAD
-  "generated": "2026-07-27T05:56:36Z",
-||||||| parent of fe0ebcc7 (Absorb the Bubble Ups successor surface (bc3 #11628))
-  "generated": "2026-07-26T17:29:02Z",
-=======
-  "generated": "2026-07-25T07:14:10Z",
->>>>>>> fe0ebcc7 (Absorb the Bubble Ups successor surface (bc3 #11628))
+  "generated": "2026-07-26T17:37:09Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/ruby/lib/basecamp/generated/services/my_notifications_service.rb
+++ b/ruby/lib/basecamp/generated/services/my_notifications_service.rb
@@ -9,10 +9,24 @@ module Basecamp
 
       # Get the current user's notification inbox (the "Hey!" menu).
       # @param page [Integer, nil] Page number for paginating through read items. Defaults to 1.
+      # @param limit_bubble_ups [Boolean, nil] Set to true to cap `bubble_ups` at 2 current bubble-ups and omit the
+      #   `scheduled_bubble_ups` key entirely. Defaults to false. Use the dedicated
+      #   bubble-ups endpoint (GetBubbleUps) to page through all current and
+      #   scheduled bubble-ups.
       # @return [Hash] response data
-      def get_my_notifications(page: nil)
+      def get_my_notifications(page: nil, limit_bubble_ups: nil)
         with_operation(service: "mynotifications", operation: "get_my_notifications", is_mutation: false) do
-          http_get("/my/readings.json", params: compact_query_params(page: page)).json
+          http_get("/my/readings.json", params: compact_query_params(page: page, limit_bubble_ups: limit_bubble_ups)).json
+        end
+      end
+
+      # Get the current user's current and scheduled bubble-ups as a paginated
+      # @param page [Integer, nil] Page number. Defaults to 1.
+      # @return [Enumerator<Hash>] paginated results
+      def get_bubble_ups(page: nil)
+        wrap_paginated(service: "mynotifications", operation: "get_bubble_ups", is_mutation: false) do
+          params = compact_query_params(page: page)
+          paginate("/my/readings/bubble_ups.json", params: params)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/my_notifications_service.rb
+++ b/ruby/lib/basecamp/generated/services/my_notifications_service.rb
@@ -20,7 +20,7 @@ module Basecamp
         end
       end
 
-      # Get the current user's current and scheduled bubble-ups as a paginated
+      # Get the current user's current and scheduled bubble-ups (paginated, 50 per page).
       # @param page [Integer, nil] Page number. Defaults to 1.
       # @return [Enumerator<Hash>] paginated results
       def get_bubble_ups(page: nil)

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
 # Auto-generated from OpenAPI spec. Do not edit manually.
-# Generated: 2026-07-27T08:00:45Z
+<<<<<<< HEAD
+# Generated: 2026-07-27T05:56:36Z
+||||||| parent of fe0ebcc7 (Absorb the Bubble Ups successor surface (bc3 #11628))
+# Generated: 2026-07-26T17:29:02Z
+=======
+# Generated: 2026-07-25T07:14:10Z
+>>>>>>> fe0ebcc7 (Absorb the Bubble Ups successor surface (bc3 #11628))
 
 require "json"
 require "time"
@@ -3579,7 +3585,7 @@ module Basecamp
           "all_day" => @all_day,
           "ends_at" => @ends_at,
           "starts_at" => @starts_at,
-        }.reject { |k, v| v.nil? && !["ends_at", "starts_at"].include?(k) }
+        }.compact
       end
 
       def to_json(*args)

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Auto-generated from OpenAPI spec. Do not edit manually.
-# Generated: 2026-07-26T17:37:09Z
+# Generated: 2026-07-27T07:13:42Z
 
 require "json"
 require "time"
@@ -3421,26 +3421,39 @@ module Basecamp
     # TimelineAttachment
     class TimelineAttachment
       include TypeHelpers
-      attr_accessor :app_download_url, :app_url, :attachable_sgid, :byte_size, :caption, :content_type, :created_at, :download_url, :filename, :height, :id, :key, :preview_url, :previewable, :sgid, :status, :status_url, :thumbnail_url, :title, :type, :updated_at, :url, :visible_to_clients, :width
+      attr_accessor :app_download_url, :app_url, :attachable_sgid, :bookmark_url, :boosts_count, :boosts_url, :bucket, :byte_size, :caption, :comments_count, :comments_url, :content_type, :created_at, :creator, :description, :description_attachments, :download_url, :filename, :height, :id, :inherits_status, :key, :parent, :position, :preview_url, :previewable, :sgid, :status, :status_url, :subscription_url, :thumbnail_url, :title, :type, :updated_at, :url, :visible_to_clients, :width
 
       def initialize(data = {})
         @app_download_url = data["app_download_url"]
         @app_url = data["app_url"]
         @attachable_sgid = data["attachable_sgid"]
+        @bookmark_url = data["bookmark_url"]
+        @boosts_count = parse_integer(data["boosts_count"])
+        @boosts_url = data["boosts_url"]
+        @bucket = parse_type(data["bucket"], "TodoBucket")
         @byte_size = parse_integer(data["byte_size"])
         @caption = data["caption"]
+        @comments_count = parse_integer(data["comments_count"])
+        @comments_url = data["comments_url"]
         @content_type = data["content_type"]
         @created_at = parse_datetime(data["created_at"])
+        @creator = parse_type(data["creator"], "Person")
+        @description = data["description"]
+        @description_attachments = parse_array(data["description_attachments"], "RichTextAttachment")
         @download_url = data["download_url"]
         @filename = data["filename"]
         @height = parse_integer(data["height"])
         @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
         @key = data["key"]
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @position = parse_integer(data["position"])
         @preview_url = data["preview_url"]
         @previewable = parse_boolean(data["previewable"])
         @sgid = data["sgid"]
         @status = data["status"]
         @status_url = data["status_url"]
+        @subscription_url = data["subscription_url"]
         @thumbnail_url = data["thumbnail_url"]
         @title = data["title"]
         @type = data["type"]
@@ -3455,20 +3468,33 @@ module Basecamp
           "app_download_url" => @app_download_url,
           "app_url" => @app_url,
           "attachable_sgid" => @attachable_sgid,
+          "bookmark_url" => @bookmark_url,
+          "boosts_count" => @boosts_count,
+          "boosts_url" => @boosts_url,
+          "bucket" => @bucket,
           "byte_size" => @byte_size,
           "caption" => @caption,
+          "comments_count" => @comments_count,
+          "comments_url" => @comments_url,
           "content_type" => @content_type,
           "created_at" => @created_at,
+          "creator" => @creator,
+          "description" => @description,
+          "description_attachments" => @description_attachments,
           "download_url" => @download_url,
           "filename" => @filename,
           "height" => @height,
           "id" => @id,
+          "inherits_status" => @inherits_status,
           "key" => @key,
+          "parent" => @parent,
+          "position" => @position,
           "preview_url" => @preview_url,
           "previewable" => @previewable,
           "sgid" => @sgid,
           "status" => @status,
           "status_url" => @status_url,
+          "subscription_url" => @subscription_url,
           "thumbnail_url" => @thumbnail_url,
           "title" => @title,
           "type" => @type,
@@ -3536,6 +3562,11 @@ module Basecamp
     class TimelineEventData
       include TypeHelpers
       attr_accessor :all_day, :ends_at, :starts_at
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[all_day ends_at starts_at].freeze
+      end
 
       def initialize(data = {})
         @all_day = parse_boolean(data["all_day"])

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Auto-generated from OpenAPI spec. Do not edit manually.
-# Generated: 2026-07-27T07:13:42Z
+# Generated: 2026-07-27T08:07:39Z
 
 require "json"
 require "time"
@@ -3579,7 +3579,7 @@ module Basecamp
           "all_day" => @all_day,
           "ends_at" => @ends_at,
           "starts_at" => @starts_at,
-        }.compact
+        }.reject { |k, v| v.nil? && !["ends_at", "starts_at"].include?(k) }
       end
 
       def to_json(*args)

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -1,13 +1,7 @@
 # frozen_string_literal: true
 
 # Auto-generated from OpenAPI spec. Do not edit manually.
-<<<<<<< HEAD
-# Generated: 2026-07-27T05:56:36Z
-||||||| parent of fe0ebcc7 (Absorb the Bubble Ups successor surface (bc3 #11628))
-# Generated: 2026-07-26T17:29:02Z
-=======
-# Generated: 2026-07-25T07:14:10Z
->>>>>>> fe0ebcc7 (Absorb the Bubble Ups successor surface (bc3 #11628))
+# Generated: 2026-07-26T17:37:09Z
 
 require "json"
 require "time"
@@ -3427,39 +3421,26 @@ module Basecamp
     # TimelineAttachment
     class TimelineAttachment
       include TypeHelpers
-      attr_accessor :app_download_url, :app_url, :attachable_sgid, :bookmark_url, :boosts_count, :boosts_url, :bucket, :byte_size, :caption, :comments_count, :comments_url, :content_type, :created_at, :creator, :description, :description_attachments, :download_url, :filename, :height, :id, :inherits_status, :key, :parent, :position, :preview_url, :previewable, :sgid, :status, :status_url, :subscription_url, :thumbnail_url, :title, :type, :updated_at, :url, :visible_to_clients, :width
+      attr_accessor :app_download_url, :app_url, :attachable_sgid, :byte_size, :caption, :content_type, :created_at, :download_url, :filename, :height, :id, :key, :preview_url, :previewable, :sgid, :status, :status_url, :thumbnail_url, :title, :type, :updated_at, :url, :visible_to_clients, :width
 
       def initialize(data = {})
         @app_download_url = data["app_download_url"]
         @app_url = data["app_url"]
         @attachable_sgid = data["attachable_sgid"]
-        @bookmark_url = data["bookmark_url"]
-        @boosts_count = parse_integer(data["boosts_count"])
-        @boosts_url = data["boosts_url"]
-        @bucket = parse_type(data["bucket"], "TodoBucket")
         @byte_size = parse_integer(data["byte_size"])
         @caption = data["caption"]
-        @comments_count = parse_integer(data["comments_count"])
-        @comments_url = data["comments_url"]
         @content_type = data["content_type"]
         @created_at = parse_datetime(data["created_at"])
-        @creator = parse_type(data["creator"], "Person")
-        @description = data["description"]
-        @description_attachments = parse_array(data["description_attachments"], "RichTextAttachment")
         @download_url = data["download_url"]
         @filename = data["filename"]
         @height = parse_integer(data["height"])
         @id = parse_integer(data["id"])
-        @inherits_status = parse_boolean(data["inherits_status"])
         @key = data["key"]
-        @parent = parse_type(data["parent"], "RecordingParent")
-        @position = parse_integer(data["position"])
         @preview_url = data["preview_url"]
         @previewable = parse_boolean(data["previewable"])
         @sgid = data["sgid"]
         @status = data["status"]
         @status_url = data["status_url"]
-        @subscription_url = data["subscription_url"]
         @thumbnail_url = data["thumbnail_url"]
         @title = data["title"]
         @type = data["type"]
@@ -3474,33 +3455,20 @@ module Basecamp
           "app_download_url" => @app_download_url,
           "app_url" => @app_url,
           "attachable_sgid" => @attachable_sgid,
-          "bookmark_url" => @bookmark_url,
-          "boosts_count" => @boosts_count,
-          "boosts_url" => @boosts_url,
-          "bucket" => @bucket,
           "byte_size" => @byte_size,
           "caption" => @caption,
-          "comments_count" => @comments_count,
-          "comments_url" => @comments_url,
           "content_type" => @content_type,
           "created_at" => @created_at,
-          "creator" => @creator,
-          "description" => @description,
-          "description_attachments" => @description_attachments,
           "download_url" => @download_url,
           "filename" => @filename,
           "height" => @height,
           "id" => @id,
-          "inherits_status" => @inherits_status,
           "key" => @key,
-          "parent" => @parent,
-          "position" => @position,
           "preview_url" => @preview_url,
           "previewable" => @previewable,
           "sgid" => @sgid,
           "status" => @status,
           "status_url" => @status_url,
-          "subscription_url" => @subscription_url,
           "thumbnail_url" => @thumbnail_url,
           "title" => @title,
           "type" => @type,
@@ -3568,11 +3536,6 @@ module Basecamp
     class TimelineEventData
       include TypeHelpers
       attr_accessor :all_day, :ends_at, :starts_at
-
-      # @return [Array<Symbol>]
-      def self.required_fields
-        %i[all_day ends_at starts_at].freeze
-      end
 
       def initialize(data = {})
         @all_day = parse_boolean(data["all_day"])

--- a/ruby/test/basecamp/services/my_notifications_service_test.rb
+++ b/ruby/test/basecamp/services/my_notifications_service_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Tests for the MyNotificationsService (generated from OpenAPI spec)
+
+require "test_helper"
+
+class MyNotificationsServiceTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @account = create_account_client(account_id: "12345")
+  end
+
+  def test_get_bubble_ups
+    bubble_ups = [
+      {
+        "id" => 2,
+        "created_at" => "2026-07-21T00:01:43.009Z",
+        "updated_at" => "2026-07-21T00:01:43.031Z",
+        "section" => "bubbles",
+        "unread_count" => 0,
+        "read_at" => "2026-07-21T00:01:43.031Z",
+        "title" => "We won Leto!",
+        "type" => "Message",
+        "bucket_name" => "The Leto Laptop"
+      },
+      {
+        "id" => 3,
+        "created_at" => "2026-07-21T00:02:00.000Z",
+        "updated_at" => "2026-07-21T00:02:00.000Z",
+        "section" => "bubbles",
+        "unread_count" => 1,
+        "title" => "Scheduled follow-up",
+        "type" => "Todo",
+        "bubble_up_at" => "2026-08-01T00:00:00Z"
+      }
+    ]
+
+    stub_get("/12345/my/readings/bubble_ups.json", response_body: bubble_ups)
+
+    result = @account.my_notifications.get_bubble_ups.to_a
+
+    assert_kind_of Array, result
+    assert_equal 2, result.length
+    assert_equal 2, result[0]["id"]
+    assert_equal "We won Leto!", result[0]["title"]
+    assert_equal "Message", result[0]["type"]
+    assert_equal "2026-08-01T00:00:00Z", result[1]["bubble_up_at"]
+  end
+end

--- a/ruby/test/basecamp/services/my_notifications_service_test.rb
+++ b/ruby/test/basecamp/services/my_notifications_service_test.rb
@@ -47,4 +47,12 @@ class MyNotificationsServiceTest < Minitest::Test
     assert_equal "Message", result[0]["type"]
     assert_equal "2026-08-01T00:00:00Z", result[1]["bubble_up_at"]
   end
+
+  def test_get_bubble_ups_propagates_not_found
+    stub_get("/12345/my/readings/bubble_ups.json", response_body: "", status: 404)
+
+    assert_raises(Basecamp::NotFoundError) do
+      @account.my_notifications.get_bubble_ups.to_a
+    end
+  end
 end

--- a/scripts/check-idempotency-parity
+++ b/scripts/check-idempotency-parity
@@ -106,11 +106,17 @@ jq -r '.operations | to_entries[] | select(.value.idempotent == true) | .key' "$
 jq -r '.operations | to_entries[] | select(.value.idempotent == true or .value.readonly == true) | .key' "$BM" \
     | sort > "$WORK/union169"
 
+# Expected source-of-truth counts. Bump `expected_union` deliberately when an
+# absorption adds readonly/idempotent operations (e.g. this stack's Bubble Ups
+# and Everything GET families). idempotent stays 69 (new GETs are not flagged
+# idempotent:true).
+expected_idempotent=69
+expected_union=170
 n69=$(wc -l < "$WORK/idempotent69" | tr -d ' ')
-n169=$(wc -l < "$WORK/union169" | tr -d ' ')
-echo "    source of truth: $n69 idempotent, $n169 idempotent∪readonly"
-if [[ "$n69" != "69" || "$n169" != "169" ]]; then
-    echo "  FAIL: unexpected source-of-truth counts (idempotent=$n69 want 69, union=$n169 want 169)"
+nUnion=$(wc -l < "$WORK/union169" | tr -d ' ')
+echo "    source of truth: $n69 idempotent, $nUnion idempotent∪readonly"
+if [[ "$n69" != "$expected_idempotent" || "$nUnion" != "$expected_union" ]]; then
+    echo "  FAIL: unexpected source-of-truth counts (idempotent=$n69 want $expected_idempotent, union=$nUnion want $expected_union)"
     echo "        behavior-model.json changed shape — update this check deliberately."
     fail=$((fail + 1))
 fi

--- a/scripts/check-idempotency-parity
+++ b/scripts/check-idempotency-parity
@@ -104,7 +104,7 @@ BM=behavior-model.json
 jq -r '.operations | to_entries[] | select(.value.idempotent == true) | .key' "$BM" \
     | sort > "$WORK/idempotent69"
 jq -r '.operations | to_entries[] | select(.value.idempotent == true or .value.readonly == true) | .key' "$BM" \
-    | sort > "$WORK/union169"
+    | sort > "$WORK/unionSet"
 
 # Expected source-of-truth counts. Bump `expected_union` deliberately when an
 # absorption adds readonly/idempotent operations (e.g. this stack's Bubble Ups
@@ -113,7 +113,7 @@ jq -r '.operations | to_entries[] | select(.value.idempotent == true or .value.r
 expected_idempotent=69
 expected_union=170
 n69=$(wc -l < "$WORK/idempotent69" | tr -d ' ')
-nUnion=$(wc -l < "$WORK/union169" | tr -d ' ')
+nUnion=$(wc -l < "$WORK/unionSet" | tr -d ' ')
 echo "    source of truth: $n69 idempotent, $nUnion idempotent∪readonly"
 if [[ "$n69" != "$expected_idempotent" || "$nUnion" != "$expected_union" ]]; then
     echo "  FAIL: unexpected source-of-truth counts (idempotent=$n69 want $expected_idempotent, union=$nUnion want $expected_union)"
@@ -169,12 +169,12 @@ GO=go/pkg/generated/client.gen.go
 awk '/var operationMetadata = map\[string\]OperationMetadata\{/{f=1} f; /^\}/{if(f)f=0}' "$GO" \
     | grep -E 'Idempotent: true' \
     | grep -oE '"[[:alnum:]]+":' | tr -d '":' | sort -u > "$WORK/go_table"
-compare "Go operationMetadata Idempotent:true set == 169" "$WORK/union169" "$WORK/go_table"
+compare "Go operationMetadata Idempotent:true set == 169" "$WORK/unionSet" "$WORK/go_table"
 # (2) call-site booleans: unique ops passed as doWithRetry(…, true, "Op", …).
 # This is the load-bearing value for the retry gate.
 grep -oE '\}, true, "[[:alnum:]]+",' "$GO" \
     | grep -oE '"[[:alnum:]]+"' | tr -d '"' | sort -u > "$WORK/go_callsite"
-compare "Go doWithRetry(…, true, …) call-site set == 169" "$WORK/union169" "$WORK/go_callsite"
+compare "Go doWithRetry(…, true, …) call-site set == 169" "$WORK/unionSet" "$WORK/go_callsite"
 # (3) table and call-site sets agree.
 compare "Go table set == call-site set" "$WORK/go_table" "$WORK/go_callsite"
 # (4) No idempotent op may carry a `false` doWithRetry call-site. Assertion (2)
@@ -186,7 +186,7 @@ compare "Go table set == call-site set" "$WORK/go_table" "$WORK/go_callsite"
 # idempotent ops bypass doWithRetry entirely — so this guards a future regression.)
 grep -oE '\}, false, "[[:alnum:]]+",' "$GO" \
     | grep -oE '"[[:alnum:]]+"' | tr -d '"' | sort -u > "$WORK/go_false_callsite"
-go_false_idempotent=$(comm -12 "$WORK/union169" "$WORK/go_false_callsite")
+go_false_idempotent=$(comm -12 "$WORK/unionSet" "$WORK/go_false_callsite")
 if [[ -z "$go_false_idempotent" ]]; then
     pass=$((pass + 1))
 else

--- a/scripts/check-idempotency-parity
+++ b/scripts/check-idempotency-parity
@@ -5,7 +5,7 @@
 #
 # The source of truth is behavior-model.json:
 #   * idempotent == true            → the 69 naturally-idempotent mutations
-#   * idempotent OR readonly == true → the 169 operations Go bakes idempotency
+#   * idempotent OR readonly == true → the idempotent∪readonly set Go bakes idempotency
 #                                      into at generation time (GET/HEAD are
 #                                      idempotent by construction, so Go folds
 #                                      the 100 read-only ops into its retry set).
@@ -14,14 +14,14 @@
 # EXACTLY (set equality, both directions — not subset):
 #
 #   * Non-Go SDKs' idempotent set == the 69.
-#   * Go's Idempotent:true set     == the 169 (idempotent ∪ readonly).
+#   * Go's Idempotent:true set     == the idempotent∪readonly set (count = expected_union).
 #
 # Go is checked FOUR ways, because the retry gate consumes an inline call-site
 # boolean (doWithRetry(…, true, "Op", …)) that is rendered INDEPENDENTLY from
 # the operationMetadata table. The call-site boolean is the load-bearing value
 # for retry, so both must be pinned and proven equal:
-#   (1) operationMetadata Idempotent:true set == 169
-#   (2) unique ops passed as doWithRetry(…, true, "Op", …) == 169
+#   (1) operationMetadata Idempotent:true set == $expected_union
+#   (2) unique ops passed as doWithRetry(…, true, "Op", …) == the idempotent∪readonly set
 #   (3) sets (1) and (2) are equal
 #   (4) no idempotent op carries a doWithRetry(…, false, "Op", …) call-site
 #       (assertion (2) sorts -u, so one variant regressing true→false could
@@ -69,7 +69,7 @@ pass=0
 compare() {
     local label="$1" expected="$2" actual="$3"
     local missing extra
-    # Fail closed: every set in this check is non-empty (69 or 169 ops). An
+    # Fail closed: every set in this check is non-empty (the 69 idempotent, or the union set). An
     # empty file means an extraction (grep/jq/awk/sed) matched nothing — a
     # broken adapter, not a real "empty == empty" match — so `comm` producing
     # no diff must not be counted as a pass.
@@ -169,12 +169,12 @@ GO=go/pkg/generated/client.gen.go
 awk '/var operationMetadata = map\[string\]OperationMetadata\{/{f=1} f; /^\}/{if(f)f=0}' "$GO" \
     | grep -E 'Idempotent: true' \
     | grep -oE '"[[:alnum:]]+":' | tr -d '":' | sort -u > "$WORK/go_table"
-compare "Go operationMetadata Idempotent:true set == 169" "$WORK/unionSet" "$WORK/go_table"
+compare "Go operationMetadata Idempotent:true set == $expected_union" "$WORK/unionSet" "$WORK/go_table"
 # (2) call-site booleans: unique ops passed as doWithRetry(…, true, "Op", …).
 # This is the load-bearing value for the retry gate.
 grep -oE '\}, true, "[[:alnum:]]+",' "$GO" \
     | grep -oE '"[[:alnum:]]+"' | tr -d '"' | sort -u > "$WORK/go_callsite"
-compare "Go doWithRetry(…, true, …) call-site set == 169" "$WORK/unionSet" "$WORK/go_callsite"
+compare "Go doWithRetry(…, true, …) call-site set == $expected_union" "$WORK/unionSet" "$WORK/go_callsite"
 # (3) table and call-site sets agree.
 compare "Go table set == call-site set" "$WORK/go_table" "$WORK/go_callsite"
 # (4) No idempotent op may carry a `false` doWithRetry call-site. Assertion (2)
@@ -182,7 +182,7 @@ compare "Go table set == call-site set" "$WORK/go_table" "$WORK/go_callsite"
 # WithBody sibling both render a doWithRetry call for the same op); a single
 # variant regressing true→false would otherwise hide behind a sibling's true.
 # So separately assert the set of ops passed as doWithRetry(…, false, …) is
-# disjoint from the 169. (Today there are zero `false` call-sites — non-
+# disjoint from the idempotent∪readonly set. (Today there are zero `false` call-sites — non-
 # idempotent ops bypass doWithRetry entirely — so this guards a future regression.)
 grep -oE '\}, false, "[[:alnum:]]+",' "$GO" \
     | grep -oE '"[[:alnum:]]+"' | tr -d '"' | sort -u > "$WORK/go_false_callsite"

--- a/spec/api-gaps/README.md
+++ b/spec/api-gaps/README.md
@@ -62,6 +62,7 @@ making the absorption journey publicly auditable.
 | [my-assignments-priorities](my-assignments-priorities.md) | addressed-in-bc3-pr-12380 | master | medium |
 | [dock-tool-visible-to-clients](dock-tool-visible-to-clients.md) | absorbed-in-sdk | post-train | low |
 | [card-table-wormholes](card-table-wormholes.md) | absorbed-in-sdk | post-train | medium |
+| [bubble-ups-surface](bubble-ups-surface.md) | absorbed-in-sdk | launch | high |
 
 > Statuses reflect how BC3's **BC5 API train** actually shipped (8 PRs merged
 > to `master`, 2026-07-18..21); BC3 #10947 closed unmerged, superseded by the

--- a/spec/api-gaps/bubble-ups-surface.md
+++ b/spec/api-gaps/bubble-ups-surface.md
@@ -1,0 +1,102 @@
+---
+gap: bubble-ups-surface
+status: absorbed-in-sdk
+detected: 2026-07-24
+sdk_demand: high
+bc3_pr: 11628
+smithy_refs:
+  - "GetMyNotificationsOutput.bubble_ups_count member (spec/basecamp.smithy:8745)"
+  - "GetMyNotificationsOutput.scheduled_bubble_ups_count member (spec/basecamp.smithy:8751)"
+  - "GetMyNotificationsInput.limit_bubble_ups member (spec/basecamp.smithy:8735)"
+  - "GetBubbleUps operation (spec/basecamp.smithy:8803)"
+bc3_refs:
+  introduced_in: master
+  routes:
+    - "GET /:account_id/my/readings.json (existing GetMyNotifications — bubble_ups_count/scheduled_bubble_ups_count/limit_bubble_ups additive)"
+    - "GET /:account_id/my/readings/bubble_ups.json (new — paginated bubble-ups list)"
+  controllers:
+    - app/controllers/my/readings_controller.rb
+    - app/controllers/my/readings/bubble_ups_controller.rb
+  related_existing_api:
+    - GetMyNotifications
+---
+
+# Bubble Ups successor surface (counts, limit param, dedicated list)
+
+## What's missing
+
+The bubble-up successor surface on `doc/api/sections/my_notifications.md`
+(codified by BC3 **#11628**) that
+[[memories-emptied-regression]] explicitly **defers to a separate additive
+PR**. That entry settles the subtractive `memories: []` delta and — by its own
+scope statement — leaves the adjacent bubble-up additions to this entry:
+
+- **`bubble_ups_count` / `scheduled_bubble_ups_count`** — top-level integer
+  counts on `GET /my/readings.json`, for notification-UI badges. Present
+  independent of the `limit_bubble_ups` cap (and `scheduled_bubble_ups_count`
+  is returned even when the `scheduled_bubble_ups` array is omitted).
+- **`limit_bubble_ups`** — optional boolean query param on `GET
+  /my/readings.json`: set `true` to cap `bubble_ups` at 2 current items and
+  **omit the `scheduled_bubble_ups` key entirely**. Defaults to `false`.
+- **`GET /my/readings/bubble_ups.json`** — a **new** dedicated operation
+  returning the current user's current and scheduled bubble-ups as a
+  **paginated bare array** (50 per page, Link-header pagination). Current
+  bubble-ups are returned first (ordered by most recently bubbled up), then
+  scheduled bubble-ups (ordered by scheduled bubble-up time). Each item uses
+  the same notification object shape as `GET /my/readings.json`. This is **not**
+  "the ≤50 most-recently-read `bubble_ups` field" — it is the full,
+  page-through-able current+scheduled list.
+
+The grouped `bubble_ups` / `scheduled_bubble_ups` arrays and their notification
+item fields (`bubble_up_url`, `bubble_up_at`, …) were **already modeled** on
+`GetMyNotificationsOutput` / `Notification`; this entry does not re-add them.
+
+## Why it matters
+
+Bubble Up is the BC5 successor to the BC4 "save forever" `memories` collection.
+Without the counts, integrations can't render notification badges without
+over-fetching; without the dedicated endpoint, they can only see the capped
+`bubble_ups` field on the readings payload and cannot page through the full
+current+scheduled set; without `limit_bubble_ups`, a lightweight badge fetch
+still pays for the full scheduled list.
+
+## Suggested API shape
+
+- Additive required `bubble_ups_count` / `scheduled_bubble_ups_count` integers
+  on the existing `GetMyNotificationsOutput`.
+- Additive optional `limit_bubble_ups: Boolean` `@httpQuery` on
+  `GetMyNotificationsInput`.
+- New `GetBubbleUps` operation (`GET /my/readings/bubble_ups.json`) with an
+  optional `page` query param and `@basecampPagination(style: "link", …)`,
+  returning a bare `NotificationList`.
+
+## Implementation notes for BC3
+
+Shipped — nothing pending. `my/readings_controller.rb` renders the counts and
+honors `limit_bubble_ups`; `my/readings/bubble_ups_controller.rb` serves the
+paginated dedicated list. `doc/api/sections/my_notifications.md` on `master`
+is the contract of record (codified by BC3 #11628).
+
+## SDK absorption plan when this lands
+
+Absorbed (basecamp-sdk PR-3 of the post-#401 follow-up program).
+
+- Added required `bubble_ups_count` / `scheduled_bubble_ups_count` to
+  `GetMyNotificationsOutput` and optional `limit_bubble_ups` to
+  `GetMyNotificationsInput`.
+- Added the new `GetBubbleUps` operation (bare-array, Link-paginated, `page`
+  query param) with tag/service mapping and the Go wrapper
+  (`MyNotificationsService.BubbleUps`, following the Link header across all
+  pages by default; a positive page returns only that page).
+- The Go `Get` wrapper gained a non-breaking `WithLimitBubbleUps()` option.
+- Tests: a Go **multi-page** pagination test for `BubbleUps` (Link-following +
+  `X-Total-Count` metadata, current-then-scheduled ordering), a single-page
+  test, and a test proving `limit_bubble_ups=true` sends the param and decodes
+  a response that **omits `scheduled_bubble_ups`** while keeping the counts.
+- Registry: this is a **new** entry — [[memories-emptied-regression]] keeps its
+  status and `pairwise`-retirement explanation intact; its scope was the
+  subtractive empty-`memories` delta, which explicitly deferred these
+  successors here.
+- Canary: a `GetBubbleUps` entry validates statically in
+  `live-my-surface.json` (the live canary is dormant pending a safe token
+  mechanism).

--- a/spec/basecamp.smithy
+++ b/spec/basecamp.smithy
@@ -291,6 +291,7 @@ service Basecamp {
 
     // Batch 16 - My Notifications
     GetMyNotifications,
+    GetBubbleUps,
     MarkAsRead,
 
     // Batch 17 - Out of Office
@@ -8759,11 +8760,29 @@ structure GetMyNotificationsInput {
   /// Page number for paginating through read items. Defaults to 1.
   @httpQuery("page")
   page: Integer
+
+  /// Set to true to cap `bubble_ups` at 2 current bubble-ups and omit the
+  /// `scheduled_bubble_ups` key entirely. Defaults to false. Use the dedicated
+  /// bubble-ups endpoint (GetBubbleUps) to page through all current and
+  /// scheduled bubble-ups.
+  @httpQuery("limit_bubble_ups")
+  limit_bubble_ups: Boolean
 }
 
 structure GetMyNotificationsOutput {
   unreads: NotificationList
   reads: NotificationList
+
+  /// Total number of current bubble-ups, for notification UI counts
+  /// (independent of the `limit_bubble_ups` cap on the `bubble_ups` array).
+  @required
+  bubble_ups_count: Integer
+
+  /// Total number of scheduled bubble-ups, for notification UI counts
+  /// (present even when `limit_bubble_ups` omits the `scheduled_bubble_ups`
+  /// array).
+  @required
+  scheduled_bubble_ups_count: Integer
 
   /// Legacy "save forever" collection. Permanently `[]` on BC5 by documented
   /// contract (`doc/api/sections/my_notifications.md`, codified by BC3 #11628):
@@ -8805,6 +8824,35 @@ structure MarkAsReadInput {
 }
 
 structure MarkAsReadOutput {}
+
+/// Get the current user's current and scheduled bubble-ups as a paginated
+/// list (50 per page). Current bubble-ups are returned first, ordered by most
+/// recently bubbled up; scheduled bubble-ups follow, ordered by scheduled
+/// bubble-up time. Each item uses the same notification object shape as
+/// GetMyNotifications.
+@readonly
+@basecampRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
+@basecampPagination(style: "link", totalCountHeader: "X-Total-Count", maxPageSize: 50)
+@http(method: "GET", uri: "/{accountId}/my/readings/bubble_ups.json")
+operation GetBubbleUps {
+  input: GetBubbleUpsInput
+  output: GetBubbleUpsOutput
+  errors: [UnauthorizedError, ForbiddenError, RateLimitError, InternalServerError]
+}
+
+structure GetBubbleUpsInput {
+  @required
+  @httpLabel
+  accountId: AccountId
+
+  /// Page number. Defaults to 1.
+  @httpQuery("page")
+  page: Integer
+}
+
+structure GetBubbleUpsOutput {
+  bubble_ups: NotificationList
+}
 
 // ===== Notification Shapes =====
 

--- a/spec/basecamp.smithy
+++ b/spec/basecamp.smithy
@@ -8825,11 +8825,10 @@ structure MarkAsReadInput {
 
 structure MarkAsReadOutput {}
 
-/// Get the current user's current and scheduled bubble-ups as a paginated
-/// list (50 per page). Current bubble-ups are returned first, ordered by most
-/// recently bubbled up; scheduled bubble-ups follow, ordered by scheduled
-/// bubble-up time. Each item uses the same notification object shape as
-/// GetMyNotifications.
+/// Get the current user's current and scheduled bubble-ups (paginated, 50 per page).
+/// Current bubble-ups are returned first, ordered by most recently bubbled up;
+/// scheduled bubble-ups follow, ordered by scheduled bubble-up time. Each item
+/// uses the same notification object shape as GetMyNotifications.
 @readonly
 @basecampRetry(maxAttempts: 3, baseDelayMs: 1000, backoff: "exponential", retryOn: [429, 503])
 @basecampPagination(style: "link", totalCountHeader: "X-Total-Count", maxPageSize: 50)

--- a/spec/overlays/tags.smithy
+++ b/spec/overlays/tags.smithy
@@ -221,6 +221,7 @@ apply GetMyDueAssignments @tags(["MyAssignments"])
 
 // My Notifications
 apply GetMyNotifications @tags(["MyNotifications"])
+apply GetBubbleUps @tags(["MyNotifications"])
 apply MarkAsRead @tags(["MyNotifications"])
 
 // Out of Office

--- a/swift/Sources/Basecamp/Generated/Metadata.swift
+++ b/swift/Sources/Basecamp/Generated/Metadata.swift
@@ -57,6 +57,7 @@ enum Metadata {
         "GetAnswersByPerson": RetryConfig(maxAttempts: 3, baseDelayMs: 1000, backoff: .exponential, retryOn: [429, 503]),
         "GetAssignedTodos": RetryConfig(maxAttempts: 3, baseDelayMs: 1000, backoff: .exponential, retryOn: [429, 503]),
         "GetBoost": RetryConfig(maxAttempts: 3, baseDelayMs: 1000, backoff: .exponential, retryOn: [429, 503]),
+        "GetBubbleUps": RetryConfig(maxAttempts: 3, baseDelayMs: 1000, backoff: .exponential, retryOn: [429, 503]),
         "GetCampfire": RetryConfig(maxAttempts: 3, baseDelayMs: 1000, backoff: .exponential, retryOn: [429, 503]),
         "GetCampfireLine": RetryConfig(maxAttempts: 3, baseDelayMs: 1000, backoff: .exponential, retryOn: [429, 503]),
         "GetCard": RetryConfig(maxAttempts: 3, baseDelayMs: 1000, backoff: .exponential, retryOn: [429, 503]),

--- a/swift/Sources/Basecamp/Generated/Models/GetMyNotificationsResponseContent.swift
+++ b/swift/Sources/Basecamp/Generated/Models/GetMyNotificationsResponseContent.swift
@@ -2,9 +2,29 @@
 import Foundation
 
 public struct GetMyNotificationsResponseContent: Codable, Sendable {
+    public let bubbleUpsCount: Int32
+    public let scheduledBubbleUpsCount: Int32
     public var bubbleUps: [Notification]?
     public var memories: [Notification]?
     public var reads: [Notification]?
     public var scheduledBubbleUps: [Notification]?
     public var unreads: [Notification]?
+
+    public init(
+        bubbleUpsCount: Int32,
+        scheduledBubbleUpsCount: Int32,
+        bubbleUps: [Notification]? = nil,
+        memories: [Notification]? = nil,
+        reads: [Notification]? = nil,
+        scheduledBubbleUps: [Notification]? = nil,
+        unreads: [Notification]? = nil
+    ) {
+        self.bubbleUpsCount = bubbleUpsCount
+        self.scheduledBubbleUpsCount = scheduledBubbleUpsCount
+        self.bubbleUps = bubbleUps
+        self.memories = memories
+        self.reads = reads
+        self.scheduledBubbleUps = scheduledBubbleUps
+        self.unreads = unreads
+    }
 }

--- a/swift/Sources/Basecamp/Generated/Services/MyNotificationsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/MyNotificationsService.swift
@@ -1,20 +1,49 @@
 // @generated from OpenAPI spec — do not edit directly
 import Foundation
 
+public struct BubbleUpsMyNotificationOptions: Sendable {
+    public var page: Int?
+    public var maxItems: Int?
+
+    public init(page: Int? = nil, maxItems: Int? = nil) {
+        self.page = page
+        self.maxItems = maxItems
+    }
+}
+
 public struct MyNotificationsMyNotificationOptions: Sendable {
     public var page: Int?
+    public var limitBubbleUps: Bool?
 
-    public init(page: Int? = nil) {
+    public init(page: Int? = nil, limitBubbleUps: Bool? = nil) {
         self.page = page
+        self.limitBubbleUps = limitBubbleUps
     }
 }
 
 
 public final class MyNotificationsService: BaseService, @unchecked Sendable {
+    public func bubbleUps(options: BubbleUpsMyNotificationOptions? = nil) async throws -> ListResult<Notification> {
+        var queryItems: [URLQueryItem] = []
+        if let page = options?.page {
+            queryItems.append(URLQueryItem(name: "page", value: String(page)))
+        }
+        return try await requestPaginated(
+            OperationInfo(service: "MyNotifications", operation: "GetBubbleUps", resourceType: "bubble_up", isMutation: false),
+            path: "/my/readings/bubble_ups.json",
+            queryItems: queryItems.isEmpty ? nil : queryItems,
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            retryConfig: Metadata.retryConfig(for: "GetBubbleUps")
+        )
+    }
+
     public func myNotifications(options: MyNotificationsMyNotificationOptions? = nil) async throws -> GetMyNotificationsResponseContent {
         var queryItems: [URLQueryItem] = []
         if let page = options?.page {
             queryItems.append(URLQueryItem(name: "page", value: String(page)))
+        }
+        if let limitBubbleUps = options?.limitBubbleUps {
+            queryItems.append(URLQueryItem(name: "limit_bubble_ups", value: String(limitBubbleUps)))
         }
         return try await request(
             OperationInfo(service: "MyNotifications", operation: "GetMyNotifications", resourceType: "my_notification", isMutation: false),

--- a/swift/Tests/BasecampTests/GeneratedServiceTests.swift
+++ b/swift/Tests/BasecampTests/GeneratedServiceTests.swift
@@ -954,20 +954,6 @@ final class GeneratedServiceTests: XCTestCase {
         XCTAssertNil(events[4].data?.startsAt)
         XCTAssertNil(events[4].data?.endsAt)
     }
-}
-
-/// Records operation-start callbacks so tests can assert emitted metadata.
-private final class SpyHooks: BasecampHooks, @unchecked Sendable {
-    private let lock = NSLock()
-    private var _operationStarts: [OperationInfo] = []
-
-    var operationStarts: [OperationInfo] {
-        lock.withLock { _operationStarts }
-    }
-
-    func onOperationStart(_ info: OperationInfo) {
-        lock.withLock { _operationStarts.append(info) }
-    }
 
     // MARK: - GetBubbleUps (paginated bare-array decode)
 
@@ -1013,5 +999,19 @@ private final class SpyHooks: BasecampHooks, @unchecked Sendable {
 
         let sentURL = transport.lastRequest!.request.url!.absoluteString
         XCTAssertTrue(sentURL.hasSuffix("/my/readings/bubble_ups.json"), "Got \(sentURL)")
+    }
+}
+
+/// Records operation-start callbacks so tests can assert emitted metadata.
+private final class SpyHooks: BasecampHooks, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _operationStarts: [OperationInfo] = []
+
+    var operationStarts: [OperationInfo] {
+        lock.withLock { _operationStarts }
+    }
+
+    func onOperationStart(_ info: OperationInfo) {
+        lock.withLock { _operationStarts.append(info) }
     }
 }

--- a/swift/Tests/BasecampTests/GeneratedServiceTests.swift
+++ b/swift/Tests/BasecampTests/GeneratedServiceTests.swift
@@ -968,4 +968,50 @@ private final class SpyHooks: BasecampHooks, @unchecked Sendable {
     func onOperationStart(_ info: OperationInfo) {
         lock.withLock { _operationStarts.append(info) }
     }
+
+    // MARK: - GetBubbleUps (paginated bare-array decode)
+
+    // Bubble-ups return a bare array of Notification. Proves the full decode path
+    // (.convertFromSnakeCase) maps bubble_up_at → bubbleUpAt and carries type/title.
+    func testBubbleUpsDecodesNotifications() async throws {
+        let fixture = """
+        [
+          {
+            "id": 2,
+            "created_at": "2026-07-21T00:01:43.009Z",
+            "updated_at": "2026-07-21T00:01:43.031Z",
+            "section": "bubbles",
+            "unread_count": 0,
+            "read_at": "2026-07-21T00:01:43.031Z",
+            "title": "We won Leto!",
+            "type": "Message",
+            "bucket_name": "The Leto Laptop"
+          },
+          {
+            "id": 3,
+            "created_at": "2026-07-21T00:02:00.000Z",
+            "updated_at": "2026-07-21T00:02:00.000Z",
+            "section": "bubbles",
+            "unread_count": 1,
+            "title": "Scheduled follow-up",
+            "type": "Todo",
+            "bubble_up_at": "2026-08-01T00:00:00Z"
+          }
+        ]
+        """
+        let transport = MockTransport(statusCode: 200, data: Data(fixture.utf8),
+                                      headers: ["X-Total-Count": "2"])
+        let account = makeTestAccountClient(transport: transport)
+
+        let bubbleUps = try await account.myNotifications.bubbleUps()
+
+        XCTAssertEqual(bubbleUps.count, 2)
+        XCTAssertEqual(bubbleUps[0].id, 2)
+        XCTAssertEqual(bubbleUps[0].title, "We won Leto!")
+        XCTAssertEqual(bubbleUps[0].type, "Message")
+        XCTAssertEqual(bubbleUps[1].bubbleUpAt, "2026-08-01T00:00:00Z")
+
+        let sentURL = transport.lastRequest!.request.url!.absoluteString
+        XCTAssertTrue(sentURL.hasSuffix("/my/readings/bubble_ups.json"), "Got \(sentURL)")
+    }
 }

--- a/typescript/scripts/generate-services.ts
+++ b/typescript/scripts/generate-services.ts
@@ -458,6 +458,7 @@ const TYPE_ALIASES: Record<string, [string, "response" | "request" | "entity"]> 
   ClientCorrespondence: ["ClientCorrespondence", "entity"],
   ClientReply: ["ClientReply", "entity"],
   TimelineEvent: ["TimelineEvent", "entity"],
+  Notification: ["Notification", "entity"],
   TimesheetEntry: ["TimesheetEntry", "entity"],
 };
 

--- a/typescript/src/generated/metadata.ts
+++ b/typescript/src/generated/metadata.ts
@@ -37,7 +37,7 @@ export interface MetadataOutput {
 const metadata: MetadataOutput = {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-07-27T08:00:45.224Z",
+  "generated": "2026-07-25T07:14:09.617Z",
   "operations": {
     "GetAccount": {
       "retry": {
@@ -1227,6 +1227,22 @@ const metadata: MetadataOutput = {
           429,
           503
         ]
+      }
+    },
+    "GetBubbleUps": {
+      "retry": {
+        "maxAttempts": 3,
+        "baseDelayMs": 1000,
+        "backoff": "exponential",
+        "retryOn": [
+          429,
+          503
+        ]
+      },
+      "pagination": {
+        "style": "link",
+        "totalCountHeader": "X-Total-Count",
+        "maxPageSize": 50
       }
     },
     "MarkAsRead": {

--- a/typescript/src/generated/metadata.ts
+++ b/typescript/src/generated/metadata.ts
@@ -37,7 +37,7 @@ export interface MetadataOutput {
 const metadata: MetadataOutput = {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-07-25T07:14:09.617Z",
+  "generated": "2026-07-26T17:37:09.045Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/typescript/src/generated/openapi-stripped.json
+++ b/typescript/src/generated/openapi-stripped.json
@@ -8326,7 +8326,7 @@
     },
     "/my/readings/bubble_ups.json": {
       "get": {
-        "description": "Get the current user's current and scheduled bubble-ups as a paginated\nlist (50 per page). Current bubble-ups are returned first, ordered by most\nrecently bubbled up; scheduled bubble-ups follow, ordered by scheduled\nbubble-up time. Each item uses the same notification object shape as\nGetMyNotifications.",
+        "description": "Get the current user's current and scheduled bubble-ups (paginated, 50 per page).\nCurrent bubble-ups are returned first, ordered by most recently bubbled up;\nscheduled bubble-ups follow, ordered by scheduled bubble-up time. Each item\nuses the same notification object shape as GetMyNotifications.",
         "operationId": "GetBubbleUps",
         "parameters": [
           {

--- a/typescript/src/generated/openapi-stripped.json
+++ b/typescript/src/generated/openapi-stripped.json
@@ -8257,6 +8257,15 @@
               "description": "Page number for paginating through read items. Defaults to 1.",
               "format": "int32"
             }
+          },
+          {
+            "name": "limit_bubble_ups",
+            "in": "query",
+            "description": "Set to true to cap `bubble_ups` at 2 current bubble-ups and omit the\n`scheduled_bubble_ups` key entirely. Defaults to false. Use the dedicated\nbubble-ups endpoint (GetBubbleUps) to page through all current and\nscheduled bubble-ups.",
+            "schema": {
+              "type": "boolean",
+              "description": "Set to true to cap `bubble_ups` at 2 current bubble-ups and omit the\n`scheduled_bubble_ups` key entirely. Defaults to false. Use the dedicated\nbubble-ups endpoint (GetBubbleUps) to page through all current and\nscheduled bubble-ups."
+            }
           }
         ],
         "responses": {
@@ -8304,6 +8313,93 @@
         "tags": [
           "MyNotifications"
         ],
+        "x-basecamp-retry": {
+          "maxAttempts": 3,
+          "baseDelayMs": 1000,
+          "backoff": "exponential",
+          "retryOn": [
+            429,
+            503
+          ]
+        }
+      }
+    },
+    "/my/readings/bubble_ups.json": {
+      "get": {
+        "description": "Get the current user's current and scheduled bubble-ups as a paginated\nlist (50 per page). Current bubble-ups are returned first, ordered by most\nrecently bubbled up; scheduled bubble-ups follow, ordered by scheduled\nbubble-up time. Each item uses the same notification object shape as\nGetMyNotifications.",
+        "operationId": "GetBubbleUps",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number. Defaults to 1.",
+            "schema": {
+              "type": "integer",
+              "description": "Page number. Defaults to 1.",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "GetBubbleUps 200 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GetBubbleUpsResponseContent"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError 401 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorResponseContent"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "ForbiddenError 403 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForbiddenErrorResponseContent"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "RateLimitError 429 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitErrorResponseContent"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "InternalServerError 500 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InternalServerErrorResponseContent"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "MyNotifications"
+        ],
+        "x-basecamp-pagination": {
+          "style": "link",
+          "totalCountHeader": "X-Total-Count",
+          "maxPageSize": 50
+        },
         "x-basecamp-retry": {
           "maxAttempts": 3,
           "baseDelayMs": 1000,
@@ -21923,6 +22019,12 @@
       "GetBoostResponseContent": {
         "$ref": "#/components/schemas/Boost"
       },
+      "GetBubbleUpsResponseContent": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Notification"
+        }
+      },
       "GetCampfireLineResponseContent": {
         "$ref": "#/components/schemas/CampfireLine"
       },
@@ -22027,6 +22129,16 @@
               "$ref": "#/components/schemas/Notification"
             }
           },
+          "bubble_ups_count": {
+            "type": "integer",
+            "description": "Total number of current bubble-ups, for notification UI counts\n(independent of the `limit_bubble_ups` cap on the `bubble_ups` array).",
+            "format": "int32"
+          },
+          "scheduled_bubble_ups_count": {
+            "type": "integer",
+            "description": "Total number of scheduled bubble-ups, for notification UI counts\n(present even when `limit_bubble_ups` omits the `scheduled_bubble_ups`\narray).",
+            "format": "int32"
+          },
           "memories": {
             "type": "array",
             "items": {
@@ -22048,7 +22160,11 @@
             },
             "description": "Bubble Ups scheduled to resurface in the future (BC5 addition)."
           }
-        }
+        },
+        "required": [
+          "bubble_ups_count",
+          "scheduled_bubble_ups_count"
+        ]
       },
       "GetMyPreferencesResponseContent": {
         "$ref": "#/components/schemas/Preferences"

--- a/typescript/src/generated/path-mapping.ts
+++ b/typescript/src/generated/path-mapping.ts
@@ -195,6 +195,7 @@ export const PATH_TO_OPERATION: Record<string, string> = {
   "PUT:/{accountId}/my/profile.json": "UpdateMyProfile",
   "GET:/{accountId}/my/question_reminders.json": "GetQuestionReminders",
   "GET:/{accountId}/my/readings.json": "GetMyNotifications",
+  "GET:/{accountId}/my/readings/bubble_ups.json": "GetBubbleUps",
   "PUT:/{accountId}/my/unreads.json": "MarkAsRead",
 
   // Projects

--- a/typescript/src/generated/schema.d.ts
+++ b/typescript/src/generated/schema.d.ts
@@ -1168,6 +1168,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/my/readings/bubble_ups.json": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * @description Get the current user's current and scheduled bubble-ups as a paginated
+         *     list (50 per page). Current bubble-ups are returned first, ordered by most
+         *     recently bubbled up; scheduled bubble-ups follow, ordered by scheduled
+         *     bubble-up time. Each item uses the same notification object shape as
+         *     GetMyNotifications.
+         */
+        get: operations["GetBubbleUps"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/my/unreads.json": {
         parameters: {
             query?: never;
@@ -3380,6 +3403,7 @@ export interface components {
             todos?: components["schemas"]["Todo"][];
         };
         GetBoostResponseContent: components["schemas"]["Boost"];
+        GetBubbleUpsResponseContent: components["schemas"]["Notification"][];
         GetCampfireLineResponseContent: components["schemas"]["CampfireLine"];
         GetCampfireResponseContent: components["schemas"]["Campfire"];
         GetCardColumnResponseContent: components["schemas"]["CardColumn"];
@@ -3409,6 +3433,19 @@ export interface components {
         GetMyNotificationsResponseContent: {
             unreads?: components["schemas"]["Notification"][];
             reads?: components["schemas"]["Notification"][];
+            /**
+             * Format: int32
+             * @description Total number of current bubble-ups, for notification UI counts
+             *     (independent of the `limit_bubble_ups` cap on the `bubble_ups` array).
+             */
+            bubble_ups_count: number;
+            /**
+             * Format: int32
+             * @description Total number of scheduled bubble-ups, for notification UI counts
+             *     (present even when `limit_bubble_ups` omits the `scheduled_bubble_ups`
+             *     array).
+             */
+            scheduled_bubble_ups_count: number;
             /**
              * @description Legacy "save forever" collection. Permanently `[]` on BC5 by documented
              *     contract (`doc/api/sections/my_notifications.md`, codified by BC3 #11628):
@@ -10831,6 +10868,13 @@ export interface operations {
             query?: {
                 /** @description Page number for paginating through read items. Defaults to 1. */
                 page?: number;
+                /**
+                 * @description Set to true to cap `bubble_ups` at 2 current bubble-ups and omit the
+                 *     `scheduled_bubble_ups` key entirely. Defaults to false. Use the dedicated
+                 *     bubble-ups endpoint (GetBubbleUps) to page through all current and
+                 *     scheduled bubble-ups.
+                 */
+                limit_bubble_ups?: boolean;
             };
             header?: never;
             path?: never;
@@ -10863,6 +10907,65 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ForbiddenErrorResponseContent"];
+                };
+            };
+            /** @description InternalServerError 500 response */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InternalServerErrorResponseContent"];
+                };
+            };
+        };
+    };
+    GetBubbleUps: {
+        parameters: {
+            query?: {
+                /** @description Page number. Defaults to 1. */
+                page?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description GetBubbleUps 200 response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetBubbleUpsResponseContent"];
+                };
+            };
+            /** @description UnauthorizedError 401 response */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UnauthorizedErrorResponseContent"];
+                };
+            };
+            /** @description ForbiddenError 403 response */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForbiddenErrorResponseContent"];
+                };
+            };
+            /** @description RateLimitError 429 response */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RateLimitErrorResponseContent"];
                 };
             };
             /** @description InternalServerError 500 response */

--- a/typescript/src/generated/schema.d.ts
+++ b/typescript/src/generated/schema.d.ts
@@ -1176,11 +1176,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * @description Get the current user's current and scheduled bubble-ups as a paginated
-         *     list (50 per page). Current bubble-ups are returned first, ordered by most
-         *     recently bubbled up; scheduled bubble-ups follow, ordered by scheduled
-         *     bubble-up time. Each item uses the same notification object shape as
-         *     GetMyNotifications.
+         * @description Get the current user's current and scheduled bubble-ups (paginated, 50 per page).
+         *     Current bubble-ups are returned first, ordered by most recently bubbled up;
+         *     scheduled bubble-ups follow, ordered by scheduled bubble-up time. Each item
+         *     uses the same notification object shape as GetMyNotifications.
          */
         get: operations["GetBubbleUps"];
         put?: never;

--- a/typescript/src/generated/services/my-notifications.ts
+++ b/typescript/src/generated/services/my-notifications.ts
@@ -85,7 +85,7 @@ export class MyNotificationsService extends BaseService {
   }
 
   /**
-   * Get the current user's current and scheduled bubble-ups as a paginated
+   * Get the current user's current and scheduled bubble-ups (paginated, 50 per page).
    * @param options - Optional query parameters
    * @returns All Notification across all pages, with .meta.totalCount
    *

--- a/typescript/src/generated/services/my-notifications.ts
+++ b/typescript/src/generated/services/my-notifications.ts
@@ -6,18 +6,35 @@
 
 import { BaseService } from "../../services/base.js";
 import type { components } from "../schema.js";
+import { ListResult } from "../../pagination.js";
+import type { PaginationOptions } from "../../pagination.js";
 import { Errors } from "../../errors.js";
 
 // =============================================================================
 // Types
 // =============================================================================
 
+/** Notification entity from the Basecamp API. */
+export type Notification = components["schemas"]["Notification"];
 
 /**
  * Options for myNotifications.
  */
 export interface MyNotificationsMyNotificationOptions {
   /** Page number for paginating through read items. Defaults to 1. */
+  page?: number;
+  /** Set to true to cap `bubble_ups` at 2 current bubble-ups and omit the
+`scheduled_bubble_ups` key entirely. Defaults to false. Use the dedicated
+bubble-ups endpoint (GetBubbleUps) to page through all current and
+scheduled bubble-ups. */
+  limitBubbleUps?: boolean;
+}
+
+/**
+ * Options for bubbleUps.
+ */
+export interface BubbleUpsMyNotificationOptions extends PaginationOptions {
+  /** Page number. Defaults to 1. */
   page?: number;
 }
 
@@ -60,11 +77,39 @@ export class MyNotificationsService extends BaseService {
       () =>
         this.client.GET("/my/readings.json", {
           params: {
-            query: { page: options?.page },
+            query: { page: options?.page, "limit_bubble_ups": options?.limitBubbleUps },
           },
         })
     );
     return response;
+  }
+
+  /**
+   * Get the current user's current and scheduled bubble-ups as a paginated
+   * @param options - Optional query parameters
+   * @returns All Notification across all pages, with .meta.totalCount
+   *
+   * @example
+   * ```ts
+   * const result = await client.myNotifications.bubbleUps();
+   * ```
+   */
+  async bubbleUps(options?: BubbleUpsMyNotificationOptions): Promise<ListResult<Notification>> {
+    return this.requestPaginated(
+      {
+        service: "MyNotifications",
+        operation: "GetBubbleUps",
+        resourceType: "bubble_up",
+        isMutation: false,
+      },
+      () =>
+        this.client.GET("/my/readings/bubble_ups.json", {
+          params: {
+            query: { page: options?.page },
+          },
+        })
+      , options
+    );
   }
 
   /**

--- a/typescript/tests/services/my-notifications.test.ts
+++ b/typescript/tests/services/my-notifications.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../setup.js";
 import { createBasecampClient } from "../../src/client.js";
+import { BasecampError } from "../../src/errors.js";
 import type { BasecampClient } from "../../src/client.js";
 
 const BASE_URL = "https://3.basecampapi.com/12345";
@@ -188,6 +189,16 @@ describe("MyNotificationsService", () => {
       expect(result[0]!.title).toBe("We won Leto!");
       expect((result[0] as Record<string, unknown>).type).toBe("Message");
       expect((result[1] as Record<string, unknown>).bubble_up_at).toBe("2026-08-01T00:00:00Z");
+    });
+
+    it("should propagate a 4xx as a BasecampError", async () => {
+      server.use(
+        http.get(`${BASE_URL}/my/readings/bubble_ups.json`, () => {
+          return HttpResponse.json({ error: "Not found" }, { status: 404 });
+        })
+      );
+
+      await expect(client.myNotifications.bubbleUps()).rejects.toThrow(BasecampError);
     });
   });
 });

--- a/typescript/tests/services/my-notifications.test.ts
+++ b/typescript/tests/services/my-notifications.test.ts
@@ -41,6 +41,8 @@ describe("MyNotificationsService", () => {
             ],
             reads: [],
             memories: [],
+            bubble_ups_count: 0,
+            scheduled_bubble_ups_count: 0,
           });
         })
       );
@@ -74,6 +76,8 @@ describe("MyNotificationsService", () => {
             ],
             reads: [],
             memories: [],
+            bubble_ups_count: 0,
+            scheduled_bubble_ups_count: 0,
           });
         })
       );
@@ -106,6 +110,8 @@ describe("MyNotificationsService", () => {
             ],
             reads: [],
             memories: [],
+            bubble_ups_count: 0,
+            scheduled_bubble_ups_count: 0,
           });
         })
       );
@@ -138,6 +144,8 @@ describe("MyNotificationsService", () => {
             ],
             reads: [],
             memories: [],
+            bubble_ups_count: 0,
+            scheduled_bubble_ups_count: 0,
           });
         })
       );

--- a/typescript/tests/services/my-notifications.test.ts
+++ b/typescript/tests/services/my-notifications.test.ts
@@ -156,29 +156,32 @@ describe("MyNotificationsService", () => {
     it("should return current and scheduled bubble-ups", async () => {
       server.use(
         http.get(`${BASE_URL}/my/readings/bubble_ups.json`, () => {
-          return HttpResponse.json([
-            {
-              id: 2,
-              created_at: "2026-07-21T00:01:43.009Z",
-              updated_at: "2026-07-21T00:01:43.031Z",
-              section: "bubbles",
-              unread_count: 0,
-              read_at: "2026-07-21T00:01:43.031Z",
-              title: "We won Leto!",
-              type: "Message",
-              bucket_name: "The Leto Laptop",
-            },
-            {
-              id: 3,
-              created_at: "2026-07-21T00:02:00.000Z",
-              updated_at: "2026-07-21T00:02:00.000Z",
-              section: "bubbles",
-              unread_count: 1,
-              title: "Scheduled follow-up",
-              type: "Todo",
-              bubble_up_at: "2026-08-01T00:00:00Z",
-            },
-          ]);
+          return HttpResponse.json(
+            [
+              {
+                id: 2,
+                created_at: "2026-07-21T00:01:43.009Z",
+                updated_at: "2026-07-21T00:01:43.031Z",
+                section: "bubbles",
+                unread_count: 0,
+                read_at: "2026-07-21T00:01:43.031Z",
+                title: "We won Leto!",
+                type: "Message",
+                bucket_name: "The Leto Laptop",
+              },
+              {
+                id: 3,
+                created_at: "2026-07-21T00:02:00.000Z",
+                updated_at: "2026-07-21T00:02:00.000Z",
+                section: "bubbles",
+                unread_count: 1,
+                title: "Scheduled follow-up",
+                type: "Todo",
+                bubble_up_at: "2026-08-01T00:00:00Z",
+              },
+            ],
+            { headers: { "X-Total-Count": "2" } }
+          );
         })
       );
 
@@ -189,6 +192,8 @@ describe("MyNotificationsService", () => {
       expect(result[0]!.title).toBe("We won Leto!");
       expect((result[0] as Record<string, unknown>).type).toBe("Message");
       expect((result[1] as Record<string, unknown>).bubble_up_at).toBe("2026-08-01T00:00:00Z");
+      // Paginated: the ListResult carries the X-Total-Count metadata.
+      expect(result.meta.totalCount).toBe(2);
     });
 
     it("should propagate a 4xx as a BasecampError", async () => {

--- a/typescript/tests/services/my-notifications.test.ts
+++ b/typescript/tests/services/my-notifications.test.ts
@@ -150,4 +150,44 @@ describe("MyNotificationsService", () => {
       expect(creatorObj.system_label).toBe("9223372036854775808");
     });
   });
+
+  describe("bubbleUps", () => {
+    it("should return current and scheduled bubble-ups", async () => {
+      server.use(
+        http.get(`${BASE_URL}/my/readings/bubble_ups.json`, () => {
+          return HttpResponse.json([
+            {
+              id: 2,
+              created_at: "2026-07-21T00:01:43.009Z",
+              updated_at: "2026-07-21T00:01:43.031Z",
+              section: "bubbles",
+              unread_count: 0,
+              read_at: "2026-07-21T00:01:43.031Z",
+              title: "We won Leto!",
+              type: "Message",
+              bucket_name: "The Leto Laptop",
+            },
+            {
+              id: 3,
+              created_at: "2026-07-21T00:02:00.000Z",
+              updated_at: "2026-07-21T00:02:00.000Z",
+              section: "bubbles",
+              unread_count: 1,
+              title: "Scheduled follow-up",
+              type: "Todo",
+              bubble_up_at: "2026-08-01T00:00:00Z",
+            },
+          ]);
+        })
+      );
+
+      const result = await client.myNotifications.bubbleUps();
+
+      expect(result).toHaveLength(2);
+      expect(result[0]!.id).toBe(2);
+      expect(result[0]!.title).toBe("We won Leto!");
+      expect((result[0] as Record<string, unknown>).type).toBe("Message");
+      expect((result[1] as Record<string, unknown>).bubble_up_at).toBe("2026-08-01T00:00:00Z");
+    });
+  });
 });


### PR DESCRIPTION
Closes #425. Part of the post-#401 BC3 follow-up absorption program (**PR-3**).

> **Stacked on #424 (PR-2) → #419 (PR-1) → #416 (PR-0).** Base is `timeline-additive-fields`; review the PR-3 commit only. Will retarget to `main` as the stack merges.

## Summary

`doc/api/sections/my_notifications.md` (codified by bc3 **#11628**) documents the BC5 bubble-up surface that `memories-emptied-regression.md` **explicitly defers to a separate additive PR**. This absorbs it.

## Changes

- **`GetMyNotificationsOutput`**: required `bubble_ups_count` + `scheduled_bubble_ups_count`.
- **`GetMyNotificationsInput`**: optional `limit_bubble_ups` boolean `@httpQuery` (`true` caps `bubble_ups` at 2 and omits `scheduled_bubble_ups`).
- **New `GetBubbleUps`** op (`GET /my/readings/bubble_ups.json`): paginated bare array (50/page, Link-header pagination, `page` param), current bubble-ups first then scheduled. Added to the service list + tagged.
- **Go wrapper**: `MyNotificationsService.BubbleUps` (Link-follows all pages by default; positive `page` = single page); `Get` gained a non-breaking `WithLimitBubbleUps()` option.

## Tests

Go: an **explicit multi-page** Link-following pagination test (with `X-Total-Count` metadata + current-then-scheduled ordering), a single-page test, and a test proving **`limit_bubble_ups=true` permits omission of `scheduled_bubble_ups`** while keeping the counts.

## Registry & notes

New `bubble-ups-surface.md` entry (`absorbed-in-sdk`); **`memories-emptied-regression.md` left fully intact** (its scope is the subtractive empty-`memories` delta and its `pairwise`-retirement explanation). Updated the `GetMyNotifications` conformance validator fixtures for the now-required counts; added a `GetBubbleUps` canary entry (validates statically; live dormant).

## Verification

`make generate && make check` — clean (24 api-gap entries validated).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Bubble Ups successor surface: top‑level counts in GetMyNotifications (with limit_bubble_ups) and a new paginated GET /my/readings/bubble_ups.json. This reduces over‑fetching and lets clients page current and scheduled bubble‑ups.

- **New Features**
  - GetMyNotifications: required bubble_ups_count and scheduled_bubble_ups_count; optional limit_bubble_ups caps bubble_ups at 2 and omits scheduled_bubble_ups (TypeScript schema validator updated).
  - New GET /my/readings/bubble_ups.json: bare array, 50/page with Link pagination and X-Total-Count; current first then scheduled; retries on 429/503; tagged as bubble_up; live canary and dispatch registered.
  - SDKs: Go adds BubbleUps() (auto-follows Link pages; positive page returns a single page) and GetWithOptions(..., WithLimitBubbleUps()); TypeScript/Python/Ruby/Swift/Kotlin add matching methods, pagination metadata, and 404 propagation tests; Kotlin models regenerated; Swift test discovered and running.
  - Conformance/docs/scripts: behavior model includes GetBubbleUps; docs show 209 ops (69 idempotent / 140 non‑idempotent); idempotency‑parity union bumped to 170 and made count‑agnostic; fixtures/stubs updated to include required counts.

- **Bug Fixes**
  - Go: preserved Get(ctx, page) signature (new GetWithOptions for flags); BubbleUps(ctx, page>0) now sets Meta.Truncated from a next‑link; bubble‑ups fixtures include required timestamps; completed the first‑line GetBubbleUps doc.

<sup>Written for commit 27eb7816d617ff5c9f0506e7c00a14eccf8a9c96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

