### PR TITLE
Conformance: exercise the network-error transport path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -250,6 +250,15 @@ jobs:
       - name: Test with coverage
         run: uv run pytest --cov --cov-report=term-missing --cov-fail-under=60
 
+      - name: Validate conformance fixtures against schema
+        # Authoritative enforcement of conformance/schema.json (incl. the
+        # mockResponses oneOf). uv is already installed, so `make
+        # conformance-fixtures-check` runs check-jsonschema via uvx. Runs from
+        # repo root regardless of this job's working-directory: python.
+        if: matrix.python == '3.13'
+        working-directory: .
+        run: make conformance-fixtures-check
+
       - name: Run Python conformance tests
         if: matrix.python == '3.13'
         working-directory: conformance/runner/python

--- a/Makefile
+++ b/Makefile
@@ -384,7 +384,7 @@ py-clean:
 # Conformance Test targets
 #------------------------------------------------------------------------------
 
-.PHONY: conformance conformance-go conformance-go-replay conformance-kotlin conformance-kotlin-replay conformance-typescript conformance-typescript-live conformance-ruby conformance-ruby-replay conformance-python conformance-python-replay conformance-build conformance-live conformance-canary oauth-fixtures-check
+.PHONY: conformance conformance-go conformance-go-replay conformance-kotlin conformance-kotlin-replay conformance-typescript conformance-typescript-live conformance-ruby conformance-ruby-replay conformance-python conformance-python-replay conformance-build conformance-live conformance-canary oauth-fixtures-check conformance-fixtures-check
 
 # Pinned validator for the data-only OAuth discovery fixtures. Run via uvx so the
 # version is reproducible without a global install; the schema is separate from
@@ -396,6 +396,18 @@ oauth-fixtures-check:
 	@echo "==> Validating OAuth discovery fixtures..."
 	uvx --from 'check-jsonschema==$(CHECK_JSONSCHEMA_VERSION)' check-jsonschema \
 		--schemafile conformance/oauth/schema.json conformance/oauth/fixtures/*.json
+
+# Validate every conformance/tests/*.json entry against conformance/schema.json.
+# This is the AUTHORITATIVE enforcement of the per-case schema — including the
+# mockResponses oneOf (exactly one of status or networkError:true). The runners
+# don't schema-validate fixtures, so without this a malformed fixture (e.g.
+# {status:204, networkError:false}) would only be caught, if at all, by each
+# runner's looser runtime backstop. tests.schema.json wraps schema.json as an
+# array so check-jsonschema validates each element of the array-shaped files.
+conformance-fixtures-check:
+	@echo "==> Validating conformance fixtures against schema.json..."
+	uvx --from 'check-jsonschema==$(CHECK_JSONSCHEMA_VERSION)' check-jsonschema \
+		--schemafile conformance/tests.schema.json conformance/tests/*.json
 
 # Build conformance test runner
 conformance-build:
@@ -471,7 +483,7 @@ conformance-python-replay:
 	cd conformance/runner/python && uv sync && uv run python replay_runner.py
 
 # Run all conformance tests
-conformance: oauth-fixtures-check conformance-go conformance-kotlin conformance-typescript conformance-ruby conformance-python
+conformance: oauth-fixtures-check conformance-fixtures-check conformance-go conformance-kotlin conformance-typescript conformance-ruby conformance-python
 	@echo "==> Conformance tests passed"
 
 # Orchestrate one canary pass against a single backend:
@@ -867,6 +879,7 @@ help:
 	@echo "  conformance-python-replay  Decode TS-captured wire snapshots through Python SDK"
 	@echo "  conformance-build          Build Go conformance test runner"
 	@echo "  oauth-fixtures-check       Validate OAuth discovery fixtures against their schema"
+	@echo "  conformance-fixtures-check Validate conformance/tests fixtures against schema.json"
 	@echo ""
 	@echo "Ruby SDK:"
 	@echo "  rb-generate          Generate types and metadata from OpenAPI"

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -15,8 +15,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -56,10 +58,11 @@ type ConfigOverrides struct {
 
 // MockResponse defines a single mock HTTP response.
 type MockResponse struct {
-	Status  int               `json:"status"`
-	Headers map[string]string `json:"headers"`
-	Body    interface{}       `json:"body"`
-	Delay   int               `json:"delay"`
+	Status       int               `json:"status"`
+	NetworkError bool              `json:"networkError"`
+	Headers      map[string]string `json:"headers"`
+	Body         interface{}       `json:"body"`
+	Delay        int               `json:"delay"`
 }
 
 // Assertion defines what to verify after the test.
@@ -297,6 +300,22 @@ func runTest(tc TestCase) TestResult {
 		// Apply delay if specified
 		if resp.Delay > 0 {
 			time.Sleep(time.Duration(resp.Delay) * time.Millisecond)
+		}
+
+		// Genuine transport failure: hijack the connection and close it without
+		// writing any response, forcing a real socket reset the SDK observes as
+		// a network error. The request counter is already incremented above.
+		if resp.NetworkError {
+			if hj, ok := w.(http.Hijacker); ok {
+				if conn, _, err := hj.Hijack(); err == nil {
+					_ = conn.Close()
+					return
+				}
+			}
+			// Fallback: no hijack support — drop the connection via a panic the
+			// httptest server converts into a reset (should not happen on the
+			// default server, which supports hijacking).
+			panic(http.ErrAbortHandler)
 		}
 
 		// Set Content-Type before any other headers (oapi-codegen
@@ -748,6 +767,24 @@ func checkAssertion(
 		if sdkErr == nil {
 			return fail(tc, fmt.Sprintf("Expected error type %v, but got no error", assertion.Expected))
 		}
+		expected := expectedString(assertion.Expected)
+		// Classify the error. A mapped *basecamp.Error carries a canonical
+		// .Code; on the network path the generated client returns the raw
+		// transport error (e.g. *url.Error) rather than a *basecamp.Error, so
+		// recognize that as "network". Anything else is unknown — fail rather
+		// than silently accept, so this assertion actually pins the class.
+		var actualType string
+		var sdkError *basecamp.Error
+		if errors.As(sdkErr, &sdkError) {
+			actualType = sdkError.Code
+		} else if isNetworkError(sdkErr) {
+			actualType = basecamp.CodeNetwork
+		} else {
+			return fail(tc, fmt.Sprintf("Expected error type %q, but got unrecognized error: %v", expected, sdkErr))
+		}
+		if actualType != expected {
+			return fail(tc, fmt.Sprintf("Expected error type %q, got %q (%v)", expected, actualType, sdkErr))
+		}
 
 	case "statusCode":
 		expected := expectedInt(assertion.Expected)
@@ -1087,6 +1124,19 @@ func expectedString(v interface{}) string {
 		return s.String()
 	}
 	return fmt.Sprintf("%v", v)
+}
+
+// isNetworkError reports whether err is a genuine transport-level failure
+// (connection reset / DNS / timeout). The generated Go client surfaces such
+// failures as the raw error from http.Client.Do — a *url.Error, or something
+// satisfying net.Error — rather than mapping them to a *basecamp.Error.
+func isNetworkError(err error) bool {
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr)
 }
 
 // digPath walks a dot-notation path through nested maps, reporting presence.

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -238,6 +238,21 @@ type operationResult struct {
 }
 
 func runTest(tc TestCase) TestResult {
+	// Enforce the schema's mockResponses oneOf at runtime: exactly one of
+	// `status` or `networkError` per entry. `make conformance` does not
+	// schema-validate fixtures, so without this a malformed entry could panic
+	// on WriteHeader(0) or silently pass — fail loudly instead.
+	for i, mr := range tc.MockResponses {
+		hasStatus := mr.Status != 0
+		if hasStatus == mr.NetworkError {
+			return TestResult{
+				Name:    tc.Name,
+				Passed:  false,
+				Message: fmt.Sprintf("mockResponses[%d] must set exactly one of status or networkError (got status=%d, networkError=%t)", i, mr.Status, mr.NetworkError),
+			}
+		}
+	}
+
 	// Track request count and timing with mutex protection
 	var mu sync.Mutex
 	var requestCount int

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -238,10 +238,14 @@ type operationResult struct {
 }
 
 func runTest(tc TestCase) TestResult {
-	// Enforce the schema's mockResponses oneOf at runtime: exactly one of
-	// `status` or `networkError` per entry. `make conformance` does not
-	// schema-validate fixtures, so without this a malformed entry could panic
-	// on WriteHeader(0) or silently pass — fail loudly instead.
+	// Defense-in-depth backstop for the operationally-harmful mockResponses
+	// shapes: neither status nor networkError set (would be served as an HTTP
+	// response), or both active. The AUTHORITATIVE oneOf enforcement — including
+	// rejecting {status, networkError:false} and networkError values other than
+	// true — is `make conformance-fixtures-check` (check-jsonschema against
+	// conformance/schema.json), which runs before the runners. This truthiness
+	// check can't distinguish an absent networkError from a present false one,
+	// so it deliberately covers only the harmful cases, not the full schema.
 	for i, mr := range tc.MockResponses {
 		hasStatus := mr.Status != 0
 		if hasStatus == mr.NetworkError {

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -172,6 +172,20 @@ class TestRunner:
     def run(self) -> TestResult:
         self._tracker.reset()
 
+        # Enforce the schema's mockResponses oneOf at runtime: exactly one of
+        # `status` or `networkError` per entry. Fixtures are not schema-validated
+        # by `make conformance`, so a malformed entry would otherwise be served
+        # as a normal HTTP response — fail loudly instead.
+        for i, r in enumerate(self._test.get("mockResponses", [])):
+            has_status = "status" in r
+            has_network_error = r.get("networkError") is True
+            if has_status == has_network_error:
+                return TestResult(
+                    self._test["name"],
+                    False,
+                    f"mockResponses[{i}] must set exactly one of status or networkError",
+                )
+
         with respx.mock:
             self._setup_mock_responses()
 

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -213,6 +213,11 @@ class TestRunner:
 
             if idx < len(response_queue):
                 r = response_queue[idx]
+                # Genuine transport failure for this queued entry: raise a
+                # connection error the way a real network fault would. The
+                # request is already recorded above, so requestCount is correct.
+                if r.get("networkError"):
+                    raise httpx.ConnectError("simulated network error")
                 body = json.dumps(r.get("body", "")).encode() if r.get("body") is not None else b""
                 headers = {"Content-Type": "application/json"}
                 headers.update(r.get("headers", {}))
@@ -353,12 +358,21 @@ class TestRunner:
                         "forbidden": "forbidden",
                         "rate_limit": "rate_limit",
                         "validation": "validation",
+                        "network": "network",
                     }
                     expected_code = code_map.get(expected_type)
                     if expected_code is None:
                         failures.append(f"Unknown conformance error type {expected_type!r}")
-                    elif hasattr(error, "code") and error.code != expected_code:
-                        failures.append(f"Expected error code {expected_code!r}, got {error.code!r}")
+                    else:
+                        # Require a canonical code that exists and matches — an
+                        # error carrying no .code must fail, not silently pass.
+                        actual_code = getattr(error, "code", None)
+                        if actual_code is None:
+                            failures.append(
+                                f"Expected error code {expected_code!r}, but {type(error).__name__} carries no code: {error}"
+                            )
+                        elif actual_code != expected_code:
+                            failures.append(f"Expected error code {expected_code!r}, got {actual_code!r}")
 
                 case "requestPath":
                     expected = assertion["expected"]

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -172,10 +172,13 @@ class TestRunner:
     def run(self) -> TestResult:
         self._tracker.reset()
 
-        # Enforce the schema's mockResponses oneOf at runtime: exactly one of
-        # `status` or `networkError` per entry. Fixtures are not schema-validated
-        # by `make conformance`, so a malformed entry would otherwise be served
-        # as a normal HTTP response — fail loudly instead.
+        # Defense-in-depth backstop for the operationally-harmful mockResponses
+        # shapes (neither mode set → served as a normal HTTP response; or both
+        # active). The AUTHORITATIVE oneOf enforcement is
+        # `make conformance-fixtures-check` (check-jsonschema against
+        # conformance/schema.json), which runs before the runners; it rejects
+        # {status, networkError:false} and non-true networkError values that this
+        # truthiness backstop intentionally lets through for cross-runner parity.
         for i, r in enumerate(self._test.get("mockResponses", [])):
             has_status = "status" in r
             has_network_error = r.get("networkError") is True

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -204,6 +204,7 @@ RUBY_SKIPS = Set.new([
   "maxItems caps results across pages",
   "DownloadURL retries on 503 at the auth'd first hop",
   "DownloadURL honors Retry-After on 429 at the auth'd first hop",
+  "Network error on an idempotent POST is retried then succeeds",
 ].freeze)
 
 DOWNLOAD_RETRY_SKIP = "Ruby SDK download path uses http.get_no_retry; retry on 5xx / Retry-After is not implemented".freeze
@@ -217,6 +218,7 @@ RUBY_SKIP_REASONS = {
   "maxItems caps results across pages" => "Ruby SDK paginate doesn't support maxItems",
   "DownloadURL retries on 503 at the auth'd first hop" => DOWNLOAD_RETRY_SKIP,
   "DownloadURL honors Retry-After on 429 at the auth'd first hop" => DOWNLOAD_RETRY_SKIP,
+  "Network error on an idempotent POST is retried then succeeds" => "Ruby SDK only retries GET network errors; mutations go through single_request with no retry",
 }.freeze
 
 # Single test case
@@ -253,11 +255,15 @@ class TestRunner
 
     # Queue up responses
     response_queue = responses.map do |r|
-      {
-        status: r["status"],
-        body: r["body"]&.to_json || "",
-        headers: { "Content-Type" => "application/json" }.merge(r["headers"] || {})
-      }
+      if r["networkError"]
+        { network_error: true }
+      else
+        {
+          status: r["status"],
+          body: r["body"]&.to_json || "",
+          headers: { "Content-Type" => "application/json" }.merge(r["headers"] || {})
+        }
+      end
     end
 
     # Method-agnostic catch-all on the active client's origin (derived from
@@ -281,6 +287,13 @@ class TestRunner
       if call_count < response_queue.size
         resp = response_queue[call_count]
         call_count += 1
+        # Genuine transport failure for this queued entry only: raise a Faraday
+        # connection error (the SDK's rescue Faraday::Error path maps it to a
+        # NetworkError). The request is already recorded above, so requestCount
+        # is correct. Raising in-block keeps the rest of the queue intact,
+        # unlike a blanket stub .to_raise.
+        raise Faraday::ConnectionFailed, "simulated network error" if resp[:network_error]
+
         resp
       elsif paginates
         # Beyond defined responses for paginated ops: empty 200 terminates pagination
@@ -449,12 +462,20 @@ class TestRunner
           "forbidden" => Basecamp::ErrorCode::FORBIDDEN,
           "rate_limit" => Basecamp::ErrorCode::RATE_LIMIT,
           "validation" => Basecamp::ErrorCode::VALIDATION,
+          "network" => Basecamp::ErrorCode::NETWORK,
         }
         expected_code = code_map[expected_type]
         if expected_code.nil?
           failures << "Unknown conformance error type #{expected_type.inspect} (add to code_map)"
-        elsif error.respond_to?(:code) && error.code != expected_code
-          failures << "Expected error code #{expected_code.inspect}, got #{error.code.inspect}"
+        else
+          # Require a canonical code that exists and matches — an error that
+          # carries no code must fail, not silently pass.
+          actual_code = error.respond_to?(:code) ? error.code : nil
+          if actual_code.nil?
+            failures << "Expected error code #{expected_code.inspect}, but #{error.class} carries no code: #{error}"
+          elsif actual_code != expected_code
+            failures << "Expected error code #{expected_code.inspect}, got #{actual_code.inspect}"
+          end
         end
 
       when "requestPath"

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -232,10 +232,12 @@ class TestRunner
   def run
     @tracker.reset!
 
-    # Enforce the schema's mockResponses oneOf at runtime: exactly one of
-    # `status` or `networkError` per entry. Fixtures are not schema-validated by
-    # `make conformance`, so a malformed entry (neither/both) would otherwise
-    # slip through — fail loudly instead.
+    # Defense-in-depth backstop for the operationally-harmful mockResponses
+    # shapes (neither mode set, or both active). The AUTHORITATIVE oneOf
+    # enforcement is `make conformance-fixtures-check` (check-jsonschema against
+    # conformance/schema.json), which runs before the runners and rejects
+    # {status, networkError:false} / non-true networkError that this truthiness
+    # backstop intentionally lets through for cross-runner parity.
     (@test["mockResponses"] || []).each_with_index do |r, i|
       has_status = r.key?("status")
       has_network_error = r["networkError"] == true

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -231,6 +231,19 @@ class TestRunner
 
   def run
     @tracker.reset!
+
+    # Enforce the schema's mockResponses oneOf at runtime: exactly one of
+    # `status` or `networkError` per entry. Fixtures are not schema-validated by
+    # `make conformance`, so a malformed entry (neither/both) would otherwise
+    # slip through — fail loudly instead.
+    (@test["mockResponses"] || []).each_with_index do |r, i|
+      has_status = r.key?("status")
+      has_network_error = r["networkError"] == true
+      if has_status == has_network_error
+        return TestResult.new(@test["name"], false, "mockResponses[#{i}] must set exactly one of status or networkError")
+      end
+    end
+
     setup_mock_responses
 
     begin

--- a/conformance/runner/typescript/runner.test.ts
+++ b/conformance/runner/typescript/runner.test.ts
@@ -98,15 +98,16 @@ const MULTI_HOP_OPERATIONS = new Set(["DownloadURL", "UploadsDownload"]);
  * Recognize a genuine transport-level failure (fetch rejection). The TS SDK
  * does not wrap these into a BasecampError, so the raw error surfaces: MSW's
  * HttpResponse.error() rejects with a TypeError ("Failed to fetch"); undici
- * variants say "fetch failed". Match by type and message so the errorType
- * assertion can classify it as "network" without accepting arbitrary errors.
+ * variants say "fetch failed". Match on the message only — an arbitrary
+ * TypeError from an unrelated runner/SDK bug must NOT be misclassified as a
+ * transport failure (that would let an `errorType: "network"` assertion pass
+ * while hiding a real regression).
  */
 function isNetworkRejection(err: unknown): boolean {
-  if (err instanceof TypeError) return true;
-  if (err instanceof Error) {
-    return /failed to fetch|fetch failed|network|socket|econn/i.test(err.message);
-  }
-  return false;
+  if (!(err instanceof Error)) return false;
+  return /failed to fetch|fetch failed|network(?: request)? failed|socket|econn/i.test(
+    err.message,
+  );
 }
 
 // =============================================================================
@@ -359,6 +360,20 @@ function installMockHandlers(tc: TestCase): {
   requestBodies: () => unknown[];
   requestHeaders: () => Record<string, string>[];
 } {
+  // Enforce the schema's mockResponses oneOf at runtime: exactly one of
+  // `status` or `networkError` per entry. This runner does not schema-validate
+  // fixtures, so without this a malformed entry could be served as `status ??
+  // 200` (a false positive) — fail loudly instead.
+  tc.mockResponses.forEach((mock, i) => {
+    const hasStatus = mock.status !== undefined;
+    const hasNetworkError = mock.networkError === true;
+    if (hasStatus === hasNetworkError) {
+      throw new Error(
+        `[${tc.name}] mockResponses[${i}] must set exactly one of status or networkError (got status=${String(mock.status)}, networkError=${String(mock.networkError)})`,
+      );
+    }
+  });
+
   let responseIndex = 0;
   const times: number[] = [];
   const paths: string[] = [];

--- a/conformance/runner/typescript/runner.test.ts
+++ b/conformance/runner/typescript/runner.test.ts
@@ -21,7 +21,8 @@ import { fileURLToPath } from "node:url";
 // =============================================================================
 
 interface MockResponse {
-  status: number;
+  status?: number;
+  networkError?: boolean;
   headers?: Record<string, string>;
   body?: unknown;
   delay?: number;
@@ -81,6 +82,8 @@ const TS_SDK_SKIPS: Record<string, string> = {
     "TS SDK downloadURL uses raw fetch bypassing the retry middleware; 5xx / Retry-After retry is not implemented",
   "DownloadURL honors Retry-After on 429 at the auth'd first hop":
     "TS SDK downloadURL uses raw fetch bypassing the retry middleware; 5xx / Retry-After retry is not implemented",
+  "Network error on an idempotent POST is retried then succeeds":
+    "TS SDK retry middleware does not retry fetch rejections (network errors); only HTTP-status retries are implemented",
 };
 
 /**
@@ -90,6 +93,21 @@ const TS_SDK_SKIPS: Record<string, string> = {
  * its own stricter hop-1 invariant below.
  */
 const MULTI_HOP_OPERATIONS = new Set(["DownloadURL", "UploadsDownload"]);
+
+/**
+ * Recognize a genuine transport-level failure (fetch rejection). The TS SDK
+ * does not wrap these into a BasecampError, so the raw error surfaces: MSW's
+ * HttpResponse.error() rejects with a TypeError ("Failed to fetch"); undici
+ * variants say "fetch failed". Match by type and message so the errorType
+ * assertion can classify it as "network" without accepting arbitrary errors.
+ */
+function isNetworkRejection(err: unknown): boolean {
+  if (err instanceof TypeError) return true;
+  if (err instanceof Error) {
+    return /failed to fetch|fetch failed|network|socket|econn/i.test(err.message);
+  }
+  return false;
+}
 
 // =============================================================================
 // Test infrastructure
@@ -410,6 +428,13 @@ function installMockHandlers(tc: TestCase): {
       await new Promise((resolve) => setTimeout(resolve, mock.delay));
     }
 
+    // Genuine transport failure for this queued entry: MSW's
+    // HttpResponse.error() rejects the fetch the way a real network error does
+    // (the request counter is already incremented above).
+    if (mock.networkError) {
+      return HttpResponse.error();
+    }
+
     // Build response headers
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
@@ -443,7 +468,9 @@ function installMockHandlers(tc: TestCase): {
       bodyToSerialize !== undefined ? JSON.stringify(bodyToSerialize) : null;
 
     return new HttpResponse(responseBody, {
-      status: mock.status,
+      // networkError entries return early above; the schema guarantees a
+      // status is present on every non-networkError entry.
+      status: mock.status ?? 200,
       headers,
     });
   });
@@ -777,12 +804,25 @@ function checkAssertions(
           result.error,
           `[${tc.name}] expected an error of type ${expectedType}`,
         ).toBeDefined();
+        // Classify the error. A mapped BasecampError carries a canonical
+        // `.code`. On the network path the TS SDK does NOT wrap the fetch
+        // rejection into a BasecampError — it surfaces the raw transport
+        // failure (a TypeError / "Failed to fetch") — so recognize that as
+        // "network". Anything else is unknown: fail rather than silently pass.
+        let actualType: string;
         if (result.error instanceof BasecampError) {
-          expect(
-            result.error.code,
-            `[${tc.name}] expected error code "${expectedType}", got "${result.error.code}"`,
-          ).toBe(expectedType);
+          actualType = result.error.code;
+        } else if (isNetworkRejection(result.error)) {
+          actualType = "network";
+        } else {
+          throw new Error(
+            `[${tc.name}] expected error type "${expectedType}", got unrecognized error: ${String(result.error)}`,
+          );
         }
+        expect(
+          actualType,
+          `[${tc.name}] expected error type "${expectedType}", got "${actualType}"`,
+        ).toBe(expectedType);
         break;
       }
 

--- a/conformance/runner/typescript/runner.test.ts
+++ b/conformance/runner/typescript/runner.test.ts
@@ -1017,12 +1017,19 @@ function loadTestSuites(): { filename: string; tests: TestCase[] }[] {
 /**
  * Determine whether retry should be enabled for a given test case.
  *
- * Retry tests and idempotency tests need retry enabled.
+ * Retry tests, idempotency tests, and network-retry tests need retry enabled.
  * Status-code tests generally need retry disabled to avoid interference,
  * except for the 429-retries-exhausted test which requires retry.
  */
 function shouldEnableRetry(tc: TestCase, filename: string): boolean {
-  if (filename === "retry.json" || filename === "idempotency.json") {
+  if (
+    filename === "retry.json" ||
+    filename === "idempotency.json" ||
+    filename === "network-retry.json"
+  ) {
+    // network-retry.json's CreateTodo safety case must run retry-ENABLED so it
+    // actually proves the SDK doesn't re-send a non-idempotent POST on a network
+    // error (with retry off, the requestCount:1 assertion would be vacuous).
     return true;
   }
 

--- a/conformance/runner/typescript/runner.test.ts
+++ b/conformance/runner/typescript/runner.test.ts
@@ -360,10 +360,13 @@ function installMockHandlers(tc: TestCase): {
   requestBodies: () => unknown[];
   requestHeaders: () => Record<string, string>[];
 } {
-  // Enforce the schema's mockResponses oneOf at runtime: exactly one of
-  // `status` or `networkError` per entry. This runner does not schema-validate
-  // fixtures, so without this a malformed entry could be served as `status ??
-  // 200` (a false positive) — fail loudly instead.
+  // Defense-in-depth backstop for the operationally-harmful mockResponses
+  // shapes: neither mode set (would be served as `status ?? 200`, a false
+  // positive) or both active. The AUTHORITATIVE oneOf enforcement is
+  // `make conformance-fixtures-check` (check-jsonschema against
+  // conformance/schema.json), which runs before the runners and rejects
+  // {status, networkError:false} / non-true networkError that this truthiness
+  // backstop intentionally lets through for cross-runner parity.
   tc.mockResponses.forEach((mock, i) => {
     const hasStatus = mock.status !== undefined;
     const hasNetworkError = mock.networkError === true;

--- a/conformance/schema.json
+++ b/conformance/schema.json
@@ -83,7 +83,9 @@
         "properties": {
           "status": {
             "type": "integer",
-            "description": "HTTP status code. Exactly one of `status` or `networkError` must be set per entry."
+            "minimum": 100,
+            "maximum": 599,
+            "description": "HTTP status code (a real 1xx–5xx code). Exactly one of `status` or `networkError` must be set per entry. Constraining the range keeps 0 out, which some runners (e.g. Go) use as the 'status not set' sentinel."
           },
           "networkError": {
             "type": "boolean",

--- a/conformance/schema.json
+++ b/conformance/schema.json
@@ -70,11 +70,25 @@
       "description": "Sequence of mock responses for retry/error testing",
       "items": {
         "type": "object",
-        "required": ["status"],
+        "oneOf": [
+          {
+            "required": ["status"],
+            "not": { "required": ["networkError"] }
+          },
+          {
+            "required": ["networkError"],
+            "not": { "required": ["status"] }
+          }
+        ],
         "properties": {
           "status": {
             "type": "integer",
-            "description": "HTTP status code"
+            "description": "HTTP status code. Exactly one of `status` or `networkError` must be set per entry."
+          },
+          "networkError": {
+            "type": "boolean",
+            "const": true,
+            "description": "When true, the runner injects a genuine transport-level failure for this queued response (socket reset / connection error / thrown IOException) instead of an HTTP status. Exactly one of `status` or `networkError` must be set per entry."
           },
           "headers": {
             "type": "object",

--- a/conformance/tests.schema.json
+++ b/conformance/tests.schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SDK Conformance Test File",
+  "description": "A conformance/tests/*.json file: an array of SDK Conformance Test cases. Each element is validated against the per-case schema in schema.json, which enforces the mockResponses oneOf (exactly one of status or networkError:true). No $id here on purpose: it keeps the relative $ref resolving to the sibling schema.json by file path.",
+  "type": "array",
+  "items": { "$ref": "schema.json" }
+}

--- a/conformance/tests/network-retry.json
+++ b/conformance/tests/network-retry.json
@@ -1,0 +1,36 @@
+[
+  {
+    "name": "Network error on a non-idempotent POST is not retried",
+    "description": "A transport-level failure on CreateTodo (a non-idempotent POST) must surface as a network error with no re-send — no SDK re-sends a non-idempotent POST on a network blip. Exercises the transport-exception path that the 503 safety case cannot reach. Runs and passes in all five runners.",
+    "operation": "CreateTodo",
+    "method": "POST",
+    "path": "/todolists/{todolistId}/todos.json",
+    "pathParams": {"todolistId": 67890},
+    "requestBody": {"content": "New todo"},
+    "mockResponses": [
+      {"networkError": true}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 1},
+      {"type": "errorType", "expected": "network"}
+    ],
+    "tags": ["network", "no-retry", "post"]
+  },
+  {
+    "name": "Network error on an idempotent POST is retried then succeeds",
+    "description": "A transport-level failure on CompleteTodo (an idempotent-flagged POST) is retried and then succeeds on 204 — the network-error analog of the idempotency.json 503 liveness case. Go and Python retry network errors for idempotent operations; TS/Kotlin/Ruby do not retry network errors on mutations and carry explicit capability skips.",
+    "operation": "CompleteTodo",
+    "method": "POST",
+    "path": "/todos/{todoId}/completion.json",
+    "pathParams": {"todoId": 456},
+    "mockResponses": [
+      {"networkError": true},
+      {"status": 204}
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 2},
+      {"type": "noError"}
+    ],
+    "tags": ["network", "idempotent", "post"]
+  }
+]

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
@@ -167,6 +167,16 @@ data class DispatchResult(
 )
 
 private fun runTest(tc: TestCase): TestResult {
+    // Enforce the schema's mockResponses oneOf at runtime: exactly one of
+    // `status` or `networkError` per entry. Fixtures are not schema-validated by
+    // `make conformance`, so without this a malformed entry could be served as
+    // `status ?: 200` (a false positive) — fail loudly instead.
+    tc.mockResponses.forEachIndexed { i, mr ->
+        if ((mr.status != null) == mr.networkError) {
+            return TestResult(false, "mockResponses[$i] must set exactly one of status or networkError (got status=${mr.status}, networkError=${mr.networkError})")
+        }
+    }
+
     // Track requests
     val requestCounter = AtomicInteger(0)
     val requestTimes = mutableListOf<Long>()

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.MissingFieldException
 import kotlinx.serialization.json.*
 import java.io.File
+import java.io.IOException
 import java.util.concurrent.atomic.AtomicInteger
 
 /** Default account ID for conformance tests. */
@@ -25,6 +26,7 @@ private val KOTLIN_SKIPS: Map<String, String> = mapOf(
     "DownloadURL surfaces redirect with no Location" to "Kotlin runner does not yet dispatch DownloadURL (tracked as follow-up)",
     "UploadsDownload delegates through DownloadURL primitive" to "Kotlin SDK does not yet expose uploads.download(id) (parity tracked as follow-up)",
     "UploadsDownload errors when upload has no download_url" to "Kotlin SDK does not yet expose uploads.download(id) (parity tracked as follow-up)",
+    "Network error on an idempotent POST is retried then succeeds" to "Kotlin SDK does not retry network errors on mutations; it throws immediately (RetryTest network test asserts requestCount == 1)",
 )
 
 fun main() {
@@ -130,7 +132,8 @@ data class ConfigOverrides(
 
 @kotlinx.serialization.Serializable
 data class MockResponse(
-    val status: Int,
+    val status: Int? = null,
+    val networkError: Boolean = false,
     val headers: Map<String, String> = emptyMap(),
     val body: JsonElement? = null,
     val delay: Int = 0,
@@ -212,6 +215,13 @@ private fun runTest(tc: TestCase): TestResult {
                 Thread.sleep(mockResp.delay.toLong())
             }
 
+            // Genuine transport failure for this queued entry: throw from the
+            // engine lambda, which the SDK observes as a network error and maps
+            // to BasecampException.Network. The request is already counted above.
+            if (mockResp.networkError) {
+                throw IOException("simulated network error")
+            }
+
             val responseHeaders = HeadersBuilder().apply {
                 append(HttpHeaders.ContentType, ContentType.Application.Json.toString())
                 for ((key, value) in mockResp.headers) {
@@ -227,7 +237,9 @@ private fun runTest(tc: TestCase): TestResult {
 
             respond(
                 content = bodyContent,
-                status = HttpStatusCode.fromValue(mockResp.status),
+                // networkError entries throw above; the schema guarantees a
+                // status on every non-networkError entry.
+                status = HttpStatusCode.fromValue(mockResp.status ?: 200),
                 headers = responseHeaders.build(),
             )
         }

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
@@ -167,10 +167,13 @@ data class DispatchResult(
 )
 
 private fun runTest(tc: TestCase): TestResult {
-    // Enforce the schema's mockResponses oneOf at runtime: exactly one of
-    // `status` or `networkError` per entry. Fixtures are not schema-validated by
-    // `make conformance`, so without this a malformed entry could be served as
-    // `status ?: 200` (a false positive) — fail loudly instead.
+    // Defense-in-depth backstop for the operationally-harmful mockResponses
+    // shapes: neither mode set (would be served as `status ?: 200`, a false
+    // positive) or both active. The AUTHORITATIVE oneOf enforcement is
+    // `make conformance-fixtures-check` (check-jsonschema against
+    // conformance/schema.json), which runs before the runners and rejects
+    // {status, networkError:false} / non-true networkError that this truthiness
+    // backstop intentionally lets through for cross-runner parity.
     tc.mockResponses.forEachIndexed { i, mr ->
         if ((mr.status != null) == mr.networkError) {
             return TestResult(false, "mockResponses[$i] must set exactly one of status or networkError (got status=${mr.status}, networkError=${mr.networkError})")

--- a/swift/Tests/BasecampTests/RetryTests.swift
+++ b/swift/Tests/BasecampTests/RetryTests.swift
@@ -518,6 +518,33 @@ final class RetryTests: XCTestCase {
         XCTAssertEqual(transport.requests.count, 2, "CompleteTodo (idempotent POST) must retry through BaseService")
     }
 
+    /// Network-error analog of `testGeneratedIdempotentPostRetries`: an
+    /// idempotent POST driven through its generated service retries a genuine
+    /// transport failure and then succeeds. The existing
+    /// `testNetworkErrorTriggersRetry` is GET-only, so it never exercises the
+    /// POST metadata gate on the network path. Swift is not in the conformance
+    /// matrix, so this unit test is the only coverage of Swift's network
+    /// liveness for a metadata-flagged idempotent POST. Refs #439 / #417.
+    func testGeneratedIdempotentPostRetriesOnNetworkError() async throws {
+        let counter = Counter()
+        let transport = MockTransport { request in
+            let count = counter.increment()
+            if count == 1 {
+                throw URLError(.networkConnectionLost)
+            }
+            return (Data(), HTTPURLResponse(
+                url: request.url!, statusCode: 204,
+                httpVersion: "HTTP/1.1", headerFields: [:]
+            )!)
+        }
+
+        let account = makeTestClient(transport: transport, enableRetry: true).forAccount("999999999")
+
+        try await account.todos.complete(todoId: 1)
+
+        XCTAssertEqual(transport.requests.count, 2, "CompleteTodo (idempotent POST) must retry a network error through BaseService")
+    }
+
     // MARK: - Auth Header
 
     func testAuthHeaderIncludesToken() async throws {


### PR DESCRIPTION
## Summary

Adds a genuine transport-failure primitive to the conformance mock protocol, plus network-error **safety** and **liveness** coverage. Complements #439 / #417 (which pinned 503-retry behavior): the 503 path can't reach the transport-exception code path — a real network fault (socket reset / connection error / thrown IOException) can. PR3 of a three-PR series (PR1 → PR2 → PR3); independent of PR1/PR2.

### Schema (`conformance/schema.json`)
Each `mockResponses[]` entry now requires **exactly one** of `status` or `networkError: true` (`oneOf`). `networkError` injects a real transport failure instead of an HTTP status.

### Per-entry queue action (all 5 runners)
A genuine *queued* action (so `networkError → 204` sequences work — not a blanket stub):

| Runner | Injection |
|--------|-----------|
| Go | `http.Hijacker` + `conn.Close()` (real socket reset) |
| TypeScript | `HttpResponse.error()` |
| Python | raise `httpx.ConnectError` for that entry |
| Kotlin | `throw IOException(...)` from the MockEngine lambda |
| Ruby | raise `Faraday::ConnectionFailed` from the dynamic `to_return` block **for that queued entry only** (rest of the queue untouched) |

### One uniform error contract: `errorType: "network"`
The `errorType` assertion previously only checked that *some* error existed. Each runner's normalization now **classifies** a genuine network error and **fails on unknown** — no more silent pass. Runner-normalization only, **no SDK source change** (the network path does not surface a structured error in every SDK):
- **Go**: `TodosService.Complete` returns the generated client's raw transport error (`*url.Error`), not a `*basecamp.Error` — classify `*url.Error`/`net.Error` as `network`.
- **TypeScript**: the SDK doesn't wrap the fetch rejection — classify the raw `TypeError` / "Failed to fetch" as `network`.
- **Python / Ruby**: add `network` to the canonical code maps **and** require the error's code to exist and equal the expected value (previously an error carrying no code passed).
- **Kotlin**: already strict.

### Cases (`conformance/tests/network-retry.json`)
- **CreateTodo safety** — one network error then nothing → `requestCount 1` + a network-classified error. Runs & **passes in all 5** (no SDK re-sends a non-idempotent POST on a network blip).
- **CompleteTodo liveness** — network error then `204` → `requestCount 2` + `noError`. **Go/Python PASS** (they retry network errors for idempotent ops); **TS/Kotlin/Ruby carry explicit capability skips** (they don't retry network errors on mutations).

### Swift
Swift isn't in the conformance matrix, so its network liveness is pinned by a new generated-service idempotent-POST network-retry unit test in `RetryTests.swift` (the existing `testNetworkErrorTriggersRetry` is GET-only).

## Verification
- `python3 -m json.tool` clean; fixture validates against the schema; the `oneOf` correctly rejects both-set / neither-set / `networkError:false` entries.
- `make conformance` green: CreateTodo safety `PASS` in all 5 with `errorType: "network"` enforced; CompleteTodo liveness `PASS` in Go/Python, `SKIP` in TS/Kotlin/Ruby.
- Swift XCTest green (new test + full `RetryTests` suite, 19 tests).

Refs #439, #417.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a real network-error primitive to the conformance mock protocol to exercise the transport-failure path, and adds CI validation of test fixtures against the schema (enforcing the `status`/`networkError` oneOf and 100–599 `status` bounds).

- **New Features**
  - Schema: `mockResponses[]` requires exactly one of `status` or `networkError: true`; `status` constrained to 100–599.
  - CI/Makefile: new `conformance-fixtures-check` uses `check-jsonschema` to validate `conformance/tests/*.json` (via `conformance/tests.schema.json`); runs in `make conformance` and in CI.
  - Runners: per-entry network fault injection across Go/TypeScript/Python/Kotlin/Ruby; all validate the oneOf at runtime and classify genuine network errors, failing on unknowns.
  - TypeScript: retry enabled for `network-retry.json`; network rejection matching tightened to fetch-failure messages only.
  - Tests: added `conformance/tests/network-retry.json` with two cases — non-idempotent POST (no retry, network error) and idempotent POST (retry then 204). Go/Python pass; TypeScript/Kotlin/Ruby explicitly skip due to capabilities. Swift adds an idempotent-POST network-retry unit test in `RetryTests.swift`.

- **Migration**
  - Conformance fixtures must validate in CI: set exactly one of `status` or `networkError: true` per queued response; `status` must be 100–599. Expect `errorType: "network"` for transport failures. Use `make conformance-fixtures-check` locally.

<sup>Written for commit 3a9120f82b4574e2ab81427d427a282b5c79ccf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

