### PR TITLE
Freshness-gate completeness: url-routes + Kotlin regenerate-and-diff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,6 +102,12 @@ jobs:
       - name: Check generated client drift
         run: ../scripts/check-go-generated-drift.sh
 
+      - name: Check url-routes freshness
+        # url-routes.json is a generated Go artifact (//go:embed in url.go).
+        # Runs from repo root regardless of this job's `working-directory: go`.
+        working-directory: .
+        run: make url-routes-check
+
       - name: Check auth-routable consumer invariants
         run: ../scripts/check-auth-routable-consumers.sh
 
@@ -369,15 +375,12 @@ jobs:
         run: ./gradlew :basecamp-sdk:check
 
       - name: Check generated code drift
-        run: |
-          ./gradlew :generator:run --args="--openapi ../openapi.json --behavior ../behavior-model.json --output sdk/src/commonMain/kotlin/com/basecamp/sdk/generated"
-          if [ -n "$(git status --porcelain -- sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/)" ]; then
-            echo "::error::Generated Kotlin code is out of date. Run 'make kt-generate-services' and commit."
-            git status --short -- sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/
-            git diff --stat -- sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/ || true
-            exit 1
-          fi
-          echo "Generated code is up to date"
+        # Regenerate-and-diff freshness gate via the root Make target, which
+        # runs the shared non-mutating scripts/check-kotlin-generated-drift.sh
+        # (regenerates into a temp dir; never touches the working tree). Runs
+        # from repo root regardless of this job's `working-directory: kotlin`.
+        working-directory: .
+        run: make kt-check-generated-drift
 
       - name: Check optional-array invariant
         run: ruby ../scripts/check-kotlin-optional-arrays.rb

--- a/Makefile
+++ b/Makefile
@@ -616,7 +616,7 @@ conformance-canary:
 # Kotlin SDK targets
 #------------------------------------------------------------------------------
 
-.PHONY: kt-generate-services kt-build kt-test kt-check kt-check-drift kt-clean gradle-stop
+.PHONY: kt-generate-services kt-build kt-test kt-check kt-check-drift kt-check-generated-drift kt-clean gradle-stop
 
 # Generate Kotlin services from OpenAPI
 kt-generate-services:
@@ -641,15 +641,24 @@ kt-check: kt-test
 #
 # NOTE: this is an operation-level *coverage* check (operationId sets match),
 # NOT a regenerate-and-diff freshness gate like check-{python,ruby,typescript}-
-# service-drift.sh or check-go-generated-drift.sh. The authoritative
-# regenerate-and-diff for Kotlin runs only in CI (the "Check generated code
-# drift" step of the test-kotlin job in .github/workflows/test.yml), which
-# regenerates and fails on any committed drift. Kotlin is intentionally a
-# CI-only exception to the non-mutating regen-and-diff program for now;
-# promoting it to a root-invocable non-mutating gate is tracked as a follow-up.
+# service-drift.sh or check-go-generated-drift.sh. It stays in the default
+# `make check` because it is fast (jq/grep, no JVM). The authoritative
+# regenerate-and-diff freshness gate is kt-check-generated-drift below.
 kt-check-drift:
 	@echo "==> Checking Kotlin service drift..."
 	@./scripts/check-kotlin-service-drift.sh
+
+# Regenerate-and-diff freshness gate for the whole generated Kotlin tree — the
+# Kotlin sibling of check-{python,ruby,swift,typescript}-service-drift.sh and
+# check-go-generated-drift.sh, completing 6-SDK parity. Non-mutating: it
+# regenerates into a temp dir and diffs, so it detects both missing and extra
+# files. Deliberately NOT part of the default `make check`: a `:generator:run`
+# is a heavy JVM/Gradle-daemon startup, so it runs as its own target and in CI
+# (the test-kotlin job's "Check generated code drift" step) rather than adding
+# seconds of local latency to every `make check`.
+kt-check-generated-drift:
+	@echo "==> Checking Kotlin generated drift (regenerate-and-diff)..."
+	@./scripts/check-kotlin-generated-drift.sh
 
 # Clean Kotlin build artifacts
 kt-clean:
@@ -865,7 +874,7 @@ generate:
 	@echo "==> Generation complete"
 
 # Run all checks (Smithy + Go + TypeScript + Ruby + Kotlin + Swift + Python + Behavior Model + Conformance + Provenance + Actions lint)
-check: lint-actions sync-spec-version-check smithy-check behavior-model-check provenance-check sync-api-version-check go-check-drift go-check-wrapper-drift go-check-generated-drift auth-routable-check kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity check-fixture-coverage kt-check-optional-arrays check-idempotency-parity
+check: lint-actions sync-spec-version-check smithy-check behavior-model-check provenance-check sync-api-version-check url-routes-check go-check-drift go-check-wrapper-drift go-check-generated-drift auth-routable-check kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity check-fixture-coverage kt-check-optional-arrays check-idempotency-parity
 	@echo "==> All checks passed"
 
 # Clean all build artifacts
@@ -916,7 +925,8 @@ help:
 	@echo "  kt-build             Build Kotlin SDK"
 	@echo "  kt-test              Run Kotlin tests"
 	@echo "  kt-check             Run all Kotlin checks"
-	@echo "  kt-check-drift       Check service drift vs OpenAPI spec"
+	@echo "  kt-check-drift       Check service drift vs OpenAPI spec (fast coverage)"
+	@echo "  kt-check-generated-drift  Regenerate-and-diff freshness gate (heavy; CI + on demand)"
 	@echo "  kt-clean             Remove Kotlin build artifacts"
 	@echo "  gradle-stop          Stop any lingering Gradle daemons"
 	@echo ""

--- a/SPEC.md
+++ b/SPEC.md
@@ -1342,8 +1342,9 @@ The following are must-pass criteria from the rubric. Each maps to a spec sectio
 | `provenance-check` | Embedded provenance matches `spec/api-provenance.json` |
 | `sync-spec-version-check` | Smithy service version matches the shared date in `spec/api-provenance.json` |
 | `sync-api-version-check` | `API_VERSION` constants match `openapi.json` `info.version` across all SDKs |
+| `url-routes-check` | `go/pkg/basecamp/url-routes.json` (embedded via `//go:embed`) matches regeneration from `openapi.json` |
 | `go-check-drift` | Go generated services match current OpenAPI spec |
-| `kt-check-drift` | Kotlin generated services match current OpenAPI spec |
+| `kt-check-drift` | Kotlin generated services match current OpenAPI spec (operation-level coverage) |
 | `go-check` | Go: lint + test |
 | `ts-check` | TypeScript: typecheck + test |
 | `rb-check` | Ruby: test + rubocop |
@@ -1351,14 +1352,15 @@ The following are must-pass criteria from the rubric. Each maps to a spec sectio
 | `swift-check` | Swift: build + test |
 | `conformance` | All conformance test categories pass with documented waivers (go, kotlin, typescript, ruby runners) |
 
-Full dependency chain: `check: sync-spec-version-check smithy-check behavior-model-check provenance-check sync-api-version-check go-check-drift kt-check-drift go-check ts-check rb-check kt-check swift-check conformance`
+Representative dependency chain (see the Makefile `check:` line for the authoritative, complete list): `check: … sync-api-version-check url-routes-check go-check-drift … kt-check-drift … go-check ts-check rb-check kt-check swift-check py-check conformance …`
+
+Regenerate-and-diff freshness gates now exist for all six SDKs' generated output. Five run inside `make check` — `check-go-generated-drift.sh`, `check-typescript-service-drift.sh`, `check-ruby-service-drift.sh`, `check-python-service-drift.sh`, and `check-swift-service-drift.sh` (via `swift-check-drift`). The sixth, Kotlin's `kt-check-generated-drift`, is a heavier Gradle/JVM run kept out of the default `make check` and exercised as its own target plus the `test-kotlin` CI job; the fast, coverage-only `kt-check-drift` remains in `make check`.
 
 ### Advisory (not in `make check` today)
 
 | Target | Status |
 |--------|--------|
-| `url-routes-check` | Exists as Makefile target but not wired into `check` |
-| TS/Ruby/Swift drift checks | Not yet implemented (only Go and Kotlin have them) |
+| `kt-check-generated-drift` | Kotlin regenerate-and-diff freshness gate; runs as a standalone target and in the `test-kotlin` CI job (kept out of default `make check` to avoid JVM/Gradle startup latency) |
 | `audit-check` | Defined in the Makefile convention (external governance reference in `basecamp/sdk` `MAKEFILE-CONVENTION.md`) but no target exists in this repo's Makefile |
 
 ---

--- a/scripts/check-kotlin-generated-drift.sh
+++ b/scripts/check-kotlin-generated-drift.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# check-kotlin-generated-drift.sh
+#
+# Verifies that the committed generated Kotlin artifacts are current by
+# regenerating the whole generated/ tree into a temp directory and diffing.
+# Non-mutating: the committed tree is never touched, so this detects both
+# missing AND extra files and is safe to run concurrently under `make -j`.
+#
+# This is the regenerate-and-diff sibling of the fast, coverage-only
+# check-kotlin-service-drift.sh (operationId-set compare). The whole generated
+# tree carries @generated; the hand-written base class lives OUTSIDE it, so a
+# plain `diff -rq` needs no exclusions and no timestamp normalization (nothing
+# generated embeds a wall-clock stamp).
+#
+# Exit codes:
+#   0 = No drift detected
+#   1 = Drift detected
+#   2 = Could not run the check: required toolchain missing, or `diff` itself
+#       failed (e.g. an unreadable path)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# The Gradle generator runs on the JVM; fail with a distinct code (like the
+# Swift sibling) when the toolchain is absent, rather than surfacing a raw
+# gradlew 127. Mirror gradlew's own JAVA_HOME-first resolution (kotlin/gradlew)
+# so we don't reject a valid environment where java is reachable only via
+# JAVA_HOME and not on PATH.
+if [ -n "${JAVA_HOME:-}" ]; then
+  if [ ! -x "$JAVA_HOME/bin/java" ] && [ ! -x "$JAVA_HOME/jre/sh/java" ]; then
+    echo "ERROR: JAVA_HOME ($JAVA_HOME) contains no executable java for check-kotlin-generated-drift.sh" >&2
+    exit 2
+  fi
+elif ! command -v java >/dev/null 2>&1; then
+  echo "ERROR: java is required for check-kotlin-generated-drift.sh (set JAVA_HOME or put java on PATH)" >&2
+  exit 2
+fi
+
+GENERATED_DIR="$ROOT_DIR/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated"
+# Explicit template so this works identically under GNU and BSD/macOS mktemp.
+TMP_OUT="$(mktemp -d "${TMPDIR:-/tmp}/kotlin-generated-drift.XXXXXX")"
+# Canonicalize to an absolute path: a relative TMPDIR (e.g. TMPDIR=tmp) yields a
+# relative TMP_OUT, and the generator runs from kotlin/ (below), which would
+# resolve it against the wrong directory and falsely report drift.
+TMP_OUT="$(cd "$TMP_OUT" && pwd)"
+trap 'rm -rf "$TMP_OUT"' EXIT
+
+echo "==> Regenerating Kotlin SDK into a temp directory..."
+# Mirror `make kt-generate-services` but emit to an absolute temp path so the
+# committed tree is untouched. The Gradle generator accepts absolute paths for
+# --openapi/--behavior/--output.
+#
+# Gradle re-tokenizes the --args string on whitespace, honoring quotes, so each
+# path is wrapped in double quotes: without it a repo or TMPDIR path containing a
+# space would be split into multiple tokens and the generator (which consumes
+# only the token immediately after each flag) would read/write the wrong path.
+# Double (not single) quotes so a path containing an apostrophe also survives;
+# the shell still expands the variables inside the outer double-quoted --args.
+(cd "$ROOT_DIR/kotlin" && \
+  ./gradlew --quiet :generator:run \
+    --args="--openapi \"$ROOT_DIR/openapi.json\" --behavior \"$ROOT_DIR/behavior-model.json\" --output \"$TMP_OUT\"") > /dev/null
+
+echo "==> Diffing against committed kotlin/.../generated/ ..."
+# A missing committed tree (accidental delete/rename) is drift, not a tool
+# error: `diff` would exit >=2 on the missing operand, which the branch below
+# reserves for genuine I/O failures. Handle it explicitly as drift (exit 1).
+if [ ! -d "$GENERATED_DIR" ]; then
+  echo "ERROR: committed generated tree is missing: $GENERATED_DIR"
+  echo "       Run 'make kt-generate-services' to regenerate it."
+  exit 1
+fi
+
+# diff exits 0 = identical, 1 = differences (drift), >=2 = trouble (e.g. an
+# unreadable path mid-comparison). Distinguish them so a diff failure is not
+# misreported as drift and maps to the reserved toolchain/error code 2. The
+# `|| diff_status=$?` keeps set -e from firing on diff's non-zero exit.
+diff_status=0
+diff_output=$(diff -rq "$GENERATED_DIR" "$TMP_OUT" 2>&1) || diff_status=$?
+if [ "$diff_status" -eq 0 ]; then
+  echo "No drift detected."
+  exit 0
+elif [ "$diff_status" -eq 1 ]; then
+  echo "ERROR: Generated Kotlin is out of date. Run 'make kt-generate-services', then"
+  echo "       delete any path the diff below reports as 'Only in $GENERATED_DIR':"
+  echo "       the generator rewrites the tree but does not prune unexpected extra files."
+  echo "$diff_output"
+  exit 1
+else
+  echo "ERROR: diff failed (exit $diff_status) while comparing generated Kotlin trees:" >&2
+  echo "$diff_output" >&2
+  exit 2
+fi


### PR DESCRIPTION
Extends #456 (regenerate-and-diff freshness gates for TS/Ruby/Go) to close the two remaining gaps in the generated-artifact gating surface. Behavior-neutral hardening — no runtime change.

## Part A — `url-routes.json`
`scripts/generate-url-routes` produces `go/pkg/basecamp/url-routes.json` (consumed via `//go:embed` in `url.go`). A non-mutating `url-routes-check` target already existed but was wired into **neither** `make check` **nor** CI, so the artifact could silently drift while every other generated artifact is gated. This adds it to the `make check` prerequisites (a fast, non-mutating script run) and to the `test-go` CI job.

## Part B — Kotlin regenerate-and-diff
Root `make check` ran only the fast, coverage-only `kt-check-drift` (operationId-set compare); the authoritative regenerate-and-diff ran solely in CI as a mutating `git status --porcelain`. This adds:

- **`scripts/check-kotlin-generated-drift.sh`** — the Kotlin sibling of the other five service-drift scripts. It regenerates the whole `generated/` tree into a temp dir and `diff -rq`s, so it is non-mutating and detects both missing **and** extra files. The whole `@generated` tree is generated (base class lives outside it) and nothing embeds a wall-clock stamp, so no exclusions or timestamp normalization are needed. Includes a `java`-toolchain guard that exits 2 when the JVM is absent, mirroring the Swift sibling.
- **`kt-check-generated-drift`** Make target — deliberately kept **out** of the default `make check` (a `:generator:run` is a heavy JVM/Gradle-daemon startup). The fast `kt-check-drift` stays in `make check` unchanged.
- The `test-kotlin` CI step now invokes `make kt-check-generated-drift`, so CI exercises both the target and the shared non-mutating script.

## Verification
- `make url-routes-check` and `make kt-check-generated-drift` exit 0 on clean main and are non-mutating (`git status --porcelain` empty after each).
- Negative proofs: a throwaway edit to `url-routes.json` fails `url-routes-check`; a throwaway edit to a generated Kotlin file fails the fresh gate; both restore cleanly.
- `java`-absent → the Kotlin script exits 2 (proven).
- `make check` green; `shellcheck` clean; `lint-actions` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds non-mutating freshness gates for `url-routes.json` and the Kotlin SDK to prevent drift and align with other generated artifacts. Wired into `make check` and CI; no runtime changes.

- **New Features**
  - Added `url-routes-check` to `make check` and the Go CI job to gate `go/pkg/basecamp/url-routes.json`.
  - Added Kotlin regenerate-and-diff gate: `scripts/check-kotlin-generated-drift.sh` and `kt-check-generated-drift` (non-mutating; regenerates into a temp dir and diffs; catches missing and extra files). CI now runs it via `make kt-check-generated-drift`; kept out of default `make check` to avoid JVM startup cost. Updated `SPEC.md` to list both `url-routes-check` and Kotlin’s standalone gate.

- **Bug Fixes**
  - Hardened Kotlin script: quote each Gradle `--args` path, honor `JAVA_HOME` first (fallback to PATH), treat missing committed tree as drift, and distinguish `diff` exit 1 (drift) vs ≥2 (tool error). Message now guides pruning unexpected extra files.

<sup>Written for commit 444153d0b520b30d2e30f4a6fd2fa18a2680865c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

