### PR TITLE
Guard idempotency classification: cross-SDK parity + Swift drift gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,6 +75,12 @@ jobs:
       - name: Check auth-routable consumer invariants
         run: ../scripts/check-auth-routable-consumers.sh
 
+      - name: Check idempotency classification parity across SDKs
+        # Repo-wide bash+jq check (jq is preinstalled on ubuntu runners). Runs
+        # from repo root regardless of this job's `working-directory: go`.
+        working-directory: .
+        run: ./scripts/check-idempotency-parity
+
       - name: Test with coverage
         run: |
           # Measure coverage for hand-written code only (generated code is excluded)
@@ -275,6 +281,14 @@ jobs:
 
       - name: Test
         run: swift test
+
+      - name: Check generated code drift
+        # Generation needs only the swift toolchain, so the freshness gate keys
+        # off `make swift-check-drift` (HAS_SWIFT-gated), the single source of
+        # truth. This job defaults to `working-directory: swift`; the make
+        # target must run from repo root.
+        working-directory: .
+        run: make swift-check-drift
   test-kotlin:
     name: Kotlin Tests
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -623,7 +623,7 @@ gradle-stop:
 HAS_SWIFT := $(shell command -v swift 2>/dev/null)
 IS_MACOS  := $(filter Darwin,$(shell uname -s))
 
-.PHONY: swift-build swift-test swift-check swift-clean swift-generate
+.PHONY: swift-build swift-test swift-check swift-check-drift swift-clean swift-generate
 
 # Build Swift SDK (macOS only — SDK requires Apple platforms)
 swift-build:
@@ -655,6 +655,17 @@ ifdef HAS_SWIFT
 	@$(MAKE) -C swift generate
 else
 	$(error swift is required for swift-generate but was not found)
+endif
+
+# Check committed generated Swift is current (needs swift on any platform, NOT
+# just macOS — generation only needs the toolchain, unlike swift-check's
+# build/test which require Apple platforms). Non-mutating regenerate + diff.
+swift-check-drift:
+ifdef HAS_SWIFT
+	@echo "==> Checking Swift service drift..."
+	@./scripts/check-swift-service-drift.sh
+else
+	@echo "SKIP: swift-check-drift (swift toolchain not found)"
 endif
 
 # Clean Swift build artifacts
@@ -743,7 +754,7 @@ tools:
 # Spec-shape lints
 #------------------------------------------------------------------------------
 
-.PHONY: check-bucket-flat-parity validate-api-gaps check-deprecation-parity kt-check-optional-arrays
+.PHONY: check-bucket-flat-parity validate-api-gaps check-deprecation-parity kt-check-optional-arrays check-idempotency-parity
 
 # Verify every bucket-scoped GET list operation has a flat-path counterpart
 # (or is justified in spec/bucket-scoped-allowlist.txt). Cross-project SDK
@@ -771,6 +782,12 @@ validate-api-gaps:
 kt-check-optional-arrays:
 	@./scripts/check-kotlin-optional-arrays.sh
 
+# Verify idempotency classification is identical across all six SDKs and matches
+# behavior-model.json (the 69 idempotent mutations; Go additionally folds in the
+# 100 read-only ops for 169). Bash+jq — runs anywhere, enforced in CI.
+check-idempotency-parity:
+	@./scripts/check-idempotency-parity
+
 #------------------------------------------------------------------------------
 # Combined targets
 #------------------------------------------------------------------------------
@@ -793,7 +810,7 @@ generate:
 	@echo "==> Generation complete"
 
 # Run all checks (Smithy + Go + TypeScript + Ruby + Kotlin + Swift + Python + Behavior Model + Conformance + Provenance + Actions lint)
-check: lint-actions sync-spec-version-check smithy-check behavior-model-check provenance-check sync-api-version-check go-check-drift go-check-wrapper-drift auth-routable-check kt-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity kt-check-optional-arrays
+check: lint-actions sync-spec-version-check smithy-check behavior-model-check provenance-check sync-api-version-check go-check-drift go-check-wrapper-drift auth-routable-check kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity kt-check-optional-arrays check-idempotency-parity
 	@echo "==> All checks passed"
 
 # Clean all build artifacts
@@ -851,6 +868,7 @@ help:
 	@echo "  swift-build      Build Swift SDK"
 	@echo "  swift-test       Run Swift tests"
 	@echo "  swift-check      Run all Swift checks"
+	@echo "  swift-check-drift  Check generated Swift is current (any OS with swift)"
 	@echo "  swift-clean      Remove Swift build artifacts"
 	@echo ""
 	@echo "Conformance:"

--- a/scripts/check-idempotency-parity
+++ b/scripts/check-idempotency-parity
@@ -54,6 +54,16 @@ pass=0
 compare() {
     local label="$1" expected="$2" actual="$3"
     local missing extra
+    # Fail closed: every set in this check is non-empty (69 or 169 ops). An
+    # empty file means an extraction (grep/jq/awk/sed) matched nothing — a
+    # broken adapter, not a real "empty == empty" match — so `comm` producing
+    # no diff must not be counted as a pass.
+    if [[ ! -s "$expected" || ! -s "$actual" ]]; then
+        fail=$((fail + 1))
+        echo "  FAIL: $label"
+        echo "        internal error: empty operation set (expected=$(wc -l < "$expected" | tr -d ' '), actual=$(wc -l < "$actual" | tr -d ' ')) — an extraction matched nothing"
+        return
+    fi
     missing=$(comm -23 "$expected" "$actual")   # in source of truth, absent from SDK
     extra=$(comm -13 "$expected" "$actual")      # in SDK, not in source of truth
     if [[ -z "$missing" && -z "$extra" ]]; then

--- a/scripts/check-idempotency-parity
+++ b/scripts/check-idempotency-parity
@@ -37,6 +37,11 @@ set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
+# Stable byte-wise collation for every sort/comm below — a non-C locale can
+# order the same op names differently than `comm` expects, yielding false
+# diffs (or masking real ones). Matches scripts/check-kotlin-service-drift.sh.
+export LC_ALL=C
+
 if ! command -v jq >/dev/null 2>&1; then
     echo "ERROR: jq is required" >&2
     exit 2

--- a/scripts/check-idempotency-parity
+++ b/scripts/check-idempotency-parity
@@ -156,6 +156,24 @@ grep -oE '\}, true, "[[:alnum:]]+",' "$GO" \
 compare "Go doWithRetry(…, true, …) call-site set == 169" "$WORK/union169" "$WORK/go_callsite"
 # (3) table and call-site sets agree.
 compare "Go table set == call-site set" "$WORK/go_table" "$WORK/go_callsite"
+# (4) No idempotent op may carry a `false` doWithRetry call-site. Assertion (2)
+# sorts -u, which collapses an op's multiple call-sites (a typed method + its
+# WithBody sibling both render a doWithRetry call for the same op); a single
+# variant regressing true→false would otherwise hide behind a sibling's true.
+# So separately assert the set of ops passed as doWithRetry(…, false, …) is
+# disjoint from the 169. (Today there are zero `false` call-sites — non-
+# idempotent ops bypass doWithRetry entirely — so this guards a future regression.)
+grep -oE '\}, false, "[[:alnum:]]+",' "$GO" \
+    | grep -oE '"[[:alnum:]]+"' | tr -d '"' | sort -u > "$WORK/go_false_callsite"
+go_false_idempotent=$(comm -12 "$WORK/union169" "$WORK/go_false_callsite")
+if [[ -z "$go_false_idempotent" ]]; then
+    pass=$((pass + 1))
+else
+    fail=$((fail + 1))
+    echo "  FAIL: Go idempotent ops must not have a false doWithRetry call-site"
+    echo "        idempotent ops dispatched with a non-retrying call-site:"
+    echo "$go_false_idempotent" | sed 's/^/          /'
+fi
 
 echo ""
 if [[ "$fail" -eq 0 ]]; then

--- a/scripts/check-idempotency-parity
+++ b/scripts/check-idempotency-parity
@@ -16,13 +16,16 @@
 #   * Non-Go SDKs' idempotent set == the 69.
 #   * Go's Idempotent:true set     == the 169 (idempotent ∪ readonly).
 #
-# Go is checked THREE ways, because the retry gate consumes an inline call-site
+# Go is checked FOUR ways, because the retry gate consumes an inline call-site
 # boolean (doWithRetry(…, true, "Op", …)) that is rendered INDEPENDENTLY from
 # the operationMetadata table. The call-site boolean is the load-bearing value
 # for retry, so both must be pinned and proven equal:
 #   (1) operationMetadata Idempotent:true set == 169
 #   (2) unique ops passed as doWithRetry(…, true, "Op", …) == 169
 #   (3) sets (1) and (2) are equal
+#   (4) no idempotent op carries a doWithRetry(…, false, "Op", …) call-site
+#       (assertion (2) sorts -u, so one variant regressing true→false could
+#        otherwise hide behind a sibling's true — see the call-site comments)
 #
 # TypeScript is additionally checked on its `.natural`-gated set (the retry gate
 # is `if (opMeta?.idempotent?.natural)`, typescript/src/client.ts): that set must
@@ -154,7 +157,7 @@ jq -r '.operations | to_entries[] | select(.value.idempotent.natural == true) | 
     | sort > "$WORK/ts_natural"
 compare "TypeScript .natural-gated set == 69" "$WORK/idempotent69" "$WORK/ts_natural"
 
-# ---- Go (client.gen.go) — three assertions -----------------------------------
+# ---- Go (client.gen.go) — four assertions -----------------------------------
 GO=go/pkg/generated/client.gen.go
 # (1) operationMetadata table, Idempotent:true.
 awk '/var operationMetadata = map\[string\]OperationMetadata\{/{f=1} f; /^\}/{if(f)f=0}' "$GO" \

--- a/scripts/check-idempotency-parity
+++ b/scripts/check-idempotency-parity
@@ -42,7 +42,8 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 2
 fi
 
-WORK="$(mktemp -d)"
+# Explicit template so this works identically under GNU and BSD/macOS mktemp.
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/idempotency-parity.XXXXXX")"
 trap 'rm -rf "$WORK"' EXIT
 
 fail=0

--- a/scripts/check-idempotency-parity
+++ b/scripts/check-idempotency-parity
@@ -48,7 +48,14 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # Explicit template so this works identically under GNU and BSD/macOS mktemp.
-WORK="$(mktemp -d "${TMPDIR:-/tmp}/idempotency-parity.XXXXXX")"
+# Fail fast if mktemp fails (this script omits `set -e` to accumulate parity
+# mismatches): an empty $WORK would turn `> "$WORK/…"` into a write to the
+# filesystem root.
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/idempotency-parity.XXXXXX")" || exit 2
+if [[ -z "$WORK" || ! -d "$WORK" ]]; then
+    echo "ERROR: could not create a temp directory" >&2
+    exit 2
+fi
 trap 'rm -rf "$WORK"' EXIT
 
 fail=0

--- a/scripts/check-idempotency-parity
+++ b/scripts/check-idempotency-parity
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# check-idempotency-parity — assert idempotency classification is identical
+# across all six SDKs and matches the source of truth.
+#
+# The source of truth is behavior-model.json:
+#   * idempotent == true            → the 69 naturally-idempotent mutations
+#   * idempotent OR readonly == true → the 169 operations Go bakes idempotency
+#                                      into at generation time (GET/HEAD are
+#                                      idempotent by construction, so Go folds
+#                                      the 100 read-only ops into its retry set).
+#
+# Every SDK's generated idempotency set must equal the appropriate source set
+# EXACTLY (set equality, both directions — not subset):
+#
+#   * Non-Go SDKs' idempotent set == the 69.
+#   * Go's Idempotent:true set     == the 169 (idempotent ∪ readonly).
+#
+# Go is checked THREE ways, because the retry gate consumes an inline call-site
+# boolean (doWithRetry(…, true, "Op", …)) that is rendered INDEPENDENTLY from
+# the operationMetadata table. The call-site boolean is the load-bearing value
+# for retry, so both must be pinned and proven equal:
+#   (1) operationMetadata Idempotent:true set == 169
+#   (2) unique ops passed as doWithRetry(…, true, "Op", …) == 169
+#   (3) sets (1) and (2) are equal
+#
+# TypeScript is additionally checked on its `.natural`-gated set (the retry gate
+# is `if (opMeta?.idempotent?.natural)`, typescript/src/client.ts): that set must
+# also equal the 69, closing the gate-predicate-vs-classification divergence.
+#
+# Cross-platform hygiene: operation names are emitted with POSIX character
+# classes (no \w/\s PCRE assumptions) and compared with `comm`.
+#
+# Exit non-zero on any violation. Wired into `make check` and CI.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq is required" >&2
+    exit 2
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+pass=0
+
+# compare <label> <expected-file> <actual-file>: set equality, both directions.
+# Inputs must be sorted. Reports names missing from / extra in the SDK set.
+compare() {
+    local label="$1" expected="$2" actual="$3"
+    local missing extra
+    missing=$(comm -23 "$expected" "$actual")   # in source of truth, absent from SDK
+    extra=$(comm -13 "$expected" "$actual")      # in SDK, not in source of truth
+    if [[ -z "$missing" && -z "$extra" ]]; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        echo "  FAIL: $label"
+        if [[ -n "$missing" ]]; then
+            echo "        missing from SDK (present in source of truth):"
+            echo "$missing" | sed 's/^/          /'
+        fi
+        if [[ -n "$extra" ]]; then
+            echo "        extra in SDK (not classified idempotent in source of truth):"
+            echo "$extra" | sed 's/^/          /'
+        fi
+    fi
+}
+
+echo "==> Checking idempotency-classification parity across six SDKs"
+
+# ---- Source of truth (behavior-model.json) -----------------------------------
+BM=behavior-model.json
+jq -r '.operations | to_entries[] | select(.value.idempotent == true) | .key' "$BM" \
+    | sort > "$WORK/idempotent69"
+jq -r '.operations | to_entries[] | select(.value.idempotent == true or .value.readonly == true) | .key' "$BM" \
+    | sort > "$WORK/union169"
+
+n69=$(wc -l < "$WORK/idempotent69" | tr -d ' ')
+n169=$(wc -l < "$WORK/union169" | tr -d ' ')
+echo "    source of truth: $n69 idempotent, $n169 idempotent∪readonly"
+if [[ "$n69" != "69" || "$n169" != "169" ]]; then
+    echo "  FAIL: unexpected source-of-truth counts (idempotent=$n69 want 69, union=$n169 want 169)"
+    echo "        behavior-model.json changed shape — update this check deliberately."
+    fail=$((fail + 1))
+fi
+
+# ---- Python (metadata.json, flat root map) -----------------------------------
+jq -r 'to_entries[] | select(.value.idempotent == true) | .key' \
+    python/src/basecamp/generated/metadata.json | sort > "$WORK/python"
+compare "Python idempotent set == 69" "$WORK/idempotent69" "$WORK/python"
+
+# ---- Ruby (metadata.json, .operations wrapper, .idempotent.natural) ----------
+jq -r '.operations | to_entries[] | select(.value.idempotent.natural == true) | .key' \
+    ruby/lib/basecamp/generated/metadata.json | sort > "$WORK/ruby"
+compare "Ruby idempotent set == 69" "$WORK/idempotent69" "$WORK/ruby"
+
+# ---- Kotlin (Metadata.kt, positional "Op" to OperationConfig(true, …)) -------
+# idempotent is the first positional arg of OperationConfig; match by position,
+# not field name.
+grep -oE '"[[:alnum:]]+" to OperationConfig\(true,' \
+    kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/Metadata.kt \
+    | sed -E 's/"([[:alnum:]]+)".*/\1/' | sort > "$WORK/kotlin"
+compare "Kotlin idempotent set == 69" "$WORK/idempotent69" "$WORK/kotlin"
+
+# ---- Swift (Metadata.swift, string literals in idempotentOperations Set) -----
+awk '/idempotentOperations: Set<String> = \[/{f=1; next} /^[[:space:]]*\]/{f=0} f' \
+    swift/Sources/Basecamp/Generated/Metadata.swift \
+    | grep -oE '"[[:alnum:]]+"' | tr -d '"' | sort > "$WORK/swift"
+compare "Swift idempotent set == 69" "$WORK/idempotent69" "$WORK/swift"
+
+# ---- TypeScript (metadata.ts, multiline JSON-style `const metadata` object) --
+# Extract the object literal and parse with jq — a single-line grep can't read
+# the multiline nested JSON.
+TS_JSON="$WORK/ts-metadata.json"
+sed -n '/^const metadata: MetadataOutput = {/,/^};/p' typescript/src/generated/metadata.ts \
+    | sed '1s/^const metadata: MetadataOutput = //; $s/;$//' > "$TS_JSON"
+# Primary: the set with an `idempotent` config present.
+jq -r '.operations | to_entries[] | select(.value.idempotent != null) | .key' "$TS_JSON" \
+    | sort > "$WORK/ts"
+compare "TypeScript idempotent set == 69" "$WORK/idempotent69" "$WORK/ts"
+# Additional: the `.natural`-gated set (the actual retry-gate predicate,
+# typescript/src/client.ts). Pins that the gate predicate matches the
+# classification — an idempotent entry missing `natural:true` would silently
+# stop retrying in TS.
+jq -r '.operations | to_entries[] | select(.value.idempotent.natural == true) | .key' "$TS_JSON" \
+    | sort > "$WORK/ts_natural"
+compare "TypeScript .natural-gated set == 69" "$WORK/idempotent69" "$WORK/ts_natural"
+
+# ---- Go (client.gen.go) — three assertions -----------------------------------
+GO=go/pkg/generated/client.gen.go
+# (1) operationMetadata table, Idempotent:true.
+awk '/var operationMetadata = map\[string\]OperationMetadata\{/{f=1} f; /^\}/{if(f)f=0}' "$GO" \
+    | grep -E 'Idempotent: true' \
+    | grep -oE '"[[:alnum:]]+":' | tr -d '":' | sort -u > "$WORK/go_table"
+compare "Go operationMetadata Idempotent:true set == 169" "$WORK/union169" "$WORK/go_table"
+# (2) call-site booleans: unique ops passed as doWithRetry(…, true, "Op", …).
+# This is the load-bearing value for the retry gate.
+grep -oE '\}, true, "[[:alnum:]]+",' "$GO" \
+    | grep -oE '"[[:alnum:]]+"' | tr -d '"' | sort -u > "$WORK/go_callsite"
+compare "Go doWithRetry(…, true, …) call-site set == 169" "$WORK/union169" "$WORK/go_callsite"
+# (3) table and call-site sets agree.
+compare "Go table set == call-site set" "$WORK/go_table" "$WORK/go_callsite"
+
+echo ""
+if [[ "$fail" -eq 0 ]]; then
+    echo "==> Idempotency parity clean ($pass checks passed)"
+    exit 0
+else
+    echo "==> Idempotency parity FAILED ($fail failure(s), $pass passed)"
+    exit 1
+fi

--- a/scripts/check-swift-service-drift.sh
+++ b/scripts/check-swift-service-drift.sh
@@ -23,7 +23,8 @@ if ! command -v swift >/dev/null 2>&1; then
 fi
 
 GENERATED_DIR="$ROOT_DIR/swift/Sources/Basecamp/Generated"
-TMP_OUT="$(mktemp -d)"
+# Explicit template so this works identically under GNU and BSD/macOS mktemp.
+TMP_OUT="$(mktemp -d "${TMPDIR:-/tmp}/swift-service-drift.XXXXXX")"
 trap 'rm -rf "$TMP_OUT"' EXIT
 
 echo "==> Regenerating Swift SDK into a temp directory..."

--- a/scripts/check-swift-service-drift.sh
+++ b/scripts/check-swift-service-drift.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# check-swift-service-drift.sh
+#
+# Verifies that the committed generated Swift artifacts are current by
+# regenerating the whole Generated/ tree into a temp directory and diffing.
+# Generation needs only the Swift toolchain (not macOS), so this runs on any
+# platform with `swift`. It is non-mutating: the committed tree is never
+# touched.
+#
+# Exit codes:
+#   0 = No drift detected
+#   1 = Drift detected
+#   2 = swift toolchain not available
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+if ! command -v swift >/dev/null 2>&1; then
+  echo "ERROR: swift is required for check-swift-service-drift.sh but was not found" >&2
+  exit 2
+fi
+
+GENERATED_DIR="$ROOT_DIR/swift/Sources/Basecamp/Generated"
+TMP_OUT="$(mktemp -d)"
+trap 'rm -rf "$TMP_OUT"' EXIT
+
+echo "==> Regenerating Swift SDK into a temp directory..."
+# The generator resolves --openapi/--behavior relative to its working
+# directory; run from swift/ (like `make swift-generate`) but emit to an
+# absolute temp path so the committed tree is untouched.
+(cd "$ROOT_DIR/swift" && \
+  swift run BasecampGenerator \
+    --openapi "$ROOT_DIR/openapi.json" \
+    --behavior "$ROOT_DIR/behavior-model.json" \
+    --output "$TMP_OUT") > /dev/null
+
+echo "==> Diffing against committed swift/Sources/Basecamp/Generated/ ..."
+if ! diff -rq "$GENERATED_DIR" "$TMP_OUT" > /dev/null; then
+  echo "ERROR: Generated Swift is out of date. Run 'make swift-generate'"
+  diff -rq "$GENERATED_DIR" "$TMP_OUT" || true
+  exit 1
+fi
+
+echo "No drift detected."
+exit 0


### PR DESCRIPTION
## Summary

Two **guard-only** additions (no generated or source code changes) closing follow-up gaps from #439, which pinned that an idempotent-flagged POST (`CompleteTodo`) must retry on 503. This is PR1 of a three-PR series (PR1 → PR2 → PR3).

### `scripts/check-idempotency-parity` — cross-SDK classification parity
Bash + `jq`. Asserts the idempotency classification is **identical across all six SDKs** and matches the source of truth, `behavior-model.json`:

- Non-Go SDKs' idempotent set **==** the 69 naturally-idempotent mutations (set equality, both directions — not subset).
- Go bakes GET/HEAD idempotency in at generation time, so its `Idempotent:true` set **==** the 169 (`idempotent ∪ readonly`).
- **Go is checked four ways** because the retry gate consumes an inline call-site boolean — `doWithRetry(…, true, "Op", …)` — rendered *independently* from the `operationMetadata` table. The call-site boolean is the load-bearing value for retry, so both are pinned and proven equal: (1) table set == 169, (2) call-site set == 169, (3) the two are equal, and (4) no idempotent op carries a `false` `doWithRetry` call-site — guards a per-variant regression that `sort -u` on the true-set would otherwise hide behind a sibling `true`.
- **TypeScript** is additionally checked on its `.natural`-gated set (the actual retry-gate predicate, `client.ts:850`) so a classification-vs-predicate divergence can't silently stop TS from retrying.

Cross-platform hygiene: POSIX character classes, `comm` for comparison. Wired into `make check` **and** enforced in CI (`test-go` job — bash+jq runs anywhere, so unlike the other parity checks it gets real CI enforcement).

### `make swift-check-drift` + `scripts/check-swift-service-drift.sh` — Swift generated-drift gate
Regenerates the Swift `Generated/` tree into a temp dir and diffs against the committed tree (non-mutating). Swift's classification set silently drifted before #440 swept it back in; nothing guarded against recurrence. Gated on `HAS_SWIFT` (generation needs only the toolchain, any OS) — distinct from `swift-check`'s macOS-gated build/test. Wired into `make check` and the `test-swift` CI job.

## Verification
- `./scripts/check-idempotency-parity` exits 0 on `main` (9 checks, all six SDKs in parity).
- `make swift-check-drift` clean on `main`.
- Negative proofs (throwaway edits, reverted): removing a Swift `idempotentOperations` entry fails **both** `swift-check-drift` and the parity check; flipping the `CompleteTodo` **call-site boolean** `true→false` (leaving the table entry `Idempotent: true`) fails the Go call-site + table-vs-call-site assertions — proving the check guards the load-bearing retry gate, not just the table.
- `make check` green.

Refs #439, #417.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two guards: a cross-SDK idempotency parity check and a Swift generated-code drift gate, both wired into `make check` and enforced in CI. Ensures retry classification stays consistent across SDKs and prevents Swift code drift.

- **New Features**
  - Cross-SDK idempotency parity (`scripts/check-idempotency-parity`, `make check-idempotency-parity`): non-Go idempotent set == 69; Go == 169 (idempotent ∪ readonly). Verifies Go `operationMetadata`, true `doWithRetry` call-sites, their equality, and forbids any idempotent op with a false call-site. Pins TypeScript’s `.natural`-gated set. Fails closed on empty extracts. Runs in `make check` and CI (`test-go`).
  - Swift generated-code drift gate (`make swift-check-drift`, `scripts/check-swift-service-drift.sh`): regenerates to a temp dir and diffs against `swift/Sources/Basecamp/Generated/`. Works on any OS with `swift`. Runs in `make check` and CI (`test-swift`).

- **Refactors**
  - Hardened temp dir handling: explicit `mktemp -d` templates; fail fast if `mktemp` fails.
  - Set `LC_ALL=C` for stable `sort`/`comm` collation.

<sup>Written for commit 9f6b05d71c7ee1c1339dae2c4c724fad93a3f684. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

