### PR TITLE
Ruby generator: multiline x-deprecated-reason no longer breaks types.rb (closes #420)

### DIFF
--- a/ruby/scripts/generate-types.rb
+++ b/ruby/scripts/generate-types.rb
@@ -87,6 +87,33 @@ def generate_helpers
   HELPERS
 end
 
+# Renders a deprecation +reason+ as one or more Ruby comment lines (#406).
+#
+# A reason can be sourced from a multi-line OpenAPI description. Interpolating
+# one into a single "# @deprecated ..." line would leave every continuation on a
+# bare, un-commented source line, which is a syntax error in the generated
+# types.rb — Ruby is the only owned generator exposed this way (Python escapes
+# the reason, Kotlin/TypeScript emit block comments). Splitting on line
+# boundaries and prefixing each line with the comment leader keeps the output
+# valid for any reason.
+#
+# +indent+ is the leading source indentation; +tag_prefix+ is inserted between
+# the "# " leader and the YARD tag (the per-attribute site nests its tag under
+# an @!attribute directive). Continuation lines are indented two columns past
+# the tag so YARD folds them into the same tag's text.
+#
+# Single-line reasons render byte-identically to the previous single-line
+# interpolation, so this is output-neutral for the current spec.
+def deprecation_doc_lines(reason, indent:, tag_prefix: '')
+  lines = reason.to_s.split(/\r?\n/, -1)
+  out = [ "#{indent}# #{tag_prefix}@deprecated #{lines.first}" ]
+  continuation = "#{indent}# #{tag_prefix}  "
+  lines.drop(1).each do |line|
+    out << (line.empty? ? "#{indent}#" : "#{continuation}#{line}")
+  end
+  out
+end
+
 # Main execution
 if __FILE__ == $PROGRAM_NAME
   openapi_path = ARGV[0] || File.expand_path('../../openapi.json', __dir__)
@@ -128,7 +155,7 @@ if __FILE__ == $PROGRAM_NAME
     # not individual params, so a class-level @deprecated tag documents a wholly
     # deprecated type.
     if schema['deprecated']
-      puts "    # @deprecated #{schema['x-deprecated-reason'] || 'deprecated'}"
+      puts deprecation_doc_lines(schema['x-deprecated-reason'] || 'deprecated', indent: '    ')
     end
     puts "    class #{name}"
     puts '      include TypeHelpers'
@@ -147,7 +174,7 @@ if __FILE__ == $PROGRAM_NAME
 
       ruby_name = k.gsub(/([A-Z])/, '_\1').downcase.gsub(/^_/, '')
       puts "      # @!attribute [rw] #{ruby_name}"
-      puts "      #   @deprecated #{ps['x-deprecated-reason'] || 'deprecated'}"
+      puts deprecation_doc_lines(ps['x-deprecated-reason'] || 'deprecated', indent: '      ', tag_prefix: '  ')
     end
 
     puts "      attr_accessor #{attr_names.map { |n| ":#{n}" }.join(", ")}"

--- a/ruby/test/scripts/generate_types_test.rb
+++ b/ruby/test/scripts/generate_types_test.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+# Fixture for the deprecation doc-comment rendering in the Ruby types generator
+# (#406, #420). A deprecation reason can be sourced from a multi-line OpenAPI
+# description; interpolating one into a single "# @deprecated ..." line would
+# leave every continuation on a bare, un-commented source line and produce a
+# types.rb that does not parse.
+#
+# Ruby is the only owned generator exposed this way: Python escapes the reason
+# (see python/tests/test_generate_deprecation.py), and Kotlin/TypeScript emit
+# block comments. Swift solves it the same way this does, with
+# deprecationDocLines (swift/Tests/BasecampTests/DeprecationDocCommentTests.swift).
+
+require "test_helper"
+require "ripper"
+
+require_relative "../../scripts/generate-types"
+
+class GenerateTypesDeprecationTest < Minitest::Test
+  # A blank interior line, embedded double quotes, a backslash, and a final line
+  # that is not valid bare Ruby — so the guard test below has real teeth.
+  MULTILINE = <<~REASON.chomp
+    prefer type_names[].
+
+    The singular "type" param is a \\ legacy alias.
+    end
+  REASON
+
+  # Renders the two emit sites into a plausible types.rb fragment.
+  def types_fragment(class_tag_lines, attribute_tag_lines)
+    <<~RUBY
+      module Basecamp
+        module Types
+      #{class_tag_lines.join("\n")}
+          class Search
+            include TypeHelpers
+      #{attribute_tag_lines.join("\n")}
+            attr_accessor :type, :type_names
+          end
+        end
+      end
+    RUBY
+  end
+
+  def assert_parses(source, message)
+    assert Ripper.sexp(source), message
+  end
+
+  def test_every_emitted_line_is_a_comment
+    lines = deprecation_doc_lines(MULTILINE, indent: "    ")
+
+    assert_operator lines.length, :>, 1, "multi-line reason should emit multiple lines"
+    lines.each do |line|
+      assert_match(/\A\s*#/, line, "line escaped the comment leader: #{line.inspect}")
+    end
+  end
+
+  def test_multiline_reason_keeps_generated_types_parseable
+    source = types_fragment(
+      deprecation_doc_lines(MULTILINE, indent: "    "),
+      deprecation_doc_lines(MULTILINE, indent: "      ", tag_prefix: "  ")
+    )
+
+    assert_parses source, "generated types.rb fragment must parse for a multi-line reason"
+  end
+
+  def test_raw_interpolation_would_break_without_this_helper
+    # Guard: the fixture really is hostile. The pre-fix single-line
+    # interpolation does not parse, so the helper is doing real work.
+    source = types_fragment(
+      [ "    # @deprecated #{MULTILINE}" ],
+      [ "      #   @deprecated #{MULTILINE}" ]
+    )
+
+    assert_nil Ripper.sexp(source),
+               "expected the raw single-line interpolation to break parsing"
+  end
+
+  def test_continuations_are_indented_under_the_yard_tag
+    lines = deprecation_doc_lines(MULTILINE, indent: "      ", tag_prefix: "  ")
+
+    assert_equal "      #   @deprecated prefer type_names[].", lines[0]
+    assert_equal "      #", lines[1], "blank interior line should stay a bare comment"
+    assert_equal '      #     The singular "type" param is a \\ legacy alias.', lines[2]
+    assert_equal "      #     end", lines[3]
+  end
+
+  # Output neutrality: a single-line reason must render byte-identically to the
+  # interpolation this replaced, so regenerating types.rb produces no drift.
+  def test_single_line_reason_matches_the_previous_interpolation
+    reason = "Use typeNames (type_names[]) instead"
+
+    assert_equal [ "    # @deprecated #{reason}" ],
+                 deprecation_doc_lines(reason, indent: "    ")
+    assert_equal [ "      #   @deprecated #{reason}" ],
+                 deprecation_doc_lines(reason, indent: "      ", tag_prefix: "  ")
+  end
+
+  def test_crlf_reason_does_not_leak_carriage_returns
+    lines = deprecation_doc_lines("first\r\nsecond", indent: "    ")
+
+    assert_equal [ "    # @deprecated first", "    #   second" ], lines
+  end
+end

--- a/ruby/test/test_helper.rb
+++ b/ruby/test/test_helper.rb
@@ -4,6 +4,10 @@ require "simplecov"
 SimpleCov.start do
   add_filter "/test/"
   add_filter "/generated/"
+  # Build-time code generators, not shipped library code. test/scripts/ loads
+  # them to unit-test their pure helpers; their emit paths run under `make
+  # rb-generate` and are covered by the regenerate-and-diff freshness gate.
+  add_filter "/scripts/"
   enable_coverage :branch
   minimum_coverage line: 90, branch: 60
 end


### PR DESCRIPTION
Closes #420.

## The bug

Both deprecation emit sites in `ruby/scripts/generate-types.rb` interpolated the reason into a **single** comment line:

```ruby
# class-level
puts "    # @deprecated #{schema['x-deprecated-reason'] || 'deprecated'}"
# per-attribute
puts "      #   @deprecated #{ps['x-deprecated-reason'] || 'deprecated'}"
```

A reason sourced from a multi-line OpenAPI description puts every continuation on a **bare, un-commented source line**, so the generated `types.rb` stops parsing.

Latent today — no current `x-deprecated-reason` contains a newline — but nothing prevents one, and the failure mode is a broken build artifact rather than a bad doc string.

## Why only Ruby

| Generator | Exposure |
|---|---|
| **Ruby** | ❌ single-line `#` comment — **breaks** |
| Python | ✅ `escape_py_string` collapses newlines |
| Kotlin / TypeScript | ✅ block comments tolerate newlines |
| Swift | ✅ already fixed — `deprecationDocLines` |

So this mirrors Swift's `deprecationDocLines` (`swift/Sources/BasecampGenerator/Utilities.swift:38`): split on line boundaries, prefix every line with the comment leader, and indent continuations two columns past the YARD tag so YARD folds them into that tag's text rather than starting a new one.

## Output-neutral

Required, since `rb-check-drift` and `check-ruby-deprecation-yard.rb` both regenerate and diff. A single-line reason renders **byte-identically** to the interpolation it replaces — the helper's first line is the same concatenation.

Verified directly:

```
$ ruby ruby/scripts/generate-types.rb openapi.json > /tmp/types-new.rb
$ diff <(normalize types.rb) <(normalize /tmp/types-new.rb)
ZERO DIFF (timestamp-normalized)
```

## Test

New `ruby/test/scripts/generate_types_test.rb`, modeled on `python/tests/test_generate_deprecation.py` (the script is `require`-able thanks to its `__FILE__ == $PROGRAM_NAME` guard; the Rakefile globs `test/**/*_test.rb`).

It carries the same **guard test** the Python fixture has: the hostile multi-line reason is asserted to break parsing under the *old* single-line interpolation. Without that, the other assertions could pass vacuously on an input that was never dangerous.

Covers: every emitted line is a comment · the fragment parses (`Ripper.sexp`) · the raw form does **not** parse · continuation indentation under the YARD tag · single-line byte-for-byte neutrality at both call sites · CRLF reasons don't leak `\r`.

## Incidental

`test_helper.rb` gains `add_filter "/scripts/"`. Requiring the generator pulled it into SimpleCov's measured set, where its emit path (which only runs under `make rb-generate`) would have dragged the 90%-line/60%-branch minimums down. Build-time generators aren't shipped library code, and their emit paths are covered by the regenerate-and-diff freshness gate.

## Verification

`make rb-check` — **766 runs, 1518 assertions, 0 failures**; line coverage 94.47%, branch 77.67%; `rubocop` clean across 128 files (`ruby/scripts/` **is** linted — autocorrected `Layout/SpaceInsideArrayLiteralBrackets`). `make check-deprecation-parity` — 40 checks passed. `rb-check-drift` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Ruby types generator so multi-line `x-deprecated-reason` values emit valid comment lines and no longer break the generated `types.rb`. Keeps single-line output byte-identical.

- **Bug Fixes**
  - Added a helper that splits the reason into lines, prefixes each with `#`, and indents continuations under the YARD `@deprecated` tag.
  - Applied at both class-level and per-attribute emit sites; handles CRLF and blank lines; ensures the generated fragment parses.
  - Output-neutral for single-line reasons; added unit tests (including a guard for the old failure) and excluded `scripts/` from coverage.

<sup>Written for commit 13df6721e08f1e0be75bf1fc8082dc032f135210. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

