### PR TITLE
Retry: hand out a copy of the declared status set, and run the parity guard in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,6 +117,12 @@ jobs:
         working-directory: .
         run: ./scripts/check-idempotency-parity
 
+      - name: Check retry metadata parity across SDKs
+        # Repo-wide python3 check (preinstalled on ubuntu runners). Runs from
+        # repo root regardless of this job's `working-directory: go`.
+        working-directory: .
+        run: make check-retry-metadata-parity
+
       - name: Test with coverage
         run: |
           # Measure coverage for hand-written code only (generated code is excluded)

--- a/Makefile
+++ b/Makefile
@@ -854,6 +854,9 @@ kt-check-optional-arrays-and-scalars:
 check-idempotency-parity:
 	@./scripts/check-idempotency-parity
 
+# Verify every SDK's emitted per-operation retry metadata equals
+# behavior-model.json, and that each SDK still consumes the fields it claims to.
+# Python3 — runs anywhere, enforced in CI (test-go job).
 check-retry-metadata-parity:
 	@python3 ./scripts/check-retry-metadata-parity.py
 

--- a/go/pkg/basecamp/generated_retry_statusset_test.go
+++ b/go/pkg/basecamp/generated_retry_statusset_test.go
@@ -144,3 +144,56 @@ func TestGeneratedRetryOn_EmptySetIsNotAbsent(t *testing.T) {
 		}
 	}
 }
+
+// The accessor must hand out a COPY. It reads a package-level map that
+// isRetryableStatus consults on every response, so returning the stored slice
+// lets any caller rewrite the retry policy for every client in the process —
+// and race with in-flight requests while doing it. Mutating what the accessor
+// returned must not be observable through a second lookup, nor change behavior.
+func TestGeneratedRetryOn_ReturnsCopy(t *testing.T) {
+	first, ok := generated.GetOperationRetryOn("GetAccount")
+	if !ok {
+		t.Fatal("GetAccount missing from operationRetryOn")
+	}
+	if len(first) != 2 {
+		t.Fatalf("GetAccount retryOn = %v, want 2 statuses", first)
+	}
+	first[0] = 599
+	first[1] = 599
+
+	second, ok := generated.GetOperationRetryOn("GetAccount")
+	if !ok {
+		t.Fatal("GetAccount missing from operationRetryOn after mutation")
+	}
+	if second[0] != 429 || second[1] != 503 {
+		t.Fatalf("accessor leaked the shared slice: after mutating the first result, "+
+			"a second lookup returns %v, want [429 503]", second)
+	}
+
+	// The behavioral half: the poisoned set must not have disabled retries.
+	// 429 is declared retryable for GetAccount, so the client must still retry.
+	var attempts int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	client, err := generated.NewClient(srv.URL)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := client.GetAccount(ctx, "1")
+	if err != nil {
+		t.Fatalf("GetAccount: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if got := atomic.LoadInt32(&attempts); got < 2 {
+		t.Errorf("made %d attempts on a 429 after a caller mutated the accessor result, "+
+			"want the declared retry policy to be intact (>=2)", got)
+	}
+}

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -20547,11 +20547,21 @@ var operationRetryOn = map[string][]int{
 	"UpdateWebhook":                      {429, 503},
 }
 
-// GetOperationRetryOn returns the declared retryable status set for the given
-// operation ID. ok is false when the operation carries no per-op set.
+// GetOperationRetryOn returns a COPY of the declared retryable status set for
+// the given operation ID. The copy matters: isRetryableStatus reads the same
+// package-level table on every response, so handing out the stored slice would
+// let any caller rewrite the retry policy for every client in the process, and
+// race with in-flight requests while doing it.
+//
+// ok is false when the operation carries no per-op set. A present-but-empty set
+// returns ok true, which is how "declared empty" stays distinguishable from
+// "absent" — ok, not nilness, is the signal.
 func GetOperationRetryOn(operationId string) ([]int, bool) {
 	r, ok := operationRetryOn[operationId]
-	return r, ok
+	if !ok {
+		return nil, false
+	}
+	return append([]int(nil), r...), true
 }
 
 // GetOperationRetryMax returns the per-operation retry ceiling (maximum total

--- a/go/templates/client.tmpl
+++ b/go/templates/client.tmpl
@@ -856,11 +856,21 @@ var operationRetryOn = map[string][]int{
 {{end}}
 }
 
-// GetOperationRetryOn returns the declared retryable status set for the given
-// operation ID. ok is false when the operation carries no per-op set.
+// GetOperationRetryOn returns a COPY of the declared retryable status set for
+// the given operation ID. The copy matters: isRetryableStatus reads the same
+// package-level table on every response, so handing out the stored slice would
+// let any caller rewrite the retry policy for every client in the process, and
+// race with in-flight requests while doing it.
+//
+// ok is false when the operation carries no per-op set. A present-but-empty set
+// returns ok true, which is how "declared empty" stays distinguishable from
+// "absent" — ok, not nilness, is the signal.
 func GetOperationRetryOn(operationId string) ([]int, bool) {
 	r, ok := operationRetryOn[operationId]
-	return r, ok
+	if !ok {
+		return nil, false
+	}
+	return append([]int(nil), r...), true
 }
 
 // GetOperationRetryMax returns the per-operation retry ceiling (maximum total


### PR DESCRIPTION
Two tails from #486. It merged with **nine of ten review threads unresolved**; an audit of all of them found exactly two real defects, and these are they. Neither is user-visible today.

## 1. `GetOperationRetryOn` handed out the shared table

`go/pkg/generated/client.gen.go` returned the slice stored in the package-level `operationRetryOn` map, and `isRetryableStatus` reads that same table on every response. Any caller who inspected the declared set could rewrite the retry policy for every client in the process, and race with in-flight requests while doing it.

Reproduced from an external module before fixing — an always-429 server:

```
before mutation: server saw 3 requests
after  set[0], set[1] = 599, 599
after  mutation: server saw 1 requests
```

It is the only exported accessor in the generated package that returns a reference type from a package-level table — `GetOperationRetryMax` returns an `int`, `GetOperationMetadata` a struct of two bools. Confirmed by sweeping for exported funcs returning slices or maps: one hit.

Fixed in `go/templates/client.tmpl` and regenerated. `append([]int(nil), r...)` rather than `slices.Clone` because the generated import block comes from oapi-codegen's base template and this needs no new import. The early return keeps `ok` — not nilness — as the signal separating a declared-empty set from an absent one, which is what `isRetryableStatus` depends on.

**The regression test is a real red proof.** Against the unfixed accessor it fails with:

```
accessor leaked the shared slice: after mutating the first result,
a second lookup returns [599 599], want [429 503]
```

It also covers the behavioural half — after a caller mutates the result, a 429 must still retry — and passes under `-race`.

## 2. The parity guard never ran in CI

`scripts/check-retry-metadata-parity.py` was reachable only through the root `check` target, and no workflow invokes it. `grep -rn "check-retry-metadata-parity\|make check" .github/` returned nothing. Retry metadata could therefore drift into main unnoticed — the exact failure the guard was added to prevent. Now wired into the Go job beside the idempotency guard it was modelled on, and the Makefile comment matches that sibling's "enforced in CI" convention.

**Stating the residual honestly, because it is narrower than it first appears:** `retry_on` is uniform `[429, 503]` across all 226 operations, so a Go template regression would be global and `generated_retry_statusset_test.go` already catches it in CI. What this guard uniquely covers is a generator bug in the TypeScript, Kotlin, Swift, or Ruby metadata values, plus the criterion-2 consumption token-smoke. That makes it low severity, not medium.

## Verification

| Check | Result |
|---|---|
| Regression test vs **unfixed** accessor | fails with the leak message above |
| `go test ./pkg/basecamp/ -run TestGeneratedRetryOn -race` | 3/3 pass |
| `go test ./...` | all packages ok |
| `make go-check` (clean lint cache) | exit 0 |
| `make go-check-generated-drift` | no drift — committed output matches the template |
| `make check-retry-metadata-parity` | exit 0, 226 operations |
| `make lint-actions` (actionlint + zizmor) | no findings |

The regenerated diff is exactly the accessor — 13 insertions, 3 deletions, no incidental churn.

## Deliberately not touched

- **Python and SPEC.md.** Four of #486's six review claims described code that was already correct at the merge tree; three of those were fixed *before* the squash while their threads stayed open, and the SPEC paragraph Codex flagged was rewritten by #486's own merge commit. Nothing to do.
- **`python/README.md:452`** still says GETs retry on "retryable `ApiError` (500, 502, 503, 504)", but the merged gate is the declared `{429, 503}` set. That is a real stale doc introduced by #486, but it is out of scope here and belongs in its own change.

`.github/workflows/` is a control-plane path, so the sensitive-change gate will comment — informational, shadow mode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return a copy from `GetOperationRetryOn` to prevent global retry policy mutation and data races. Add a CI step to enforce retry metadata parity across SDKs.

- **Bug Fixes**
  - `GetOperationRetryOn` now returns a copy of the per-operation status set, preserving the `ok` signal to distinguish empty vs. absent.
  - Updated the Go template and regenerated the client to apply the fix.

- **New Features**
  - CI runs `make check-retry-metadata-parity` to enforce cross-SDK retry metadata parity alongside the idempotency guard.

<sup>Written for commit 12fcdf54d5727b8525269ffc338474ed4e6954da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

