### PR TITLE
Test: pin idempotent-POST 503→success retry through the service API

### DIFF
--- a/go/pkg/basecamp/todos_test.go
+++ b/go/pkg/basecamp/todos_test.go
@@ -1789,3 +1789,35 @@ func TestTodosService_RepositionWithParentID(t *testing.T) {
 		t.Errorf("expected parent_id 99999, got %v", receivedBody["parent_id"])
 	}
 }
+
+// TestTodosService_Complete_RetriesOn503 pins that Complete (CompleteTodo) — a
+// POST that is nonetheless flagged idempotent in behavior-model.json — is
+// retried on a transient 503 and then succeeds. It drives the generated service
+// path (Todos().Complete), so it fails if CompleteTodo's idempotency
+// classification is ever flipped off (in Go the load-bearing value is the
+// generated call-site boolean doWithRetry(…, true, "CompleteTodo", …)).
+// Regression guard for the hole closed by #439 / #417.
+func TestTodosService_Complete_RetriesOn503(t *testing.T) {
+	attempts := 0
+	svc := testTodosServer(t, func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/todos/100/completion.json") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if attempts == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	if err := svc.Complete(context.Background(), 100); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 2 {
+		t.Errorf("expected 2 attempts (initial 503 + 1 retry), got %d", attempts)
+	}
+}

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/RetryTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/RetryTest.kt
@@ -1,5 +1,6 @@
 package com.basecamp.sdk
 
+import com.basecamp.sdk.generated.todos
 import com.basecamp.sdk.http.BasecampHttpClient
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
@@ -393,6 +394,36 @@ class RetryTest {
         assertEquals(2, retryDelays.size)
         assertTrue(retryDelays[0] > 0, "First retry delay should be positive")
         assertTrue(retryDelays[1] > retryDelays[0], "Second retry delay should be larger (exponential)")
+        client.close()
+    }
+
+    @Test
+    fun retriesIdempotentPostThroughGeneratedService() = runTest {
+        var requestCount = 0
+        val engine = MockEngine { _ ->
+            requestCount++
+            if (requestCount == 1) {
+                respond(content = "", status = HttpStatusCode.ServiceUnavailable)
+            } else {
+                respond(content = "", status = HttpStatusCode.NoContent)
+            }
+        }
+
+        val client = testBasecampClient {
+            accessToken("test-token")
+            this.engine = engine
+        }
+
+        val account = client.forAccount("12345")
+        // CompleteTodo is a POST flagged idempotent in metadata. The existing
+        // retryForIdempotentOperationWithMetadata test uses PUT/UpdateProject,
+        // which is retried via the method allowlist (method in IDEMPOTENT_METHODS)
+        // — it does NOT exercise the POST metadata gate. Driving the generated
+        // service (account.todos.complete) does, so this fails if CompleteTodo's
+        // metadata idempotent flag is flipped off. Regression guard for #439 / #417.
+        account.todos.complete(todoId = 100)
+
+        assertEquals(2, requestCount)
         client.close()
     }
 }

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/RetryTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/RetryTest.kt
@@ -400,8 +400,12 @@ class RetryTest {
     @Test
     fun retriesIdempotentPostThroughGeneratedService() = runTest {
         var requestCount = 0
-        val engine = MockEngine { _ ->
+        val methods = mutableListOf<String>()
+        val paths = mutableListOf<String>()
+        val engine = MockEngine { request ->
             requestCount++
+            methods.add(request.method.value)
+            paths.add(request.url.encodedPath)
             if (requestCount == 1) {
                 respond(content = "", status = HttpStatusCode.ServiceUnavailable)
             } else {
@@ -424,6 +428,14 @@ class RetryTest {
         account.todos.complete(todoId = 100)
 
         assertEquals(2, requestCount)
+        // Pin the generated CompleteTodo wire shape: both the initial attempt and
+        // the retry must be POST to /…/todos/100/completion.json. Without this the
+        // test could pass on a wrong route/method as long as something retried once.
+        assertTrue(methods.all { it == "POST" }, "expected all POST, got $methods")
+        assertTrue(
+            paths.all { it.endsWith("/todos/100/completion.json") },
+            "expected the CompleteTodo completion path, got $paths",
+        )
         client.close()
     }
 }

--- a/python/tests/services/test_todos.py
+++ b/python/tests/services/test_todos.py
@@ -8,7 +8,7 @@ import httpx
 import pytest
 import respx
 
-from basecamp import AsyncClient, Client
+from basecamp import AsyncClient, Client, Config
 from basecamp.errors import UsageError
 from basecamp.hooks import BasecampHooks, OperationInfo
 
@@ -340,3 +340,38 @@ class TestDescriptionAttachments:
         # None is preserved verbatim despite the TypedDict's non-optional width.
         assert attachments[1]["width"] is None
         assert attachments[1]["height"] is None
+
+
+# Instant retries: CompleteTodo's retry config would otherwise back off ~1s.
+_FAST = Config(base_delay=0.0, max_jitter=0.0)
+
+
+class TestCompleteRetriesIdempotentPost:
+    """CompleteTodo is a POST flagged idempotent in metadata, so it must be
+    retried on a transient 503. Driving the generated ``todos.complete`` service
+    (not the raw HTTP client) exercises the metadata idempotency gate
+    (``_is_retryable_operation``), so these fail if CompleteTodo's ``idempotent``
+    flag is flipped off. Sync and async use separate retry loops (_http.py vs
+    _async_http.py), so both are pinned. Regression guard for #439 / #417.
+    """
+
+    @respx.mock
+    def test_sync_retries_on_503_then_succeeds(self):
+        route = respx.post(f"{BASE}/todos/42/completion.json")
+        route.side_effect = [httpx.Response(503), httpx.Response(204)]
+
+        client = Client(access_token="test-token", config=_FAST)
+        client.for_account("12345").todos.complete(todo_id=42)
+
+        assert route.call_count == 2  # initial 503 + 1 retry that succeeds
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_retries_on_503_then_succeeds(self):
+        route = respx.post(f"{BASE}/todos/42/completion.json")
+        route.side_effect = [httpx.Response(503), httpx.Response(204)]
+
+        client = AsyncClient(access_token="test-token", config=_FAST)
+        await client.for_account("12345").todos.complete(todo_id=42)
+
+        assert route.call_count == 2  # initial 503 + 1 retry that succeeds

--- a/typescript/tests/services/todos.test.ts
+++ b/typescript/tests/services/todos.test.ts
@@ -422,6 +422,35 @@ describe("TodosService", () => {
 
       await expect(client.todos.complete(42)).resolves.toBeUndefined();
     });
+
+    it("should retry an idempotent POST (CompleteTodo) on 503 then succeed", async () => {
+      // CompleteTodo is a POST but is flagged idempotent in metadata
+      // (idempotent.natural === true), so the retry middleware MUST retry it on
+      // 503. Drives the generated service path (client.todos.complete), not the
+      // raw client, so this fails if CompleteTodo's metadata idempotent flag is
+      // ever flipped off — the analog of Swift's testGeneratedIdempotentPostRetries.
+      let attempts = 0;
+
+      server.use(
+        http.post(`${BASE_URL}/todos/42/completion.json`, () => {
+          attempts++;
+          if (attempts === 1) {
+            return new HttpResponse(null, { status: 503 });
+          }
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      // The suite default is enableRetry:false; this operation needs a
+      // retry-enabled client to exercise the POST idempotency gate.
+      const retryClient = createBasecampClient({
+        accountId: "12345",
+        accessToken: "test-token",
+      });
+
+      await expect(retryClient.todos.complete(42)).resolves.toBeUndefined();
+      expect(attempts).toBe(2); // initial 503 + 1 retry that succeeds
+    });
   });
 
   describe("uncomplete", () => {

--- a/typescript/tests/services/todos.test.ts
+++ b/typescript/tests/services/todos.test.ts
@@ -442,10 +442,13 @@ describe("TodosService", () => {
       );
 
       // The suite default is enableRetry:false; this operation needs a
-      // retry-enabled client to exercise the POST idempotency gate.
+      // retry-enabled client to exercise the POST idempotency gate. Set it
+      // explicitly rather than relying on createBasecampClient's default so the
+      // test keeps testing retry even if that default ever changes.
       const retryClient = createBasecampClient({
         accountId: "12345",
         accessToken: "test-token",
+        enableRetry: true,
       });
 
       await expect(retryClient.todos.complete(42)).resolves.toBeUndefined();


### PR DESCRIPTION
## Summary

Positive per-SDK unit coverage for the hole #439 / #417 addressed: an idempotent-flagged **POST** (`CompleteTodo`) must retry on a transient 503 and succeed. Test-only; **no SDK source change**. PR2 of a three-PR series (PR1 → PR2 → PR3); independent of PR1.

Each test drives the **generated account/service path** (`todos.complete` → `CompleteTodo`), not the raw HTTP client, so it fails if `CompleteTodo`'s metadata idempotency classification is ever flipped off — the per-SDK analog of Swift's `testGeneratedIdempotentPostRetries`.

## Five tests

| SDK | Why it's needed |
|-----|-----------------|
| **Kotlin** (`RetryTest`) | The existing `retryForIdempotentOperationWithMetadata` drives PUT/`UpdateProject`, retried via the method allowlist (`method in IDEMPOTENT_METHODS`) — it never exercises the POST metadata gate. This one does, via `account.todos.complete`. |
| **Go** (`todos_test`) | `httptest` attempt-counting through `Todos().Complete`. In Go the load-bearing value is the generated call-site boolean `doWithRetry(…, true, "CompleteTodo", …)`, so this guards that gate. |
| **TypeScript** (`todos.test`) | The suite defaults `enableRetry:false`, so the new test instantiates a **retry-enabled** client and drives `client.todos.complete`. |
| **Python** (`test_todos`) | Sync and async clients have **separate retry loops** (`_http.py` vs `_async_http.py`), so **both** are covered (two tests). Fast retry config (`base_delay=0`) keeps them instant. |

## Verification
- All 5 tests pass (TS, Go, Kotlin, Python-sync, Python-async).
- Each verified to **fail** when its SDK's `CompleteTodo` idempotent flag is flipped off (Kotlin/Python/TS metadata; Go call-site boolean) — proving they guard the metadata/classification gate, not incidental behavior.

Refs #439, #417.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add cross-SDK tests to ensure the idempotent POST `CompleteTodo` retries on a 503 and succeeds when called via `todos.complete`.

Covers Kotlin (now also asserts POST and `/todos/{id}/completion.json` path), Go, TypeScript (explicit `enableRetry: true`), and Python (sync + async); each fails if `CompleteTodo`’s idempotent flag is removed; test-only, no SDK source changes; refs #439, #417.

<sup>Written for commit 5c98535918db0eb9e85293711e5e31acb3c9e981. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

