### PR TITLE
Go: map HTTP 400 to validation (not api_error)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -316,7 +316,7 @@ END
 
 ### Error Code Table
 
-Status-mapped codes are verified per the Verification column. Most are `[conformance]`-verified; 400→`validation` is `[static]` (no conformance test). Client-side codes (`usage`, `network`, `ambiguous`) and exit codes are `[static]`.
+Status-mapped codes are verified per the Verification column and are `[conformance]`-verified. Client-side codes (`usage`, `network`, `ambiguous`) and exit codes are `[static]`.
 
 | Code | Exit Code | HTTP Status | Retryable | Description | Verification |
 |------|-----------|-------------|-----------|-------------|-------------|
@@ -329,11 +329,11 @@ Status-mapped codes are verified per the Verification column. Most are `[conform
 | `api_error` | 7 | 500, 502, 503, 504 | true | Server-side error | `[conformance]` |
 | `ambiguous` | 8 | — | false | Multiple matches found (CLI disambiguation) | `[static]` |
 | `validation` | 9 | 422 | false | Request validation failed | `[conformance]` |
-| `validation` | 9 | 400 | false | Request validation failed | `[static]` |
+| `validation` | 9 | 400 | false | Request validation failed | `[conformance]` |
 
 ### HTTP Status Mapping Algorithm
 
-Each mapping below is `[conformance]`-verified except step 5 (400 → `validation`) which is `[static]`.
+Each explicitly enumerated status mapping below (steps 1–10) is `[conformance]`-verified. The two catch-all fallback steps (11: general 5xx; 12: any other non-mapped status) have no dedicated conformance case and are `[static]`.
 
 Given an HTTP response with status code `status` and body `body`:
 
@@ -341,14 +341,14 @@ Given an HTTP response with status code `status` and body `body`:
 2. If `status == 403` → `BasecampError(code: "forbidden", http_status: 403, retryable: false)`.
 3. If `status == 404` → `BasecampError(code: "not_found", http_status: 404, retryable: false)`.
 4. If `status == 429` → `BasecampError(code: "rate_limit", http_status: 429, retryable: true, retry_after: parseRetryAfter(headers))`.
-5. If `status == 400` → `BasecampError(code: "validation", http_status: 400, retryable: false)`. `[CONFLICT: Go currently maps 400 to "api_error" (falls through to default case). The spec prescribes "validation" to match other SDKs. No conformance test exists for 400 specifically.]` `[static]`
+5. If `status == 400` → `BasecampError(code: "validation", http_status: 400, retryable: false)`.
 6. If `status == 422` → `BasecampError(code: "validation", http_status: 422, retryable: false)`.
 7. If `status == 500` → `BasecampError(code: "api_error", http_status: 500, retryable: true)`.
 8. If `status == 502` → `BasecampError(code: "api_error", http_status: 502, retryable: true)`.
 9. If `status == 503` → `BasecampError(code: "api_error", http_status: 503, retryable: true)`.
 10. If `status == 504` → `BasecampError(code: "api_error", http_status: 504, retryable: true)`.
-11. If `status >= 500` → `BasecampError(code: "api_error", http_status: status, retryable: true)`.
-12. Otherwise → `BasecampError(code: "api_error", http_status: status, retryable: false)`.
+11. If `status >= 500` → `BasecampError(code: "api_error", http_status: status, retryable: true)`. `[static]`
+12. Otherwise → `BasecampError(code: "api_error", http_status: status, retryable: false)`. `[static]`
 
 In all cases, extract `request_id` from `X-Request-Id` response header if present. `[conformance]`
 
@@ -772,7 +772,7 @@ All 4xx and 5xx responses must produce typed `BasecampError` errors (not silentl
 
 Status codes 401, 403, 404, and 422 must NOT be retried. Conformance tests assert `requestCount == 1` for these statuses. `[conformance]`
 
-Status code 400 must also NOT be retried. This is a `[static]` contract (no dedicated conformance test exists for 400).
+Status code 400 must also NOT be retried. The error-mapping conformance suite asserts `retryable == false` for 400 (mapped to `validation`), so its non-retryable classification is `[conformance]`-verified; there is no dedicated `requestCount` fixture for 400. `[conformance]`
 
 ### Retry Exhaustion
 
@@ -1494,6 +1494,7 @@ account, attachments, automation, boosts, campfires, cardColumns, cardSteps, car
 | `error-mapping.json` | 401 → auth_required | §6 |
 | `error-mapping.json` | 403 → forbidden | §6 |
 | `error-mapping.json` | 404 → not_found | §6 |
+| `error-mapping.json` | 400 → validation | §6 |
 | `error-mapping.json` | 422 → validation | §6 |
 | `error-mapping.json` | 429 → rate_limit | §6 |
 | `error-mapping.json` | 500 → api_error | §6 |

--- a/conformance/tests/error-mapping.json
+++ b/conformance/tests/error-mapping.json
@@ -50,6 +50,23 @@
     "tags": ["error-mapping", "not-found", "structured-error"]
   },
   {
+    "name": "400 maps to validation error code",
+    "description": "Verifies that 400 Bad Request maps to structured error with code 'validation' and retryable=false",
+    "operation": "GetProject",
+    "method": "GET",
+    "path": "/projects/{projectId}",
+    "pathParams": {"projectId": 12345},
+    "mockResponses": [
+      {"status": 400, "headers": {"X-Request-Id": "req-bad-400"}, "body": {"error": "Bad request"}}
+    ],
+    "assertions": [
+      {"type": "errorCode", "expected": "validation"},
+      {"type": "errorField", "path": "httpStatus", "expected": 400},
+      {"type": "errorField", "path": "retryable", "expected": false}
+    ],
+    "tags": ["error-mapping", "validation", "structured-error"]
+  },
+  {
     "name": "422 maps to validation error code",
     "description": "Verifies that 422 Unprocessable Entity maps to structured error with code 'validation'",
     "operation": "CreateProject",

--- a/go/pkg/basecamp/helpers.go
+++ b/go/pkg/basecamp/helpers.go
@@ -82,6 +82,8 @@ func checkResponse(resp *http.Response, body []byte) error {
 	serverMsg, serverHint := parseErrorBody(body)
 
 	switch resp.StatusCode {
+	case http.StatusBadRequest:
+		return &Error{Code: CodeValidation, Message: msgOrDefault(serverMsg, "validation error"), Hint: serverHint, HTTPStatus: 400, RequestID: requestID}
 	case http.StatusUnauthorized:
 		return &Error{Code: CodeAuth, Message: msgOrDefault(serverMsg, "authentication required"), Hint: serverHint, HTTPStatus: 401, RequestID: requestID}
 	case http.StatusForbidden:

--- a/go/pkg/basecamp/helpers_test.go
+++ b/go/pkg/basecamp/helpers_test.go
@@ -27,6 +27,7 @@ func TestCheckResponse_ErrorCodes(t *testing.T) {
 		wantCode  string
 		wantRetry bool
 	}{
+		{400, CodeValidation, false},
 		{401, CodeAuth, false},
 		{403, CodeForbidden, false},
 		{404, CodeNotFound, false},


### PR DESCRIPTION
## Problem

`SPEC.md` §6 prescribes `400 → validation` to match the other five SDKs, but Go's `checkResponse` had no `case http.StatusBadRequest`, so 400 Bad Request fell through to the `default` arm and was mislabeled `api_error`. The SPEC self-tagged this as a `[CONFLICT]`/`[static]` carve-out with no conformance coverage.

## Fix

- Add `case http.StatusBadRequest → CodeValidation` (`retryable: false`) to `go/pkg/basecamp/helpers.go`. This is a code/message correction, not a retry-behavior change.
- Resolve the SPEC carve-outs: mark the error-code table row, the mapping-algorithm step, the non-retryable-errors note, and Appendix D as `[conformance]`-verified; drop the stale "Go currently maps 400 to api_error" note.
- Add a `400 → validation` case to the shared conformance fixture `conformance/tests/error-mapping.json` and a 400 row to `helpers_test.go`.

## Tests / Verify

- `helpers_test.go` 400 row proven to fail pre-fix (`api_error` != `validation`).
- The new fixture case is **green across all five conformance runners** (Go, Kotlin, TypeScript, Ruby, Python) and passes `conformance-fixtures-check`.

---
Part of the retry-contract follow-up (#456 / #460 / #461 / #476). Independent of the other two PRs in the series (no shared files).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Maps HTTP 400 to `validation` in the Go SDK to align with SPEC §6 and other SDKs. Adds conformance coverage and a unit test; 400 remains non-retryable.

- **Bug Fixes**
  - Go: map 400 → `validation` in `go/pkg/basecamp/helpers.go` (`retryable: false`).
  - Tests: add 400 case to `conformance/tests/error-mapping.json` and `helpers_test.go`.
  - Spec: mark 400 mapping and non-retryable note as `[conformance]`; clarify mapping algorithm fallbacks.

<sup>Written for commit 28a3be88d20167e9ece63fb467d3cc686f451021. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

