### PR TITLE
Re-pin dependabot-sync past the bot-author fix

### DIFF
--- a/.github/workflows/dependabot-sync-actions-comments.yml
+++ b/.github/workflows/dependabot-sync-actions-comments.yml
@@ -21,7 +21,7 @@ permissions: {}
 
 jobs:
   sync:
-    uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@45d3fc9588f15d50fbccde7476418007dd19e16e
+    uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@fdf2ae72b33bb13413919b87bb493f23633e938d
     permissions:
       contents: read
       actions: write


### PR DESCRIPTION
basecamp/.github#12 fixed the `app/<slug>` author constant that the exercise's fail-closed re-verification tripped on (run 30308416366). This PR's own merge — a workflow-file push to main with the workflow enabled — is the next exercise trigger: the run should adopt repair PR #466, update it behind the lease, arm auto-merge, approve its held runs, and the repair's merge should produce the terminal no-op run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-pinned the reusable `dependabot-sync-actions-comments` workflow to the version with the bot-author fix to ensure correct author detection and unblock auto-merge verification.

<sup>Written for commit 5c0747171f561692591e2b67e13baaa531ec1d2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

