### PR TITLE
Python README: state the retry contract the code actually implements

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -440,7 +440,7 @@ Every `BasecampError` provides:
 - `code` - `ErrorCode` enum value
 - `hint` - Human-readable suggestion
 - `http_status` - HTTP status code (if applicable)
-- `retryable` - Whether the error is safe to retry
+- `retryable` - Whether the error is safe to retry. This is a classification hint for your own code, not a prediction of SDK behavior: whether an HTTP status is actually retried is governed by the operation's declared set (see [Retry Behavior](#retry-behavior)). A 500 reports `retryable=True` but is not retried
 - `retry_after` - Seconds to wait before retry (for rate limits)
 - `request_id` - Server request ID (if available)
 - `exit_code` - CLI-friendly exit code (`ExitCode` enum)
@@ -449,13 +449,14 @@ Every `BasecampError` provides:
 
 The SDK automatically retries failed requests with exponential backoff:
 
-- **GET requests** - Retried on `RateLimitError` (429), `NetworkError`, and retryable `ApiError` (500, 502, 503, 504)
+- **Which statuses** - Only the statuses an operation declares retryable. Every operation declares `429, 503`, and the declared set is exhaustive: a status outside it — **including 500, 502, and 504** — is surfaced to you on the first attempt rather than retried
+- **GET requests** - Retried on the declared statuses above, plus `NetworkError`, which carries no HTTP status and so is governed by its error classification instead
 - **Idempotent mutations** - Operations marked idempotent in the OpenAPI metadata also retry through the same path
 - **Non-idempotent mutations** - NOT retried to prevent duplicate operations
 - **401 responses** - Token refresh attempted, then single retry for all methods (regardless of idempotency)
 - **Backoff** - Exponential with jitter (`base_delay * 2^(attempt-1) + random() * max_jitter`)
 - **Retry-After** - Respected for 429 responses (overrides calculated backoff)
-- **Max retries** - Controlled by `config.max_retries` (a total attempt count including the initial request; default: 3 attempts. `0` means a single request with no retry)
+- **Max retries** - `min(config.max_retries, the operation's declared maximum)`. `config.max_retries` is a total attempt count including the initial request (default: 3 attempts; `0` means a single request with no retry). An operation declaring a lower maximum wins — the declared value can only lower the cap, never raise it
 
 ## Observability
 

--- a/python/README.md
+++ b/python/README.md
@@ -440,7 +440,7 @@ Every `BasecampError` provides:
 - `code` - `ErrorCode` enum value
 - `hint` - Human-readable suggestion
 - `http_status` - HTTP status code (if applicable)
-- `retryable` - Whether the error is safe to retry. This is a classification hint for your own code, not a prediction of SDK behavior: whether an HTTP status is actually retried is governed by the operation's declared set (see [Retry Behavior](#retry-behavior)). A 500 reports `retryable=True` but is not retried
+- `retryable` - Whether the error is safe to retry. This is a classification hint for your own code, not a prediction of transport behavior: for Basecamp API operations, what actually gets retried is the operation's declared status set (see [Retry Behavior](#retry-behavior)), so a 500 reports `retryable=True` but is not retried
 - `retry_after` - Seconds to wait before retry (for rate limits)
 - `request_id` - Server request ID (if available)
 - `exit_code` - CLI-friendly exit code (`ExitCode` enum)
@@ -449,7 +449,7 @@ Every `BasecampError` provides:
 
 The SDK automatically retries failed requests with exponential backoff:
 
-- **Which statuses** - Only the statuses an operation declares retryable. Every operation declares `429, 503`, and the declared set is exhaustive: a status outside it — **including 500, 502, and 504** — is surfaced to you on the first attempt rather than retried
+- **Which statuses** - For Basecamp API operations, only the statuses that operation declares retryable. Every operation declares `429, 503`, and the declared set is exhaustive: a status outside it — **including 500, 502, and 504** — is surfaced to you on the first attempt rather than retried
 - **GET requests** - Retried on the declared statuses above, plus `NetworkError`, which carries no HTTP status and so is governed by its error classification instead
 - **Idempotent mutations** - Operations marked idempotent in the OpenAPI metadata also retry through the same path
 - **Non-idempotent mutations** - NOT retried to prevent duplicate operations
@@ -457,6 +457,7 @@ The SDK automatically retries failed requests with exponential backoff:
 - **Backoff** - Exponential with jitter (`base_delay * 2^(attempt-1) + random() * max_jitter`)
 - **Retry-After** - Respected for 429 responses (overrides calculated backoff)
 - **Max retries** - `min(config.max_retries, the operation's declared maximum)`. `config.max_retries` is a total attempt count including the initial request (default: 3 attempts; `0` means a single request with no retry). An operation declaring a lower maximum wins — the declared value can only lower the cap, never raise it
+- **`client.authorization.get()`** - The Launchpad authorization endpoint is not a Basecamp API operation, so it carries no declared policy and neither rule above applies to it. It retries whatever `retryable` reports — **including 500, 502 and 504** — bounded only by `config.max_retries`
 
 ## Observability
 


### PR DESCRIPTION
The Python README's Retry Behavior section still described the pre-#486 contract. Three claims were wrong or incomplete — all the same failure, the contract changed and the README didn't follow.

## What was wrong

**The status set.** "Retried on `RateLimitError` (429), `NetworkError`, and retryable `ApiError` (500, 502, 503, 504)" — 500, 502 and 504 have not been retried since #486. The gate is the operation's declared `retry_on` set, and it is exhaustive in both directions. A reader planning around this expected three attempts on a 500 and got one.

**The attempt budget.** "Controlled by `config.max_retries`" — #483 made it `min(config.max_retries, the operation's declared max)`. Not hypothetical: **43 of 226 operations declare max 2** against a default cap of 3, so they retry once fewer than the README promised.

**The error table read as a retry prediction.** It was accurate — 500 really is `ApiError(retryable=True)` — but nothing said that `retryable` is a taxonomy hint rather than a statement about the transport. That gap is what makes the first bullet's error believable. `SPEC.md:432` already draws this line; the README hadn't.

## Verification

Everything here is measured, not read.

| Claim | How confirmed |
|---|---|
| 226/226 operations declare `[429, 503]` | parsed `generated/metadata.json` — one distinct set |
| Declared max is 3 (183 ops) or 2 (43 ops) | same parse — the ceiling is live, not theoretical |
| 429 → `RateLimitError`, 500/502/503/504 → `ApiError`, all `retryable=True`; 418 `False` | executed `error_from_response` |
| 500/502/504 get **one** attempt; 429/503 get three | `TestDeclaredRetryStatuses` `[500-1] [502-1] [504-1] [429-3] [503-3]` |
| A declared max of 2 beats a caller cap of 5 | `TestPerOperationRetryMax` `CapTwoOp-5-2` |
| Nothing else broke | `make py-check` — 508 passed; `make check-retry-metadata-parity` green |

**One process note worth recording.** My first probe passed an `httpx.Response` where `error_from_response` wants an `int` status. It fell through to the `else` branch and reported 500 as `retryable=False` — which, taken at face value, would have had me "correct" an accurate table into an inaccurate one. Re-run against the real signature it gives the opposite answer. The table was right; the probe was wrong.

## Scope

Documentation only — no code change, and no change to the error taxonomy itself, which is correct as it stands. This is the last of the three defects found while auditing #486's nine unresolved review threads; the other two shipped in #500.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the Python README to match the SDK’s actual retry behavior and scope the rules to Basecamp API operations. Clarifies which statuses retry, how the retry cap works, and that `client.authorization.get()` follows error classification.

- **Bug Fixes**
  - Which statuses: Only operation-declared statuses retry; all ops declare 429 and 503; 500/502/504 are not retried. Scoped to Basecamp API operations.
  - Max retries: `min(config.max_retries, operation's declared maximum)`; the declared max can only lower the cap.
  - `retryable` flag: A classification hint for your code, not a retry promise (e.g., 500 is `retryable=True` but not retried for API operations).
  - Authorization: `client.authorization.get()` is not a Basecamp API operation; it retries whatever `retryable` reports — including 500/502/504 — bounded only by `config.max_retries`.

<sup>Written for commit 8985a281a6213a911e21994aa8e5f2a019b5da66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

