### PR TITLE
CI: add missing python path-labeler entry

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,6 +18,10 @@ swift:
   - changed-files:
       - any-glob-to-any-file: "swift/**"
 
+python:
+  - changed-files:
+      - any-glob-to-any-file: "python/**"
+
 spec:
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
## What

Add the missing `python` path-labeler entry to `.github/labeler.yml`.

The config had stanzas for `go`/`typescript`/`ruby`/`kotlin`/`swift`/`spec`/…
but **no `python`**, so PRs touching `python/**` never auto-got the existing
`python` label — it had to be added by hand (e.g. on #440).

```yaml
python:
  - changed-files:
      - any-glob-to-any-file: "python/**"
```

Mirrors the other language stanzas. (The `python:uv` deps label is separate and
left alone.)

## Why enhancement

Configuration/tooling hygiene — no wire or behavior change. The effect is
observable only on the next PR that touches `python/`.

## Verified

`labeler.yml` parses; the `python` stanza resolves to `python/**`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing python path-labeler entry so PRs that touch python/** automatically get the python label. Mirrors other language stanzas; CI config only.

<sup>Written for commit bab6905e3cd333a60ed439cef4a680c20c67c3cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

