### PR TITLE
CONTRIBUTING: release notes come from PR labels, not a CHANGELOG

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,7 +233,26 @@ All SDKs are generated from a single Smithy specification. When adding support f
 
 6. **Update documentation**:
    - Add to the services table in each SDK's README
-   - Add to CHANGELOG under `[Unreleased]`
+   - Note which release-note section the change belongs in. There is no
+     CHANGELOG in this repo — release notes are generated from **PR labels** by
+     `.github/release.yml`, and an unlabeled PR falls into **Other**. Applying
+     labels needs triage rights, so if you don't have them, say which section
+     fits in the PR description and a maintainer will label it:
+
+     | Section | Labels |
+     |---|---|
+     | ⚠️ Breaking Changes | `breaking` |
+     | Features | `enhancement` |
+     | Bug Fixes | `bug` |
+     | CI & Infrastructure | `ci`, `dependencies`, `github-actions` |
+     | Documentation | `documentation` |
+     | Other | anything else |
+
+     A PR may carry several — `breaking` plus `bug` is common — and language
+     labels (`go`, `python`, …) are applied automatically and don't affect
+     categorization. `ci` is configured in `.github/release.yml` but does not
+     yet exist as a repository label; use `github-actions` for workflow changes
+     until it does.
 
 ## Spec-shape lints
 


### PR DESCRIPTION
`CONTRIBUTING.md` step 6 of "add an operation" says:

> - Add to CHANGELOG under `[Unreleased]`

There is no `CHANGELOG` in this repo. Release notes are generated from PR labels by `.github/release.yml`, so the instruction was impossible to follow, and — worse — it left contributors with no reason to label their PR, which is what actually determines where the change appears in the notes. An unlabeled PR silently lands in "Other".

Replaced with the real mechanism and the label vocabulary (`breaking`, `enhancement`, `bug`, `github-actions`/`dependencies`, `documentation`).

Found while working through the v0.10.0 release checklist, which flagged this as knowingly stale.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the nonexistent CHANGELOG step with the real flow: release notes come from PR labels via `.github/release.yml` (unlabeled PRs go to Other).
Map labels—`breaking`, `enhancement`, `bug`, `ci`/`github-actions`/`dependencies`, `documentation`—and note: multi-label OK, language labels don’t affect grouping, and if you lack triage rights, state the section so a maintainer can label; use `github-actions` until `ci` exists.

<sup>Written for commit a75ecd944eae45d8a03017f2b4bc48c9fe5b749e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

