### PR TITLE
Sync action pin version comments + port the dependabot sync automation

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -188,7 +188,8 @@ jobs:
           } > body.md
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.0 # zizmor: ignore[superfluous-actions] -- consider removal
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
+        # zizmor: ignore[superfluous-actions] -- consider removal
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           name: Basecamp SDK ${{ steps.version.outputs.version }}

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -39,7 +39,8 @@ jobs:
           git merge-base --is-ancestor "$GITHUB_SHA" origin/main
 
       - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6.4.0 # zizmor: ignore[cache-poisoning] -- cached deps are for testing, not release artifact generation
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        # zizmor: ignore[cache-poisoning] -- cached deps are for testing, not release artifact generation
         with:
           go-version-file: 'go/go.mod'
           cache-dependency-path: 'go/go.sum'
@@ -77,7 +78,8 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.2 # zizmor: ignore[artipacked] -- credentials needed for git push to create module tag
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        # zizmor: ignore[artipacked] -- credentials needed for git push to create module tag
 
       - name: Push go/ subdirectory tag
         run: |

--- a/.github/workflows/release-kotlin.yml
+++ b/.github/workflows/release-kotlin.yml
@@ -38,7 +38,8 @@ jobs:
           java-version: '17'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.1.0 # zizmor: ignore[cache-poisoning] -- cached deps are for testing, not release artifact generation
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        # zizmor: ignore[cache-poisoning] -- cached deps are for testing, not release artifact generation
         with:
           cache-provider: basic
 
@@ -88,7 +89,8 @@ jobs:
           java-version: '17'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.1.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
         with:
           cache-provider: basic
 

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -32,7 +32,8 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2 # zizmor: ignore[cache-poisoning] -- cached deps are for testing, not release artifact generation
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        # zizmor: ignore[cache-poisoning] -- cached deps are for testing, not release artifact generation
 
       - name: Set up Python
         run: uv python install 3.13
@@ -87,7 +88,8 @@ jobs:
           git merge-base --is-ancestor "$GITHUB_SHA" origin/main
 
       - name: Install uv
-        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
 
       - name: Set up Python
         run: uv python install 3.13

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -32,7 +32,8 @@ jobs:
           persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.302.0 # zizmor: ignore[cache-poisoning] -- cached deps are for testing, not release artifact generation
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
+        # zizmor: ignore[cache-poisoning] -- cached deps are for testing, not release artifact generation
         with:
           ruby-version: '3.3'
           bundler-cache: true
@@ -68,7 +69,8 @@ jobs:
           git merge-base --is-ancestor "$GITHUB_SHA" origin/main
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.302.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
+        # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
         with:
           ruby-version: '3.3'
           bundler-cache: true

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -32,7 +32,8 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6.3.0 # zizmor: ignore[cache-poisoning] -- cached deps are for testing, not release artifact generation
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        # zizmor: ignore[cache-poisoning] -- cached deps are for testing, not release artifact generation
         with:
           node-version: '22'
           cache: 'npm'
@@ -80,7 +81,8 @@ jobs:
       # requires. Publishing therefore uses the npm shipped in the verified Node
       # tarball rather than installing one from the registry at release time.
       - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6.3.0 # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Problem

Dependabot PR #454 bumped 12 action SHAs but left stale `# vX.Y.Z` comments on 9 lines. Two compounding causes:

1. **Dependabot only rewrites *bare* version comments.** Every stale line carried a trailing `# zizmor: ignore[...]` suffix; dependabot updated the SHA but wouldn't touch the compound comment (verified empirically in 61a5d6b8: bare comments were rewritten, compound ones untouched).
2. **Current zizmor can't see or fix compound comments either.** Since ~1.26, `# v6.4.0 # zizmor: ignore[...]` no longer parses as a version comment; `ref-version-mismatch` degrades from a regular-persona auto-fixable `warning` to a pedantic-persona `help` with no auto-fix. CI runs zizmor-action `version: latest` → audit green, `--fix=all` a no-op on exactly these lines.

## Change

Fix the 9 stale comments and restructure all 11 compound-comment pin lines: each inline `# zizmor: ignore[...]` moves to its own line directly below the `uses:` line (reason text kept). Verified against zizmor 1.28.0: the target audit stays ignored (ignored-count unchanged at 15), and the now-bare version comment can be maintained by dependabot and by zizmor's `ref-version-mismatch` auto-fix. Version values verified against upstream tags via `git ls-remote`:

| Action | Comment |
|---|---|
| setup-go | v6.4.0 → v7.0.0 |
| checkout (go tag push) | v6.0.2 → v7.0.1 |
| setup-ruby ×2 | v1.302.0 → v1.319.0 |
| setup-node ×2 | v6.3.0 → v7.0.0 |
| setup-gradle ×2 | v6.1.0 → v6.2.0 |
| action-gh-release | v3.0.0 → v3.0.2 |
| setup-uv ×2 | v8.3.2 (already correct — restructure only) |

`dependabot-auto-merge.yml:14` is untouched — its ignore is on an `if:` line, not a pin.

## Automation withdrawn from this PR

An earlier revision also ported the push-triggered `dependabot-sync-actions-comments.yml` from basecamp-mcp-server. Review surfaced two real problems with that lineage: the push-triggered form executes the freshly-bumped (unreviewed) checkout action with a write token, and `GITHUB_TOKEN` cannot push workflow-file modifications at all (openclaw-basecamp hit exactly this on its first live run — openclaw-basecamp@54c96d3e — and moved to a deploy key). The automation is being rebuilt instead on openclaw-basecamp's hardened model (`workflow_run` from the default branch, head branch fetched as data only, deploy-key lease push) as a reusable workflow in basecamp/.github with thin callers across basecamp-sdk, basecamp-cli, hey-cli, fizzy-cli, and cli. This PR is now the comment fix only.

## Verification

- `zizmor` 1.28.0 (matches CI's `latest`): no findings, 15 ignored (unchanged). Local Homebrew zizmor upgraded 1.24.1 → 1.28.0; 1.24.1 was already failing `make lint-actions` on main (it still warned on the 9 stale compound comments).
- `make lint-actions` (actionlint + zizmor 1.28.0) passes.
- Sabotage test: broke `# v7.0.0` → `# v6.9.9`, ran `zizmor --fix=all` → repaired exactly, no other churn.