### PR TITLE
Re-pin dependabot-sync past the re-verification retry

### DIFF
--- a/.github/workflows/dependabot-sync-actions-comments.yml
+++ b/.github/workflows/dependabot-sync-actions-comments.yml
@@ -21,7 +21,7 @@ permissions: {}
 
 jobs:
   sync:
-    uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@fdf2ae72b33bb13413919b87bb493f23633e938d
+    uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@06fd9cf3d96439d0c5a8ca6ccc2ed2dd23552d9e
     permissions:
       contents: read
       actions: write


### PR DESCRIPTION
basecamp/.github#13 adds a bounded poll for the PR API to catch up with the lease push (round-2 failure was a stale headRefOid read). This merge's own push is exercise round 3: expect the run to adopt repair PR #466, pass all invariants, arm auto-merge, approve held runs, and the repair merge to yield the terminal no-op.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-pinned the dependabot sync reusable workflow to the updated version in `basecamp/.github` that adds a bounded PR API poll. This prevents stale head reads during re-verification retries and improves reliability of Dependabot comment sync.

<sup>Written for commit a87182fc4540436c0c084cdaee18ff5e33009918. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

