### PR TITLE
Seed a stale pin comment for the sync rollout exercise

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -39,7 +39,7 @@ jobs:
           git merge-base --is-ancestor "$GITHUB_SHA" origin/main
 
       - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v6.9.9
         # zizmor: ignore[cache-poisoning] -- cached deps are for testing, not release artifact generation
         with:
           go-version-file: 'go/go.mod'


### PR DESCRIPTION
Rollout exercise for the post-merge comment-sync (basecamp/.github#11, caller #462): deliberately mislabels the setup-go pin comment (`# v7.0.0` → `# v6.9.9`; the SHA is untouched and correct). After this merges, the sync workflow gets enabled in this repo only and dispatched — the expected outcome is a bot repair PR restoring exactly this comment, auto-merging once checks pass, followed by a terminal no-op run. Full-cycle proof before enabling the fleet.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeds a stale version comment on the pinned `actions/setup-go` step in `.github/workflows/release-go.yml` by changing `# v7.0.0` to `# v6.9.9` (SHA unchanged). This intentionally triggers the post-merge comment-sync workflow to open a repair PR that restores the comment and then no-ops.

<sup>Written for commit 9845ca64eee68c7e8ffee3536ca6fdff209d8e59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

