### PR TITLE
Re-pin dependabot-sync; contents: write for auto-merge arming

### DIFF
--- a/.github/workflows/dependabot-sync-actions-comments.yml
+++ b/.github/workflows/dependabot-sync-actions-comments.yml
@@ -21,9 +21,9 @@ permissions: {}
 
 jobs:
   sync:
-    uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@06fd9cf3d96439d0c5a8ca6ccc2ed2dd23552d9e
+    uses: basecamp/.github/.github/workflows/dependabot-sync-actions-comments.yml@d7a98882c52e021fa0d4ae31e92e56d03dcce774
     permissions:
-      contents: read
+      contents: write
       actions: write
       pull-requests: write
     # The deploy key is scoped to this repo's dependabot-sync environment


### PR DESCRIPTION
basecamp/.github#14: round 3 passed every invariant and failed only at `enablePullRequestAutoMerge` (needs `contents: write`, the dependabot-auto-merge grant). Caller permission raised to match. This merge's push is exercise round 4 — expected to complete the cycle: adopt #466, arm auto-merge, approve held runs, auto-merge, terminal no-op, audit green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-pinned the Dependabot sync workflow to commit `d7a98882` and switched the job token to `contents: write`. This enables `enablePullRequestAutoMerge` so Dependabot PRs can auto-merge after approval.

<sup>Written for commit 578de7d06a8c8d7add8d78b462fdcf3d029cc314. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

