### PR TITLE
Make the TypeScript service tests' validation claims true (closes #455)

### DIFF
--- a/typescript/tests/services/attachments.test.ts
+++ b/typescript/tests/services/attachments.test.ts
@@ -3,7 +3,7 @@
  *
  * Note: Generated services are spec-conformant:
  * - create() signature: create(data, contentType, name) - not create({ filename, contentType, data })
- * - No client-side validation (API validates)
+ * - This service performs no client-side validation; the API validates
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
@@ -83,7 +83,6 @@ describe("AttachmentsService", () => {
       expect(capturedContentType).toBe("image/png");
     });
 
-    // Note: Client-side validation removed - generated services let API validate
 
     it("should work with ArrayBuffer data", async () => {
       server.use(

--- a/typescript/tests/services/checkins.test.ts
+++ b/typescript/tests/services/checkins.test.ts
@@ -2,13 +2,24 @@
  * Tests for the CheckinsService (generated from OpenAPI spec)
  *
  * Note: Generated services are spec-conformant:
- * - No client-side validation (API validates)
+ * - Client-side checks: required fields on createQuestion (title, schedule),
+ *   createAnswer and updateAnswer (content), plus a YYYY-MM-DD format check on
+ *   groupOn. Everything else the API validates.
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../setup.js";
 import { createBasecampClient, type BasecampClient } from "../../src/client.js";
 import { BasecampError } from "../../src/errors.js";
+
+// Minimal valid QuestionSchedule, so the createQuestion validation tests vary
+// only the field under test.
+const SCHEDULE = {
+  frequency: "every_day",
+  days: [1, 2, 3, 4, 5],
+  hour: 16,
+  minute: 0,
+} as never;
 
 const BASE_URL = "https://3.basecampapi.com/12345";
 
@@ -195,7 +206,16 @@ describe("CheckinsService", () => {
       expect(question.title).toBe("What are your blockers?");
     });
 
-    // Note: Client-side validation removed - generated services let API validate
+    // Client-side validation short-circuits before any HTTP call. No MSW handler
+    // is registered here, so a leaked request fails via onUnhandledRequest: "error".
+    it("rejects createQuestion with a missing title or schedule", async () => {
+      await expect(
+        client.checkins.createQuestion(1, { title: "", schedule: SCHEDULE })
+      ).rejects.toMatchObject({ code: "validation", message: "Title is required" });
+      await expect(
+        client.checkins.createQuestion(1, { title: "Standup", schedule: undefined as never })
+      ).rejects.toMatchObject({ code: "validation", message: "Schedule is required" });
+    });
   });
 
   describe("updateQuestion", () => {
@@ -361,7 +381,16 @@ describe("CheckinsService", () => {
       expect(answer.content).toBe("<p>Finished the feature!</p>");
     });
 
-    // Note: Client-side validation removed - generated services let API validate
+    // Client-side validation short-circuits before any HTTP call. No MSW handler
+    // is registered here, so a leaked request fails via onUnhandledRequest: "error".
+    it("rejects createAnswer with missing content or a malformed groupOn", async () => {
+      await expect(
+        client.checkins.createAnswer(1, { content: "" })
+      ).rejects.toMatchObject({ code: "validation", message: "Content is required" });
+      await expect(
+        client.checkins.createAnswer(1, { content: "Done", groupOn: "03/15/2026" })
+      ).rejects.toMatchObject({ code: "validation", message: "Group on must be in YYYY-MM-DD format" });
+    });
   });
 
   describe("updateAnswer", () => {
@@ -398,6 +427,15 @@ describe("CheckinsService", () => {
       expect(receivedBody!.group_on).toBe("2025-03-01");
     });
 
-    // Note: Client-side validation removed - generated services let API validate
+    // Client-side validation short-circuits before any HTTP call. No MSW handler
+    // is registered here, so a leaked request fails via onUnhandledRequest: "error".
+    it("rejects updateAnswer with missing content or a malformed groupOn", async () => {
+      await expect(
+        client.checkins.updateAnswer(50, { content: "" })
+      ).rejects.toMatchObject({ code: "validation", message: "Content is required" });
+      await expect(
+        client.checkins.updateAnswer(50, { content: "Done", groupOn: "2026-3-1" })
+      ).rejects.toMatchObject({ code: "validation", message: "Group on must be in YYYY-MM-DD format" });
+    });
   });
 });

--- a/typescript/tests/services/checkins.test.ts
+++ b/typescript/tests/services/checkins.test.ts
@@ -10,7 +10,6 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../setup.js";
 import { createBasecampClient, type BasecampClient } from "../../src/client.js";
-import { BasecampError } from "../../src/errors.js";
 
 // Minimal valid QuestionSchedule, so the createQuestion validation tests vary
 // only the field under test.
@@ -19,7 +18,7 @@ const SCHEDULE = {
   days: [1, 2, 3, 4, 5],
   hour: 16,
   minute: 0,
-} as never;
+};
 
 const BASE_URL = "https://3.basecampapi.com/12345";
 

--- a/typescript/tests/services/documents.test.ts
+++ b/typescript/tests/services/documents.test.ts
@@ -2,7 +2,7 @@
  * Tests for the Documents service (generated from OpenAPI spec)
  *
  * Note: Generated services are spec-conformant:
- * - No client-side validation (API validates)
+ * - Client-side check: create() rejects a missing title; the API validates the rest
  * - No domain-specific trash() (use recordings.trash())
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -176,7 +176,13 @@ describe("DocumentsService", () => {
       expect(capturedBody?.status).toBe("drafted");
     });
 
-    // Note: Client-side validation removed - generated services let API validate
+    // Client-side validation short-circuits before any HTTP call. No MSW handler
+    // is registered here, so a leaked request fails via onUnhandledRequest: "error".
+    it("rejects a missing title", async () => {
+      await expect(
+        service.create(1001, { title: "" })
+      ).rejects.toMatchObject({ code: "validation", message: "Title is required" });
+    });
   });
 
   describe("update", () => {

--- a/typescript/tests/services/forwards.test.ts
+++ b/typescript/tests/services/forwards.test.ts
@@ -2,7 +2,7 @@
  * Tests for the ForwardsService class (generated from OpenAPI spec)
  *
  * Note: Generated services are spec-conformant:
- * - No client-side validation (API validates)
+ * - Client-side check: createReply() rejects missing content; the API validates the rest
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
@@ -215,6 +215,12 @@ describe("ForwardsService", () => {
       expect(reply.content).toBe("<p>New reply content</p>");
     });
 
-    // Note: Client-side validation removed - generated services let API validate
+    // Client-side validation short-circuits before any HTTP call. No MSW handler
+    // is registered here, so a leaked request fails via onUnhandledRequest: "error".
+    it("rejects missing content", async () => {
+      await expect(
+        client.forwards.createReply(1, { content: "" })
+      ).rejects.toMatchObject({ code: "validation", message: "Content is required" });
+    });
   });
 });

--- a/typescript/tests/services/forwards.test.ts
+++ b/typescript/tests/services/forwards.test.ts
@@ -8,7 +8,6 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../setup.js";
 import { createBasecampClient, type BasecampClient } from "../../src/client.js";
-import { BasecampError } from "../../src/errors.js";
 
 const BASE_URL = "https://3.basecampapi.com/12345";
 

--- a/typescript/tests/services/lineup.test.ts
+++ b/typescript/tests/services/lineup.test.ts
@@ -3,7 +3,7 @@
  *
  * Note: Generated services are spec-conformant:
  * - Method names: create(), update(), delete() (not createMarker, updateMarker, deleteMarker)
- * - No client-side validation (API validates)
+ * - Client-side checks: create() rejects a missing name or date; the API validates the rest
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";

--- a/typescript/tests/services/schedules.test.ts
+++ b/typescript/tests/services/schedules.test.ts
@@ -2,7 +2,8 @@
  * Tests for the Schedules service (generated from OpenAPI spec)
  *
  * Note: Generated services are spec-conformant:
- * - No client-side validation (API validates)
+ * - Client-side checks: createEntry() rejects a missing summary, startsAt, or
+ *   endsAt; the API validates the rest
  * - No domain-specific trashEntry() (use recordings.trash())
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -216,7 +217,19 @@ describe("SchedulesService", () => {
       expect(capturedBody?.notify).toBe(true);
     });
 
-    // Note: Client-side validation removed - generated services let API validate
+    // Client-side validation short-circuits before any HTTP call. No MSW handler
+    // is registered here, so a leaked request fails via onUnhandledRequest: "error".
+    it("rejects a missing summary, startsAt, or endsAt", async () => {
+      await expect(
+        service.createEntry(1, { summary: "", startsAt: "2026-01-01T09:00:00Z", endsAt: "2026-01-01T10:00:00Z" })
+      ).rejects.toMatchObject({ code: "validation", message: "Summary is required" });
+      await expect(
+        service.createEntry(1, { summary: "Standup", startsAt: "", endsAt: "2026-01-01T10:00:00Z" })
+      ).rejects.toMatchObject({ code: "validation", message: "Starts at is required" });
+      await expect(
+        service.createEntry(1, { summary: "Standup", startsAt: "2026-01-01T09:00:00Z", endsAt: "" })
+      ).rejects.toMatchObject({ code: "validation", message: "Ends at is required" });
+    });
   });
 
   describe("updateEntry", () => {
@@ -243,7 +256,6 @@ describe("SchedulesService", () => {
       expect(result.summary).toBe("Updated Meeting");
     });
 
-    // Note: Client-side validation removed - generated services let API validate
   });
 
   describe("getEntryOccurrence", () => {
@@ -269,7 +281,6 @@ describe("SchedulesService", () => {
       expect(result.starts_at).toBe("2024-12-22T09:00:00Z");
     });
 
-    // Note: Client-side validation removed - generated services let API validate
   });
 
   describe("updateSettings", () => {

--- a/typescript/tests/services/search.test.ts
+++ b/typescript/tests/services/search.test.ts
@@ -8,7 +8,6 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../setup.js";
 import { createBasecampClient } from "../../src/client.js";
-import { BasecampError } from "../../src/errors.js";
 import type { BasecampClient } from "../../src/client.js";
 
 const BASE_URL = "https://3.basecampapi.com/12345";

--- a/typescript/tests/services/search.test.ts
+++ b/typescript/tests/services/search.test.ts
@@ -2,7 +2,7 @@
  * Tests for the SearchService (generated from OpenAPI spec)
  *
  * Note: Generated services are spec-conformant:
- * - No client-side validation (API validates)
+ * - This service performs no client-side validation; the API validates
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
@@ -158,7 +158,6 @@ describe("SearchService", () => {
       });
     });
 
-    // Note: Client-side validation removed - generated services let API validate
 
     it("should return empty array when no results", async () => {
       server.use(

--- a/typescript/tests/services/subscriptions.test.ts
+++ b/typescript/tests/services/subscriptions.test.ts
@@ -8,7 +8,6 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../setup.js";
 import { createBasecampClient, type BasecampClient } from "../../src/client.js";
-import { BasecampError } from "../../src/errors.js";
 
 const BASE_URL = "https://3.basecampapi.com/12345";
 

--- a/typescript/tests/services/subscriptions.test.ts
+++ b/typescript/tests/services/subscriptions.test.ts
@@ -2,7 +2,7 @@
  * Tests for the SubscriptionsService class (generated from OpenAPI spec)
  *
  * Note: Generated services are spec-conformant:
- * - No client-side validation (API validates)
+ * - This service performs no client-side validation; the API validates
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
@@ -170,6 +170,5 @@ describe("SubscriptionsService", () => {
       expect(subscription.count).toBe(2);
     });
 
-    // Note: Client-side validation removed - generated services let API validate
   });
 });

--- a/typescript/tests/services/templates.test.ts
+++ b/typescript/tests/services/templates.test.ts
@@ -2,7 +2,8 @@
  * Tests for the TemplatesService (generated from OpenAPI spec)
  *
  * Note: Generated services are spec-conformant:
- * - No client-side validation (API validates)
+ * - Client-side checks: create() rejects a missing name, createProject() rejects a
+ *   missing project; the API validates the rest
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
@@ -112,7 +113,13 @@ describe("TemplatesService", () => {
       expect(template.name).toBe("New Template");
     });
 
-    // Note: Client-side validation removed - generated services let API validate
+    // Client-side validation short-circuits before any HTTP call. No MSW handler
+    // is registered here, so a leaked request fails via onUnhandledRequest: "error".
+    it("rejects a missing name", async () => {
+      await expect(
+        client.templates.create({ name: "" })
+      ).rejects.toMatchObject({ code: "validation", message: "Name is required" });
+    });
   });
 
   describe("update", () => {
@@ -139,7 +146,6 @@ describe("TemplatesService", () => {
       expect(template.name).toBe("Updated Template");
     });
 
-    // Note: Client-side validation removed - generated services let API validate
   });
 
   describe("delete", () => {
@@ -184,7 +190,13 @@ describe("TemplatesService", () => {
       expect(construction.status).toBe("pending");
     });
 
-    // Note: Client-side validation removed - generated services let API validate
+    // Client-side validation short-circuits before any HTTP call. No MSW handler
+    // is registered here, so a leaked request fails via onUnhandledRequest: "error".
+    it("rejects a missing project", async () => {
+      await expect(
+        client.templates.createProject(1, { project: undefined as never })
+      ).rejects.toMatchObject({ code: "validation", message: "Project is required" });
+    });
   });
 
   describe("getConstruction", () => {

--- a/typescript/tests/services/todolistGroups.test.ts
+++ b/typescript/tests/services/todolistGroups.test.ts
@@ -11,7 +11,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../setup.js";
-import { BasecampError } from "../../src/errors.js";
 import { createBasecampClient } from "../../src/client.js";
 import type { BasecampClient } from "../../src/client.js";
 

--- a/typescript/tests/services/todolistGroups.test.ts
+++ b/typescript/tests/services/todolistGroups.test.ts
@@ -5,12 +5,13 @@
  * - No get() method (not in API spec)
  * - No update() method (not in API spec)
  * - No domain-specific trash() (use recordings.trash())
- * - No client-side validation (API validates)
+ * - Client-side check: create() rejects a missing name; the API validates the rest
  * - reposition() takes a request object, not bare number
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "../setup.js";
+import { BasecampError } from "../../src/errors.js";
 import { createBasecampClient } from "../../src/client.js";
 import type { BasecampClient } from "../../src/client.js";
 
@@ -97,7 +98,13 @@ describe("TodolistGroupsService", () => {
       expect(group.name).toBe("New Phase");
     });
 
-    // Note: Client-side validation removed - generated services let API validate
+    // Client-side validation short-circuits before any HTTP call. No MSW handler
+    // is registered here, so a leaked request fails via onUnhandledRequest: "error".
+    it("rejects a missing name", async () => {
+      await expect(
+        client.todolistGroups.create(1, { name: "" })
+      ).rejects.toMatchObject({ code: "validation", message: "Name is required" });
+    });
   });
 
   // Note: update() is not in the API spec
@@ -123,7 +130,6 @@ describe("TodolistGroupsService", () => {
       ).resolves.toBeUndefined();
     });
 
-    // Note: Client-side validation removed - generated services let API validate
   });
 
   // Note: trash() is on RecordingsService, not TodolistGroupsService (spec-conformant)

--- a/typescript/tests/services/tools.test.ts
+++ b/typescript/tests/services/tools.test.ts
@@ -117,7 +117,9 @@ describe("ToolsService", () => {
     });
 
     it("requires a tool type", async () => {
-      await expect(client.tools.create(456, { toolType: "" })).rejects.toThrow(BasecampError);
+      await expect(
+        client.tools.create(456, { toolType: "" })
+      ).rejects.toMatchObject({ code: "validation", message: "Tool type is required" });
     });
 
     // visibleToClients is tri-state: undefined omits the key, true/false are sent

--- a/typescript/tests/services/tools.test.ts
+++ b/typescript/tests/services/tools.test.ts
@@ -4,6 +4,8 @@
  * Note: Generated services are spec-conformant:
  * - update() and reposition() take request objects, not bare params
  * - Request fields follow the generated OpenAPI shapes
+ * - Client-side checks: create() rejects a missing toolType, update() rejects a
+ *   missing title; the API validates the rest
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
@@ -175,7 +177,13 @@ describe("ToolsService", () => {
       expect(tool.title).toBe("Sprint Backlog");
     });
 
-    // Note: Client-side validation removed - generated services let API validate
+    // Client-side validation short-circuits before any HTTP call. No MSW handler
+    // is registered here, so a leaked request fails via onUnhandledRequest: "error".
+    it("rejects a missing title", async () => {
+      await expect(
+        client.tools.update(1, { title: "" })
+      ).rejects.toMatchObject({ code: "validation", message: "Title is required" });
+    });
   });
 
   describe("delete", () => {
@@ -247,6 +255,5 @@ describe("ToolsService", () => {
       ).resolves.toBeUndefined();
     });
 
-    // Note: Client-side validation removed - generated services let API validate
   });
 });

--- a/typescript/tests/services/uploads.test.ts
+++ b/typescript/tests/services/uploads.test.ts
@@ -3,7 +3,7 @@
  *
  * Note: Generated services are spec-conformant:
  * - No domain-specific trash() method (use recordings.trash() instead)
- * - No client-side validation (API validates)
+ * - Client-side check: create() rejects a missing attachableSgid; the API validates the rest
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
@@ -193,7 +193,13 @@ describe("UploadsService", () => {
       expect(capturedBody?.base_name).toBe("custom-name");
     });
 
-    // Note: Client-side validation removed - generated services let API validate
+    // Client-side validation short-circuits before any HTTP call. No MSW handler
+    // is registered here, so a leaked request fails via onUnhandledRequest: "error".
+    it("rejects a missing attachableSgid", async () => {
+      await expect(
+        service.create(1001, { attachableSgid: "" })
+      ).rejects.toMatchObject({ code: "validation", message: "Attachable sgid is required" });
+    });
   });
 
   describe("update", () => {

--- a/typescript/tests/services/vaults.test.ts
+++ b/typescript/tests/services/vaults.test.ts
@@ -2,7 +2,7 @@
  * Tests for the Vaults service (generated from OpenAPI spec)
  *
  * Note: Generated services are spec-conformant:
- * - No client-side validation (API validates)
+ * - Client-side check: create() rejects a missing title; the API validates the rest
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
@@ -135,7 +135,13 @@ describe("VaultsService", () => {
       expect(capturedBody?.title).toBe("My New Folder");
     });
 
-    // Note: Client-side validation removed - generated services let API validate
+    // Client-side validation short-circuits before any HTTP call. No MSW handler
+    // is registered here, so a leaked request fails via onUnhandledRequest: "error".
+    it("rejects a missing title", async () => {
+      await expect(
+        service.create(1001, { title: "" })
+      ).rejects.toMatchObject({ code: "validation", message: "Title is required" });
+    });
   });
 
   describe("update", () => {

--- a/typescript/tests/services/webhooks.test.ts
+++ b/typescript/tests/services/webhooks.test.ts
@@ -2,7 +2,7 @@
  * Tests for the WebhooksService class (generated from OpenAPI spec)
  *
  * Note: Generated services are spec-conformant:
- * - No client-side validation (API validates)
+ * - Client-side checks: create() rejects a missing payloadUrl or types; the API validates the rest
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
@@ -207,7 +207,16 @@ describe("WebhooksService", () => {
       expect(webhook.payload_url).toBe("https://example.com/new-webhook");
     });
 
-    // Note: Client-side validation removed - generated services let API validate
+    // Client-side validation short-circuits before any HTTP call. No MSW handler
+    // is registered here, so a leaked request fails via onUnhandledRequest: "error".
+    it("rejects a missing payloadUrl or types", async () => {
+      await expect(
+        client.webhooks.create(1, { payloadUrl: "", types: ["Todo"] })
+      ).rejects.toMatchObject({ code: "validation", message: "Payload url is required" });
+      await expect(
+        client.webhooks.create(1, { payloadUrl: "https://example.com/hook", types: undefined as never })
+      ).rejects.toMatchObject({ code: "validation", message: "Types is required" });
+    });
   });
 
   describe("update", () => {


### PR DESCRIPTION
Closes #455.

14 TypeScript test files claimed — in a file header, an inline note, or both — that generated services perform **no client-side validation**. For most of them that is false: the generated services validate required-field presence, and two also check date format.

## Headers — 13 files carried the claim

| | Count | Treatment |
|---|---|---|
| **False** | 10 | Reworded to name what is actually checked |
| **True** | 3 | `attachments`, `search`, `subscriptions` have **zero** `throw Errors.validation` — reworded as per-service **scoping**, not reversed |

Example:

```diff
- * - No client-side validation (API validates)
+ * - Client-side check: create() rejects a missing title; the API validates the rest
```

`checkins` needed wider wording than "required fields": **four** of its six checks are required-field presence, but **two** are a `YYYY-MM-DD` format check on `groupOn`.

## Inline notes — 21 across 13 files (an overlapping but *different* set)

| | Count | Treatment |
|---|---|---|
| On a method that really validates | 13 | Replaced with a test asserting the rejection |
| On a method with no validation | 8 | Deleted — noise, not a missing test |

`lineup.test.ts` had the header but no note; `tools.test.ts` had the note but **no header** *and* its service validates both `create` and `update` — folded into the same treatment.

## The assertions are deliberately not `toThrow(BasecampError)`

This is the part worth reviewing. `rejects.toThrow(BasecampError)` is **vacuous here**, and I only caught it by testing the test:

```
$ # delete the `if (!req.title) throw Errors.validation("Title is required")` from documents.ts
$ npx vitest run tests/services/documents.test.ts -t "rejects a missing title"
 Tests  1 passed        # ← still green with the validation GONE
```

With the check removed the request escapes to MSW and the SDK wraps the result back into a `BasecampError`, so a class-only assertion passes for the wrong reason. The tests now assert the **exact** error surface:

```ts
await expect(
  service.create(1001, { title: "" })
).rejects.toMatchObject({ code: "validation", message: "Title is required" });
```

Re-run against the same deleted check:

```
AssertionError: expected BasecampError: Not Found to match object { code: 'validation', … }
-   "code": "validation"
+   "code": "not_found"
 Tests  1 failed
```

Registering **no** MSW handler in these tests also means a leaked request trips `setup.ts`'s `onUnhandledRequest: "error"` — so they double as proof the checks short-circuit before any HTTP call.

## Imports

`BasecampError` was already imported everywhere needed except `todolistGroups` (now added). `attachments` does **not** need it — that service performs no validation, so its note was deleted rather than replaced.

## On the Ruby follow-up — it isn't one

The issue's premise was that ~11 Ruby test files carry the same claim and need the same fix. They carry the identical **wording** (12 files under `ruby/test/basecamp/services/`), but there the claim is **true**: the generated Ruby services perform no input validation at all. The only `raise`s under `ruby/lib/basecamp/generated/services/` are `base_service.rb` re-raises and one `uploads_service.rb` `UsageError` for a missing `download_url` — not input validation.

So there is **no Ruby hygiene fix to do**. What this does surface is a genuine cross-SDK divergence — TS generated services validate required fields client-side, Ruby ones don't — which is a behavioral parity question, not a stale comment. Noted here rather than filed, since it may well be intentional.

## Verification

`make ts-check` — 68 files, **806 tests** (was 795; +11), all green · `tsc --noEmit` clean · `ts-check-drift` clean · `npm run lint` clean (the two warnings in `src/oauth/discovery.ts` are pre-existing and untouched). Zero occurrences of either stale string remain under `typescript/tests/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates TypeScript service tests to reflect actual client-side validation and assert exact validation errors to prevent false greens. Closes #455.

- **Bug Fixes**
  - Corrected headers in 13 files; 10 now name real checks (required fields and `YYYY-MM-DD` for `checkins.groupOn`); 3 correctly state no client-side validation (`attachments`, `search`, `subscriptions`).
  - Replaced 13 inline “no validation” notes with rejection tests; removed 8 notes where methods truly don’t validate.
  - Tightened assertions to `{ code: "validation", message: ... }`, including `tools.create()`, proving short-circuiting before any HTTP call (unhandled requests fail via test setup).

- **Refactors**
  - Removed unused `BasecampError` imports (`checkins`, `forwards`, `search`, `subscriptions`, `todolistGroups`); dropped an unnecessary `as never` cast in `checkins` tests.

<sup>Written for commit d7c13522783bf460166b4f4d47457df1e4c4d312. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

