### PR TITLE
Correct the SearchResult generic-attachments carve-out (closes #428)

### DIFF
--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -2230,9 +2230,18 @@ type SearchResult struct {
 	// projection. A given result is one recording type, so it carries only
 	// the array matching its rich-text attribute (`content_attachments` for a
 	// Comment/Message, `description_attachments` for a Todo); a webhook-sourced
-	// result carries neither. Optional (no `@required`), non-nullable. Distinct
-	// from the generic `attachments` key (the recording's aggregate downloadable
-	// files), which is a separate projection concern and not modeled here.
+	// result carries neither. Optional (no `@required`), non-nullable.
+	//
+	// Search results additionally repeat this same array under a generic
+	// `attachments` key. It is a redundant projection, not a distinct
+	// aggregate: `searches/show.json.jbuilder` emits
+	// `recording.downloadable_attachments`, which delegates to the recordable's
+	// sole `rich_text_content`, through the same `attachments/_attachment`
+	// partial that `recordings/_rich_text.json.jbuilder` uses to build the
+	// companion array. `RichText.rich_text_attribute` permits exactly one
+	// rich-text attribute per model, so the two keys always carry identical
+	// elements. Modeling `attachments` would duplicate the field, so it is
+	// deliberately not modeled.
 	ContentAttachments []RichTextAttachment `json:"content_attachments,omitempty"`
 	CreatedAt          time.Time            `json:"created_at,omitempty"`
 	Creator            Person               `json:"creator,omitempty"`

--- a/openapi.json
+++ b/openapi.json
@@ -29398,7 +29398,7 @@
             "items": {
               "$ref": "#/components/schemas/RichTextAttachment"
             },
-            "description": "Rich-text companion arrays carried through the polymorphic search\nprojection. A given result is one recording type, so it carries only\nthe array matching its rich-text attribute (`content_attachments` for a\nComment/Message, `description_attachments` for a Todo); a webhook-sourced\nresult carries neither. Optional (no `@required`), non-nullable. Distinct\nfrom the generic `attachments` key (the recording's aggregate downloadable\nfiles), which is a separate projection concern and not modeled here."
+            "description": "Rich-text companion arrays carried through the polymorphic search\nprojection. A given result is one recording type, so it carries only\nthe array matching its rich-text attribute (`content_attachments` for a\nComment/Message, `description_attachments` for a Todo); a webhook-sourced\nresult carries neither. Optional (no `@required`), non-nullable.\n\nSearch results additionally repeat this same array under a generic\n`attachments` key. It is a redundant projection, not a distinct\naggregate: `searches/show.json.jbuilder` emits\n`recording.downloadable_attachments`, which delegates to the recordable's\nsole `rich_text_content`, through the same `attachments/_attachment`\npartial that `recordings/_rich_text.json.jbuilder` uses to build the\ncompanion array. `RichText.rich_text_attribute` permits exactly one\nrich-text attribute per model, so the two keys always carry identical\nelements. Modeling `attachments` would duplicate the field, so it is\ndeliberately not modeled."
           },
           "description_attachments": {
             "type": "array",

--- a/spec/api-gaps/rich-text-attachments-coverage.md
+++ b/spec/api-gaps/rich-text-attachments-coverage.md
@@ -90,9 +90,23 @@ SDK decodes now carries its companion array, reusing `RichTextAttachment` +
 
 **Explicitly out of scope (not "absorbed" — accurate status per item):**
 
-- **Generic `attachments` key on SearchResult** (`searches/show:25`): the
-  recording's aggregate downloadable files, a *different* projection concern, not
-  a rich-text companion array. Not modeled; tracked in #428.
+- **Generic `attachments` key on SearchResult** (`searches/show:25`):
+  **deliberately not modeled — it is a redundant projection of the companion
+  array, not a distinct aggregate.** (Corrected: an earlier version of this
+  entry called it "the recording's aggregate downloadable files, a *different*
+  projection concern". That was wrong, and #428 — filed on that premise — is
+  closed as a result.) Verified against bc3 `c308693171`:
+  `searches/show.json.jbuilder:25` emits
+  `recording.downloadable_attachments` through the `attachments/_attachment`
+  partial; `Recording::Attachables` delegates `downloadable_attachments` to
+  `attachable_rich_text_content`, i.e. `recordable.rich_text_content`; and
+  `recordings/_rich_text.json.jbuilder:3` builds the companion array from
+  `rich_text&.downloadable_attachments` through that *same* partial. Since
+  `RichText.rich_text_attribute` registers exactly one attribute per model
+  (`RichText::ATTRIBUTES[model_name.name] = attribute_name`, and a second call
+  raises `NotImplementedError`), the two keys always carry identical elements.
+  Modeling `attachments` would duplicate `content_attachments` /
+  `description_attachments` under a second name.
 - **everything/aggregates endpoints** (`everything/*`, which also render full
   partials): **unmodeled in the SDK** — no decode path exists to carry an array
   into. Covered by the separate `everything-aggregates.md` gap

--- a/spec/basecamp.smithy
+++ b/spec/basecamp.smithy
@@ -7982,9 +7982,18 @@ structure SearchResult {
   /// projection. A given result is one recording type, so it carries only
   /// the array matching its rich-text attribute (`content_attachments` for a
   /// Comment/Message, `description_attachments` for a Todo); a webhook-sourced
-  /// result carries neither. Optional (no `@required`), non-nullable. Distinct
-  /// from the generic `attachments` key (the recording's aggregate downloadable
-  /// files), which is a separate projection concern and not modeled here.
+  /// result carries neither. Optional (no `@required`), non-nullable.
+  ///
+  /// Search results additionally repeat this same array under a generic
+  /// `attachments` key. It is a redundant projection, not a distinct
+  /// aggregate: `searches/show.json.jbuilder` emits
+  /// `recording.downloadable_attachments`, which delegates to the recordable's
+  /// sole `rich_text_content`, through the same `attachments/_attachment`
+  /// partial that `recordings/_rich_text.json.jbuilder` uses to build the
+  /// companion array. `RichText.rich_text_attribute` permits exactly one
+  /// rich-text attribute per model, so the two keys always carry identical
+  /// elements. Modeling `attachments` would duplicate the field, so it is
+  /// deliberately not modeled.
   content_attachments: RichTextAttachmentList
   /// See `content_attachments` — the description-attribute companion array.
   description_attachments: RichTextAttachmentList

--- a/typescript/src/generated/openapi-stripped.json
+++ b/typescript/src/generated/openapi-stripped.json
@@ -26822,7 +26822,7 @@
             "items": {
               "$ref": "#/components/schemas/RichTextAttachment"
             },
-            "description": "Rich-text companion arrays carried through the polymorphic search\nprojection. A given result is one recording type, so it carries only\nthe array matching its rich-text attribute (`content_attachments` for a\nComment/Message, `description_attachments` for a Todo); a webhook-sourced\nresult carries neither. Optional (no `@required`), non-nullable. Distinct\nfrom the generic `attachments` key (the recording's aggregate downloadable\nfiles), which is a separate projection concern and not modeled here."
+            "description": "Rich-text companion arrays carried through the polymorphic search\nprojection. A given result is one recording type, so it carries only\nthe array matching its rich-text attribute (`content_attachments` for a\nComment/Message, `description_attachments` for a Todo); a webhook-sourced\nresult carries neither. Optional (no `@required`), non-nullable.\n\nSearch results additionally repeat this same array under a generic\n`attachments` key. It is a redundant projection, not a distinct\naggregate: `searches/show.json.jbuilder` emits\n`recording.downloadable_attachments`, which delegates to the recordable's\nsole `rich_text_content`, through the same `attachments/_attachment`\npartial that `recordings/_rich_text.json.jbuilder` uses to build the\ncompanion array. `RichText.rich_text_attribute` permits exactly one\nrich-text attribute per model, so the two keys always carry identical\nelements. Modeling `attachments` would duplicate the field, so it is\ndeliberately not modeled."
           },
           "description_attachments": {
             "type": "array",

--- a/typescript/src/generated/schema.d.ts
+++ b/typescript/src/generated/schema.d.ts
@@ -4760,9 +4760,18 @@ export interface components {
              *     projection. A given result is one recording type, so it carries only
              *     the array matching its rich-text attribute (`content_attachments` for a
              *     Comment/Message, `description_attachments` for a Todo); a webhook-sourced
-             *     result carries neither. Optional (no `@required`), non-nullable. Distinct
-             *     from the generic `attachments` key (the recording's aggregate downloadable
-             *     files), which is a separate projection concern and not modeled here.
+             *     result carries neither. Optional (no `@required`), non-nullable.
+             *
+             *     Search results additionally repeat this same array under a generic
+             *     `attachments` key. It is a redundant projection, not a distinct
+             *     aggregate: `searches/show.json.jbuilder` emits
+             *     `recording.downloadable_attachments`, which delegates to the recordable's
+             *     sole `rich_text_content`, through the same `attachments/_attachment`
+             *     partial that `recordings/_rich_text.json.jbuilder` uses to build the
+             *     companion array. `RichText.rich_text_attribute` permits exactly one
+             *     rich-text attribute per model, so the two keys always carry identical
+             *     elements. Modeling `attachments` would duplicate the field, so it is
+             *     deliberately not modeled.
              */
             content_attachments?: components["schemas"]["RichTextAttachment"][];
             /** @description See `content_attachments` — the description-attribute companion array. */


### PR DESCRIPTION
## What

`spec/basecamp.smithy` and `spec/api-gaps/rich-text-attachments-coverage.md` both recorded that the generic `attachments` key on a search result is *"the recording's aggregate downloadable files, a **different** projection concern"* from the rich-text companion arrays.

That is false. It is the **same collection**, repeated under a second key.

## Evidence (bc3 `c308693171`, the SHA `spec/api-provenance.json` pins)

| Source | Fact |
|---|---|
| `app/views/api/searches/show.json.jbuilder:25` | `json.attachments recording.downloadable_attachments, partial: "attachments/attachment"` |
| `app/models/recording/attachables.rb:6,45` | `downloadable_attachments` delegates to `attachable_rich_text_content` = `recordable.try(:rich_text_content) \|\| ActionText::Content.new` |
| `app/views/api/recordings/_rich_text.json.jbuilder:3` | `json.set! :"#{attribute}_attachments", rich_text&.downloadable_attachments.to_a, partial: "attachments/attachment"` |
| `app/models/concerns/rich_text.rb` | `RichText::ATTRIBUTES[model_name.name] = attribute_name`; a second `rich_text_attribute` call raises `NotImplementedError` — **exactly one rich-text attribute per model** |

Same selector (`downloadable_attachments`), same source (the sole `rich_text_content`), same partial (`attachments/_attachment`). With one rich-text attribute per model, the two keys always carry identical elements.

## Why it still shouldn't be modeled — but for the opposite reason

Leaving `attachments` unmodeled remains correct. The recorded rationale was backwards: modeling it would **duplicate** `content_attachments` / `description_attachments` under a second name, not close a coverage gap. Both carve-outs now say that.

## Scope

Doc-comment-only. Regenerated so the corrected text reaches `go/pkg/generated/client.gen.go` and `typescript/src/generated/schema.d.ts`. Timestamp-only churn in `ruby/.../types.rb`, `ruby/.../metadata.json`, and `typescript/src/generated/metadata.ts` was restored after diffing content (both drift gates normalize the `generated` stamp). **Operation count unchanged at 226.** No wire change, no type change.

## Verification

`smithy-check` · `validate-api-gaps` (27 entries clean) · `go-check-generated-drift` · `ts-check-drift` · `rb-check-drift` · `go-check-wrapper-drift` (83 pairs, 1117 fields) · `kt-check-drift` (226/226) · `swift-check-drift` · `go-check` · `ts-typecheck` — all green.

## Follow-up

Closes #428. A **separate and larger** finding surfaced while verifying this and is filed on its own: `searches/show.json.jbuilder` sets `json.content nil` / `json.description nil` and then emits `plain_text_content` / `plain_text_description`, neither of which is modeled — so `SearchResult.content` and `SearchResult.description` are always null on the wire while the fields carrying the actual search text have no typed surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the SearchResult `attachments` carve‑out: the generic `attachments` in search results repeats the rich‑text companion array, so it stays intentionally unmodeled. Updated comments in `spec/basecamp.smithy`, `openapi.json`, and generated clients; no wire or type changes, and closes #428.

<sup>Written for commit e2327270908364550f5f9c7fada92dbbb1ce7bb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

