### PR TITLE
Align generated Go + Python retry loops to total-attempt semantics (A4b1)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -127,7 +127,10 @@ All validation errors are `BasecampError(code: "usage")` (see §6 error taxonomy
 1. Parse `base_url`. → `⊥ BasecampError(code: "usage")` if malformed.
 2. If `base_url` is not the default (`https://3.basecampapi.com`) and not localhost (§9), enforce HTTPS. → `⊥ BasecampError(code: "usage", message: "base URL must use HTTPS")` if scheme ≠ `https`.
 3. Validate `timeout > 0`. → `⊥ BasecampError(code: "usage")` otherwise.
-4. Validate `max_retries ≥ 1`. → `⊥ BasecampError(code: "usage")` otherwise. (`max_retries` is total attempts including the initial request; 0 would mean no request is made.) **Divergence:** Ruby and Go currently accept `max_retries = 0`; the spec prescribes `≥ 1` as the intended contract.
+4. Validate `max_retries ≥ 1`. → `⊥ BasecampError(code: "usage")` otherwise. (`max_retries` is total attempts including the initial request; 0 would mean no request is made.) **Divergence:** the SDKs handle `max_retries = 0` in three distinct outcomes across four implementations, none of which is the spec's `⊥`:
+   - **Generated Go** (low-level `pkg/generated` client) and **Python** (sync + async): accept `0` as a compatibility exception and make a single attempt with no retry. Both reject a *negative* value as a configuration error (generated Go: `WithRetryConfig`/`doWithRetry` return a plain `error`; Python: `Config` raises `ValueError` at construction).
+   - **Ruby:** `0` passes config validation, but the GET-only retry loop's `break if attempt > max_retries` fires before the first request, so it makes **zero** requests and raises `Basecamp::ApiError("Request failed after 0 attempts")`.
+   - **Hand-written Go** (`pkg/basecamp` client): rejects `0` — `NewClient` panics `"basecamp: max retries must be at least 1"` (its GET/download loops treat `MaxRetries` as the total attempt count with a minimum of 1).
 5. Validate `max_pages > 0`. → `⊥ BasecampError(code: "usage")` otherwise.
 6. Normalize `base_url`: strip trailing `/`.
 

--- a/go/pkg/basecamp/client.go
+++ b/go/pkg/basecamp/client.go
@@ -653,6 +653,13 @@ func (c *Client) doRequestURL(ctx context.Context, method, url string, body any)
 			return nil, err
 		}
 
+		// MaxRetries is the total attempt count. After the final attempt there is
+		// no retry, so don't sleep the backoff delay or fire OnRetry for an
+		// attempt that will never happen — return the last error immediately.
+		if attempt >= c.httpOpts.MaxRetries {
+			break
+		}
+
 		c.logger.Debug("retrying request", "attempt", attempt, "maxRetries", c.httpOpts.MaxRetries, "delay", delay, "error", lastErr)
 
 		// Notify hooks about the retry
@@ -667,7 +674,11 @@ func (c *Client) doRequestURL(ctx context.Context, method, url string, body any)
 		}
 	}
 
-	return nil, fmt.Errorf("request failed after %d retries: %w", c.httpOpts.MaxRetries, lastErr)
+	noun := "attempts"
+	if c.httpOpts.MaxRetries == 1 {
+		noun = "attempt"
+	}
+	return nil, fmt.Errorf("request failed after %d %s: %w", c.httpOpts.MaxRetries, noun, lastErr)
 }
 
 func (c *Client) singleRequest(ctx context.Context, method, url string, body any, attempt int) (*Response, error) {

--- a/go/pkg/basecamp/client_retry_finalattempt_test.go
+++ b/go/pkg/basecamp/client_retry_finalattempt_test.go
@@ -1,0 +1,54 @@
+package basecamp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// retryCountingHooks counts OnRetry invocations; all other hook methods are
+// inherited as no-ops.
+type retryCountingHooks struct {
+	NoopHooks
+	onRetry int32
+}
+
+func (h *retryCountingHooks) OnRetry(context.Context, RequestInfo, int, error) {
+	atomic.AddInt32(&h.onRetry, 1)
+}
+
+// TestClient_NoRetryAfterFinalAttempt pins that the hand-written GET retry loop
+// makes exactly MaxRetries attempts (total-attempt semantics) and does NOT
+// sleep or fire OnRetry after the final attempt — OnRetry fires once per
+// gap between attempts, i.e. MaxRetries-1 times.
+func TestClient_NoRetryAfterFinalAttempt(t *testing.T) {
+	var requests int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&requests, 1)
+		w.WriteHeader(http.StatusServiceUnavailable) // retryable
+	}))
+	defer server.Close()
+
+	cfg := &Config{BaseURL: server.URL, CacheEnabled: false}
+	hooks := &retryCountingHooks{}
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+	client.httpOpts.MaxRetries = 3
+	client.httpOpts.BaseDelay = time.Millisecond
+	client.hooks = hooks
+
+	if _, err := client.Get(context.Background(), "/test.json"); err == nil {
+		t.Fatal("expected an error after retry exhaustion, got nil")
+	}
+
+	if got := atomic.LoadInt32(&requests); got != 3 {
+		t.Errorf("made %d requests, want 3 (MaxRetries is a total attempt count)", got)
+	}
+	// One OnRetry per inter-attempt gap: 3 attempts → 2 retries. A third call
+	// would mean a wasted sleep + misleading hook after the final attempt.
+	if got := atomic.LoadInt32(&hooks.onRetry); got != 2 {
+		t.Errorf("OnRetry fired %d times, want 2 (no retry notification after the final attempt)", got)
+	}
+}

--- a/go/pkg/basecamp/generated_retry_test.go
+++ b/go/pkg/basecamp/generated_retry_test.go
@@ -1,0 +1,163 @@
+package basecamp
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/basecamp/basecamp-sdk/go/pkg/generated"
+)
+
+// doerFunc adapts a function to generated.HttpRequestDoer so a test can inject
+// a fake transport.
+type doerFunc func(*http.Request) (*http.Response, error)
+
+func (f doerFunc) Do(req *http.Request) (*http.Response, error) { return f(req) }
+
+// These tests pin the generated client's total-attempt retry semantics for
+// idempotent operations: RetryConfig.MaxRetries is a TOTAL attempt count (3
+// means 3 attempts, not 4), 0 means a single attempt, and a negative value is
+// a configuration error. They drive the generated retry loop (doWithRetry)
+// directly through an exported idempotent operation (CompleteTodo, a POST
+// flagged idempotent in behavior-model.json), staying outside pkg/generated per
+// the repo rule that generated code carries no hand-written tests.
+
+// fastRetryConfig returns a RetryConfig with the given total-attempt count and
+// tiny delays so multi-attempt retry tests run quickly.
+func fastRetryConfig(maxRetries int) generated.RetryConfig {
+	return generated.RetryConfig{
+		MaxRetries: maxRetries,
+		BaseDelay:  time.Millisecond,
+		MaxDelay:   2 * time.Millisecond,
+		Multiplier: 2.0,
+	}
+}
+
+// always503 returns a handler that always responds 503 (a retryable status)
+// and counts each request it receives.
+func always503(counter *int32) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(counter, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}
+}
+
+func TestGeneratedDoWithRetry_TotalAttempts(t *testing.T) {
+	cases := []struct {
+		name         string
+		maxRetries   int
+		wantAttempts int32
+	}{
+		{"zero means a single attempt", 0, 1},
+		{"one means a single attempt", 1, 1},
+		{"three means three attempts", 3, 3},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var attempts int32
+			server := httptest.NewServer(always503(&attempts))
+			defer server.Close()
+
+			client, err := generated.NewClient(server.URL, generated.WithRetryConfig(fastRetryConfig(tc.maxRetries)))
+			if err != nil {
+				t.Fatalf("NewClient: %v", err)
+			}
+
+			// Exhaustion returns the last 503 response with a nil error.
+			resp, err := client.CompleteTodo(context.Background(), "99999", 100)
+			if err != nil {
+				t.Fatalf("CompleteTodo returned error: %v", err)
+			}
+			_ = resp.Body.Close()
+
+			if got := atomic.LoadInt32(&attempts); got != tc.wantAttempts {
+				t.Errorf("made %d attempts, want %d (MaxRetries is a total attempt count)", got, tc.wantAttempts)
+			}
+		})
+	}
+}
+
+func TestGeneratedRetryConfig_NegativeRejectedAtConstruction(t *testing.T) {
+	_, err := generated.NewClient(
+		"https://example.com",
+		generated.WithRetryConfig(generated.RetryConfig{MaxRetries: -1}),
+	)
+	if err == nil {
+		t.Fatal("expected a configuration error for negative MaxRetries, got nil")
+	}
+}
+
+func TestGeneratedRetryConfig_NegativeRejectedAfterMutation(t *testing.T) {
+	// RetryConfig is a public field, so a caller can set an invalid value after
+	// construction. doWithRetry must re-validate and surface a configuration
+	// error without making any request.
+	var attempts int32
+	server := httptest.NewServer(always503(&attempts))
+	defer server.Close()
+
+	client, err := generated.NewClient(server.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	client.RetryConfig.MaxRetries = -1
+
+	resp, err := client.CompleteTodo(context.Background(), "99999", 100)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if err == nil {
+		t.Fatal("expected a configuration error for negative MaxRetries, got nil")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 0 {
+		t.Errorf("made %d requests with an invalid config, want 0", got)
+	}
+}
+
+func TestGeneratedDoWithRetry_NoSleepAfterFinalAttempt(t *testing.T) {
+	// Deterministic (no wall-clock threshold): a fake transport cancels the
+	// context on the final attempt. The correct loop returns the final 503
+	// before any sleep, so CompleteTodo returns that response with a nil error.
+	// A spurious sleep after the final attempt would observe the cancellation in
+	// its select and return context.Canceled instead — which this test rejects.
+	const maxRetries = 2
+	var attempts int32
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	doer := doerFunc(func(_ *http.Request) (*http.Response, error) {
+		if int(atomic.AddInt32(&attempts, 1)) == maxRetries {
+			cancel() // cancel during the final attempt only
+		}
+		return &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	client, err := generated.NewClient(
+		"https://example.com",
+		generated.WithHTTPClient(doer),
+		generated.WithRetryConfig(fastRetryConfig(maxRetries)),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	resp, err := client.CompleteTodo(ctx, "99999", 100)
+	if err != nil {
+		t.Fatalf("CompleteTodo returned %v — a sleep after the final attempt observed the cancellation", err)
+	}
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	if got := atomic.LoadInt32(&attempts); got != maxRetries {
+		t.Errorf("made %d attempts, want %d", got, maxRetries)
+	}
+}

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -3819,7 +3819,12 @@ type HttpRequestDoer interface {
 
 // RetryConfig configures retry behavior for idempotent operations.
 type RetryConfig struct {
-	// MaxRetries is the maximum number of retry attempts (default: 3)
+	// MaxRetries is the TOTAL number of attempts for an idempotent operation,
+	// including the initial request — not the number of retries after the first
+	// attempt (default: 3, so up to 3 attempts total). A value of 0 is accepted
+	// as a compatibility exception and means a single attempt with no retry; a
+	// negative value is a configuration error rejected by WithRetryConfig and
+	// doWithRetry.
 	MaxRetries int
 	// BaseDelay is the initial delay between retries (default: 1s)
 	BaseDelay time.Duration
@@ -3907,9 +3912,32 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 	}
 }
 
+// effectiveMaxAttempts resolves RetryConfig.MaxRetries (a TOTAL attempt count)
+// into the number of attempts an idempotent operation should make:
+//   - MaxRetries < 0  → configuration error (a plain error; the low-level
+//     generated package has no BasecampError usage type).
+//   - MaxRetries == 0 → 1 attempt (compatibility exception; no retry).
+//   - MaxRetries > 0  → MaxRetries attempts.
+//
+// Every non-error result is >= 1, so doWithRetry always makes at least one
+// attempt (never returns a nil response with a nil error).
+func (cfg RetryConfig) effectiveMaxAttempts() (int, error) {
+	if cfg.MaxRetries < 0 {
+		return 0, fmt.Errorf("basecamp: invalid RetryConfig: MaxRetries must be >= 0, got %d", cfg.MaxRetries)
+	}
+	if cfg.MaxRetries == 0 {
+		return 1, nil
+	}
+	return cfg.MaxRetries, nil
+}
+
 // WithRetryConfig allows setting custom retry configuration for idempotent operations.
+// It returns a configuration error if cfg.MaxRetries is negative.
 func WithRetryConfig(cfg RetryConfig) ClientOption {
 	return func(c *Client) error {
+		if _, err := cfg.effectiveMaxAttempts(); err != nil {
+			return err
+		}
 		c.RetryConfig = cfg
 		return nil
 	}
@@ -3939,9 +3967,15 @@ func isRetryableStatus(statusCode int) bool {
 
 // doWithRetry executes a request with retry logic for idempotent operations.
 func (c *Client) doWithRetry(ctx context.Context, buildRequest func() (*http.Request, error), isIdempotent bool, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	maxAttempts := 1
-	if isIdempotent {
-		maxAttempts = c.RetryConfig.MaxRetries + 1
+	// MaxRetries is a TOTAL attempt count. Re-validate here (not just in
+	// WithRetryConfig) because RetryConfig is publicly mutable after client
+	// construction.
+	maxAttempts, err := c.RetryConfig.effectiveMaxAttempts()
+	if err != nil {
+		return nil, err
+	}
+	if !isIdempotent {
+		maxAttempts = 1
 	}
 
 	var lastResp *http.Response

--- a/go/templates/client.tmpl
+++ b/go/templates/client.tmpl
@@ -12,7 +12,12 @@ type HttpRequestDoer interface {
 
 // RetryConfig configures retry behavior for idempotent operations.
 type RetryConfig struct {
-	// MaxRetries is the maximum number of retry attempts (default: 3)
+	// MaxRetries is the TOTAL number of attempts for an idempotent operation,
+	// including the initial request — not the number of retries after the first
+	// attempt (default: 3, so up to 3 attempts total). A value of 0 is accepted
+	// as a compatibility exception and means a single attempt with no retry; a
+	// negative value is a configuration error rejected by WithRetryConfig and
+	// doWithRetry.
 	MaxRetries int
 	// BaseDelay is the initial delay between retries (default: 1s)
 	BaseDelay time.Duration
@@ -100,9 +105,32 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 	}
 }
 
+// effectiveMaxAttempts resolves RetryConfig.MaxRetries (a TOTAL attempt count)
+// into the number of attempts an idempotent operation should make:
+//   - MaxRetries < 0  → configuration error (a plain error; the low-level
+//     generated package has no BasecampError usage type).
+//   - MaxRetries == 0 → 1 attempt (compatibility exception; no retry).
+//   - MaxRetries > 0  → MaxRetries attempts.
+//
+// Every non-error result is >= 1, so doWithRetry always makes at least one
+// attempt (never returns a nil response with a nil error).
+func (cfg RetryConfig) effectiveMaxAttempts() (int, error) {
+	if cfg.MaxRetries < 0 {
+		return 0, fmt.Errorf("basecamp: invalid RetryConfig: MaxRetries must be >= 0, got %d", cfg.MaxRetries)
+	}
+	if cfg.MaxRetries == 0 {
+		return 1, nil
+	}
+	return cfg.MaxRetries, nil
+}
+
 // WithRetryConfig allows setting custom retry configuration for idempotent operations.
+// It returns a configuration error if cfg.MaxRetries is negative.
 func WithRetryConfig(cfg RetryConfig) ClientOption {
 	return func(c *{{ $clientTypeName }}) error {
+		if _, err := cfg.effectiveMaxAttempts(); err != nil {
+			return err
+		}
 		c.RetryConfig = cfg
 		return nil
 	}
@@ -132,9 +160,15 @@ func isRetryableStatus(statusCode int) bool {
 
 // doWithRetry executes a request with retry logic for idempotent operations.
 func (c *{{ $clientTypeName }}) doWithRetry(ctx context.Context, buildRequest func() (*http.Request, error), isIdempotent bool, operationId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	maxAttempts := 1
-	if isIdempotent {
-		maxAttempts = c.RetryConfig.MaxRetries + 1
+	// MaxRetries is a TOTAL attempt count. Re-validate here (not just in
+	// WithRetryConfig) because RetryConfig is publicly mutable after client
+	// construction.
+	maxAttempts, err := c.RetryConfig.effectiveMaxAttempts()
+	if err != nil {
+		return nil, err
+	}
+	if !isIdempotent {
+		maxAttempts = 1
 	}
 
 	var lastResp *http.Response

--- a/python/README.md
+++ b/python/README.md
@@ -76,7 +76,7 @@ asyncio.run(main())
 |----------|-------------|---------|
 | `BASECAMP_BASE_URL` | API base URL | `https://3.basecampapi.com` |
 | `BASECAMP_TIMEOUT` | Request timeout (seconds) | `30` |
-| `BASECAMP_MAX_RETRIES` | Maximum retries (up to N+1 total attempts) | `3` |
+| `BASECAMP_MAX_RETRIES` | Total attempts including the initial request | `3` |
 
 ### Programmatic Configuration
 
@@ -455,7 +455,7 @@ The SDK automatically retries failed requests with exponential backoff:
 - **401 responses** - Token refresh attempted, then single retry for all methods (regardless of idempotency)
 - **Backoff** - Exponential with jitter (`base_delay * 2^(attempt-1) + random() * max_jitter`)
 - **Retry-After** - Respected for 429 responses (overrides calculated backoff)
-- **Max retries** - Controlled by `config.max_retries` (default: 3 retries, up to 4 total attempts including the initial request)
+- **Max retries** - Controlled by `config.max_retries` (a total attempt count including the initial request; default: 3 attempts. `0` means a single request with no retry)
 
 ## Observability
 

--- a/python/src/basecamp/_async_http.py
+++ b/python/src/basecamp/_async_http.py
@@ -146,12 +146,16 @@ class AsyncHttpClient:
         files: dict | None = None,
         allow_cross_origin: bool = False,
     ) -> httpx.Response:
+        # max_retries is a TOTAL attempt count (config validation guarantees it
+        # is >= 0). 0 is accepted as a compatibility exception and means a single
+        # attempt with no retry.
+        max_attempts = self._config.max_retries if self._config.max_retries > 0 else 1
         attempt = 0
         last_error: BasecampError | None = None
 
         while True:
             attempt += 1
-            if attempt > self._config.max_retries + 1:
+            if attempt > max_attempts:
                 break
 
             try:
@@ -170,7 +174,7 @@ class AsyncHttpClient:
                 if not e.retryable:
                     raise
                 last_error = e
-                if attempt > self._config.max_retries:
+                if attempt >= max_attempts:
                     break
                 delay = self._calculate_delay(attempt, e.retry_after)
                 safe_hook(
@@ -184,7 +188,8 @@ class AsyncHttpClient:
 
         if last_error:
             raise last_error
-        raise ApiError(f"Request failed after {self._config.max_retries} retries")
+        noun = "attempt" if max_attempts == 1 else "attempts"
+        raise ApiError(f"Request failed after {max_attempts} {noun}")
 
     async def _single_request(
         self,

--- a/python/src/basecamp/_http.py
+++ b/python/src/basecamp/_http.py
@@ -146,12 +146,16 @@ class HttpClient:
         files: dict | None = None,
         allow_cross_origin: bool = False,
     ) -> httpx.Response:
+        # max_retries is a TOTAL attempt count (config validation guarantees it
+        # is >= 0). 0 is accepted as a compatibility exception and means a single
+        # attempt with no retry.
+        max_attempts = self._config.max_retries if self._config.max_retries > 0 else 1
         attempt = 0
         last_error: BasecampError | None = None
 
         while True:
             attempt += 1
-            if attempt > self._config.max_retries + 1:
+            if attempt > max_attempts:
                 break
 
             try:
@@ -170,7 +174,7 @@ class HttpClient:
                 if not e.retryable:
                     raise
                 last_error = e
-                if attempt > self._config.max_retries:
+                if attempt >= max_attempts:
                     break
                 delay = self._calculate_delay(attempt, e.retry_after)
                 safe_hook(
@@ -184,7 +188,8 @@ class HttpClient:
 
         if last_error:
             raise last_error
-        raise ApiError(f"Request failed after {self._config.max_retries} retries")
+        noun = "attempt" if max_attempts == 1 else "attempts"
+        raise ApiError(f"Request failed after {max_attempts} {noun}")
 
     def _single_request(
         self,

--- a/python/src/basecamp/config.py
+++ b/python/src/basecamp/config.py
@@ -35,6 +35,11 @@ class Config:
         # Validation
         if self.timeout <= 0:
             raise ValueError("timeout must be positive")
+        # bool is an int subclass; exclude it so True/False don't masquerade as a
+        # retry count. A non-integer max_retries would make the total-attempt
+        # bound fractional (e.g. 0.5 → zero requests), so reject it here.
+        if isinstance(self.max_retries, bool) or not isinstance(self.max_retries, int):
+            raise ValueError("max_retries must be an integer")
         if self.max_retries < 0:
             raise ValueError("max_retries must be non-negative")
         if self.base_delay < 0:

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -62,6 +62,16 @@ class TestValidation:
         c = Config(max_retries=0)
         assert c.max_retries == 0
 
+    def test_max_retries_fractional_raises(self):
+        # A non-integer would make the total-attempt bound fractional
+        # (e.g. 0.5 → zero requests), so it must be rejected at construction.
+        with pytest.raises(ValueError, match="max_retries must be an integer"):
+            Config(max_retries=0.5)
+
+    def test_max_retries_bool_raises(self):
+        with pytest.raises(ValueError, match="max_retries must be an integer"):
+            Config(max_retries=True)
+
 
 class TestHttpsEnforcement:
     def test_http_non_localhost_raises(self):

--- a/python/tests/test_http.py
+++ b/python/tests/test_http.py
@@ -6,7 +6,9 @@ import httpx
 import pytest
 import respx
 
+from basecamp._async_http import AsyncHttpClient
 from basecamp._http import HttpClient
+from basecamp.async_auth import AsyncBearerAuth, AsyncStaticTokenProvider
 from basecamp.auth import BearerAuth, StaticTokenProvider
 from basecamp.config import Config
 from basecamp.errors import (
@@ -140,6 +142,68 @@ class TestRetryBehavior:
         with pytest.raises(ApiError):
             client.post("/test", json_body={"x": 1})
         assert route.call_count == 1
+
+
+def make_async_client(max_retries=3, base_delay=0.001, max_jitter=0.0, timeout=30.0):
+    config = Config(
+        base_url="https://3.basecampapi.com",
+        max_retries=max_retries,
+        base_delay=base_delay,
+        max_jitter=max_jitter,
+        timeout=timeout,
+    )
+    auth = AsyncBearerAuth(AsyncStaticTokenProvider("test-token"))
+    return AsyncHttpClient(config, auth, BasecampHooks())
+
+
+class TestTotalAttemptSemantics:
+    """max_retries is a TOTAL attempt count (including the initial request), not
+    the number of retries after the first attempt. 3 → 3 attempts, 0 → a single
+    attempt with no retry. Sync and async transports must agree."""
+
+    @pytest.mark.parametrize(
+        "max_retries,want_attempts",
+        [(0, 1), (1, 1), (3, 3)],
+    )
+    @respx.mock
+    def test_sync_attempt_count(self, max_retries, want_attempts):
+        route = respx.get("https://3.basecampapi.com/test").mock(return_value=httpx.Response(503))
+        client = make_client(max_retries=max_retries)
+        with pytest.raises(ApiError):
+            client.get("/test")
+        assert route.call_count == want_attempts
+
+    @pytest.mark.parametrize(
+        "max_retries,want_attempts",
+        [(0, 1), (1, 1), (3, 3)],
+    )
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_async_attempt_count(self, max_retries, want_attempts):
+        route = respx.get("https://3.basecampapi.com/test").mock(return_value=httpx.Response(503))
+        client = make_async_client(max_retries=max_retries)
+        with pytest.raises(ApiError):
+            await client.get("/test")
+        assert route.call_count == want_attempts
+
+    @respx.mock
+    def test_sync_succeeds_on_final_allowed_attempt(self):
+        # 3 attempts: two 503s then a 200 — the success on the last allowed
+        # attempt proves the loop makes exactly max_retries attempts.
+        route = respx.get("https://3.basecampapi.com/test")
+        route.side_effect = [
+            httpx.Response(503),
+            httpx.Response(503),
+            httpx.Response(200, json={"ok": True}),
+        ]
+        client = make_client(max_retries=3)
+        resp = client.get("/test")
+        assert resp.status_code == 200
+        assert route.call_count == 3
+
+    def test_negative_max_retries_rejected_at_construction(self):
+        with pytest.raises(ValueError):
+            Config(base_url="https://3.basecampapi.com", max_retries=-1)
 
 
 class TestNetworkErrors:

--- a/ruby/lib/basecamp/http.rb
+++ b/ruby/lib/basecamp/http.rb
@@ -377,7 +377,8 @@ module Basecamp
         end
       end
 
-      raise last_error || Basecamp::ApiError.new("Request failed after #{@config.max_retries} retries")
+      noun = @config.max_retries == 1 ? "attempt" : "attempts"
+      raise last_error || Basecamp::ApiError.new("Request failed after #{@config.max_retries} #{noun}")
     end
 
     def single_request(method, url, params:, body:, attempt:, retry_count: 0, allow_cross_origin: false)


### PR DESCRIPTION
`SPEC.md` and `behavior-model.json` define `max_retries` / `retry.max` as a **total attempt count** (including the initial request): `max_retries = 3` means at most 3 attempts. Ruby, Kotlin, and the hand-written Go client already honor this; generated Go (`doWithRetry`) and Python (sync + async `_request_with_retry`) treated it as **additional** retries (`MaxRetries + 1`), making one extra request.

This aligns both to total-attempts.

## ⚠️ Observable change
With the default of 3, requests now make **up to 3 attempts, not 4**. (`max_retries` was already documented as a total attempt count; the generated-Go and Python transports were the outliers.)

## Effective-attempts algorithm (identical for generated Go and Python)
- `max_retries < 0` → **configuration error**. Generated Go returns a plain `error` from `WithRetryConfig` **and** re-checks inside `doWithRetry` (`RetryConfig` is publicly mutable after construction); Python already raises `ValueError` at `Config` construction (immutable thereafter).
- `max_retries == 0` → a single attempt, no retry — an explicit compatibility exception to SPEC's `≥ 1`.
- `max_retries > 0` → `max_retries` attempts.

This also fixes a latent generated-Go bug: a negative `MaxRetries` previously made the loop body never execute and returned `(nil, nil)`.

## Docs / user-visible strings brought in line
- SPEC.md validation note now enumerates the three distinct `max_retries = 0` outcomes across four implementations (generated Go & Python accept → 1 request; Ruby makes 0 requests and raises; hand-written Go panics) and distinguishes generated from hand-written Go.
- `python/README.md`: "3 retries, up to 4 total attempts" → "3 attempts"; env-var table "N+1 total attempts" → "Total attempts including the initial request".
- Python / Ruby / hand-written-Go exhaustion strings: "retries" → "attempts" (values were already total-correct; only the wording lied).

## Scope
A4b1 only. **A4b2** (generated Go / Python honoring per-op `retry.max`) is deliberately **deferred** — that per-op divergence remains and is not addressed here.

## Tests
- Generated-Go retry counts `{0→1, 1→1, 3→3}`, negative rejected both at `WithRetryConfig` and via post-construction mutation into `doWithRetry`, and a **deterministic** no-sleep-after-final-attempt test (fake `HttpRequestDoer` + context cancellation — no wall-clock threshold). Lives in `go/pkg/basecamp`, outside `pkg/generated` per the repo rule.
- Python sync + async attempt-count parity and negative-at-construction.

`make check` green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns generated Go and Python retry loops to total-attempt semantics so `max_retries` is the total number of attempts. With the default of 3, requests now make up to 3 attempts, not 4.

- **Bug Fixes**
  - Generated Go (`doWithRetry`) and Python (sync + async) now use total-attempts: `< 0` → configuration error; `0` → one attempt; `> 0` → N attempts. Go validates in `WithRetryConfig` and re-validates in-call; fixes the negative-`MaxRetries` `(nil, nil)` bug.
  - Python `Config` rejects negatives and non-integers (including `bool`), preventing fractional or misleading attempt counts.
  - No sleep or `OnRetry` after the final attempt in both generated and hand-written Go; tests pin this behavior. Exhaustion messages now say “attempt(s)” in Go, Python, and Ruby; docs updated (`SPEC.md`, `python/README.md`).

- **Migration**
  - Behavior change: default `3` means up to 3 attempts. Update tests/monitoring that assumed 4.
  - Scope: A4b1 only. Per-operation `retry.max` (A4b2) is unchanged.

<sup>Written for commit 0dd8303bbf025c3d8c7e7abf2fe9b2ed1062d266. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

