### PR TITLE
Freshness gates: regenerate-and-diff for TS, Ruby, and Go generated output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,9 @@ jobs:
       - name: Check service layer drift
         run: ../scripts/check-service-drift.sh
 
+      - name: Check generated client drift
+        run: ../scripts/check-go-generated-drift.sh
+
       - name: Check auth-routable consumer invariants
         run: ../scripts/check-auth-routable-consumers.sh
 
@@ -163,6 +166,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Check generated code drift
+        run: ../scripts/check-typescript-service-drift.sh
+
       - name: Verify root pack includes compiled SDK
         working-directory: .
         run: |
@@ -217,6 +223,13 @@ jobs:
       - name: Lint
         if: matrix.ruby == '3.3'
         run: bundle exec rubocop
+
+      # Regenerate-and-diff freshness gate. Runs on the canonical matrix entry
+      # only (like Lint / conformance); the generated output is Ruby-version
+      # independent, so one entry is sufficient.
+      - name: Check generated code drift
+        if: matrix.ruby == '3.3'
+        run: ../scripts/check-ruby-service-drift.sh
 
       - name: Test
         run: bundle exec rake test

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ sync-api-version-check:
 # Go SDK targets (delegates to go/Makefile)
 #------------------------------------------------------------------------------
 
-.PHONY: go-test go-lint go-check go-clean go-check-drift go-check-wrapper-drift
+.PHONY: go-test go-lint go-check go-clean go-check-drift go-check-wrapper-drift go-check-generated-drift
 
 go-test:
 	@$(MAKE) -C go test
@@ -222,6 +222,15 @@ go-clean:
 go-check-drift:
 	@echo "==> Checking service layer drift..."
 	@./scripts/check-service-drift.sh
+
+# Check that the committed generated Go client is current. Regenerates
+# client.gen.go (oapi-codegen + normalization) into a temp location and diffs;
+# non-mutative and safe under `make -j`. Distinct from go-check-drift
+# (operation-level coverage) and go-check-wrapper-drift (field-level): this is
+# output freshness of the generated file itself.
+go-check-generated-drift:
+	@echo "==> Checking generated Go client drift..."
+	@./scripts/check-go-generated-drift.sh
 
 # Check for field-level drift between generated structs and hand-written
 # wrappers in go/pkg/basecamp/. Sibling of go-check-drift; that check is
@@ -244,7 +253,7 @@ auth-routable-check:
 # TypeScript SDK targets
 #------------------------------------------------------------------------------
 
-.PHONY: ts-install ts-generate ts-generate-services ts-build ts-test ts-typecheck ts-check ts-clean
+.PHONY: ts-install ts-generate ts-generate-services ts-build ts-test ts-typecheck ts-check ts-check-drift ts-clean
 
 TS_NODE_STAMP := typescript/node_modules/.install-stamp
 
@@ -286,8 +295,16 @@ ts-typecheck:
 	@echo "==> Type checking TypeScript SDK..."
 	cd typescript && npm run typecheck
 
+# Check that committed generated TypeScript artifacts are current. Regenerates
+# the whole src/generated/ tree (stripped OpenAPI, schema, metadata,
+# path-mapping, services) into a temp project and diffs; non-mutative and safe
+# under `make -j`.
+ts-check-drift: ts-install
+	@echo "==> Checking TypeScript generated code drift..."
+	@./scripts/check-typescript-service-drift.sh
+
 # Run all TypeScript checks
-ts-check: ts-typecheck ts-test
+ts-check: ts-check-drift ts-typecheck ts-test
 	@echo "==> TypeScript SDK checks passed"
 
 # Clean TypeScript build artifacts
@@ -299,7 +316,7 @@ ts-clean:
 # Ruby SDK targets
 #------------------------------------------------------------------------------
 
-.PHONY: rb-generate rb-generate-services rb-build rb-test rb-check rb-doc rb-clean
+.PHONY: rb-generate rb-generate-services rb-build rb-test rb-check rb-check-drift rb-doc rb-clean
 
 # Generate Ruby types and metadata from OpenAPI
 rb-generate:
@@ -329,8 +346,15 @@ rb-test: rb-build
 	@echo "==> Running Ruby tests..."
 	cd ruby && bundle exec rake test
 
+# Check that committed generated Ruby artifacts are current. Regenerates
+# metadata.json, types.rb, and the service files and diffs; non-mutative. The
+# metadata/types diff canonicalizes the embedded generation timestamp.
+rb-check-drift:
+	@echo "==> Checking Ruby generated code drift..."
+	@./scripts/check-ruby-service-drift.sh
+
 # Run all Ruby checks
-rb-check: rb-test
+rb-check: rb-check-drift rb-test
 	@echo "==> Running Ruby linter..."
 	cd ruby && bundle exec rubocop
 	@echo "==> Ruby SDK checks passed"
@@ -613,7 +637,16 @@ kt-test:
 kt-check: kt-test
 	@echo "==> Kotlin SDK checks passed"
 
-# Check for drift between generated Kotlin services and OpenAPI spec
+# Check for drift between generated Kotlin services and OpenAPI spec.
+#
+# NOTE: this is an operation-level *coverage* check (operationId sets match),
+# NOT a regenerate-and-diff freshness gate like check-{python,ruby,typescript}-
+# service-drift.sh or check-go-generated-drift.sh. The authoritative
+# regenerate-and-diff for Kotlin runs only in CI (the "Check generated code
+# drift" step of the test-kotlin job in .github/workflows/test.yml), which
+# regenerates and fails on any committed drift. Kotlin is intentionally a
+# CI-only exception to the non-mutating regen-and-diff program for now;
+# promoting it to a root-invocable non-mutating gate is tracked as a follow-up.
 kt-check-drift:
 	@echo "==> Checking Kotlin service drift..."
 	@./scripts/check-kotlin-service-drift.sh
@@ -832,7 +865,7 @@ generate:
 	@echo "==> Generation complete"
 
 # Run all checks (Smithy + Go + TypeScript + Ruby + Kotlin + Swift + Python + Behavior Model + Conformance + Provenance + Actions lint)
-check: lint-actions sync-spec-version-check smithy-check behavior-model-check provenance-check sync-api-version-check go-check-drift go-check-wrapper-drift auth-routable-check kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity check-fixture-coverage kt-check-optional-arrays check-idempotency-parity
+check: lint-actions sync-spec-version-check smithy-check behavior-model-check provenance-check sync-api-version-check go-check-drift go-check-wrapper-drift go-check-generated-drift auth-routable-check kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity check-fixture-coverage kt-check-optional-arrays check-idempotency-parity
 	@echo "==> All checks passed"
 
 # Clean all build artifacts
@@ -865,6 +898,7 @@ help:
 	@echo "  go-check         Run all Go checks"
 	@echo "  go-check-drift           Check service layer drift vs generated client (operation-level)"
 	@echo "  go-check-wrapper-drift   Check wrapper struct drift vs generated structs (field-level)"
+	@echo "  go-check-generated-drift Check generated client.gen.go is current (regenerate + diff)"
 	@echo "  go-clean         Remove Go build artifacts"
 	@echo ""
 	@echo "TypeScript SDK:"
@@ -873,7 +907,8 @@ help:
 	@echo "  ts-build              Build TypeScript SDK"
 	@echo "  ts-test               Run TypeScript tests"
 	@echo "  ts-typecheck          Run TypeScript type checking"
-		@echo "  ts-check              Run all TypeScript checks"
+	@echo "  ts-check-drift        Check generated src/generated/ is current (regenerate + diff)"
+	@echo "  ts-check              Run all TypeScript checks"
 	@echo "  ts-clean              Remove TypeScript build artifacts"
 	@echo ""
 	@echo "Kotlin SDK:"
@@ -914,6 +949,7 @@ help:
 	@echo "  rb-generate-services Generate service classes from OpenAPI"
 	@echo "  rb-build             Build Ruby SDK (install deps)"
 	@echo "  rb-test              Run Ruby tests (with coverage)"
+	@echo "  rb-check-drift       Check generated metadata/types/services are current (regenerate + diff)"
 	@echo "  rb-check             Run all Ruby checks"
 	@echo "  rb-doc               Generate YARD documentation"
 	@echo "  rb-clean             Remove Ruby build artifacts"

--- a/scripts/check-go-generated-drift.sh
+++ b/scripts/check-go-generated-drift.sh
@@ -38,16 +38,36 @@ TMP_CONFIG="$TMPDIR_BASE/oapi-codegen.yaml"
 GEN_LOG="$TMPDIR_BASE/oapi-codegen.log"
 NORM_LOG="$TMPDIR_BASE/normalize.log"
 
-# Copy the committed config, overriding only the `output:` line to an absolute
-# temp path. `output-options:` (a different key) is left untouched; the
-# user-template paths stay relative and resolve against the go/ working dir.
-sed "s#^output: .*#output: $REGEN#" "$GO_DIR/oapi-codegen.yaml" > "$TMP_CONFIG"
+# Copy the committed config, overriding only the top-level `output:` line to an
+# absolute temp path. The match tolerates leading/trailing whitespace so a
+# reformat of oapi-codegen.yaml doesn't silently slip through; `output-options:`
+# (a different key) is left untouched, and the user-template paths stay relative
+# and resolve against the go/ working dir.
+sed -E "s#^[[:space:]]*output:[[:space:]]*.*#output: $REGEN#" "$GO_DIR/oapi-codegen.yaml" > "$TMP_CONFIG"
+
+# Assert the override actually took effect. If the substitution missed (e.g. the
+# config was reformatted in a way this pattern doesn't match), the temp config
+# would keep the committed relative `output:` path and oapi-codegen would write
+# into the working tree — silently breaking the non-mutating guarantee AND making
+# the diff compare the committed file against itself. Fail loudly instead.
+if ! grep -qF "output: $REGEN" "$TMP_CONFIG"; then
+  echo "ERROR: could not redirect oapi-codegen output to a temp path." >&2
+  echo "       Unexpected 'output:' format in go/oapi-codegen.yaml." >&2
+  exit 1
+fi
 
 echo "==> Regenerating Go client into a temp directory (non-mutating)..."
 # Run from go/ so the relative user-template paths in the config resolve.
 if ! (cd "$GO_DIR" && go tool oapi-codegen -config "$TMP_CONFIG" ../openapi.json) > "$GEN_LOG" 2>&1; then
   echo "ERROR: oapi-codegen failed:" >&2
   cat "$GEN_LOG" >&2
+  exit 1
+fi
+
+# The temp output must exist — its absence would mean oapi-codegen wrote
+# somewhere else (e.g. the committed tree), which must never happen.
+if [ ! -f "$REGEN" ]; then
+  echo "ERROR: oapi-codegen did not write the expected temp output ($REGEN)." >&2
   exit 1
 fi
 

--- a/scripts/check-go-generated-drift.sh
+++ b/scripts/check-go-generated-drift.sh
@@ -34,7 +34,9 @@ trap 'rm -rf "$TMPDIR_BASE"' EXIT
 
 REGEN="$TMPDIR_BASE/client.gen.go"
 TMP_CONFIG="$TMPDIR_BASE/oapi-codegen.yaml"
-GEN_LOG="$TMPDIR_BASE/generate.log"
+# Separate log per phase so a later failure never clobbers earlier diagnostics.
+GEN_LOG="$TMPDIR_BASE/oapi-codegen.log"
+NORM_LOG="$TMPDIR_BASE/normalize.log"
 
 # Copy the committed config, overriding only the `output:` line to an absolute
 # temp path. `output-options:` (a different key) is left untouched; the
@@ -50,9 +52,9 @@ if ! (cd "$GO_DIR" && go tool oapi-codegen -config "$TMP_CONFIG" ../openapi.json
 fi
 
 # Apply the same normalization the committed file receives (see generate.go).
-if ! "$SCRIPT_DIR/normalize-go-deprecation-godoc.sh" "$REGEN" > "$GEN_LOG" 2>&1; then
+if ! "$SCRIPT_DIR/normalize-go-deprecation-godoc.sh" "$REGEN" > "$NORM_LOG" 2>&1; then
   echo "ERROR: normalization failed:" >&2
-  cat "$GEN_LOG" >&2
+  cat "$NORM_LOG" >&2
   exit 1
 fi
 

--- a/scripts/check-go-generated-drift.sh
+++ b/scripts/check-go-generated-drift.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# check-go-generated-drift.sh
+#
+# Verifies that the committed generated Go client is current by regenerating
+# and diffing against the committed file:
+#   go/pkg/generated/client.gen.go  (oapi-codegen output, AFTER the
+#                                    normalize-go-deprecation-godoc.sh pass)
+#
+# This is a freshness gate: it re-runs the generation pipeline (oapi-codegen +
+# normalization) and asserts the committed output matches. It is distinct from
+# check-service-drift.sh, which is an operation-level coverage check of the
+# service wrappers.
+#
+# Non-mutating: oapi-codegen honors the `output:` path in its config and ignores
+# -o, so generation is redirected by writing a throwaway config whose `output:`
+# points at a temp file. The committed working tree is never touched, so this is
+# safe to run concurrently with other `make check` targets (including under
+# `make -j`). The generator embeds no timestamp; the comparison is verbatim.
+#
+# Exit codes:
+#   0 = No drift detected
+#   1 = Drift detected
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+GO_DIR="$ROOT_DIR/go"
+GENERATED_FILE="$GO_DIR/pkg/generated/client.gen.go"
+
+TMPDIR_BASE=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+REGEN="$TMPDIR_BASE/client.gen.go"
+TMP_CONFIG="$TMPDIR_BASE/oapi-codegen.yaml"
+GEN_LOG="$TMPDIR_BASE/generate.log"
+
+# Copy the committed config, overriding only the `output:` line to an absolute
+# temp path. `output-options:` (a different key) is left untouched; the
+# user-template paths stay relative and resolve against the go/ working dir.
+sed "s#^output: .*#output: $REGEN#" "$GO_DIR/oapi-codegen.yaml" > "$TMP_CONFIG"
+
+echo "==> Regenerating Go client into a temp directory (non-mutating)..."
+# Run from go/ so the relative user-template paths in the config resolve.
+if ! (cd "$GO_DIR" && go tool oapi-codegen -config "$TMP_CONFIG" ../openapi.json) > "$GEN_LOG" 2>&1; then
+  echo "ERROR: oapi-codegen failed:" >&2
+  cat "$GEN_LOG" >&2
+  exit 1
+fi
+
+# Apply the same normalization the committed file receives (see generate.go).
+if ! "$SCRIPT_DIR/normalize-go-deprecation-godoc.sh" "$REGEN" > "$GEN_LOG" 2>&1; then
+  echo "ERROR: normalization failed:" >&2
+  cat "$GEN_LOG" >&2
+  exit 1
+fi
+
+echo ""
+if ! diff -q "$GENERATED_FILE" "$REGEN" > /dev/null; then
+  echo "ERROR: Generated Go client is out of date."
+  echo "Run 'make -C go generate' and commit."
+  diff "$GENERATED_FILE" "$REGEN" | head -40 || true
+  exit 1
+fi
+
+echo "No drift detected."
+exit 0

--- a/scripts/check-ruby-service-drift.sh
+++ b/scripts/check-ruby-service-drift.sh
@@ -86,7 +86,11 @@ mkdir -p "$SERVICES_TMP"
 
 SERVICES_COMMITTED="$TMPDIR_BASE/services_committed"
 mkdir -p "$SERVICES_COMMITTED"
-cp "$GENERATED_DIR/services/"*.rb "$SERVICES_COMMITTED/"
+# Copy the WHOLE committed services/ tree (not just *.rb) so any stray extra
+# artifact — a non-.rb file or a nested directory the generator never emits —
+# surfaces as drift against the generated set. The generator writes only
+# *_service.rb into an empty temp dir, so anything else here is extra.
+cp -R "$GENERATED_DIR/services/." "$SERVICES_COMMITTED/"
 # Exclude the hand-written base class (lives alongside generated services but is
 # not produced by the generator; it carries no @generated marker).
 rm -f "$SERVICES_COMMITTED/base_service.rb"

--- a/scripts/check-ruby-service-drift.sh
+++ b/scripts/check-ruby-service-drift.sh
@@ -49,7 +49,10 @@ echo "==> Checking metadata.json freshness..."
 META_TMP="$TMPDIR_BASE/metadata.json"
 (cd "$ROOT_DIR/ruby" && ruby scripts/generate-metadata.rb) > "$META_TMP"
 
-if ! diff -q <(normalize_stamp "$GENERATED_DIR/metadata.json") <(normalize_stamp "$META_TMP") > /dev/null; then
+if [ ! -f "$GENERATED_DIR/metadata.json" ]; then
+  echo "ERROR: committed metadata.json is missing. Run 'make rb-generate'"
+  DRIFT=1
+elif ! diff -q <(normalize_stamp "$GENERATED_DIR/metadata.json") <(normalize_stamp "$META_TMP") > /dev/null; then
   echo "ERROR: metadata.json is out of date. Run 'make rb-generate'"
   diff <(normalize_stamp "$GENERATED_DIR/metadata.json") <(normalize_stamp "$META_TMP") || true
   DRIFT=1
@@ -66,7 +69,10 @@ echo "==> Checking types.rb freshness..."
 TYPES_TMP="$TMPDIR_BASE/types.rb"
 (cd "$ROOT_DIR/ruby" && ruby scripts/generate-types.rb) > "$TYPES_TMP"
 
-if ! diff -q <(normalize_stamp "$GENERATED_DIR/types.rb") <(normalize_stamp "$TYPES_TMP") > /dev/null; then
+if [ ! -f "$GENERATED_DIR/types.rb" ]; then
+  echo "ERROR: committed types.rb is missing. Run 'make rb-generate'"
+  DRIFT=1
+elif ! diff -q <(normalize_stamp "$GENERATED_DIR/types.rb") <(normalize_stamp "$TYPES_TMP") > /dev/null; then
   echo "ERROR: types.rb is out of date. Run 'make rb-generate'"
   diff <(normalize_stamp "$GENERATED_DIR/types.rb") <(normalize_stamp "$TYPES_TMP") || true
   DRIFT=1
@@ -86,21 +92,26 @@ mkdir -p "$SERVICES_TMP"
 
 SERVICES_COMMITTED="$TMPDIR_BASE/services_committed"
 mkdir -p "$SERVICES_COMMITTED"
-# Copy the WHOLE committed services/ tree (not just *.rb) so any stray extra
-# artifact — a non-.rb file or a nested directory the generator never emits —
-# surfaces as drift against the generated set. The generator writes only
-# *_service.rb into an empty temp dir, so anything else here is extra.
-cp -R "$GENERATED_DIR/services/." "$SERVICES_COMMITTED/"
-# Exclude the hand-written base class (lives alongside generated services but is
-# not produced by the generator; it carries no @generated marker).
-rm -f "$SERVICES_COMMITTED/base_service.rb"
-
-if ! diff -rq "$SERVICES_COMMITTED" "$SERVICES_TMP" > /dev/null; then
-  echo "ERROR: Generated services are out of date. Run 'make rb-generate-services'"
-  diff -rq "$SERVICES_COMMITTED" "$SERVICES_TMP" || true
+if [ ! -d "$GENERATED_DIR/services" ]; then
+  echo "ERROR: committed services/ directory is missing. Run 'make rb-generate-services'"
   DRIFT=1
 else
-  echo "Generated services are up to date"
+  # Copy the WHOLE committed services/ tree (not just *.rb) so any stray extra
+  # artifact — a non-.rb file or a nested directory the generator never emits —
+  # surfaces as drift against the generated set. The generator writes only
+  # *_service.rb into an empty temp dir, so anything else here is extra.
+  cp -R "$GENERATED_DIR/services/." "$SERVICES_COMMITTED/"
+  # Exclude the hand-written base class (lives alongside generated services but
+  # is not produced by the generator; it carries no @generated marker).
+  rm -f "$SERVICES_COMMITTED/base_service.rb"
+
+  if ! diff -rq "$SERVICES_COMMITTED" "$SERVICES_TMP" > /dev/null; then
+    echo "ERROR: Generated services are out of date. Run 'make rb-generate-services'"
+    diff -rq "$SERVICES_COMMITTED" "$SERVICES_TMP" || true
+    DRIFT=1
+  else
+    echo "Generated services are up to date"
+  fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/scripts/check-ruby-service-drift.sh
+++ b/scripts/check-ruby-service-drift.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+# check-ruby-service-drift.sh
+#
+# Verifies that ALL generated Ruby artifacts are current by regenerating
+# to a temp directory and diffing against the committed files:
+#   1. metadata.json (from openapi.json + behavior-model.json)
+#   2. types.rb       (from openapi.json)
+#   3. Generated service files (from openapi.json)
+#
+# Non-mutative: regeneration lands in a temp dir; the working tree is never
+# touched. Detects BOTH missing (in spec, not committed) and extra (committed,
+# not in spec) drift.
+#
+# NOTE on timestamps: generate-metadata.rb and generate-types.rb embed a
+# wall-clock `generated` stamp (Time.now.utc.iso8601). That single line changes
+# on every run and is NOT drift, so both sides are canonicalized through
+# normalize_stamp() before the metadata/types diff. Every other line is
+# compared verbatim. (The service generator embeds no timestamp.)
+#
+# Exit codes:
+#   0 = No drift detected
+#   1 = Drift detected
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+GENERATED_DIR="$ROOT_DIR/ruby/lib/basecamp/generated"
+TMPDIR_BASE=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+DRIFT=0
+
+# Canonicalize the embedded generation timestamp so it never registers as drift.
+# Targets exactly the two known stamp lines and nothing else.
+normalize_stamp() {
+  sed -E \
+    -e 's/("generated": )"[^"]*"/\1"<NORMALIZED>"/' \
+    -e 's/(# Generated: ).*/\1<NORMALIZED>/' \
+    "$1"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Check metadata.json freshness
+# ---------------------------------------------------------------------------
+echo "==> Checking metadata.json freshness..."
+
+META_TMP="$TMPDIR_BASE/metadata.json"
+(cd "$ROOT_DIR/ruby" && ruby scripts/generate-metadata.rb) > "$META_TMP"
+
+if ! diff -q <(normalize_stamp "$GENERATED_DIR/metadata.json") <(normalize_stamp "$META_TMP") > /dev/null; then
+  echo "ERROR: metadata.json is out of date. Run 'make rb-generate'"
+  diff <(normalize_stamp "$GENERATED_DIR/metadata.json") <(normalize_stamp "$META_TMP") || true
+  DRIFT=1
+else
+  echo "metadata.json is up to date"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Check types.rb freshness
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Checking types.rb freshness..."
+
+TYPES_TMP="$TMPDIR_BASE/types.rb"
+(cd "$ROOT_DIR/ruby" && ruby scripts/generate-types.rb) > "$TYPES_TMP"
+
+if ! diff -q <(normalize_stamp "$GENERATED_DIR/types.rb") <(normalize_stamp "$TYPES_TMP") > /dev/null; then
+  echo "ERROR: types.rb is out of date. Run 'make rb-generate'"
+  diff <(normalize_stamp "$GENERATED_DIR/types.rb") <(normalize_stamp "$TYPES_TMP") || true
+  DRIFT=1
+else
+  echo "types.rb is up to date"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Check generated services freshness
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Checking generated services freshness..."
+
+SERVICES_TMP="$TMPDIR_BASE/services"
+mkdir -p "$SERVICES_TMP"
+(cd "$ROOT_DIR/ruby" && ruby scripts/generate-services.rb --output "$SERVICES_TMP") > /dev/null
+
+SERVICES_COMMITTED="$TMPDIR_BASE/services_committed"
+mkdir -p "$SERVICES_COMMITTED"
+cp "$GENERATED_DIR/services/"*.rb "$SERVICES_COMMITTED/"
+# Exclude the hand-written base class (lives alongside generated services but is
+# not produced by the generator; it carries no @generated marker).
+rm -f "$SERVICES_COMMITTED/base_service.rb"
+
+if ! diff -rq "$SERVICES_COMMITTED" "$SERVICES_TMP" > /dev/null; then
+  echo "ERROR: Generated services are out of date. Run 'make rb-generate-services'"
+  diff -rq "$SERVICES_COMMITTED" "$SERVICES_TMP" || true
+  DRIFT=1
+else
+  echo "Generated services are up to date"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+if [ "$DRIFT" -eq 1 ]; then
+  echo "DRIFT DETECTED. Run 'make rb-generate rb-generate-services' to regenerate."
+  exit 1
+fi
+
+echo "No drift detected."
+exit 0

--- a/scripts/check-typescript-service-drift.sh
+++ b/scripts/check-typescript-service-drift.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# check-typescript-service-drift.sh
+#
+# Verifies that ALL generated TypeScript artifacts under src/generated/ are
+# current by regenerating and diffing against the committed tree:
+#   1. openapi-stripped.json (stripped OpenAPI)
+#   2. schema.d.ts           (openapi-typescript, patched)
+#   3. metadata.ts           (x-basecamp-* extension metadata)
+#   4. path-mapping.ts       (operation -> path map)
+#   5. Generated service files (+ services/index.ts)
+#
+# Non-mutating: the `npm run generate` pipeline writes to paths resolved from the
+# generator scripts' own location (import.meta __dirname), so it cannot be
+# redirected by changing the working directory. Instead this script assembles a
+# throwaway project OUTSIDE the repo — the real generator scripts, a symlinked
+# node_modules, and a copy of openapi.json placed where the pipeline's relative
+# `../openapi.json` resolves — and runs the committed `npm run generate` +
+# generate-services verbatim there. The committed working tree is never touched,
+# so this is safe to run concurrently with other `make check` targets (including
+# under `make -j`). Regenerating into an empty tree also means the diff detects
+# BOTH missing and extra files (stale artifacts survive only in the committed
+# copy).
+#
+# NOTE on timestamps: extract-metadata.ts embeds a wall-clock `generated` stamp
+# in metadata.ts. That single line changes on every run and is NOT drift, so
+# both sides are canonicalized through normalize_stamp() before the diff. Every
+# other line is compared verbatim. (No other artifact embeds a timestamp.)
+#
+# Exit codes:
+#   0 = No drift detected
+#   1 = Drift detected
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+TS_DIR="$ROOT_DIR/typescript"
+GENERATED_DIR="$TS_DIR/src/generated"
+
+if [ ! -d "$TS_DIR/node_modules" ]; then
+  echo "ERROR: $TS_DIR/node_modules is missing. Run 'make ts-install' first." >&2
+  exit 1
+fi
+
+TMPBASE=$(mktemp -d)
+trap 'rm -rf "$TMPBASE"' EXIT
+
+# openapi.json copied to the temp parent so the pipeline's relative
+# `../openapi.json` (from the project dir) resolves to it.
+cp "$ROOT_DIR/openapi.json" "$TMPBASE/openapi.json"
+
+PROJ="$TMPBASE/proj"
+mkdir -p "$PROJ/src/generated"
+cp -R "$TS_DIR/scripts" "$PROJ/scripts"
+cp "$TS_DIR/package.json" "$PROJ/package.json"
+cp "$TS_DIR"/tsconfig*.json "$PROJ/" 2>/dev/null || true
+ln -s "$TS_DIR/node_modules" "$PROJ/node_modules"
+
+GEN_LOG="$TMPBASE/generate.log"
+
+echo "==> Regenerating TypeScript artifacts into a temp project (non-mutating)..."
+# Verbatim `npm run generate` (robust to pipeline changes) + generate-services.
+if ! (cd "$PROJ" && npm run generate && npx tsx scripts/generate-services.ts) > "$GEN_LOG" 2>&1; then
+  echo "ERROR: TypeScript generation failed:" >&2
+  cat "$GEN_LOG" >&2
+  exit 1
+fi
+
+REGEN="$PROJ/src/generated"
+
+# Snapshot the committed tree (never mutate it) so the timestamp line can be
+# canonicalized on both sides before diffing.
+CMT="$TMPBASE/committed"
+mkdir -p "$CMT"
+cp -R "$GENERATED_DIR/." "$CMT/"
+
+normalize_stamp() {
+  if [ -f "$1/metadata.ts" ]; then
+    sed -E -i.bak 's/("generated": )"[^"]*"/\1"<NORMALIZED>"/' "$1/metadata.ts"
+    rm -f "$1/metadata.ts.bak"
+  fi
+}
+normalize_stamp "$CMT"
+normalize_stamp "$REGEN"
+
+echo ""
+if ! diff -rq "$CMT" "$REGEN" > /dev/null; then
+  echo "ERROR: Generated TypeScript code is out of date."
+  echo "Run 'make ts-generate ts-generate-services' and commit."
+  diff -rq "$CMT" "$REGEN" || true
+  exit 1
+fi
+
+echo "No drift detected."
+exit 0


### PR DESCRIPTION
## What

Adds non-mutating **regenerate-and-diff freshness gates** for the three SDKs whose `make check` entry was coverage/typecheck-only, mirroring the existing `check-swift-service-drift.sh` / `check-python-service-drift.sh`:

- `scripts/check-typescript-service-drift.sh` — the whole `src/generated/` tree (stripped OpenAPI, schema, metadata, path-mapping, generated services)
- `scripts/check-ruby-service-drift.sh` — `metadata.json`, `types.rb`, generated services (`base_service.rb` excluded as hand-written)
- `scripts/check-go-generated-drift.sh` — `client.gen.go` after the `normalize-go-deprecation-godoc.sh` pass; distinct from `check-service-drift.sh` (operation-level coverage) and `check-wrapper-drift` (field-level)

Wired into root `make check` (Go standalone in the drift cluster; TS/Ruby as deps of `ts-check`/`rb-check`, like `py-check-drift`) plus each SDK's CI job. The Ruby CI step runs only on the canonical `3.3` matrix entry since generated output is Ruby-version independent.

## Why

Each of these `make check` entries was coverage/typecheck-only, so a committed generated artifact could silently drift from the current generator/spec without failing `make check`. These gates close that hole for TS, Ruby, and Go, matching what Swift/Python already had.

## Design notes

**All three are fully non-mutative — they regenerate entirely into temp locations and never touch the committed working tree.** That gives both `make -j` race-safety (a gate can't rewrite a tree while a sibling `check` target reads it) and correct **extra-file** detection (regenerating into an empty tree makes stale committed files surface as drift). How each redirects generation out-of-tree:

- **Ruby** generators accept `--output`/stdout → emit straight to a temp dir.
- **Go**'s oapi-codegen honors its config `output:` and ignores `-o`, so the gate writes a throwaway config whose `output:` points at a temp file.
- **TS**'s pipeline resolves output paths from the generator scripts' own location (`import.meta` `__dirname`), so the gate assembles a throwaway project outside the repo — the real scripts, a symlinked `node_modules`, and a copy of `openapi.json` placed where the pipeline's `../openapi.json` resolves — and runs the committed `npm run generate` + `generate-services` **verbatim** there (robust to pipeline changes).

**Timestamps:** Ruby `metadata.json`/`types.rb` and TS `metadata.ts` embed a wall-clock `generated` stamp; those single lines are canonicalized before diffing so a re-run isn't mistaken for drift. Go and the other TS artifacts are deterministic and compared verbatim. Generator stderr is preserved and printed on failure.

**Kotlin** stays a CI-only exception: `kt-check-drift` remains an operation-level coverage check at root, while its authoritative regenerate-and-diff runs in the `test-kotlin` CI job. Documented in the Makefile; promoting it to a root-invocable non-mutating gate is a follow-up.

No SDK-source changes.

## Verification

- 3 gates exit 0 on clean `main`; **non-mutative** (working tree untouched after every run)
- Negative proofs: content drift, extra file at `services/` **and** at the generated-tree root, timestamp-only change ignored, failure-path (broken `openapi.json`) exits 1 with diagnostics and leaves the tree untouched
- `make check` → green; `make -j check` → green (full 5-language conformance)
- `shellcheck` clean; `actionlint` clean

## Context

Part of the post-0.9.0 retry-contract follow-up program — the ship-now item, independent of the held retry-behavior work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds non-mutating regenerate-and-diff freshness gates for TypeScript, Ruby, and Go generated code to prevent drift. Runs in temp dirs, detects missing and extra files (including non-.rb artifacts in Ruby services), is safe under parallel make, and now guards missing Ruby artifacts and asserts Go output redirection.

- **New Features**
  - TypeScript: `scripts/check-typescript-service-drift.sh` regenerates the entire `src/generated/` tree and diffs; normalizes the `generated` stamp in `metadata.ts`.
  - Ruby: `scripts/check-ruby-service-drift.sh` regenerates `metadata.json`, `types.rb`, and snapshots the whole `generated/services/` tree for diffing (excludes hand-written `base_service.rb`); normalizes timestamps; detects missing files cleanly.
  - Go: `scripts/check-go-generated-drift.sh` regenerates `client.gen.go` via a temp `oapi-codegen` config, asserts the `output:` redirect before running, applies `normalize-go-deprecation-godoc.sh`, and uses separate logs per phase.

- **CI and Makefile**
  - New targets: `ts-check-drift`, `rb-check-drift`, `go-check-generated-drift`; wired into `ts-check`, `rb-check`, and root `make check`.
  - CI runs the new gates for TS, Ruby (only on 3.3), and Go; Kotlin unchanged (regen-and-diff remains CI-only).

<sup>Written for commit 949f050a6b5c27afe85d00ea01665d932d509d0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

