### PR TITLE
Absorb external-links (doors) list surface; defer create/image/composite (bc3 #12375)

### DIFF
--- a/conformance/runner/typescript/live-dispatch.ts
+++ b/conformance/runner/typescript/live-dispatch.ts
@@ -86,7 +86,12 @@ export const LIVE_OPERATIONS: Record<string, DispatchSpec> = {
     call: async (ctx) => {
       // Backs the type=Door external-links canary; validates the door shape
       // (external url + service + description) against the Recording schema.
-      const result = await ctx.client.recordings.list("Door");
+      //
+      // maxItems caps pagination: without it, requestPaginated would follow every
+      // Link page for an account with many Door recordings — potentially a large
+      // number of credentialed requests and an oversized snapshot. A handful of
+      // rows is plenty to validate the Recording (Door) schema.
+      const result = await ctx.client.recordings.list("Door", { maxItems: 5 });
       return { resolvedIds: {}, result };
     },
   },

--- a/conformance/runner/typescript/live-dispatch.ts
+++ b/conformance/runner/typescript/live-dispatch.ts
@@ -99,7 +99,10 @@ export const LIVE_OPERATIONS: Record<string, DispatchSpec> = {
   GetProgressReport: {
     fixtures: [],
     call: async (ctx) => {
-      const result = await ctx.client.reports.progress();
+      // maxItems caps pagination: the progress feed can be very long on an
+      // active account, and requestPaginated would otherwise follow every Link
+      // page. A small sample is enough to validate the TimelineEvent schema.
+      const result = await ctx.client.reports.progress({ maxItems: 5 });
       return { resolvedIds: {}, result };
     },
   },

--- a/conformance/runner/typescript/live-dispatch.ts
+++ b/conformance/runner/typescript/live-dispatch.ts
@@ -81,13 +81,28 @@ export const LIVE_OPERATIONS: Record<string, DispatchSpec> = {
     },
   },
 
+  ListRecordings: {
+    fixtures: [],
+    call: async (ctx) => {
+      // Backs the type=Door external-links canary; validates the door shape
+      // (external url + service + description) against the Recording schema.
+      const result = await ctx.client.recordings.list("Door");
+      return { resolvedIds: {}, result };
+    },
+  },
+
+  GetProgressReport: {
+    fixtures: [],
+    call: async (ctx) => {
+      const result = await ctx.client.reports.progress();
+      return { resolvedIds: {}, result };
+    },
+  },
+
   GetBubbleUps: {
     fixtures: [],
     call: async (ctx) => {
-      // maxItems caps pagination: bubble_ups is a paginated feed (50/page), so a
-      // small sample validates the Notification schema without following every
-      // Link page on an active account.
-      const result = await ctx.client.myNotifications.bubbleUps({ maxItems: 5 });
+      const result = await ctx.client.myNotifications.bubbleUps();
       return { resolvedIds: {}, result };
     },
   },

--- a/conformance/runner/typescript/live-dispatch.ts
+++ b/conformance/runner/typescript/live-dispatch.ts
@@ -110,7 +110,10 @@ export const LIVE_OPERATIONS: Record<string, DispatchSpec> = {
   GetBubbleUps: {
     fixtures: [],
     call: async (ctx) => {
-      const result = await ctx.client.myNotifications.bubbleUps();
+      // maxItems caps pagination: bubble_ups is a paginated feed (50/page), so a
+      // small sample validates the Notification schema without following every
+      // Link page on an active account.
+      const result = await ctx.client.myNotifications.bubbleUps({ maxItems: 5 });
       return { resolvedIds: {}, result };
     },
   },

--- a/conformance/tests/live-my-surface.json
+++ b/conformance/tests/live-my-surface.json
@@ -182,5 +182,19 @@
       { "type": "liveCallSucceeds" },
       { "type": "liveSchemaValidate" }
     ]
+  },
+  {
+    "mode": "live",
+    "name": "ListRecordings type=Door decodes the external-link (door) shape",
+    "description": "DECODING coverage for the absorbed external-links/doors list surface (spec/api-gaps/external-links-doors.md, bc3 #12375). Drives the type=Door recordings query and validates each recording against the Recording schema, including the door-specific url/service/description/position fields. Live-dormant: validates statically until credentials are provisioned. Create/image/composite remain residual gaps (see the entry).",
+    "operation": "ListRecordings",
+    "method": "GET",
+    "path": "/projects/recordings.json",
+    "queryParams": { "type": "Door" },
+    "tags": ["live", "read-only", "bc5-additive"],
+    "liveAssertions": [
+      { "type": "liveCallSucceeds" },
+      { "type": "liveSchemaValidate" }
+    ]
   }
 ]

--- a/go/pkg/basecamp/recordings.go
+++ b/go/pkg/basecamp/recordings.go
@@ -17,6 +17,7 @@ type RecordingType string
 const (
 	RecordingTypeComment        RecordingType = "Comment"
 	RecordingTypeDocument       RecordingType = "Document"
+	RecordingTypeDoor           RecordingType = "Door"
 	RecordingTypeKanbanCard     RecordingType = "Kanban::Card"
 	RecordingTypeKanbanStep     RecordingType = "Kanban::Step"
 	RecordingTypeMessage        RecordingType = "Message"
@@ -61,9 +62,28 @@ type Recording struct {
 	CommentsCount          int                   `json:"comments_count,omitempty"`
 	CommentsURL            string                `json:"comments_url,omitempty"`
 	SubscriptionURL        string                `json:"subscription_url,omitempty"`
-	Parent                 *Parent               `json:"parent,omitempty"`
-	Bucket                 *Bucket               `json:"bucket,omitempty"`
-	Creator                *Person               `json:"creator,omitempty"`
+	// Position, Description, and Service are door-specific (external-link)
+	// fields, populated only on Door recordings returned by the type=Door
+	// recordings query (the only endpoint that returns the full door shape).
+	// See spec/api-gaps/external-links-doors.md.
+	Position    int32        `json:"position,omitempty"`
+	Description string       `json:"description,omitempty"`
+	Service     *DoorService `json:"service,omitempty"`
+	Parent      *Parent      `json:"parent,omitempty"`
+	Bucket      *Bucket      `json:"bucket,omitempty"`
+	Creator     *Person      `json:"creator,omitempty"`
+}
+
+// DoorService describes the recognized external service backing an external
+// link (Door recording): its display name, a canonical example URL, a short
+// code (or "other" for a generic link), the URL patterns Basecamp recognizes,
+// and human supporting text.
+type DoorService struct {
+	Name           string   `json:"name,omitempty"`
+	ExampleURL     string   `json:"example_url,omitempty"`
+	Code           string   `json:"code,omitempty"`
+	ValidPatterns  []string `json:"valid_patterns,omitempty"`
+	SupportingText string   `json:"supporting_text,omitempty"`
 }
 
 // DefaultRecordingLimit is the default number of recordings to return when no limit is specified.
@@ -424,6 +444,20 @@ func recordingFromGenerated(gr generated.Recording) Recording {
 
 	r.ContentAttachments = richTextAttachmentsPtrFromGenerated(gr.ContentAttachments)
 	r.DescriptionAttachments = richTextAttachmentsPtrFromGenerated(gr.DescriptionAttachments)
+
+	// Door-specific fields (populated only for type=Door recordings).
+	r.Position = gr.Position
+	r.Description = gr.Description
+	if gr.Service.Name != "" || gr.Service.Code != "" || gr.Service.ExampleUrl != "" ||
+		gr.Service.SupportingText != "" || len(gr.Service.ValidPatterns) > 0 {
+		r.Service = &DoorService{
+			Name:           gr.Service.Name,
+			ExampleURL:     gr.Service.ExampleUrl,
+			Code:           gr.Service.Code,
+			ValidPatterns:  append([]string(nil), gr.Service.ValidPatterns...),
+			SupportingText: gr.Service.SupportingText,
+		}
+	}
 
 	return r
 }

--- a/go/pkg/basecamp/recordings_test.go
+++ b/go/pkg/basecamp/recordings_test.go
@@ -1,7 +1,10 @@
 package basecamp
 
 import (
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -289,7 +292,10 @@ func TestRecordingType_Constants(t *testing.T) {
 
 // TestRecording_UnmarshalDoor verifies that a type=Door recording (external
 // link) decodes with the full door shape — the outside url, the service struct,
-// the description, and the position — through the shared Recording projection.
+// the description, and the position. The fixture is driven through the real
+// RecordingsService.List pipeline (generated decode -> recordingFromGenerated)
+// so it fails if the generated Door fields or the converter assignments regress,
+// not merely if the hand-written Recording type can decode the JSON.
 func TestRecording_UnmarshalDoor(t *testing.T) {
 	data := `[
 		{
@@ -317,14 +323,30 @@ func TestRecording_UnmarshalDoor(t *testing.T) {
 		}
 	]`
 
-	var recordings []Recording
-	if err := json.Unmarshal([]byte(data), &recordings); err != nil {
-		t.Fatalf("failed to unmarshal door recording: %v", err)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/99999/projects/recordings.json" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("type"); got != "Door" {
+			t.Errorf("expected type=Door query, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(data))
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := DefaultConfig()
+	cfg.BaseURL = server.URL
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+	result, err := client.ForAccount("99999").Recordings().List(context.Background(), "Door", nil)
+	if err != nil {
+		t.Fatalf("List(Door) failed: %v", err)
 	}
-	if len(recordings) != 1 {
-		t.Fatalf("expected 1 recording, got %d", len(recordings))
+	if len(result.Recordings) != 1 {
+		t.Fatalf("expected 1 recording, got %d", len(result.Recordings))
 	}
-	d := recordings[0]
+	d := result.Recordings[0]
 	if d.Type != "Door" {
 		t.Errorf("expected type Door, got %q", d.Type)
 	}

--- a/go/pkg/basecamp/recordings_test.go
+++ b/go/pkg/basecamp/recordings_test.go
@@ -268,6 +268,7 @@ func TestRecordingType_Constants(t *testing.T) {
 	}{
 		{RecordingTypeComment, "Comment"},
 		{RecordingTypeDocument, "Document"},
+		{RecordingTypeDoor, "Door"},
 		{RecordingTypeKanbanCard, "Kanban::Card"},
 		{RecordingTypeKanbanStep, "Kanban::Step"},
 		{RecordingTypeMessage, "Message"},
@@ -283,6 +284,86 @@ func TestRecordingType_Constants(t *testing.T) {
 		if string(tc.typ) != tc.expected {
 			t.Errorf("RecordingType %v: expected %q, got %q", tc.typ, tc.expected, string(tc.typ))
 		}
+	}
+}
+
+// TestRecording_UnmarshalDoor verifies that a type=Door recording (external
+// link) decodes with the full door shape — the outside url, the service struct,
+// the description, and the position — through the shared Recording projection.
+func TestRecording_UnmarshalDoor(t *testing.T) {
+	data := `[
+		{
+			"id": 1069480290,
+			"status": "active",
+			"visible_to_clients": false,
+			"created_at": "2026-07-22T15:51:54.872Z",
+			"updated_at": "2026-07-22T15:51:54.886Z",
+			"title": "Design system",
+			"inherits_status": true,
+			"type": "Door",
+			"url": "https://www.figma.com/file/abc123/Design-system",
+			"app_url": "https://3.basecampapi.com/195539477/buckets/2085958504/dock/doors/1069480290",
+			"position": 8,
+			"bucket": {"id": 2085958504, "name": "The Leto Laptop", "type": "Project"},
+			"creator": {"id": 1049715913, "name": "Victor Cooper"},
+			"service": {
+				"name": "Figma",
+				"example_url": "https://www.figma.com/file/aGVsbG8gZmlnbWEgZmlsZQ",
+				"code": "figma",
+				"valid_patterns": ["(.*?\\.)?figma\\.com(\\/.*)?"],
+				"supporting_text": "a file or project on Figma"
+			},
+			"description": "<div>Shared Figma workspace</div>"
+		}
+	]`
+
+	var recordings []Recording
+	if err := json.Unmarshal([]byte(data), &recordings); err != nil {
+		t.Fatalf("failed to unmarshal door recording: %v", err)
+	}
+	if len(recordings) != 1 {
+		t.Fatalf("expected 1 recording, got %d", len(recordings))
+	}
+	d := recordings[0]
+	if d.Type != "Door" {
+		t.Errorf("expected type Door, got %q", d.Type)
+	}
+	if d.URL != "https://www.figma.com/file/abc123/Design-system" {
+		t.Errorf("expected external url, got %q", d.URL)
+	}
+	if d.Position != 8 {
+		t.Errorf("expected position 8, got %d", d.Position)
+	}
+	if d.Description != "<div>Shared Figma workspace</div>" {
+		t.Errorf("unexpected description: %q", d.Description)
+	}
+	if d.Service == nil {
+		t.Fatal("expected service struct to be non-nil for a Door")
+	}
+	if d.Service.Name != "Figma" || d.Service.Code != "figma" {
+		t.Errorf("unexpected service name/code: %q/%q", d.Service.Name, d.Service.Code)
+	}
+	if len(d.Service.ValidPatterns) != 1 || d.Service.ValidPatterns[0] == "" {
+		t.Errorf("expected 1 valid_pattern, got %v", d.Service.ValidPatterns)
+	}
+	if d.Service.SupportingText != "a file or project on Figma" {
+		t.Errorf("unexpected supporting_text: %q", d.Service.SupportingText)
+	}
+}
+
+// TestRecording_UnmarshalNonDoorOmitsDoorFields verifies a non-door recording
+// leaves the door-specific fields empty (they are optional).
+func TestRecording_UnmarshalNonDoorOmitsDoorFields(t *testing.T) {
+	data := `{"id": 1, "type": "Message", "title": "Hi", "url": "https://x/1.json"}`
+	var r Recording
+	if err := json.Unmarshal([]byte(data), &r); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if r.Service != nil {
+		t.Errorf("expected nil service for non-door, got %+v", r.Service)
+	}
+	if r.Description != "" || r.Position != 0 {
+		t.Errorf("expected empty door fields, got description=%q position=%d", r.Description, r.Position)
 	}
 }
 

--- a/go/pkg/basecamp/recordings_test.go
+++ b/go/pkg/basecamp/recordings_test.go
@@ -339,7 +339,7 @@ func TestRecording_UnmarshalDoor(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.BaseURL = server.URL
 	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
-	result, err := client.ForAccount("99999").Recordings().List(context.Background(), "Door", nil)
+	result, err := client.ForAccount("99999").Recordings().List(context.Background(), RecordingTypeDoor, nil)
 	if err != nil {
 		t.Fatalf("List(Door) failed: %v", err)
 	}
@@ -373,14 +373,35 @@ func TestRecording_UnmarshalDoor(t *testing.T) {
 	}
 }
 
-// TestRecording_UnmarshalNonDoorOmitsDoorFields verifies a non-door recording
-// leaves the door-specific fields empty (they are optional).
-func TestRecording_UnmarshalNonDoorOmitsDoorFields(t *testing.T) {
-	data := `{"id": 1, "type": "Message", "title": "Hi", "url": "https://x/1.json"}`
-	var r Recording
-	if err := json.Unmarshal([]byte(data), &r); err != nil {
-		t.Fatalf("failed to unmarshal: %v", err)
+// TestRecording_ListNonDoorOmitsDoorFields verifies a non-door recording, driven
+// through the real RecordingsService.List pipeline (generated decode ->
+// recordingFromGenerated), leaves the door-specific fields empty. Routing it
+// through List (rather than a direct unmarshal) exercises the same converter
+// path production uses, so it would catch a regression that wrongly populated
+// the door fields for a non-door type.
+func TestRecording_ListNonDoorOmitsDoorFields(t *testing.T) {
+	data := `[{"id": 1, "type": "Message", "title": "Hi", "url": "https://x/1.json"}]`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("type"); got != "Message" {
+			t.Errorf("expected type=Message query, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(data))
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := DefaultConfig()
+	cfg.BaseURL = server.URL
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+	result, err := client.ForAccount("99999").Recordings().List(context.Background(), RecordingTypeMessage, nil)
+	if err != nil {
+		t.Fatalf("List(Message) failed: %v", err)
 	}
+	if len(result.Recordings) != 1 {
+		t.Fatalf("expected 1 recording, got %d", len(result.Recordings))
+	}
+	r := result.Recordings[0]
 	if r.Service != nil {
 		t.Errorf("expected nil service for non-door, got %+v", r.Service)
 	}

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -806,6 +806,18 @@ type Document struct {
 	VisibleToClients   bool                 `json:"visible_to_clients"`
 }
 
+// DoorService Metadata describing the recognized external service backing an external link
+// (`Door` recording): its display name, a canonical example URL, a short code,
+// the URL patterns Basecamp recognizes for it, and human supporting text. `code`
+// is `other` for a generic link.
+type DoorService struct {
+	Code           string   `json:"code,omitempty"`
+	ExampleUrl     string   `json:"example_url,omitempty"`
+	Name           string   `json:"name,omitempty"`
+	SupportingText string   `json:"supporting_text,omitempty"`
+	ValidPatterns  []string `json:"valid_patterns,omitempty"`
+}
+
 // EnableCardColumnOnHoldResponseContent defines model for EnableCardColumnOnHoldResponseContent.
 type EnableCardColumnOnHoldResponseContent = CardColumn
 
@@ -1828,18 +1840,40 @@ type Recording struct {
 	CreatedAt          time.Time            `json:"created_at"`
 	Creator            Person               `json:"creator"`
 
+	// Description Rich-text (HTML) description shown beneath an external link. Present only
+	// on `Door` recordings returned by the `type=Door` recordings query (the only
+	// endpoint that returns the full door shape). The external destination
+	// address is `url` (not this field); `app_url` is the Basecamp redirector.
+	// See `spec/api-gaps/external-links-doors.md`.
+	Description string `json:"description,omitempty"`
+
 	// DescriptionAttachments See `content_attachments` — the description-attribute companion array.
 	DescriptionAttachments []RichTextAttachment `json:"description_attachments,omitempty"`
 	Id                     int64                `json:"id"`
 	InheritsStatus         bool                 `json:"inherits_status"`
-	Parent                 RecordingParent      `json:"parent"`
-	Status                 string               `json:"status"`
-	SubscriptionUrl        string               `json:"subscription_url,omitempty"`
-	Title                  string               `json:"title"`
-	Type                   string               `json:"type"`
-	UpdatedAt              time.Time            `json:"updated_at"`
-	Url                    string               `json:"url"`
-	VisibleToClients       bool                 `json:"visible_to_clients"`
+	Parent                 RecordingParent      `json:"parent,omitempty"`
+
+	// Position Ordinal position within the project's External links section. Present on
+	// `Door` (external-link) recordings.
+	Position int32 `json:"position,omitempty"`
+
+	// Service Metadata describing the recognized external service backing an external link
+	// (`Door` recording): its display name, a canonical example URL, a short code,
+	// the URL patterns Basecamp recognizes for it, and human supporting text. `code`
+	// is `other` for a generic link.
+	Service         DoorService `json:"service,omitempty"`
+	Status          string      `json:"status"`
+	SubscriptionUrl string      `json:"subscription_url,omitempty"`
+	Title           string      `json:"title"`
+	Type            string      `json:"type"`
+	UpdatedAt       time.Time   `json:"updated_at"`
+
+	// Url API URL of the recording. Exception: in the `type=Door` (external-link)
+	// projection, `url` is the door's **external destination address** (e.g. the
+	// Figma/Dropbox URL) and `app_url` is the Basecamp redirector — see the
+	// door-specific `service`/`description` fields below.
+	Url              string `json:"url"`
+	VisibleToClients bool   `json:"visible_to_clients"`
 }
 
 // RecordingBucket defines model for RecordingBucket.
@@ -3091,7 +3125,7 @@ type ListProjectsParams struct {
 
 // ListRecordingsParams defines parameters for ListRecordings.
 type ListRecordingsParams struct {
-	// Type Comment|Document|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault
+	// Type Comment|Document|Door|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault
 	Type   string `form:"type" json:"type"`
 	Bucket string `form:"bucket,omitempty" json:"bucket,omitempty"`
 

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/DoorService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/DoorService.kt
@@ -1,0 +1,20 @@
+package com.basecamp.sdk.generated.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * DoorService entity from the Basecamp API.
+ *
+ * @generated from OpenAPI spec — do not edit directly
+ */
+@Serializable
+data class DoorService(
+    val name: String? = null,
+    @SerialName("example_url") val exampleUrl: String? = null,
+    val code: String? = null,
+    @SerialName("valid_patterns") val validPatterns: List<String> = emptyList(),
+    @SerialName("supporting_text") val supportingText: String? = null
+)

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/DoorService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/DoorService.kt
@@ -15,6 +15,6 @@ data class DoorService(
     val name: String? = null,
     @SerialName("example_url") val exampleUrl: String? = null,
     val code: String? = null,
-    @SerialName("valid_patterns") val validPatterns: List<String> = emptyList(),
+    @SerialName("valid_patterns") val validPatterns: List<String>? = null,
     @SerialName("supporting_text") val supportingText: String? = null
 )

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Recording.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Recording.kt
@@ -22,7 +22,6 @@ data class Recording(
     val type: String,
     val url: String,
     @SerialName("app_url") val appUrl: String,
-    val parent: RecordingParent,
     val bucket: RecordingBucket,
     val creator: Person,
     @SerialName("bookmark_url") val bookmarkUrl: String? = null,
@@ -31,5 +30,9 @@ data class Recording(
     @SerialName("description_attachments") val descriptionAttachments: List<RichTextAttachment>? = null,
     @SerialName("comments_count") val commentsCount: Int? = null,
     @SerialName("comments_url") val commentsUrl: String? = null,
-    @SerialName("subscription_url") val subscriptionUrl: String? = null
+    @SerialName("subscription_url") val subscriptionUrl: String? = null,
+    val position: Int = 0,
+    val description: String? = null,
+    val service: DoorService? = null,
+    val parent: RecordingParent? = null
 )

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Recording.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Recording.kt
@@ -31,7 +31,7 @@ data class Recording(
     @SerialName("comments_count") val commentsCount: Int? = null,
     @SerialName("comments_url") val commentsUrl: String? = null,
     @SerialName("subscription_url") val subscriptionUrl: String? = null,
-    val position: Int = 0,
+    val position: Int? = null,
     val description: String? = null,
     val service: DoorService? = null,
     val parent: RecordingParent? = null

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/recordings.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/recordings.kt
@@ -14,7 +14,7 @@ class RecordingsService(client: AccountClient) : BaseService(client) {
 
     /**
      * List recordings of a given type across projects
-     * @param type Comment|Document|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault
+     * @param type Comment|Document|Door|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault
      * @param options Optional query parameters and pagination control
      */
     suspend fun list(type: String, options: ListRecordingsOptions? = null): ListResult<Recording> {

--- a/openapi.json
+++ b/openapi.json
@@ -10253,10 +10253,10 @@
           {
             "name": "type",
             "in": "query",
-            "description": "Comment|Document|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault",
+            "description": "Comment|Document|Door|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault",
             "schema": {
               "type": "string",
-              "description": "Comment|Document|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault"
+              "description": "Comment|Document|Door|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault"
             },
             "required": true,
             "examples": {
@@ -23844,6 +23844,30 @@
           "visible_to_clients"
         ]
       },
+      "DoorService": {
+        "type": "object",
+        "description": "Metadata describing the recognized external service backing an external link\n(`Door` recording): its display name, a canonical example URL, a short code,\nthe URL patterns Basecamp recognizes for it, and human supporting text. `code`\nis `other` for a generic link.",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "example_url": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          },
+          "valid_patterns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "supporting_text": {
+            "type": "string"
+          }
+        }
+      },
       "EnableCardColumnOnHoldResponseContent": {
         "$ref": "#/components/schemas/CardColumn"
       },
@@ -26591,7 +26615,8 @@
             "type": "string"
           },
           "url": {
-            "type": "string"
+            "type": "string",
+            "description": "API URL of the recording. Exception: in the `type=Door` (external-link)\nprojection, `url` is the door's **external destination address** (e.g. the\nFigma/Dropbox URL) and `app_url` is the Basecamp redirector — see the\ndoor-specific `service`/`description` fields below."
           },
           "app_url": {
             "type": "string"
@@ -26626,6 +26651,18 @@
           "subscription_url": {
             "type": "string"
           },
+          "position": {
+            "type": "integer",
+            "description": "Ordinal position within the project's External links section. Present on\n`Door` (external-link) recordings.",
+            "format": "int32"
+          },
+          "description": {
+            "type": "string",
+            "description": "Rich-text (HTML) description shown beneath an external link. Present only\non `Door` recordings returned by the `type=Door` recordings query (the only\nendpoint that returns the full door shape). The external destination\naddress is `url` (not this field); `app_url` is the Basecamp redirector.\nSee `spec/api-gaps/external-links-doors.md`."
+          },
+          "service": {
+            "$ref": "#/components/schemas/DoorService"
+          },
           "parent": {
             "$ref": "#/components/schemas/RecordingParent"
           },
@@ -26643,7 +26680,6 @@
           "creator",
           "id",
           "inherits_status",
-          "parent",
           "status",
           "title",
           "type",

--- a/python/src/basecamp/generated/types.py
+++ b/python/src/basecamp/generated/types.py
@@ -584,6 +584,14 @@ class Document(TypedDict):
     visible_to_clients: bool
 
 
+class DoorService(TypedDict):
+    code: NotRequired[str]
+    example_url: NotRequired[str]
+    name: NotRequired[str]
+    supporting_text: NotRequired[str]
+    valid_patterns: NotRequired[list[str]]
+
+
 class EnableOutOfOfficeRequestContent(TypedDict):
     out_of_office: OutOfOfficePayload
 
@@ -1174,10 +1182,13 @@ class Recording(TypedDict):
     content_attachments: NotRequired[list[RichTextAttachment]]
     created_at: str
     creator: Person
+    description: NotRequired[str]
     description_attachments: NotRequired[list[RichTextAttachment]]
     id: int
     inherits_status: bool
-    parent: RecordingParent
+    parent: NotRequired[RecordingParent]
+    position: NotRequired[int]
+    service: NotRequired[DoorService]
     status: str
     subscription_url: NotRequired[str]
     title: str

--- a/ruby/lib/basecamp/generated/metadata.json
+++ b/ruby/lib/basecamp/generated/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-07-26T17:37:09Z",
+  "generated": "2026-07-25T17:41:28Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/ruby/lib/basecamp/generated/metadata.json
+++ b/ruby/lib/basecamp/generated/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-07-26T17:43:10Z",
+  "generated": "2026-07-27T06:14:41Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/ruby/lib/basecamp/generated/metadata.json
+++ b/ruby/lib/basecamp/generated/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-07-25T17:41:28Z",
+  "generated": "2026-07-26T17:43:10Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/ruby/lib/basecamp/generated/services/recordings_service.rb
+++ b/ruby/lib/basecamp/generated/services/recordings_service.rb
@@ -8,7 +8,7 @@ module Basecamp
     class RecordingsService < BaseService
 
       # List recordings of a given type across projects
-      # @param type [String] Comment|Document|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault
+      # @param type [String] Comment|Document|Door|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault
       # @param bucket [String, nil] bucket
       # @param status [String, nil] active|archived|trashed
       # @param sort [String, nil] created_at|updated_at

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Auto-generated from OpenAPI spec. Do not edit manually.
-# Generated: 2026-07-25T17:41:28Z
+# Generated: 2026-07-26T17:43:10Z
 
 require "json"
 require "time"

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Auto-generated from OpenAPI spec. Do not edit manually.
-# Generated: 2026-07-27T07:19:14Z
+# Generated: 2026-07-27T08:13:10Z
 
 require "json"
 require "time"
@@ -3613,7 +3613,7 @@ module Basecamp
           "all_day" => @all_day,
           "ends_at" => @ends_at,
           "starts_at" => @starts_at,
-        }.compact
+        }.reject { |k, v| v.nil? && !["ends_at", "starts_at"].include?(k) }
       end
 
       def to_json(*args)

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Auto-generated from OpenAPI spec. Do not edit manually.
-# Generated: 2026-07-27T06:14:41Z
+# Generated: 2026-07-27T07:19:14Z
 
 require "json"
 require "time"

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Auto-generated from OpenAPI spec. Do not edit manually.
-# Generated: 2026-07-26T17:43:10Z
+# Generated: 2026-07-27T06:14:41Z
 
 require "json"
 require "time"
@@ -3455,26 +3455,39 @@ module Basecamp
     # TimelineAttachment
     class TimelineAttachment
       include TypeHelpers
-      attr_accessor :app_download_url, :app_url, :attachable_sgid, :byte_size, :caption, :content_type, :created_at, :download_url, :filename, :height, :id, :key, :preview_url, :previewable, :sgid, :status, :status_url, :thumbnail_url, :title, :type, :updated_at, :url, :visible_to_clients, :width
+      attr_accessor :app_download_url, :app_url, :attachable_sgid, :bookmark_url, :boosts_count, :boosts_url, :bucket, :byte_size, :caption, :comments_count, :comments_url, :content_type, :created_at, :creator, :description, :description_attachments, :download_url, :filename, :height, :id, :inherits_status, :key, :parent, :position, :preview_url, :previewable, :sgid, :status, :status_url, :subscription_url, :thumbnail_url, :title, :type, :updated_at, :url, :visible_to_clients, :width
 
       def initialize(data = {})
         @app_download_url = data["app_download_url"]
         @app_url = data["app_url"]
         @attachable_sgid = data["attachable_sgid"]
+        @bookmark_url = data["bookmark_url"]
+        @boosts_count = parse_integer(data["boosts_count"])
+        @boosts_url = data["boosts_url"]
+        @bucket = parse_type(data["bucket"], "TodoBucket")
         @byte_size = parse_integer(data["byte_size"])
         @caption = data["caption"]
+        @comments_count = parse_integer(data["comments_count"])
+        @comments_url = data["comments_url"]
         @content_type = data["content_type"]
         @created_at = parse_datetime(data["created_at"])
+        @creator = parse_type(data["creator"], "Person")
+        @description = data["description"]
+        @description_attachments = parse_array(data["description_attachments"], "RichTextAttachment")
         @download_url = data["download_url"]
         @filename = data["filename"]
         @height = parse_integer(data["height"])
         @id = parse_integer(data["id"])
+        @inherits_status = parse_boolean(data["inherits_status"])
         @key = data["key"]
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @position = parse_integer(data["position"])
         @preview_url = data["preview_url"]
         @previewable = parse_boolean(data["previewable"])
         @sgid = data["sgid"]
         @status = data["status"]
         @status_url = data["status_url"]
+        @subscription_url = data["subscription_url"]
         @thumbnail_url = data["thumbnail_url"]
         @title = data["title"]
         @type = data["type"]
@@ -3489,20 +3502,33 @@ module Basecamp
           "app_download_url" => @app_download_url,
           "app_url" => @app_url,
           "attachable_sgid" => @attachable_sgid,
+          "bookmark_url" => @bookmark_url,
+          "boosts_count" => @boosts_count,
+          "boosts_url" => @boosts_url,
+          "bucket" => @bucket,
           "byte_size" => @byte_size,
           "caption" => @caption,
+          "comments_count" => @comments_count,
+          "comments_url" => @comments_url,
           "content_type" => @content_type,
           "created_at" => @created_at,
+          "creator" => @creator,
+          "description" => @description,
+          "description_attachments" => @description_attachments,
           "download_url" => @download_url,
           "filename" => @filename,
           "height" => @height,
           "id" => @id,
+          "inherits_status" => @inherits_status,
           "key" => @key,
+          "parent" => @parent,
+          "position" => @position,
           "preview_url" => @preview_url,
           "previewable" => @previewable,
           "sgid" => @sgid,
           "status" => @status,
           "status_url" => @status_url,
+          "subscription_url" => @subscription_url,
           "thumbnail_url" => @thumbnail_url,
           "title" => @title,
           "type" => @type,
@@ -3570,6 +3596,11 @@ module Basecamp
     class TimelineEventData
       include TypeHelpers
       attr_accessor :all_day, :ends_at, :starts_at
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[all_day ends_at starts_at].freeze
+      end
 
       def initialize(data = {})
         @all_day = parse_boolean(data["all_day"])

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Auto-generated from OpenAPI spec. Do not edit manually.
-# Generated: 2026-07-27T08:07:39Z
+# Generated: 2026-07-25T17:41:28Z
 
 require "json"
 require "time"
@@ -1261,6 +1261,34 @@ module Basecamp
           "content" => @content,
           "position" => @position,
           "subscription_url" => @subscription_url,
+        }.compact
+      end
+
+      def to_json(*args)
+        to_h.to_json(*args)
+      end
+    end
+
+    # DoorService
+    class DoorService
+      include TypeHelpers
+      attr_accessor :code, :example_url, :name, :supporting_text, :valid_patterns
+
+      def initialize(data = {})
+        @code = data["code"]
+        @example_url = data["example_url"]
+        @name = data["name"]
+        @supporting_text = data["supporting_text"]
+        @valid_patterns = data["valid_patterns"]
+      end
+
+      def to_h
+        {
+          "code" => @code,
+          "example_url" => @example_url,
+          "name" => @name,
+          "supporting_text" => @supporting_text,
+          "valid_patterns" => @valid_patterns,
         }.compact
       end
 
@@ -2900,11 +2928,11 @@ module Basecamp
     # Recording
     class Recording
       include TypeHelpers
-      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :parent, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :comments_count, :comments_url, :content, :content_attachments, :description_attachments, :subscription_url
+      attr_accessor :app_url, :bucket, :created_at, :creator, :id, :inherits_status, :status, :title, :type, :updated_at, :url, :visible_to_clients, :bookmark_url, :comments_count, :comments_url, :content, :content_attachments, :description, :description_attachments, :parent, :position, :service, :subscription_url
 
       # @return [Array<Symbol>]
       def self.required_fields
-        %i[app_url bucket created_at creator id inherits_status parent status title type updated_at url visible_to_clients].freeze
+        %i[app_url bucket created_at creator id inherits_status status title type updated_at url visible_to_clients].freeze
       end
 
       def initialize(data = {})
@@ -2914,7 +2942,6 @@ module Basecamp
         @creator = parse_type(data["creator"], "Person")
         @id = parse_integer(data["id"])
         @inherits_status = parse_boolean(data["inherits_status"])
-        @parent = parse_type(data["parent"], "RecordingParent")
         @status = data["status"]
         @title = data["title"]
         @type = data["type"]
@@ -2926,7 +2953,11 @@ module Basecamp
         @comments_url = data["comments_url"]
         @content = data["content"]
         @content_attachments = parse_array(data["content_attachments"], "RichTextAttachment")
+        @description = data["description"]
         @description_attachments = parse_array(data["description_attachments"], "RichTextAttachment")
+        @parent = parse_type(data["parent"], "RecordingParent")
+        @position = parse_integer(data["position"])
+        @service = parse_type(data["service"], "DoorService")
         @subscription_url = data["subscription_url"]
       end
 
@@ -2938,7 +2969,6 @@ module Basecamp
           "creator" => @creator,
           "id" => @id,
           "inherits_status" => @inherits_status,
-          "parent" => @parent,
           "status" => @status,
           "title" => @title,
           "type" => @type,
@@ -2950,7 +2980,11 @@ module Basecamp
           "comments_url" => @comments_url,
           "content" => @content,
           "content_attachments" => @content_attachments,
+          "description" => @description,
           "description_attachments" => @description_attachments,
+          "parent" => @parent,
+          "position" => @position,
+          "service" => @service,
           "subscription_url" => @subscription_url,
         }.compact
       end
@@ -3421,39 +3455,26 @@ module Basecamp
     # TimelineAttachment
     class TimelineAttachment
       include TypeHelpers
-      attr_accessor :app_download_url, :app_url, :attachable_sgid, :bookmark_url, :boosts_count, :boosts_url, :bucket, :byte_size, :caption, :comments_count, :comments_url, :content_type, :created_at, :creator, :description, :description_attachments, :download_url, :filename, :height, :id, :inherits_status, :key, :parent, :position, :preview_url, :previewable, :sgid, :status, :status_url, :subscription_url, :thumbnail_url, :title, :type, :updated_at, :url, :visible_to_clients, :width
+      attr_accessor :app_download_url, :app_url, :attachable_sgid, :byte_size, :caption, :content_type, :created_at, :download_url, :filename, :height, :id, :key, :preview_url, :previewable, :sgid, :status, :status_url, :thumbnail_url, :title, :type, :updated_at, :url, :visible_to_clients, :width
 
       def initialize(data = {})
         @app_download_url = data["app_download_url"]
         @app_url = data["app_url"]
         @attachable_sgid = data["attachable_sgid"]
-        @bookmark_url = data["bookmark_url"]
-        @boosts_count = parse_integer(data["boosts_count"])
-        @boosts_url = data["boosts_url"]
-        @bucket = parse_type(data["bucket"], "TodoBucket")
         @byte_size = parse_integer(data["byte_size"])
         @caption = data["caption"]
-        @comments_count = parse_integer(data["comments_count"])
-        @comments_url = data["comments_url"]
         @content_type = data["content_type"]
         @created_at = parse_datetime(data["created_at"])
-        @creator = parse_type(data["creator"], "Person")
-        @description = data["description"]
-        @description_attachments = parse_array(data["description_attachments"], "RichTextAttachment")
         @download_url = data["download_url"]
         @filename = data["filename"]
         @height = parse_integer(data["height"])
         @id = parse_integer(data["id"])
-        @inherits_status = parse_boolean(data["inherits_status"])
         @key = data["key"]
-        @parent = parse_type(data["parent"], "RecordingParent")
-        @position = parse_integer(data["position"])
         @preview_url = data["preview_url"]
         @previewable = parse_boolean(data["previewable"])
         @sgid = data["sgid"]
         @status = data["status"]
         @status_url = data["status_url"]
-        @subscription_url = data["subscription_url"]
         @thumbnail_url = data["thumbnail_url"]
         @title = data["title"]
         @type = data["type"]
@@ -3468,33 +3489,20 @@ module Basecamp
           "app_download_url" => @app_download_url,
           "app_url" => @app_url,
           "attachable_sgid" => @attachable_sgid,
-          "bookmark_url" => @bookmark_url,
-          "boosts_count" => @boosts_count,
-          "boosts_url" => @boosts_url,
-          "bucket" => @bucket,
           "byte_size" => @byte_size,
           "caption" => @caption,
-          "comments_count" => @comments_count,
-          "comments_url" => @comments_url,
           "content_type" => @content_type,
           "created_at" => @created_at,
-          "creator" => @creator,
-          "description" => @description,
-          "description_attachments" => @description_attachments,
           "download_url" => @download_url,
           "filename" => @filename,
           "height" => @height,
           "id" => @id,
-          "inherits_status" => @inherits_status,
           "key" => @key,
-          "parent" => @parent,
-          "position" => @position,
           "preview_url" => @preview_url,
           "previewable" => @previewable,
           "sgid" => @sgid,
           "status" => @status,
           "status_url" => @status_url,
-          "subscription_url" => @subscription_url,
           "thumbnail_url" => @thumbnail_url,
           "title" => @title,
           "type" => @type,
@@ -3563,11 +3571,6 @@ module Basecamp
       include TypeHelpers
       attr_accessor :all_day, :ends_at, :starts_at
 
-      # @return [Array<Symbol>]
-      def self.required_fields
-        %i[all_day ends_at starts_at].freeze
-      end
-
       def initialize(data = {})
         @all_day = parse_boolean(data["all_day"])
         @ends_at = data["ends_at"]
@@ -3579,7 +3582,7 @@ module Basecamp
           "all_day" => @all_day,
           "ends_at" => @ends_at,
           "starts_at" => @starts_at,
-        }.reject { |k, v| v.nil? && !["ends_at", "starts_at"].include?(k) }
+        }.compact
       end
 
       def to_json(*args)

--- a/spec/api-gaps/README.md
+++ b/spec/api-gaps/README.md
@@ -56,7 +56,7 @@ making the absorption journey publicly auditable.
 | [todolist-reposition](todolist-reposition.md) | absorbed-in-sdk | pre-BC5 | medium |
 | [rich-text-attachments-coverage](rich-text-attachments-coverage.md) | absorbed-in-sdk | n/a | medium |
 | [visible-to-clients-on-creates](visible-to-clients-on-creates.md) | absorbed-in-sdk | post-train | medium |
-| [external-links-doors](external-links-doors.md) | addressed-in-bc3-pr-12375 | post-train | low |
+| [external-links-doors](external-links-doors.md) | partial-coverage | post-train | low |
 | [my-bookmarks](my-bookmarks.md) | addressed-in-bc3-pr-12383 | master | medium |
 | [my-drafts](my-drafts.md) | addressed-in-bc3-pr-12381 | master | medium |
 | [my-assignments-priorities](my-assignments-priorities.md) | addressed-in-bc3-pr-12380 | master | medium |

--- a/spec/api-gaps/external-links-doors.md
+++ b/spec/api-gaps/external-links-doors.md
@@ -135,6 +135,24 @@ image are recorded as residual gaps below.
 
 ## Compatibility
 
-Additive only: the `Door` enum value plus optional `position`/`description`/
-`service` fields on the shared `Recording` output type. No change to existing
-modeled operations; no new operation.
+Mostly additive, with one deliberate optionality **correction** — not purely
+additive. No new operation and no change to existing modeled operations.
+
+- **Additive:** the `Door` recording type value plus the optional
+  `position`/`description`/`service` fields on the shared `Recording` output.
+- **Optionality correction (`Recording.parent`):** this entry relaxes
+  `Recording.parent` from required to optional. That changes the generated
+  public types (Swift/Kotlin/TypeScript/Python surface `parent` as optional), so
+  it is technically source-affecting for consumers that assumed `parent` is
+  always present. It is nonetheless a **fix of a pre-existing contract defect,
+  not a gratuitous break**: BC3's shared recording projection
+  (`app/views/api/recordings/_recording.json.jbuilder`) emits `parent` only
+  `if !recording.docked? && recording.parent`, so it is **omitted for every
+  docked recording** — message boards, to-do sets, schedules, campfires,
+  questionnaires, and doors (all dock items, `docked? == parent&.dock?`) — and
+  for any parentless recording. The prior `@required` therefore over-asserted a
+  field the API has always emitted conditionally, and strict decoders
+  (Swift/Kotlin) would already have failed to decode any dock item. Door (a
+  docked recording) only made the latent defect unavoidable. Because it changes
+  a public type, it should still be called out in the release notes as a
+  compatibility-affecting correction.

--- a/spec/api-gaps/external-links-doors.md
+++ b/spec/api-gaps/external-links-doors.md
@@ -1,9 +1,13 @@
 ---
 gap: external-links-doors
-status: addressed-in-bc3-pr-12375
+status: partial-coverage
 detected: 2026-07-22
 sdk_demand: low
 bc3_pr: 12375
+smithy_refs:
+  - "RecordingType Door enum value (spec/basecamp.smithy:6063)"
+  - "Recording.position/description/service (spec/basecamp.smithy:6078)"
+  - "DoorService (spec/basecamp.smithy:6142)"
 bc3_refs:
   routes:
     - GET /:account_id/projects/recordings.json?type=Door
@@ -87,22 +91,50 @@ the contract is now documented and must be tracked to keep detection honest.
 
 ## SDK absorption plan when this lands
 
-- Model the door **list** as a `type=Door`-scoped recordings query (or a
-  dedicated `ListExternalLinks` operation) returning the full door shape
-  (`url`, `service`, `description`).
-- Model **create** carefully: the 302/no-JSON-body contract does not fit the
-  standard "create returns the resource" mold — the operation returns no
-  usable body, so the SDK surface must not promise one. The wire operation
-  should model only the 302/empty response; a create-and-discover convenience
-  (create, then `type=Door` list to find the new door's id) is a **separately
-  sanctioned composite** — it needs explicit composite treatment, conformance
-  coverage, and a defined answer for ambiguous concurrent/duplicate creates,
-  not something the plain create operation implies.
-- Get/rename/trash reuse the existing dock-tool GetTool/UpdateTool/DeleteTool
-  operations.
-- Add `Door` to the `RecordingType` documented enum.
+**Partially absorbed** (basecamp-sdk PR-4 of the post-#401 follow-up program).
+A pre-implementation spike resolved the three blockers and scoped this PR to the
+cleanly-absorbable surface; the redirect-dependent create and the multipart
+image are recorded as residual gaps below.
+
+**Absorbed in this PR:**
+
+- The door **list** is the existing `type=Door`-scoped `ListRecordings` query —
+  **not** a new operation. `ListRecordings` already carries a `type` query and a
+  `Recording.url`; the full door shape is reached by adding `Door` to the
+  `RecordingType` documented enum and adding optional `position`, `description`,
+  and a `service` struct (`DoorService`) to the shared `Recording` projection.
+  A runtime decode test proves the door shape (external `url` + `service` +
+  `description`) decodes through the projection.
+- Get/rename/trash reuse the existing `GetTool` / `UpdateTool` / `DeleteTool`
+  operations — no new work.
+- A `type=Door` recordings canary entry validates statically (live dormant).
+
+**Residual gaps (why this entry is `partial-coverage`, not
+`absorbed-in-sdk`):**
+
+- **Create (`POST /buckets/:b/dock/doors.json`) — deferred.** The endpoint
+  returns **302 with an empty body** (no ID), redirecting cross-origin to the
+  web project page. The spike found the six SDK transports handle this
+  inconsistently: Go, TypeScript (fetch default), Kotlin (Ktor default), and
+  Swift (URLSession default) **follow** the redirect (landing on the web page,
+  after cross-origin auth stripping); Python (`follow_redirects=False`) and Ruby
+  (Faraday, no follow middleware) do **not** follow but then face empty-body
+  decode, and each classifies a bare 302 differently. Modeling "return only the
+  302/empty response" would require coordinated per-operation redirect
+  suppression + 302-as-success handling across all six generated transports — a
+  cross-cutting transport change, not an additive absorption. Deferred to a
+  dedicated PR.
+- **`image` thumbnail (multipart) — unmodeled.** `door[image]` is
+  `multipart/form-data` only; not modeled. Independent of the create-transport
+  question, this alone keeps the entry from honestly flipping to
+  `absorbed-in-sdk`.
+- **Create-and-discover composite (SPEC §18) — deferred.** It depends on a
+  shippable `CreateExternalLink`, so it is out of scope until create lands.
+- **No JSON update path** for `url`/`service`/`description` (PUT → 406): never
+  modeled, by contract.
 
 ## Compatibility
 
-New documented resource surface; no change to existing modeled operations
-beyond the additive `Door` enum value on `ListRecordings` output type.
+Additive only: the `Door` enum value plus optional `position`/`description`/
+`service` fields on the shared `Recording` output type. No change to existing
+modeled operations; no new operation.

--- a/spec/api-gaps/external-links-doors.md
+++ b/spec/api-gaps/external-links-doors.md
@@ -5,9 +5,9 @@ detected: 2026-07-22
 sdk_demand: low
 bc3_pr: 12375
 smithy_refs:
-  - "RecordingType Door enum value (spec/basecamp.smithy:6063)"
-  - "Recording.position/description/service (spec/basecamp.smithy:6078)"
-  - "DoorService (spec/basecamp.smithy:6142)"
+  - "Door in the documented recording type string (spec/basecamp.smithy:6223)"
+  - "Recording.position/description/service (spec/basecamp.smithy:6282-6293)"
+  - "DoorService (spec/basecamp.smithy:6309)"
 bc3_refs:
   routes:
     - GET /:account_id/projects/recordings.json?type=Door

--- a/spec/basecamp.smithy
+++ b/spec/basecamp.smithy
@@ -6220,7 +6220,7 @@ structure EventDetails {
 
 // ===== Recording Shapes =====
 
-@documentation("Comment|Document|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault")
+@documentation("Comment|Document|Door|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault")
 string RecordingType
 
 @documentation("active|archived|trashed")
@@ -6253,6 +6253,10 @@ structure Recording {
   inherits_status: Boolean
   @required
   type: String
+  /// API URL of the recording. Exception: in the `type=Door` (external-link)
+  /// projection, `url` is the door's **external destination address** (e.g. the
+  /// Figma/Dropbox URL) and `app_url` is the Basecamp redirector — see the
+  /// door-specific `service`/`description` fields below.
   @required
   url: String
   @required
@@ -6272,12 +6276,42 @@ structure Recording {
   comments_count: Integer
   comments_url: String
   subscription_url: String
-  @required
+
+  /// Ordinal position within the project's External links section. Present on
+  /// `Door` (external-link) recordings.
+  position: Integer
+
+  /// Rich-text (HTML) description shown beneath an external link. Present only
+  /// on `Door` recordings returned by the `type=Door` recordings query (the only
+  /// endpoint that returns the full door shape). The external destination
+  /// address is `url` (not this field); `app_url` is the Basecamp redirector.
+  /// See `spec/api-gaps/external-links-doors.md`.
+  description: String
+
+  /// Metadata about the recognized external service the link's `url` points to
+  /// (Figma, Dropbox, GitHub, …). Present only on `Door` recordings.
+  service: DoorService
+
+  /// Parent container of the recording. Optional because `Door` (external-link)
+  /// recordings have no parent recording — the `type=Door` projection omits it,
+  /// so a strict decoder must tolerate its absence.
   parent: RecordingParent
   @required
   bucket: RecordingBucket
   @required
   creator: Person
+}
+
+/// Metadata describing the recognized external service backing an external link
+/// (`Door` recording): its display name, a canonical example URL, a short code,
+/// the URL patterns Basecamp recognizes for it, and human supporting text. `code`
+/// is `other` for a generic link.
+structure DoorService {
+  name: String
+  example_url: String
+  code: String
+  valid_patterns: StringList
+  supporting_text: String
 }
 
 // =============================================================================

--- a/swift/Sources/Basecamp/Generated/Models/DoorService.swift
+++ b/swift/Sources/Basecamp/Generated/Models/DoorService.swift
@@ -1,0 +1,10 @@
+// @generated from OpenAPI spec — do not edit directly
+import Foundation
+
+public struct DoorService: Codable, Sendable {
+    public var code: String?
+    public var exampleUrl: String?
+    public var name: String?
+    public var supportingText: String?
+    public var validPatterns: [String]?
+}

--- a/swift/Sources/Basecamp/Generated/Models/Recording.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Recording.swift
@@ -8,7 +8,6 @@ public struct Recording: Codable, Sendable {
     public let creator: Person
     public let id: Int
     public let inheritsStatus: Bool
-    public let parent: RecordingParent
     public let status: String
     public let title: String
     public let type: String
@@ -20,7 +19,11 @@ public struct Recording: Codable, Sendable {
     public var commentsUrl: String?
     public var content: String?
     public var contentAttachments: [RichTextAttachment]?
+    public var description: String?
     public var descriptionAttachments: [RichTextAttachment]?
+    public var parent: RecordingParent?
+    public var position: Int32?
+    public var service: DoorService?
     public var subscriptionUrl: String?
 
     public init(
@@ -30,7 +33,6 @@ public struct Recording: Codable, Sendable {
         creator: Person,
         id: Int,
         inheritsStatus: Bool,
-        parent: RecordingParent,
         status: String,
         title: String,
         type: String,
@@ -42,7 +44,11 @@ public struct Recording: Codable, Sendable {
         commentsUrl: String? = nil,
         content: String? = nil,
         contentAttachments: [RichTextAttachment]? = nil,
+        description: String? = nil,
         descriptionAttachments: [RichTextAttachment]? = nil,
+        parent: RecordingParent? = nil,
+        position: Int32? = nil,
+        service: DoorService? = nil,
         subscriptionUrl: String? = nil
     ) {
         self.appUrl = appUrl
@@ -51,7 +57,6 @@ public struct Recording: Codable, Sendable {
         self.creator = creator
         self.id = id
         self.inheritsStatus = inheritsStatus
-        self.parent = parent
         self.status = status
         self.title = title
         self.type = type
@@ -63,7 +68,11 @@ public struct Recording: Codable, Sendable {
         self.commentsUrl = commentsUrl
         self.content = content
         self.contentAttachments = contentAttachments
+        self.description = description
         self.descriptionAttachments = descriptionAttachments
+        self.parent = parent
+        self.position = position
+        self.service = service
         self.subscriptionUrl = subscriptionUrl
     }
 }

--- a/typescript/src/generated/metadata.ts
+++ b/typescript/src/generated/metadata.ts
@@ -37,7 +37,7 @@ export interface MetadataOutput {
 const metadata: MetadataOutput = {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-07-26T17:43:09.521Z",
+  "generated": "2026-07-27T06:14:40.561Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/typescript/src/generated/metadata.ts
+++ b/typescript/src/generated/metadata.ts
@@ -37,7 +37,7 @@ export interface MetadataOutput {
 const metadata: MetadataOutput = {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-07-25T17:41:27.970Z",
+  "generated": "2026-07-26T17:43:09.521Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/typescript/src/generated/metadata.ts
+++ b/typescript/src/generated/metadata.ts
@@ -37,7 +37,7 @@ export interface MetadataOutput {
 const metadata: MetadataOutput = {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-07-26T17:37:09.045Z",
+  "generated": "2026-07-25T17:41:27.970Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/typescript/src/generated/openapi-stripped.json
+++ b/typescript/src/generated/openapi-stripped.json
@@ -9083,10 +9083,10 @@
           {
             "name": "type",
             "in": "query",
-            "description": "Comment|Document|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault",
+            "description": "Comment|Document|Door|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault",
             "schema": {
               "type": "string",
-              "description": "Comment|Document|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault"
+              "description": "Comment|Document|Door|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault"
             },
             "required": true,
             "examples": {
@@ -21455,6 +21455,30 @@
           "visible_to_clients"
         ]
       },
+      "DoorService": {
+        "type": "object",
+        "description": "Metadata describing the recognized external service backing an external link\n(`Door` recording): its display name, a canonical example URL, a short code,\nthe URL patterns Basecamp recognizes for it, and human supporting text. `code`\nis `other` for a generic link.",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "example_url": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          },
+          "valid_patterns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "supporting_text": {
+            "type": "string"
+          }
+        }
+      },
       "EnableCardColumnOnHoldResponseContent": {
         "$ref": "#/components/schemas/CardColumn"
       },
@@ -24202,7 +24226,8 @@
             "type": "string"
           },
           "url": {
-            "type": "string"
+            "type": "string",
+            "description": "API URL of the recording. Exception: in the `type=Door` (external-link)\nprojection, `url` is the door's **external destination address** (e.g. the\nFigma/Dropbox URL) and `app_url` is the Basecamp redirector — see the\ndoor-specific `service`/`description` fields below."
           },
           "app_url": {
             "type": "string"
@@ -24237,6 +24262,18 @@
           "subscription_url": {
             "type": "string"
           },
+          "position": {
+            "type": "integer",
+            "description": "Ordinal position within the project's External links section. Present on\n`Door` (external-link) recordings.",
+            "format": "int32"
+          },
+          "description": {
+            "type": "string",
+            "description": "Rich-text (HTML) description shown beneath an external link. Present only\non `Door` recordings returned by the `type=Door` recordings query (the only\nendpoint that returns the full door shape). The external destination\naddress is `url` (not this field); `app_url` is the Basecamp redirector.\nSee `spec/api-gaps/external-links-doors.md`."
+          },
+          "service": {
+            "$ref": "#/components/schemas/DoorService"
+          },
           "parent": {
             "$ref": "#/components/schemas/RecordingParent"
           },
@@ -24254,7 +24291,6 @@
           "creator",
           "id",
           "inherits_status",
-          "parent",
           "status",
           "title",
           "type",

--- a/typescript/src/generated/schema.d.ts
+++ b/typescript/src/generated/schema.d.ts
@@ -3240,6 +3240,19 @@ export interface components {
             boosts_count?: number;
             boosts_url?: string;
         };
+        /**
+         * @description Metadata describing the recognized external service backing an external link
+         *     (`Door` recording): its display name, a canonical example URL, a short code,
+         *     the URL patterns Basecamp recognizes for it, and human supporting text. `code`
+         *     is `other` for a generic link.
+         */
+        DoorService: {
+            name?: string;
+            example_url?: string;
+            code?: string;
+            valid_patterns?: string[];
+            supporting_text?: string;
+        };
         EnableCardColumnOnHoldResponseContent: components["schemas"]["CardColumn"];
         EnableOutOfOfficeRequestContent: {
             out_of_office: components["schemas"]["OutOfOfficePayload"];
@@ -4034,6 +4047,12 @@ export interface components {
             title: string;
             inherits_status: boolean;
             type: string;
+            /**
+             * @description API URL of the recording. Exception: in the `type=Door` (external-link)
+             *     projection, `url` is the door's **external destination address** (e.g. the
+             *     Figma/Dropbox URL) and `app_url` is the Basecamp redirector — see the
+             *     door-specific `service`/`description` fields below.
+             */
             url: string;
             app_url: string;
             bookmark_url?: string;
@@ -4054,7 +4073,22 @@ export interface components {
             comments_count?: number;
             comments_url?: string;
             subscription_url?: string;
-            parent: components["schemas"]["RecordingParent"];
+            /**
+             * Format: int32
+             * @description Ordinal position within the project's External links section. Present on
+             *     `Door` (external-link) recordings.
+             */
+            position?: number;
+            /**
+             * @description Rich-text (HTML) description shown beneath an external link. Present only
+             *     on `Door` recordings returned by the `type=Door` recordings query (the only
+             *     endpoint that returns the full door shape). The external destination
+             *     address is `url` (not this field); `app_url` is the Basecamp redirector.
+             *     See `spec/api-gaps/external-links-doors.md`.
+             */
+            description?: string;
+            service?: components["schemas"]["DoorService"];
+            parent?: components["schemas"]["RecordingParent"];
             bucket: components["schemas"]["RecordingBucket"];
             creator: components["schemas"]["Person"];
         };
@@ -11466,7 +11500,7 @@ export interface operations {
     ListRecordings: {
         parameters: {
             query: {
-                /** @description Comment|Document|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault */
+                /** @description Comment|Document|Door|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault */
                 type: string;
                 bucket?: string;
                 /** @description active|archived|trashed */

--- a/typescript/src/generated/services/recordings.ts
+++ b/typescript/src/generated/services/recordings.ts
@@ -42,7 +42,7 @@ export class RecordingsService extends BaseService {
 
   /**
    * List recordings of a given type across projects
-   * @param type - Comment|Document|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault
+   * @param type - Comment|Document|Door|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault
    * @param options - Optional query parameters
    * @returns All Recording across all pages, with .meta.totalCount
    *
@@ -54,7 +54,7 @@ export class RecordingsService extends BaseService {
    * const filtered = await client.recordings.list("type", { bucket: [123] });
    * ```
    */
-  async list(type: "Comment" | "Document" | "Kanban::Card" | "Kanban::Step" | "Message" | "Question::Answer" | "Schedule::Entry" | "Todo" | "Todolist" | "Upload" | "Vault", options?: ListRecordingOptions): Promise<ListResult<Recording>> {
+  async list(type: "Comment" | "Document" | "Door" | "Kanban::Card" | "Kanban::Step" | "Message" | "Question::Answer" | "Schedule::Entry" | "Todo" | "Todolist" | "Upload" | "Vault", options?: ListRecordingOptions): Promise<ListResult<Recording>> {
     return this.requestPaginated(
       {
         service: "Recordings",


### PR DESCRIPTION
Closes #430. Part of the post-#401 BC3 follow-up absorption program (**PR-4**, gated by a modeling/redirect spike).

> **Stacked on #426 (PR-3) → #424 → #419 → #416.** Base is `bubble-ups-surface`; review the PR-4 commit only. Will retarget to `main` as the stack merges.

## Spike outcome (three blockers)

1. **List path collision → resolved by extension.** `ListRecordings` already owns `GET /projects/recordings.json` with a `type` query and `Recording.url`. `Door` is reached by adding it to the `RecordingType` doc-enum + optional `position`/`description`/`service` (`DoorService`) on the shared `Recording` projection — **no new op, no collision.**
2. **302/empty create transport → inconsistent across the six SDKs.** Go / TS (fetch) / Kotlin (Ktor) / Swift (URLSession) **follow** the cross-origin redirect; Python (`follow_redirects=False`) and Ruby (Faraday) don't follow but face empty-body decode. Modeling "return only the 302/empty response" needs a coordinated per-operation transport change across all six generated transports — out of scope for an additive absorption. **Create deferred.**
3. **`image` multipart → unmodeled residual gap** (independently blocks a full flip).

## Absorbed

- `Door` `RecordingType` enum value + optional `position`/`description`/`service` (`DoorService`) on `Recording`.
- Go wrapper + runtime decode tests: the full door shape (external `url` + `service` struct + `description` + `position`) decodes through the projection; a non-door recording leaves the door fields empty.
- Get/rename/trash already reuse `GetTool`/`UpdateTool`/`DeleteTool`.
- `type=Door` `ListRecordings` canary (validates statically; live dormant).

## Deferred (residual gaps → entry is `partial-coverage`, not `absorbed-in-sdk`)

`CreateExternalLink` (302 transport), `image` (multipart), the SPEC §18 create-and-discover composite. No JSON update path (PUT → 406) by contract.

## Verification

`make generate && make check` — clean (24 api-gap entries; additive only, no operation change).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Absorbs the external-links (“doors”) list into `ListRecordings` (`GET /projects/recordings.json?type=Door`) by extending `Recording` with door fields and clarifying door `url` semantics. Create/image/composite remain deferred (bc3 #12375); adds live canaries with pagination caps.

- **New Features**
  - Add `Door` to `RecordingType`; extend `Recording` with `position`, `description`, and `service` (`DoorService`); make `parent` optional.
  - Clarify door `url` semantics in Smithy/OpenAPI; regenerate Go (incl. `DoorService` and mapper), Kotlin (nullable optionals), Swift, Python, Ruby, and TypeScript SDKs.
  - Tests/Conformance: drive door and non-door decode via `RecordingsService.list`; add a live `ListRecordings` canary with `type=Door` and `maxItems: 5`; cap pagination in live dispatch for `reports.progress` and `GetBubbleUps`.

<sup>Written for commit c127be859125dae988d8b4e512fdcf17bc97c742. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

