### PR TITLE
BC5 OAuth: RFC 8707 resource indicator + 429 poll contract (5 SDKs)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -408,7 +408,7 @@ py-clean:
 # Conformance Test targets
 #------------------------------------------------------------------------------
 
-.PHONY: conformance conformance-go conformance-go-replay conformance-kotlin conformance-kotlin-replay conformance-typescript conformance-typescript-live conformance-ruby conformance-ruby-replay conformance-python conformance-python-replay conformance-build conformance-live conformance-canary oauth-fixtures-check conformance-fixtures-check
+.PHONY: conformance conformance-go conformance-go-replay conformance-kotlin conformance-kotlin-replay conformance-typescript conformance-typescript-live conformance-ruby conformance-ruby-replay conformance-python conformance-python-replay conformance-build conformance-live conformance-canary oauth-fixtures-check oauth-token-fixtures-check conformance-fixtures-check
 
 # Pinned validator for the data-only OAuth discovery fixtures. Run via uvx so the
 # version is reproducible without a global install; the schema is separate from
@@ -420,6 +420,15 @@ oauth-fixtures-check:
 	@echo "==> Validating OAuth discovery fixtures..."
 	uvx --from 'check-jsonschema==$(CHECK_JSONSCHEMA_VERSION)' check-jsonschema \
 		--schemafile conformance/oauth/schema.json conformance/oauth/fixtures/*.json
+
+# Validate OAuth token wire-behavior fixtures (RFC 8707 resource echo/decode)
+# against their JSON Schema. A separate family from conformance/oauth/ — that
+# schema is discovery-only and every discovery harness globs its whole fixtures
+# directory, so token cases must live here.
+oauth-token-fixtures-check:
+	@echo "==> Validating OAuth token fixtures..."
+	uvx --from 'check-jsonschema==$(CHECK_JSONSCHEMA_VERSION)' check-jsonschema \
+		--schemafile conformance/oauth-token/schema.json conformance/oauth-token/fixtures/*.json
 
 # Validate every conformance/tests/*.json entry against conformance/schema.json.
 # This is the AUTHORITATIVE enforcement of the per-case schema — including the
@@ -507,7 +516,7 @@ conformance-python-replay:
 	cd conformance/runner/python && uv sync && uv run python replay_runner.py
 
 # Run all conformance tests
-conformance: oauth-fixtures-check conformance-fixtures-check conformance-go conformance-kotlin conformance-typescript conformance-ruby conformance-python
+conformance: oauth-fixtures-check oauth-token-fixtures-check conformance-fixtures-check conformance-go conformance-kotlin conformance-typescript conformance-ruby conformance-python
 	@echo "==> Conformance tests passed"
 
 # Orchestrate one canary pass against a single backend:
@@ -960,6 +969,7 @@ help:
 	@echo "  conformance-python-replay  Decode TS-captured wire snapshots through Python SDK"
 	@echo "  conformance-build          Build Go conformance test runner"
 	@echo "  oauth-fixtures-check       Validate OAuth discovery fixtures against their schema"
+	@echo "  oauth-token-fixtures-check Validate OAuth token wire-behavior fixtures against their schema"
 	@echo "  conformance-fixtures-check Validate conformance/tests fixtures against schema.json"
 	@echo ""
 	@echo "Ruby SDK:"

--- a/SPEC.md
+++ b/SPEC.md
@@ -1408,7 +1408,10 @@ FUNCTION pollDeviceToken(tokenEndpoint, clientId, deviceCode, interval, expiresI
               wait rule above) and then decays — it never permanently inflates
               the slow_down-driven interval. A missing, malformed, fractional,
               non-positive, or overflowing Retry-After falls back to the current
-              interval. Cancellation stays live through the (possibly longer)
+              interval. Parsing trims ONLY ASCII SP and HTAB around the value
+              (RFC 9110 optional whitespace): delta-seconds is 1*DIGIT, so a
+              value wrapped in any other whitespace (NBSP, Unicode spaces) is
+              malformed and falls back — never trimmed into validity. Cancellation stays live through the (possibly longer)
               wait. ONLY this exact combination is retryable: a 429 without
               error=too_many_requests, or too_many_requests on any other
               status, stays terminal (api_error) like any unrecognized error.

--- a/SPEC.md
+++ b/SPEC.md
@@ -1407,11 +1407,17 @@ FUNCTION pollDeviceToken(tokenEndpoint, clientId, deviceCode, interval, expiresI
               NEXT wait only (still clamped to the remaining lifetime by the
               wait rule above) and then decays — it never permanently inflates
               the slow_down-driven interval. A missing, malformed, fractional,
-              non-positive, or overflowing Retry-After falls back to the current
-              interval. Parsing trims ONLY ASCII SP and HTAB around the value
-              (RFC 9110 optional whitespace): delta-seconds is 1*DIGIT, so a
-              value wrapped in any other whitespace (NBSP, Unicode spaces) is
-              malformed and falls back — never trimmed into validity. Cancellation stays live through the (possibly longer)
+              non-positive, or UNREPRESENTABLE (overflowing the parser's native
+              integer range or digit bound) Retry-After falls back to the
+              current interval. A representable delta beyond the shared device
+              ceiling CLAMPS to the ceiling instead of falling back: the wait
+              rule clamps to the remaining code lifetime anyway, so an
+              over-ceiling throttle waits out the rest of the lifetime rather
+              than resending before the server's throttle. Parsing trims ONLY
+              ASCII SP and HTAB around the value (RFC 9110 optional
+              whitespace): delta-seconds is 1*DIGIT, so a value wrapped in any
+              other whitespace (NBSP, Unicode spaces) is malformed and falls
+              back — never trimmed into validity. Cancellation stays live through the (possibly longer)
               wait. ONLY this exact combination is retryable: a 429 without
               error=too_many_requests, or too_many_requests on any other
               status, stays terminal (api_error) like any unrecognized error.

--- a/SPEC.md
+++ b/SPEC.md
@@ -244,7 +244,12 @@ END
 **OAuthTokenProvider** (Go/Ruby only):
 - Caches the access token and its expiry timestamp.
 - Proactively refreshes when `expires_at - now() < TOKEN_REFRESH_BUFFER` (Go uses 300s; Ruby refreshes only on expiry).
-- `refresh()` POSTs to the token URL with `grant_type=refresh_token`.
+- `refresh()` POSTs to the token URL with `grant_type=refresh_token`. Go's
+  `AuthManager` additionally submits `client_id` when stored (BC5 public
+  clients authenticate by id alone) and echoes/preserves the stored RFC 8707
+  `resource` per §16's Token Response `resource` section. The Ruby and Python
+  legacy token providers are Launchpad-only and out of the BC5 resource-echo
+  scope.
 
 ### 401 Refresh-and-Retry Algorithm
 
@@ -1063,8 +1068,8 @@ END
 *Rubric-critical: BC5 OAuth go-live (communique §2/§3).*
 
 BC5's Authorization Server (AS) metadata lives **only** at the canonical issuer
-(the web host, e.g. `https://3.basecamp.com`). Probing the API host
-(`3.basecampapi.com/.well-known/oauth-authorization-server`) 404s permanently
+(the web host — production canonical `https://app.basecamp.com`). Probing the
+API host (`3.basecampapi.com/.well-known/oauth-authorization-server`) 404s permanently
 because RFC 8414 §3.3 requires `issuer` to equal the URL the metadata was
 derived from, and BC5's issuer is the web host. Discovery therefore starts from
 the **resource** (RFC 9728) and composes with AS discovery (RFC 8414).
@@ -1210,9 +1215,11 @@ every `fetchJSON` above MUST:
    re-validate each target against the origin-root profile.
 4. **Read the body under a genuine, bounded/streaming cap that aborts once the
    limit is exceeded** — NOT a post-hoc size check on an already-buffered body.
-   Python (`httpx.stream()`) and Ruby (Faraday `on_data`/capped read) must switch
-   from buffered reads to bounded streaming reads; Go/Kotlin/TS gain bounded reads
-   they lack today.
+   Python streams via `httpx.stream()`; Ruby's default transport is the
+   headers-first bounded `Fetcher.stream_http` primitive (Net::HTTP block form:
+   status classified at header time, watchdog wall-clock deadline, streamed cap
+   — injected Faraday connections keep a capped `on_data` read); Go/Kotlin/TS
+   use bounded reads.
 
 Non-2xx on either hop → `api_error` (not `network`).
 
@@ -1254,11 +1261,51 @@ FUNCTION exchangeCode(token_endpoint, code, redirect_uri, client_id, client_secr
 END
 ```
 
+### Token Response `resource` Indicator (RFC 8707) `[conformance]`
+
+*BC5 go-live. Contract source: bc3 #9471 (`Oauth::RefreshToken#resolve_target_account!`,
+`Oauth::ResourceIndicator`).*
+
+Every token response — authorization-code exchange, device grant, AND refresh —
+MAY carry a `resource` member: an RFC 8707 resource indicator naming the account
+the token is bound to. BC5 emits the URN form `urn:bc:account:<queenbee_id>`
+(the server also parses a URL form). Token models in all five SDKs carry it as
+an **optional string, appended after all existing fields** (never repositioning
+existing positional/keyword parameters):
+
+- Omitted or JSON `null` → absent (same null-as-absent rule as
+  `refresh_token`/`scope` in §16 device validation).
+- Present → MUST be a non-empty string; a present-but-empty `""` or non-string
+  value is a malformed response (`api_error`). No format validation beyond
+  non-empty: the indicator is an opaque echo token from the client's viewpoint.
+
+**Refresh contract.** Refresh requests accept an optional `resource` form
+parameter, sent only when set and appended without repositioning existing
+parameters. BC5's `trusted` clients (e.g. `basecamp-cli`) receive
+**multi-account refresh tokens** (identity-wide grant, no bound account); for
+these the BC5 refresh grant HARD-REQUIRES `resource` — a refresh without it is
+rejected 400 `invalid_request` ("resource parameter required for multi-account
+token"). The rule for every consumer:
+
+> **Echo the stored token's `resource` when refreshing.**
+
+**Lifecycle managers** (TS `TokenManager`, Go `AuthManager`, and any consumer
+that owns the refresh loop) do this automatically: they submit the stored
+`resource` on every refresh, and when a refresh response OMITS `resource` they
+preserve the prior stored value on the rotated credentials (same
+carry-forward rule as an omitted rotated `refresh_token`). A refresh response
+that carries `resource` replaces the stored value.
+
 ### RFC 8628 Device Authorization Grant `[conformance]`
 
 *BC5 go-live (communique §4). Public pre-registered client `basecamp-cli`:
 `token_endpoint_auth_method: none`, grants `device_code`+`refresh_token`, no
-redirect URIs, no secret. An omitted scope defaults to `read`.*
+redirect URIs, no secret. An omitted scope defaults to the registry's
+least-privilege first entry (`read` for `basecamp-cli`) — consumers SHOULD pin
+the scope explicitly rather than rely on the server default. While BC5 OAuth is
+dark-launched (`issuance_enabled` off), the device authorization endpoint
+answers **503** — surfaced as `api_error` with that status, meaning "not yet
+enabled here", not a protocol failure.*
 
 Three functions per SDK. All device-auth + token requests are TLS-guarded (§9).
 
@@ -1327,11 +1374,14 @@ FUNCTION pollDeviceToken(tokenEndpoint, clientId, deviceCode, interval, expiresI
               accepted and coerced to whole seconds, matching the device-duration
               rule; every SDK decodes the numeric value and validates it
               explicitly to reject a fractional lifetime);
-              refresh_token/token_type/scope, when present and non-null, MUST be
-              strings — a JSON null is treated as absent (like an omitted field),
-              consistent with the null-duration rule above. token_type is
+              refresh_token/token_type/scope/resource, when present and non-null,
+              MUST be strings — a JSON null is treated as absent (like an omitted
+              field), consistent with the null-duration rule above. token_type is
               additionally non-empty when present: absent or JSON null defaults to
-              Bearer, while an explicit "" is malformed (api_error). A non-object
+              Bearer, while an explicit "" is malformed (api_error). resource is
+              likewise non-empty when present (RFC 8707 indicator, see the
+              Token Response `resource` section above) and is captured onto the
+              returned Token. A non-object
               or unparsable body, and every field/status error above, carries the
               HTTP status on the raised api_error.
               Absent expires_in is allowed (the token carries no expiry).
@@ -1347,11 +1397,25 @@ FUNCTION pollDeviceToken(tokenEndpoint, clientId, deviceCode, interval, expiresI
          error slow_down → interval += 5   (this AND all subsequent polls)
          error access_denied → raise DeviceFlowError(access_denied)
          error expired_token → raise DeviceFlowError(expired)
+         HTTP 429 AND error too_many_requests → keep polling with a ONE-SHOT
+              next-wait override: nextWaitOverride = max(interval, retryAfter)
+              when the response carries a positive integral Retry-After delta
+              (seconds), else the current interval. The override applies to the
+              NEXT wait only (still clamped to the remaining lifetime by the
+              wait rule above) and then decays — it never permanently inflates
+              the slow_down-driven interval. A missing, malformed, fractional,
+              non-positive, or overflowing Retry-After falls back to the current
+              interval. Cancellation stays live through the (possibly longer)
+              wait. ONLY this exact combination is retryable: a 429 without
+              error=too_many_requests, or too_many_requests on any other
+              status, stays terminal (api_error) like any unrecognized error.
          connection timeout → backoff = min(backoff × 2, 60), keep polling
        ANY completed round-trip (2xx or OAuth error) → backoff = interval
        # The two timers never contaminate each other: slow_down inflates
        # interval permanently; timeouts inflate backoff transiently, and a
-       # completed round-trip resets backoff to the current interval.
+       # completed round-trip resets backoff to the current interval; a 429
+       # Retry-After override outlives neither — it is consumed by the next
+       # wait and gone.
 END
 ```
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1338,12 +1338,15 @@ FUNCTION pollDeviceToken(tokenEndpoint, clientId, deviceCode, interval, expiresI
   2. deadline = clock.now() + expiresIn    # MONOTONIC clock, injectable
      backoff = interval                    # transient timeout backoff, SEPARATE
                                            # from the server-driven interval
+     nextWaitOverride = 0                  # one-shot 429 Retry-After override
   3. LOOP (cancellation-aware):
        IF cancelled → raise DeviceFlowError(cancelled)
        IF clock.now() ≥ deadline → raise DeviceFlowError(expired)   # check BEFORE waiting,
               # so a long display hook, a stalled prior request, or a long backoff
               # cannot carry the loop past expiry undetected
-       wait = max(interval, backoff), clamped to the remaining lifetime (> 0 here)
+       wait = max(interval, backoff, nextWaitOverride), clamped to the
+              remaining lifetime (> 0 here)
+       nextWaitOverride = 0   # one-shot: consumed by this wait, then gone
        SLEEP wait   # abortable; a cancel mid-wait → DeviceFlowError(cancelled)
        IF clock.now() ≥ deadline → raise DeviceFlowError(expired)
               # re-check AFTER the wait, before POSTing: the clamp above makes the

--- a/conformance/oauth-token/README.md
+++ b/conformance/oauth-token/README.md
@@ -1,0 +1,29 @@
+# OAuth token wire-behavior fixtures
+
+Data-only, cross-language fixtures for token-endpoint **wire behavior**: the
+RFC 8707 `resource` echo on refresh requests and the decode rules for a token
+response's `resource` member (round-trip, absent/JSON-null as unset,
+present-empty/non-string rejected). See SPEC.md §16, "Token Response `resource`
+Indicator".
+
+A separate family from `conformance/oauth/` — that schema is discovery-only
+and every discovery harness globs its whole fixtures directory, so token cases
+here would break them.
+
+Consumers:
+
+- **Go** `go/pkg/basecamp/oauth/token_conformance_test.go`
+- **TypeScript** `typescript/tests/oauth/token-conformance.test.ts`
+- **Python** `python/tests/oauth/test_token_conformance.py`
+- **Ruby** `ruby/test/basecamp/oauth_token_conformance_test.rb`
+- **Kotlin** mirrors the scenarios in code (`OAuthTest.kt`), its established
+  pattern for the discovery fixtures.
+
+Schema-validated by `make oauth-token-fixtures-check` (part of `make
+conformance`, so `make check` gates it).
+
+**Deliberately out of scope:** response-omission *preservation* — carrying a
+stored `resource` forward when a refresh response omits it — is lifecycle
+behavior owned by token managers, tested per-manager (TS `TokenManager`, Go
+`AuthManager`, basecamp-cli), not modeled as wire fixtures. 429 poll scheduling
+likewise stays in per-SDK device tests.

--- a/conformance/oauth-token/fixtures/01-resource-round-trip.json
+++ b/conformance/oauth-token/fixtures/01-resource-round-trip.json
@@ -1,0 +1,10 @@
+{
+  "name": "resource-round-trip",
+  "description": "A token response carrying an RFC 8707 resource indicator round-trips onto the returned token.",
+  "operation": "refreshToken",
+  "response": {
+    "status": 200,
+    "body": { "access_token": "tok", "token_type": "Bearer", "resource": "urn:bc:account:42" }
+  },
+  "expect": { "outcome": "token", "resource": "urn:bc:account:42" }
+}

--- a/conformance/oauth-token/fixtures/01-resource-round-trip.json
+++ b/conformance/oauth-token/fixtures/01-resource-round-trip.json
@@ -4,7 +4,15 @@
   "operation": "refreshToken",
   "response": {
     "status": 200,
-    "body": { "access_token": "tok", "token_type": "Bearer", "resource": "urn:bc:account:42" }
+    "body": {
+      "access_token": "tok",
+      "token_type": "Bearer",
+      "resource": "urn:bc:account:42"
+    }
   },
-  "expect": { "outcome": "token", "resource": "urn:bc:account:42" }
+  "expect": {
+    "outcome": "token",
+    "resource": "urn:bc:account:42",
+    "formResourceAbsent": true
+  }
 }

--- a/conformance/oauth-token/fixtures/02-resource-absent.json
+++ b/conformance/oauth-token/fixtures/02-resource-absent.json
@@ -4,7 +4,14 @@
   "operation": "refreshToken",
   "response": {
     "status": 200,
-    "body": { "access_token": "tok", "token_type": "Bearer" }
+    "body": {
+      "access_token": "tok",
+      "token_type": "Bearer"
+    }
   },
-  "expect": { "outcome": "token", "resourceAbsent": true }
+  "expect": {
+    "outcome": "token",
+    "resourceAbsent": true,
+    "formResourceAbsent": true
+  }
 }

--- a/conformance/oauth-token/fixtures/02-resource-absent.json
+++ b/conformance/oauth-token/fixtures/02-resource-absent.json
@@ -1,0 +1,10 @@
+{
+  "name": "resource-absent",
+  "description": "A token response without a resource member yields a token with no resource binding.",
+  "operation": "refreshToken",
+  "response": {
+    "status": 200,
+    "body": { "access_token": "tok", "token_type": "Bearer" }
+  },
+  "expect": { "outcome": "token", "resourceAbsent": true }
+}

--- a/conformance/oauth-token/fixtures/03-resource-null.json
+++ b/conformance/oauth-token/fixtures/03-resource-null.json
@@ -4,7 +4,15 @@
   "operation": "refreshToken",
   "response": {
     "status": 200,
-    "body": { "access_token": "tok", "token_type": "Bearer", "resource": null }
+    "body": {
+      "access_token": "tok",
+      "token_type": "Bearer",
+      "resource": null
+    }
   },
-  "expect": { "outcome": "token", "resourceAbsent": true }
+  "expect": {
+    "outcome": "token",
+    "resourceAbsent": true,
+    "formResourceAbsent": true
+  }
 }

--- a/conformance/oauth-token/fixtures/03-resource-null.json
+++ b/conformance/oauth-token/fixtures/03-resource-null.json
@@ -1,0 +1,10 @@
+{
+  "name": "resource-null",
+  "description": "A JSON null resource is treated exactly like an omitted member (unset), matching the null-as-absent rule for the other optional token fields.",
+  "operation": "refreshToken",
+  "response": {
+    "status": 200,
+    "body": { "access_token": "tok", "token_type": "Bearer", "resource": null }
+  },
+  "expect": { "outcome": "token", "resourceAbsent": true }
+}

--- a/conformance/oauth-token/fixtures/04-resource-empty-rejected.json
+++ b/conformance/oauth-token/fixtures/04-resource-empty-rejected.json
@@ -1,10 +1,17 @@
 {
   "name": "resource-empty-rejected",
-  "description": "A present-but-empty resource is a malformed response — an empty binding is not a binding (SPEC §16).",
+  "description": "A present-but-empty resource is a malformed response \u2014 an empty binding is not a binding (SPEC \u00a716).",
   "operation": "refreshToken",
   "response": {
     "status": 200,
-    "body": { "access_token": "tok", "token_type": "Bearer", "resource": "" }
+    "body": {
+      "access_token": "tok",
+      "token_type": "Bearer",
+      "resource": ""
+    }
   },
-  "expect": { "outcome": "reject" }
+  "expect": {
+    "outcome": "reject",
+    "formResourceAbsent": true
+  }
 }

--- a/conformance/oauth-token/fixtures/04-resource-empty-rejected.json
+++ b/conformance/oauth-token/fixtures/04-resource-empty-rejected.json
@@ -1,0 +1,10 @@
+{
+  "name": "resource-empty-rejected",
+  "description": "A present-but-empty resource is a malformed response — an empty binding is not a binding (SPEC §16).",
+  "operation": "refreshToken",
+  "response": {
+    "status": 200,
+    "body": { "access_token": "tok", "token_type": "Bearer", "resource": "" }
+  },
+  "expect": { "outcome": "reject" }
+}

--- a/conformance/oauth-token/fixtures/05-resource-non-string-rejected.json
+++ b/conformance/oauth-token/fixtures/05-resource-non-string-rejected.json
@@ -1,0 +1,10 @@
+{
+  "name": "resource-non-string-rejected",
+  "description": "A non-string resource is a malformed response and must be rejected, never coerced.",
+  "operation": "refreshToken",
+  "response": {
+    "status": 200,
+    "body": { "access_token": "tok", "token_type": "Bearer", "resource": 7 }
+  },
+  "expect": { "outcome": "reject" }
+}

--- a/conformance/oauth-token/fixtures/05-resource-non-string-rejected.json
+++ b/conformance/oauth-token/fixtures/05-resource-non-string-rejected.json
@@ -4,7 +4,14 @@
   "operation": "refreshToken",
   "response": {
     "status": 200,
-    "body": { "access_token": "tok", "token_type": "Bearer", "resource": 7 }
+    "body": {
+      "access_token": "tok",
+      "token_type": "Bearer",
+      "resource": 7
+    }
   },
-  "expect": { "outcome": "reject" }
+  "expect": {
+    "outcome": "reject",
+    "formResourceAbsent": true
+  }
 }

--- a/conformance/oauth-token/fixtures/06-refresh-sends-resource.json
+++ b/conformance/oauth-token/fixtures/06-refresh-sends-resource.json
@@ -1,0 +1,11 @@
+{
+  "name": "refresh-sends-resource",
+  "description": "A refresh with a resource set sends it as the resource form parameter (the multi-account echo).",
+  "operation": "refreshToken",
+  "request": { "resource": "urn:bc:account:42" },
+  "response": {
+    "status": 200,
+    "body": { "access_token": "tok", "token_type": "Bearer" }
+  },
+  "expect": { "outcome": "token", "resourceAbsent": true, "formResource": "urn:bc:account:42" }
+}

--- a/conformance/oauth-token/fixtures/07-refresh-omits-resource.json
+++ b/conformance/oauth-token/fixtures/07-refresh-omits-resource.json
@@ -1,0 +1,10 @@
+{
+  "name": "refresh-omits-resource",
+  "description": "A refresh with no resource set sends no resource form key at all — never an empty value.",
+  "operation": "refreshToken",
+  "response": {
+    "status": 200,
+    "body": { "access_token": "tok", "token_type": "Bearer" }
+  },
+  "expect": { "outcome": "token", "resourceAbsent": true, "formResourceAbsent": true }
+}

--- a/conformance/oauth-token/schema.json
+++ b/conformance/oauth-token/schema.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://basecamp.com/schemas/oauth-token-fixture.json",
+  "title": "OAuth Token Wire-Behavior Fixture",
+  "description": "Data-only, cross-language fixture describing one token-endpoint wire behavior: what a refresh request sends (the RFC 8707 resource form parameter) and how a token response's resource member decodes (round-trip, absent/null as unset, present-empty/non-string rejected). Lifecycle behavior — response-omission preservation across a stored credential — is deliberately NOT modeled here: it lives in per-manager tests (TS TokenManager, Go AuthManager, CLI). Validated by `make oauth-token-fixtures-check`. Kotlin mirrors these scenarios in code (its established pattern); Go/TS/Python/Ruby load these files directly.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["name", "operation", "response", "expect"],
+  "properties": {
+    "name": { "type": "string", "description": "Kebab-case fixture identifier." },
+    "description": { "type": "string" },
+    "operation": {
+      "type": "string",
+      "enum": ["refreshToken"],
+      "description": "Which entry point the harness drives. refreshToken exercises both the sent form and the response decode in one round-trip."
+    },
+    "request": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Inputs to the refresh call beyond the harness's fixed endpoint/refresh-token/client-id.",
+      "properties": {
+        "resource": {
+          "type": "string",
+          "description": "RFC 8707 resource indicator passed to the refresh call. Omit to exercise the unset path."
+        }
+      }
+    },
+    "response": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["body"],
+      "properties": {
+        "status": { "type": "integer", "minimum": 100, "maximum": 599, "default": 200 },
+        "body": {
+          "type": "object",
+          "description": "Raw JSON token response the mock endpoint returns, verbatim — including malformed resource values the SDK must reject."
+        }
+      }
+    },
+    "expect": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["outcome"],
+      "properties": {
+        "outcome": {
+          "type": "string",
+          "enum": ["token", "reject"],
+          "description": "token: the call returns a token. reject: the call fails (Go surfaces a plain error; the other SDKs raise their api_error taxonomy)."
+        },
+        "resource": {
+          "type": "string",
+          "description": "On `token`: the exact resource value the returned token must carry."
+        },
+        "resourceAbsent": {
+          "type": "boolean",
+          "description": "On `token`: the returned token must carry NO resource (unset/nil/undefined)."
+        },
+        "formResource": {
+          "type": "string",
+          "description": "The exact `resource` form value the refresh request must have sent."
+        },
+        "formResourceAbsent": {
+          "type": "boolean",
+          "description": "The refresh request must NOT have sent a `resource` form key at all."
+        }
+      },
+      "allOf": [
+        {
+          "description": "A token fixture must pin the resource expectation one way or the other.",
+          "if": { "required": ["outcome"], "properties": { "outcome": { "const": "token" } } },
+          "then": { "anyOf": [{ "required": ["resource"] }, { "required": ["resourceAbsent"] }] }
+        }
+      ]
+    }
+  }
+}

--- a/conformance/oauth-token/schema.json
+++ b/conformance/oauth-token/schema.json
@@ -21,7 +21,8 @@
       "properties": {
         "resource": {
           "type": "string",
-          "description": "RFC 8707 resource indicator passed to the refresh call. Omit to exercise the unset path."
+          "minLength": 1,
+          "description": "RFC 8707 resource indicator passed to the refresh call. Omit to exercise the unset path (present-but-empty is malformed per SPEC \u00a716)."
         }
       }
     },
@@ -49,6 +50,7 @@
         },
         "resource": {
           "type": "string",
+          "minLength": 1,
           "description": "On `token`: the exact resource value the returned token must carry."
         },
         "resourceAbsent": {
@@ -57,6 +59,7 @@
         },
         "formResource": {
           "type": "string",
+          "minLength": 1,
           "description": "The exact `resource` form value the refresh request must have sent."
         },
         "formResourceAbsent": {

--- a/conformance/oauth-token/schema.json
+++ b/conformance/oauth-token/schema.json
@@ -52,16 +52,16 @@
           "description": "On `token`: the exact resource value the returned token must carry."
         },
         "resourceAbsent": {
-          "type": "boolean",
-          "description": "On `token`: the returned token must carry NO resource (unset/nil/undefined)."
+          "const": true,
+          "description": "On `token`: the returned token must carry NO resource (unset/nil/undefined). Only `true` is valid — every harness conditions the absence assertion on truthiness, so a `false` would satisfy the oneOf while asserting nothing."
         },
         "formResource": {
           "type": "string",
           "description": "The exact `resource` form value the refresh request must have sent."
         },
         "formResourceAbsent": {
-          "type": "boolean",
-          "description": "The refresh request must NOT have sent a `resource` form key at all."
+          "const": true,
+          "description": "The refresh request must NOT have sent a `resource` form key at all. Only `true` is valid — a `false` would assert nothing."
         }
       },
       "allOf": [

--- a/conformance/oauth-token/schema.json
+++ b/conformance/oauth-token/schema.json
@@ -66,9 +66,13 @@
       },
       "allOf": [
         {
-          "description": "A token fixture must pin the resource expectation one way or the other.",
+          "description": "A token fixture must pin the resource expectation exactly one way — a fixture stating both a value and absence is contradictory.",
           "if": { "required": ["outcome"], "properties": { "outcome": { "const": "token" } } },
-          "then": { "anyOf": [{ "required": ["resource"] }, { "required": ["resourceAbsent"] }] }
+          "then": { "oneOf": [{ "required": ["resource"] }, { "required": ["resourceAbsent"] }] }
+        },
+        {
+          "description": "formResource and formResourceAbsent are mutually exclusive — a fixture cannot both pin a sent value and assert the key was absent.",
+          "not": { "required": ["formResource", "formResourceAbsent"] }
         }
       ]
     }

--- a/conformance/oauth-token/schema.json
+++ b/conformance/oauth-token/schema.json
@@ -74,8 +74,8 @@
           "then": { "oneOf": [{ "required": ["resource"] }, { "required": ["resourceAbsent"] }] }
         },
         {
-          "description": "formResource and formResourceAbsent are mutually exclusive — a fixture cannot both pin a sent value and assert the key was absent.",
-          "not": { "required": ["formResource", "formResourceAbsent"] }
+          "description": "Every refresh round-trip sends a form: pin the resource key exactly one way. A fixture omitting both would silently skip the form assertion entirely, and stating both is contradictory.",
+          "oneOf": [{ "required": ["formResource"] }, { "required": ["formResourceAbsent"] }]
         }
       ]
     }

--- a/go/README.md
+++ b/go/README.md
@@ -290,9 +290,10 @@ err = authMgr.Store().Save(basecamp.NormalizeBaseURL(sdkCfg.BaseURL), &basecamp.
 ```
 
 Pass the discovered base origin without a trailing slash everywhere a base URL
-or issuer is expected: discovery binds the issuer code-point exact, so
-`https://app.basecamp.com/` (trailing slash) would silently soft-fall back to
-Launchpad.
+or issuer is expected: binding is code-point exact — a trailing-slash
+`WithExpectedIssuer` value fails the advertised-member lookup as a **hard**
+`ErrExpectedIssuerUnavailable`, while a trailing-slash resource origin breaks
+the hop-1 binding and silently soft-falls back to Launchpad.
 
 ## Configuration
 

--- a/go/README.md
+++ b/go/README.md
@@ -274,7 +274,11 @@ bridges the two — saving the client id it used and the token's resource so
 later refreshes can echo them:
 
 ```go
-import "github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
+import (
+    "net/http"
+
+    "github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
+)
 
 // sdkCfg is the SDK *basecamp.Config (the device-login example above binds
 // its discovery result to result.Config, an *oauth.Config — a different type).

--- a/go/README.md
+++ b/go/README.md
@@ -255,7 +255,41 @@ between polls, enforces a monotonic expiry deadline, sustains `slow_down` bumps
 cancellation. The clock (`oauth.WithDeviceClock`) and inter-poll wait
 (`oauth.WithDeviceSleep`) are injectable for deterministic tests; scope is
 omitted from the authorization request unless set with `oauth.WithDeviceScope`,
-so the server applies its default (`read`).
+so the server applies its default (`read`) — prefer pinning it explicitly.
+
+### Persisting device-login credentials (RFC 8707 resource echo)
+
+BC5 device logins as `basecamp-cli` mint **multi-account** refresh tokens: the
+token response carries an RFC 8707 `resource` indicator
+(`urn:bc:account:<id>`, on `token.Resource`), and every refresh of a
+multi-account token MUST send it back or the server rejects the refresh
+(400 `invalid_request`). `AuthManager` echoes the stored `resource` (and
+submits the stored `client_id` — BC5 public clients send no secret)
+automatically, and preserves the stored value when a refresh response omits
+it.
+
+The oauth helpers return an `*oauth.Token`; they never write the root
+package's `Credentials`. After a device login (or code exchange) the caller
+bridges the two — saving the client id it used and the token's resource so
+later refreshes can echo them:
+
+```go
+authMgr := basecamp.NewAuthManager(cfg, httpClient)
+err = authMgr.Store().Save(basecamp.NormalizeBaseURL(cfg.BaseURL), &basecamp.Credentials{
+    AccessToken:   token.AccessToken,
+    RefreshToken:  token.RefreshToken,
+    ExpiresAt:     token.ExpiresAt.Unix(),
+    Scope:         token.Scope,
+    TokenEndpoint: result.Config.TokenEndpoint,
+    ClientID:      "basecamp-cli",       // the id the login used
+    Resource:      token.Resource,       // the account binding to echo on refresh
+})
+```
+
+Pass the discovered base origin without a trailing slash everywhere a base URL
+or issuer is expected: discovery binds the issuer code-point exact, so
+`https://app.basecamp.com/` (trailing slash) would silently soft-fall back to
+Launchpad.
 
 ## Configuration
 

--- a/go/README.md
+++ b/go/README.md
@@ -274,8 +274,11 @@ bridges the two — saving the client id it used and the token's resource so
 later refreshes can echo them:
 
 ```go
-authMgr := basecamp.NewAuthManager(cfg, httpClient)
-err = authMgr.Store().Save(basecamp.NormalizeBaseURL(cfg.BaseURL), &basecamp.Credentials{
+// sdkCfg is the SDK *basecamp.Config (the device-login example above binds
+// its discovery result to result.Config, an *oauth.Config — a different type).
+sdkCfg := &basecamp.Config{BaseURL: "https://3.basecampapi.com"}
+authMgr := basecamp.NewAuthManager(sdkCfg, httpClient)
+err = authMgr.Store().Save(basecamp.NormalizeBaseURL(sdkCfg.BaseURL), &basecamp.Credentials{
     AccessToken:   token.AccessToken,
     RefreshToken:  token.RefreshToken,
     ExpiresAt:     token.ExpiresAt.Unix(),

--- a/go/README.md
+++ b/go/README.md
@@ -278,15 +278,21 @@ later refreshes can echo them:
 // its discovery result to result.Config, an *oauth.Config — a different type).
 sdkCfg := &basecamp.Config{BaseURL: "https://3.basecampapi.com"}
 authMgr := basecamp.NewAuthManager(sdkCfg, httpClient)
-err = authMgr.Store().Save(basecamp.NormalizeBaseURL(sdkCfg.BaseURL), &basecamp.Credentials{
+creds := &basecamp.Credentials{
     AccessToken:   token.AccessToken,
     RefreshToken:  token.RefreshToken,
-    ExpiresAt:     token.ExpiresAt.Unix(),
     Scope:         token.Scope,
     TokenEndpoint: result.Config.TokenEndpoint,
     ClientID:      "basecamp-cli",       // the id the login used
     Resource:      token.Resource,       // the account binding to echo on refresh
-})
+}
+// A token response may omit expires_in; a zero ExpiresAt means no known
+// expiry (never force-refreshed) — storing zero-time.Unix()'s negative value
+// would instead mark the fresh token expired.
+if !token.ExpiresAt.IsZero() {
+    creds.ExpiresAt = token.ExpiresAt.Unix()
+}
+err = authMgr.Store().Save(basecamp.NormalizeBaseURL(sdkCfg.BaseURL), creds)
 ```
 
 Pass the discovered base origin without a trailing slash everywhere a base URL

--- a/go/README.md
+++ b/go/README.md
@@ -274,10 +274,12 @@ bridges the two — saving the client id it used and the token's resource so
 later refreshes can echo them:
 
 ```go
+import "github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
+
 // sdkCfg is the SDK *basecamp.Config (the device-login example above binds
 // its discovery result to result.Config, an *oauth.Config — a different type).
 sdkCfg := &basecamp.Config{BaseURL: "https://3.basecampapi.com"}
-authMgr := basecamp.NewAuthManager(sdkCfg, httpClient)
+authMgr := basecamp.NewAuthManager(sdkCfg, http.DefaultClient)
 creds := &basecamp.Credentials{
     AccessToken:   token.AccessToken,
     RefreshToken:  token.RefreshToken,

--- a/go/pkg/basecamp/auth.go
+++ b/go/pkg/basecamp/auth.go
@@ -389,6 +389,12 @@ func (m *AuthManager) refreshLocked(ctx context.Context, origin string, creds *C
 	}
 	if tokenResp.ExpiresIn > 0 {
 		creds.ExpiresAt = time.Now().Unix() + tokenResp.ExpiresIn
+	} else {
+		// A refresh response may legally omit expires_in. Leaving the OLD
+		// (already-passed) ExpiresAt would mark the fresh token expired and
+		// force a refresh on EVERY subsequent call — clear to 0, the
+		// no-known-expiry state AccessToken never force-refreshes.
+		creds.ExpiresAt = 0
 	}
 	// An omitted (or null) resource preserves the stored binding
 	// (carry-forward, like an omitted rotated refresh_token); a present one

--- a/go/pkg/basecamp/auth.go
+++ b/go/pkg/basecamp/auth.go
@@ -382,9 +382,15 @@ func (m *AuthManager) refreshLocked(ctx context.Context, origin string, creds *C
 	if tokenResp.ExpiresIn > 0 {
 		creds.ExpiresAt = time.Now().Unix() + tokenResp.ExpiresIn
 	}
-	// An omitted resource preserves the stored binding (carry-forward, like an
-	// omitted rotated refresh_token); a present one replaces it.
-	if tokenResp.Resource != nil && *tokenResp.Resource != "" {
+	// An omitted (or null) resource preserves the stored binding
+	// (carry-forward, like an omitted rotated refresh_token); a present one
+	// replaces it. A present-but-EMPTY resource is a malformed response
+	// (SPEC §16: present ⇒ non-empty) — fail the refresh rather than
+	// persisting rotated credentials under a stale binding.
+	if tokenResp.Resource != nil {
+		if *tokenResp.Resource == "" {
+			return ErrAPI(resp.StatusCode, "token refresh response resource must be a non-empty string when present")
+		}
 		creds.Resource = *tokenResp.Resource
 	}
 

--- a/go/pkg/basecamp/auth.go
+++ b/go/pkg/basecamp/auth.go
@@ -394,6 +394,14 @@ func (m *AuthManager) refreshLocked(ctx context.Context, origin string, creds *C
 		return ErrAPI(resp.StatusCode, fmt.Sprintf("parsing token refresh response: %v", err))
 	}
 
+	// A 200 with a missing or empty access_token is a malformed response
+	// (SPEC §16), not a rotation: persisting it would overwrite working
+	// credentials with an unusable empty token — an effective logout. Fail
+	// before mutating anything, matching the device/exchange paths.
+	if tokenResp.AccessToken == "" {
+		return ErrAPI(resp.StatusCode, "token refresh response missing access_token")
+	}
+
 	creds.AccessToken = tokenResp.AccessToken
 	if tokenResp.RefreshToken != "" {
 		creds.RefreshToken = tokenResp.RefreshToken

--- a/go/pkg/basecamp/auth.go
+++ b/go/pkg/basecamp/auth.go
@@ -16,6 +16,14 @@ import (
 
 const serviceName = "basecamp-sdk"
 
+// maxRefreshTokenLifetimeSeconds caps a refresh response's expires_in at the
+// shared cross-SDK token-lifetime ceiling (2147483647 s ≈ 68 years, SPEC §16
+// — the same bound the oauth package's device/exchange parsers enforce). It
+// bounds the Unix-time addition in refreshLocked: an unbounded value like
+// math.MaxInt64 would overflow into a negative ExpiresAt that the
+// no-known-expiry rule reads as never-expiring.
+const maxRefreshTokenLifetimeSeconds = 2_147_483_647
+
 // Credentials holds OAuth tokens and metadata.
 type Credentials struct {
 	AccessToken   string `json:"access_token"`
@@ -403,6 +411,13 @@ func (m *AuthManager) refreshLocked(ctx context.Context, origin string, creds *C
 		// no-expiry would persist an already-expired token that never
 		// refreshes again. Fail without persisting anything.
 		return ErrAPI(resp.StatusCode, "token refresh response expires_in must be positive when present")
+	case *tokenResp.ExpiresIn > maxRefreshTokenLifetimeSeconds:
+		// An absurd lifetime (math.MaxInt64 above all) would overflow the
+		// Unix-time addition below into a NEGATIVE ExpiresAt — which the
+		// no-known-expiry rule then treats as never-expiring, so an
+		// effectively-expired token would never refresh again. The shared
+		// token-lifetime ceiling (SPEC §16) makes it a malformed response.
+		return ErrAPI(resp.StatusCode, fmt.Sprintf("token refresh response expires_in must be no greater than %d seconds", maxRefreshTokenLifetimeSeconds))
 	default:
 		creds.ExpiresAt = time.Now().Unix() + *tokenResp.ExpiresIn
 	}

--- a/go/pkg/basecamp/auth.go
+++ b/go/pkg/basecamp/auth.go
@@ -24,6 +24,22 @@ type Credentials struct {
 	Scope         string `json:"scope"`
 	TokenEndpoint string `json:"token_endpoint"`
 	UserID        string `json:"user_id,omitempty"`
+
+	// ClientID is the OAuth client the tokens were issued to. BC5 public
+	// clients (token_endpoint_auth_method: none) authenticate refreshes by
+	// client_id alone, so refresh submits it when present.
+	ClientID string `json:"client_id,omitempty"`
+
+	// Resource is the RFC 8707 resource indicator the tokens are bound to
+	// (BC5: urn:bc:account:<id>). Refresh echoes it and preserves it when a
+	// refresh response omits it — BC5 multi-account refresh tokens reject a
+	// refresh without it (SPEC §16).
+	//
+	// The oauth helpers only return an oauth.Token; after a device login or
+	// code exchange the CALLER saves Credentials carrying the ClientID it
+	// used and the token's Resource (see the README OAuth section) — there is
+	// no automatic bridge from oauth.Token to Credentials.
+	Resource string `json:"resource,omitempty"`
 }
 
 // TokenProvider is the interface for obtaining access tokens.
@@ -317,6 +333,12 @@ func (m *AuthManager) refreshLocked(ctx context.Context, origin string, creds *C
 	data := url.Values{}
 	data.Set("grant_type", "refresh_token")
 	data.Set("refresh_token", creds.RefreshToken)
+	if creds.ClientID != "" {
+		data.Set("client_id", creds.ClientID)
+	}
+	if creds.Resource != "" {
+		data.Set("resource", creds.Resource)
+	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", tokenEndpoint, strings.NewReader(data.Encode()))
 	if err != nil {
@@ -339,6 +361,10 @@ func (m *AuthManager) refreshLocked(ctx context.Context, origin string, creds *C
 		AccessToken  string `json:"access_token"`
 		RefreshToken string `json:"refresh_token"`
 		ExpiresIn    int64  `json:"expires_in"`
+		// *string so an omitted (or null) resource is distinguishable from a
+		// present one: omission preserves the stored value, presence replaces
+		// it (SPEC §16 lifecycle rule).
+		Resource *string `json:"resource"`
 	}
 	const maxTokenResponseSize int64 = 1 << 20 // 1 MB
 	body, err := limitedReadAll(resp.Body, maxTokenResponseSize)
@@ -355,6 +381,11 @@ func (m *AuthManager) refreshLocked(ctx context.Context, origin string, creds *C
 	}
 	if tokenResp.ExpiresIn > 0 {
 		creds.ExpiresAt = time.Now().Unix() + tokenResp.ExpiresIn
+	}
+	// An omitted resource preserves the stored binding (carry-forward, like an
+	// omitted rotated refresh_token); a present one replaces it.
+	if tokenResp.Resource != nil && *tokenResp.Resource != "" {
+		creds.Resource = *tokenResp.Resource
 	}
 
 	return m.store.Save(origin, creds)

--- a/go/pkg/basecamp/auth.go
+++ b/go/pkg/basecamp/auth.go
@@ -365,7 +365,10 @@ func (m *AuthManager) refreshLocked(ctx context.Context, origin string, creds *C
 	var tokenResp struct {
 		AccessToken  string `json:"access_token"`
 		RefreshToken string `json:"refresh_token"`
-		ExpiresIn    int64  `json:"expires_in"`
+		// *int64 so an omitted (or null) expires_in is distinguishable from an
+		// explicit value: omission clears the stale expiry (no known expiry),
+		// while an explicit non-positive value is a malformed response.
+		ExpiresIn *int64 `json:"expires_in"`
 		// *string so an omitted (or null) resource is distinguishable from a
 		// present one: omission preserves the stored value, presence replaces
 		// it (SPEC §16 lifecycle rule).
@@ -387,14 +390,21 @@ func (m *AuthManager) refreshLocked(ctx context.Context, origin string, creds *C
 	if tokenResp.RefreshToken != "" {
 		creds.RefreshToken = tokenResp.RefreshToken
 	}
-	if tokenResp.ExpiresIn > 0 {
-		creds.ExpiresAt = time.Now().Unix() + tokenResp.ExpiresIn
-	} else {
+	switch {
+	case tokenResp.ExpiresIn == nil:
 		// A refresh response may legally omit expires_in. Leaving the OLD
 		// (already-passed) ExpiresAt would mark the fresh token expired and
 		// force a refresh on EVERY subsequent call — clear to 0, the
 		// no-known-expiry state AccessToken never force-refreshes.
 		creds.ExpiresAt = 0
+	case *tokenResp.ExpiresIn <= 0:
+		// An EXPLICIT zero/negative lifetime is a malformed response, not an
+		// omission (SPEC §16's positive-lifetime rule): treating it as
+		// no-expiry would persist an already-expired token that never
+		// refreshes again. Fail without persisting anything.
+		return ErrAPI(resp.StatusCode, "token refresh response expires_in must be positive when present")
+	default:
+		creds.ExpiresAt = time.Now().Unix() + *tokenResp.ExpiresIn
 	}
 	// An omitted (or null) resource preserves the stored binding
 	// (carry-forward, like an omitted rotated refresh_token); a present one

--- a/go/pkg/basecamp/auth.go
+++ b/go/pkg/basecamp/auth.go
@@ -372,7 +372,10 @@ func (m *AuthManager) refreshLocked(ctx context.Context, origin string, creds *C
 		return fmt.Errorf("reading token response: %w", err)
 	}
 	if err := json.Unmarshal(body, &tokenResp); err != nil {
-		return err
+		// A malformed 200 body — including a non-string resource failing the
+		// *string decode — is an api fault (SPEC §16), not a raw
+		// json.UnmarshalTypeError callers cannot classify.
+		return ErrAPI(resp.StatusCode, fmt.Sprintf("parsing token refresh response: %v", err))
 	}
 
 	creds.AccessToken = tokenResp.AccessToken

--- a/go/pkg/basecamp/auth.go
+++ b/go/pkg/basecamp/auth.go
@@ -402,17 +402,17 @@ func (m *AuthManager) refreshLocked(ctx context.Context, origin string, creds *C
 		return ErrAPI(resp.StatusCode, "token refresh response missing access_token")
 	}
 
-	creds.AccessToken = tokenResp.AccessToken
-	if tokenResp.RefreshToken != "" {
-		creds.RefreshToken = tokenResp.RefreshToken
-	}
+	// Validate EVERYTHING before mutating creds — an error return below must
+	// not leave a partially-updated in-memory Credentials behind (the nearby
+	// access_token check states the same fail-before-mutating intent).
+	var expiresAt int64
 	switch {
 	case tokenResp.ExpiresIn == nil:
 		// A refresh response may legally omit expires_in. Leaving the OLD
 		// (already-passed) ExpiresAt would mark the fresh token expired and
 		// force a refresh on EVERY subsequent call — clear to 0, the
 		// no-known-expiry state AccessToken never force-refreshes.
-		creds.ExpiresAt = 0
+		expiresAt = 0
 	case *tokenResp.ExpiresIn <= 0:
 		// An EXPLICIT zero/negative lifetime is a malformed response, not an
 		// omission (SPEC §16's positive-lifetime rule): treating it as
@@ -427,17 +427,23 @@ func (m *AuthManager) refreshLocked(ctx context.Context, origin string, creds *C
 		// token-lifetime ceiling (SPEC §16) makes it a malformed response.
 		return ErrAPI(resp.StatusCode, fmt.Sprintf("token refresh response expires_in must be no greater than %d seconds", maxRefreshTokenLifetimeSeconds))
 	default:
-		creds.ExpiresAt = time.Now().Unix() + *tokenResp.ExpiresIn
+		expiresAt = time.Now().Unix() + *tokenResp.ExpiresIn
 	}
 	// An omitted (or null) resource preserves the stored binding
 	// (carry-forward, like an omitted rotated refresh_token); a present one
 	// replaces it. A present-but-EMPTY resource is a malformed response
 	// (SPEC §16: present ⇒ non-empty) — fail the refresh rather than
 	// persisting rotated credentials under a stale binding.
+	if tokenResp.Resource != nil && *tokenResp.Resource == "" {
+		return ErrAPI(resp.StatusCode, "token refresh response resource must be a non-empty string when present")
+	}
+
+	creds.AccessToken = tokenResp.AccessToken
+	if tokenResp.RefreshToken != "" {
+		creds.RefreshToken = tokenResp.RefreshToken
+	}
+	creds.ExpiresAt = expiresAt
 	if tokenResp.Resource != nil {
-		if *tokenResp.Resource == "" {
-			return ErrAPI(resp.StatusCode, "token refresh response resource must be a non-empty string when present")
-		}
 		creds.Resource = *tokenResp.Resource
 	}
 

--- a/go/pkg/basecamp/auth.go
+++ b/go/pkg/basecamp/auth.go
@@ -270,8 +270,13 @@ func (m *AuthManager) AccessToken(ctx context.Context) (string, error) {
 		return "", ErrAuth("Not authenticated")
 	}
 
-	// Check if token is expired (with 5 minute buffer)
-	if time.Now().Unix() >= creds.ExpiresAt-300 {
+	// Check if token is expired (with 5 minute buffer). ExpiresAt <= 0 means
+	// NO KNOWN EXPIRY (a token response may legally omit expires_in — the
+	// device/exchange parsers leave ExpiresAt zero, and refreshLocked stores
+	// no expiry when the server sends none): such credentials are used as-is,
+	// never force-refreshed — a fresh token without a refresh token would
+	// otherwise hard-fail here despite being perfectly usable.
+	if creds.ExpiresAt > 0 && time.Now().Unix() >= creds.ExpiresAt-300 {
 		if err := m.refreshLocked(ctx, origin, creds); err != nil {
 			return "", err
 		}

--- a/go/pkg/basecamp/auth_test.go
+++ b/go/pkg/basecamp/auth_test.go
@@ -491,3 +491,40 @@ func TestAuthManager_Refresh_NonStringResourceIsAPIError(t *testing.T) {
 		t.Errorf("want *basecamp.Error with code %q, got %v", CodeAPI, err)
 	}
 }
+
+func TestAuthManager_AccessToken_NoExpiryIsNotRefreshed(t *testing.T) {
+	t.Setenv("BASECAMP_TOKEN", "")
+	t.Setenv("BASECAMP_NO_KEYRING", "1")
+
+	// ExpiresAt <= 0 means no known expiry (a token response may omit
+	// expires_in): the credential is used as-is — a forced refresh would
+	// hard-fail a fresh, usable token that carries no refresh token.
+	refreshed := false
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		refreshed = true
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
+
+	store := &CredentialStore{useKeyring: false, fallbackDir: t.TempDir()}
+	origin := NormalizeBaseURL(ts.URL)
+	for _, expiresAt := range []int64{0, -62135596800} { // zero and time.Time{}.Unix()
+		_ = store.Save(origin, &Credentials{
+			AccessToken:   "fresh-access",
+			TokenEndpoint: ts.URL + "/token",
+			ExpiresAt:     expiresAt,
+		})
+
+		m := NewAuthManagerWithStore(&Config{BaseURL: ts.URL}, ts.Client(), store)
+		tok, err := m.AccessToken(context.Background())
+		if err != nil {
+			t.Fatalf("ExpiresAt=%d: %v", expiresAt, err)
+		}
+		if tok != "fresh-access" {
+			t.Errorf("ExpiresAt=%d: token = %q", expiresAt, tok)
+		}
+	}
+	if refreshed {
+		t.Error("no-expiry credentials must never be force-refreshed")
+	}
+}

--- a/go/pkg/basecamp/auth_test.go
+++ b/go/pkg/basecamp/auth_test.go
@@ -578,3 +578,47 @@ func TestAuthManager_Refresh_OmittedExpiresInClearsStaleExpiry(t *testing.T) {
 		t.Errorf("ExpiresAt = %d, want 0 (no known expiry)", creds.ExpiresAt)
 	}
 }
+
+func TestAuthManager_Refresh_ExplicitNonPositiveExpiresInIsAPIError(t *testing.T) {
+	t.Setenv("BASECAMP_TOKEN", "")
+	t.Setenv("BASECAMP_NO_KEYRING", "1")
+
+	// An explicit zero/negative expires_in is malformed — distinct from
+	// omission (which clears to no-known-expiry): persisting it as
+	// non-expiring would store an already-expired token that never refreshes.
+	for _, expiresIn := range []int64{0, -30} {
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"access_token": "new-access",
+				"expires_in":   expiresIn,
+			})
+		}))
+
+		store := &CredentialStore{useKeyring: false, fallbackDir: t.TempDir()}
+		origin := NormalizeBaseURL(ts.URL)
+		_ = store.Save(origin, &Credentials{
+			AccessToken:   "old-access",
+			RefreshToken:  "old-refresh",
+			ExpiresAt:     1,
+			TokenEndpoint: ts.URL + "/token",
+		})
+
+		m := NewAuthManagerWithStore(&Config{BaseURL: ts.URL}, ts.Client(), store)
+		err := m.Refresh(context.Background())
+		if err == nil {
+			t.Fatalf("expires_in=%d: expected api_error", expiresIn)
+		}
+		var be *Error
+		if !errors.As(err, &be) || be.Code != CodeAPI {
+			t.Errorf("expires_in=%d: want *basecamp.Error CodeAPI, got %v", expiresIn, err)
+		}
+
+		// Nothing was persisted — the old credentials stand.
+		creds, _ := store.Load(origin)
+		if creds.AccessToken != "old-access" {
+			t.Errorf("expires_in=%d: AccessToken = %q, want untouched", expiresIn, creds.AccessToken)
+		}
+		ts.Close()
+	}
+}

--- a/go/pkg/basecamp/auth_test.go
+++ b/go/pkg/basecamp/auth_test.go
@@ -406,3 +406,50 @@ func TestAuthManager_Refresh_ResponseResourceReplacesStored(t *testing.T) {
 		t.Errorf("stored Resource = %q, want replaced urn:bc:account:7", creds.Resource)
 	}
 }
+
+func TestAuthManager_Refresh_RejectsEmptyResource(t *testing.T) {
+	t.Setenv("BASECAMP_TOKEN", "")
+	t.Setenv("BASECAMP_NO_KEYRING", "1")
+
+	// A present-but-empty resource is malformed (SPEC §16): the refresh must
+	// FAIL — persisting the rotated tokens while silently keeping the old
+	// binding would store credentials under a stale resource.
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "new-access",
+			"resource":     "",
+		})
+	}))
+	defer ts.Close()
+
+	store := &CredentialStore{useKeyring: false, fallbackDir: t.TempDir()}
+	origin := NormalizeBaseURL(ts.URL)
+	_ = store.Save(origin, &Credentials{
+		AccessToken:   "old-access",
+		RefreshToken:  "old-refresh",
+		ExpiresAt:     1,
+		TokenEndpoint: ts.URL + "/token",
+		Resource:      "urn:bc:account:42",
+	})
+
+	cfg := &Config{BaseURL: ts.URL}
+	m := NewAuthManagerWithStore(cfg, ts.Client(), store)
+
+	err := m.Refresh(context.Background())
+	if err == nil {
+		t.Fatal("expected error for present-but-empty resource")
+	}
+	if !strings.Contains(err.Error(), "resource") {
+		t.Errorf("error = %q, expected mention of resource", err.Error())
+	}
+
+	// The stored credentials must be untouched — no rotation was persisted.
+	creds, _ := store.Load(origin)
+	if creds.AccessToken != "old-access" {
+		t.Errorf("AccessToken = %q, want old-access untouched", creds.AccessToken)
+	}
+	if creds.Resource != "urn:bc:account:42" {
+		t.Errorf("Resource = %q, want untouched binding", creds.Resource)
+	}
+}

--- a/go/pkg/basecamp/auth_test.go
+++ b/go/pkg/basecamp/auth_test.go
@@ -586,7 +586,7 @@ func TestAuthManager_Refresh_ExplicitNonPositiveExpiresInIsAPIError(t *testing.T
 	// An explicit zero/negative expires_in is malformed — distinct from
 	// omission (which clears to no-known-expiry): persisting it as
 	// non-expiring would store an already-expired token that never refreshes.
-	for _, expiresIn := range []int64{0, -30} {
+	for _, expiresIn := range []int64{0, -30, 9223372036854775807} {
 		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]any{

--- a/go/pkg/basecamp/auth_test.go
+++ b/go/pkg/basecamp/auth_test.go
@@ -318,3 +318,91 @@ func TestCredentialStore_UsingKeyring(t *testing.T) {
 		t.Error("expected UsingKeyring=false")
 	}
 }
+
+func TestAuthManager_Refresh_EchoesClientIDAndResource(t *testing.T) {
+	t.Setenv("BASECAMP_TOKEN", "")
+	t.Setenv("BASECAMP_NO_KEYRING", "1")
+
+	// The refresh response deliberately OMITS resource: the stored binding
+	// must be echoed on the form and survive the rotation (SPEC §16).
+	var gotClientID, gotResource string
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotClientID = r.PostFormValue("client_id")
+		gotResource = r.PostFormValue("resource")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "new-access",
+			"refresh_token": "new-refresh",
+			"expires_in":    3600,
+		})
+	}))
+	defer ts.Close()
+
+	store := &CredentialStore{useKeyring: false, fallbackDir: t.TempDir()}
+	origin := NormalizeBaseURL(ts.URL)
+	_ = store.Save(origin, &Credentials{
+		AccessToken:   "old-access",
+		RefreshToken:  "old-refresh",
+		ExpiresAt:     1,
+		TokenEndpoint: ts.URL + "/token",
+		ClientID:      "basecamp-cli",
+		Resource:      "urn:bc:account:42",
+	})
+
+	cfg := &Config{BaseURL: ts.URL}
+	m := NewAuthManagerWithStore(cfg, ts.Client(), store)
+
+	if err := m.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if gotClientID != "basecamp-cli" {
+		t.Errorf("client_id form value = %q, want basecamp-cli", gotClientID)
+	}
+	if gotResource != "urn:bc:account:42" {
+		t.Errorf("resource form value = %q, want urn:bc:account:42", gotResource)
+	}
+
+	creds, _ := store.Load(origin)
+	if creds.Resource != "urn:bc:account:42" {
+		t.Errorf("stored Resource = %q, want preserved urn:bc:account:42", creds.Resource)
+	}
+	if creds.ClientID != "basecamp-cli" {
+		t.Errorf("stored ClientID = %q, want basecamp-cli", creds.ClientID)
+	}
+}
+
+func TestAuthManager_Refresh_ResponseResourceReplacesStored(t *testing.T) {
+	t.Setenv("BASECAMP_TOKEN", "")
+	t.Setenv("BASECAMP_NO_KEYRING", "1")
+
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "new-access",
+			"resource":     "urn:bc:account:7",
+		})
+	}))
+	defer ts.Close()
+
+	store := &CredentialStore{useKeyring: false, fallbackDir: t.TempDir()}
+	origin := NormalizeBaseURL(ts.URL)
+	_ = store.Save(origin, &Credentials{
+		AccessToken:   "old-access",
+		RefreshToken:  "old-refresh",
+		ExpiresAt:     1,
+		TokenEndpoint: ts.URL + "/token",
+		Resource:      "urn:bc:account:42",
+	})
+
+	cfg := &Config{BaseURL: ts.URL}
+	m := NewAuthManagerWithStore(cfg, ts.Client(), store)
+
+	if err := m.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	creds, _ := store.Load(origin)
+	if creds.Resource != "urn:bc:account:7" {
+		t.Errorf("stored Resource = %q, want replaced urn:bc:account:7", creds.Resource)
+	}
+}

--- a/go/pkg/basecamp/auth_test.go
+++ b/go/pkg/basecamp/auth_test.go
@@ -528,3 +528,53 @@ func TestAuthManager_AccessToken_NoExpiryIsNotRefreshed(t *testing.T) {
 		t.Error("no-expiry credentials must never be force-refreshed")
 	}
 }
+
+func TestAuthManager_Refresh_OmittedExpiresInClearsStaleExpiry(t *testing.T) {
+	t.Setenv("BASECAMP_TOKEN", "")
+	t.Setenv("BASECAMP_NO_KEYRING", "1")
+
+	// A refresh response that omits expires_in must CLEAR the old expiry:
+	// keeping the stale past ExpiresAt would force a refresh on every
+	// subsequent AccessToken call despite the fresh token.
+	refreshes := 0
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		refreshes++
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "new-access",
+			"refresh_token": "new-refresh",
+		})
+	}))
+	defer ts.Close()
+
+	store := &CredentialStore{useKeyring: false, fallbackDir: t.TempDir()}
+	origin := NormalizeBaseURL(ts.URL)
+	_ = store.Save(origin, &Credentials{
+		AccessToken:   "old-access",
+		RefreshToken:  "old-refresh",
+		ExpiresAt:     1, // long past
+		TokenEndpoint: ts.URL + "/token",
+	})
+
+	m := NewAuthManagerWithStore(&Config{BaseURL: ts.URL}, ts.Client(), store)
+
+	// First call refreshes (stale expiry) and stores the new token with no
+	// known expiry; the second call must use it as-is.
+	for i := 0; i < 2; i++ {
+		tok, err := m.AccessToken(context.Background())
+		if err != nil {
+			t.Fatalf("call %d: %v", i+1, err)
+		}
+		if tok != "new-access" {
+			t.Errorf("call %d: token = %q", i+1, tok)
+		}
+	}
+	if refreshes != 1 {
+		t.Errorf("refreshes = %d, want exactly 1 (stale expiry cleared)", refreshes)
+	}
+
+	creds, _ := store.Load(origin)
+	if creds.ExpiresAt != 0 {
+		t.Errorf("ExpiresAt = %d, want 0 (no known expiry)", creds.ExpiresAt)
+	}
+}

--- a/go/pkg/basecamp/auth_test.go
+++ b/go/pkg/basecamp/auth_test.go
@@ -3,6 +3,7 @@ package basecamp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -451,5 +452,42 @@ func TestAuthManager_Refresh_RejectsEmptyResource(t *testing.T) {
 	}
 	if creds.Resource != "urn:bc:account:42" {
 		t.Errorf("Resource = %q, want untouched binding", creds.Resource)
+	}
+}
+
+func TestAuthManager_Refresh_NonStringResourceIsAPIError(t *testing.T) {
+	t.Setenv("BASECAMP_TOKEN", "")
+	t.Setenv("BASECAMP_NO_KEYRING", "1")
+
+	// A non-string resource fails the *string decode; that malformed 200 body
+	// must surface as a classifiable api_error, not a raw UnmarshalTypeError.
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "new-access",
+			"resource":     7,
+		})
+	}))
+	defer ts.Close()
+
+	store := &CredentialStore{useKeyring: false, fallbackDir: t.TempDir()}
+	origin := NormalizeBaseURL(ts.URL)
+	_ = store.Save(origin, &Credentials{
+		AccessToken:   "old-access",
+		RefreshToken:  "old-refresh",
+		ExpiresAt:     1,
+		TokenEndpoint: ts.URL + "/token",
+	})
+
+	cfg := &Config{BaseURL: ts.URL}
+	m := NewAuthManagerWithStore(cfg, ts.Client(), store)
+
+	err := m.Refresh(context.Background())
+	if err == nil {
+		t.Fatal("expected error for non-string resource")
+	}
+	var be *Error
+	if !errors.As(err, &be) || be.Code != CodeAPI {
+		t.Errorf("want *basecamp.Error with code %q, got %v", CodeAPI, err)
 	}
 }

--- a/go/pkg/basecamp/auth_test.go
+++ b/go/pkg/basecamp/auth_test.go
@@ -455,6 +455,55 @@ func TestAuthManager_Refresh_RejectsEmptyResource(t *testing.T) {
 	}
 }
 
+func TestAuthManager_Refresh_MissingAccessTokenIsAPIError(t *testing.T) {
+	t.Setenv("BASECAMP_TOKEN", "")
+	t.Setenv("BASECAMP_NO_KEYRING", "1")
+
+	// A 200 with a missing (or empty) access_token is a malformed response,
+	// not a rotation: persisting it would overwrite working credentials with
+	// an unusable empty token — an effective logout. The device and exchange
+	// paths already classify this as an api fault; the refresh must too.
+	for _, body := range []map[string]any{
+		{"refresh_token": "rotated-refresh"},
+		{"access_token": "", "refresh_token": "rotated-refresh"},
+	} {
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(body)
+		}))
+
+		store := &CredentialStore{useKeyring: false, fallbackDir: t.TempDir()}
+		origin := NormalizeBaseURL(ts.URL)
+		_ = store.Save(origin, &Credentials{
+			AccessToken:   "old-access",
+			RefreshToken:  "old-refresh",
+			ExpiresAt:     1,
+			TokenEndpoint: ts.URL + "/token",
+		})
+
+		cfg := &Config{BaseURL: ts.URL}
+		m := NewAuthManagerWithStore(cfg, ts.Client(), store)
+
+		err := m.Refresh(context.Background())
+		if err == nil {
+			t.Fatalf("body %v: expected error for missing access_token", body)
+		}
+		if !strings.Contains(err.Error(), "access_token") {
+			t.Errorf("body %v: error = %q, expected mention of access_token", body, err.Error())
+		}
+
+		// The stored credentials must be untouched — no rotation persisted.
+		creds, _ := store.Load(origin)
+		if creds.AccessToken != "old-access" {
+			t.Errorf("body %v: AccessToken = %q, want old-access untouched", body, creds.AccessToken)
+		}
+		if creds.RefreshToken != "old-refresh" {
+			t.Errorf("body %v: RefreshToken = %q, want old-refresh untouched", body, creds.RefreshToken)
+		}
+		ts.Close()
+	}
+}
+
 func TestAuthManager_Refresh_NonStringResourceIsAPIError(t *testing.T) {
 	t.Setenv("BASECAMP_TOKEN", "")
 	t.Setenv("BASECAMP_NO_KEYRING", "1")

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -738,6 +738,15 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 				oauthError = oauthError[:maxErrorMessageLen-3] + "..."
 			}
 		}
+		// A 429 recognizes ONLY too_many_requests (the exact retryable pair):
+		// a throttling endpoint whose body parrots authorization_pending or
+		// slow_down must not keep the loop polling until code expiry — any
+		// other code on a 429 is forced to http_429 and terminates as
+		// api_error. Conversely too_many_requests off a 429 is already
+		// terminal in the loop.
+		if resp.StatusCode == http.StatusTooManyRequests && oauthError != "too_many_requests" {
+			oauthError = fmt.Sprintf("http_%d", resp.StatusCode)
+		}
 	}
 	return pollResult{kind: pollOAuthError, oauthError: oauthError, status: resp.StatusCode,
 		retryAfter: resp.Header.Get("Retry-After")}

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -551,11 +551,12 @@ type pollResult struct {
 }
 
 // parseRetryAfterSeconds validates a Retry-After delta for the 429 poll
-// contract (SPEC §16): ASCII digits only (HTTP delta-seconds permits no sign),
-// positive, no greater than maxDeviceSeconds (the shared 32-bit-ms timer
-// bound). Anything else — missing, an HTTP-date, signed ("+30"), fractional,
-// non-positive, or overflowing — returns 0 so the caller falls back to the
-// current interval. Trimming is ASCII SP/HTAB only (RFC 9110 OWS) — NOT
+// contract (SPEC §16): ASCII digits only (HTTP delta-seconds permits no
+// sign), positive. A representable delta beyond maxDeviceSeconds (the shared
+// 32-bit-ms timer bound) CLAMPS to the ceiling — the wait rule clips to the
+// remaining code lifetime, honoring the throttle. Anything else — missing,
+// an HTTP-date, signed ("+30"), fractional, non-positive, or unrepresentable
+// (ErrRange) — returns 0 so the caller falls back to the current interval. Trimming is ASCII SP/HTAB only (RFC 9110 OWS) — NOT
 // strings.TrimSpace, whose Unicode whitespace (NBSP above all) would trim a
 // malformed value into validity.
 func parseRetryAfterSeconds(header string) int {

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -617,6 +617,10 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 			TokenType    *string  `json:"token_type"`
 			ExpiresIn    *float64 `json:"expires_in"`
 			Scope        *string  `json:"scope"`
+			// *string like token_type: absent and JSON null map to nil, while
+			// a present-but-empty "" is malformed (SPEC §16 resource rule) —
+			// a plain string could not tell those apart.
+			Resource *string `json:"resource"`
 		}
 		if err := json.Unmarshal(body, &raw); err != nil {
 			return pollResult{kind: pollInvalidResponse, status: resp.StatusCode, err: fmt.Errorf("parsing device token response: %w", err)}
@@ -626,6 +630,9 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 		}
 		if raw.TokenType != nil && *raw.TokenType == "" {
 			return pollResult{kind: pollInvalidResponse, status: resp.StatusCode, err: errors.New("device token response token_type must be a non-empty string")}
+		}
+		if raw.Resource != nil && *raw.Resource == "" {
+			return pollResult{kind: pollInvalidResponse, status: resp.StatusCode, err: errors.New("device token response resource must be a non-empty string when present")}
 		}
 		token := Token{
 			AccessToken: raw.AccessToken,
@@ -639,6 +646,9 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 		}
 		if raw.TokenType != nil {
 			token.TokenType = *raw.TokenType
+		}
+		if raw.Resource != nil {
+			token.Resource = *raw.Resource
 		}
 		// When present, expires_in must be a positive WHOLE number of seconds no
 		// greater than maxTokenLifetimeSeconds — an explicit 0, a fractional

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -756,8 +756,15 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 			oauthError = fmt.Sprintf("http_%d", resp.StatusCode)
 		}
 	}
+	// Exactly one Retry-After field line: duplicates make the combined field
+	// ambiguous (Header.Get silently takes the first), so anything but a
+	// single value falls back to the current interval via the empty string.
+	retryAfter := ""
+	if vals := resp.Header.Values("Retry-After"); len(vals) == 1 {
+		retryAfter = vals[0]
+	}
 	return pollResult{kind: pollOAuthError, oauthError: oauthError, status: resp.StatusCode,
-		retryAfter: resp.Header.Get("Retry-After")}
+		retryAfter: retryAfter}
 }
 
 // PerformDeviceLogin runs the full RFC 8628 device authorization grant against

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -569,8 +569,19 @@ func parseRetryAfterSeconds(header string) int {
 			return 0
 		}
 	}
+	// The shared 10-significant-digit bound (SPEC §16): strip leading zeros
+	// first so a padded in-range delta is honored, then treat longer strings
+	// as unrepresentable → interval fallback — matching TS/Python/Ruby, where
+	// an 11-digit delta must not clamp in one SDK and fall back in another.
+	significant := strings.TrimLeft(trimmed, "0")
+	if significant == "" {
+		significant = "0"
+	}
+	if len(significant) > 10 {
+		return 0
+	}
 	// A digit string too long for int returns ErrRange → malformed → 0.
-	v, err := strconv.Atoi(trimmed)
+	v, err := strconv.Atoi(significant)
 	if err != nil || v <= 0 {
 		return 0
 	}

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -411,6 +412,10 @@ func pollDeviceTokenUntil(ctx context.Context, cfg deviceConfig, tokenEndpoint, 
 		intervalSeconds = defaultDeviceInterval
 	}
 	backoffSeconds := intervalSeconds
+	// One-shot next-wait override from a 429 too_many_requests Retry-After
+	// (SPEC §16): consumed by the next wait, never inflating the slow_down
+	// interval. 0 = none.
+	overrideSeconds := 0
 
 	form := url.Values{}
 	form.Set("grant_type", DeviceCodeGrantType)
@@ -432,7 +437,8 @@ func pollDeviceTokenUntil(ctx context.Context, cfg deviceConfig, tokenEndpoint, 
 		// backoff, whichever is larger, clamped to the time left before the
 		// deadline so a long backoff never overshoots expiry; the deadline
 		// check below then terminates the flow promptly.
-		wait := time.Duration(max(intervalSeconds, backoffSeconds)) * time.Second
+		wait := time.Duration(max(intervalSeconds, backoffSeconds, overrideSeconds)) * time.Second
+		overrideSeconds = 0 // one-shot: consumed by this wait, then gone
 		if remaining < wait {
 			wait = remaining
 		}
@@ -483,6 +489,18 @@ func pollDeviceTokenUntil(ctx context.Context, cfg deviceConfig, tokenEndpoint, 
 			switch result.oauthError {
 			case "authorization_pending":
 				continue
+			case "too_many_requests":
+				// Retryable ONLY as the exact 429 + too_many_requests pair
+				// (SPEC §16). The next wait honors a positive integral
+				// Retry-After delta via a one-shot max(interval, Retry-After)
+				// override — a missing/malformed header falls back to the
+				// current interval, and the override decays after one wait.
+				if result.status != http.StatusTooManyRequests {
+					return nil, basecamp.ErrAPI(result.status,
+						fmt.Sprintf("device token request failed: %s", result.oauthError))
+				}
+				overrideSeconds = parseRetryAfterSeconds(result.retryAfter)
+				continue
 			case "slow_down":
 				intervalSeconds += slowDownIncrementSeconds
 				// Re-sync the backoff to the GROWN interval: the reset above used
@@ -527,6 +545,22 @@ type pollResult struct {
 	oauthError string
 	status     int
 	err        error
+	// retryAfter is the raw Retry-After header on an OAuth-error response,
+	// consumed by the loop's 429 too_many_requests handling only.
+	retryAfter string
+}
+
+// parseRetryAfterSeconds validates a Retry-After delta for the 429 poll
+// contract (SPEC §16): a positive integral number of seconds no greater than
+// maxDeviceSeconds (the shared 32-bit-ms timer bound). Anything else —
+// missing, an HTTP-date, fractional, non-positive, or overflowing — returns 0
+// so the caller falls back to the current interval.
+func parseRetryAfterSeconds(header string) int {
+	v, err := strconv.Atoi(strings.TrimSpace(header))
+	if err != nil || v <= 0 || v > maxDeviceSeconds {
+		return 0
+	}
+	return v
 }
 
 // postDeviceToken performs one token-endpoint poll and classifies the outcome.
@@ -694,7 +728,8 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 			}
 		}
 	}
-	return pollResult{kind: pollOAuthError, oauthError: oauthError, status: resp.StatusCode}
+	return pollResult{kind: pollOAuthError, oauthError: oauthError, status: resp.StatusCode,
+		retryAfter: resp.Header.Get("Retry-After")}
 }
 
 // PerformDeviceLogin runs the full RFC 8628 device authorization grant against

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -555,9 +555,11 @@ type pollResult struct {
 // positive, no greater than maxDeviceSeconds (the shared 32-bit-ms timer
 // bound). Anything else — missing, an HTTP-date, signed ("+30"), fractional,
 // non-positive, or overflowing — returns 0 so the caller falls back to the
-// current interval.
+// current interval. Trimming is ASCII SP/HTAB only (RFC 9110 OWS) — NOT
+// strings.TrimSpace, whose Unicode whitespace (NBSP above all) would trim a
+// malformed value into validity.
 func parseRetryAfterSeconds(header string) int {
-	trimmed := strings.TrimSpace(header)
+	trimmed := strings.Trim(header, " \t")
 	if trimmed == "" {
 		return 0
 	}

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -570,10 +570,15 @@ func parseRetryAfterSeconds(header string) int {
 	}
 	// A digit string too long for int returns ErrRange → malformed → 0.
 	v, err := strconv.Atoi(trimmed)
-	if err != nil || v <= 0 || v > maxDeviceSeconds {
+	if err != nil || v <= 0 {
 		return 0
 	}
-	return v
+	// A REPRESENTABLE delta beyond the shared device ceiling clamps rather
+	// than falling back: the wait rule clamps to the remaining code lifetime
+	// anyway, so an over-ceiling throttle waits out the rest of the lifetime
+	// instead of resending before the server's throttle. Only unrepresentable
+	// strings (ErrRange above) are malformed → interval fallback.
+	return min(v, maxDeviceSeconds)
 }
 
 // postDeviceToken performs one token-endpoint poll and classifies the outcome.

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -551,12 +551,23 @@ type pollResult struct {
 }
 
 // parseRetryAfterSeconds validates a Retry-After delta for the 429 poll
-// contract (SPEC §16): a positive integral number of seconds no greater than
-// maxDeviceSeconds (the shared 32-bit-ms timer bound). Anything else —
-// missing, an HTTP-date, fractional, non-positive, or overflowing — returns 0
-// so the caller falls back to the current interval.
+// contract (SPEC §16): ASCII digits only (HTTP delta-seconds permits no sign),
+// positive, no greater than maxDeviceSeconds (the shared 32-bit-ms timer
+// bound). Anything else — missing, an HTTP-date, signed ("+30"), fractional,
+// non-positive, or overflowing — returns 0 so the caller falls back to the
+// current interval.
 func parseRetryAfterSeconds(header string) int {
-	v, err := strconv.Atoi(strings.TrimSpace(header))
+	trimmed := strings.TrimSpace(header)
+	if trimmed == "" {
+		return 0
+	}
+	for _, r := range trimmed {
+		if r < '0' || r > '9' {
+			return 0
+		}
+	}
+	// A digit string too long for int returns ErrRange → malformed → 0.
+	v, err := strconv.Atoi(trimmed)
 	if err != nil || v <= 0 || v > maxDeviceSeconds {
 		return 0
 	}

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -2144,6 +2144,8 @@ func TestPollDeviceToken_429WrongPairStaysTerminal(t *testing.T) {
 		body   map[string]any
 	}{
 		{"429 without too_many_requests", http.StatusTooManyRequests, map[string]any{"error": "rate_limited"}},
+		{"429 parroting authorization_pending", http.StatusTooManyRequests, map[string]any{"error": "authorization_pending"}},
+		{"429 parroting slow_down", http.StatusTooManyRequests, map[string]any{"error": "slow_down"}},
 		{"too_many_requests on 400", http.StatusBadRequest, tooManyRequestsBody},
 	}
 	for _, tc := range cases {

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -2121,7 +2121,9 @@ func TestParseRetryAfterSeconds_ASCIIOWSOnly(t *testing.T) {
 func TestPollDeviceToken_429MalformedRetryAfterFallsBackToInterval(t *testing.T) {
 	// The final case runs NBSP+"30" end-to-end through a real HTTP round trip
 	// (Go passes obs-text header bytes through unmodified).
-	for _, header := range []string{"", "abc", "1.5", "-1", "0", "99999999999999999999", "+30", "\u00a030"} {
+	// "99999999999": 11 significant digits — representable in an int, but past
+	// the shared 10-digit bound, so it must fall back like TS/Python/Ruby.
+	for _, header := range []string{"", "abc", "1.5", "-1", "0", "99999999999999999999", "99999999999", "+30", "\u00a030"} {
 		t.Run("header="+header, func(t *testing.T) {
 			srv := queueTokenResponses429(t, []struct {
 				status     int

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -2093,7 +2093,7 @@ func TestPollDeviceToken_RetriesAfter429WithRetryAfterOverride(t *testing.T) {
 }
 
 func TestPollDeviceToken_429MalformedRetryAfterFallsBackToInterval(t *testing.T) {
-	for _, header := range []string{"", "abc", "1.5", "-1", "0", "99999999999999999999"} {
+	for _, header := range []string{"", "abc", "1.5", "-1", "0", "99999999999999999999", "+30"} {
 		t.Run("header="+header, func(t *testing.T) {
 			srv := queueTokenResponses429(t, []struct {
 				status     int

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -2043,3 +2043,184 @@ func TestPollDeviceToken_ResourceValidation(t *testing.T) {
 		})
 	}
 }
+
+// queueTokenResponses429 serves a fixed sequence of token-endpoint responses
+// with an optional Retry-After header per response (the last repeats).
+func queueTokenResponses429(t *testing.T, responses []struct {
+	status     int
+	body       map[string]any
+	retryAfter string
+}) *httptest.Server {
+	t.Helper()
+	calls := 0
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		i := min(calls, len(responses)-1)
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		if responses[i].retryAfter != "" {
+			w.Header().Set("Retry-After", responses[i].retryAfter)
+		}
+		w.WriteHeader(responses[i].status)
+		_ = json.NewEncoder(w).Encode(responses[i].body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+var tooManyRequestsBody = map[string]any{"error": "too_many_requests"}
+
+func TestPollDeviceToken_RetriesAfter429WithRetryAfterOverride(t *testing.T) {
+	srv := queueTokenResponses429(t, []struct {
+		status     int
+		body       map[string]any
+		retryAfter string
+	}{
+		{http.StatusTooManyRequests, tooManyRequestsBody, "30"},
+		{http.StatusOK, tokenBody, ""},
+	})
+	sleep := &recordingSleep{}
+
+	token, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token.AccessToken != "device_access_token" {
+		t.Errorf("AccessToken = %q", token.AccessToken)
+	}
+	// Initial 5s wait, then the one-shot max(interval, Retry-After) = 30s.
+	assertWaits(t, sleep.waits, []time.Duration{5 * time.Second, 30 * time.Second})
+}
+
+func TestPollDeviceToken_429MalformedRetryAfterFallsBackToInterval(t *testing.T) {
+	for _, header := range []string{"", "abc", "1.5", "-1", "0", "99999999999999999999"} {
+		t.Run("header="+header, func(t *testing.T) {
+			srv := queueTokenResponses429(t, []struct {
+				status     int
+				body       map[string]any
+				retryAfter string
+			}{
+				{http.StatusTooManyRequests, tooManyRequestsBody, header},
+				{http.StatusOK, tokenBody, ""},
+			})
+			sleep := &recordingSleep{}
+
+			_, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+				WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			assertWaits(t, sleep.waits, []time.Duration{5 * time.Second, 5 * time.Second})
+		})
+	}
+}
+
+func TestPollDeviceToken_429RetryAfterOverrideDecaysAfterOneWait(t *testing.T) {
+	srv := queueTokenResponses429(t, []struct {
+		status     int
+		body       map[string]any
+		retryAfter string
+	}{
+		{http.StatusTooManyRequests, tooManyRequestsBody, "30"},
+		{http.StatusBadRequest, map[string]any{"error": "authorization_pending"}, ""},
+		{http.StatusOK, tokenBody, ""},
+	})
+	sleep := &recordingSleep{}
+
+	_, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// 5s initial, 30s one-shot override, then back to the 5s interval — the
+	// override never inflates the slow_down-driven cadence.
+	assertWaits(t, sleep.waits, []time.Duration{5 * time.Second, 30 * time.Second, 5 * time.Second})
+}
+
+func TestPollDeviceToken_429WrongPairStaysTerminal(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   map[string]any
+	}{
+		{"429 without too_many_requests", http.StatusTooManyRequests, map[string]any{"error": "rate_limited"}},
+		{"too_many_requests on 400", http.StatusBadRequest, tooManyRequestsBody},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := queueTokenResponses429(t, []struct {
+				status     int
+				body       map[string]any
+				retryAfter string
+			}{{tc.status, tc.body, "30"}})
+			sleep := &recordingSleep{}
+
+			_, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+				WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+			assertBasecampCode(t, err, basecamp.CodeAPI)
+		})
+	}
+}
+
+func TestPollDeviceToken_429WaitClampedToExpiry(t *testing.T) {
+	srv := queueTokenResponses429(t, []struct {
+		status     int
+		body       map[string]any
+		retryAfter string
+	}{{http.StatusTooManyRequests, tooManyRequestsBody, "3600"}})
+	sleep := &recordingSleep{}
+
+	// Scripted monotonic clock: deadline anchors at t=0 with a 20s lifetime.
+	// The second iteration's huge Retry-After override must clamp to the 14s
+	// remaining, and the post-wait check then expires the flow.
+	times := []time.Time{
+		time.Unix(0, 0),  // deadline anchor
+		time.Unix(0, 0),  // iter 1 remaining
+		time.Unix(5, 0),  // iter 1 post-wait check
+		time.Unix(6, 0),  // iter 2 remaining
+		time.Unix(20, 0), // iter 2 post-wait check → expired
+	}
+	idx := 0
+	clock := func() time.Time {
+		v := times[min(idx, len(times)-1)]
+		idx++
+		return v
+	}
+
+	_, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 20,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn), WithDeviceClock(clock))
+
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) || dfe.Reason != DeviceFlowExpired {
+		t.Fatalf("want DeviceFlowError(expired), got %v", err)
+	}
+	assertWaits(t, sleep.waits, []time.Duration{5 * time.Second, 14 * time.Second})
+}
+
+func TestPollDeviceToken_CancellationDuring429Wait(t *testing.T) {
+	srv := queueTokenResponses429(t, []struct {
+		status     int
+		body       map[string]any
+		retryAfter string
+	}{{http.StatusTooManyRequests, tooManyRequestsBody, "30"}})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	waitCount := 0
+	sleep := &recordingSleep{before: func() {
+		waitCount++
+		if waitCount == 2 {
+			cancel() // cancel during the post-429 override wait
+		}
+	}}
+
+	_, err := PollDeviceToken(ctx, srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+
+	var dfe *DeviceFlowError
+	if !errors.As(err, &dfe) || dfe.Reason != DeviceFlowCancelled {
+		t.Fatalf("want DeviceFlowError(cancelled), got %v", err)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("cancelled error should wrap context.Canceled, got %v", err)
+	}
+}

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -1985,3 +1985,61 @@ func TestPollDeviceToken_CancelledDuringIgnoredTransportBeatsTerminalError(t *te
 		t.Fatalf("want DeviceFlowError(cancelled), got %v", err)
 	}
 }
+
+func TestPollDeviceToken_CapturesResource(t *testing.T) {
+	srv, _ := queueTokenResponses(t, []struct {
+		status int
+		body   map[string]any
+	}{
+		{http.StatusOK, map[string]any{
+			"access_token":  "device_access_token",
+			"refresh_token": "device_refresh_token",
+			"resource":      "urn:bc:account:42",
+		}},
+	})
+	sleep := &recordingSleep{}
+
+	token, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token.Resource != "urn:bc:account:42" {
+		t.Errorf("Resource = %q, want urn:bc:account:42", token.Resource)
+	}
+}
+
+func TestPollDeviceToken_ResourceValidation(t *testing.T) {
+	cases := []struct {
+		name     string
+		resource any
+		wantErr  bool
+	}{
+		{"null resource is absent", nil, false},
+		{"empty resource is malformed", "", true},
+		{"non-string resource is malformed", 7, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := map[string]any{"access_token": "device_access_token", "resource": tc.resource}
+			srv, _ := queueTokenResponses(t, []struct {
+				status int
+				body   map[string]any
+			}{{http.StatusOK, body}})
+			sleep := &recordingSleep{}
+
+			token, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+				WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+			if tc.wantErr {
+				assertBasecampCode(t, err, basecamp.CodeAPI)
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if token.Resource != "" {
+				t.Errorf("Resource = %q, want unset", token.Resource)
+			}
+		})
+	}
+}

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -2143,6 +2143,34 @@ func TestPollDeviceToken_429MalformedRetryAfterFallsBackToInterval(t *testing.T)
 	}
 }
 
+func TestPollDeviceToken_429DuplicateRetryAfterFallsBackToInterval(t *testing.T) {
+	// Duplicate Retry-After field lines are ambiguous — Header.Get would
+	// silently take the first ("30") even though the combined field is
+	// malformed; the override must fall back to the current interval.
+	step := 0
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if step == 0 {
+			step++
+			w.Header().Add("Retry-After", "30")
+			w.Header().Add("Retry-After", "bogus")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_ = json.NewEncoder(w).Encode(tooManyRequestsBody)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(tokenBody)
+	}))
+	defer srv.Close()
+	sleep := &recordingSleep{}
+
+	_, err := PollDeviceToken(context.Background(), srv.URL, "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceSleep(sleep.fn))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assertWaits(t, sleep.waits, []time.Duration{5 * time.Second, 5 * time.Second})
+}
+
 func TestPollDeviceToken_429RetryAfterOverrideDecaysAfterOneWait(t *testing.T) {
 	srv := queueTokenResponses429(t, []struct {
 		status     int

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -2092,8 +2092,32 @@ func TestPollDeviceToken_RetriesAfter429WithRetryAfterOverride(t *testing.T) {
 	assertWaits(t, sleep.waits, []time.Duration{5 * time.Second, 30 * time.Second})
 }
 
+func TestParseRetryAfterSeconds_ASCIIOWSOnly(t *testing.T) {
+	// RFC 9110: delta-seconds is 1*DIGIT and optional whitespace is ONLY
+	// SP/HTAB. Unicode whitespace (NBSP above all) must not be trimmed into
+	// validity — strings.TrimSpace would accept NBSP+"30" as 30.
+	for _, tc := range []struct {
+		header string
+		want   int
+	}{
+		{" 30 ", 30},
+		{"\t30\t", 30},
+		{" \t30\t ", 30},
+		{"\u00a030", 0},
+		{"30\u00a0", 0},
+		{"\u200930", 0},
+		{"\n30\n", 0},
+	} {
+		if got := parseRetryAfterSeconds(tc.header); got != tc.want {
+			t.Errorf("parseRetryAfterSeconds(%q) = %d, want %d", tc.header, got, tc.want)
+		}
+	}
+}
+
 func TestPollDeviceToken_429MalformedRetryAfterFallsBackToInterval(t *testing.T) {
-	for _, header := range []string{"", "abc", "1.5", "-1", "0", "99999999999999999999", "+30"} {
+	// The final case runs NBSP+"30" end-to-end through a real HTTP round trip
+	// (Go passes obs-text header bytes through unmodified).
+	for _, header := range []string{"", "abc", "1.5", "-1", "0", "99999999999999999999", "+30", "\u00a030"} {
 		t.Run("header="+header, func(t *testing.T) {
 			srv := queueTokenResponses429(t, []struct {
 				status     int

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -2107,6 +2107,10 @@ func TestParseRetryAfterSeconds_ASCIIOWSOnly(t *testing.T) {
 		{"30\u00a0", 0},
 		{"\u200930", 0},
 		{"\n30\n", 0},
+		// A representable over-ceiling delta clamps (the wait rule clips to
+		// the remaining lifetime); an unrepresentable one stays malformed.
+		{"2147484", maxDeviceSeconds},
+		{"99999999999999999999", 0},
 	} {
 		if got := parseRetryAfterSeconds(tc.header); got != tc.want {
 			t.Errorf("parseRetryAfterSeconds(%q) = %d, want %d", tc.header, got, tc.want)

--- a/go/pkg/basecamp/oauth/exchange.go
+++ b/go/pkg/basecamp/oauth/exchange.go
@@ -160,6 +160,11 @@ func (e *Exchanger) doTokenRequest(ctx context.Context, tokenEndpoint string, da
 		// classify it via errors.As(*basecamp.Error) with the HTTP status.
 		return nil, basecamp.ErrAPI(resp.StatusCode, fmt.Sprintf("parsing token response: %v", err))
 	}
+	// A 2xx without a usable access_token is malformed, not a success — the
+	// device-flow and AuthManager paths already enforce this.
+	if token.AccessToken == "" {
+		return nil, basecamp.ErrAPI(resp.StatusCode, "token response missing access_token")
+	}
 
 	// resource re-decodes through a *string because Token's plain string field
 	// cannot distinguish an absent field from an explicit "": absent and JSON

--- a/go/pkg/basecamp/oauth/exchange.go
+++ b/go/pkg/basecamp/oauth/exchange.go
@@ -170,7 +170,10 @@ func (e *Exchanger) doTokenRequest(ctx context.Context, tokenEndpoint string, da
 		return nil, fmt.Errorf("parsing token response: %w", err)
 	}
 	if rawResource.Resource != nil && *rawResource.Resource == "" {
-		return nil, fmt.Errorf("token response resource must be a non-empty string when present")
+		// A typed api fault (SPEC §16), not a bare error: callers classify
+		// malformed server responses via errors.As(*basecamp.Error) and need
+		// the HTTP status — matching the device-token and AuthManager paths.
+		return nil, basecamp.ErrAPI(resp.StatusCode, "token response resource must be a non-empty string when present")
 	}
 
 	// Calculate ExpiresAt from ExpiresIn

--- a/go/pkg/basecamp/oauth/exchange.go
+++ b/go/pkg/basecamp/oauth/exchange.go
@@ -155,7 +155,10 @@ func (e *Exchanger) doTokenRequest(ctx context.Context, tokenEndpoint string, da
 
 	var token Token
 	if err := json.Unmarshal(body, &token); err != nil {
-		return nil, fmt.Errorf("parsing token response: %w", err)
+		// A malformed 200 body — including a non-string resource failing the
+		// string decode — is a typed api fault (SPEC §16) so callers can
+		// classify it via errors.As(*basecamp.Error) with the HTTP status.
+		return nil, basecamp.ErrAPI(resp.StatusCode, fmt.Sprintf("parsing token response: %v", err))
 	}
 
 	// resource re-decodes through a *string because Token's plain string field
@@ -167,7 +170,7 @@ func (e *Exchanger) doTokenRequest(ctx context.Context, tokenEndpoint string, da
 		Resource *string `json:"resource"`
 	}
 	if err := json.Unmarshal(body, &rawResource); err != nil {
-		return nil, fmt.Errorf("parsing token response: %w", err)
+		return nil, basecamp.ErrAPI(resp.StatusCode, fmt.Sprintf("parsing token response: %v", err))
 	}
 	if rawResource.Resource != nil && *rawResource.Resource == "" {
 		// A typed api fault (SPEC §16), not a bare error: callers classify

--- a/go/pkg/basecamp/oauth/exchange.go
+++ b/go/pkg/basecamp/oauth/exchange.go
@@ -172,7 +172,8 @@ func (e *Exchanger) doTokenRequest(ctx context.Context, tokenEndpoint string, da
 	// malformed response (SPEC §16) — an empty binding is not a binding. A
 	// non-string resource already failed the Token unmarshal above.
 	var rawResource struct {
-		Resource *string `json:"resource"`
+		Resource  *string `json:"resource"`
+		TokenType *string `json:"token_type"`
 	}
 	if err := json.Unmarshal(body, &rawResource); err != nil {
 		return nil, basecamp.ErrAPI(resp.StatusCode, fmt.Sprintf("parsing token response: %v", err))
@@ -182,6 +183,14 @@ func (e *Exchanger) doTokenRequest(ctx context.Context, tokenEndpoint string, da
 		// malformed server responses via errors.As(*basecamp.Error) and need
 		// the HTTP status — matching the device-token and AuthManager paths.
 		return nil, basecamp.ErrAPI(resp.StatusCode, "token response resource must be a non-empty string when present")
+	}
+	// token_type: absent/JSON-null defaults to Bearer; a present-but-empty
+	// value is malformed (SPEC §16) — matching the device-flow parser.
+	if rawResource.TokenType != nil && *rawResource.TokenType == "" {
+		return nil, basecamp.ErrAPI(resp.StatusCode, "token response token_type must be a non-empty string when present")
+	}
+	if rawResource.TokenType == nil {
+		token.TokenType = "Bearer"
 	}
 
 	// Calculate ExpiresAt from ExpiresIn

--- a/go/pkg/basecamp/oauth/exchange.go
+++ b/go/pkg/basecamp/oauth/exchange.go
@@ -87,6 +87,9 @@ func (e *Exchanger) Refresh(ctx context.Context, req RefreshRequest) (*Token, er
 	if req.ClientSecret != "" {
 		data.Set("client_secret", req.ClientSecret)
 	}
+	if req.Resource != "" {
+		data.Set("resource", req.Resource)
+	}
 
 	return e.doTokenRequest(ctx, req.TokenEndpoint, data)
 }
@@ -153,6 +156,21 @@ func (e *Exchanger) doTokenRequest(ctx context.Context, tokenEndpoint string, da
 	var token Token
 	if err := json.Unmarshal(body, &token); err != nil {
 		return nil, fmt.Errorf("parsing token response: %w", err)
+	}
+
+	// resource re-decodes through a *string because Token's plain string field
+	// cannot distinguish an absent field from an explicit "": absent and JSON
+	// null map to unset (nil), while a present-but-empty resource is a
+	// malformed response (SPEC §16) — an empty binding is not a binding. A
+	// non-string resource already failed the Token unmarshal above.
+	var rawResource struct {
+		Resource *string `json:"resource"`
+	}
+	if err := json.Unmarshal(body, &rawResource); err != nil {
+		return nil, fmt.Errorf("parsing token response: %w", err)
+	}
+	if rawResource.Resource != nil && *rawResource.Resource == "" {
+		return nil, fmt.Errorf("token response resource must be a non-empty string when present")
 	}
 
 	// Calculate ExpiresAt from ExpiresIn

--- a/go/pkg/basecamp/oauth/oauth_test.go
+++ b/go/pkg/basecamp/oauth/oauth_test.go
@@ -614,13 +614,13 @@ func TestExchanger_TokenResponseResource(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Refresh() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if tt.name == "empty resource rejected" {
+			if tt.name == "empty resource rejected" || tt.name == "non-string resource rejected" {
 				// A typed api fault (SPEC §16), not a bare error: callers
 				// classify malformed responses via errors.As and need the
 				// HTTP status, matching the device-token/AuthManager paths.
 				var apiErr *basecamp.Error
 				if !errors.As(err, &apiErr) || apiErr.Code != basecamp.CodeAPI {
-					t.Fatalf("empty resource error = %T %v, want *basecamp.Error with CodeAPI", err, err)
+					t.Fatalf("%s error = %T %v, want *basecamp.Error with CodeAPI", tt.name, err, err)
 				}
 				if apiErr.HTTPStatus != http.StatusOK {
 					t.Errorf("HTTPStatus = %d, want 200", apiErr.HTTPStatus)

--- a/go/pkg/basecamp/oauth/oauth_test.go
+++ b/go/pkg/basecamp/oauth/oauth_test.go
@@ -614,6 +614,18 @@ func TestExchanger_TokenResponseResource(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Refresh() error = %v, wantErr %v", err, tt.wantErr)
 			}
+			if tt.name == "empty resource rejected" {
+				// A typed api fault (SPEC §16), not a bare error: callers
+				// classify malformed responses via errors.As and need the
+				// HTTP status, matching the device-token/AuthManager paths.
+				var apiErr *basecamp.Error
+				if !errors.As(err, &apiErr) || apiErr.Code != basecamp.CodeAPI {
+					t.Fatalf("empty resource error = %T %v, want *basecamp.Error with CodeAPI", err, err)
+				}
+				if apiErr.HTTPStatus != http.StatusOK {
+					t.Errorf("HTTPStatus = %d, want 200", apiErr.HTTPStatus)
+				}
+			}
 			if !tt.wantErr && token.Resource != tt.wantResource {
 				t.Errorf("token.Resource = %q, want %q", token.Resource, tt.wantResource)
 			}

--- a/go/pkg/basecamp/oauth/oauth_test.go
+++ b/go/pkg/basecamp/oauth/oauth_test.go
@@ -584,6 +584,52 @@ func TestExchanger_Refresh_ResourceEcho(t *testing.T) {
 	}
 }
 
+func TestExchanger_TokenTypeContract(t *testing.T) {
+	// SPEC §16: token_type defaults to Bearer only when absent/JSON-null; a
+	// present-but-empty value is a malformed response — matching the
+	// device-flow parser.
+	tests := []struct {
+		name     string
+		response string
+		wantErr  bool
+		wantType string
+	}{
+		{name: "absent token_type defaults to Bearer", response: `{"access_token":"a"}`, wantType: "Bearer"},
+		{name: "null token_type defaults to Bearer", response: `{"access_token":"a","token_type":null}`, wantType: "Bearer"},
+		{name: "present token_type round-trips", response: `{"access_token":"a","token_type":"Bearer"}`, wantType: "Bearer"},
+		{name: "empty token_type rejected", response: `{"access_token":"a","token_type":""}`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			e := NewExchanger(server.Client())
+			token, err := e.Refresh(context.Background(), RefreshRequest{
+				TokenEndpoint: server.URL,
+				RefreshToken:  "refresh123",
+			})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Refresh() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				var apiErr *basecamp.Error
+				if !errors.As(err, &apiErr) || apiErr.Code != basecamp.CodeAPI {
+					t.Fatalf("error = %T %v, want *basecamp.Error with CodeAPI", err, err)
+				}
+				return
+			}
+			if token.TokenType != tt.wantType {
+				t.Errorf("TokenType = %q, want %q", token.TokenType, tt.wantType)
+			}
+		})
+	}
+}
+
 func TestExchanger_TokenResponseResource(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/go/pkg/basecamp/oauth/oauth_test.go
+++ b/go/pkg/basecamp/oauth/oauth_test.go
@@ -539,3 +539,84 @@ func TestNewDeviceConfig_TimeoutClamp(t *testing.T) {
 		})
 	}
 }
+
+func TestExchanger_Refresh_ResourceEcho(t *testing.T) {
+	tests := []struct {
+		name         string
+		resource     string
+		wantSent     bool
+		wantResource string
+	}{
+		{name: "resource sent when set", resource: "urn:bc:account:123", wantSent: true, wantResource: "urn:bc:account:123"},
+		{name: "resource omitted when unset", resource: "", wantSent: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sawResourceKey bool
+			var receivedResource string
+
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = r.ParseForm()
+				_, sawResourceKey = r.PostForm["resource"]
+				receivedResource = r.PostFormValue("resource")
+				_ = json.NewEncoder(w).Encode(map[string]any{"access_token": "new_access"})
+			}))
+			defer server.Close()
+
+			e := NewExchanger(server.Client())
+			_, err := e.Refresh(context.Background(), RefreshRequest{
+				TokenEndpoint: server.URL,
+				RefreshToken:  "refresh123",
+				ClientID:      "basecamp-cli",
+				Resource:      tt.resource,
+			})
+			if err != nil {
+				t.Fatalf("Refresh() error = %v", err)
+			}
+			if sawResourceKey != tt.wantSent {
+				t.Errorf("resource form key present = %v, want %v", sawResourceKey, tt.wantSent)
+			}
+			if receivedResource != tt.wantResource {
+				t.Errorf("resource form value = %q, want %q", receivedResource, tt.wantResource)
+			}
+		})
+	}
+}
+
+func TestExchanger_TokenResponseResource(t *testing.T) {
+	tests := []struct {
+		name         string
+		response     string
+		wantErr      bool
+		wantResource string
+	}{
+		{name: "resource round-trips", response: `{"access_token":"a","resource":"urn:bc:account:42"}`, wantResource: "urn:bc:account:42"},
+		{name: "absent resource is unset", response: `{"access_token":"a"}`, wantResource: ""},
+		{name: "null resource is unset", response: `{"access_token":"a","resource":null}`, wantResource: ""},
+		{name: "empty resource rejected", response: `{"access_token":"a","resource":""}`, wantErr: true},
+		{name: "non-string resource rejected", response: `{"access_token":"a","resource":7}`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			e := NewExchanger(server.Client())
+			token, err := e.Refresh(context.Background(), RefreshRequest{
+				TokenEndpoint: server.URL,
+				RefreshToken:  "refresh123",
+			})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Refresh() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && token.Resource != tt.wantResource {
+				t.Errorf("token.Resource = %q, want %q", token.Resource, tt.wantResource)
+			}
+		})
+	}
+}

--- a/go/pkg/basecamp/oauth/token_conformance_test.go
+++ b/go/pkg/basecamp/oauth/token_conformance_test.go
@@ -1,0 +1,136 @@
+package oauth
+
+// Drives the shared, data-only fixtures in conformance/oauth-token/fixtures:
+// one refresh round-trip per fixture, asserting the sent resource form
+// parameter and the response decode (round-trip, absent/null as unset,
+// present-empty/non-string rejected). Lifecycle preservation across a stored
+// credential is per-manager behavior, tested in auth_test.go — not here.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+type tokenFixture struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Operation   string `json:"operation"`
+	Request     struct {
+		Resource string `json:"resource"`
+	} `json:"request"`
+	Response struct {
+		Status int             `json:"status"`
+		Body   json.RawMessage `json:"body"`
+	} `json:"response"`
+	Expect struct {
+		Outcome            string  `json:"outcome"`
+		Resource           *string `json:"resource"`
+		ResourceAbsent     bool    `json:"resourceAbsent"`
+		FormResource       *string `json:"formResource"`
+		FormResourceAbsent bool    `json:"formResourceAbsent"`
+	} `json:"expect"`
+}
+
+func tokenFixtureDir(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	root := filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "..")
+	return filepath.Join(root, "conformance", "oauth-token", "fixtures")
+}
+
+func TestOAuthTokenFixtures(t *testing.T) {
+	dir := tokenFixtureDir(t)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading fixture dir %s: %v", dir, err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".json") {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	if len(names) == 0 {
+		t.Fatalf("no fixtures found in %s", dir)
+	}
+
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			raw, err := os.ReadFile(filepath.Join(dir, name)) // #nosec G304 -- test fixture path
+			if err != nil {
+				t.Fatalf("reading fixture: %v", err)
+			}
+			var fx tokenFixture
+			if err := json.Unmarshal(raw, &fx); err != nil {
+				t.Fatalf("parsing fixture: %v", err)
+			}
+			if fx.Operation != "refreshToken" {
+				t.Fatalf("unsupported operation %q", fx.Operation)
+			}
+
+			var sawResourceKey bool
+			var sentResource string
+			status := fx.Response.Status
+			if status == 0 {
+				status = http.StatusOK
+			}
+			srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = r.ParseForm()
+				_, sawResourceKey = r.PostForm["resource"]
+				sentResource = r.PostFormValue("resource")
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(status)
+				_, _ = w.Write(fx.Response.Body)
+			}))
+			defer srv.Close()
+
+			e := NewExchanger(srv.Client())
+			token, err := e.Refresh(context.Background(), RefreshRequest{
+				TokenEndpoint: srv.URL,
+				RefreshToken:  "refresh-token",
+				ClientID:      "basecamp-cli",
+				Resource:      fx.Request.Resource,
+			})
+
+			switch fx.Expect.Outcome {
+			case "token":
+				if err != nil {
+					t.Fatalf("expected token, got error: %v", err)
+				}
+				if fx.Expect.Resource != nil && token.Resource != *fx.Expect.Resource {
+					t.Errorf("token.Resource = %q, want %q", token.Resource, *fx.Expect.Resource)
+				}
+				if fx.Expect.ResourceAbsent && token.Resource != "" {
+					t.Errorf("token.Resource = %q, want unset", token.Resource)
+				}
+			case "reject":
+				if err == nil {
+					t.Fatal("expected rejection, got token")
+				}
+			default:
+				t.Fatalf("unsupported outcome %q", fx.Expect.Outcome)
+			}
+
+			if fx.Expect.FormResource != nil {
+				if !sawResourceKey || sentResource != *fx.Expect.FormResource {
+					t.Errorf("form resource = %q (present=%v), want %q", sentResource, sawResourceKey, *fx.Expect.FormResource)
+				}
+			}
+			if fx.Expect.FormResourceAbsent && sawResourceKey {
+				t.Errorf("form resource key present, want absent")
+			}
+		})
+	}
+}

--- a/go/pkg/basecamp/oauth/types.go
+++ b/go/pkg/basecamp/oauth/types.go
@@ -222,12 +222,13 @@ type RefreshRequest struct {
 	ClientID      string
 	ClientSecret  string
 
-	// Resource is the RFC 8707 resource indicator to bind the refreshed
-	// token to, sent only when non-empty. Echo the stored token's Resource:
-	// BC5 multi-account refresh tokens hard-require it (SPEC §16).
-	Resource string
-
 	// UseLegacyFormat uses Launchpad's non-standard token format:
 	// type=refresh instead of grant_type=refresh_token
 	UseLegacyFormat bool
+
+	// Resource is the RFC 8707 resource indicator to bind the refreshed
+	// token to, sent only when non-empty. Echo the stored token's Resource:
+	// BC5 multi-account refresh tokens hard-require it (SPEC §16).
+	// APPENDED LAST: existing positional literals keep their field positions.
+	Resource string
 }

--- a/go/pkg/basecamp/oauth/types.go
+++ b/go/pkg/basecamp/oauth/types.go
@@ -193,6 +193,12 @@ type Token struct {
 	ExpiresIn    int       `json:"expires_in,omitempty"`
 	ExpiresAt    time.Time `json:"-"`
 	Scope        string    `json:"scope,omitempty"`
+
+	// Resource is the RFC 8707 resource indicator the token is bound to
+	// (BC5: urn:bc:account:<id>). Empty when the server sent none. Echo it
+	// as the resource form parameter when refreshing — BC5 multi-account
+	// refresh tokens reject a refresh without it (SPEC §16).
+	Resource string `json:"resource,omitempty"`
 }
 
 // ExchangeRequest contains parameters for exchanging an authorization code for tokens.
@@ -215,6 +221,11 @@ type RefreshRequest struct {
 	RefreshToken  string
 	ClientID      string
 	ClientSecret  string
+
+	// Resource is the RFC 8707 resource indicator to bind the refreshed
+	// token to, sent only when non-empty. Echo the stored token's Resource:
+	// BC5 multi-account refresh tokens hard-require it (SPEC §16).
+	Resource string
 
 	// UseLegacyFormat uses Launchpad's non-standard token format:
 	// type=refresh instead of grant_type=refresh_token

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -284,9 +284,10 @@ For input-constrained clients (CLIs, TVs) the SDK implements the OAuth 2.0 devic
 authorization grant. The public `basecamp-cli` client is pre-registered with
 `token_endpoint_auth_method: none` — it sends no client secret, and an omitted
 scope defaults to `read` (prefer pinning it explicitly with `scope = "read"`).
-Pass bare origins everywhere (no trailing slash): issuer binding is code-point
-exact, so `https://app.basecamp.com/` would silently soft-fall back to
-Launchpad.
+Pass bare origins everywhere (no trailing slash): binding is code-point exact
+— a trailing-slash `expectedIssuer` fails the advertised-member lookup as a
+**hard** `expected_issuer_unavailable`, while a trailing-slash resource origin
+breaks the hop-1 binding and silently soft-falls back to Launchpad.
 
 ```kotlin
 import com.basecamp.sdk.BasecampClient

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -25,6 +25,12 @@ Official Kotlin SDK for the [Basecamp API](https://github.com/basecamp/bc3-api).
 - JDK 17+
 - Kotlin 2.0+
 
+**Compatibility policy (pre-1.0).** Releases in the 0.x series guarantee
+*source* compatibility only: public APIs evolve append-only (new optional
+parameters are added after existing ones), so code compiles unchanged across
+minor versions, but recompile against each release — Kotlin default-argument
+and data-class synthetics make JVM *binary* compatibility infeasible to
+promise, and we don't.
 ## Installation
 
 The SDK is published to [GitHub Packages](https://github.com/basecamp/basecamp-sdk/packages). GitHub Packages requires an access token for every download — including for public packages like this one — so there are three steps rather than one.

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -283,7 +283,10 @@ if (isTokenExpired(token)) {
 For input-constrained clients (CLIs, TVs) the SDK implements the OAuth 2.0 device
 authorization grant. The public `basecamp-cli` client is pre-registered with
 `token_endpoint_auth_method: none` — it sends no client secret, and an omitted
-scope defaults to `read`.
+scope defaults to `read` (prefer pinning it explicitly with `scope = "read"`).
+Pass bare origins everywhere (no trailing slash): issuer binding is code-point
+exact, so `https://app.basecamp.com/` would silently soft-fall back to
+Launchpad.
 
 ```kotlin
 import com.basecamp.sdk.BasecampClient
@@ -316,6 +319,20 @@ val token = performDeviceLogin(
 val client = BasecampClient {
     accessToken(token.accessToken)
 }
+
+// BC5 device logins as basecamp-cli mint MULTI-ACCOUNT refresh tokens: the
+// token carries an RFC 8707 resource indicator (token.resource,
+// "urn:bc:account:<id>"), and refreshing without echoing it is rejected
+// (400 invalid_request). Persist token.resource alongside the tokens and
+// echo it on refresh:
+val fresh = refreshToken(
+    tokenEndpoint = config.tokenEndpoint,
+    refreshToken = token.refreshToken!!,
+    clientId = "basecamp-cli",  // public client — no secret
+    resource = token.resource,
+)
+// A refresh response MAY omit resource (the binding is unchanged) — persist
+// `fresh.resource ?: token.resource` so the next refresh still echoes it.
 ```
 
 The two building blocks are also public if you need finer control:

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -326,14 +326,21 @@ val client = BasecampClient {
 // "urn:bc:account:<id>"), and refreshing without echoing it is rejected
 // (400 invalid_request). Persist token.resource alongside the tokens and
 // echo it on refresh:
-val fresh = refreshToken(
-    tokenEndpoint = config.tokenEndpoint,
-    refreshToken = token.refreshToken!!,
-    clientId = "basecamp-cli",  // public client — no secret
-    resource = token.resource,
-)
-// A refresh response MAY omit resource (the binding is unchanged) — persist
-// `fresh.resource ?: token.resource` so the next refresh still echoes it.
+// A device-token response MAY omit refresh_token — GUARD it rather than
+// force-unwrapping: without one, refreshing is impossible and the user must
+// re-run the device login when the access token expires.
+val storedRefresh = token.refreshToken
+if (storedRefresh != null) {
+    val fresh = refreshToken(
+        tokenEndpoint = config.tokenEndpoint,
+        refreshToken = storedRefresh,
+        clientId = "basecamp-cli",  // public client — no secret
+        resource = token.resource,
+    )
+    // A refresh response MAY omit refresh_token and resource — persist
+    // `fresh.refreshToken ?: storedRefresh` and `fresh.resource ?: token.resource`
+    // so the next refresh still works and still echoes the binding.
+}
 ```
 
 The two building blocks are also public if you need finer control:

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -669,7 +669,12 @@ private suspend fun postDeviceTokenPoll(
             // until code expiry — any other code on a 429 is terminal via
             // Other. Conversely too_many_requests off a 429 is terminal too.
             status == 429 && error == "too_many_requests" ->
-                PollResult.TooManyRequests(parseRetryAfterSeconds(response.headers["Retry-After"]))
+                // Exactly one Retry-After field line: duplicates make the
+                // combined field ambiguous (headers[] silently takes the
+                // first) — anything else falls back to the current interval.
+                PollResult.TooManyRequests(
+                    parseRetryAfterSeconds(response.headers.getAll("Retry-After")?.singleOrNull()),
+                )
             status == 429 -> PollResult.Other("http_$status", status)
             error == "authorization_pending" -> PollResult.Pending
             error == "slow_down" -> PollResult.SlowDown

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -143,6 +143,7 @@ private data class RawDeviceTokenResponse(
     @SerialName("token_type") val tokenType: String? = null,
     @SerialName("expires_in") val expiresIn: Double? = null,
     val scope: String? = null,
+    val resource: String? = null,
 )
 
 /** Raw RFC 8628 device authorization response; all fields nullable to validate. */
@@ -564,6 +565,15 @@ private suspend fun postDeviceTokenPoll(
                 )
             }
         } ?: "Bearer"
+        // resource: absent and JSON null decode to null (unset); when present
+        // it must be non-empty (SPEC §16) — an empty binding is not a binding.
+        // A non-string resource fails deserialization above.
+        if (raw.resource != null && raw.resource.isEmpty()) {
+            throw BasecampException.Api(
+                "Device token response resource must be a non-empty string when present",
+                httpStatus = status,
+            )
+        }
         val now = currentTimeMillis()
         val expiresAt = expiresInSeconds?.let { now + it * 1000 }
         PollResult.Token(
@@ -574,6 +584,7 @@ private suspend fun postDeviceTokenPoll(
                 expiresIn = expiresInSeconds,
                 expiresAt = expiresAt,
                 scope = raw.scope,
+                resource = raw.resource,
             ),
         )
     } else {

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -501,7 +501,9 @@ private sealed interface PollResult {
  * back to the current interval.
  */
 private fun parseRetryAfterSeconds(header: String?): Long {
-    val trimmed = header?.trim() ?: return 0
+    // ASCII SP/HTAB only (RFC 9110 OWS) — NOT String.trim(), whose Unicode
+    // whitespace (NBSP above all) would trim a malformed value into validity.
+    val trimmed = header?.trim { it == ' ' || it == '\t' } ?: return 0
     // ASCII '0'..'9' only — NOT Char.isDigit(), which is Unicode-aware and
     // accepts digit-shaped non-ASCII (fullwidth "１２", Arabic-Indic "٣٠")
     // that toLongOrNull() then converts, treating a malformed HTTP

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -653,15 +653,18 @@ private suspend fun postDeviceTokenPoll(
             }
         }
         when {
+            // A 429 recognizes ONLY too_many_requests (the exact retryable
+            // pair, SPEC §16): a throttling endpoint whose body parrots
+            // authorization_pending/slow_down must not keep the loop polling
+            // until code expiry — any other code on a 429 is terminal via
+            // Other. Conversely too_many_requests off a 429 is terminal too.
+            status == 429 && error == "too_many_requests" ->
+                PollResult.TooManyRequests(parseRetryAfterSeconds(response.headers["Retry-After"]))
+            status == 429 -> PollResult.Other("http_$status", status)
             error == "authorization_pending" -> PollResult.Pending
             error == "slow_down" -> PollResult.SlowDown
             error == "access_denied" -> PollResult.AccessDenied
             error == "expired_token" -> PollResult.Expired
-            // Retryable ONLY as the exact 429 + too_many_requests pair
-            // (SPEC §16); too_many_requests on any other status stays terminal
-            // via Other below.
-            error == "too_many_requests" && status == 429 ->
-                PollResult.TooManyRequests(parseRetryAfterSeconds(response.headers["Retry-After"]))
             else -> PollResult.Other(error, status)
         }
     }

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -510,7 +510,13 @@ private fun parseRetryAfterSeconds(header: String?): Long {
     // delta-seconds value as valid instead of falling back to the interval.
     if (trimmed.isEmpty() || !trimmed.all { it in '0'..'9' }) return 0
     val value = trimmed.toLongOrNull() ?: return 0
-    return if (value in 1..MAX_DEVICE_SECONDS) value else 0
+    if (value <= 0) return 0
+    // A representable delta beyond the shared device ceiling clamps rather
+    // than falling back: the wait rule clamps to the remaining code lifetime
+    // anyway, so an over-ceiling throttle waits out the rest of the lifetime
+    // instead of resending before the server's throttle. Only unrepresentable
+    // strings (toLongOrNull() overflow above) are malformed → interval fallback.
+    return minOf(value, MAX_DEVICE_SECONDS)
 }
 
 private suspend fun postDeviceTokenPoll(

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -366,6 +366,10 @@ suspend fun pollDeviceToken(
     // cadence: each wait is max(interval, backoff), a timeout doubles the
     // backoff (capped), and any completed round-trip resets it to the interval.
     var backoffSeconds = intervalSeconds
+    // One-shot next-wait override from a 429 too_many_requests Retry-After
+    // (SPEC §16): consumed by the next wait, never inflating the slow_down
+    // interval. 0 = none.
+    var overrideSeconds = 0L
 
     val params = parametersOf(
         "grant_type" to listOf(DEVICE_CODE_GRANT_TYPE),
@@ -384,7 +388,8 @@ suspend fun pollDeviceToken(
             // Clamp the wait to the time remaining so a long interval or an
             // exponential backoff can never overshoot the monotonic deadline.
             val remaining = -deadline.elapsedNow()
-            val wait = minOf(maxOf(intervalSeconds, backoffSeconds).seconds, remaining)
+            val wait = minOf(maxOf(intervalSeconds, backoffSeconds, overrideSeconds).seconds, remaining)
+            overrideSeconds = 0L // one-shot: consumed by this wait, then gone
             delay(if (wait > Duration.ZERO) wait else Duration.ZERO)
 
             val postRemaining = -deadline.elapsedNow()
@@ -437,6 +442,14 @@ suspend fun pollDeviceToken(
             when (result) {
                 is PollResult.Token -> return result.token
                 PollResult.Pending -> continue
+                is PollResult.TooManyRequests -> {
+                    // The next wait honors the validated Retry-After via a
+                    // one-shot max(interval, Retry-After) override — 0 (missing/
+                    // malformed) falls back to the current interval, and the
+                    // override decays after one wait.
+                    overrideSeconds = result.retryAfterSeconds
+                    continue
+                }
                 PollResult.SlowDown -> {
                     intervalSeconds += SLOW_DOWN_INCREMENT_SECONDS
                     // Re-sync the backoff to the GROWN interval (the reset above used
@@ -470,7 +483,28 @@ private sealed interface PollResult {
     data object SlowDown : PollResult
     data object AccessDenied : PollResult
     data object Expired : PollResult
+
+    /**
+     * The exact 429 + too_many_requests pair (SPEC §16): retryable with a
+     * one-shot next-wait override. [retryAfterSeconds] is the validated
+     * Retry-After delta, 0 when missing/malformed (→ current interval).
+     */
+    data class TooManyRequests(val retryAfterSeconds: Long) : PollResult
     data class Other(val error: String, val status: Int) : PollResult
+}
+
+/**
+ * Validates a Retry-After delta for the 429 poll contract (SPEC §16): a
+ * positive integral number of seconds no greater than [MAX_DEVICE_SECONDS]
+ * (the shared 32-bit-ms timer bound). Anything else — missing, an HTTP-date,
+ * fractional, non-positive, or overflowing — returns 0 so the caller falls
+ * back to the current interval.
+ */
+private fun parseRetryAfterSeconds(header: String?): Long {
+    val trimmed = header?.trim() ?: return 0
+    if (!trimmed.all { it.isDigit() } || trimmed.isEmpty()) return 0
+    val value = trimmed.toLongOrNull() ?: return 0
+    return if (value in 1..MAX_DEVICE_SECONDS) value else 0
 }
 
 private suspend fun postDeviceTokenPoll(
@@ -614,11 +648,16 @@ private suspend fun postDeviceTokenPoll(
                 "http_$status"
             }
         }
-        when (error) {
-            "authorization_pending" -> PollResult.Pending
-            "slow_down" -> PollResult.SlowDown
-            "access_denied" -> PollResult.AccessDenied
-            "expired_token" -> PollResult.Expired
+        when {
+            error == "authorization_pending" -> PollResult.Pending
+            error == "slow_down" -> PollResult.SlowDown
+            error == "access_denied" -> PollResult.AccessDenied
+            error == "expired_token" -> PollResult.Expired
+            // Retryable ONLY as the exact 429 + too_many_requests pair
+            // (SPEC §16); too_many_requests on any other status stays terminal
+            // via Other below.
+            error == "too_many_requests" && status == 429 ->
+                PollResult.TooManyRequests(parseRetryAfterSeconds(response.headers["Retry-After"]))
             else -> PollResult.Other(error, status)
         }
     }

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -495,10 +495,12 @@ private sealed interface PollResult {
 
 /**
  * Validates a Retry-After delta for the 429 poll contract (SPEC §16): a
- * positive integral number of seconds no greater than [MAX_DEVICE_SECONDS]
- * (the shared 32-bit-ms timer bound). Anything else — missing, an HTTP-date,
- * fractional, non-positive, or overflowing — returns 0 so the caller falls
- * back to the current interval.
+ * positive integral number of seconds. A representable delta beyond
+ * [MAX_DEVICE_SECONDS] (the shared 32-bit-ms timer bound) CLAMPS to the
+ * ceiling — the wait rule clips to the remaining code lifetime, honoring the
+ * throttle. Anything else — missing, an HTTP-date, fractional, non-positive,
+ * or unrepresentable (toLongOrNull() overflow) — returns 0 so the caller
+ * falls back to the current interval.
  */
 private fun parseRetryAfterSeconds(header: String?): Long {
     // ASCII SP/HTAB only (RFC 9110 OWS) — NOT String.trim(), whose Unicode

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -502,7 +502,11 @@ private sealed interface PollResult {
  */
 private fun parseRetryAfterSeconds(header: String?): Long {
     val trimmed = header?.trim() ?: return 0
-    if (!trimmed.all { it.isDigit() } || trimmed.isEmpty()) return 0
+    // ASCII '0'..'9' only — NOT Char.isDigit(), which is Unicode-aware and
+    // accepts digit-shaped non-ASCII (fullwidth "１２", Arabic-Indic "٣٠")
+    // that toLongOrNull() then converts, treating a malformed HTTP
+    // delta-seconds value as valid instead of falling back to the interval.
+    if (trimmed.isEmpty() || !trimmed.all { it in '0'..'9' }) return 0
     val value = trimmed.toLongOrNull() ?: return 0
     return if (value in 1..MAX_DEVICE_SECONDS) value else 0
 }

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -511,7 +511,12 @@ private fun parseRetryAfterSeconds(header: String?): Long {
     // that toLongOrNull() then converts, treating a malformed HTTP
     // delta-seconds value as valid instead of falling back to the interval.
     if (trimmed.isEmpty() || !trimmed.all { it in '0'..'9' }) return 0
-    val value = trimmed.toLongOrNull() ?: return 0
+    // The shared 10-significant-digit bound (SPEC §16): strip leading zeros
+    // first so a padded in-range delta is honored, then treat longer strings
+    // as unrepresentable → interval fallback — matching TS/Python/Ruby.
+    val significant = trimmed.trimStart('0').ifEmpty { "0" }
+    if (significant.length > 10) return 0
+    val value = significant.toLongOrNull() ?: return 0
     if (value <= 0) return 0
     // A representable delta beyond the shared device ceiling clamps rather
     // than falling back: the wait rule clamps to the remaining code lifetime

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Exchange.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Exchange.kt
@@ -7,6 +7,7 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import com.basecamp.sdk.BasecampException
 import com.basecamp.sdk.requireSecureEndpoint

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Exchange.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Exchange.kt
@@ -7,7 +7,6 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import com.basecamp.sdk.BasecampException
 import com.basecamp.sdk.requireSecureEndpoint

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Exchange.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Exchange.kt
@@ -206,6 +206,15 @@ private suspend fun postTokenRequest(
                 httpStatus = response.status.value,
             )
         }
+        // A 2xx with an EMPTY access_token is malformed, not a success —
+        // matching the device flow and the other SDKs' non-empty contract.
+        if (raw.accessToken.isEmpty()) {
+            throw BasecampException.Api(
+                "Token response missing access_token",
+                httpStatus = response.status.value,
+            )
+        }
+
         val now = currentTimeMillis()
         val expiresAt = raw.expiresIn?.let { now + it * 1000 }
 

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Exchange.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Exchange.kt
@@ -36,7 +36,7 @@ data class OAuthToken(
 internal data class RawTokenResponse(
     @SerialName("access_token") val accessToken: String,
     @SerialName("refresh_token") val refreshToken: String? = null,
-    @SerialName("token_type") val tokenType: String = "Bearer",
+    @SerialName("token_type") val tokenType: String? = null,
     @SerialName("expires_in") val expiresIn: Long? = null,
     val scope: String? = null,
     val resource: String? = null,
@@ -217,10 +217,21 @@ private suspend fun postTokenRequest(
         val now = currentTimeMillis()
         val expiresAt = raw.expiresIn?.let { now + it * 1000 }
 
+        // token_type: absent/JSON-null defaults to Bearer; a present-but-empty
+        // value is malformed (SPEC §16) — matching the device-flow parser.
+        val tokenType = raw.tokenType?.also {
+            if (it.isEmpty()) {
+                throw BasecampException.Api(
+                    "Token response token_type must be a non-empty string when present",
+                    httpStatus = response.status.value,
+                )
+            }
+        } ?: "Bearer"
+
         return OAuthToken(
             accessToken = raw.accessToken,
             refreshToken = raw.refreshToken,
-            tokenType = raw.tokenType,
+            tokenType = tokenType,
             expiresIn = raw.expiresIn,
             expiresAt = expiresAt,
             scope = raw.scope,

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Exchange.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Exchange.kt
@@ -23,6 +23,13 @@ data class OAuthToken(
     /** Computed wall-clock expiration time (epoch milliseconds). */
     val expiresAt: Long?,
     val scope: String?,
+    /**
+     * RFC 8707 resource indicator the token is bound to (BC5:
+     * `urn:bc:account:<id>`). Echo it as the `resource` parameter when
+     * refreshing — BC5 multi-account refresh tokens reject a refresh without
+     * it (SPEC §16). Appended last: earlier parameters keep their positions.
+     */
+    val resource: String? = null,
 )
 
 @Serializable
@@ -32,6 +39,7 @@ internal data class RawTokenResponse(
     @SerialName("token_type") val tokenType: String = "Bearer",
     @SerialName("expires_in") val expiresIn: Long? = null,
     val scope: String? = null,
+    val resource: String? = null,
 )
 
 @Serializable
@@ -116,6 +124,10 @@ suspend fun refreshToken(
     clientSecret: String? = null,
     useLegacyFormat: Boolean = false,
     client: HttpClient? = null,
+    // RFC 8707 resource indicator, sent only when set. Echo the stored
+    // token's resource: BC5 multi-account refresh tokens hard-require it
+    // (SPEC §16). Appended last: earlier parameters keep their positions.
+    resource: String? = null,
 ): OAuthToken {
     val params = Parameters.build {
         if (useLegacyFormat) {
@@ -126,6 +138,7 @@ suspend fun refreshToken(
         append("refresh_token", refreshToken)
         append("client_id", clientId)
         if (!clientSecret.isNullOrEmpty()) append("client_secret", clientSecret)
+        if (!resource.isNullOrEmpty()) append("resource", resource)
     }
 
     return postTokenRequest(tokenEndpoint, params, client)
@@ -183,6 +196,15 @@ private suspend fun postTokenRequest(
         val raw = runCatching { tokenJson.decodeFromString<RawTokenResponse>(body) }.getOrElse {
             throw BasecampException.Api("Failed to parse token response", httpStatus = response.status.value)
         }
+        // resource: absent and JSON null decode to null (unset); when present
+        // it must be non-empty (SPEC §16) — an empty binding is not a binding.
+        // A non-string resource fails deserialization above.
+        if (raw.resource != null && raw.resource.isEmpty()) {
+            throw BasecampException.Api(
+                "Token response resource must be a non-empty string when present",
+                httpStatus = response.status.value,
+            )
+        }
         val now = currentTimeMillis()
         val expiresAt = raw.expiresIn?.let { now + it * 1000 }
 
@@ -193,6 +215,7 @@ private suspend fun postTokenRequest(
             expiresIn = raw.expiresIn,
             expiresAt = expiresAt,
             scope = raw.scope,
+            resource = raw.resource,
         )
     } finally {
         if (shouldClose) httpClient.close()

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -1039,31 +1039,31 @@ class OAuthDeviceTest {
         client.close()
     }
 
-    @Test
-fun pollRejectsMalformedTokenExpiresInOn2xx() = runTest {
-    // A 2xx whose expires_in cannot be a schedulable lifetime is api_error:
-    // 1e400 parses to Infinity (past the ceiling), an explicit 0 or negative
-    // value violates the positive rule, a past-ceiling value would overflow
-    // `it * 1000` in expiresAt, and 3600.5 breaks the whole-second contract.
-    val bodies = listOf(
-        """{"access_token":"tok","token_type":"Bearer","expires_in":1e400}""",
-        """{"access_token":"tok","token_type":"Bearer","expires_in":-1}""",
-        """{"access_token":"tok","token_type":"Bearer","expires_in":0}""",
-        """{"access_token":"tok","token_type":"Bearer","expires_in":2147483648}""",
-        """{"access_token":"tok","token_type":"Bearer","expires_in":3600.5}""",
-    )
-    for (body in bodies) {
-        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
-        val client = HttpClient(engine)
-        val e = assertFailsWith<BasecampException.Api>("expected api_error for $body") {
-            pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+        @Test
+    fun pollRejectsMalformedTokenExpiresInOn2xx() = runTest {
+        // A 2xx whose expires_in cannot be a schedulable lifetime is api_error:
+        // 1e400 parses to Infinity (past the ceiling), an explicit 0 or negative
+        // value violates the positive rule, a past-ceiling value would overflow
+        // `it * 1000` in expiresAt, and 3600.5 breaks the whole-second contract.
+        val bodies = listOf(
+            """{"access_token":"tok","token_type":"Bearer","expires_in":1e400}""",
+            """{"access_token":"tok","token_type":"Bearer","expires_in":-1}""",
+            """{"access_token":"tok","token_type":"Bearer","expires_in":0}""",
+            """{"access_token":"tok","token_type":"Bearer","expires_in":2147483648}""",
+            """{"access_token":"tok","token_type":"Bearer","expires_in":3600.5}""",
+        )
+        for (body in bodies) {
+            val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+            val client = HttpClient(engine)
+            val e = assertFailsWith<BasecampException.Api>("expected api_error for $body") {
+                pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+            }
+            assertEquals("api_error", e.code)
+            client.close()
         }
-        assertEquals("api_error", e.code)
-        client.close()
     }
-}
 
-    @Test
+        @Test
     fun pollRejectsExplicitEmptyTokenTypeOn2xx() = runTest {
         // An explicit "token_type": "" is malformed token metadata (api_error),
         // distinct from an absent field — uniform with Go/Python/Ruby/TS.

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -605,6 +605,38 @@ class OAuthDeviceTest {
     }
 
     @Test
+    fun poll429DuplicateRetryAfterFallsBackToInterval() = runTest {
+        // Duplicate Retry-After field lines are ambiguous — headers[] would
+        // silently take the first ("30") even though the combined field is
+        // malformed; the override must fall back to the current interval.
+        val pollTimes = mutableListOf<Long>()
+        var i = 0
+        val start = testScheduler.currentTime
+        val engine = MockEngine {
+            pollTimes.add(testScheduler.currentTime - start)
+            i += 1
+            if (i == 1) {
+                respond(
+                    tooManyJson,
+                    HttpStatusCode.TooManyRequests,
+                    headersOf(
+                        HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()),
+                        HttpHeaders.RetryAfter to listOf("30", "bogus"),
+                    ),
+                )
+            } else {
+                respond(tokenJson, HttpStatusCode.OK, jsonHeaders)
+            }
+        }
+        val client = HttpClient(engine)
+
+        pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+
+        assertEquals(listOf(5_000L, 10_000L), pollTimes)
+        client.close()
+    }
+
+    @Test
     fun poll429RetryAfterOverrideDecaysAfterOneWait() = runTest {
         val pollTimes = mutableListOf<Long>()
         val responses = listOf(

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -581,7 +581,9 @@ class OAuthDeviceTest {
 
     @Test
     fun poll429MalformedRetryAfterFallsBackToInterval() = runTest {
-        for (header in listOf(null, "abc", "1.5", "-1", "0", "99999999999999999999", "+30", "\uFF11\uFF12", "\u00A030", "\u200930")) {
+        // "99999999999": 11 significant digits — representable in a Long, but
+        // past the shared 10-digit bound, so it must fall back like TS/Py/Rb.
+        for (header in listOf(null, "abc", "1.5", "-1", "0", "99999999999999999999", "99999999999", "+30", "\uFF11\uFF12", "\u00A030", "\u200930")) {
             val pollTimes = mutableListOf<Long>()
             var i = 0
             val start = testScheduler.currentTime

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -650,6 +650,27 @@ class OAuthDeviceTest {
     }
 
     @Test
+    fun poll429OverCeilingRetryAfterClampsToDeadline() = runTest {
+        // A representable delta beyond the shared device ceiling clamps (SPEC
+        // §16): with a 20s code lifetime the wait clips to the deadline and
+        // expiry fires there — never an interval-cadence resend against the
+        // server's throttle.
+        val pollTimes = mutableListOf<Long>()
+        val engine = MockEngine {
+            pollTimes.add(testScheduler.currentTime)
+            respond(tooManyJson, HttpStatusCode.TooManyRequests, headers429("2147484"))
+        }
+        val client = HttpClient(engine)
+
+        val e = assertFailsWith<BasecampException.DeviceFlow> {
+            pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 20, testTimeSource, client)
+        }
+        assertEquals(BasecampException.DEVICE_EXPIRED, e.reason)
+        assertEquals(listOf(5_000L), pollTimes, "no second poll may fire before the clamped wait expires the code")
+        client.close()
+    }
+
+    @Test
     fun poll429WaitClampedToDeadline() = runTest {
         // interval 5s, code lifetime 20s. The 429's huge Retry-After would wait
         // 3600s, but the deadline at t=20s clamps the wait so expiry fires then.

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -966,6 +966,41 @@ class OAuthDeviceTest {
     }
 
     @Test
+    fun pollCapturesResourceAndTreatsNullAsAbsent() = runTest {
+        // resource (RFC 8707) round-trips onto the token; JSON null is absent.
+        val body = """{"access_token":"tok","token_type":"Bearer","resource":"urn:bc:account:42"}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val token = pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+        assertEquals("urn:bc:account:42", token.resource)
+        client.close()
+
+        val nullBody = """{"access_token":"tok","token_type":"Bearer","resource":null}"""
+        val nullEngine = MockEngine { respond(nullBody, HttpStatusCode.OK, jsonHeaders) }
+        val nullClient = HttpClient(nullEngine)
+
+        val nullToken = pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, nullClient)
+        assertNull(nullToken.resource)
+        nullClient.close()
+    }
+
+    @Test
+    fun pollRejectsEmptyResourceOn2xx() = runTest {
+        // A present-but-empty resource is malformed (SPEC §16) — an empty
+        // binding is not a binding. Uniform with Go/Python/Ruby/TS.
+        val body = """{"access_token":"tok","token_type":"Bearer","resource":""}"""
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+
+        val e = assertFailsWith<BasecampException.Api> {
+            pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+        }
+        assertEquals("api_error", e.code)
+        client.close()
+    }
+
+    @Test
     fun pollAcceptsTokenWithoutExpiresIn() = runTest {
         // Absent expires_in (RFC 6749 §5.1) is allowed — the token has no expiry.
         val body = """{"access_token":"tok","token_type":"Bearer"}"""

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -633,6 +633,8 @@ class OAuthDeviceTest {
     fun poll429WrongPairStaysTerminal() = runTest {
         val cases = listOf(
             HttpStatusCode.TooManyRequests to errorJson("rate_limited"),
+            HttpStatusCode.TooManyRequests to errorJson("authorization_pending"),
+            HttpStatusCode.TooManyRequests to errorJson("slow_down"),
             HttpStatusCode.BadRequest to tooManyJson,
         )
         for ((status, body) in cases) {

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -1039,7 +1039,7 @@ class OAuthDeviceTest {
         client.close()
     }
 
-        @Test
+    @Test
     fun pollRejectsMalformedTokenExpiresInOn2xx() = runTest {
         // A 2xx whose expires_in cannot be a schedulable lifetime is api_error:
         // 1e400 parses to Infinity (past the ceiling), an explicit 0 or negative
@@ -1063,7 +1063,7 @@ class OAuthDeviceTest {
         }
     }
 
-        @Test
+    @Test
     fun pollRejectsExplicitEmptyTokenTypeOn2xx() = runTest {
         // An explicit "token_type": "" is malformed token metadata (api_error),
         // distinct from an absent field — uniform with Go/Python/Ruby/TS.

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -540,6 +540,149 @@ class OAuthDeviceTest {
         assertEquals(0, displayed, "display must never fire for a cancelled flow")
     }
 
+    // =========================================================================
+    // pollDeviceToken 429 too_many_requests handling (SPEC §16)
+    // =========================================================================
+
+    private val tooManyJson = """{"error":"too_many_requests"}"""
+
+    private fun headers429(retryAfter: String? = null) =
+        if (retryAfter == null) {
+            jsonHeaders
+        } else {
+            headersOf(
+                HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()),
+                HttpHeaders.RetryAfter to listOf(retryAfter),
+            )
+        }
+
+    @Test
+    fun pollRetriesAfter429WithRetryAfterOverride() = runTest {
+        val pollTimes = mutableListOf<Long>()
+        var i = 0
+        val engine = MockEngine {
+            pollTimes.add(testScheduler.currentTime)
+            i += 1
+            if (i == 1) {
+                respond(tooManyJson, HttpStatusCode.TooManyRequests, headers429("30"))
+            } else {
+                respond(tokenJson, HttpStatusCode.OK, jsonHeaders)
+            }
+        }
+        val client = HttpClient(engine)
+
+        val token = pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+
+        assertEquals("device_access_token", token.accessToken)
+        // Initial 5s wait, then the one-shot max(interval, Retry-After) = 30s.
+        assertEquals(listOf(5_000L, 35_000L), pollTimes)
+        client.close()
+    }
+
+    @Test
+    fun poll429MalformedRetryAfterFallsBackToInterval() = runTest {
+        for (header in listOf(null, "abc", "1.5", "-1", "0", "99999999999999999999")) {
+            val pollTimes = mutableListOf<Long>()
+            var i = 0
+            val start = testScheduler.currentTime
+            val engine = MockEngine {
+                pollTimes.add(testScheduler.currentTime - start)
+                i += 1
+                if (i == 1) {
+                    respond(tooManyJson, HttpStatusCode.TooManyRequests, headers429(header))
+                } else {
+                    respond(tokenJson, HttpStatusCode.OK, jsonHeaders)
+                }
+            }
+            val client = HttpClient(engine)
+
+            pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+
+            // Fallback: both waits are the plain 5s interval.
+            assertEquals(listOf(5_000L, 10_000L), pollTimes, "header=$header")
+            client.close()
+        }
+    }
+
+    @Test
+    fun poll429RetryAfterOverrideDecaysAfterOneWait() = runTest {
+        val pollTimes = mutableListOf<Long>()
+        val responses = listOf(
+            Triple(HttpStatusCode.TooManyRequests, tooManyJson, "30"),
+            Triple(HttpStatusCode.BadRequest, errorJson("authorization_pending"), null),
+            Triple(HttpStatusCode.OK, tokenJson, null),
+        )
+        var i = 0
+        val engine = MockEngine {
+            pollTimes.add(testScheduler.currentTime)
+            val (status, body, retryAfter) = responses[minOf(i, responses.size - 1)]
+            i += 1
+            respond(body, status, headers429(retryAfter))
+        }
+        val client = HttpClient(engine)
+
+        pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+
+        // 5s initial, 30s one-shot override, then back to the 5s interval —
+        // cumulative poll times 5s, 35s, 40s.
+        assertEquals(listOf(5_000L, 35_000L, 40_000L), pollTimes)
+        client.close()
+    }
+
+    @Test
+    fun poll429WrongPairStaysTerminal() = runTest {
+        val cases = listOf(
+            HttpStatusCode.TooManyRequests to errorJson("rate_limited"),
+            HttpStatusCode.BadRequest to tooManyJson,
+        )
+        for ((status, body) in cases) {
+            val engine = MockEngine { respond(body, status, headers429("30")) }
+            val client = HttpClient(engine)
+
+            val e = assertFailsWith<BasecampException.Api> {
+                pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+            }
+            assertEquals("api_error", e.code)
+            client.close()
+        }
+    }
+
+    @Test
+    fun poll429WaitClampedToDeadline() = runTest {
+        // interval 5s, code lifetime 20s. The 429's huge Retry-After would wait
+        // 3600s, but the deadline at t=20s clamps the wait so expiry fires then.
+        val pollTimes = mutableListOf<Long>()
+        val engine = MockEngine {
+            pollTimes.add(testScheduler.currentTime)
+            respond(tooManyJson, HttpStatusCode.TooManyRequests, headers429("3600"))
+        }
+        val client = HttpClient(engine)
+
+        val e = assertFailsWith<BasecampException.DeviceFlow> {
+            pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 20, testTimeSource, client)
+        }
+        assertEquals(BasecampException.DEVICE_EXPIRED, e.reason)
+        // One poll at t=5s; the override wait clamps to the 15s remaining and
+        // the loop expires at t=20s without a second poll.
+        assertEquals(listOf(5_000L), pollTimes)
+        client.close()
+    }
+
+    @Test
+    fun pollPropagatesCancellationDuring429Wait() = runTest {
+        // The 429 override parks the loop in a 30s delay; a 10s timeout cancels
+        // mid-override-wait and the CancellationException must propagate.
+        val engine = MockEngine { respond(tooManyJson, HttpStatusCode.TooManyRequests, headers429("30")) }
+        val client = HttpClient(engine)
+
+        assertFailsWith<TimeoutCancellationException> {
+            withTimeout(10_000) {
+                pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
+            }
+        }
+        client.close()
+    }
+
     @Test
     fun pollCancelledDuringTokenRoundTripNeverReturnsAToken() = runTest {
         // The mock engine cancels the flow's job as it serves the TOKEN,

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -1006,28 +1006,28 @@ class OAuthDeviceTest {
     }
 
     @Test
-    fun pollRejectsMalformedTokenExpiresInOn2xx() = runTest {
-        // A 2xx whose expires_in cannot be a schedulable lifetime is api_error:
-        // 1e400 parses to Infinity (past the ceiling), an explicit 0 or negative
-        // value violates the positive rule, a past-ceiling value would overflow
-        // `it * 1000` in expiresAt, and 3600.5 breaks the whole-second contract.
-        val bodies = listOf(
-            """{"access_token":"tok","token_type":"Bearer","expires_in":1e400}""",
-            """{"access_token":"tok","token_type":"Bearer","expires_in":-1}""",
-            """{"access_token":"tok","token_type":"Bearer","expires_in":0}""",
-            """{"access_token":"tok","token_type":"Bearer","expires_in":2147483648}""",
-            """{"access_token":"tok","token_type":"Bearer","expires_in":3600.5}""",
-        )
-        for (body in bodies) {
-            val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
-            val client = HttpClient(engine)
-            val e = assertFailsWith<BasecampException.Api>("expected api_error for $body") {
-                pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
-            }
-            assertEquals("api_error", e.code)
-            client.close()
+fun pollRejectsMalformedTokenExpiresInOn2xx() = runTest {
+    // A 2xx whose expires_in cannot be a schedulable lifetime is api_error:
+    // 1e400 parses to Infinity (past the ceiling), an explicit 0 or negative
+    // value violates the positive rule, a past-ceiling value would overflow
+    // `it * 1000` in expiresAt, and 3600.5 breaks the whole-second contract.
+    val bodies = listOf(
+        """{"access_token":"tok","token_type":"Bearer","expires_in":1e400}""",
+        """{"access_token":"tok","token_type":"Bearer","expires_in":-1}""",
+        """{"access_token":"tok","token_type":"Bearer","expires_in":0}""",
+        """{"access_token":"tok","token_type":"Bearer","expires_in":2147483648}""",
+        """{"access_token":"tok","token_type":"Bearer","expires_in":3600.5}""",
+    )
+    for (body in bodies) {
+        val engine = MockEngine { respond(body, HttpStatusCode.OK, jsonHeaders) }
+        val client = HttpClient(engine)
+        val e = assertFailsWith<BasecampException.Api>("expected api_error for $body") {
+            pollDeviceToken(tokenEndpoint, "basecamp-cli", "dev-code-123", 5, 900, testTimeSource, client)
         }
+        assertEquals("api_error", e.code)
+        client.close()
     }
+}
 
     @Test
     fun pollRejectsExplicitEmptyTokenTypeOn2xx() = runTest {

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -581,7 +581,7 @@ class OAuthDeviceTest {
 
     @Test
     fun poll429MalformedRetryAfterFallsBackToInterval() = runTest {
-        for (header in listOf(null, "abc", "1.5", "-1", "0", "99999999999999999999")) {
+        for (header in listOf(null, "abc", "1.5", "-1", "0", "99999999999999999999", "+30", "\uFF11\uFF12")) {
             val pollTimes = mutableListOf<Long>()
             var i = 0
             val start = testScheduler.currentTime

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthDeviceTest.kt
@@ -581,7 +581,7 @@ class OAuthDeviceTest {
 
     @Test
     fun poll429MalformedRetryAfterFallsBackToInterval() = runTest {
-        for (header in listOf(null, "abc", "1.5", "-1", "0", "99999999999999999999", "+30", "\uFF11\uFF12")) {
+        for (header in listOf(null, "abc", "1.5", "-1", "0", "99999999999999999999", "+30", "\uFF11\uFF12", "\u00A030", "\u200930")) {
             val pollTimes = mutableListOf<Long>()
             var i = 0
             val start = testScheduler.currentTime

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthTest.kt
@@ -173,6 +173,53 @@ class OAuthTest {
     }
 
     @Test
+    fun exchangeEmptyTokenTypeIsApiFault() = runTest {
+        // SPEC §16: token_type defaults to Bearer only when absent/JSON-null;
+        // a present-but-empty value is a malformed response — matching the
+        // device-flow parser.
+        val engine = MockEngine {
+            respond(
+                content = "{\"access_token\": \"a\", \"token_type\": \"\"}",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val httpClient = HttpClient(engine)
+        val e = assertFailsWith<BasecampException.Api> {
+            exchangeCode(
+                tokenEndpoint = "https://launchpad.37signals.com/authorization/token",
+                code = "c",
+                redirectUri = "https://myapp.com/callback",
+                clientId = "id",
+                clientSecret = "s",
+                client = httpClient,
+            )
+        }
+        assertTrue(e.message!!.contains("token_type"))
+    }
+
+    @Test
+    fun exchangeNullTokenTypeDefaultsToBearer() = runTest {
+        val engine = MockEngine {
+            respond(
+                content = "{\"access_token\": \"a\", \"token_type\": null}",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+        val httpClient = HttpClient(engine)
+        val token = exchangeCode(
+            tokenEndpoint = "https://launchpad.37signals.com/authorization/token",
+            code = "c",
+            redirectUri = "https://myapp.com/callback",
+            clientId = "id",
+            clientSecret = "s",
+            client = httpClient,
+        )
+        assertEquals("Bearer", token.tokenType)
+    }
+
+    @Test
     fun exchangeCodeSuccess() = runTest {
         val engine = MockEngine { request ->
             assertEquals(HttpMethod.Post, request.method)

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthTest.kt
@@ -373,6 +373,34 @@ class OAuthTest {
     }
 
     @Test
+    fun refreshTokenRejectsNonStringResourceAsApiError() = runTest {
+        // Mirrors conformance/oauth-token 05-resource-non-string-rejected: a
+        // wrong-typed resource fails deserialization, surfaced as api_error.
+        val engine = MockEngine { _ ->
+            respond(
+                content = """{"access_token": "a", "resource": 7}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+
+        val httpClient = HttpClient(engine)
+        try {
+            refreshToken(
+                tokenEndpoint = "https://launchpad.37signals.com/authorization/token",
+                refreshToken = "refresh-456",
+                clientId = "basecamp-cli",
+                client = httpClient,
+            )
+            assertTrue(false, "Should have thrown")
+        } catch (e: BasecampException.Api) {
+            assertEquals("api_error", e.code)
+        } finally {
+            httpClient.close()
+        }
+    }
+
+    @Test
     fun refreshTokenRejectsEmptyResourceAsApiError() = runTest {
         val engine = MockEngine { _ ->
             respond(

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/OAuthTest.kt
@@ -312,6 +312,92 @@ class OAuthTest {
         httpClient.close()
     }
 
+    @Test
+    fun refreshTokenSendsResourceWhenSetAndOmitsWhenUnset() = runTest {
+        var lastBody = ""
+        val engine = MockEngine { request ->
+            lastBody = request.body.toByteArray().decodeToString()
+            respond(
+                content = """{"access_token": "new-access"}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+
+        val httpClient = HttpClient(engine)
+        refreshToken(
+            tokenEndpoint = "https://launchpad.37signals.com/authorization/token",
+            refreshToken = "refresh-456",
+            clientId = "basecamp-cli",
+            client = httpClient,
+            resource = "urn:bc:account:42",
+        )
+        assertTrue(lastBody.contains("resource=urn%3Abc%3Aaccount%3A42"))
+
+        refreshToken(
+            tokenEndpoint = "https://launchpad.37signals.com/authorization/token",
+            refreshToken = "refresh-456",
+            clientId = "basecamp-cli",
+            client = httpClient,
+        )
+        assertTrue(!lastBody.contains("resource="))
+
+        httpClient.close()
+    }
+
+    @Test
+    fun refreshTokenCapturesResourceAndTreatsNullAsAbsent() = runTest {
+        suspend fun tokenFor(resourceJson: String): OAuthToken {
+            val engine = MockEngine { _ ->
+                respond(
+                    content = """{"access_token": "a", "resource": $resourceJson}""",
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+                )
+            }
+            val httpClient = HttpClient(engine)
+            try {
+                return refreshToken(
+                    tokenEndpoint = "https://launchpad.37signals.com/authorization/token",
+                    refreshToken = "refresh-456",
+                    clientId = "basecamp-cli",
+                    client = httpClient,
+                )
+            } finally {
+                httpClient.close()
+            }
+        }
+
+        assertEquals("urn:bc:account:42", tokenFor("\"urn:bc:account:42\"").resource)
+        assertEquals(null, tokenFor("null").resource)
+    }
+
+    @Test
+    fun refreshTokenRejectsEmptyResourceAsApiError() = runTest {
+        val engine = MockEngine { _ ->
+            respond(
+                content = """{"access_token": "a", "resource": ""}""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+
+        val httpClient = HttpClient(engine)
+        try {
+            refreshToken(
+                tokenEndpoint = "https://launchpad.37signals.com/authorization/token",
+                refreshToken = "refresh-456",
+                clientId = "basecamp-cli",
+                client = httpClient,
+            )
+            assertTrue(false, "Should have thrown")
+        } catch (e: BasecampException.Api) {
+            assertTrue(e.message!!.contains("resource"))
+        } finally {
+            httpClient.close()
+        }
+    }
+
     // =========================================================================
     // PKCE challenge is correct SHA-256 of verifier
     // =========================================================================

--- a/python/README.md
+++ b/python/README.md
@@ -189,9 +189,11 @@ fallback). Without it, the SDK identifies BC5 by exclusion: exactly one
 non-Launchpad issuer is selected; two or more raise `ambiguous_issuers`; zero
 falls back to Launchpad.
 
-Pass bare origins — no trailing slash. Issuer binding is code-point exact, so
-`https://app.basecamp.com/` would mismatch the advertised issuer and silently
-soft-fall back to Launchpad.
+Pass bare origins — no trailing slash. Binding is code-point exact, and the
+failure mode depends on which parameter carries the slash: a trailing-slash
+`expected_issuer` fails the advertised-member lookup and raises a **hard**
+`expected_issuer_unavailable`, while a trailing-slash *resource* origin breaks
+the hop-1 resource binding and silently soft-falls back to Launchpad.
 
 **Stage-sensitive fallback.** `discover_from_resource` returns a
 `DiscoveryResult` that is either `selected` or a soft `fallback` whose `reason`

--- a/python/README.md
+++ b/python/README.md
@@ -275,8 +275,11 @@ new_token = refresh_token(
     # without it (400 invalid_request); it is sent only when set.
     resource=token.resource,
 )
-# A refresh response MAY omit resource (the binding is unchanged) — persist
-# `new_token.resource or token.resource` so the next refresh still echoes it.
+# A refresh response MAY omit resource (binding unchanged) AND refresh_token
+# (no rotation) — carry BOTH forward when persisting, or the next refresh
+# loses its token:
+#   stored_resource = new_token.resource or token.resource
+#   stored_refresh  = new_token.refresh_token or token.refresh_token
 ```
 
 ### Launchpad Legacy Format

--- a/python/README.md
+++ b/python/README.md
@@ -182,11 +182,16 @@ else:  # result.kind == "fallback"
     config = discover_launchpad()  # result.reason explains why
 ```
 
-**Selection.** Pass `expected_issuer="https://3.basecamp.com"` for an explicit,
-authoritative choice (raises `expected_issuer_unavailable` if it is not
-advertised — never a silent fallback). Without it, the SDK identifies BC5 by
-exclusion: exactly one non-Launchpad issuer is selected; two or more raise
-`ambiguous_issuers`; zero falls back to Launchpad.
+**Selection.** Pass `expected_issuer="https://app.basecamp.com"` (the
+production canonical issuer) for an explicit, authoritative choice (raises
+`expected_issuer_unavailable` if it is not advertised — never a silent
+fallback). Without it, the SDK identifies BC5 by exclusion: exactly one
+non-Launchpad issuer is selected; two or more raise `ambiguous_issuers`; zero
+falls back to Launchpad.
+
+Pass bare origins — no trailing slash. Issuer binding is code-point exact, so
+`https://app.basecamp.com/` would mismatch the advertised issuer and silently
+soft-fall back to Launchpad.
 
 **Stage-sensitive fallback.** `discover_from_resource` returns a
 `DiscoveryResult` that is either `selected` or a soft `fallback` whose `reason`
@@ -263,7 +268,13 @@ new_token = refresh_token(
     refresh_tok=token.refresh_token,
     client_id="your-client-id",
     client_secret="your-client-secret",
+    # Echo the stored token's RFC 8707 resource indicator. BC5 multi-account
+    # refresh tokens (e.g. basecamp-cli device logins) REJECT a refresh
+    # without it (400 invalid_request); it is sent only when set.
+    resource=token.resource,
 )
+# A refresh response MAY omit resource (the binding is unchanged) — persist
+# `new_token.resource or token.resource` so the next refresh still echoes it.
 ```
 
 ### Launchpad Legacy Format
@@ -313,7 +324,10 @@ client = Client(access_token=token.access_token)
 The capability guard requires both `config.device_authorization_endpoint` and
 `"urn:ietf:params:oauth:grant-type:device_code"` in `config.grant_types_supported`;
 otherwise it raises `DeviceFlowError(reason="unavailable")` before any request.
-An omitted `scope` lets the server apply its default (`read`).
+An omitted `scope` lets the server apply its default (`read`) — prefer pinning
+it explicitly with `scope="read"`. The returned token MAY carry an RFC 8707
+`resource` indicator (`token.resource`) — persist it and echo it on refresh
+(see Token Refresh above).
 
 The two building blocks compose directly when you want finer control:
 

--- a/python/src/basecamp/async_auth.py
+++ b/python/src/basecamp/async_auth.py
@@ -39,6 +39,12 @@ class AsyncOAuthTokenProvider:
     """Async token provider that supports OAuth token refresh.
 
     Uses an asyncio lock for concurrency safety.
+
+    Launchpad-only: the token URL is fixed to Launchpad's legacy endpoint and
+    no RFC 8707 ``resource`` indicator is sent. BC5 multi-account refresh
+    tokens require the resource echo — use the discovery +
+    :func:`basecamp.oauth.exchange.refresh_token` path (passing
+    ``token.resource``) instead of this provider.
     """
 
     TOKEN_URL = "https://launchpad.37signals.com/authorization/token"

--- a/python/src/basecamp/auth.py
+++ b/python/src/basecamp/auth.py
@@ -38,6 +38,12 @@ class OAuthTokenProvider:
     """Token provider that supports OAuth token refresh.
 
     Thread-safe: uses a lock around refresh operations.
+
+    Launchpad-only: the token URL is fixed to Launchpad's legacy endpoint and
+    no RFC 8707 ``resource`` indicator is sent. BC5 multi-account refresh
+    tokens require the resource echo — use the discovery +
+    :func:`basecamp.oauth.exchange.refresh_token` path (passing
+    ``token.resource``) instead of this provider.
     """
 
     TOKEN_URL = "https://launchpad.37signals.com/authorization/token"

--- a/python/src/basecamp/oauth/_transport.py
+++ b/python/src/basecamp/oauth/_transport.py
@@ -65,6 +65,7 @@ def request_bounded(
     timeout: float,
     max_body_bytes: int,
     read_body: Callable[[int], bool] = lambda _status: True,
+    on_headers: Callable[[httpx.Headers], None] | None = None,
     context: str = "OAuth",
 ) -> tuple[int, bytes]:
     """SSRF-hardened request: suppress redirects, bound the WHOLE round-trip by
@@ -169,6 +170,7 @@ def request_bounded(
                 raise
 
     async def _request(client: httpx.AsyncClient) -> tuple[int, bytes]:
+
         async with client.stream(method, url, data=params, headers=request_headers) as response:
             try:
                 return await _read(response)
@@ -182,6 +184,10 @@ def request_bounded(
                 raise
 
     async def _read(response: httpx.Response) -> tuple[int, bytes]:
+        # Response headers are available once the stream opens; the poll
+        # loop uses this to read Retry-After without widening the return.
+        if on_headers is not None:
+            on_headers(response.headers)
         if not read_body(response.status_code):
             # Deadline first, symmetric with the body paths: headers
             # becoming runnable past the total bound mean the status was

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -705,6 +705,11 @@ def _post_device_token(
     error = (
         truncate(raw_error) if 400 <= status < 500 and isinstance(raw_error, str) and raw_error else f"http_{status}"
     )
+    # A 429 recognizes ONLY too_many_requests (the exact retryable pair): a
+    # throttling endpoint whose body parrots authorization_pending/slow_down
+    # must not keep the loop polling until code expiry.
+    if status == 429 and error != "too_many_requests":
+        error = f"http_{status}"
     return _PollResult(error=error, status=status, retry_after=retry_after)
 
 

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -283,10 +283,14 @@ def _parse_retry_after_seconds(header: str | None) -> int:
     (``"00000000030"`` = 30) is honored; the 10-significant-digit ceiling
     comfortably covers MAX_DEVICE_SECONDS (7 digits) while keeping ``int()``
     total.
+
+    Trimming is ASCII SP/HTAB only (RFC 9110 OWS) — NOT bare ``str.strip()``,
+    whose Unicode whitespace (NBSP above all) would trim a malformed value
+    into validity.
     """
-    if header is None or not re.fullmatch(r"[0-9]+", header.strip()):
+    if header is None or not re.fullmatch(r"[0-9]+", header.strip(" \t")):
         return 0
-    significant = header.strip().lstrip("0")
+    significant = header.strip(" \t").lstrip("0")
     if not significant or len(significant) > 10:
         # All zeros (value 0, non-positive) or too many significant digits
         # (overflows the ceiling regardless) → interval fallback.

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -562,12 +562,23 @@ def _build_token(data: dict[str, Any], status: int) -> OAuthToken:
     if scope is not None and not isinstance(scope, str):
         raise OAuthError("api_error", "Device token response scope must be a string", http_status=status)
 
+    # resource: absent and JSON null are unset; when present it must be a
+    # non-empty string (SPEC §16) — an empty binding is not a binding.
+    resource = data.get("resource")
+    if resource is not None and (not isinstance(resource, str) or not resource):
+        raise OAuthError(
+            "api_error",
+            "Device token response resource must be a non-empty string when present",
+            http_status=status,
+        )
+
     return OAuthToken(
         access_token=access_token,
         token_type=token_type,
         refresh_token=refresh_token,
         expires_in=expires_in,
         scope=scope,
+        resource=resource,
     )
 
 

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -278,13 +278,20 @@ def _parse_retry_after_seconds(header: str | None) -> int:
     NOT ``str.isdigit()``: it accepts non-ASCII digit-shaped characters
     (``"²"``, ``"٣"``) that ``int()`` rejects with ValueError, and an unbounded
     digit string would trip CPython's int-conversion length limit — both would
-    escape the loop as a crash instead of a fallback. A 10-digit ceiling
+    escape the loop as a crash instead of a fallback. Leading zeros are
+    stripped BEFORE the length guard so a padded in-range delta
+    (``"00000000030"`` = 30) is honored; the 10-significant-digit ceiling
     comfortably covers MAX_DEVICE_SECONDS (7 digits) while keeping ``int()``
     total.
     """
-    if header is None or not re.fullmatch(r"[0-9]{1,10}", header.strip()):
+    if header is None or not re.fullmatch(r"[0-9]+", header.strip()):
         return 0
-    value = int(header.strip())
+    significant = header.strip().lstrip("0")
+    if not significant or len(significant) > 10:
+        # All zeros (value 0, non-positive) or too many significant digits
+        # (overflows the ceiling regardless) → interval fallback.
+        return 0
+    value = int(significant)
     return value if 0 < value <= MAX_DEVICE_SECONDS else 0
 
 

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -76,6 +76,7 @@ def _post_form_bounded(
     timeout: float,
     max_body_bytes: int,
     read_body: Callable[[int], bool] = lambda _status: True,
+    on_headers: Callable[[Any], None] | None = None,
 ) -> tuple[int, bytes]:
     """SSRF-hardened form POST: suppress redirects, bound the timeout, and read
     the body under a genuine streaming cap that aborts once ``max_body_bytes`` is
@@ -104,6 +105,7 @@ def _post_form_bounded(
         timeout=timeout,
         max_body_bytes=max_body_bytes,
         read_body=read_body,
+        on_headers=on_headers,
         context="Device flow",
     )
 
@@ -260,6 +262,22 @@ class _PollResult:
     token: OAuthToken | None = None
     error: str | None = None
     status: int = 0
+    #: Raw Retry-After header on an OAuth-error response, consumed by the
+    #: loop's 429 too_many_requests handling only.
+    retry_after: str | None = None
+
+
+def _parse_retry_after_seconds(header: str | None) -> int:
+    """Validate a Retry-After delta for the 429 poll contract (SPEC §16): a
+    positive integral number of seconds no greater than
+    :data:`MAX_DEVICE_SECONDS` (the shared 32-bit-ms timer bound). Anything
+    else — missing, an HTTP-date, fractional, non-positive, or overflowing —
+    returns 0 so the caller falls back to the current interval.
+    """
+    if header is None or not header.strip().isdigit():
+        return 0
+    value = int(header.strip())
+    return value if 0 < value <= MAX_DEVICE_SECONDS else 0
 
 
 def _validated_clock_sample(value: object, entry: str) -> float:
@@ -394,6 +412,10 @@ def poll_device_token(
         # authorization_pending endpoint would be polled indefinitely.
         return _validated_clock_sample(clock(), "poll_device_token")
 
+    # One-shot next-wait override from a 429 too_many_requests Retry-After
+    # (SPEC §16): consumed by the next wait, never inflating the slow_down
+    # interval. 0 = none.
+    override_seconds = 0
     # An absolute issuance-anchored deadline (perform_device_login passes
     # issued_at + expires_in) beats re-anchoring: clock time elapsing between
     # the caller's remaining-lifetime computation and this entry — a process
@@ -436,7 +458,9 @@ def poll_device_token(
         remaining = deadline - _sample_clock()
         if remaining <= 0:
             raise DeviceFlowError("expired", "Device code expired before authorization completed")
-        _wait_cancellable(min(max(interval_seconds, backoff_seconds), remaining), should_cancel, sleep)
+        wait = min(max(interval_seconds, backoff_seconds, override_seconds), remaining)
+        override_seconds = 0  # one-shot: consumed by this wait, then gone
+        _wait_cancellable(wait, should_cancel, sleep)
 
         if should_cancel is not None and should_cancel():
             raise DeviceFlowError("cancelled", "Device flow cancelled")
@@ -480,6 +504,14 @@ def poll_device_token(
 
         error = result.error
         if error == "authorization_pending":
+            continue
+        if error == "too_many_requests" and result.status == 429:
+            # Retryable ONLY as the exact 429 + too_many_requests pair
+            # (SPEC §16). The next wait honors a positive integral Retry-After
+            # delta via a one-shot max(interval, Retry-After) override — a
+            # missing/malformed header falls back to the current interval, and
+            # the override decays after one wait.
+            override_seconds = _parse_retry_after_seconds(result.retry_after)
             continue
         if error == "slow_down":
             interval_seconds += SLOW_DOWN_INCREMENT_SECONDS
@@ -597,13 +629,16 @@ def _post_device_token(
     # A 3xx token response is an api fault whose body is unused — skip draining it
     # so a slow redirect body can't time out and be retried by the poll loop until
     # expiry. A 4xx body IS read (it carries authorization_pending/slow_down).
+    captured_headers: list[Any] = []
     status, body = _post_form_bounded(
         token_endpoint,
         params,
         timeout,
         max_body_bytes,
         read_body=lambda s: s == 200 or 400 <= s < 500,
+        on_headers=captured_headers.append,
     )
+    retry_after = captured_headers[0].get("Retry-After") if captured_headers else None
 
     # A redirect is never a token-endpoint outcome. Classify it before parsing
     # so a 3xx body carrying {"error": "authorization_pending"} cannot keep the
@@ -662,7 +697,7 @@ def _post_device_token(
     error = (
         truncate(raw_error) if 400 <= status < 500 and isinstance(raw_error, str) and raw_error else f"http_{status}"
     )
-    return _PollResult(error=error, status=status)
+    return _PollResult(error=error, status=status, retry_after=retry_after)
 
 
 def perform_device_login(

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -270,10 +270,12 @@ class _PollResult:
 
 def _parse_retry_after_seconds(header: str | None) -> int:
     """Validate a Retry-After delta for the 429 poll contract (SPEC §16): ASCII
-    digits only, positive, no greater than :data:`MAX_DEVICE_SECONDS` (the
-    shared 32-bit-ms timer bound). Anything else — missing, an HTTP-date,
-    signed, fractional, non-positive, or overflowing — returns 0 so the caller
-    falls back to the current interval.
+    digits only, positive. A representable delta beyond
+    :data:`MAX_DEVICE_SECONDS` (the shared 32-bit-ms timer bound) CLAMPS to
+    the ceiling — the wait rule clips to the remaining code lifetime, honoring
+    the throttle. Anything else — missing, an HTTP-date, signed, fractional,
+    non-positive, or unrepresentable (the digit bound below) — returns 0 so
+    the caller falls back to the current interval.
 
     NOT ``str.isdigit()``: it accepts non-ASCII digit-shaped characters
     (``"²"``, ``"٣"``) that ``int()`` rejects with ValueError, and an unbounded

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import math
+import re
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -268,13 +269,20 @@ class _PollResult:
 
 
 def _parse_retry_after_seconds(header: str | None) -> int:
-    """Validate a Retry-After delta for the 429 poll contract (SPEC §16): a
-    positive integral number of seconds no greater than
-    :data:`MAX_DEVICE_SECONDS` (the shared 32-bit-ms timer bound). Anything
-    else — missing, an HTTP-date, fractional, non-positive, or overflowing —
-    returns 0 so the caller falls back to the current interval.
+    """Validate a Retry-After delta for the 429 poll contract (SPEC §16): ASCII
+    digits only, positive, no greater than :data:`MAX_DEVICE_SECONDS` (the
+    shared 32-bit-ms timer bound). Anything else — missing, an HTTP-date,
+    signed, fractional, non-positive, or overflowing — returns 0 so the caller
+    falls back to the current interval.
+
+    NOT ``str.isdigit()``: it accepts non-ASCII digit-shaped characters
+    (``"²"``, ``"٣"``) that ``int()`` rejects with ValueError, and an unbounded
+    digit string would trip CPython's int-conversion length limit — both would
+    escape the loop as a crash instead of a fallback. A 10-digit ceiling
+    comfortably covers MAX_DEVICE_SECONDS (7 digits) while keeping ``int()``
+    total.
     """
-    if header is None or not header.strip().isdigit():
+    if header is None or not re.fullmatch(r"[0-9]{1,10}", header.strip()):
         return 0
     value = int(header.strip())
     return value if 0 < value <= MAX_DEVICE_SECONDS else 0

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -296,7 +296,12 @@ def _parse_retry_after_seconds(header: str | None) -> int:
         # (overflows the ceiling regardless) → interval fallback.
         return 0
     value = int(significant)
-    return value if 0 < value <= MAX_DEVICE_SECONDS else 0
+    # A representable delta beyond the shared device ceiling clamps rather
+    # than falling back: the wait rule clamps to the remaining code lifetime
+    # anyway, so an over-ceiling throttle waits out the rest of the lifetime
+    # instead of resending before the server's throttle. Only unrepresentable
+    # strings (the digit bound above) are malformed -> interval fallback.
+    return min(value, MAX_DEVICE_SECONDS)
 
 
 def _validated_clock_sample(value: object, entry: str) -> float:

--- a/python/src/basecamp/oauth/exchange.py
+++ b/python/src/basecamp/oauth/exchange.py
@@ -156,8 +156,16 @@ def _parse_token_response(response: httpx.Response) -> OAuthToken:
     if not response.is_success:
         _handle_error(response.status_code, data)
 
-    if not data.get("access_token"):
-        raise OAuthError("api_error", "Token response missing access_token")
+    access_token = data.get("access_token")
+    if not isinstance(access_token, str) or not access_token:
+        # Non-empty STRING, not merely truthy: a numeric access_token is not a
+        # usable credential (SPEC §16), and the status makes the malformed
+        # response diagnosable — matching the device-flow parser.
+        raise OAuthError(
+            "api_error",
+            "Token response missing or non-string access_token",
+            http_status=response.status_code,
+        )
 
     # resource: absent and JSON null are unset; when present it must be a
     # non-empty string (SPEC §16) — an empty binding is not a binding.

--- a/python/src/basecamp/oauth/exchange.py
+++ b/python/src/basecamp/oauth/exchange.py
@@ -85,7 +85,10 @@ def refresh_token(
         params["client_id"] = client_id
     if client_secret is not None:
         params["client_secret"] = client_secret
-    if resource is not None:
+    # Truthiness, not `is not None`: an empty string is not a binding — treat
+    # it as unset (omit) per the send-only-when-set contract, matching the
+    # other SDKs. Sending `resource=` would provoke a 400 on BC5.
+    if resource:
         params["resource"] = resource
 
     return _token_request(token_endpoint, params)

--- a/python/src/basecamp/oauth/exchange.py
+++ b/python/src/basecamp/oauth/exchange.py
@@ -57,9 +57,14 @@ def refresh_token(
     *,
     client_id: str | None = None,
     client_secret: str | None = None,
+    resource: str | None = None,
     use_legacy_format: bool = False,
 ) -> OAuthToken:
     """Refresh an access token.
+
+    Pass *resource* to echo the stored token's RFC 8707 resource indicator —
+    BC5 multi-account refresh tokens reject a refresh without it (SPEC §16);
+    it is sent only when set.
 
     Set *use_legacy_format* to ``True`` for Launchpad's non-standard
     ``type=refresh`` format instead of the standard ``grant_type``.
@@ -80,6 +85,8 @@ def refresh_token(
         params["client_id"] = client_id
     if client_secret is not None:
         params["client_secret"] = client_secret
+    if resource is not None:
+        params["resource"] = resource
 
     return _token_request(token_endpoint, params)
 
@@ -146,12 +153,23 @@ def _parse_token_response(response: httpx.Response) -> OAuthToken:
     if not data.get("access_token"):
         raise OAuthError("api_error", "Token response missing access_token")
 
+    # resource: absent and JSON null are unset; when present it must be a
+    # non-empty string (SPEC §16) — an empty binding is not a binding.
+    resource = data.get("resource")
+    if resource is not None and (not isinstance(resource, str) or not resource):
+        raise OAuthError(
+            "api_error",
+            "Token response resource must be a non-empty string when present",
+            http_status=response.status_code,
+        )
+
     return OAuthToken(
         access_token=data["access_token"],
         token_type=data.get("token_type", "Bearer"),
         refresh_token=data.get("refresh_token"),
         expires_in=data.get("expires_in"),
         scope=data.get("scope"),
+        resource=resource,
     )
 
 

--- a/python/src/basecamp/oauth/exchange.py
+++ b/python/src/basecamp/oauth/exchange.py
@@ -57,8 +57,11 @@ def refresh_token(
     *,
     client_id: str | None = None,
     client_secret: str | None = None,
-    resource: str | None = None,
     use_legacy_format: bool = False,
+    # APPENDED LAST (SPEC append-only refresh contract): keyword-only keeps
+    # calls source-compatible, but reflected/published signature order must
+    # not shift existing parameters.
+    resource: str | None = None,
 ) -> OAuthToken:
     """Refresh an access token.
 

--- a/python/src/basecamp/oauth/exchange.py
+++ b/python/src/basecamp/oauth/exchange.py
@@ -177,9 +177,22 @@ def _parse_token_response(response: httpx.Response) -> OAuthToken:
             http_status=response.status_code,
         )
 
+    # token_type: absent or JSON null defaults to Bearer (dict.get's default
+    # covers only absence — an explicit null passed through as None); present
+    # must be a non-empty string — matching the device-flow parser (SPEC §16).
+    token_type = data.get("token_type")
+    if token_type is None:
+        token_type = "Bearer"
+    elif not isinstance(token_type, str) or not token_type:
+        raise OAuthError(
+            "api_error",
+            "Token response token_type must be a non-empty string when present",
+            http_status=response.status_code,
+        )
+
     return OAuthToken(
         access_token=data["access_token"],
-        token_type=data.get("token_type", "Bearer"),
+        token_type=token_type,
         refresh_token=data.get("refresh_token"),
         expires_in=data.get("expires_in"),
         scope=data.get("scope"),

--- a/python/src/basecamp/oauth/token.py
+++ b/python/src/basecamp/oauth/token.py
@@ -14,6 +14,12 @@ class OAuthToken:
     expires_in: int | None = None
     expires_at: float | None = field(default=None)
     scope: str | None = None
+    #: RFC 8707 resource indicator the token is bound to (BC5:
+    #: ``urn:bc:account:<id>``). Echo it as the ``resource`` parameter when
+    #: refreshing — BC5 multi-account refresh tokens reject a refresh
+    #: without it (SPEC §16). Appended last: earlier fields keep their
+    #: positional slots.
+    resource: str | None = None
 
     def __post_init__(self) -> None:
         # Calculate expires_at from expires_in when not explicitly provided.

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -1024,6 +1024,8 @@ class TestPollDeviceTokenTimeoutNormalization:
             timeout=None,
         )
         assert token.access_token == "device_access_token"  # gitleaks:allow
+
+
 class TestParseRetryAfterSeconds:
     def test_rejects_non_ascii_digits_and_oversized_strings(self):
         # str.isdigit() accepts digit-shaped non-ASCII ("\u00b2") that int()

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -1046,6 +1046,10 @@ class TestParseRetryAfterSeconds:
         assert _parse_retry_after_seconds("30\u00a0") == 0
         assert _parse_retry_after_seconds("\u200930") == 0  # thin space is not OWS
         assert _parse_retry_after_seconds("30") == 30
+        # Representable over-ceiling clamps (the wait rule clips to the
+        # remaining lifetime); >10 significant digits is unrepresentable.
+        assert _parse_retry_after_seconds("2147484") == 2_147_483
+        assert _parse_retry_after_seconds("99999999999") == 0
 
 
 class TestPollDeviceTokenCancelAfterRoundTrip:

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -1274,7 +1274,17 @@ class TestPollDeviceToken429:
         assert sleep.waits == [5, 30]
 
     @respx.mock
-    @pytest.mark.parametrize("headers", [{}, {"Retry-After": "abc"}, {"Retry-After": "1.5"}, {"Retry-After": "-1"}, {"Retry-After": "0"}, {"Retry-After": "99999999999999999999"}])
+    @pytest.mark.parametrize(
+        "headers",
+        [
+            {},
+            {"Retry-After": "abc"},
+            {"Retry-After": "1.5"},
+            {"Retry-After": "-1"},
+            {"Retry-After": "0"},
+            {"Retry-After": "99999999999999999999"},
+        ],
+    )
     def test_missing_or_malformed_retry_after_falls_back_to_interval(self, headers):
         _queue_token_responses(
             [
@@ -1284,9 +1294,7 @@ class TestPollDeviceToken429:
         )
         sleep = RecordingSleep()
 
-        poll_device_token(
-            TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=sleep
-        )
+        poll_device_token(TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=sleep)
 
         assert sleep.waits == [5, 5]
 
@@ -1301,9 +1309,7 @@ class TestPollDeviceToken429:
         )
         sleep = RecordingSleep()
 
-        poll_device_token(
-            TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=sleep
-        )
+        poll_device_token(TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=sleep)
 
         # 5s initial, 30s one-shot override, then back to the 5s interval.
         assert sleep.waits == [5, 30, 5]
@@ -1324,9 +1330,7 @@ class TestPollDeviceToken429:
 
     @respx.mock
     def test_429_wait_clamped_to_expiry(self):
-        _queue_token_responses(
-            [httpx.Response(429, json=self.TOO_MANY, headers={"Retry-After": "3600"})]
-        )
+        _queue_token_responses([httpx.Response(429, json=self.TOO_MANY, headers={"Retry-After": "3600"})])
         sleep = RecordingSleep()
         # Scripted monotonic clock: deadline anchors at t=0 with a 20s
         # lifetime. The second iteration's huge Retry-After override must clamp
@@ -1341,17 +1345,20 @@ class TestPollDeviceToken429:
 
         with pytest.raises(DeviceFlowError) as exc_info:
             poll_device_token(
-                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123",
-                interval=5, expires_in=20, sleep=sleep, clock=clock,
+                TOKEN_ENDPOINT,
+                "basecamp-cli",
+                "dev-code-123",
+                interval=5,
+                expires_in=20,
+                sleep=sleep,
+                clock=clock,
             )
         assert exc_info.value.reason == "expired"
         assert sleep.waits == [5, 14]
 
     @respx.mock
     def test_cancellation_during_429_wait(self):
-        _queue_token_responses(
-            [httpx.Response(429, json=self.TOO_MANY, headers={"Retry-After": "30"})]
-        )
+        _queue_token_responses([httpx.Response(429, json=self.TOO_MANY, headers={"Retry-After": "30"})])
         slept = {"total": 0.0}
         cancelled = {"flag": False}
 
@@ -1365,8 +1372,12 @@ class TestPollDeviceToken429:
 
         with pytest.raises(DeviceFlowError) as exc_info:
             poll_device_token(
-                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123",
-                interval=5, expires_in=900, sleep=sleep,
+                TOKEN_ENDPOINT,
+                "basecamp-cli",
+                "dev-code-123",
+                interval=5,
+                expires_in=900,
+                sleep=sleep,
                 should_cancel=lambda: cancelled["flag"],
             )
         assert exc_info.value.reason == "cancelled"

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -1252,6 +1252,126 @@ class TestPollDeviceTokenExact200:
             )
         assert exc_info.value.code == "api_error"
         assert exc_info.value.http_status == status
+class TestPollDeviceToken429:
+    TOO_MANY = {"error": "too_many_requests"}
+
+    @respx.mock
+    def test_retries_after_429_with_retry_after_override(self):
+        _queue_token_responses(
+            [
+                httpx.Response(429, json=self.TOO_MANY, headers={"Retry-After": "30"}),
+                httpx.Response(200, json=TOKEN_RESPONSE),
+            ]
+        )
+        sleep = RecordingSleep()
+
+        token = poll_device_token(
+            TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=sleep
+        )
+
+        assert token.access_token == "device_access_token"  # gitleaks:allow
+        # Initial 5s wait, then the one-shot max(interval, Retry-After) = 30s.
+        assert sleep.waits == [5, 30]
+
+    @respx.mock
+    @pytest.mark.parametrize("headers", [{}, {"Retry-After": "abc"}, {"Retry-After": "1.5"}, {"Retry-After": "-1"}, {"Retry-After": "0"}, {"Retry-After": "99999999999999999999"}])
+    def test_missing_or_malformed_retry_after_falls_back_to_interval(self, headers):
+        _queue_token_responses(
+            [
+                httpx.Response(429, json=self.TOO_MANY, headers=headers),
+                httpx.Response(200, json=TOKEN_RESPONSE),
+            ]
+        )
+        sleep = RecordingSleep()
+
+        poll_device_token(
+            TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=sleep
+        )
+
+        assert sleep.waits == [5, 5]
+
+    @respx.mock
+    def test_retry_after_override_decays_after_one_wait(self):
+        _queue_token_responses(
+            [
+                httpx.Response(429, json=self.TOO_MANY, headers={"Retry-After": "30"}),
+                httpx.Response(400, json={"error": "authorization_pending"}),
+                httpx.Response(200, json=TOKEN_RESPONSE),
+            ]
+        )
+        sleep = RecordingSleep()
+
+        poll_device_token(
+            TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=sleep
+        )
+
+        # 5s initial, 30s one-shot override, then back to the 5s interval.
+        assert sleep.waits == [5, 30, 5]
+
+    @respx.mock
+    @pytest.mark.parametrize(
+        ("status", "body"),
+        [(429, {"error": "rate_limited"}), (400, {"error": "too_many_requests"})],
+    )
+    def test_wrong_pair_stays_terminal(self, status, body):
+        _queue_token_responses([httpx.Response(status, json=body, headers={"Retry-After": "30"})])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+        assert exc_info.value.code == "api_error"
+
+    @respx.mock
+    def test_429_wait_clamped_to_expiry(self):
+        _queue_token_responses(
+            [httpx.Response(429, json=self.TOO_MANY, headers={"Retry-After": "3600"})]
+        )
+        sleep = RecordingSleep()
+        # Scripted monotonic clock: deadline anchors at t=0 with a 20s
+        # lifetime. The second iteration's huge Retry-After override must clamp
+        # to the 14s remaining, and the post-wait check then expires the flow.
+        times = [0, 0, 5, 6, 20]
+        state = {"i": 0}
+
+        def clock() -> float:
+            value = times[min(state["i"], len(times) - 1)]
+            state["i"] += 1
+            return value
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123",
+                interval=5, expires_in=20, sleep=sleep, clock=clock,
+            )
+        assert exc_info.value.reason == "expired"
+        assert sleep.waits == [5, 14]
+
+    @respx.mock
+    def test_cancellation_during_429_wait(self):
+        _queue_token_responses(
+            [httpx.Response(429, json=self.TOO_MANY, headers={"Retry-After": "30"})]
+        )
+        slept = {"total": 0.0}
+        cancelled = {"flag": False}
+
+        def sleep(seconds: float) -> None:
+            # The cancellable wait chunks each interval, so count elapsed time:
+            # once past the first 5s wait we are inside the post-429 override
+            # wait — cancel there.
+            slept["total"] += seconds
+            if slept["total"] > 5.0:
+                cancelled["flag"] = True
+
+        with pytest.raises(DeviceFlowError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123",
+                interval=5, expires_in=900, sleep=sleep,
+                should_cancel=lambda: cancelled["flag"],
+            )
+        assert exc_info.value.reason == "cancelled"
+
+
 class TestPollDeviceTokenResource:
     @respx.mock
     def test_captures_resource(self):

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -1337,7 +1337,12 @@ class TestPollDeviceToken429:
     @respx.mock
     @pytest.mark.parametrize(
         ("status", "body"),
-        [(429, {"error": "rate_limited"}), (400, {"error": "too_many_requests"})],
+        [
+            (429, {"error": "rate_limited"}),
+            (429, {"error": "authorization_pending"}),
+            (429, {"error": "slow_down"}),
+            (400, {"error": "too_many_requests"}),
+        ],
     )
     def test_wrong_pair_stays_terminal(self, status, body):
         _queue_token_responses([httpx.Response(status, json=body, headers={"Retry-After": "30"})])

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -1024,6 +1024,21 @@ class TestPollDeviceTokenTimeoutNormalization:
             timeout=None,
         )
         assert token.access_token == "device_access_token"  # gitleaks:allow
+class TestParseRetryAfterSeconds:
+    def test_rejects_non_ascii_digits_and_oversized_strings(self):
+        # str.isdigit() accepts digit-shaped non-ASCII ("\u00b2") that int()
+        # rejects with ValueError, and CPython's int-conversion length limit
+        # raises on unbounded digit strings — both must be a 0 fallback, never
+        # an exception out of the poll loop. (Non-ASCII can't ride an httpx
+        # mock header, so the parser is exercised directly.)
+        from basecamp.oauth.device import _parse_retry_after_seconds
+
+        assert _parse_retry_after_seconds("\u00b2") == 0
+        assert _parse_retry_after_seconds("\u0663\u0660") == 0  # Arabic-Indic 30
+        assert _parse_retry_after_seconds("9" * 5000) == 0
+        assert _parse_retry_after_seconds("+30") == 0
+        assert _parse_retry_after_seconds(" 30 ") == 30
+        assert _parse_retry_after_seconds("30") == 30
 
 
 class TestPollDeviceTokenCancelAfterRoundTrip:
@@ -1252,6 +1267,8 @@ class TestPollDeviceTokenExact200:
             )
         assert exc_info.value.code == "api_error"
         assert exc_info.value.http_status == status
+
+
 class TestPollDeviceToken429:
     TOO_MANY = {"error": "too_many_requests"}
 
@@ -1283,6 +1300,7 @@ class TestPollDeviceToken429:
             {"Retry-After": "-1"},
             {"Retry-After": "0"},
             {"Retry-After": "99999999999999999999"},
+            {"Retry-After": "+30"},
         ],
     )
     def test_missing_or_malformed_retry_after_falls_back_to_interval(self, headers):

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -1252,6 +1252,39 @@ class TestPollDeviceTokenExact200:
             )
         assert exc_info.value.code == "api_error"
         assert exc_info.value.http_status == status
+class TestPollDeviceTokenResource:
+    @respx.mock
+    def test_captures_resource(self):
+        _queue_token_responses([httpx.Response(200, json={**TOKEN_RESPONSE, "resource": "urn:bc:account:42"})])
+
+        token = poll_device_token(
+            TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+        )
+
+        assert token.resource == "urn:bc:account:42"
+
+    @respx.mock
+    def test_null_resource_is_absent(self):
+        _queue_token_responses([httpx.Response(200, json={**TOKEN_RESPONSE, "resource": None})])
+
+        token = poll_device_token(
+            TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+        )
+
+        assert token.resource is None
+
+    @respx.mock
+    @pytest.mark.parametrize("resource", ["", 7])
+    def test_malformed_resource_rejected(self, resource):
+        _queue_token_responses([httpx.Response(200, json={**TOKEN_RESPONSE, "resource": resource})])
+
+        with pytest.raises(OAuthError) as exc_info:
+            poll_device_token(
+                TOKEN_ENDPOINT, "basecamp-cli", "dev-code-123", interval=5, expires_in=900, sleep=RecordingSleep()
+            )
+
+        assert exc_info.value.code == "api_error"
+        assert "resource" in str(exc_info.value)
 
 
 class TestPerformDeviceLogin:

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -1036,6 +1036,7 @@ class TestParseRetryAfterSeconds:
         from basecamp.oauth.device import _parse_retry_after_seconds
 
         assert _parse_retry_after_seconds("\u00b2") == 0
+        assert _parse_retry_after_seconds("00000000030") == 30  # padded in-range delta
         assert _parse_retry_after_seconds("\u0663\u0660") == 0  # Arabic-Indic 30
         assert _parse_retry_after_seconds("9" * 5000) == 0
         assert _parse_retry_after_seconds("+30") == 0

--- a/python/tests/oauth/test_device.py
+++ b/python/tests/oauth/test_device.py
@@ -1041,6 +1041,10 @@ class TestParseRetryAfterSeconds:
         assert _parse_retry_after_seconds("9" * 5000) == 0
         assert _parse_retry_after_seconds("+30") == 0
         assert _parse_retry_after_seconds(" 30 ") == 30
+        assert _parse_retry_after_seconds("\t30\t") == 30  # ASCII OWS (RFC 9110: SP/HTAB)
+        assert _parse_retry_after_seconds("\u00a030") == 0  # NBSP is not OWS
+        assert _parse_retry_after_seconds("30\u00a0") == 0
+        assert _parse_retry_after_seconds("\u200930") == 0  # thin space is not OWS
         assert _parse_retry_after_seconds("30") == 30
 
 

--- a/python/tests/oauth/test_exchange.py
+++ b/python/tests/oauth/test_exchange.py
@@ -143,3 +143,57 @@ class TestRefreshToken:
         body = request.content.decode()
         assert "type=refresh" in body
         assert "grant_type" not in body
+
+
+class TestResourceIndicator:
+    @respx.mock
+    def test_refresh_sends_resource_when_set(self):
+        route = respx.post(TOKEN_ENDPOINT).mock(return_value=httpx.Response(200, json=TOKEN_RESPONSE))
+
+        refresh_token(
+            TOKEN_ENDPOINT,
+            refresh_tok="refresh-tok-123",
+            client_id="basecamp-cli",
+            resource="urn:bc:account:42",
+        )
+
+        body = route.calls[0].request.content.decode()
+        assert "resource=urn%3Abc%3Aaccount%3A42" in body
+
+    @respx.mock
+    def test_refresh_omits_resource_when_unset(self):
+        route = respx.post(TOKEN_ENDPOINT).mock(return_value=httpx.Response(200, json=TOKEN_RESPONSE))
+
+        refresh_token(TOKEN_ENDPOINT, refresh_tok="refresh-tok-123")
+
+        body = route.calls[0].request.content.decode()
+        assert "resource=" not in body
+
+    @respx.mock
+    def test_token_response_resource_round_trips(self):
+        respx.post(TOKEN_ENDPOINT).mock(
+            return_value=httpx.Response(200, json={**TOKEN_RESPONSE, "resource": "urn:bc:account:42"})
+        )
+
+        token = refresh_token(TOKEN_ENDPOINT, refresh_tok="refresh-tok-123")
+
+        assert token.resource == "urn:bc:account:42"
+
+    @respx.mock
+    def test_token_response_null_resource_is_absent(self):
+        respx.post(TOKEN_ENDPOINT).mock(return_value=httpx.Response(200, json={**TOKEN_RESPONSE, "resource": None}))
+
+        token = refresh_token(TOKEN_ENDPOINT, refresh_tok="refresh-tok-123")
+
+        assert token.resource is None
+
+    @respx.mock
+    @pytest.mark.parametrize("resource", ["", 7])
+    def test_token_response_malformed_resource_rejected(self, resource):
+        respx.post(TOKEN_ENDPOINT).mock(return_value=httpx.Response(200, json={**TOKEN_RESPONSE, "resource": resource}))
+
+        with pytest.raises(OAuthError) as exc_info:
+            refresh_token(TOKEN_ENDPOINT, refresh_tok="refresh-tok-123")
+
+        assert exc_info.value.code == "api_error"
+        assert "resource" in str(exc_info.value)

--- a/python/tests/oauth/test_exchange.py
+++ b/python/tests/oauth/test_exchange.py
@@ -85,6 +85,38 @@ class TestExchangeCode:
         assert "grant_type" not in body
 
     @respx.mock
+    def test_token_type_contract(self):
+        # SPEC §16: token_type defaults to Bearer only when absent/JSON-null;
+        # a present-but-empty or non-string value is a malformed response —
+        # matching the device-flow parser.
+        for body, expected in (
+            ({"access_token": "a"}, "Bearer"),
+            ({"access_token": "a", "token_type": None}, "Bearer"),
+            ({"access_token": "a", "token_type": "Bearer"}, "Bearer"),
+        ):
+            respx.post(TOKEN_ENDPOINT).mock(return_value=httpx.Response(200, json=body))
+            token = exchange_code(
+                TOKEN_ENDPOINT,
+                code="c",
+                redirect_uri="https://myapp.com/callback",
+                client_id="client-id",
+            )
+            assert token.token_type == expected, body
+
+        for bad in ("", 7):
+            respx.post(TOKEN_ENDPOINT).mock(
+                return_value=httpx.Response(200, json={"access_token": "a", "token_type": bad})
+            )
+            with pytest.raises(OAuthError) as exc_info:
+                exchange_code(
+                    TOKEN_ENDPOINT,
+                    code="c",
+                    redirect_uri="https://myapp.com/callback",
+                    client_id="client-id",
+                )
+            assert exc_info.value.oauth_type == "api_error", bad
+
+    @respx.mock
     def test_exchange_error(self):
         respx.post(TOKEN_ENDPOINT).mock(
             return_value=httpx.Response(

--- a/python/tests/oauth/test_exchange.py
+++ b/python/tests/oauth/test_exchange.py
@@ -161,10 +161,13 @@ class TestResourceIndicator:
         assert "resource=urn%3Abc%3Aaccount%3A42" in body
 
     @respx.mock
-    def test_refresh_omits_resource_when_unset(self):
+    @pytest.mark.parametrize("resource", [None, ""])
+    def test_refresh_omits_resource_when_unset_or_empty(self, resource):
+        # None is unset; an empty string is not a binding — both must omit the
+        # form key entirely (send-only-when-set; `resource=` provokes a 400).
         route = respx.post(TOKEN_ENDPOINT).mock(return_value=httpx.Response(200, json=TOKEN_RESPONSE))
 
-        refresh_token(TOKEN_ENDPOINT, refresh_tok="refresh-tok-123")
+        refresh_token(TOKEN_ENDPOINT, refresh_tok="refresh-tok-123", resource=resource)
 
         body = route.calls[0].request.content.decode()
         assert "resource=" not in body

--- a/python/tests/oauth/test_token_conformance.py
+++ b/python/tests/oauth/test_token_conformance.py
@@ -52,7 +52,10 @@ def test_oauth_token_fixture(path: Path) -> None:
             refresh_token(TOKEN_ENDPOINT, refresh_tok="refresh-token", client_id="basecamp-cli", **kwargs)
         assert exc_info.value.code == "api_error"
 
-    form = parse_qs(route.calls[0].request.content.decode())
+    # keep_blank_values: a regression that sends `resource=` (blank value)
+    # instead of omitting the key must FAIL formResourceAbsent — parse_qs drops
+    # blank-valued parameters by default, which would mask exactly that bug.
+    form = parse_qs(route.calls[0].request.content.decode(), keep_blank_values=True)
     if "formResource" in expect:
         assert form.get("resource") == [expect["formResource"]]
     if expect.get("formResourceAbsent"):

--- a/python/tests/oauth/test_token_conformance.py
+++ b/python/tests/oauth/test_token_conformance.py
@@ -1,0 +1,65 @@
+"""Drives the shared, data-only fixtures in ``conformance/oauth-token/fixtures``:
+one refresh round-trip per fixture, asserting the sent resource form parameter
+and the response decode (round-trip, absent/null as unset,
+present-empty/non-string rejected). Lifecycle preservation across a stored
+credential is per-manager behavior — not modeled here.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from urllib.parse import parse_qs
+
+import httpx
+import pytest
+import respx
+
+from basecamp.oauth.errors import OAuthError
+from basecamp.oauth.exchange import refresh_token
+
+FIXTURE_DIR = Path(__file__).resolve().parents[2].parent / "conformance" / "oauth-token" / "fixtures"
+TOKEN_ENDPOINT = "https://issuer.token-fixtures.example/oauth/token"
+
+FIXTURES = sorted(FIXTURE_DIR.glob("*.json"))
+assert FIXTURES, f"no fixtures found in {FIXTURE_DIR}"
+
+
+@pytest.mark.parametrize("path", FIXTURES, ids=lambda p: p.name)
+@respx.mock
+def test_oauth_token_fixture(path: Path) -> None:
+    fixture = json.loads(path.read_text())
+    assert fixture["operation"] == "refreshToken"
+
+    route = respx.post(TOKEN_ENDPOINT).mock(
+        return_value=httpx.Response(
+            fixture["response"].get("status", 200), json=fixture["response"]["body"]
+        )
+    )
+
+    kwargs = {}
+    resource = fixture.get("request", {}).get("resource")
+    if resource is not None:
+        kwargs["resource"] = resource
+
+    expect = fixture["expect"]
+    if expect["outcome"] == "token":
+        token = refresh_token(
+            TOKEN_ENDPOINT, refresh_tok="refresh-token", client_id="basecamp-cli", **kwargs
+        )
+        if "resource" in expect:
+            assert token.resource == expect["resource"]
+        if expect.get("resourceAbsent"):
+            assert token.resource is None
+    else:
+        with pytest.raises(OAuthError) as exc_info:
+            refresh_token(
+                TOKEN_ENDPOINT, refresh_tok="refresh-token", client_id="basecamp-cli", **kwargs
+            )
+        assert exc_info.value.code == "api_error"
+
+    form = parse_qs(route.calls[0].request.content.decode())
+    if "formResource" in expect:
+        assert form.get("resource") == [expect["formResource"]]
+    if expect.get("formResourceAbsent"):
+        assert "resource" not in form

--- a/python/tests/oauth/test_token_conformance.py
+++ b/python/tests/oauth/test_token_conformance.py
@@ -32,9 +32,7 @@ def test_oauth_token_fixture(path: Path) -> None:
     assert fixture["operation"] == "refreshToken"
 
     route = respx.post(TOKEN_ENDPOINT).mock(
-        return_value=httpx.Response(
-            fixture["response"].get("status", 200), json=fixture["response"]["body"]
-        )
+        return_value=httpx.Response(fixture["response"].get("status", 200), json=fixture["response"]["body"])
     )
 
     kwargs = {}
@@ -44,18 +42,14 @@ def test_oauth_token_fixture(path: Path) -> None:
 
     expect = fixture["expect"]
     if expect["outcome"] == "token":
-        token = refresh_token(
-            TOKEN_ENDPOINT, refresh_tok="refresh-token", client_id="basecamp-cli", **kwargs
-        )
+        token = refresh_token(TOKEN_ENDPOINT, refresh_tok="refresh-token", client_id="basecamp-cli", **kwargs)
         if "resource" in expect:
             assert token.resource == expect["resource"]
         if expect.get("resourceAbsent"):
             assert token.resource is None
     else:
         with pytest.raises(OAuthError) as exc_info:
-            refresh_token(
-                TOKEN_ENDPOINT, refresh_tok="refresh-token", client_id="basecamp-cli", **kwargs
-            )
+            refresh_token(TOKEN_ENDPOINT, refresh_tok="refresh-token", client_id="basecamp-cli", **kwargs)
         assert exc_info.value.code == "api_error"
 
     form = parse_qs(route.calls[0].request.content.decode())

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -172,7 +172,9 @@ client = Basecamp.client(access_token: token.access_token)
 # "urn:bc:account:<id>"), and refreshing without echoing it is rejected
 # (400 invalid_request). Persist token.resource alongside the tokens and
 # echo it on refresh:
-if token.expired?
+# A device-token response MAY omit refresh_token — guard it: without one,
+# refreshing is impossible and the user must re-run the device login.
+if token.expired? && token.refresh_token
   fresh = Basecamp::Oauth.refresh_token(
     token_endpoint: config.token_endpoint,
     refresh_token: token.refresh_token,

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -138,7 +138,10 @@ end
 For input-constrained clients (CLIs, TVs) that can't host a redirect URI, the
 device flow trades a redirect for a user-entered code. Basecamp pre-registers the
 public `basecamp-cli` client (`token_endpoint_auth_method: none`, no secret); an
-omitted scope defaults to `read`.
+omitted scope defaults to `read` — prefer pinning it explicitly with
+`scope: "read"`. Pass bare origins everywhere (no trailing slash): issuer
+binding is code-point exact, so `https://app.basecamp.com/` would silently
+soft-fall back to Launchpad.
 
 ```ruby
 # The device grant runs against an ALREADY-SELECTED config whose issuer advertises
@@ -162,6 +165,22 @@ token = Basecamp::Oauth.perform_device_login(
 )
 
 client = Basecamp.client(access_token: token.access_token)
+
+# BC5 device logins as basecamp-cli mint MULTI-ACCOUNT refresh tokens: the
+# token carries an RFC 8707 resource indicator (token.resource,
+# "urn:bc:account:<id>"), and refreshing without echoing it is rejected
+# (400 invalid_request). Persist token.resource alongside the tokens and
+# echo it on refresh:
+if token.expired?
+  fresh = Basecamp::Oauth.refresh_token(
+    token_endpoint: config.token_endpoint,
+    refresh_token: token.refresh_token,
+    client_id: "basecamp-cli",   # public client — no secret
+    resource: token.resource
+  )
+  # A refresh response MAY omit resource (the binding is unchanged) — persist
+  # `fresh.resource || token.resource` so the next refresh still echoes it.
+end
 ```
 
 The capability guard requires BOTH `config.device_authorization_endpoint` AND the

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -139,9 +139,10 @@ For input-constrained clients (CLIs, TVs) that can't host a redirect URI, the
 device flow trades a redirect for a user-entered code. Basecamp pre-registers the
 public `basecamp-cli` client (`token_endpoint_auth_method: none`, no secret); an
 omitted scope defaults to `read` — prefer pinning it explicitly with
-`scope: "read"`. Pass bare origins everywhere (no trailing slash): issuer
-binding is code-point exact, so `https://app.basecamp.com/` would silently
-soft-fall back to Launchpad.
+`scope: "read"`. Pass bare origins everywhere (no trailing slash): binding is
+code-point exact — a trailing-slash `expected_issuer` raises a **hard**
+`expected_issuer_unavailable`, while a trailing-slash resource origin breaks
+the hop-1 binding and silently soft-falls back to Launchpad.
 
 ```ruby
 # The device grant runs against an ALREADY-SELECTED config whose issuer advertises

--- a/ruby/lib/basecamp/oauth.rb
+++ b/ruby/lib/basecamp/oauth.rb
@@ -133,12 +133,12 @@ module Basecamp
     def self.refresh_token(
       token_endpoint:, refresh_token:,
       client_id: nil, client_secret: nil,
-      use_legacy_format: false, timeout: 30
+      use_legacy_format: false, timeout: 30, resource: nil
     )
       request = RefreshRequest.new(
         token_endpoint: token_endpoint, refresh_token: refresh_token,
         client_id: client_id, client_secret: client_secret,
-        use_legacy_format: use_legacy_format
+        use_legacy_format: use_legacy_format, resource: resource
       )
       Exchange.new(timeout: timeout).refresh(request)
     end

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -673,9 +673,11 @@ module Basecamp
             value.is_a?(Numeric) && value.positive? && value <= MAX_DEVICE_SECONDS && (value % 1).zero?
           end
 
-          # Returns +[:token, Token, status]+ on success or +[:error, code, status]+
-          # when the server reports an OAuth error. Raises +api_error+ on a
-          # malformed, redirecting, or 2xx-but-tokenless response.
+          # Returns +[:token, Token, status]+ on success or
+          # +[:error, code, status, retry_after]+ when the server reports an
+          # OAuth error — +retry_after+ is the raw Retry-After header (or nil),
+          # consumed only by the poll loop's 429 handling. Raises +api_error+
+          # on a malformed, redirecting, or 200-but-tokenless response.
           def post_device_token(client, token_endpoint, params, timeout:, max_body_bytes:)
             retry_after = nil
             status, body = post_form(

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -758,8 +758,12 @@ module Basecamp
           # overflowing — returns 0 so the caller falls back to the current
           # interval.
           def parse_retry_after_seconds(header)
-            if header.is_a?(String) && header.strip.match?(/\A\d+\z/)
-              value = header.strip.to_i
+            # ASCII SP/HTAB only (RFC 9110 OWS) — NOT String#strip, which also
+            # removes \v \f \r \n \0 and would trim a malformed value into
+            # validity (SPEC §16 pins SP/HTAB-only trimming).
+            trimmed = header.is_a?(String) ? header.gsub(/\A[ \t]+|[ \t]+\z/, "") : ""
+            if trimmed.match?(/\A\d+\z/)
+              value = trimmed.to_i
               (1..MAX_DEVICE_SECONDS).cover?(value) ? value : 0
             else
               0

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -767,12 +767,24 @@ module Basecamp
               )
             end
 
+            # resource: absent and JSON null are unset; when present it must be
+            # a non-empty string (SPEC §16) — an empty binding is not a binding.
+            resource = data["resource"]
+            unless resource.nil? || (resource.is_a?(String) && !resource.empty?)
+              raise OauthError.new(
+                "api_error",
+                "Invalid device token response: resource must be a non-empty string when present",
+                http_status: status
+              )
+            end
+
             Token.new(
               access_token: data["access_token"],
               refresh_token: refresh_token,
               token_type: token_type || "Bearer",
               expires_in: expires_in,
-              scope: scope
+              scope: scope,
+              resource: resource
             )
           end
 

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -763,8 +763,19 @@ module Basecamp
             # validity (SPEC §16 pins SP/HTAB-only trimming).
             trimmed = header.is_a?(String) ? header.gsub(/\A[ \t]+|[ \t]+\z/, "") : ""
             if trimmed.match?(/\A\d+\z/)
-              value = trimmed.to_i
-              (1..MAX_DEVICE_SECONDS).cover?(value) ? value : 0
+              # Leading zeros stripped BEFORE the length bound so a padded
+              # in-range delta is honored; >10 significant digits is
+              # unrepresentable (matches the Python parser) -> fallback. A
+              # representable delta beyond the shared device ceiling CLAMPS:
+              # the wait rule clamps to the remaining code lifetime anyway, so
+              # an over-ceiling throttle waits out the rest of the lifetime
+              # instead of resending before the server's throttle.
+              significant = trimmed.sub(/\A0+/, "")
+              if significant.empty? || significant.length > 10
+                0
+              else
+                [ significant.to_i, MAX_DEVICE_SECONDS ].min
+              end
             else
               0
             end

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -179,6 +179,10 @@ module Basecamp
 
           interval_seconds = interval
           backoff_seconds = interval_seconds
+          # One-shot next-wait override from a 429 too_many_requests Retry-After
+          # (SPEC.md §16): consumed by the next wait, never inflating the
+          # slow_down interval. 0 = none.
+          override_seconds = 0
           # An absolute issuance-anchored deadline (perform_device_login
           # passes issued_at + expires_in) beats re-anchoring: clock time
           # elapsing between the caller's remaining-lifetime computation and
@@ -223,7 +227,9 @@ module Basecamp
             now = sample_clock(clock, "poll_device_token")
             raise DeviceFlowError.new(:expired, "Device code expired before authorization completed") if now >= deadline
 
-            wait_cancellable([ [ interval_seconds, backoff_seconds ].max, deadline - now ].min, cancelled, sleeper)
+            wait = [ [ interval_seconds, backoff_seconds, override_seconds ].max, deadline - now ].min
+            override_seconds = 0 # one-shot: consumed by this wait, then gone
+            wait_cancellable(wait, cancelled, sleeper)
 
             raise DeviceFlowError.new(:cancelled, "Device flow cancelled") if cancelled.call
 
@@ -263,12 +269,23 @@ module Basecamp
             # current server-driven interval.
             backoff_seconds = interval_seconds
 
-            kind, value, status = outcome
+            kind, value, status, retry_after = outcome
             return value if kind == :token
 
             case value
             when "authorization_pending"
               next
+            when "too_many_requests"
+              # Retryable ONLY as the exact 429 + too_many_requests pair
+              # (SPEC.md §16). The next wait honors a positive integral
+              # Retry-After delta via a one-shot max(interval, Retry-After)
+              # override — a missing/malformed header falls back to the current
+              # interval, and the override decays after one wait.
+              unless status == 429
+                raise OauthError.new("api_error", "Device token request failed: #{value}", http_status: status)
+              end
+
+              override_seconds = parse_retry_after_seconds(retry_after)
             when "slow_down"
               interval_seconds += SLOW_DOWN_INCREMENT_SECONDS
               # Re-sync the backoff to the GROWN interval (the reset above used the
@@ -450,12 +467,17 @@ module Basecamp
           # forever), and a watchdog bounds the whole request — including a
           # stalled or byte-dripped header phase — at the timeout. An INJECTED
           # Faraday connection keeps the Faraday path below.
-          def post_form(client, url, params, timeout:, max_body_bytes:, skip_status: nil)
+          #
+          # +on_headers+, when given, receives a case-insensitive header lookup
+          # (+#[]+) once response headers are available — the poll loop reads
+          # Retry-After through it without widening the return shape.
+          def post_form(client, url, params, timeout:, max_body_bytes:, skip_status: nil, on_headers: nil)
             if client.nil?
               return Fetcher.stream_http(
                 :post, url,
                 headers: { "Content-Type" => "application/x-www-form-urlencoded", "Accept" => "application/json" },
-                form: params, timeout: timeout, max_body_bytes: max_body_bytes, skip_status: skip_status
+                form: params, timeout: timeout, max_body_bytes: max_body_bytes, skip_status: skip_status,
+                on_headers: on_headers
               )
             end
 
@@ -506,6 +528,7 @@ module Basecamp
             # (request path: :transport; poll path: backoff, capped by code expiry)
             # rather than this status-first classification. Bounded and
             # redirect-safe (3xx Locations are never followed).
+            on_headers&.call(response.headers)
             return [ response.status, "" ] if skip_status && skip_status.call(response.status)
 
             # Timeout.timeout's interrupt can be delivered late: a response
@@ -654,12 +677,14 @@ module Basecamp
           # when the server reports an OAuth error. Raises +api_error+ on a
           # malformed, redirecting, or 2xx-but-tokenless response.
           def post_device_token(client, token_endpoint, params, timeout:, max_body_bytes:)
+            retry_after = nil
             status, body = post_form(
               client, token_endpoint, params,
               timeout: timeout, max_body_bytes: max_body_bytes,
               # A 3xx token response is a redirect fault whose body is unused; a 4xx
               # body IS read (it carries authorization_pending/slow_down).
-              skip_status: ->(s) { !(s == 200 || (400..499).cover?(s)) }
+              skip_status: ->(s) { !(s == 200 || (400..499).cover?(s)) },
+              on_headers: ->(headers) { retry_after = headers["Retry-After"] }
             )
 
             # A redirect is never a valid token-endpoint outcome: it is not
@@ -715,7 +740,22 @@ module Basecamp
               # controls this string and an unrecognized value is interpolated
               # into the api_error message. Real protocol codes are short, so
               # classification is unaffected.
-              [ :error, recognized ? Basecamp::Security.truncate(error) : "http_#{status}", status ]
+              [ :error, recognized ? Basecamp::Security.truncate(error) : "http_#{status}", status, retry_after ]
+            end
+          end
+
+          # Validates a Retry-After delta for the 429 poll contract (SPEC.md
+          # §16): a positive integral number of seconds no greater than
+          # {MAX_DEVICE_SECONDS} (the shared 32-bit-ms timer bound). Anything
+          # else — missing, an HTTP-date, fractional, non-positive, or
+          # overflowing — returns 0 so the caller falls back to the current
+          # interval.
+          def parse_retry_after_seconds(header)
+            if header.is_a?(String) && header.strip.match?(/\A\d+\z/)
+              value = header.strip.to_i
+              (1..MAX_DEVICE_SECONDS).cover?(value) ? value : 0
+            else
+              0
             end
           end
 

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -528,7 +528,9 @@ module Basecamp
             # (request path: :transport; poll path: backoff, capped by code expiry)
             # rather than this status-first classification. Bounded and
             # redirect-safe (3xx Locations are never followed).
-            on_headers&.call(response.headers)
+            # +|| {}+: an injected duck-typed double may omit +headers+ —
+            # absent headers mean no Retry-After, never a nil deref.
+            on_headers&.call(response.headers || {})
             return [ response.status, "" ] if skip_status && skip_status.call(response.status)
 
             # Timeout.timeout's interrupt can be delivered late: a response

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -738,6 +738,11 @@ module Basecamp
               # back to http_<status>, which the loop terminates as api_error.
               error = data["error"]
               recognized = (400..499).cover?(status) && error.is_a?(String) && !error.empty?
+              # A 429 recognizes ONLY too_many_requests (the exact retryable
+              # pair): a throttling endpoint whose body parrots
+              # authorization_pending/slow_down must not keep the loop polling
+              # until code expiry.
+              recognized &&= error == "too_many_requests" if status == 429
               # Truncate at extraction (SPEC §9's 500-unit cap): the server
               # controls this string and an unrecognized value is interpolated
               # into the api_error message. Real protocol codes are short, so

--- a/ruby/lib/basecamp/oauth/device_flow.rb
+++ b/ruby/lib/basecamp/oauth/device_flow.rb
@@ -752,10 +752,12 @@ module Basecamp
           end
 
           # Validates a Retry-After delta for the 429 poll contract (SPEC.md
-          # §16): a positive integral number of seconds no greater than
-          # {MAX_DEVICE_SECONDS} (the shared 32-bit-ms timer bound). Anything
-          # else — missing, an HTTP-date, fractional, non-positive, or
-          # overflowing — returns 0 so the caller falls back to the current
+          # §16): a positive integral number of seconds. A representable delta
+          # beyond {MAX_DEVICE_SECONDS} (the shared 32-bit-ms timer bound)
+          # CLAMPS to the ceiling — the wait rule clips to the remaining code
+          # lifetime, honoring the throttle. Anything else — missing, an
+          # HTTP-date, fractional, non-positive, or unrepresentable (the digit
+          # bound below) — returns 0 so the caller falls back to the current
           # interval.
           def parse_retry_after_seconds(header)
             # ASCII SP/HTAB only (RFC 9110 OWS) — NOT String#strip, which also

--- a/ruby/lib/basecamp/oauth/exchange.rb
+++ b/ruby/lib/basecamp/oauth/exchange.rb
@@ -165,7 +165,12 @@ module Basecamp
 
         handle_error_response(response.status, data) unless response.success?
 
-        raise OauthError.new("api_error", "Token response missing access_token") unless data["access_token"]
+        unless data["access_token"].is_a?(String) && !data["access_token"].empty?
+          raise OauthError.new(
+            "api_error", "Token response missing or non-string access_token",
+            http_status: response.status
+          )
+        end
 
         # resource: absent and JSON null are unset; when present it must be a
         # non-empty string (SPEC §16) — an empty binding is not a binding.

--- a/ruby/lib/basecamp/oauth/exchange.rb
+++ b/ruby/lib/basecamp/oauth/exchange.rb
@@ -183,10 +183,22 @@ module Basecamp
           )
         end
 
+        # token_type: absent/JSON-null defaults to Bearer; present must be a
+        # non-empty String ("" is truthy in Ruby, so || alone would admit it) —
+        # matching the device-flow parser and SPEC §16.
+        token_type = data["token_type"]
+        unless token_type.nil? || (token_type.is_a?(String) && !token_type.empty?)
+          raise OauthError.new(
+            "api_error",
+            "Token response token_type must be a non-empty string when present",
+            http_status: response.status
+          )
+        end
+
         Token.new(
           access_token: data["access_token"],
           refresh_token: data["refresh_token"],
-          token_type: data["token_type"] || "Bearer",
+          token_type: token_type || "Bearer",
           expires_in: data["expires_in"],
           scope: data["scope"],
           resource: resource

--- a/ruby/lib/basecamp/oauth/exchange.rb
+++ b/ruby/lib/basecamp/oauth/exchange.rb
@@ -134,7 +134,10 @@ module Basecamp
         params["refresh_token"] = request.refresh_token
         params["client_id"] = request.client_id if request.client_id
         params["client_secret"] = request.client_secret if request.client_secret
-        params["resource"] = request.resource if request.resource
+        # An empty string is truthy in Ruby but an empty resource is not a
+        # binding — treat it as unset (omit) per the send-only-when-set
+        # contract, matching Go/TS/Kotlin.
+        params["resource"] = request.resource unless request.resource.to_s.empty?
 
         params
       end

--- a/ruby/lib/basecamp/oauth/exchange.rb
+++ b/ruby/lib/basecamp/oauth/exchange.rb
@@ -134,6 +134,7 @@ module Basecamp
         params["refresh_token"] = request.refresh_token
         params["client_id"] = request.client_id if request.client_id
         params["client_secret"] = request.client_secret if request.client_secret
+        params["resource"] = request.resource if request.resource
 
         params
       end
@@ -163,12 +164,24 @@ module Basecamp
 
         raise OauthError.new("api_error", "Token response missing access_token") unless data["access_token"]
 
+        # resource: absent and JSON null are unset; when present it must be a
+        # non-empty string (SPEC §16) — an empty binding is not a binding.
+        resource = data["resource"]
+        unless resource.nil? || (resource.is_a?(String) && !resource.empty?)
+          raise OauthError.new(
+            "api_error",
+            "Token response resource must be a non-empty string when present",
+            http_status: response.status
+          )
+        end
+
         Token.new(
           access_token: data["access_token"],
           refresh_token: data["refresh_token"],
           token_type: data["token_type"] || "Bearer",
           expires_in: data["expires_in"],
-          scope: data["scope"]
+          scope: data["scope"],
+          resource: resource
         )
       rescue JSON::ParserError
         # A token response that fails to parse may still contain credential

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -295,6 +295,9 @@ module Basecamp
       #   session the moment it exists if the deadline fired mid-connect)
       # @param max_body_bytes [Integer] bounded read cap in bytes
       # @param skip_status [Proc, nil] statuses whose body is never read
+      # @param on_headers [Proc, nil] called with the +Net::HTTPResponse+ once
+      #   headers arrive, before any body read or skip decision — the device
+      #   poll loop reads +Retry-After+ here without widening the return shape
       # @return [Array(Integer, String)] status and (possibly empty) body
       def self.stream_http(method, url, headers: {}, form: nil, timeout:, max_body_bytes: DEFAULT_MAX_BODY_BYTES, skip_status: nil, on_headers: nil)
         # Response state first, before ANY call the def-level rescues could
@@ -566,15 +569,15 @@ module Basecamp
         end
         [ status, chunks.join.force_encoding(Encoding::UTF_8) ]
       rescue SkipBody => e
-          [ e.status, "" ]
+        [ e.status, "" ]
       rescue Timeout::Error, Errno::ETIMEDOUT => e
-          # Timeout::Error covers Net::OpenTimeout/ReadTimeout/WriteTimeout alike
-          # (a peer that accepts the connection but stops READING trips the write
-          # timeout). Errno::ETIMEDOUT is a SystemCallError, but it is a TIMEOUT:
-          # both must map with the timeouts — the exact pair faraday-net_http
-          # rescues — or the device poll would terminate instead of applying its
-          # transient backoff.
-          raise Faraday::TimeoutError, "OAuth request timed out: #{e.message}"
+        # Timeout::Error covers Net::OpenTimeout/ReadTimeout/WriteTimeout alike
+        # (a peer that accepts the connection but stops READING trips the write
+        # timeout). Errno::ETIMEDOUT is a SystemCallError, but it is a TIMEOUT:
+        # both must map with the timeouts — the exact pair faraday-net_http
+        # rescues — or the device poll would terminate instead of applying its
+        # transient backoff.
+        raise Faraday::TimeoutError, "OAuth request timed out: #{e.message}"
       rescue IOError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError,
              SystemCallError, SocketError, Zlib::Error => e
         # The clock outranks the watchdog FLAG: a wire fault observed past the
@@ -609,8 +612,8 @@ module Basecamp
 
         raise Faraday::SSLError, e.message
       ensure
-          watchdog&.kill
-          watchdog&.join
+        watchdog&.kill
+        watchdog&.join
       end
 
       # Fetches +url+ and returns the parsed JSON object (a Hash).

--- a/ruby/lib/basecamp/oauth/fetcher.rb
+++ b/ruby/lib/basecamp/oauth/fetcher.rb
@@ -296,7 +296,7 @@ module Basecamp
       # @param max_body_bytes [Integer] bounded read cap in bytes
       # @param skip_status [Proc, nil] statuses whose body is never read
       # @return [Array(Integer, String)] status and (possibly empty) body
-      def self.stream_http(method, url, headers: {}, form: nil, timeout:, max_body_bytes: DEFAULT_MAX_BODY_BYTES, skip_status: nil)
+      def self.stream_http(method, url, headers: {}, form: nil, timeout:, max_body_bytes: DEFAULT_MAX_BODY_BYTES, skip_status: nil, on_headers: nil)
         # Response state first, before ANY call the def-level rescues could
         # catch, so every rescue path sees it assigned (the completed_at guard
         # means it is only READ once genuinely populated).
@@ -498,6 +498,9 @@ module Basecamp
 
           http.request(request) do |response|
             status = response.code.to_i
+            # Headers are available before any body read; the device poll loop
+            # uses this to read Retry-After without widening the return shape.
+            on_headers&.call(response)
             if skip_status&.call(status)
               # Deadline first for a status NOT known in time: headers that
               # become runnable past the monotonic deadline (but before the
@@ -563,15 +566,15 @@ module Basecamp
         end
         [ status, chunks.join.force_encoding(Encoding::UTF_8) ]
       rescue SkipBody => e
-        [ e.status, "" ]
+          [ e.status, "" ]
       rescue Timeout::Error, Errno::ETIMEDOUT => e
-        # Timeout::Error covers Net::OpenTimeout/ReadTimeout/WriteTimeout alike
-        # (a peer that accepts the connection but stops READING trips the write
-        # timeout). Errno::ETIMEDOUT is a SystemCallError, but it is a TIMEOUT:
-        # both must map with the timeouts — the exact pair faraday-net_http
-        # rescues — or the device poll would terminate instead of applying its
-        # transient backoff.
-        raise Faraday::TimeoutError, "OAuth request timed out: #{e.message}"
+          # Timeout::Error covers Net::OpenTimeout/ReadTimeout/WriteTimeout alike
+          # (a peer that accepts the connection but stops READING trips the write
+          # timeout). Errno::ETIMEDOUT is a SystemCallError, but it is a TIMEOUT:
+          # both must map with the timeouts — the exact pair faraday-net_http
+          # rescues — or the device poll would terminate instead of applying its
+          # transient backoff.
+          raise Faraday::TimeoutError, "OAuth request timed out: #{e.message}"
       rescue IOError, Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError,
              SystemCallError, SocketError, Zlib::Error => e
         # The clock outranks the watchdog FLAG: a wire fault observed past the
@@ -606,8 +609,8 @@ module Basecamp
 
         raise Faraday::SSLError, e.message
       ensure
-        watchdog&.kill
-        watchdog&.join
+          watchdog&.kill
+          watchdog&.join
       end
 
       # Fetches +url+ and returns the parsed JSON object (a Hash).

--- a/ruby/lib/basecamp/oauth/refresh_request.rb
+++ b/ruby/lib/basecamp/oauth/refresh_request.rb
@@ -9,19 +9,25 @@ module Basecamp
     # @attr client_id [String, nil] The client identifier (optional)
     # @attr client_secret [String, nil] The client secret (optional)
     # @attr use_legacy_format [Boolean] Use Launchpad's non-standard token format
+    # @attr resource [String, nil] RFC 8707 resource indicator to bind the
+    #   refreshed token to, sent only when set. Echo the stored token's
+    #   resource: BC5 multi-account refresh tokens hard-require it (SPEC §16).
+    #   Appended last so earlier members keep their positions.
     RefreshRequest = Data.define(
       :token_endpoint,
       :refresh_token,
       :client_id,
       :client_secret,
-      :use_legacy_format
+      :use_legacy_format,
+      :resource
     ) do
       def initialize(
         token_endpoint:,
         refresh_token:,
         client_id: nil,
         client_secret: nil,
-        use_legacy_format: false
+        use_legacy_format: false,
+        resource: nil
       )
         super
       end

--- a/ruby/lib/basecamp/oauth/token.rb
+++ b/ruby/lib/basecamp/oauth/token.rb
@@ -10,13 +10,18 @@ module Basecamp
     # @attr expires_in [Integer, nil] Lifetime of the access token in seconds
     # @attr expires_at [Time, nil] Calculated expiration time
     # @attr scope [String, nil] OAuth scope granted
+    # @attr resource [String, nil] RFC 8707 resource indicator the token is
+    #   bound to (BC5: +urn:bc:account:<id>+). Echo it when refreshing —
+    #   BC5 multi-account refresh tokens reject a refresh without it
+    #   (SPEC §16). Appended last so earlier members keep their positions.
     Token = Data.define(
       :access_token,
       :token_type,
       :refresh_token,
       :expires_in,
       :expires_at,
-      :scope
+      :scope,
+      :resource
     ) do
       def initialize(
         access_token:,
@@ -24,7 +29,8 @@ module Basecamp
         refresh_token: nil,
         expires_in: nil,
         expires_at: nil,
-        scope: nil
+        scope: nil,
+        resource: nil
       )
         # Calculate expires_at from expires_in if not provided
         calculated_expires_at = expires_at || (expires_in ? Time.now + expires_in : nil)
@@ -34,7 +40,8 @@ module Basecamp
           refresh_token: refresh_token,
           expires_in: expires_in,
           expires_at: calculated_expires_at,
-          scope: scope
+          scope: scope,
+          resource: resource
         )
       end
 

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -1443,6 +1443,24 @@ class OAuthDeviceTest < Minitest::Test
     end
   end
 
+  def test_parse_retry_after_trims_only_ascii_ows
+    # RFC 9110: delta-seconds is 1*DIGIT and OWS is only SP/HTAB. String#strip
+    # also removes \v \f \r \n \0 — which would trim a malformed value into
+    # validity — so the parser trims exactly SP/HTAB (SPEC \u00a716). Control
+    # characters cannot ride a WebMock header, so the parser is exercised
+    # directly, like the NBSP cases in the other SDKs.
+    parse = ->(header) { Basecamp::Oauth::DeviceFlow.send(:parse_retry_after_seconds, header) }
+
+    assert_equal 30, parse.call(" 30 ")
+    assert_equal 30, parse.call("\t30\t")
+    assert_equal 30, parse.call(" \t30\t ")
+    assert_equal 0, parse.call("\v30")
+    assert_equal 0, parse.call("\f30\f")
+    assert_equal 0, parse.call("\r30\n")
+    assert_equal 0, parse.call("\u00a030")
+    assert_equal 0, parse.call("\u200930")
+  end
+
   def test_poll_429_retry_after_override_decays_after_one_wait
     stub_request(:post, TOKEN_ENDPOINT).to_return(
       json429(retry_after: "30"),

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -477,6 +477,36 @@ class OAuthDeviceTest < Minitest::Test
     assert_equal :cancelled, error.reason
   end
 
+  def test_poll_captures_resource_and_treats_null_as_absent
+    [ [ "urn:bc:account:42", "urn:bc:account:42" ], [ nil, nil ] ].each do |sent, expected|
+      stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response.merge("resource" => sent)))
+      _waits, sleeper = recording_sleeper
+
+      token = Basecamp::Oauth.poll_device_token(
+        token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+        device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+      )
+
+      expected.nil? ? assert_nil(token.resource) : assert_equal(expected, token.resource)
+    end
+  end
+
+  def test_poll_rejects_malformed_resource_on_token_response
+    [ "", 7 ].each do |resource|
+      stub_request(:post, TOKEN_ENDPOINT).to_return(json(token_response.merge("resource" => resource)))
+      _waits, sleeper = recording_sleeper
+
+      error = assert_raises(Basecamp::Oauth::OauthError) do
+        Basecamp::Oauth.poll_device_token(
+          token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+          device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+        )
+      end
+      assert_equal "api_error", error.type
+      assert_match(/resource/, error.message)
+    end
+  end
+
   def test_poll_accepts_token_response_without_expires_in
     # expires_in is optional (RFC 6749 §5.1): absent means no known expiry, so
     # the Token carries nil expires_in/expires_at rather than raising.

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -1463,6 +1463,8 @@ class OAuthDeviceTest < Minitest::Test
   def test_poll_429_wrong_pair_stays_terminal
     [
       json({ "error" => "rate_limited" }, status: 429),
+      json({ "error" => "authorization_pending" }, status: 429),
+      json({ "error" => "slow_down" }, status: 429),
       json({ "error" => "too_many_requests" }, status: 400)
     ].each do |response|
       stub_request(:post, TOKEN_ENDPOINT).to_return(response)

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -1427,7 +1427,7 @@ class OAuthDeviceTest < Minitest::Test
   end
 
   def test_poll_429_missing_or_malformed_retry_after_falls_back_to_interval
-    [ nil, "abc", "1.5", "-1", "0", "99999999999999999999" ].each do |header|
+    [ nil, "abc", "1.5", "-1", "0", "99999999999999999999", "\u00a030", "\u200930" ].each do |header|
       stub_request(:post, TOKEN_ENDPOINT).to_return(
         json429(retry_after: header),
         json(token_response)

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -18,7 +18,7 @@ class OAuthDeviceTest < Minitest::Test
   # A Faraday-shaped double that returns a scripted sequence of outcomes. Each
   # step is either a StandardError (raised) or a Hash (a status/body response).
   class SequencedHttpClient
-    Response = Struct.new(:status, :body)
+    Response = Struct.new(:status, :body, :headers)
 
     # Exposed so cancellation tests can flip a probe the moment a request
     # has been attempted (index goes positive before a step raises).
@@ -34,7 +34,7 @@ class OAuthDeviceTest < Minitest::Test
       @index += 1
       raise step if step.is_a?(StandardError)
 
-      Response.new(step[:status], step[:body])
+      Response.new(step[:status], step[:body], step[:headers] || {})
     end
   end
 
@@ -1399,5 +1399,122 @@ class OAuthDeviceTest < Minitest::Test
     assert_equal :expired, error.reason
     assert_equal [ 3 ], waits # clamped to the 3s remaining, not the full 900s
     assert_not_requested(polled)
+  end
+
+  # --- poll_device_token 429 handling ---------------------------------------
+
+  def json429(retry_after: nil)
+    headers = { "Content-Type" => "application/json" }
+    headers["Retry-After"] = retry_after if retry_after
+    { status: 429, body: { "error" => "too_many_requests" }.to_json, headers: headers }
+  end
+
+  def test_poll_retries_after_429_with_retry_after_override
+    stub_request(:post, TOKEN_ENDPOINT).to_return(
+      json429(retry_after: "30"),
+      json(token_response)
+    )
+    waits, sleeper = recording_sleeper
+
+    token = Basecamp::Oauth.poll_device_token(
+      token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+      device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+    )
+
+    assert_equal "device_access_token", token.access_token
+    # Initial 5s wait, then the one-shot max(interval, Retry-After) = 30s.
+    assert_equal [ 5, 30 ], waits
+  end
+
+  def test_poll_429_missing_or_malformed_retry_after_falls_back_to_interval
+    [ nil, "abc", "1.5", "-1", "0", "99999999999999999999" ].each do |header|
+      stub_request(:post, TOKEN_ENDPOINT).to_return(
+        json429(retry_after: header),
+        json(token_response)
+      )
+      waits, sleeper = recording_sleeper
+
+      Basecamp::Oauth.poll_device_token(
+        token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+        device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+      )
+
+      assert_equal [ 5, 5 ], waits, "header=#{header.inspect}"
+    end
+  end
+
+  def test_poll_429_retry_after_override_decays_after_one_wait
+    stub_request(:post, TOKEN_ENDPOINT).to_return(
+      json429(retry_after: "30"),
+      json({ "error" => "authorization_pending" }, status: 400),
+      json(token_response)
+    )
+    waits, sleeper = recording_sleeper
+
+    Basecamp::Oauth.poll_device_token(
+      token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+      device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+    )
+
+    # 5s initial, 30s one-shot override, then back to the 5s interval.
+    assert_equal [ 5, 30, 5 ], waits
+  end
+
+  def test_poll_429_wrong_pair_stays_terminal
+    [
+      json({ "error" => "rate_limited" }, status: 429),
+      json({ "error" => "too_many_requests" }, status: 400)
+    ].each do |response|
+      stub_request(:post, TOKEN_ENDPOINT).to_return(response)
+      _waits, sleeper = recording_sleeper
+
+      error = assert_raises(Basecamp::Oauth::OauthError) do
+        Basecamp::Oauth.poll_device_token(
+          token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+          device_code: "dev-code-123", interval: 5, expires_in: 900, sleeper: sleeper
+        )
+      end
+      assert_equal "api_error", error.type
+    end
+  end
+
+  def test_poll_429_wait_clamped_to_expiry
+    stub_request(:post, TOKEN_ENDPOINT).to_return(json429(retry_after: "3600"))
+    waits, sleeper = recording_sleeper
+    # Scripted monotonic clock: deadline anchors at t=0 with a 20s lifetime.
+    # The second iteration's huge Retry-After override must clamp to the 14s
+    # remaining, and the post-wait check then expires the flow.
+    clock = scripted_clock([ 0, 0, 5, 6, 20 ])
+
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth.poll_device_token(
+        token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+        device_code: "dev-code-123", interval: 5, expires_in: 20,
+        sleeper: sleeper, clock: clock
+      )
+    end
+    assert_equal :expired, error.reason
+    assert_equal [ 5, 14 ], waits
+  end
+
+  def test_poll_cancellation_during_429_wait
+    stub_request(:post, TOKEN_ENDPOINT).to_return(json429(retry_after: "30"))
+    slept = { total: 0.0 }
+    cancelled = { flag: false }
+    # The cancellable wait chunks each interval, so count elapsed time: once
+    # past the first 5s wait we are inside the post-429 override wait.
+    sleeper = lambda do |seconds|
+      slept[:total] += seconds
+      cancelled[:flag] = true if slept[:total] > 5.0
+    end
+
+    error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
+      Basecamp::Oauth.poll_device_token(
+        token_endpoint: TOKEN_ENDPOINT, client_id: "basecamp-cli",
+        device_code: "dev-code-123", interval: 5, expires_in: 900,
+        sleeper: sleeper, cancelled: -> { cancelled[:flag] }
+      )
+    end
+    assert_equal :cancelled, error.reason
   end
 end

--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -1459,6 +1459,11 @@ class OAuthDeviceTest < Minitest::Test
     assert_equal 0, parse.call("\r30\n")
     assert_equal 0, parse.call("\u00a030")
     assert_equal 0, parse.call("\u200930")
+    # Representable over-ceiling clamps (the wait rule clips to the remaining
+    # lifetime); >10 significant digits is unrepresentable -> fallback.
+    assert_equal 2_147_483, parse.call("2147484")
+    assert_equal 30, parse.call("00000000030")
+    assert_equal 0, parse.call("99999999999")
   end
 
   def test_poll_429_retry_after_override_decays_after_one_wait

--- a/ruby/test/basecamp/oauth_test.rb
+++ b/ruby/test/basecamp/oauth_test.rb
@@ -231,6 +231,36 @@ class OAuthTest < Minitest::Test
     assert_nil error.cause
   end
 
+  def test_exchange_token_type_contract
+    # SPEC §16: token_type defaults to Bearer only when absent/JSON-null; a
+    # present-but-empty or non-string value ("" is truthy in Ruby) is a
+    # malformed response — matching the device-flow parser.
+    endpoint = "https://launchpad.37signals.com/authorization/token"
+    [ {}, { "token_type" => nil }, { "token_type" => "Bearer" } ].each do |extra|
+      stub_request(:post, endpoint)
+        .to_return(status: 200, body: { "access_token" => "a" }.merge(extra).to_json,
+                   headers: { "Content-Type" => "application/json" })
+      token = Basecamp::Oauth.exchange_code(
+        token_endpoint: endpoint, code: "c",
+        redirect_uri: "https://myapp.com/callback", client_id: "id"
+      )
+      assert_equal "Bearer", token.token_type, extra.inspect
+    end
+
+    [ "", 7 ].each do |bad|
+      stub_request(:post, endpoint)
+        .to_return(status: 200, body: { "access_token" => "a", "token_type" => bad }.to_json,
+                   headers: { "Content-Type" => "application/json" })
+      error = assert_raises(Basecamp::Oauth::OauthError) do
+        Basecamp::Oauth.exchange_code(
+          token_endpoint: endpoint, code: "c",
+          redirect_uri: "https://myapp.com/callback", client_id: "id"
+        )
+      end
+      assert_equal "api_error", error.type, bad.inspect
+    end
+  end
+
   def test_exchange_code
     token_response = {
       "access_token" => "access_token_123",

--- a/ruby/test/basecamp/oauth_test.rb
+++ b/ruby/test/basecamp/oauth_test.rb
@@ -314,18 +314,24 @@ class OAuthTest < Minitest::Test
     assert_requested stub
   end
 
-  def test_refresh_token_omits_resource_when_unset
-    stub = stub_request(:post, "https://launchpad.37signals.com/authorization/token")
-      .with { |req| !URI.decode_www_form(req.body).to_h.key?("resource") }
-      .to_return(status: 200, body: { "access_token" => "new_access_token" }.to_json,
-                 headers: { "Content-Type" => "application/json" })
+  def test_refresh_token_omits_resource_when_unset_or_empty
+    # nil is unset; "" is truthy in Ruby but an empty resource is not a
+    # binding — both must omit the form key entirely (send-only-when-set).
+    [ nil, "" ].each do |resource|
+      stub = stub_request(:post, "https://launchpad.37signals.com/authorization/token")
+        .with { |req| !URI.decode_www_form(req.body).to_h.key?("resource") }
+        .to_return(status: 200, body: { "access_token" => "new_access_token" }.to_json,
+                   headers: { "Content-Type" => "application/json" })
 
-    Basecamp::Oauth.refresh_token(
-      token_endpoint: "https://launchpad.37signals.com/authorization/token",
-      refresh_token: "old_refresh_token"
-    )
+      Basecamp::Oauth.refresh_token(
+        token_endpoint: "https://launchpad.37signals.com/authorization/token",
+        refresh_token: "old_refresh_token",
+        resource: resource
+      )
 
-    assert_requested stub
+      assert_requested stub
+      WebMock.reset!
+    end
   end
 
   def test_token_response_resource_round_trips_and_null_is_absent

--- a/ruby/test/basecamp/oauth_test.rb
+++ b/ruby/test/basecamp/oauth_test.rb
@@ -298,6 +298,70 @@ class OAuthTest < Minitest::Test
     assert_equal "new_refresh_token", token.refresh_token
   end
 
+  def test_refresh_token_sends_resource_when_set
+    stub = stub_request(:post, "https://launchpad.37signals.com/authorization/token")
+      .with(body: hash_including("resource" => "urn:bc:account:42"))
+      .to_return(status: 200, body: { "access_token" => "new_access_token" }.to_json,
+                 headers: { "Content-Type" => "application/json" })
+
+    Basecamp::Oauth.refresh_token(
+      token_endpoint: "https://launchpad.37signals.com/authorization/token",
+      refresh_token: "old_refresh_token",
+      client_id: "basecamp-cli",
+      resource: "urn:bc:account:42"
+    )
+
+    assert_requested stub
+  end
+
+  def test_refresh_token_omits_resource_when_unset
+    stub = stub_request(:post, "https://launchpad.37signals.com/authorization/token")
+      .with { |req| !URI.decode_www_form(req.body).to_h.key?("resource") }
+      .to_return(status: 200, body: { "access_token" => "new_access_token" }.to_json,
+                 headers: { "Content-Type" => "application/json" })
+
+    Basecamp::Oauth.refresh_token(
+      token_endpoint: "https://launchpad.37signals.com/authorization/token",
+      refresh_token: "old_refresh_token"
+    )
+
+    assert_requested stub
+  end
+
+  def test_token_response_resource_round_trips_and_null_is_absent
+    [ [ "urn:bc:account:42", "urn:bc:account:42" ], [ nil, nil ] ].each do |sent, expected|
+      stub_request(:post, "https://launchpad.37signals.com/authorization/token")
+        .to_return(status: 200,
+                   body: { "access_token" => "a", "resource" => sent }.to_json,
+                   headers: { "Content-Type" => "application/json" })
+
+      token = Basecamp::Oauth.refresh_token(
+        token_endpoint: "https://launchpad.37signals.com/authorization/token",
+        refresh_token: "old_refresh_token"
+      )
+
+      expected.nil? ? assert_nil(token.resource) : assert_equal(expected, token.resource)
+    end
+  end
+
+  def test_token_response_malformed_resource_rejected
+    [ "", 7 ].each do |resource|
+      stub_request(:post, "https://launchpad.37signals.com/authorization/token")
+        .to_return(status: 200,
+                   body: { "access_token" => "a", "resource" => resource }.to_json,
+                   headers: { "Content-Type" => "application/json" })
+
+      error = assert_raises(Basecamp::Oauth::OauthError) do
+        Basecamp::Oauth.refresh_token(
+          token_endpoint: "https://launchpad.37signals.com/authorization/token",
+          refresh_token: "old_refresh_token"
+        )
+      end
+      assert_equal "api_error", error.type
+      assert_match(/resource/, error.message)
+    end
+  end
+
   def test_token_expired
     token = Basecamp::Oauth::Token.new(
       access_token: "test",

--- a/ruby/test/basecamp/oauth_token_conformance_test.rb
+++ b/ruby/test/basecamp/oauth_token_conformance_test.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Drives the shared, data-only fixtures in conformance/oauth-token/fixtures:
+# one refresh round-trip per fixture, asserting the sent resource form
+# parameter and the response decode (round-trip, absent/null as unset,
+# present-empty/non-string rejected). Lifecycle preservation across a stored
+# credential is per-manager behavior — not modeled here.
+class OAuthTokenConformanceTest < Minitest::Test
+  include TestHelper
+
+  FIXTURE_DIR = File.expand_path("../../../conformance/oauth-token/fixtures", __dir__)
+  TOKEN_ENDPOINT = "https://issuer.token-fixtures.example/oauth/token"
+
+  fixtures = Dir.glob(File.join(FIXTURE_DIR, "*.json")).sort
+  raise "no fixtures found in #{FIXTURE_DIR}" if fixtures.empty?
+
+  fixtures.each do |path|
+    fixture = JSON.parse(File.read(path))
+    define_method("test_fixture_#{File.basename(path, '.json').tr('-', '_')}") do
+      assert_equal "refreshToken", fixture["operation"]
+
+      sent_form = nil
+      stub_request(:post, TOKEN_ENDPOINT)
+        .with { |req| sent_form = URI.decode_www_form(req.body).to_h }
+        .to_return(
+          status: fixture["response"].fetch("status", 200),
+          body: fixture["response"].fetch("body").to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+      resource = fixture.dig("request", "resource")
+      expect = fixture.fetch("expect")
+
+      run_refresh = lambda do
+        Basecamp::Oauth.refresh_token(
+          token_endpoint: TOKEN_ENDPOINT, refresh_token: "refresh-token",
+          client_id: "basecamp-cli", resource: resource
+        )
+      end
+
+      if expect.fetch("outcome") == "token"
+        token = run_refresh.call
+        assert_equal expect["resource"], token.resource if expect.key?("resource")
+        assert_nil token.resource if expect["resourceAbsent"]
+      else
+        error = assert_raises(Basecamp::Oauth::OauthError) { run_refresh.call }
+        assert_equal "api_error", error.type
+      end
+
+      refute_nil sent_form, "the refresh request never reached the stub"
+      assert_equal expect["formResource"], sent_form["resource"] if expect.key?("formResource")
+      assert_not sent_form.key?("resource") if expect["formResourceAbsent"]
+    end
+  end
+end

--- a/ruby/test/basecamp/oauth_token_conformance_test.rb
+++ b/ruby/test/basecamp/oauth_token_conformance_test.rb
@@ -49,7 +49,7 @@ class OAuthTokenConformanceTest < Minitest::Test
         assert_equal "api_error", error.type
       end
 
-      refute_nil sent_form, "the refresh request never reached the stub"
+      assert_not_nil sent_form, "the refresh request never reached the stub"
       assert_equal expect["formResource"], sent_form["resource"] if expect.key?("formResource")
       assert_not sent_form.key?("resource") if expect["formResourceAbsent"]
     end

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -271,7 +271,8 @@ try {
   const token = await performDeviceLogin({
     config: result.config,
     clientId: "basecamp-cli",
-    // scope omitted → server default (read). Prefer pinning it explicitly:
+    // scope pinned explicitly — "read" is also the server default, but an
+    // explicit scope never depends on registry defaults staying put.
     scope: "read",
     display: ({ userCode, verificationUri }) => {
       console.log(`Visit ${verificationUri} and enter code: ${userCode}`);

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -205,9 +205,11 @@ selected (else a hard `expected_issuer_unavailable`). Without it, the SDK uses a
 documented Basecamp-profile heuristic: exactly one non-Launchpad issuer → selected;
 ≥2 → hard `ambiguous_issuers` (never guesses); zero → Launchpad.
 
-Pass bare origins — no trailing slash. Issuer binding is code-point exact, so
-`https://app.basecamp.com/` would mismatch the advertised issuer and silently
-soft-fall back to Launchpad.
+Pass bare origins — no trailing slash. Binding is code-point exact, and the
+failure mode depends on which parameter carries the slash: a trailing-slash
+`expectedIssuer` fails the advertised-member lookup and throws a **hard**
+`expected_issuer_unavailable`, while a trailing-slash *resource* origin breaks
+the hop-1 resource binding and silently soft-falls back to Launchpad.
 
 **Fallback is allowed only before a first-party issuer is committed.** Once valid
 resource metadata advertises it and it is selected, every later failure is fatal —

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -199,10 +199,15 @@ await performInteractiveLogin({
 });
 ```
 
-**Selection.** With `expectedIssuer`, the advertised member equal by code-point is
+**Selection.** With `expectedIssuer` (production canonical:
+`https://app.basecamp.com`), the advertised member equal by code-point is
 selected (else a hard `expected_issuer_unavailable`). Without it, the SDK uses a
 documented Basecamp-profile heuristic: exactly one non-Launchpad issuer → selected;
 ≥2 → hard `ambiguous_issuers` (never guesses); zero → Launchpad.
+
+Pass bare origins — no trailing slash. Issuer binding is code-point exact, so
+`https://app.basecamp.com/` would mismatch the advertised issuer and silently
+soft-fall back to Launchpad.
 
 **Fallback is allowed only before a first-party issuer is committed.** Once valid
 resource metadata advertises it and it is selected, every later failure is fatal —
@@ -266,7 +271,8 @@ try {
   const token = await performDeviceLogin({
     config: result.config,
     clientId: "basecamp-cli",
-    // scope omitted → server default (read)
+    // scope omitted → server default (read). Prefer pinning it explicitly:
+    scope: "read",
     display: ({ userCode, verificationUri }) => {
       console.log(`Visit ${verificationUri} and enter code: ${userCode}`);
     },
@@ -291,12 +297,19 @@ try {
         tokenEndpoint: result.config.tokenEndpoint,
         clientId: "basecamp-cli", // public client — no secret
         refreshToken: token.refreshToken,
+        // ECHO the token's RFC 8707 resource indicator: BC5 device logins as
+        // basecamp-cli mint MULTI-ACCOUNT refresh tokens, and refreshing one
+        // without `resource` is rejected (400 invalid_request).
+        resource: token.resource,
       });
       // A refresh response MAY omit refresh_token (the server keeps the current
-      // one). Persist the fresh access token but FALL BACK to the prior refresh
-      // token when none was returned, so the next refresh still works:
+      // one) and MAY omit resource (the binding is unchanged). Persist the fresh
+      // access token but FALL BACK to the prior values so the next refresh still
+      // works:
       const nextRefresh = fresh.refreshToken ?? token.refreshToken;
-      // ...persist { ...fresh, refreshToken: nextRefresh } and rebuild the client.
+      const nextResource = fresh.resource ?? token.resource;
+      // ...persist { ...fresh, refreshToken: nextRefresh, resource: nextResource }
+      // and rebuild the client. (TokenManager does all of this automatically.)
     } else {
       // No refresh token was issued: refreshing is impossible, so the user must
       // authorize again. Re-run the device login to get a new token — pass the

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -606,11 +606,15 @@ type TokenPollResult =
  * positive integral number of seconds no greater than MAX_DEVICE_SECONDS (the
  * shared 32-bit-ms timer bound). Anything else — missing, an HTTP-date,
  * fractional, non-positive, or overflowing — returns 0 so the caller falls
- * back to the current interval.
+ * back to the current interval. Trimming is ASCII SP/HTAB only (RFC 9110
+ * OWS) — NOT String.prototype.trim(), whose Unicode whitespace (NBSP above
+ * all) would trim a malformed value into validity.
  */
-function parseRetryAfterSeconds(header: string | null): number {
-  if (!header || !/^\d+$/.test(header.trim())) return 0;
-  const parsed = parseInt(header, 10);
+export function parseRetryAfterSeconds(header: string | null): number {
+  if (!header) return 0;
+  const trimmed = header.replace(/^[ \t]+|[ \t]+$/g, "");
+  if (!/^\d+$/.test(trimmed)) return 0;
+  const parsed = parseInt(trimmed, 10);
   if (!Number.isInteger(parsed) || parsed <= 0 || parsed > MAX_DEVICE_SECONDS) return 0;
   return parsed;
 }

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -603,10 +603,12 @@ type TokenPollResult =
 
 /**
  * Validates a Retry-After delta for the 429 poll contract (SPEC §16): a
- * positive integral number of seconds no greater than MAX_DEVICE_SECONDS (the
- * shared 32-bit-ms timer bound). Anything else — missing, an HTTP-date,
- * fractional, non-positive, or overflowing — returns 0 so the caller falls
- * back to the current interval. Trimming is ASCII SP/HTAB only (RFC 9110
+ * positive integral number of seconds. A representable delta beyond
+ * MAX_DEVICE_SECONDS (the shared 32-bit-ms timer bound) CLAMPS to the
+ * ceiling — the wait rule clips to the remaining code lifetime, honoring the
+ * throttle. Anything else — missing, an HTTP-date, fractional, non-positive,
+ * or unrepresentable (beyond 2^53) — returns 0 so the caller falls back to
+ * the current interval. Trimming is ASCII SP/HTAB only (RFC 9110
  * OWS) — NOT String.prototype.trim(), whose Unicode whitespace (NBSP above
  * all) would trim a malformed value into validity.
  */

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -616,7 +616,14 @@ export function parseRetryAfterSeconds(header: string | null): number {
   if (!header) return 0;
   const trimmed = header.replace(/^[ \t]+|[ \t]+$/g, "");
   if (!/^\d+$/.test(trimmed)) return 0;
-  const parsed = parseInt(trimmed, 10);
+  // The shared 10-significant-digit bound (Python/Ruby mirror it; Go/Kotlin
+  // get it from bounded int parses): strip leading zeros first so a padded
+  // in-range delta ("00000000030") is honored, then treat longer strings as
+  // unrepresentable — interval fallback — instead of feeding parseInt an
+  // unbounded digit string. Comfortably covers MAX_DEVICE_SECONDS (7 digits).
+  const significant = trimmed.replace(/^0+/, "") || "0";
+  if (significant.length > 10) return 0;
+  const parsed = parseInt(significant, 10);
   // Safe-integer, not merely integer: parseInt("9".repeat(20)) yields an
   // integer-valued double past 2^53 — unrepresentable → interval fallback. A
   // representable delta beyond the shared device ceiling CLAMPS instead: the

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -704,6 +704,13 @@ async function postDeviceToken(
             httpStatus: response.status,
           });
         }
+        // resource: absent and JSON null are unset; when present it must be a
+        // non-empty string (SPEC §16) — an empty binding is not a binding.
+        if (token.resource != null && !isNonEmptyString(token.resource)) {
+          throw new BasecampError("api_error", "Device token response resource must be a non-empty string when present", {
+            httpStatus: response.status,
+          });
+        }
         return {
           kind: "token",
           token: {
@@ -715,6 +722,7 @@ async function postDeviceToken(
             expiresIn: token.expires_in ?? undefined,
             expiresAt: token.expires_in != null ? new Date(Date.now() + token.expires_in * 1000) : undefined,
             scope: token.scope ?? undefined,
+            resource: token.resource ?? undefined,
           },
         };
       }

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -615,8 +615,14 @@ export function parseRetryAfterSeconds(header: string | null): number {
   const trimmed = header.replace(/^[ \t]+|[ \t]+$/g, "");
   if (!/^\d+$/.test(trimmed)) return 0;
   const parsed = parseInt(trimmed, 10);
-  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > MAX_DEVICE_SECONDS) return 0;
-  return parsed;
+  // Safe-integer, not merely integer: parseInt("9".repeat(20)) yields an
+  // integer-valued double past 2^53 — unrepresentable → interval fallback. A
+  // representable delta beyond the shared device ceiling CLAMPS instead: the
+  // wait rule clamps to the remaining code lifetime anyway, so an over-ceiling
+  // throttle waits out the rest of the lifetime rather than resending before
+  // the server's throttle.
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return 0;
+  return Math.min(parsed, MAX_DEVICE_SECONDS);
 }
 
 async function postDeviceToken(

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -773,10 +773,16 @@ async function postDeviceToken(
       // controls this string and an unrecognized value is interpolated into the
       // api_error message. Real protocol codes are short, so classification is
       // unaffected.
-      const error =
+      let error =
         response.status >= 400 && response.status < 500 && typeof rawError === "string" && rawError !== ""
           ? truncateErrorMessage(rawError)
           : `http_${response.status}`;
+      // A 429 recognizes ONLY too_many_requests (the exact retryable pair): a
+      // throttling endpoint whose body parrots authorization_pending/slow_down
+      // must not keep the loop polling until code expiry.
+      if (response.status === 429 && error !== "too_many_requests") {
+        error = `http_${response.status}`;
+      }
       return { kind: "error", error, status: response.status, retryAfter: response.headers.get("Retry-After") };
     });
   } finally {

--- a/typescript/src/oauth/device.ts
+++ b/typescript/src/oauth/device.ts
@@ -461,6 +461,10 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
   // two, so intermittent timeouts never permanently inflate the poll cadence.
   let intervalSeconds = params.interval;
   let backoffSeconds = intervalSeconds;
+  // One-shot next-wait override from a 429 too_many_requests Retry-After
+  // (SPEC §16): consumed by the next wait, never inflating the slow_down
+  // interval. 0 = none.
+  let overrideWaitSeconds = 0;
   const deadline = params.deadlineAtMs ?? nowMs + expiresIn * 1000;
 
   const body = new URLSearchParams();
@@ -492,7 +496,11 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
     // max(1, floor(...)): floor stays inside the remaining lifetime, and the
     // 1ms floor keeps a caller-supplied sub-millisecond interval from
     // degrading into a 0ms hot loop.
-    const waitMs = Math.max(1, Math.floor(Math.min(Math.max(intervalSeconds, backoffSeconds) * 1000, remainingMs)));
+    const waitMs = Math.max(1, Math.floor(Math.min(
+      Math.max(intervalSeconds, backoffSeconds, overrideWaitSeconds) * 1000,
+      remainingMs
+    )));
+    overrideWaitSeconds = 0; // one-shot: consumed by this wait, then gone
     try {
       // Race the injected sleep against the signal: a custom sleepFn that
       // ignores its signal argument must not hold a cancelled poll open until
@@ -560,6 +568,19 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
     switch (result.error) {
       case "authorization_pending":
         continue;
+      case "too_many_requests":
+        // Retryable ONLY as the exact 429 + too_many_requests pair (SPEC §16).
+        // The next wait honors a positive integral Retry-After delta via a
+        // one-shot max(interval, Retry-After) override — a missing/malformed
+        // header falls back to the current interval, and the override decays
+        // after one wait.
+        if (result.status !== 429) {
+          throw new BasecampError("api_error", `Device token request failed: ${result.error}`, {
+            httpStatus: result.status,
+          });
+        }
+        overrideWaitSeconds = parseRetryAfterSeconds(result.retryAfter);
+        continue;
       case "slow_down":
         intervalSeconds += SLOW_DOWN_INCREMENT_SECONDS;
         backoffSeconds = intervalSeconds;
@@ -578,7 +599,21 @@ export async function pollDeviceToken(params: PollDeviceTokenParams): Promise<OA
 
 type TokenPollResult =
   | { kind: "token"; token: OAuthToken }
-  | { kind: "error"; error: string; status: number };
+  | { kind: "error"; error: string; status: number; retryAfter: string | null };
+
+/**
+ * Validates a Retry-After delta for the 429 poll contract (SPEC §16): a
+ * positive integral number of seconds no greater than MAX_DEVICE_SECONDS (the
+ * shared 32-bit-ms timer bound). Anything else — missing, an HTTP-date,
+ * fractional, non-positive, or overflowing — returns 0 so the caller falls
+ * back to the current interval.
+ */
+function parseRetryAfterSeconds(header: string | null): number {
+  if (!header || !/^\d+$/.test(header.trim())) return 0;
+  const parsed = parseInt(header, 10);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > MAX_DEVICE_SECONDS) return 0;
+  return parsed;
+}
 
 async function postDeviceToken(
   tokenEndpoint: string,
@@ -742,7 +777,7 @@ async function postDeviceToken(
         response.status >= 400 && response.status < 500 && typeof rawError === "string" && rawError !== ""
           ? truncateErrorMessage(rawError)
           : `http_${response.status}`;
-      return { kind: "error", error, status: response.status };
+      return { kind: "error", error, status: response.status, retryAfter: response.headers.get("Retry-After") };
     });
   } finally {
     clearTimeout(timeoutId);

--- a/typescript/src/oauth/exchange.ts
+++ b/typescript/src/oauth/exchange.ts
@@ -162,6 +162,9 @@ export async function refreshToken(
   if (request.clientSecret) {
     body.set("client_secret", request.clientSecret);
   }
+  if (request.resource) {
+    body.set("resource", request.resource);
+  }
 
   return doTokenRequest(request.tokenEndpoint, body, options);
 }
@@ -403,6 +406,14 @@ async function doTokenRequest(
       );
     }
 
+    // resource: absent and JSON null are unset; when present it must be a
+    // non-empty string (SPEC §16) — an empty binding is not a binding.
+    if (tokenData.resource != null && (typeof tokenData.resource !== "string" || tokenData.resource === "")) {
+      throw new BasecampError("api_error", "Token response resource must be a non-empty string when present", {
+        httpStatus: response.status,
+      });
+    }
+
     return {
       accessToken: tokenData.access_token,
       // `?? undefined`: JSON null is legal on the wire for the optional
@@ -414,6 +425,7 @@ async function doTokenRequest(
         ? new Date(Date.now() + tokenData.expires_in * 1000)
         : undefined,
       scope: tokenData.scope ?? undefined,
+      resource: tokenData.resource ?? undefined,
     };
   } catch (err) {
     if (err instanceof BasecampError) {

--- a/typescript/src/oauth/token-manager.ts
+++ b/typescript/src/oauth/token-manager.ts
@@ -146,13 +146,20 @@ export class TokenManager {
       refreshToken: refreshTokenValue,
       clientId: this.clientId,
       clientSecret: this.clientSecret,
+      // Echo the stored RFC 8707 resource: BC5 multi-account refresh tokens
+      // reject a refresh without it (SPEC §16).
+      resource: this.token?.resource,
       useLegacyFormat: this.useLegacyFormat,
     });
 
-    // Preserve the previous refresh token when the server omits one
-    const merged: OAuthToken = newToken.refreshToken
-      ? newToken
-      : { ...newToken, refreshToken: refreshTokenValue };
+    // Preserve the previous refresh token when the server omits one, and the
+    // previous resource binding when the response omits it (SPEC §16
+    // carry-forward rule).
+    const merged: OAuthToken = {
+      ...newToken,
+      refreshToken: newToken.refreshToken || refreshTokenValue,
+      resource: newToken.resource ?? this.token?.resource,
+    };
 
     this.token = merged;
     await this.store.save(merged);

--- a/typescript/src/oauth/token-manager.ts
+++ b/typescript/src/oauth/token-manager.ts
@@ -154,11 +154,15 @@ export class TokenManager {
 
     // Preserve the previous refresh token when the server omits one, and the
     // previous resource binding when the response omits it (SPEC §16
-    // carry-forward rule).
+    // carry-forward rule). Truthiness, not ?? — the standard exchange path
+    // already rejects a present-empty resource, but an injected refreshToken
+    // implementation could hand back resource: "", and persisting it would
+    // strand a multi-account token (present ⇒ non-empty everywhere else,
+    // and later refreshes would omit the binding via the truthy send check).
     const merged: OAuthToken = {
       ...newToken,
       refreshToken: newToken.refreshToken || refreshTokenValue,
-      resource: newToken.resource ?? this.token?.resource,
+      resource: newToken.resource || this.token?.resource,
     };
 
     this.token = merged;

--- a/typescript/src/oauth/token-store.ts
+++ b/typescript/src/oauth/token-store.ts
@@ -107,7 +107,10 @@ export class FileTokenStore implements TokenStore {
       expiresIn: data.expiresIn,
       expiresAt: data.expiresAt ? new Date(data.expiresAt) : undefined,
       scope: data.scope,
-      resource: data.resource,
+      // A hand-edited or legacy token file can carry null/empty/non-string:
+      // present-but-empty is malformed per SPEC and the public type is
+      // `string | undefined` — normalize anything else to absent.
+      resource: typeof data.resource === "string" && data.resource !== "" ? data.resource : undefined,
     };
   }
 
@@ -119,7 +122,8 @@ export class FileTokenStore implements TokenStore {
       expiresIn: token.expiresIn,
       expiresAt: token.expiresAt?.toISOString(),
       scope: token.scope,
-      resource: token.resource,
+      // Never persist an empty binding: JSON.stringify drops undefined keys.
+      resource: token.resource || undefined,
     };
 
     const json = JSON.stringify(serialized, null, 2) + "\n";

--- a/typescript/src/oauth/token-store.ts
+++ b/typescript/src/oauth/token-store.ts
@@ -32,6 +32,12 @@ interface SerializedToken {
   expiresIn?: number;
   expiresAt?: string; // ISO 8601
   scope?: string;
+  /**
+   * RFC 8707 resource indicator. Must round-trip through persistence: losing
+   * it strands a BC5 multi-account refresh token — after a restart the
+   * refresh would carry no resource and be rejected (400).
+   */
+  resource?: string;
 }
 
 /**
@@ -101,6 +107,7 @@ export class FileTokenStore implements TokenStore {
       expiresIn: data.expiresIn,
       expiresAt: data.expiresAt ? new Date(data.expiresAt) : undefined,
       scope: data.scope,
+      resource: data.resource,
     };
   }
 
@@ -112,6 +119,7 @@ export class FileTokenStore implements TokenStore {
       expiresIn: token.expiresIn,
       expiresAt: token.expiresAt?.toISOString(),
       scope: token.scope,
+      resource: token.resource,
     };
 
     const json = JSON.stringify(serialized, null, 2) + "\n";

--- a/typescript/src/oauth/types.ts
+++ b/typescript/src/oauth/types.ts
@@ -159,16 +159,17 @@ export interface RefreshRequest {
   /** The client secret (optional) */
   clientSecret?: string;
   /**
-   * RFC 8707 resource indicator to bind the refreshed token to, sent only
-   * when set. Echo the stored token's `resource`: BC5 multi-account refresh
-   * tokens hard-require it (SPEC §16).
-   */
-  resource?: string;
-  /**
    * Use Launchpad's non-standard token format.
    * When true, uses `type=refresh` instead of `grant_type=refresh_token`.
    */
   useLegacyFormat?: boolean;
+  /**
+   * RFC 8707 resource indicator to bind the refreshed token to, sent only
+   * when set. Echo the stored token's `resource`: BC5 multi-account refresh
+   * tokens hard-require it (SPEC §16). APPENDED LAST: declaration order is
+   * published API surface for schema/doc generators (append-only contract).
+   */
+  resource?: string;
 }
 
 /**

--- a/typescript/src/oauth/types.ts
+++ b/typescript/src/oauth/types.ts
@@ -114,6 +114,13 @@ export interface OAuthToken {
   expiresAt?: Date;
   /** OAuth scope granted (optional) */
   scope?: string;
+  /**
+   * RFC 8707 resource indicator the token is bound to (BC5:
+   * `urn:bc:account:<id>`). Echo it as the `resource` parameter when
+   * refreshing — BC5 multi-account refresh tokens reject a refresh
+   * without it (SPEC §16).
+   */
+  resource?: string;
 }
 
 /**
@@ -152,6 +159,12 @@ export interface RefreshRequest {
   /** The client secret (optional) */
   clientSecret?: string;
   /**
+   * RFC 8707 resource indicator to bind the refreshed token to, sent only
+   * when set. Echo the stored token's `resource`: BC5 multi-account refresh
+   * tokens hard-require it (SPEC §16).
+   */
+  resource?: string;
+  /**
    * Use Launchpad's non-standard token format.
    * When true, uses `type=refresh` instead of `grant_type=refresh_token`.
    */
@@ -172,6 +185,7 @@ export interface RawTokenResponse {
   token_type?: string | null;
   expires_in?: number;
   scope?: string | null;
+  resource?: string | null;
 }
 
 /**

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -1791,3 +1791,118 @@ describe("pollDeviceToken resource capture", () => {
     }
   });
 });
+
+/** Serves a fixed response sequence with optional Retry-After headers. */
+function queueTokenResponses429(
+  responses: Array<{ status: number; body: object; retryAfter?: string }>
+) {
+  let i = 0;
+  server.use(
+    mswHttp.post(TOKEN_ENDPOINT, () => {
+      const r = responses[Math.min(i, responses.length - 1)];
+      i += 1;
+      const headers = r.retryAfter != null ? { "Retry-After": r.retryAfter } : undefined;
+      return HttpResponse.json(r.body, { status: r.status, headers });
+    })
+  );
+}
+
+const tooManyRequestsBody = { error: "too_many_requests" };
+
+describe("pollDeviceToken 429 handling", () => {
+  const pollParams = {
+    tokenEndpoint: TOKEN_ENDPOINT,
+    clientId: "basecamp-cli",
+    deviceCode: "dev-code-123",
+    interval: 5,
+    expiresIn: 900,
+  };
+
+  it("retries after 429 too_many_requests with a one-shot max(interval, Retry-After) wait", async () => {
+    queueTokenResponses429([
+      { status: 429, body: tooManyRequestsBody, retryAfter: "30" },
+      { status: 200, body: tokenResponse },
+    ]);
+    const { waits, fn } = recordingSleep();
+
+    const token = await pollDeviceToken({ ...pollParams, sleepFn: fn });
+
+    expect(token.accessToken).toBe("device_access_token");
+    expect(waits).toEqual([5000, 30000]);
+  });
+
+  it.each(["abc", "1.5", "-1", "0", "99999999999999999999", undefined])(
+    "falls back to the interval on a missing/malformed Retry-After (%s)",
+    async (retryAfter) => {
+      queueTokenResponses429([
+        { status: 429, body: tooManyRequestsBody, retryAfter },
+        { status: 200, body: tokenResponse },
+      ]);
+      const { waits, fn } = recordingSleep();
+
+      await pollDeviceToken({ ...pollParams, sleepFn: fn });
+
+      expect(waits).toEqual([5000, 5000]);
+    }
+  );
+
+  it("decays the Retry-After override after one wait", async () => {
+    queueTokenResponses429([
+      { status: 429, body: tooManyRequestsBody, retryAfter: "30" },
+      { status: 400, body: { error: "authorization_pending" } },
+      { status: 200, body: tokenResponse },
+    ]);
+    const { waits, fn } = recordingSleep();
+
+    await pollDeviceToken({ ...pollParams, sleepFn: fn });
+
+    expect(waits).toEqual([5000, 30000, 5000]);
+  });
+
+  it.each([
+    { name: "429 without too_many_requests", status: 429, body: { error: "rate_limited" } },
+    { name: "too_many_requests on 400", status: 400, body: tooManyRequestsBody },
+  ])("stays terminal on $name", async ({ status, body }) => {
+    queueTokenResponses429([{ status, body, retryAfter: "30" }]);
+
+    await expect(
+      pollDeviceToken({ ...pollParams, sleepFn: recordingSleep().fn })
+    ).rejects.toMatchObject({ code: "api_error" });
+  });
+
+  it("clamps the 429 override wait to the expiry deadline", async () => {
+    queueTokenResponses429([{ status: 429, body: tooManyRequestsBody, retryAfter: "3600" }]);
+    const { waits, fn } = recordingSleep();
+    // Scripted monotonic clock (ms): deadline anchors at t=0 with a 20s
+    // lifetime; the second iteration's huge override clamps to the 14s
+    // remaining and the post-wait check expires the flow.
+    const times = [0, 0, 5000, 6000, 20000];
+    let i = 0;
+    const clock = () => times[Math.min(i++, times.length - 1)];
+
+    await expect(
+      pollDeviceToken({ ...pollParams, expiresIn: 20, sleepFn: fn, clock })
+    ).rejects.toMatchObject({ reason: "expired" });
+    expect(waits).toEqual([5000, 14000]);
+  });
+
+  it("preserves cancellation during the 429 override wait", async () => {
+    queueTokenResponses429([{ status: 429, body: tooManyRequestsBody, retryAfter: "30" }]);
+    const controller = new AbortController();
+    let waitCount = 0;
+    const fn = (ms: number, signal?: AbortSignal): Promise<void> => {
+      waitCount += 1;
+      if (waitCount === 2) {
+        controller.abort(); // cancel during the post-429 override wait
+        return Promise.reject(Object.assign(new Error("Aborted"), { name: "AbortError" }));
+      }
+      void ms;
+      void signal;
+      return Promise.resolve();
+    };
+
+    await expect(
+      pollDeviceToken({ ...pollParams, signal: controller.signal, sleepFn: fn })
+    ).rejects.toMatchObject({ reason: "cancelled" });
+  });
+});

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -1861,6 +1861,8 @@ describe("pollDeviceToken 429 handling", () => {
 
   it.each([
     { name: "429 without too_many_requests", status: 429, body: { error: "rate_limited" } },
+    { name: "429 parroting authorization_pending", status: 429, body: { error: "authorization_pending" } },
+    { name: "429 parroting slow_down", status: 429, body: { error: "slow_down" } },
     { name: "too_many_requests on 400", status: 400, body: tooManyRequestsBody },
   ])("stays terminal on $name", async ({ status, body }) => {
     queueTokenResponses429([{ status, body, retryAfter: "30" }]);

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -1741,3 +1741,53 @@ describe("performDeviceLogin cancellation around the authorization request", () 
     expect(displayed).toEqual([]);
   });
 });
+
+describe("pollDeviceToken resource capture", () => {
+  it("captures resource from the device token response and treats null as absent", async () => {
+    queueTokenResponses([
+      { status: 200, body: { ...tokenResponse, resource: "urn:bc:account:42" } },
+    ]);
+    const { fn } = recordingSleep();
+
+    const token = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: fn,
+    });
+    expect(token.resource).toBe("urn:bc:account:42");
+
+    queueTokenResponses([
+      { status: 200, body: { ...tokenResponse, resource: null } },
+    ]);
+    const nullToken = await pollDeviceToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      clientId: "basecamp-cli",
+      deviceCode: "dev-code-123",
+      interval: 5,
+      expiresIn: 900,
+      sleepFn: recordingSleep().fn,
+    });
+    expect(nullToken.resource).toBeUndefined();
+  });
+
+  it("rejects a present-but-empty or non-string resource as api_error", async () => {
+    for (const resource of ["", 7]) {
+      queueTokenResponses([
+        { status: 200, body: { ...tokenResponse, resource } },
+      ]);
+      await expect(
+        pollDeviceToken({
+          tokenEndpoint: TOKEN_ENDPOINT,
+          clientId: "basecamp-cli",
+          deviceCode: "dev-code-123",
+          interval: 5,
+          expiresIn: 900,
+          sleepFn: recordingSleep().fn,
+        })
+      ).rejects.toMatchObject({ code: "api_error" });
+    }
+  });
+});

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -1860,6 +1860,14 @@ describe("pollDeviceToken 429 handling", () => {
     expect(parseRetryAfterSeconds("\n30\n")).toBe(0);
   });
 
+  it("clamps a representable over-ceiling Retry-After; unrepresentable falls back", () => {
+    // The wait rule clips to the remaining code lifetime, so clamping honors
+    // the throttle (wait out the lifetime) instead of resending on the
+    // interval; a beyond-2^53 digit string is unrepresentable → fallback.
+    expect(parseRetryAfterSeconds("2147484")).toBe(2_147_483);
+    expect(parseRetryAfterSeconds("99999999999999999999")).toBe(0);
+  });
+
   it("decays the Retry-After override after one wait", async () => {
     queueTokenResponses429([
       { status: 429, body: tooManyRequestsBody, retryAfter: "30" },

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -15,6 +15,7 @@ import {
   DeviceFlowError,
   DEVICE_CODE_GRANT_TYPE,
 } from "../../src/oauth/index.js";
+import { parseRetryAfterSeconds } from "../../src/oauth/device.js";
 import type { OAuthConfig, DeviceAuthorization } from "../../src/oauth/types.js";
 import { BasecampError } from "../../src/errors.js";
 
@@ -1845,6 +1846,19 @@ describe("pollDeviceToken 429 handling", () => {
       expect(waits).toEqual([5000, 5000]);
     }
   );
+
+  it("trims only ASCII SP/HTAB around a Retry-After delta (RFC 9110 OWS)", () => {
+    // Direct parser test: msw cannot carry NBSP header values (the Python
+    // suite tests its parser directly for the same reason). Unicode
+    // whitespace must never trim a malformed value into validity.
+    expect(parseRetryAfterSeconds(" 30 ")).toBe(30);
+    expect(parseRetryAfterSeconds("\t30\t")).toBe(30);
+    expect(parseRetryAfterSeconds(" \t30\t ")).toBe(30);
+    expect(parseRetryAfterSeconds("\u00a030")).toBe(0);
+    expect(parseRetryAfterSeconds("30\u00a0")).toBe(0);
+    expect(parseRetryAfterSeconds("\u200930")).toBe(0);
+    expect(parseRetryAfterSeconds("\n30\n")).toBe(0);
+  });
 
   it("decays the Retry-After override after one wait", async () => {
     queueTokenResponses429([

--- a/typescript/tests/oauth/device.test.ts
+++ b/typescript/tests/oauth/device.test.ts
@@ -1866,6 +1866,12 @@ describe("pollDeviceToken 429 handling", () => {
     // interval; a beyond-2^53 digit string is unrepresentable → fallback.
     expect(parseRetryAfterSeconds("2147484")).toBe(2_147_483);
     expect(parseRetryAfterSeconds("99999999999999999999")).toBe(0);
+    // The shared 10-significant-digit bound: leading zeros strip first, so a
+    // padded in-range delta is honored while >10 significant digits (or an
+    // unbounded digit string) fall back without feeding parseInt.
+    expect(parseRetryAfterSeconds("0".repeat(30) + "30")).toBe(30);
+    expect(parseRetryAfterSeconds("9".repeat(11))).toBe(0);
+    expect(parseRetryAfterSeconds("1" + "0".repeat(100000))).toBe(0);
   });
 
   it("decays the Retry-After override after one wait", async () => {

--- a/typescript/tests/oauth/oauth.test.ts
+++ b/typescript/tests/oauth/oauth.test.ts
@@ -560,6 +560,63 @@ describe("Token Exchange", () => {
         })
       ).rejects.toThrow("Refresh token is required");
     });
+
+    it("sends resource when set and omits it when unset", async () => {
+      let sawResource: string | null = null;
+      let hasResource = true;
+      server.use(
+        http.post(tokenEndpoint, async ({ request }) => {
+          const params = new URLSearchParams(await request.text());
+          sawResource = params.get("resource");
+          hasResource = params.has("resource");
+          return HttpResponse.json(mockTokenResponse);
+        })
+      );
+
+      await refreshToken({
+        tokenEndpoint,
+        refreshToken: "my_refresh_token",
+        resource: "urn:bc:account:42",
+      });
+      expect(sawResource).toBe("urn:bc:account:42");
+
+      await refreshToken({
+        tokenEndpoint,
+        refreshToken: "my_refresh_token",
+      });
+      expect(hasResource).toBe(false);
+    });
+
+    it("captures resource from the token response and treats null as absent", async () => {
+      server.use(
+        http.post(tokenEndpoint, () =>
+          HttpResponse.json({ ...mockTokenResponse, resource: "urn:bc:account:42" })
+        )
+      );
+      const token = await refreshToken({ tokenEndpoint, refreshToken: "my_refresh_token" });
+      expect(token.resource).toBe("urn:bc:account:42");
+
+      server.use(
+        http.post(tokenEndpoint, () =>
+          HttpResponse.json({ ...mockTokenResponse, resource: null })
+        )
+      );
+      const nullToken = await refreshToken({ tokenEndpoint, refreshToken: "my_refresh_token" });
+      expect(nullToken.resource).toBeUndefined();
+    });
+
+    it("rejects a present-but-empty or non-string resource as api_error", async () => {
+      for (const resource of ["", 7]) {
+        server.use(
+          http.post(tokenEndpoint, () =>
+            HttpResponse.json({ ...mockTokenResponse, resource })
+          )
+        );
+        await expect(
+          refreshToken({ tokenEndpoint, refreshToken: "my_refresh_token" })
+        ).rejects.toThrow("resource must be a non-empty string");
+      }
+    });
   });
 });
 

--- a/typescript/tests/oauth/token-conformance.test.ts
+++ b/typescript/tests/oauth/token-conformance.test.ts
@@ -44,7 +44,11 @@ afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
 describe("conformance/oauth-token fixtures", () => {
-  expect(fixtureNames.length).toBeGreaterThan(0);
+  it("discovers at least one fixture", () => {
+    // A proper test failure (not a describe-phase crash) if the fixture dir
+    // moves or empties — it.each below silently runs zero cases otherwise.
+    expect(fixtureNames.length).toBeGreaterThan(0);
+  });
 
   it.each(fixtureNames)("%s", async (name) => {
     const fixture = JSON.parse(

--- a/typescript/tests/oauth/token-conformance.test.ts
+++ b/typescript/tests/oauth/token-conformance.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Drives the shared, data-only fixtures in conformance/oauth-token/fixtures:
+ * one refresh round-trip per fixture, asserting the sent resource form
+ * parameter and the response decode (round-trip, absent/null as unset,
+ * present-empty/non-string rejected). Lifecycle preservation across a stored
+ * credential is per-manager behavior, tested in token-manager.test.ts — not
+ * here.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
+import { setupServer } from "msw/node";
+import { http, HttpResponse } from "msw";
+import { refreshToken } from "../../src/oauth/exchange.js";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = join(HERE, "../../../conformance/oauth-token/fixtures");
+const TOKEN_ENDPOINT = "https://issuer.token-fixtures.example/oauth/token";
+
+interface TokenFixture {
+  name: string;
+  operation: string;
+  request?: { resource?: string };
+  response: { status?: number; body: Record<string, unknown> };
+  expect: {
+    outcome: "token" | "reject";
+    resource?: string;
+    resourceAbsent?: boolean;
+    formResource?: string;
+    formResourceAbsent?: boolean;
+  };
+}
+
+const fixtureNames = readdirSync(FIXTURE_DIR)
+  .filter((f) => f.endsWith(".json"))
+  .sort();
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe("conformance/oauth-token fixtures", () => {
+  expect(fixtureNames.length).toBeGreaterThan(0);
+
+  it.each(fixtureNames)("%s", async (name) => {
+    const fixture = JSON.parse(
+      readFileSync(join(FIXTURE_DIR, name), "utf8")
+    ) as TokenFixture;
+    expect(fixture.operation).toBe("refreshToken");
+
+    let sawResourceKey = false;
+    let sentResource: string | null = null;
+    server.use(
+      http.post(TOKEN_ENDPOINT, async ({ request }) => {
+        const params = new URLSearchParams(await request.text());
+        sawResourceKey = params.has("resource");
+        sentResource = params.get("resource");
+        return HttpResponse.json(fixture.response.body, {
+          status: fixture.response.status ?? 200,
+        });
+      })
+    );
+
+    const call = refreshToken({
+      tokenEndpoint: TOKEN_ENDPOINT,
+      refreshToken: "refresh-token",
+      clientId: "basecamp-cli",
+      resource: fixture.request?.resource,
+    });
+
+    if (fixture.expect.outcome === "token") {
+      const token = await call;
+      if (fixture.expect.resource !== undefined) {
+        expect(token.resource).toBe(fixture.expect.resource);
+      }
+      if (fixture.expect.resourceAbsent) {
+        expect(token.resource).toBeUndefined();
+      }
+    } else {
+      await expect(call).rejects.toMatchObject({ code: "api_error" });
+    }
+
+    if (fixture.expect.formResource !== undefined) {
+      expect(sawResourceKey).toBe(true);
+      expect(sentResource).toBe(fixture.expect.formResource);
+    }
+    if (fixture.expect.formResourceAbsent) {
+      expect(sawResourceKey).toBe(false);
+    }
+  });
+});

--- a/typescript/tests/oauth/token-conformance.test.ts
+++ b/typescript/tests/oauth/token-conformance.test.ts
@@ -33,9 +33,17 @@ interface TokenFixture {
   };
 }
 
-const fixtureNames = readdirSync(FIXTURE_DIR)
-  .filter((f) => f.endsWith(".json"))
-  .sort();
+// Guarded: a missing/renamed fixture dir must surface as the proper test
+// failure below, not a describe-phase import crash.
+const fixtureNames = (() => {
+  try {
+    return readdirSync(FIXTURE_DIR)
+      .filter((f) => f.endsWith(".json"))
+      .sort();
+  } catch {
+    return [];
+  }
+})();
 
 const server = setupServer();
 

--- a/typescript/tests/oauth/token-manager.test.ts
+++ b/typescript/tests/oauth/token-manager.test.ts
@@ -248,6 +248,48 @@ describe("TokenManager", () => {
 
       await expect(manager.forceRefresh()).rejects.toThrow("No refresh token available");
     });
+
+    it("echoes the stored resource on refresh and preserves it when the response omits it", async () => {
+      const store = createMockStore(expiredToken({ resource: "urn:bc:account:42" }));
+      mockRefreshFn.mockResolvedValue(freshToken({
+        accessToken: "new_access",
+        resource: undefined,
+      }));
+
+      const manager = new TokenManager({
+        store,
+        refreshToken: mockRefreshFn,
+        tokenEndpoint: "https://example.com/token",
+      });
+
+      await manager.getToken();
+
+      expect(mockRefreshFn).toHaveBeenCalledWith(
+        expect.objectContaining({ resource: "urn:bc:account:42" }),
+      );
+      expect(manager.currentToken!.resource).toBe("urn:bc:account:42");
+      expect(store.save).toHaveBeenCalledWith(
+        expect.objectContaining({ resource: "urn:bc:account:42" }),
+      );
+    });
+
+    it("replaces the stored resource when the response carries one", async () => {
+      const store = createMockStore(expiredToken({ resource: "urn:bc:account:42" }));
+      mockRefreshFn.mockResolvedValue(freshToken({
+        accessToken: "new_access",
+        resource: "urn:bc:account:7",
+      }));
+
+      const manager = new TokenManager({
+        store,
+        refreshToken: mockRefreshFn,
+        tokenEndpoint: "https://example.com/token",
+      });
+
+      await manager.getToken();
+
+      expect(manager.currentToken!.resource).toBe("urn:bc:account:7");
+    });
   });
 
   describe("concurrent refresh deduplication", () => {

--- a/typescript/tests/oauth/token-manager.test.ts
+++ b/typescript/tests/oauth/token-manager.test.ts
@@ -273,6 +273,31 @@ describe("TokenManager", () => {
       );
     });
 
+    it("treats an injected empty-string resource as unset and carries the binding forward", async () => {
+      // The standard exchange path rejects present-empty, but an injected
+      // refreshToken implementation can hand back resource: "" — persisting
+      // it would strand a multi-account token (later refreshes would omit
+      // the binding via the truthy send check).
+      const store = createMockStore(expiredToken({ resource: "urn:bc:account:42" }));
+      mockRefreshFn.mockResolvedValue(freshToken({
+        accessToken: "new_access",
+        resource: "" as unknown as string,
+      }));
+
+      const manager = new TokenManager({
+        store,
+        refreshToken: mockRefreshFn,
+        tokenEndpoint: "https://example.com/token",
+      });
+
+      await manager.getToken();
+
+      expect(manager.currentToken!.resource).toBe("urn:bc:account:42");
+      expect(store.save).toHaveBeenCalledWith(
+        expect.objectContaining({ resource: "urn:bc:account:42" }),
+      );
+    });
+
     it("replaces the stored resource when the response carries one", async () => {
       const store = createMockStore(expiredToken({ resource: "urn:bc:account:42" }));
       mockRefreshFn.mockResolvedValue(freshToken({

--- a/typescript/tests/oauth/token-store.test.ts
+++ b/typescript/tests/oauth/token-store.test.ts
@@ -47,6 +47,24 @@ describe("FileTokenStore", () => {
       expect(loaded!.scope).toBe("read write");
     });
 
+    it("round-trips the RFC 8707 resource through save and load", async () => {
+      // Losing resource across persistence strands a BC5 multi-account
+      // refresh token: after a restart the refresh would carry no resource
+      // and be rejected (400 invalid_request).
+      const store = new FileTokenStore(join(tempDir, "tokens.json"));
+      const token = makeToken({ resource: "urn:bc:account:42" });
+
+      await store.save(token);
+      const loaded = await store.load();
+
+      expect(loaded!.resource).toBe("urn:bc:account:42");
+
+      // Absent stays absent — no phantom key on the round-trip.
+      await store.save(makeToken());
+      const noResource = await store.load();
+      expect(noResource!.resource).toBeUndefined();
+    });
+
     it("serializes expiresAt as ISO string and deserializes back to Date", async () => {
       const store = new FileTokenStore(join(tempDir, "tokens.json"));
       const expiresAt = new Date("2026-06-15T12:00:00.000Z");


### PR DESCRIPTION
Stacked on #376 (which stacks on #370). Closes the one confirmed contract break against bc3 #9471's modern OAuth stack: `basecamp-cli` is a **trusted** client, so a device approval records an identity-wide grant and mints a **multi-account refresh token** (`account_id nil`) — and bc3's refresh grant hard-requires the RFC 8707 `resource` parameter for those (`Oauth::RefreshToken#resolve_target_account!`, 400 `invalid_request` without it). Before this PR, no SDK could send it and every SDK discarded the `resource` member token responses return, so every device login died at its first token expiry (~1h). Contract re-verified against #9471 head `8270eff0` at execution time.

## What's here

**SPEC** — token responses may carry `resource` (`urn:bc:account:<id>`; absent/JSON-null = unset, present ⇒ non-empty string); the refresh contract is *echo the stored token's resource*, with lifecycle managers doing it automatically and preserving the prior value when a refresh response omits it; a normative 429 device-poll contract; truth-ups (canonical issuer `app.basecamp.com`, scope defaulting + explicit pinning, dark-launch 503 semantics, Ruby's headers-first `stream_http` transport).

**Token models + refresh (one commit per SDK)** — append-only optional `resource` on the token models, captured from exchange, device, and refresh responses with uniform validation (absent/null unset; present-empty or non-string rejected as `api_error`); refresh functions gain an optional `resource` sent only when set, appended without repositioning existing parameters (Kotlin/Python/Ruby positional callers unaffected).

**Lifecycle managers** — TS `TokenManager` and Go `AuthManager` echo the stored `resource` automatically and carry it forward when a refresh response omits it (same rule as an omitted rotated refresh token). Go `Credentials` also gains `ClientID`, submitted on refresh — a BC5 public-client refresh fails `invalid_client` without it. The Go oauth helpers never write root `Credentials` (and can't: `oauth` already imports the root package), so the README documents the manual save a device-login caller performs, and a consumer-level test proves saved `ClientID`+`Resource` reach the next refresh form and survive a resource-less response. **The Ruby and Python legacy token providers are Launchpad-only and deliberately out of scope.**

**429 poll contract (separate commit)** — only the exact HTTP 429 + `error=too_many_requests` pair is retryable; the next wait honors a positive integral `Retry-After` via a one-shot `max(interval, Retry-After)` override that clamps to the code lifetime and decays after one use (never inflating the `slow_down` interval); malformed headers fall back to the current interval; cancellation stays live through the wait. Per-SDK tests cover success-after-429 (proven to fail pre-fix), malformed-header fallback, one-shot decay, wrong-pair terminality, expiry clamping, and cancellation mid-override-wait.

**Conformance** — new `conformance/oauth-token/` fixture family for the wire behavior only (`conformance/oauth/` is discovery-only and its harnesses glob the whole fixtures dir). Go/TS/Python/Ruby load the fixtures; Kotlin mirrors them in code per its established pattern. `make oauth-token-fixtures-check` schema-validates the family inside `make check`. Response-omission preservation is lifecycle behavior and stays in per-manager tests by design.

## Out of scope
DPoP, PAR, DCR, PATs, revocation endpoint, Swift, and the Launchpad-only legacy token providers.

## Landing
Lands after #370/#376 in the same sequence — **no SDK release between #370 and this PR**: device flow without the resource echo ships logins that die at first refresh. basecamp-cli adoption follows as a CLI PR pinned to this PR's merged SHA.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds RFC 8707 resource indicator support across Go, TypeScript, Python, Ruby, and Kotlin, and a strict device‑flow 429 Retry‑After contract. Tightens token/refresh parsing across SDKs, pins the issuer to https://app.basecamp.com, and adds `conformance/oauth-token` fixtures validated by `make oauth-token-fixtures-check`.

- **Bug Fixes**
  - RFC 8707: decode `resource` as unset when absent/JSON‑null; reject present‑empty/non‑string; refresh sends `resource` only when set; managers auto‑echo and preserve on omission; stores round‑trip it; TS store normalizes on load/save and treats injected empty as unset; Go refresh submits stored `client_id` and `resource`, and fails a refresh with an empty `resource`.
  - Device flow 429s: only 429 + `too_many_requests` retries; one‑shot max(interval, ASCII‑digit `Retry‑After`) override trimmed by ASCII SP/HTAB, accepts zero‑padded, enforces a shared 10‑digit bound (leading zeros stripped), clamps representable over‑ceiling deltas, rejects duplicate `Retry‑After` headers, treats wrong‑pair 429s as terminal; cancellation stays live.
  - Token parsing/refresh: malformed 2xx bodies become typed `api_error` with HTTP status; `access_token` must be a non‑empty string; `token_type` defaults to Bearer only when absent/JSON‑null (present‑empty/non‑string rejected); Go refresh validates‑then‑mutates, clears stale expiry when `expires_in` is omitted, fails on non‑positive or over‑ceiling `expires_in` (cap 2,147,483,647s), never force‑refreshes no‑expiry tokens, and rejects 2xx without `access_token`; Kotlin device/exchange faults drop decoder causes; Python/Ruby legacy token providers are Launchpad‑only.

- **Migration**
  - If you call refresh directly, pass the stored `resource`; managers handle echo/preserve automatically. Persist `resource` and any rotated `refresh_token`.
  - Use the bare origin https://app.basecamp.com (no trailing slash). A trailing slash on `expected_issuer` fails hard; a trailing slash on the resource origin soft‑falls back to Launchpad. Pin scope explicitly.

<sup>Written for commit 077915f1e19d69ee8cedc9b27f5e87d2b35fbae7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

