### PR TITLE
Kotlin installation: complete instructions, no version to rot

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -180,6 +180,7 @@ jobs:
             echo '```kotlin'
             echo "implementation(\"com.basecamp:basecamp-sdk:${SEMVER}\")"
             echo '```'
+            echo "Requires the GitHub Packages repository and a token — see [Kotlin installation](https://github.com/basecamp/basecamp-sdk/blob/${VERSION}/kotlin/README.md#installation)."
             echo ""
             echo "**Python**"
             echo '```'

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -27,23 +27,58 @@ Official Kotlin SDK for the [Basecamp API](https://github.com/basecamp/bc3-api).
 
 ## Installation
 
-The SDK is published to GitHub Packages. Add the repository and dependency to your `build.gradle.kts`:
+The SDK is published to [GitHub Packages](https://github.com/basecamp/basecamp-sdk/packages). GitHub Packages requires an access token for every download — including for public packages like this one — so there are three steps rather than one.
+
+### 1. Create an access token
+
+Create a [**classic** personal access token](https://github.com/settings/tokens) with the `read:packages` scope. Fine-grained personal access tokens do not work with GitHub Packages.
+
+### 2. Store the credentials
+
+Put them in `~/.gradle/gradle.properties`, so they stay out of your repository:
+
+```properties
+gpr.user=YOUR_GITHUB_USERNAME
+gpr.key=YOUR_CLASSIC_TOKEN
+```
+
+The repository block below falls back to the `GITHUB_USER` and `GITHUB_ACCESS_TOKEN` environment variables, which is usually what you want in CI.
+
+### 3. Declare the repository and dependency
+
+In your `build.gradle.kts`:
 
 ```kotlin
 repositories {
+    mavenCentral()
     maven {
         url = uri("https://maven.pkg.github.com/basecamp/basecamp-sdk")
         credentials {
-            username = System.getenv("GITHUB_USER") ?: "x-access-token"
-            password = System.getenv("GITHUB_ACCESS_TOKEN") ?: ""
+            username = project.findProperty("gpr.user") as String? ?: System.getenv("GITHUB_USER")
+            password = project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_ACCESS_TOKEN")
         }
     }
 }
 
 dependencies {
-    implementation("com.basecamp:basecamp-sdk:0.2.1")
+    // Latest release: https://github.com/basecamp/basecamp-sdk/releases/latest
+    implementation("com.basecamp:basecamp-sdk:VERSION")
 }
 ```
+
+`mavenCentral()` is needed for the SDK's own dependencies — Ktor, kotlinx.serialization, and the Kotlin stdlib all resolve from there.
+
+### Maven
+
+Use `com.basecamp:basecamp-sdk-jvm` instead. Gradle reads the Gradle Module Metadata that ships alongside the root `com.basecamp:basecamp-sdk` artifact and transparently redirects to the JVM variant; Maven does not, so it resolves the root jar directly and finds a Kotlin Multiplatform metadata jar with no classes in it.
+
+### Troubleshooting
+
+| Error | Cause |
+|---|---|
+| `Could not find com.basecamp:basecamp-sdk` | The `maven { }` repository block is missing. |
+| `Username must not be null!` | Neither `gpr.user` nor `GITHUB_USER` is set. |
+| `Received status code 401 from server: Unauthorized` | The token is wrong, expired, fine-grained rather than classic, or missing the `read:packages` scope. |
 
 ## Quick Start
 

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -42,7 +42,15 @@ gpr.user=YOUR_GITHUB_USERNAME
 gpr.key=YOUR_CLASSIC_TOKEN
 ```
 
-The repository block below falls back to the `GITHUB_USER` and `GITHUB_ACCESS_TOKEN` environment variables, which is usually what you want in CI.
+The repository block below also reads the `GITHUB_USER` and `GITHUB_ACCESS_TOKEN` environment variables. Those names are this project's own convention, not GitHub Actions defaults — Actions gives you `github.actor` and `secrets.GITHUB_TOKEN` — so a workflow has to map them:
+
+```yaml
+env:
+  GITHUB_USER: x-access-token
+  GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+`secrets.GITHUB_TOKEN` is scoped to the repository running the workflow. Consuming this package from a different repository needs a classic PAT stored as a secret instead.
 
 ### 3. Declare the repository and dependency
 
@@ -61,7 +69,8 @@ repositories {
 }
 
 dependencies {
-    // Latest release: https://github.com/basecamp/basecamp-sdk/releases/latest
+    // Replace VERSION with the latest release:
+    // https://github.com/basecamp/basecamp-sdk/releases/latest
     implementation("com.basecamp:basecamp-sdk:VERSION")
 }
 ```
@@ -70,7 +79,43 @@ dependencies {
 
 ### Maven
 
-Use `com.basecamp:basecamp-sdk-jvm` instead. Gradle reads the Gradle Module Metadata that ships alongside the root `com.basecamp:basecamp-sdk` artifact and transparently redirects to the JVM variant; Maven does not, so it resolves the root jar directly and finds a Kotlin Multiplatform metadata jar with no classes in it.
+Maven needs a different artifact, plus its own repository declaration and credentials.
+
+Depend on **`basecamp-sdk-jvm`**, not `basecamp-sdk`. Gradle reads the Gradle Module Metadata that ships alongside the root `com.basecamp:basecamp-sdk` artifact and transparently redirects to the JVM variant. Maven does not read that metadata, so it resolves the root jar directly — which *succeeds*, and puts a Kotlin Multiplatform metadata jar containing no classes on your classpath. Nothing fails until compile time.
+
+```xml
+<dependency>
+  <groupId>com.basecamp</groupId>
+  <artifactId>basecamp-sdk-jvm</artifactId>
+  <!-- Replace with the latest release: https://github.com/basecamp/basecamp-sdk/releases/latest -->
+  <version>VERSION</version>
+</dependency>
+```
+
+Declare the repository in the same `pom.xml`:
+
+```xml
+<repositories>
+  <repository>
+    <id>github</id>
+    <url>https://maven.pkg.github.com/basecamp/basecamp-sdk</url>
+  </repository>
+</repositories>
+```
+
+And put the credentials in `~/.m2/settings.xml`, where `<id>` must match the repository's:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>github</id>
+      <username>YOUR_GITHUB_USERNAME</username>
+      <password>YOUR_CLASSIC_TOKEN</password>
+    </server>
+  </servers>
+</settings>
+```
 
 ### Troubleshooting
 

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -50,7 +50,9 @@ env:
   GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
 
-`secrets.GITHUB_TOKEN` is scoped to the repository running the workflow. Consuming this package from a different repository needs a classic PAT stored as a secret instead.
+`secrets.GITHUB_TOKEN` is scoped to the repository running the workflow. To consume the package from a *different* repository, grant that repository access under the package's Actions access settings and give the job `permissions: packages: read` — that avoids a long-lived PAT. Failing that, store a classic PAT as a secret and use it as `GITHUB_ACCESS_TOKEN`.
+
+The username is not load-bearing; GitHub Packages authenticates on the token. `${{ github.actor }}` works just as well as `x-access-token`.
 
 ### 3. Declare the repository and dependency
 

--- a/swift/README.md
+++ b/swift/README.md
@@ -25,11 +25,14 @@ Official Swift SDK for the [Basecamp API](https://github.com/basecamp/bc3-api).
 
 ## Installation
 
-Add the package to your `Package.swift`:
+In Xcode: **File > Add Package Dependencies**, enter `https://github.com/basecamp/basecamp-sdk`, and choose the version you want.
+
+Or add the package to your `Package.swift`:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/basecamp/basecamp-sdk", from: "0.2.1"),
+    // Latest release: https://github.com/basecamp/basecamp-sdk/releases/latest
+    .package(url: "https://github.com/basecamp/basecamp-sdk", from: "MAJOR.MINOR.PATCH"),
 ],
 targets: [
     .target(
@@ -40,8 +43,6 @@ targets: [
     ),
 ]
 ```
-
-Or add it via Xcode: File > Add Package Dependencies and enter the repository URL.
 
 ## Quick Start
 

--- a/swift/README.md
+++ b/swift/README.md
@@ -27,11 +27,12 @@ Official Swift SDK for the [Basecamp API](https://github.com/basecamp/bc3-api).
 
 In Xcode: **File > Add Package Dependencies**, enter `https://github.com/basecamp/basecamp-sdk`, and choose the version you want.
 
-Or add the package to your `Package.swift`:
+Or add the package to your `Package.swift`. Replace `MAJOR.MINOR.PATCH` with the version you want — `Package.swift` requires a literal, so this snippet does not compile until you do:
 
 ```swift
 dependencies: [
-    // Latest release: https://github.com/basecamp/basecamp-sdk/releases/latest
+    // Replace with the latest release:
+    // https://github.com/basecamp/basecamp-sdk/releases/latest
     .package(url: "https://github.com/basecamp/basecamp-sdk", from: "MAJOR.MINOR.PATCH"),
 ],
 targets: [


### PR DESCRIPTION
Closes #494.

The Kotlin SDK publishes to GitHub Packages, not Maven Central. That imposes two requirements no other language here has — a `repositories { }` declaration and an access token — and our two installation surfaces each carried only part of the story.

| Surface | Repository block | Auth story | Version |
|---|---|---|---|
| Generated release notes | no | no | correct (`${SEMVER}`) |
| `kotlin/README.md` | yes | one sentence | stale — `0.2.1` |

Neither is sufficient alone. Copying the release-notes line gives `Could not find com.basecamp:basecamp-sdk`; following the README gives an SDK eight minor releases old, and only if you independently work out that a token is needed.

## Approach

The staleness is systemic rather than an oversight: `0.2.1` was written by the 0.2.1 release commit itself and has survived thirteen consecutive releases. `scripts/bump-version.sh` rewrites ten files, none of them markdown. A "remember to update the README" convention that has failed thirteen times out of thirteen will not start working, so the fix removes the thing that rots rather than promising to maintain it.

The two surfaces split along what each can keep correct:

- **Release notes are version-bearing.** Generated per-tag from `${SEMVER}`, correct by construction. They now carry the exact pin *and* a link to the README section for setup, pinned to `${VERSION}` so it points at the README as it stood for that release.
- **READMEs are structure-bearing.** Repository block, token steps, coordinate — none of which changes per release — and no version literal at all.

A release-notes reader already holds the version, so nothing is lost.

## Kotlin README

Leads with the token, because two things about it are surprising and each costs an hour to discover by trial: GitHub Packages requires a token even for **public** packages, and it rejects fine-grained PATs — classic only, `read:packages`. Neither appeared anywhere in the repo before this.

Credentials move to `gradle.properties` with env-var fallback, matching GitHub's documented `gpr.user`/`gpr.key` convention and keeping the existing env var names so anyone already using them is unaffected. This replaces a `?: ""` default that configured fine and then failed at resolution with an opaque 401.

Also adds a **Maven** path, absent from the repo until now. Maven needs a different artifact — `com.basecamp:basecamp-sdk-jvm` — plus its own `<repository>` declaration and a matching `<server>` entry in `~/.m2/settings.xml`, all three of which are documented here.

The `-jvm` artifact matters more than it sounds. Gradle follows the module metadata from the root coordinate to the JVM variant; Maven does not read Gradle Module Metadata, so it resolves the root jar directly — and that *succeeds*, putting a 521-byte Kotlin Multiplatform metadata jar with no classes on the classpath. Nothing fails until compile time, which is what makes it worth a warning rather than a footnote.

## Swift

One genuine trade-off, flagged rather than buried: today's `from: "0.2.1"` *looks* stale but is functionally correct — SwiftPM `from:` is a floor, so it already resolves to 0.10.0. `Package.swift` needs a literal, so a placeholder cannot compile as-is. This trades a snippet that works-but-misleads for one that must be filled in, following the non-rot and cross-language-consistency decision. It is the one place where the version-less approach is worse than the status quo, and it is easy to reverse. The Xcode path needs no version at all, so it now leads.

## Verification

**The Kotlin snippet end-to-end**, in a scratch project outside the repo, pasted verbatim, credentials supplied only via `gradle.properties`, against an isolated cold `GRADLE_USER_HOME` (the user's shared module cache was left untouched rather than deleted — same cold-cache guarantee, non-destructive):

- `dependencies --configuration compileClasspath` resolves `com.basecamp:basecamp-sdk:0.10.0` → `com.basecamp:basecamp-sdk-jvm:0.10.0`
- `compileKotlin` compiles the README's own Quick Start against it, and the only jar fetched is `basecamp-sdk-jvm-0.10.0.jar` — confirming the module-metadata redirect

**The three troubleshooting rows are measured, not guessed** — the plan assumed all failures surface as `Could not find`, which turned out to be wrong for the case a copy-paste user is most likely to hit:

| Condition | Actual Gradle output |
|---|---|
| No repository block | `Could not find com.basecamp:basecamp-sdk:0.10.0.` |
| No credentials | `Username must not be null!` |
| Bad token | `Received status code 401 from server: Unauthorized` |

The middle one is the improvement over `?: ""`, which would have produced the opaque 401 instead of naming the missing input.

**Auth claims** — anonymous `curl` against `maven.pkg.github.com/basecamp/basecamp-sdk` returns **401** for `maven-metadata.xml`, the `.module`, and the `-jvm` POM. Authenticated, all four artifacts return 200.

**Release notes** — extracted the `Build installation body` block and ran it with `VERSION=v0.10.0 SEMVER=0.10.0`; the Kotlin section renders correctly and the generated URL resolves 200. No release was triggered.

**The Maven path**, same method — cold local repository, `pom.xml` and `settings.xml` exactly as documented:

| Case | Result |
|---|---|
| Documented setup, `-jvm` coordinate | exit 0, fetches `basecamp-sdk-jvm-0.10.0.jar` |
| Same setup, no `<server>` credentials | exit 1, `status code: 401 Unauthorized` |
| Root `basecamp-sdk` coordinate | **exit 0** — 521-byte, 3-file, zero-class jar on the classpath |

Also: `make lint-actions` (actionlint + zizmor) clean; `#installation` anchors and `releases/latest` confirmed resolving; no version literal remains in either README.

One correction to the issue's stated mechanism, in the same direction: the root artifact is not `packaging=pom` with no dependencies. It publishes a real jar containing only `META-INF/kotlin-project-structure-metadata.json` — zero classes — and its POM does carry the ktor/serialization/stdlib runtime deps. The conclusion holds; the README documents the verified mechanism.

## Not touched

`scripts/bump-version.sh` — no markdown enters the bump list, so its "Bumped 10 files" message and `AGENTS.md`'s matching "10 version files" stay accurate. The version-less choice means there is no version to match, so #494's proposed version-matching guard is moot.

## Out of scope

- Root `README.md` has no installation section for any language — a real gap, but a different one.
- `SPEC.md:944`'s `0.6.0` is an illustration inside the User-Agent spec, not an install instruction.
- Maven Central migration would remove the auth friction entirely, but needs Sonatype namespace verification and GPG signing in CI.

`.github/workflows/` is a control-plane path, so the sensitive-change gate will comment. It is informational (shadow mode), not blocking.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Complete Kotlin install guide with GitHub Packages auth, CI mapping (including cross‑repo via `GITHUB_TOKEN`), and Maven setup; remove hardcoded versions so docs don’t rot. Release notes now link to the Kotlin install section and call out that a repository + token are required; Swift leads with Xcode and uses a version placeholder.

- **Refactors**
  - Kotlin README: 3‑step GitHub Packages setup (classic PAT with `read:packages`), store creds in `~/.gradle/gradle.properties` as `gpr.user`/`gpr.key` with `GITHUB_USER`/`GITHUB_ACCESS_TOKEN` fallback; show CI mapping to `github.actor`/`secrets.GITHUB_TOKEN`, note cross‑repo access via package grant + `permissions: packages: read` with PAT as fallback, clarify the username isn’t load‑bearing; include `mavenCentral()`, add a short troubleshooting table, and drop pinned versions (link to latest).
  - Maven: depend on `com.basecamp:basecamp-sdk-jvm`, add a GitHub Packages `<repository>` in `pom.xml` and matching `<server>` creds in `~/.m2/settings.xml`; explain why the root artifact compiles empty under Maven.
  - Release notes generator adds a per‑tag link to Kotlin install and a “repository + token required” hint; Swift README prefers the Xcode path and replaces `from:` with a version placeholder.

<sup>Written for commit 32481ff6e8ebf34ff6400a64d2d20e960854ff37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

