### PR TITLE
Unify resourceId selection across the five generators

### DIFF
--- a/kotlin/generator/src/main/kotlin/com/basecamp/sdk/generator/ServiceEmitter.kt
+++ b/kotlin/generator/src/main/kotlin/com/basecamp/sdk/generator/ServiceEmitter.kt
@@ -107,7 +107,7 @@ class ServiceEmitter(private val api: OpenApiParser) {
 
         // Build OperationInfo
         val projectParam = op.pathParams.find { it.name == "projectId" || it.name == "bucketId" }
-        val resourceParam = op.pathParams.findLast { it.name != "projectId" && it.name != "bucketId" && it.name.endsWith("Id") }
+        val resourceParam = op.pathParams.findLast { it.name != "projectId" && it.name != "bucketId" && (it.name.endsWith("Id") || it.name == "id") }
         val projectArg = if (projectParam != null) projectParam.name.snakeToCamelCase() else "null"
         val resourceArg = if (resourceParam != null) resourceParam.name.snakeToCamelCase() else "null"
 

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/todolists.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/todolists.kt
@@ -23,7 +23,7 @@ class TodolistsService(client: AccountClient) : BaseService(client) {
             resourceType = "todolist_or_group",
             isMutation = false,
             projectId = null,
-            resourceId = null,
+            resourceId = id,
         )
         return request(info, {
             httpGet("/todolists/${id}", operationName = info.operation)
@@ -44,7 +44,7 @@ class TodolistsService(client: AccountClient) : BaseService(client) {
             resourceType = "todolist_or_group",
             isMutation = true,
             projectId = null,
-            resourceId = null,
+            resourceId = id,
         )
         return request(info, {
             httpPut("/todolists/${id}", json.encodeToString(kotlinx.serialization.json.buildJsonObject {

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TodolistsServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TodolistsServiceTest.kt
@@ -1,0 +1,85 @@
+package com.basecamp.sdk
+
+import com.basecamp.sdk.generated.services.UpdateTodolistOrGroupBody
+import com.basecamp.sdk.generated.todolists
+import io.ktor.client.engine.mock.*
+import io.ktor.http.*
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class TodolistsServiceTest {
+
+    private val todolistJson = """{
+        "id": 42,
+        "name": "Launch list",
+        "description": "<p>Things to do before launch</p>",
+        "description_attachments": [],
+        "completed": false,
+        "completed_ratio": "0/5",
+        "created_at": "2025-01-01T00:00:00Z",
+        "updated_at": "2025-01-01T00:00:00Z"
+    }"""
+
+    @Test
+    fun getEmitsTodolistIdAsResourceId() = runTest {
+        var capturedInfo: OperationInfo? = null
+        val hooks = object : BasecampHooks {
+            override fun onOperationStart(info: OperationInfo) {
+                if (info.operation == "GetTodolistOrGroup") capturedInfo = info
+            }
+        }
+        val engine = MockEngine { _ ->
+            respond(
+                content = todolistJson,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val client = testBasecampClient {
+            accessToken("test-token")
+            this.engine = engine
+            this.hooks = hooks
+        }
+
+        client.forAccount("12345").todolists.get(id = 42)
+
+        assertNotNull(capturedInfo)
+        assertEquals(42L, capturedInfo!!.resourceId)
+
+        client.close()
+    }
+
+    @Test
+    fun updateEmitsTodolistIdAsResourceId() = runTest {
+        var capturedInfo: OperationInfo? = null
+        val hooks = object : BasecampHooks {
+            override fun onOperationStart(info: OperationInfo) {
+                if (info.operation == "UpdateTodolistOrGroup") capturedInfo = info
+            }
+        }
+        val engine = MockEngine { _ ->
+            respond(
+                content = todolistJson,
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val client = testBasecampClient {
+            accessToken("test-token")
+            this.engine = engine
+            this.hooks = hooks
+        }
+
+        client.forAccount("12345").todolists.update(
+            id = 42,
+            body = UpdateTodolistOrGroupBody(name = "Updated list"),
+        )
+
+        assertNotNull(capturedInfo)
+        assertEquals(42L, capturedInfo!!.resourceId)
+
+        client.close()
+    }
+}

--- a/python/scripts/generate_services.py
+++ b/python/scripts/generate_services.py
@@ -587,7 +587,12 @@ def build_info_kwargs(op: dict, service_name: str) -> str:
 
     project_param = next((p for p in op["path_params"] if p["name"] in ("projectId", "bucketId")), None)
     resource_param = next(
-        (p for p in reversed(op["path_params"]) if p["name"] not in ("projectId", "bucketId")),
+        (
+            p
+            for p in reversed(op["path_params"])
+            if p["name"] not in ("projectId", "bucketId")
+            and (p["name"].endswith("Id") or p["name"] == "id")
+        ),
         None,
     )
 

--- a/python/src/basecamp/generated/services/schedules.py
+++ b/python/src/basecamp/generated/services/schedules.py
@@ -48,7 +48,9 @@ class SchedulesService(BaseService):
 
     def get_entry_occurrence(self, *, entry_id: int, date: str) -> dict[str, Any]:
         return self._request(
-            OperationInfo(service="schedules", operation="get_entry_occurrence", is_mutation=False, resource_id=date),
+            OperationInfo(
+                service="schedules", operation="get_entry_occurrence", is_mutation=False, resource_id=entry_id
+            ),
             "GET",
             f"/schedule_entries/{entry_id}/occurrences/{date}",
         )
@@ -147,7 +149,9 @@ class AsyncSchedulesService(AsyncBaseService):
 
     async def get_entry_occurrence(self, *, entry_id: int, date: str) -> dict[str, Any]:
         return await self._request(
-            OperationInfo(service="schedules", operation="get_entry_occurrence", is_mutation=False, resource_id=date),
+            OperationInfo(
+                service="schedules", operation="get_entry_occurrence", is_mutation=False, resource_id=entry_id
+            ),
             "GET",
             f"/schedule_entries/{entry_id}/occurrences/{date}",
         )

--- a/python/tests/services/test_schedules_service.py
+++ b/python/tests/services/test_schedules_service.py
@@ -1,0 +1,63 @@
+"""Tests for schedule entry occurrence operation metadata (sync + async).
+
+The occurrence path ends in ``{date}`` (a string), not an ``Id``-suffixed
+param. ``resource_id`` must fall back to the entry id, never the date string.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from basecamp import AsyncClient, Client
+from basecamp.hooks import BasecampHooks, OperationInfo
+
+OCCURRENCE_URL = "https://3.basecampapi.com/12345/schedule_entries/789/occurrences/2024-12-22"
+
+
+class _RecordingHooks(BasecampHooks):
+    def __init__(self) -> None:
+        self.operations: list[OperationInfo] = []
+
+    def on_operation_start(self, info: OperationInfo) -> None:
+        self.operations.append(info)
+
+
+def _occurrence() -> dict:
+    return {"id": 789, "summary": "Team Meeting", "occurrence_date": "2024-12-22"}
+
+
+class TestSyncScheduleOccurrence:
+    @respx.mock
+    def test_get_entry_occurrence_scopes_resource_to_entry_id(self):
+        respx.get(OCCURRENCE_URL).mock(return_value=httpx.Response(200, json=_occurrence()))
+
+        hooks = _RecordingHooks()
+        c = Client(access_token="test-token", hooks=hooks)
+        c.for_account("12345").schedules.get_entry_occurrence(entry_id=789, date="2024-12-22")
+        c.close()
+
+        assert len(hooks.operations) == 1
+        info = hooks.operations[0]
+        assert info.service == "schedules"
+        assert info.operation == "get_entry_occurrence"
+        assert info.resource_id == 789
+
+
+class TestAsyncScheduleOccurrence:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_entry_occurrence_scopes_resource_to_entry_id(self):
+        respx.get(OCCURRENCE_URL).mock(return_value=httpx.Response(200, json=_occurrence()))
+
+        hooks = _RecordingHooks()
+        c = AsyncClient(access_token="test-token", hooks=hooks)
+        await c.for_account("12345").schedules.get_entry_occurrence(entry_id=789, date="2024-12-22")
+        await c.close()
+
+        assert len(hooks.operations) == 1
+        info = hooks.operations[0]
+        assert info.service == "schedules"
+        assert info.operation == "get_entry_occurrence"
+        assert info.resource_id == 789

--- a/python/tests/services/test_todolists_service.py
+++ b/python/tests/services/test_todolists_service.py
@@ -10,8 +10,17 @@ import respx
 
 from basecamp import AsyncClient, Client
 from basecamp.errors import NotFoundError
+from basecamp.hooks import BasecampHooks, OperationInfo
 
 BASE = "https://3.basecampapi.com/12345"
+
+
+class _RecordingHooks(BasecampHooks):
+    def __init__(self) -> None:
+        self.operations: list[OperationInfo] = []
+
+    def on_operation_start(self, info: OperationInfo) -> None:
+        self.operations.append(info)
 
 
 def _put_body(route) -> dict:
@@ -68,3 +77,80 @@ class TestAsyncReposition:
 
         with pytest.raises(NotFoundError):
             await _async_todolists().reposition(todolist_id=999, position=1)
+
+
+# The get/update path label is the unsuffixed ``{id}``. resource_id must still
+# carry it (predicate is ``endswith("Id") or == "id"``); a suffix-only
+# regression would silently drop resource_id here.
+class TestSyncTodolistMetadata:
+    @respx.mock
+    def test_get_scopes_resource_to_todolist_id(self):
+        respx.get(f"{BASE}/todolists/2").mock(
+            return_value=httpx.Response(200, json={"id": 2, "name": "Sprint Tasks", "description_attachments": []})
+        )
+
+        hooks = _RecordingHooks()
+        c = Client(access_token="test-token", hooks=hooks)
+        c.for_account("12345").todolists.get(id=2)
+        c.close()
+
+        assert len(hooks.operations) == 1
+        info = hooks.operations[0]
+        assert info.service == "todolists"
+        assert info.operation == "get"
+        assert info.resource_id == 2
+
+    @respx.mock
+    def test_update_scopes_resource_to_todolist_id(self):
+        respx.put(f"{BASE}/todolists/2").mock(
+            return_value=httpx.Response(200, json={"id": 2, "name": "Updated List", "description_attachments": []})
+        )
+
+        hooks = _RecordingHooks()
+        c = Client(access_token="test-token", hooks=hooks)
+        c.for_account("12345").todolists.update(id=2, name="Updated List")
+        c.close()
+
+        assert len(hooks.operations) == 1
+        info = hooks.operations[0]
+        assert info.service == "todolists"
+        assert info.operation == "update"
+        assert info.resource_id == 2
+
+
+class TestAsyncTodolistMetadata:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_get_scopes_resource_to_todolist_id(self):
+        respx.get(f"{BASE}/todolists/2").mock(
+            return_value=httpx.Response(200, json={"id": 2, "name": "Sprint Tasks", "description_attachments": []})
+        )
+
+        hooks = _RecordingHooks()
+        c = AsyncClient(access_token="test-token", hooks=hooks)
+        await c.for_account("12345").todolists.get(id=2)
+        await c.close()
+
+        assert len(hooks.operations) == 1
+        info = hooks.operations[0]
+        assert info.service == "todolists"
+        assert info.operation == "get"
+        assert info.resource_id == 2
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_update_scopes_resource_to_todolist_id(self):
+        respx.put(f"{BASE}/todolists/2").mock(
+            return_value=httpx.Response(200, json={"id": 2, "name": "Updated List", "description_attachments": []})
+        )
+
+        hooks = _RecordingHooks()
+        c = AsyncClient(access_token="test-token", hooks=hooks)
+        await c.for_account("12345").todolists.update(id=2, name="Updated List")
+        await c.close()
+
+        assert len(hooks.operations) == 1
+        info = hooks.operations[0]
+        assert info.service == "todolists"
+        assert info.operation == "update"
+        assert info.resource_id == 2

--- a/ruby/lib/basecamp/generated/services/schedules_service.rb
+++ b/ruby/lib/basecamp/generated/services/schedules_service.rb
@@ -37,7 +37,7 @@ module Basecamp
       # @param date [String] date ID
       # @return [Hash] response data
       def get_entry_occurrence(entry_id:, date:)
-        with_operation(service: "schedules", operation: "get_entry_occurrence", is_mutation: false, resource_id: date) do
+        with_operation(service: "schedules", operation: "get_entry_occurrence", is_mutation: false, resource_id: entry_id) do
           http_get("/schedule_entries/#{entry_id}/occurrences/#{date}").json
         end
       end

--- a/ruby/scripts/generate-services.rb
+++ b/ruby/scripts/generate-services.rb
@@ -705,7 +705,8 @@ class ServiceGenerator
     kwargs << "is_mutation: #{op[:is_mutation]}"
 
     project_param = op[:path_params].find { |p| %w[projectId bucketId].include?(p[:name]) }
-    resource_param = op[:path_params].reject { |p| %w[projectId bucketId].include?(p[:name]) }.last
+    resource_param = op[:path_params].reject { |p| %w[projectId bucketId].include?(p[:name]) }
+      .select { |p| p[:name].end_with?("Id") || p[:name] == "id" }.last
 
     kwargs << "project_id: #{to_snake_case(project_param[:name])}" if project_param
     kwargs << "resource_id: #{to_snake_case(resource_param[:name])}" if resource_param

--- a/ruby/test/basecamp/services/schedules_service_test.rb
+++ b/ruby/test/basecamp/services/schedules_service_test.rb
@@ -133,6 +133,25 @@ class SchedulesServiceTest < Minitest::Test
     assert_equal "2024-12-22", result["occurrence_date"]
   end
 
+  # The occurrence path ends in `{date}` (a string), not an `Id`-suffixed param.
+  # resource_id must fall back to the entry id, never the date string.
+  def test_get_entry_occurrence_operation_metadata
+    events = []
+    account = create_account_client(account_id: "12345", hooks: CapturingHooks.new(events))
+
+    occurrence = sample_entry.merge("occurrence_date" => "2024-12-22")
+    stub_get("/12345/schedule_entries/789/occurrences/2024-12-22", response_body: occurrence)
+
+    account.schedules.get_entry_occurrence(entry_id: 789, date: "2024-12-22")
+
+    event = events.find { |e| e[:event] == :on_operation_start }
+    assert event, "Expected on_operation_start to fire"
+    info = event[:info]
+    assert_equal "schedules", info.service
+    assert_equal "get_entry_occurrence", info.operation
+    assert_equal 789, info.resource_id
+  end
+
   def test_update_settings
     updated_schedule = sample_schedule.merge("include_due_assignments" => false)
     stub_put("/12345/schedules/456", response_body: updated_schedule)
@@ -147,4 +166,20 @@ class SchedulesServiceTest < Minitest::Test
 
   # Note: trash_entry() is on RecordingsService, not SchedulesService (spec-conformant)
   # Use @account.recordings.trash(project_id:, recording_id:) instead
+
+  private
+
+  # Captures the OperationInfo passed to on_operation_start so tests can
+  # assert the metadata emitted by the real generated service call.
+  class CapturingHooks
+    include Basecamp::Hooks
+
+    def initialize(events)
+      @events = events
+    end
+
+    def on_operation_start(info)
+      @events << { event: :on_operation_start, info: info }
+    end
+  end
 end

--- a/ruby/test/basecamp/services/todolists_service_test.rb
+++ b/ruby/test/basecamp/services/todolists_service_test.rb
@@ -86,4 +86,59 @@ class TodolistsServiceTest < Minitest::Test
       @account.todolists.reposition(todolist_id: 999, position: 1)
     end
   end
+
+  # The get/update path label is the unsuffixed `{id}`. resource_id must still
+  # carry it (predicate is `end_with?("Id") || == "id"`); a suffix-only
+  # regression would silently drop resource_id here.
+  def test_get_operation_metadata
+    events = []
+    account = create_account_client(account_id: "12345", hooks: CapturingHooks.new(events))
+
+    response = { "id" => 2, "name" => "Sprint Tasks", "description_attachments" => [] }
+    stub_request(:get, %r{https://3\.basecampapi\.com/12345/todolists/\d+$})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    account.todolists.get(id: 2)
+
+    event = events.find { |e| e[:event] == :on_operation_start }
+    assert event, "Expected on_operation_start to fire"
+    info = event[:info]
+    assert_equal "todolists", info.service
+    assert_equal "get", info.operation
+    assert_equal 2, info.resource_id
+  end
+
+  def test_update_operation_metadata
+    events = []
+    account = create_account_client(account_id: "12345", hooks: CapturingHooks.new(events))
+
+    response = { "id" => 2, "name" => "Updated List", "description_attachments" => [] }
+    stub_request(:put, %r{https://3\.basecampapi\.com/12345/todolists/\d+$})
+      .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    account.todolists.update(id: 2, name: "Updated List")
+
+    event = events.find { |e| e[:event] == :on_operation_start }
+    assert event, "Expected on_operation_start to fire"
+    info = event[:info]
+    assert_equal "todolists", info.service
+    assert_equal "update", info.operation
+    assert_equal 2, info.resource_id
+  end
+
+  private
+
+  # Captures the OperationInfo passed to on_operation_start so tests can
+  # assert the metadata emitted by the real generated service call.
+  class CapturingHooks
+    include Basecamp::Hooks
+
+    def initialize(events)
+      @events = events
+    end
+
+    def on_operation_start(info)
+      @events << { event: :on_operation_start, info: info }
+    end
+  end
 end

--- a/swift/Sources/Basecamp/Generated/Services/TodolistsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/TodolistsService.swift
@@ -25,7 +25,7 @@ public final class TodolistsService: BaseService, @unchecked Sendable {
 
     public func get(id: Int) async throws -> TodolistOrGroup {
         return try await request(
-            OperationInfo(service: "Todolists", operation: "GetTodolistOrGroup", resourceType: "todolist_or_group", isMutation: false),
+            OperationInfo(service: "Todolists", operation: "GetTodolistOrGroup", resourceType: "todolist_or_group", isMutation: false, resourceId: id),
             method: "GET",
             path: "/todolists/\(id)",
             retryConfig: Metadata.retryConfig(for: "GetTodolistOrGroup")
@@ -58,7 +58,7 @@ public final class TodolistsService: BaseService, @unchecked Sendable {
 
     public func update(id: Int, req: UpdateTodolistOrGroupRequest) async throws -> TodolistOrGroup {
         return try await request(
-            OperationInfo(service: "Todolists", operation: "UpdateTodolistOrGroup", resourceType: "todolist_or_group", isMutation: true),
+            OperationInfo(service: "Todolists", operation: "UpdateTodolistOrGroup", resourceType: "todolist_or_group", isMutation: true, resourceId: id),
             method: "PUT",
             path: "/todolists/\(id)",
             body: req,

--- a/swift/Sources/BasecampGenerator/ServiceEmitter.swift
+++ b/swift/Sources/BasecampGenerator/ServiceEmitter.swift
@@ -179,7 +179,7 @@ private func emitMethod(_ op: ParsedOperation, serviceName: String, schemas: [St
     // Build OperationInfo
     let swiftPath = pathToSwiftInterpolation(op.path)
     let projectParam = op.pathParams.first { $0.name == "projectId" || $0.name == "bucketId" }
-    let resourceParam = op.pathParams.last { $0.name != "projectId" && $0.name != "bucketId" && $0.name.hasSuffix("Id") }
+    let resourceParam = op.pathParams.last { $0.name != "projectId" && $0.name != "bucketId" && ($0.name.hasSuffix("Id") || $0.name == "id") }
 
     var opInfoParts: [String] = []
     opInfoParts.append("service: \"\(serviceName)\"")

--- a/swift/Tests/BasecampTests/GeneratedServiceTests.swift
+++ b/swift/Tests/BasecampTests/GeneratedServiceTests.swift
@@ -352,6 +352,36 @@ final class GeneratedServiceTests: XCTestCase {
         XCTAssertNil(info.resourceId, "collection op has no deeper resource id")
     }
 
+    // GetTodolistOrGroup's path label is the unsuffixed `{id}`; the resource
+    // selector must still pick it up (endsWith("Id") OR == "id").
+    func testGetTodolistOrGroupEmitsTodolistIdAsResourceId() async throws {
+        let spy = SpyHooks()
+        let data = try JSONSerialization.data(withJSONObject: [:] as [String: Any])
+        let transport = MockTransport(statusCode: 200, data: data)
+        let account = makeTestAccountClient(transport: transport, hooks: spy)
+
+        _ = try await account.todolists.get(id: 42)
+
+        XCTAssertEqual(spy.operationStarts.count, 1)
+        let info = spy.operationStarts.first!
+        XCTAssertEqual(info.operation, "GetTodolistOrGroup")
+        XCTAssertEqual(info.resourceId, 42, "resourceId should be the todolist id")
+    }
+
+    func testUpdateTodolistOrGroupEmitsTodolistIdAsResourceId() async throws {
+        let spy = SpyHooks()
+        let data = try JSONSerialization.data(withJSONObject: [:] as [String: Any])
+        let transport = MockTransport(statusCode: 200, data: data)
+        let account = makeTestAccountClient(transport: transport, hooks: spy)
+
+        _ = try await account.todolists.update(id: 42, req: UpdateTodolistOrGroupRequest(name: "Updated list"))
+
+        XCTAssertEqual(spy.operationStarts.count, 1)
+        let info = spy.operationStarts.first!
+        XCTAssertEqual(info.operation, "UpdateTodolistOrGroup")
+        XCTAssertEqual(info.resourceId, 42, "resourceId should be the todolist id")
+    }
+
     func testCommentsServiceGet() async throws {
         let responseJSON: [String: Any] = [
             "id": 7, "content": "Great idea!", "content_attachments": [],

--- a/typescript/scripts/generate-services.ts
+++ b/typescript/scripts/generate-services.ts
@@ -1296,7 +1296,7 @@ function generateMethod(op: ParsedOperation, serviceName: string): string[] {
     lines.push(projectParam.name === "projectId" ? `        projectId,` : `        projectId: ${projectParam.name},`);
   }
 
-  const resourceParam = op.pathParams.findLast((p) => p.name !== "projectId" && p.name !== "bucketId" && p.name.endsWith("Id"));
+  const resourceParam = op.pathParams.findLast((p) => p.name !== "projectId" && p.name !== "bucketId" && (p.name.endsWith("Id") || p.name === "id"));
   if (resourceParam) {
     lines.push(`        resourceId: ${resourceParam.name},`);
   }

--- a/typescript/src/generated/services/todolists.ts
+++ b/typescript/src/generated/services/todolists.ts
@@ -83,6 +83,7 @@ export class TodolistsService extends BaseService {
         operation: "GetTodolistOrGroup",
         resourceType: "todolist_or_group",
         isMutation: false,
+        resourceId: id,
       },
       () =>
         this.client.GET("/todolists/{id}", {
@@ -113,6 +114,7 @@ export class TodolistsService extends BaseService {
         operation: "UpdateTodolistOrGroup",
         resourceType: "todolist_or_group",
         isMutation: true,
+        resourceId: id,
       },
       () =>
         this.client.PUT("/todolists/{id}", {

--- a/typescript/tests/services/todolists.test.ts
+++ b/typescript/tests/services/todolists.test.ts
@@ -7,6 +7,7 @@ import { server } from "../setup.js";
 import { createBasecampClient } from "../../src/client.js";
 import { BasecampError } from "../../src/errors.js";
 import type { BasecampClient } from "../../src/client.js";
+import type { OperationInfo } from "../../src/hooks.js";
 
 const BASE_URL = "https://3.basecampapi.com/12345";
 
@@ -55,6 +56,31 @@ describe("TodolistsService", () => {
       );
 
       await expect(client.todolists.get(999)).rejects.toThrow(BasecampError);
+    });
+
+    it("scopes the resource to the todolist id (unsuffixed {id} path param)", async () => {
+      const id = 42;
+      let captured: OperationInfo | undefined;
+
+      const hookedClient = createBasecampClient({
+        accountId: "12345",
+        accessToken: "test-token",
+        enableRetry: false,
+        hooks: {
+          onOperationStart: (info) => {
+            captured = info;
+          },
+        },
+      });
+
+      server.use(
+        http.get(`${BASE_URL}/todolists/${id}`, () => HttpResponse.json(sampleTodolist(id)))
+      );
+
+      await hookedClient.todolists.get(id);
+
+      expect(captured?.operation).toBe("GetTodolistOrGroup");
+      expect(captured?.resourceId).toBe(id);
     });
   });
 
@@ -123,6 +149,31 @@ describe("TodolistsService", () => {
         name: "Updated list",
       });
       expect(todolist.id).toBe(id);
+    });
+
+    it("scopes the resource to the todolist id (unsuffixed {id} path param)", async () => {
+      const id = 42;
+      let captured: OperationInfo | undefined;
+
+      const hookedClient = createBasecampClient({
+        accountId: "12345",
+        accessToken: "test-token",
+        enableRetry: false,
+        hooks: {
+          onOperationStart: (info) => {
+            captured = info;
+          },
+        },
+      });
+
+      server.use(
+        http.put(`${BASE_URL}/todolists/${id}`, () => HttpResponse.json(sampleTodolist(id)))
+      );
+
+      await hookedClient.todolists.update(id, { name: "Updated list" });
+
+      expect(captured?.operation).toBe("UpdateTodolistOrGroup");
+      expect(captured?.resourceId).toBe(id);
     });
   });
 


### PR DESCRIPTION
## What

Unify `resourceId` selection across the five generated SDKs (TypeScript,
Kotlin, Swift, Ruby, Python) so per-operation hook/observability metadata
carries the correct resource id. This converges all five on Go's existing
hand-written behavior — the same pattern #440 used for project scope.

The generators derive `resourceId` from the last non-project path param. The
two path labels in the spec that aren't `{…Id}`-suffixed — `{id}` and `{date}`
— diverged:

| Path / op | Before | After (= Go) |
|---|---|---|
| `/{accountId}/todolists/{id}` — `GetTodolistOrGroup`, `UpdateTodolistOrGroup` | TS/Kotlin/Swift: **no resourceId** (suffix guard dropped it) | `id` |
| `/{accountId}/schedule_entries/{entryId}/occurrences/{date}` — `GetScheduleEntryOccurrence` | Ruby/Python: **`resource_id = date`** (a string!) | `entryId` |

## The unified rule

`resourceId` = last path param, excluding `projectId`/`bucketId`, whose name
**ends with `"Id"` OR is exactly `"id"`**.

- TS/Kotlin/Swift already had the suffix guard; adding the `== "id"` carve-out
  gains the todolist id on get/update.
- Ruby/Python had **no** guard; adding it drops the bogus string-`date` (falls
  back to `entryId`) while keeping `resource_id = id` on the todolist ops.

**No Go changes** — Go was already correct for both (`todolists.go`, `schedules.go`).

## Why bug

Corrects wrong `resource_id` metadata, including Ruby/Python emitting a
string date where a numeric id belongs.

## Scope

- Wire/provenance unchanged: no Smithy edits, no `api-provenance.json` bump;
  `openapi.json`/`behavior-model.json`/`url-routes.json` regenerate byte-identical.
- Operation count stays at **208**; service groupings/counts unchanged.
- Generated diff is exactly: `resourceId = id` gained on TS/Kotlin/Swift
  todolists get/update; `resource_id` `date`→`entry_id` on Ruby/Python
  `GetScheduleEntryOccurrence`.

## Tests

Per-op metadata via each language's hook spy (real generated-service call →
capture `OperationInfo` → assert `resourceId`). Ruby/Python — which *add* a
predicate where none existed — assert **both** the `{date}` fallback and the
`{id}` carve-out, so a regression to suffix-only would fail loudly. Kotlin gains
a new `TodolistsServiceTest`; Python gains a new `test_schedules_service.py`.

`make check && make url-routes-check` green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies resourceId selection across the TypeScript, Kotlin, Swift, Ruby, and Python generators to match Go so per-operation hooks carry the correct resource id. We now pick the last non-project path param whose name ends with "Id" or is exactly "id".

- **Bug Fixes**
  - TypeScript/Kotlin/Swift: Todolists get/update now emit resourceId = id.
  - Ruby/Python: Schedule entry occurrence now uses resourceId = entryId (no longer the date string).
  - No API/wire changes; operation count unchanged (208).
  - Added focused tests in each SDK to assert the new selection and prevent regressions.

<sup>Written for commit e0a956de31df08daf8049e36f3141218f4af0535. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

