### PR TITLE
Sync Dependabot action pin comments via reusable workflow

### DIFF
--- a/.github/workflows/dependabot-sync-actions-comments.yml
+++ b/.github/workflows/dependabot-sync-actions-comments.yml
@@ -1,0 +1,46 @@
+name: Sync Dependabot action pin comments
+
+# Thin caller: all logic lives in basecamp/.github's reusable workflow —
+# trusted default-branch code that fetches the Dependabot head branch as data
+# only, rewrites stale `# vX.Y.Z` pin comments, and pushes back behind a
+# compare-and-swap lease using the write deploy key scoped to this repo's
+# dependabot-sync environment.
+
+on:
+  workflow_run: # zizmor: ignore[dangerous-triggers] -- only the SHA-pinned reusable workflow (reviewed default-branch code) executes; the Dependabot head branch is fetched as data, never executed
+    workflows: [Test]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Dependabot branch to sync (dependabot/github_actions/...)
+        required: true
+        type: string
+      e2e:
+        description: "E2E proof mode: expect a draft PR authored by the dispatcher on a dependabot/github_actions/e2e-proof-* branch"
+        required: false
+        default: false
+        type: boolean
+
+permissions: {}
+
+jobs:
+  sync:
+    # Cheap prefilter to avoid a skipped-run entry on every CI completion;
+    # the reusable workflow re-checks this and everything else.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.workflow_run.head_branch, 'dependabot/github_actions/')
+    uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@95a9f7a2bd69c73cd2839eb4a27616e1651497e2
+    with:
+      ci-workflow-name: Test
+      branch: ${{ inputs.branch || '' }}
+      e2e: ${{ inputs.e2e || false }}
+    permissions:
+      contents: read
+      actions: write
+      pull-requests: read
+    # The deploy key is scoped to this repo's dependabot-sync environment
+    # (deployment branches: default branch only); environment secrets cannot
+    # be forwarded explicitly to a reusable workflow, so inherit is required.
+    secrets: inherit # zizmor: ignore[secrets-inherit] -- see above; the called workflow is SHA-pinned and reads only SYNC_ACTIONS_DEPLOY_KEY, gated by the dependabot-sync environment

--- a/.github/workflows/dependabot-sync-actions-comments.yml
+++ b/.github/workflows/dependabot-sync-actions-comments.yml
@@ -10,6 +10,7 @@ on:
   workflow_run: # zizmor: ignore[dangerous-triggers] -- only the SHA-pinned reusable workflow (reviewed default-branch code) executes; the Dependabot head branch is fetched as data, never executed
     workflows: [Test]
     types: [completed]
+    branches: ["dependabot/github_actions/**"]
   workflow_dispatch:
     inputs:
       branch:
@@ -26,8 +27,9 @@ permissions: {}
 
 jobs:
   sync:
-    # Cheap prefilter to avoid a skipped-run entry on every CI completion;
-    # the reusable workflow re-checks this and everything else.
+    # Defense-in-depth behind the trigger-level branches filter (which stops
+    # runs from being created for other branches at all); the reusable
+    # workflow re-checks this and everything else.
     if: >-
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.workflow_run.head_branch, 'dependabot/github_actions/')

--- a/.github/workflows/dependabot-sync-actions-comments.yml
+++ b/.github/workflows/dependabot-sync-actions-comments.yml
@@ -33,7 +33,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.workflow_run.head_branch, 'dependabot/github_actions/')
-    uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@95a9f7a2bd69c73cd2839eb4a27616e1651497e2
+    uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@9ca40e3b2d6be769b370b7cee86e8448267c95d8
     with:
       ci-workflow-name: Test
       branch: ${{ inputs.branch || '' }}


### PR DESCRIPTION
Thin caller for the `dependabot-sync-actions-comments` reusable workflow (basecamp/.github#8, merged as 95a9f7a2). After CI completes on a Dependabot `github_actions` branch, trusted default-branch code fixes any stale `# vX.Y.Z` pin comments — including compound ones with trailing `# zizmor: ignore[...]` annotations that Dependabot can't rewrite — and pushes back behind a compare-and-swap lease.

This is the automation that was withdrawn from #458 after review: the push-triggered lineage executed the freshly-bumped (unreviewed) checkout action with a write token, and `GITHUB_TOKEN` can't push workflow-file changes at all (openclaw-basecamp@54c96d3e). The reusable model runs only reviewed default-branch code, fetches the Dependabot head branch as *data*, and pushes with a write deploy key scoped to this repo's `dependabot-sync` environment (deployment branches: main only). Environment + deploy key are already provisioned.

#458 (comment fix + ignore restructure) remains complementary: bare version comments there let Dependabot itself maintain them as the first line of defense; this workflow is the backstop that catches what Dependabot can't rewrite.

Runtime validation: after merge, a `workflow_dispatch` run against a live Dependabot actions branch (basecamp-cli#566 is the standing candidate for the fleet) proves the full fix→guard→push→re-CI loop.

Sibling callers: basecamp-cli#572, hey-cli#141, fizzy-cli#189, cli#51.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a thin GitHub Actions caller for the reusable `dependabot-sync-actions-comments` to fix stale `# vX.Y.Z` pin comments on `dependabot/github_actions/*` branches after CI, then push via the repo’s `dependabot-sync` environment deploy key. Runs reviewed default-branch code only; the reusable workflow is re-pinned to the version that removed the CI-dispatch fallback and now verifies CI started on the pushed head.

- **New Features**
  - Triggers on `workflow_run` of `Test` and manual `workflow_dispatch` (`branch`, `e2e`), and filters `workflow_run` to `dependabot/github_actions/**` at the trigger (job-level guard remains).
  - Uses a SHA-pinned reusable workflow that fetches the Dependabot branch as data, rewrites pin comments (including `# zizmor: ignore[...]`), guards pushes with a compare-and-swap lease, and verifies CI started on the pushed head instead of dispatching a fallback.
  - Minimal permissions; `secrets: inherit` enables the environment-scoped deploy key to push.

<sup>Written for commit e4acea254ec66c30bb1607218c18563a8ae7b5de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

