### PR TITLE
CI: add Swift generated-code drift gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -275,6 +275,9 @@ jobs:
 
       - name: Test
         run: swift test
+
+      - name: Check generated code drift
+        run: ../scripts/check-swift-service-drift.sh
   test-kotlin:
     name: Kotlin Tests
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -623,7 +623,7 @@ gradle-stop:
 HAS_SWIFT := $(shell command -v swift 2>/dev/null)
 IS_MACOS  := $(filter Darwin,$(shell uname -s))
 
-.PHONY: swift-build swift-test swift-check swift-clean swift-generate
+.PHONY: swift-build swift-test swift-check swift-check-drift swift-clean swift-generate
 
 # Build Swift SDK (macOS only — SDK requires Apple platforms)
 swift-build:
@@ -647,6 +647,14 @@ ifdef IS_MACOS
 	@$(MAKE) -C swift check
 else
 	@echo "SKIP: swift-check (macOS only)"
+endif
+
+# Check for drift between generated Swift code and the OpenAPI spec (macOS only)
+swift-check-drift:
+ifdef IS_MACOS
+	@scripts/check-swift-service-drift.sh
+else
+	@echo "SKIP: swift-check-drift (macOS only)"
 endif
 
 # Regenerate Swift SDK services from OpenAPI spec (needs swift on any platform)
@@ -787,7 +795,7 @@ generate:
 	@echo "==> Generation complete"
 
 # Run all checks (Smithy + Go + TypeScript + Ruby + Kotlin + Swift + Python + Behavior Model + Conformance + Provenance + Actions lint)
-check: lint-actions sync-spec-version-check smithy-check behavior-model-check provenance-check sync-api-version-check go-check-drift go-check-wrapper-drift auth-routable-check kt-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity
+check: lint-actions sync-spec-version-check smithy-check behavior-model-check provenance-check sync-api-version-check go-check-drift go-check-wrapper-drift auth-routable-check kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity
 	@echo "==> All checks passed"
 
 # Clean all build artifacts
@@ -845,6 +853,7 @@ help:
 	@echo "  swift-build      Build Swift SDK"
 	@echo "  swift-test       Run Swift tests"
 	@echo "  swift-check      Run all Swift checks"
+	@echo "  swift-check-drift    Check generated Swift code drift vs OpenAPI spec"
 	@echo "  swift-clean      Remove Swift build artifacts"
 	@echo ""
 	@echo "Conformance:"

--- a/scripts/check-swift-service-drift.sh
+++ b/scripts/check-swift-service-drift.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# check-swift-service-drift.sh
+#
+# Verifies that ALL generated Swift artifacts are current by regenerating to a
+# temp directory and diffing against the committed Generated/ tree.
+#
+# Everything under swift/Sources/Basecamp/Generated/ is emitted by
+# BasecampGenerator (Models/ and Services/ are wiped+rewritten; the root files
+# AccountClient+Services.swift, Metadata.swift, and QueryString.swift are each
+# written directly). None of it is hand-written, and none of it embeds a
+# timestamp, so a plain regen-and-diff is exact.
+#
+# Exit codes:
+#   0 = No drift detected
+#   1 = Drift detected
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+echo "==> Checking generated Swift code freshness..."
+
+# Regenerate into the temp dir directly. We invoke the generator ourselves
+# rather than `make swift-generate`, which hardcodes the committed output path.
+(cd "$ROOT_DIR/swift" && swift run BasecampGenerator \
+  --openapi ../openapi.json \
+  --behavior ../behavior-model.json \
+  --output "$TMP") > /dev/null
+
+# Guard the diff so `set -e` can't swallow the diagnostic: a bare `diff`
+# returning non-zero would abort before the echo.
+if ! diff -rq "$ROOT_DIR/swift/Sources/Basecamp/Generated/" "$TMP/" > /dev/null; then
+  echo "ERROR: Generated Swift code is out of date. Run 'make swift-generate'"
+  diff -rq "$ROOT_DIR/swift/Sources/Basecamp/Generated/" "$TMP/" || true
+  exit 1
+fi
+
+echo "Generated Swift code is up to date"


### PR DESCRIPTION
## What

Add a generated-code drift gate for Swift, closing the gap that let a stale
`Metadata.swift` reach `main` in #440.

`make check` already runs drift gates for Go (`go-check-drift`), Kotlin
(`kt-check-drift`), and Python (`py-check-drift`) — but none for Swift/TS/Ruby.
Swift is a clean regen-and-diff candidate: everything under
`swift/Sources/Basecamp/Generated/` is generator-emitted (`Models/` and
`Services/` are wiped+rewritten; the root files `AccountClient+Services.swift`,
`Metadata.swift`, `QueryString.swift` are each written directly) and embeds
**no timestamp**, so a plain diff against a fresh regen is exact.

## Changes

- **`scripts/check-swift-service-drift.sh`** (new, `100755`): mirrors
  `check-python-service-drift.sh`. Regenerates into a `mktemp -d` (invoking the
  generator directly, not `make swift-generate`, which hardcodes the committed
  output path), then diffs against the committed tree. The diff is guarded so
  `set -e` can't swallow the diagnostic before the error message prints.
- **`Makefile`**: new `swift-check-drift` target guarded exactly like
  `swift-check` (`ifdef IS_MACOS … else SKIP`); added to `.PHONY`, to the
  `check` dependency list next to `kt-check-drift`, and to help text. On Linux
  it prints SKIP; on macOS it runs.
- **`.github/workflows/test.yml`**: a "Check generated code drift" step in the
  `test-swift` job (`macos-15`, Swift toolchain already present), so the gate
  has real teeth in CI.

## Why enhancement

Tooling/CI improvement — no wire or behavior change.

## Verified

- Clean tree → script exits 0; hand-edited generated file → exits 1 with a clear
  diagnostic; reverted → 0 again.
- `make check` green (gate runs on macOS); `make swift-check-drift IS_MACOS=`
  prints SKIP and exits 0 (Linux path).
- `make lint-actions` (actionlint + zizmor) clean.

## Follow-up

TS `metadata.ts` and Ruby `metadata.json`/`types.rb` embed a `generated:`
timestamp; a drift gate for those needs timestamp normalization first, left out
of scope here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Swift generated-code drift gate to block stale files from merging. Runs in CI and via `make check` to ensure `swift/Sources/Basecamp/Generated` matches a fresh regen.

- **New Features**
  - Adds `scripts/check-swift-service-drift.sh` to regen into a temp dir and diff against committed output.
  - Adds `swift-check-drift` Makefile target; included in `check` and gated to macOS (prints SKIP on non-macOS).
  - Adds a "Check generated code drift" step to the `test-swift` GitHub Actions job.

- **Migration**
  - If the drift check fails, run `make swift-generate` and commit the changes.

<sup>Written for commit cafb5bbf787d429ea08e6b3895655473cbbfe52d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

