### PR TITLE
Hygiene: cross-ref rich-text attachments in recordable-subtypes plan

### DIFF
--- a/spec/api-gaps/recordable-subtypes-doc.md
+++ b/spec/api-gaps/recordable-subtypes-doc.md
@@ -85,6 +85,11 @@ Journal::Entry — there is no contract to model.
   do not model ahead of a BC3 contract.
 - Where Recording is polymorphic, extend the discriminated structure with the
   new `type` values.
+- `CloudFile` and `GoogleDocument` are rich-text emitters: their responses
+  carry their own `*_attachments` companion arrays (see
+  [[rich-text-attachments-coverage]]). Model those members alongside the base
+  shapes at absorption time so the rich-text projection stays complete — a
+  newly-absorbed subtype must not silently drop its companion array.
 - Door now has its own documented surface (list/create/get/rename/trash) and is
   tracked under [[external-links-doors]] — model it there, not here. It still
   also appears as a string `type` value on generic Recording responses.

--- a/spec/api-gaps/rich-text-attachments-coverage.md
+++ b/spec/api-gaps/rich-text-attachments-coverage.md
@@ -52,8 +52,9 @@ bc3_refs:
 > file metadata (documented in upstream `doc/api/sections/rich_text.md`,
 > addressed by bc3 #9980). The gap was SDK-side: the SDK modeled the rich-text
 > *strings* but not their companion attachment arrays. #400 shipped the first
-> slice (`Todo.description_attachments`); **#405 completes coverage across every
-> modeled rich-text decode path** and flips this entry to `absorbed-in-sdk`.
+> slice (`Todo.description_attachments`); **#408 (closes #405) completes
+> coverage across every modeled rich-text decode path** and flips this entry to
+> `absorbed-in-sdk`.
 > This is absorption, not a provenance sync — the contract was already within
 > the current pin, so no repin.
 
@@ -91,7 +92,7 @@ SDK decodes now carries its companion array, reusing `RichTextAttachment` +
 
 - **Generic `attachments` key on SearchResult** (`searches/show:25`): the
   recording's aggregate downloadable files, a *different* projection concern, not
-  a rich-text companion array. Not modeled; tracked separately if demanded.
+  a rich-text companion array. Not modeled; tracked in #428.
 - **everything/aggregates endpoints** (`everything/*`, which also render full
   partials): **unmodeled in the SDK** — no decode path exists to carry an array
   into. Covered by the separate `everything-aggregates.md` gap
@@ -158,7 +159,7 @@ Complete. Shipped in two increments, both reusing `RichTextAttachment`:
    float-tolerant dimension representation — Go `types.FlexInt`, Kotlin
    `FlexibleIntSerializer` on a nullable `Int?`, Swift `Int32?`, Python
    `int | float`, Ruby nilable — is documented in SPEC.md §10 Type Fidelity.
-2. **#405 (this PR):** `content_attachments` / `description_attachments` on the
+2. **#408 (merged #405):** `content_attachments` / `description_attachments` on the
    remaining 17 structures (19 members) — 14 concrete `@required`, Gauge and the
    two polymorphic projections (SearchResult, Recording) optional/non-nullable —
    reusing `RichTextAttachment` and the same per-SDK decode assertions unchanged.

--- a/spec/api-gaps/rich-text-attachments-coverage.md
+++ b/spec/api-gaps/rich-text-attachments-coverage.md
@@ -159,7 +159,7 @@ Complete. Shipped in two increments, both reusing `RichTextAttachment`:
    float-tolerant dimension representation — Go `types.FlexInt`, Kotlin
    `FlexibleIntSerializer` on a nullable `Int?`, Swift `Int32?`, Python
    `int | float`, Ruby nilable — is documented in SPEC.md §10 Type Fidelity.
-2. **#408 (merged #405):** `content_attachments` / `description_attachments` on the
+2. **#408 (closes #405):** `content_attachments` / `description_attachments` on the
    remaining 17 structures (19 members) — 14 concrete `@required`, Gauge and the
    two polymorphic projections (SearchResult, Recording) optional/non-nullable —
    reusing `RichTextAttachment` and the same per-SDK decode assertions unchanged.


### PR DESCRIPTION
Follow-up hygiene track after #408 (rich-text `*_attachments` coverage).

## What

Adds a forward-looking cross-reference to `recordable-subtypes-doc.md`:
`CloudFile` and `GoogleDocument` are rich-text emitters, so their eventual
absorption must carry their own `*_attachments` companion arrays — otherwise
the rich-text projection coverage completed in #408 would silently regress for
the newly-modeled subtypes.

## Companion issue work (this track, not code)

- **Closes #355** — the Go `Todo` model now carries all three fields it flagged
  (`completion_subscribers`, `comments_count` via #375; `description_attachments`
  via #400). Verified present in `go/pkg/basecamp/todos.go`.
  Note: the retrospective mis-cited these as #372; the actual PR is **#375**.
- **Files one new issue (#428): `SearchResult.attachments`** — the generic aggregate
  downloadable-files key (`searches/show.json.jbuilder:25`) is a `SearchResult`
  field, not a generic Recording field; unmodeled aggregate projection, low
  demand.
- No issues filed for clients/forwards + clients/introductions — not standalone
  modeled decode paths; already recorded as demand-gated in
  `rich-text-attachments-coverage.md`.

## Verify

- `make validate-api-gaps` clean (23 entries).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cross-reference in `recordable-subtypes-doc.md` so `CloudFile` and `GoogleDocument` keep their own `*_attachments` arrays when absorbed, preserving rich‑text coverage from #408. Also updates `rich-text-attachments-coverage.md` to point provenance to #408 (closes #405), standardize that phrasing, and link the out‑of‑scope `SearchResult.attachments` to #428; closes #355.

<sup>Written for commit f975a26b48aec10483b9442fb18bebbff9436f8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

