### PR TITLE
Add shared Gauge/GaugeNeedle fixtures, retire their coverage exclusions (closes #429)

### DIFF
--- a/spec/fixtures/gauges/get.json
+++ b/spec/fixtures/gauges/get.json
@@ -1,0 +1,71 @@
+{
+  "id": 1069479800,
+  "status": "active",
+  "visible_to_clients": false,
+  "created_at": "2022-11-22T08:40:00.000Z",
+  "updated_at": "2022-11-28T14:12:00.000Z",
+  "title": "Gauge",
+  "inherits_status": true,
+  "type": "Gauge",
+  "url": "https://3.basecampapi.com/999999999/buckets/2085958500/gauges/1069479800.json",
+  "app_url": "https://3.basecamp.com/999999999/buckets/2085958500/gauges/1069479800",
+  "bookmark_url": "https://3.basecampapi.com/999999999/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5ODAwP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--abcd1234.json",
+  "bucket": {
+    "id": 2085958500,
+    "name": "The Leto Laptop",
+    "type": "Project"
+  },
+  "creator": {
+    "id": 1049715915,
+    "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--abcd1234",
+    "name": "Victor Cooper",
+    "email_address": "victor@honchodesign.com",
+    "personable_type": "User",
+    "title": "Chief Strategist",
+    "bio": "Don't let your dreams be dreams",
+    "location": "Chicago, IL",
+    "created_at": "2022-11-22T08:23:21.000Z",
+    "updated_at": "2022-11-22T08:23:21.000Z",
+    "admin": true,
+    "owner": true,
+    "client": false,
+    "employee": true,
+    "time_zone": "America/Chicago",
+    "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--5520caeec1845b5a20c5b41d2c9de6578bcbb83d/avatar?v=1",
+    "can_manage_projects": true,
+    "can_manage_people": true
+  },
+  "description": "<div>Shipped the new onboarding flow — see the burndown and the retro notes.</div>",
+  "description_attachments": [
+    {
+      "id": 1069480040,
+      "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--gauge001",
+      "filename": "burndown.png",
+      "content_type": "image/png",
+      "byte_size": 40960,
+      "download_url": "https://3.basecampapi.com/999999999/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--gauge001/download/burndown.png",
+      "width": 1024.0,
+      "height": 768,
+      "previewable": true,
+      "preview_url": "https://3.basecampapi.com/999999999/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--gauge001/previews/burndown.png",
+      "thumbnail_url": "https://3.basecampapi.com/999999999/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--gauge001/thumbnails/burndown.png"
+    },
+    {
+      "id": 1069480041,
+      "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MQY6BkVU--gauge002",
+      "filename": "retro-notes.pdf",
+      "content_type": "application/pdf",
+      "byte_size": 81920,
+      "download_url": "https://3.basecampapi.com/999999999/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MQY6BkVU--gauge002/download/retro-notes.pdf",
+      "width": null,
+      "height": null,
+      "previewable": false,
+      "preview_url": "https://3.basecampapi.com/999999999/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MQY6BkVU--gauge002/previews/retro-notes.pdf",
+      "thumbnail_url": "https://3.basecampapi.com/999999999/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MQY6BkVU--gauge002/thumbnails/retro-notes.pdf"
+    }
+  ],
+  "enabled": true,
+  "last_needle_color": "green",
+  "last_needle_position": 72,
+  "previous_needle_position": 45
+}

--- a/spec/fixtures/gauges/needle_get.json
+++ b/spec/fixtures/gauges/needle_get.json
@@ -1,0 +1,81 @@
+{
+  "id": 1069479850,
+  "status": "active",
+  "visible_to_clients": false,
+  "created_at": "2022-11-28T14:12:00.000Z",
+  "updated_at": "2022-11-28T14:12:00.000Z",
+  "title": "Progress update",
+  "inherits_status": true,
+  "type": "Gauge::Needle",
+  "url": "https://3.basecampapi.com/999999999/buckets/2085958500/gauge_needles/1069479850.json",
+  "app_url": "https://3.basecamp.com/999999999/buckets/2085958500/gauge_needles/1069479850",
+  "bookmark_url": "https://3.basecampapi.com/999999999/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5ODUwP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--abcd1234.json",
+  "subscription_url": "https://3.basecampapi.com/999999999/buckets/2085958500/recordings/1069479850/subscription.json",
+  "comments_count": 2,
+  "comments_url": "https://3.basecampapi.com/999999999/buckets/2085958500/recordings/1069479850/comments.json",
+  "boosts_count": 3,
+  "boosts_url": "https://3.basecampapi.com/999999999/buckets/2085958500/recordings/1069479850/boosts.json",
+  "parent": {
+    "id": 1069479800,
+    "title": "Gauge",
+    "type": "Gauge",
+    "url": "https://3.basecampapi.com/999999999/buckets/2085958500/gauges/1069479800.json",
+    "app_url": "https://3.basecamp.com/999999999/buckets/2085958500/gauges/1069479800"
+  },
+  "bucket": {
+    "id": 2085958500,
+    "name": "The Leto Laptop",
+    "type": "Project"
+  },
+  "creator": {
+    "id": 1049715915,
+    "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--abcd1234",
+    "name": "Victor Cooper",
+    "email_address": "victor@honchodesign.com",
+    "personable_type": "User",
+    "title": "Chief Strategist",
+    "bio": "Don't let your dreams be dreams",
+    "location": "Chicago, IL",
+    "created_at": "2022-11-22T08:23:21.000Z",
+    "updated_at": "2022-11-22T08:23:21.000Z",
+    "admin": true,
+    "owner": true,
+    "client": false,
+    "employee": true,
+    "time_zone": "America/Chicago",
+    "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--5520caeec1845b5a20c5b41d2c9de6578bcbb83d/avatar?v=1",
+    "can_manage_projects": true,
+    "can_manage_people": true
+  },
+  "description": "<div>Shipped the new onboarding flow — see the burndown and the retro notes.</div>",
+  "description_attachments": [
+    {
+      "id": 1069480040,
+      "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--gauge001",
+      "filename": "burndown.png",
+      "content_type": "image/png",
+      "byte_size": 40960,
+      "download_url": "https://3.basecampapi.com/999999999/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--gauge001/download/burndown.png",
+      "width": 1024.0,
+      "height": 768,
+      "previewable": true,
+      "preview_url": "https://3.basecampapi.com/999999999/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--gauge001/previews/burndown.png",
+      "thumbnail_url": "https://3.basecampapi.com/999999999/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--gauge001/thumbnails/burndown.png"
+    },
+    {
+      "id": 1069480041,
+      "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MQY6BkVU--gauge002",
+      "filename": "retro-notes.pdf",
+      "content_type": "application/pdf",
+      "byte_size": 81920,
+      "download_url": "https://3.basecampapi.com/999999999/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MQY6BkVU--gauge002/download/retro-notes.pdf",
+      "width": null,
+      "height": null,
+      "previewable": false,
+      "preview_url": "https://3.basecampapi.com/999999999/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MQY6BkVU--gauge002/previews/retro-notes.pdf",
+      "thumbnail_url": "https://3.basecampapi.com/999999999/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MQY6BkVU--gauge002/thumbnails/retro-notes.pdf"
+    }
+  ],
+  "color": "green",
+  "position": 72
+}

--- a/spec/fixtures/manifest.yaml
+++ b/spec/fixtures/manifest.yaml
@@ -163,6 +163,22 @@ targets:
     pointer: "/description_attachments/0"
     schema: RichTextAttachment
 
+  # Gauge is a docked tool: bc3 app/views/api/gauges/_gauge.json.jbuilder renders
+  # the base recordings/recording partial (no commentable/boostable), then — only
+  # when `gauge.any_needles?` — the rich-text partial for the last needle plus
+  # enabled/last_needle_*/previous_needle_position. The fixture is the
+  # has-needles variant so the optional description_attachments array is present.
+  - id: gauge-get
+    fixture: gauges/get.json
+    pointer: ""
+    schema: Gauge
+  # gauges/needles/_needle.json.jbuilder renders the base partial WITH
+  # commentable + boostable, then rich text, color, and position.
+  - id: gauge-needle-get
+    fixture: gauges/needle_get.json
+    pointer: ""
+    schema: GaugeNeedle
+
 covered_schemas:
   Comment: [comment-get]
   Message: [message-get]
@@ -181,20 +197,10 @@ covered_schemas:
   Todo: [todo-get]
   SearchResult: [search-result-0]
   RichTextAttachment: [richtext-comment-0, richtext-upload-0]
+  Gauge: [gauge-get]
+  GaugeNeedle: [gauge-needle-get]
 
 excluded_schemas:
-  Gauge:
-    reason: >-
-      No shared JSON fixture. Gauge is exercised only inline in
-      go/pkg/basecamp/gauges_test.go, so its optional non-nullable
-      description_attachments array has no manifest'd representative.
-    issue: 429
-  GaugeNeedle:
-    reason: >-
-      No shared JSON fixture (same Gauge inline-only situation). GaugeNeedle
-      carries a @required description_attachments array not represented in any
-      shared fixture.
-    issue: 429
   TimelineAttachment:
     reason: >-
       No shared JSON fixture. TimelineAttachment is the optional-field superset


### PR DESCRIPTION
Closes #429.

`Gauge` and `GaugeNeedle` were the only two schemas excluded from the fixture-completeness guard for want of a shared representative. Their exclusion reasons said it plainly — *"exercised only inline in `go/pkg/basecamp/gauges_test.go`"* — which left `Gauge.description_attachments` (optional, non-nullable) and `GaugeNeedle.description_attachments` (`@required`) with no manifest'd instance, so a future required field on either schema would not be forced into a fixture.

## Authored from bc3, not lifted from the Go test

The inline body in `gauges_test.go` carries `id`, `type`, `description`, and `description_attachments` — **no `created_at`, no `updated_at`**, both `@required` on `GaugeNeedle`. Lifting it verbatim would have failed the guard.

Both fixtures are instead derived from the bc3 partials at `c308693171`:

| Fixture | bc3 source | Shape |
|---|---|---|
| `gauges/get.json` | `app/views/api/gauges/_gauge.json.jbuilder` | base `recordings/recording` partial (**no** `commentable`/`boostable`; no `parent` — Gauge is docked), then the `if gauge.any_needles?` branch: rich text, `enabled`, `last_needle_color`, `last_needle_position`, `previous_needle_position` |
| `gauges/needle_get.json` | `app/views/api/gauges/needles/_needle.json.jbuilder` | base partial **with** `commentable: true, boostable: true`, then rich text, `color`, `position`, with the Gauge as `parent` |

The Gauge fixture is deliberately the **has-needles** variant, so the optional `description_attachments` key is present rather than omitted.

## Populated attachments

Both carry the same two-variant element shape as `uploads/get.json`: one image with a **float-spelled** `width` (`1024.0`) and an integer `height`, one non-image with **null** dimensions. That is the shape worth borrowing from `gauges_test.go` — it gives the `FlexInt`/nullable decode path a manifest'd representative instead of only an inline one.

Population matters for `GaugeNeedle`/`Gauge` coverage quality but is not what makes the root schemas covered — the concrete-instance rule is satisfied by the declared root schema either way.

## Guard verified to have teeth

Not just "the gate is green" — the new targets were checked to actually fail on a real omission:

```
$ # temporarily delete created_at from gauges/needle_get.json
$ ./scripts/check-fixture-coverage.sh
Fixture-coverage check failed:
  - target `gauge-needle-get`: gauges/needle_get.json missing required field `created_at`
```

## Result

```
==> Fixture coverage clean — 19 covered schemas, 20 manifest targets,
    2 tracked exclusions, 20 rich-text emitters accounted for
==> Fixture-coverage self-test passed — 1 positive + 8 negative + 20 synthetic cases
```

17 → **19** covered schemas, 18 → **20** targets, 4 → **2** exclusions. Both `excluded_schemas` blocks are deleted (the checker fails on covered/excluded overlap).

## Scope note

The fixtures are manifest-only, which is an established pattern here (`search/results.json` is likewise not consumed by an SDK test). Repointing `gauges_test.go` at the shared fixture would further guard the two against drifting apart, but that is a Go-test refactor beyond this issue and is deliberately left out.

## Verification

`make check-fixture-coverage` (incl. the self-test) · `make conformance-fixtures-check` — both green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds shared JSON fixtures for Gauge and GaugeNeedle and removes their coverage exclusions, closing #429. Both schemas are now enforced by the fixture guard to cover required fields (created_at/updated_at) and description_attachments.

- **Refactors**
  - Added fixtures: spec/fixtures/gauges/get.json and spec/fixtures/gauges/needle_get.json; Gauge uses the has-needles variant; both include image and non-image description_attachments.
  - Updated manifest: added targets `gauge-get` and `gauge-needle-get`, marked Gauge and GaugeNeedle covered, removed both exclusions.
  - Coverage now 19 covered schemas / 20 targets; guard verified to fail if required fields are missing (e.g., created_at).

<sup>Written for commit 6803e6075bbea9e5866e22e491d1edae930dbd07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

