### PR TITLE
TypeScript: one request lifecycle, so every attempt is observed exactly once

### DIFF
--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -312,14 +312,14 @@ export function createBasecampClient(options: BasecampClientOptions): BasecampCl
 
   const client = createClient<paths>({ baseUrl });
 
-  // Apply middleware in order: auth first, then hooks, then cache, then retry.
+  // Apply middleware in order: auth, lifecycle, cache, retry.
   // onRequest runs in this order; onResponse and onError run in reverse, so the
-  // retry middleware sees a response first and the hooks middleware last.
+  // retry middleware sees a response first and the lifecycle middleware last.
   client.use(createAuthMiddleware(authStrategy, userAgent, requestTimeoutMs, baseUrl));
 
-  // One lifecycle shared by the hooks and retry middleware: the retry loop lives
-  // inside a single middleware callback, so per-attempt hooks have to be emitted
-  // from there rather than by a middleware that is only visited once.
+  // One lifecycle, shared with the retry middleware: the retry loop lives inside a
+  // single middleware callback, so per-attempt hooks have to be emitted from there
+  // rather than by a middleware that is only visited once per request.
   const lifecycle = new RequestLifecycle(hooks);
 
   // Registered even when no hooks are configured. It emits nothing in that case
@@ -333,7 +333,7 @@ export function createBasecampClient(options: BasecampClientOptions): BasecampCl
   }
 
   // Registered last so that on the reverse-order response pass it runs first,
-  // before the cache and hooks middleware see the response.
+  // before the cache and lifecycle middleware see the response.
   if (enableRetry) {
     client.use(createRetryMiddleware(lifecycle, authStrategy));
   }
@@ -499,16 +499,15 @@ function createAuthMiddleware(authStrategy: AuthStrategy, userAgent: string, req
 }
 
 // =============================================================================
-// Hooks Middleware
+// Request Lifecycle
 // =============================================================================
 
-/** Tracks request timing for hooks */
 /**
  * Per-attempt observability state for one logical request.
  *
  * `attempt` is the 1-based attempt currently in flight. `finalized` makes
  * onRequestEnd idempotent: the retry middleware ends an attempt as soon as it
- * knows its outcome, and the hooks middleware's own onResponse then runs later
+ * knows its outcome, and the lifecycle middleware's onResponse then runs later
  * for the same logical request and must not emit a second end.
  */
 interface AttemptState {
@@ -530,7 +529,7 @@ interface AttemptState {
  * spec-reserved BC3 *response* header; sending an SDK-internal value under that
  * name was a collision.)
  *
- * Shared by the hooks and retry middleware because the retry loop lives inside
+ * Shared with the retry middleware because the retry loop lives inside
  * one middleware callback: openapi-fetch visits each middleware once per request,
  * so per-attempt hooks cannot be emitted by a separate middleware.
  */
@@ -1010,7 +1009,7 @@ function createRetryMiddleware(
       // Get operation-specific retry config from metadata
       const retryConfig = getRetryConfigForRequest(method, url);
 
-      // Not retrying: let the hooks middleware end the attempt, and drop the body.
+      // Not retrying: let the lifecycle middleware end the attempt, and drop the body.
       if (!retryConfig.retryOn.includes(response.status)) {
         bodyCache.delete(id);
         return response;
@@ -1071,7 +1070,7 @@ function createRetryMiddleware(
         // through the cache middleware, which may rewrite a 304 into a cached 200;
         // finalizing now would freeze the pre-transformation status and
         // fromCache: false, and an idempotent finalize means the hooks pass could
-        // not correct it. The hooks middleware ends this attempt instead, reading
+        // not correct it. The lifecycle middleware ends this attempt instead, reading
         // attempt 2 from the state begun above.
         return await fetch(retryRequest);
       } catch (error) {
@@ -1092,7 +1091,7 @@ function createRetryMiddleware(
 
     async onError({ id }) {
       // The initial fetch rejected, so onResponse never ran and the cached body
-      // would leak. The hooks middleware owns ending the attempt.
+      // would leak. The lifecycle middleware owns ending the attempt.
       bodyCache.delete(id);
       return undefined;
     },

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -322,9 +322,11 @@ export function createBasecampClient(options: BasecampClientOptions): BasecampCl
   // from there rather than by a middleware that is only visited once.
   const lifecycle = new RequestLifecycle(hooks);
 
-  if (hooks) {
-    client.use(createHooksMiddleware(lifecycle));
-  }
+  // Registered even when no hooks are configured. It emits nothing in that case
+  // (every call is optional-chained), but it still owns releasing per-request
+  // state — and the retry middleware records an attempt whether or not anyone is
+  // listening, so skipping this would strand one map entry per retried request.
+  client.use(createLifecycleMiddleware(lifecycle));
 
   if (enableCache) {
     client.use(createCacheMiddleware());
@@ -615,7 +617,7 @@ class RequestLifecycle {
   }
 }
 
-function createHooksMiddleware(lifecycle: RequestLifecycle): Middleware {
+function createLifecycleMiddleware(lifecycle: RequestLifecycle): Middleware {
   return {
     async onRequest({ request, id }) {
       lifecycle.begin(id, request.method, request.url, 1);
@@ -1061,24 +1063,28 @@ function createRetryMiddleware(
           await authStrategy.authenticate(retryRequest.headers);
         }
 
-        // This raw fetch bypasses the middleware chain, so nothing downstream will
-        // observe it — this middleware owns the whole lifecycle of the retry.
+        // This raw fetch bypasses the middleware chain, so no downstream middleware
+        // sees the attempt begin — start it here.
         lifecycle.begin(id, method, url, failedAttempt + 1);
-        try {
-          const retryResponse = await fetch(retryRequest);
-          lifecycle.finalize(id, method, url, { statusCode: retryResponse.status });
-          return retryResponse;
-        } catch (error) {
-          // openapi-fetch only routes the INITIAL fetch through onError, so a
-          // failed retry would otherwise escape unobserved. End it here and
-          // rethrow the original error unchanged.
-          lifecycle.finalize(id, method, url, {
-            statusCode: 0,
-            error: error instanceof Error ? error : new Error(String(error)),
-          });
-          lifecycle.release(id);
-          throw error;
-        }
+
+        // Deliberately NOT finalized here. The returned response still flows
+        // through the cache middleware, which may rewrite a 304 into a cached 200;
+        // finalizing now would freeze the pre-transformation status and
+        // fromCache: false, and an idempotent finalize means the hooks pass could
+        // not correct it. The hooks middleware ends this attempt instead, reading
+        // attempt 2 from the state begun above.
+        return await fetch(retryRequest);
+      } catch (error) {
+        // openapi-fetch routes only the INITIAL fetch through onError, so anything
+        // thrown in here — the retry fetch, the auth refresh, the sleep — would
+        // otherwise escape with the attempt still open and its state stranded.
+        lifecycle.finalize(id, method, url, {
+          statusCode: 0,
+          error: error instanceof Error ? error : new Error(String(error)),
+        });
+        lifecycle.release(id);
+        // Rethrow the original value so its identity survives.
+        throw error;
       } finally {
         bodyCache.delete(id);
       }

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -1055,6 +1055,16 @@ function createRetryMiddleware(
 
         await sleep(delay);
 
+        // The raw fetch below bypasses the middleware chain, so no downstream
+        // middleware sees this attempt begin — start it here.
+        //
+        // Started after the backoff but before any work that can throw. After, so
+        // the attempt's duration measures the request rather than the sleep;
+        // before, so that if the auth refresh or the fetch throws, the catch has a
+        // live attempt to finalize. Starting it later would let onRetry announce
+        // attempt 2 and then never account for it.
+        lifecycle.begin(id, method, url, failedAttempt + 1);
+
         const body = bodyCache.get(id) ?? null;
 
         const retryRequest = new Request(url, {
@@ -1068,10 +1078,6 @@ function createRetryMiddleware(
         if (authStrategy) {
           await authStrategy.authenticate(retryRequest.headers);
         }
-
-        // This raw fetch bypasses the middleware chain, so no downstream middleware
-        // sees the attempt begin — start it here.
-        lifecycle.begin(id, method, url, failedAttempt + 1);
 
         // Deliberately NOT finalized here. The returned response still flows
         // through the cache middleware, which may rewrite a 304 into a cached 200;

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -1046,6 +1046,13 @@ function createRetryMiddleware(
         lifecycle.finalize(id, method, url, { statusCode: response.status });
         lifecycle.retrying(id, method, url, failedAttempt, statusError, delay);
 
+        // This response is being discarded, so release its stream before we sleep
+        // rather than leaving it open across the backoff — otherwise a throttled
+        // client holds a connection per in-flight retry and cannot reuse any of
+        // them. The multipart transport in services/base.ts already does this.
+        // Errors are ignored: the body may already be consumed or closed.
+        void response.body?.cancel().catch(() => {});
+
         await sleep(delay);
 
         const body = bodyCache.get(id) ?? null;

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -312,19 +312,28 @@ export function createBasecampClient(options: BasecampClientOptions): BasecampCl
 
   const client = createClient<paths>({ baseUrl });
 
-  // Apply middleware in order: auth first, then hooks, then cache, then retry
+  // Apply middleware in order: auth first, then hooks, then cache, then retry.
+  // onRequest runs in this order; onResponse and onError run in reverse, so the
+  // retry middleware sees a response first and the hooks middleware last.
   client.use(createAuthMiddleware(authStrategy, userAgent, requestTimeoutMs, baseUrl));
 
+  // One lifecycle shared by the hooks and retry middleware: the retry loop lives
+  // inside a single middleware callback, so per-attempt hooks have to be emitted
+  // from there rather than by a middleware that is only visited once.
+  const lifecycle = new RequestLifecycle(hooks);
+
   if (hooks) {
-    client.use(createHooksMiddleware(hooks));
+    client.use(createHooksMiddleware(lifecycle));
   }
 
   if (enableCache) {
     client.use(createCacheMiddleware());
   }
 
+  // Registered last so that on the reverse-order response pass it runs first,
+  // before the cache and hooks middleware see the response.
   if (enableRetry) {
-    client.use(createRetryMiddleware(hooks, authStrategy));
+    client.use(createRetryMiddleware(lifecycle, authStrategy));
   }
 
   // Create enhanced client with additional properties
@@ -492,77 +501,154 @@ function createAuthMiddleware(authStrategy: AuthStrategy, userAgent: string, req
 // =============================================================================
 
 /** Tracks request timing for hooks */
-interface RequestTiming {
+/**
+ * Per-attempt observability state for one logical request.
+ *
+ * `attempt` is the 1-based attempt currently in flight. `finalized` makes
+ * onRequestEnd idempotent: the retry middleware ends an attempt as soon as it
+ * knows its outcome, and the hooks middleware's own onResponse then runs later
+ * for the same logical request and must not emit a second end.
+ */
+interface AttemptState {
   startTime: number;
   attempt: number;
+  finalized: boolean;
 }
 
-/** Counter for generating unique request IDs */
-let requestIdCounter = 0;
+/**
+ * Owns the onRequestStart / onRequestEnd / onRetry lifecycle for every attempt of
+ * every in-flight request, keyed by openapi-fetch's per-request `id`.
+ *
+ * The id is minted once per logical request (one client.GET/POST/... call) and is
+ * passed unchanged to onRequest, onResponse and onError, so it survives a
+ * middleware replacing the Request object. It deliberately does NOT distinguish
+ * attempts — per-attempt data lives nested under it here — and it never goes on
+ * the wire, which is why this replaces the old `X-SDK-Request-Id` and
+ * `X-Request-Id` correlation headers. (`X-Request-Id` in particular is a
+ * spec-reserved BC3 *response* header; sending an SDK-internal value under that
+ * name was a collision.)
+ *
+ * Shared by the hooks and retry middleware because the retry loop lives inside
+ * one middleware callback: openapi-fetch visits each middleware once per request,
+ * so per-attempt hooks cannot be emitted by a separate middleware.
+ */
+class RequestLifecycle {
+  private readonly states = new Map<string, AttemptState>();
 
-function createHooksMiddleware(hooks: BasecampHooks): Middleware {
-  // Track request timing by unique request ID
-  const timings = new Map<string, RequestTiming>();
+  constructor(private readonly hooks: BasecampHooks | undefined) {}
 
+  /** Begin an attempt and fire onRequestStart for it. */
+  begin(id: string, method: string, url: string, attempt: number): void {
+    this.states.set(id, { startTime: performance.now(), attempt, finalized: false });
+    this.emit(() => this.hooks?.onRequestStart?.({ method, url, attempt }));
+  }
+
+  /** The attempt currently in flight, or 1 if we have no record. */
+  attemptOf(id: string): number {
+    return this.states.get(id)?.attempt ?? 1;
+  }
+
+  /**
+   * Fire onRequestEnd for the in-flight attempt, exactly once.
+   *
+   * A network failure or timeout carries statusCode 0 and the originating error,
+   * matching the multipart transport in services/base.ts and SPEC section 7.
+   */
+  finalize(
+    id: string,
+    method: string,
+    url: string,
+    outcome: { statusCode: number; fromCache?: boolean; error?: Error },
+  ): void {
+    const state = this.states.get(id);
+    if (!state || state.finalized) return;
+    state.finalized = true;
+
+    const durationMs = Math.round(performance.now() - state.startTime);
+    const result: RequestResult = {
+      statusCode: outcome.statusCode,
+      durationMs,
+      fromCache: outcome.fromCache ?? false,
+      ...(outcome.error ? { error: outcome.error } : {}),
+    };
+    this.emit(() =>
+      this.hooks?.onRequestEnd?.({ method, url, attempt: state.attempt }, result),
+    );
+  }
+
+  /**
+   * Fire onRetry between two attempts.
+   *
+   * SPEC section 7 splits the two numbers: RequestInfo.attempt is the attempt that
+   * just FAILED, while the standalone argument is the UPCOMING attempt. Go,
+   * Python, Ruby and Kotlin all pass (failed, failed + 1).
+   */
+  retrying(
+    id: string,
+    method: string,
+    url: string,
+    failedAttempt: number,
+    error: Error,
+    delayMs: number,
+  ): void {
+    this.emit(() =>
+      this.hooks?.onRetry?.(
+        { method, url, attempt: failedAttempt },
+        failedAttempt + 1,
+        error,
+        delayMs,
+      ),
+    );
+  }
+
+  /** Drop all state for a logical request. Safe to call more than once. */
+  release(id: string): void {
+    this.states.delete(id);
+  }
+
+  private emit(fn: () => void): void {
+    try {
+      fn();
+    } catch {
+      // Hooks must never interrupt the request.
+    }
+  }
+}
+
+function createHooksMiddleware(lifecycle: RequestLifecycle): Middleware {
   return {
-    async onRequest({ request }) {
-      // Generate unique request ID to handle concurrent identical requests
-      const requestId = `${++requestIdCounter}`;
-      request.headers.set("X-SDK-Request-Id", requestId);
-
-      const attemptHeader = request.headers.get("X-Retry-Attempt");
-      const attempt = attemptHeader ? parseInt(attemptHeader, 10) + 1 : 1;
-
-      timings.set(requestId, { startTime: performance.now(), attempt });
-
-      const info: RequestInfo = {
-        method: request.method,
-        url: request.url,
-        attempt,
-      };
-
-      try {
-        hooks.onRequestStart?.(info);
-      } catch {
-        // Hooks should not interrupt the request
-      }
-
+    async onRequest({ request, id }) {
+      lifecycle.begin(id, request.method, request.url, 1);
       return request;
     },
 
-    async onResponse({ request, response }) {
-      const requestId = request.headers.get("X-SDK-Request-Id") ?? "";
-      const timing = timings.get(requestId);
-      const durationMs = timing ? Math.round(performance.now() - timing.startTime) : 0;
-      const attempt = timing?.attempt ?? 1;
-
-      timings.delete(requestId);
-
-      const info: RequestInfo = {
-        method: request.method,
-        url: request.url,
-        attempt,
-      };
-
-      // Check for cache hit via header set by cache middleware
+    async onResponse({ request, response, id }) {
+      // Runs after the retry middleware, which has already ended the final
+      // attempt whenever it retried — finalize is idempotent, so this is a no-op
+      // in that case and the authoritative end for a single-attempt request.
       const fromCacheHeader = response.headers.get("X-From-Cache");
-      const fromCache =
-        fromCacheHeader === "1" ||
-        response.status === 304;
+      const fromCache = fromCacheHeader === "1" || response.status === 304;
 
-      const result: RequestResult = {
+      lifecycle.finalize(id, request.method, request.url, {
         statusCode: response.status,
-        durationMs,
         fromCache,
-      };
-
-      try {
-        hooks.onRequestEnd?.(info, result);
-      } catch {
-        // Hooks should not interrupt the response
-      }
+      });
+      lifecycle.release(id);
 
       return response;
+    },
+
+    async onError({ request, error, id }) {
+      // openapi-fetch skips onResponse entirely when the initial fetch rejects,
+      // so this is the only place a network error or timeout can be observed.
+      lifecycle.finalize(id, request.method, request.url, {
+        statusCode: 0,
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
+      lifecycle.release(id);
+
+      // Returning nothing preserves the original error's identity and rethrows it.
+      return undefined;
     },
   };
 }
@@ -889,123 +975,120 @@ function getRetryConfigForRequest(method: string, url: string): RetryConfig {
   return DEFAULT_RETRY_CONFIG;
 }
 
-function createRetryMiddleware(hooks?: BasecampHooks, authStrategy?: AuthStrategy): Middleware {
-  // Store request body clones keyed by a request identifier
-  // This is needed because Request.body can only be read once
+function createRetryMiddleware(
+  lifecycle: RequestLifecycle,
+  authStrategy?: AuthStrategy,
+): Middleware {
+  // Serialized request bodies, keyed by openapi-fetch's per-request id, because
+  // Request.body can only be read once and the retry needs to replay it. Keyed on
+  // the id rather than method+url+timestamp: two concurrent mutations to the same
+  // URL used to collide on one slot and replay each other's bytes.
   const bodyCache = new Map<string, ArrayBuffer | null>();
 
   return {
-    async onRequest({ request }) {
+    async onRequest({ request, id }) {
       // For methods that may have a body, clone it before the initial fetch
       // so we can use it for retries. Request.body can only be consumed once.
       const method = request.method.toUpperCase();
       if (method === "POST" || method === "PUT" || method === "PATCH") {
-        const requestId = `${method}:${request.url}:${Date.now()}`;
-        request.headers.set("X-Request-Id", requestId);
-
         if (request.body) {
           // Clone the body before it gets consumed
           const cloned = request.clone();
-          bodyCache.set(requestId, await cloned.arrayBuffer());
+          bodyCache.set(id, await cloned.arrayBuffer());
         } else {
-          bodyCache.set(requestId, null);
+          bodyCache.set(id, null);
         }
       }
 
       return request;
     },
 
-    async onResponse({ request, response }) {
+    async onResponse({ request, response, id }) {
+      const { method, url } = request;
       // Get operation-specific retry config from metadata
-      const retryConfig = getRetryConfigForRequest(request.method, request.url);
+      const retryConfig = getRetryConfigForRequest(method, url);
 
-      const requestId = request.headers.get("X-Request-Id");
-
-      // Helper to clean up cached body
-      const cleanupBody = () => {
-        if (requestId) bodyCache.delete(requestId);
-      };
-
-      // Check if status code should trigger retry
+      // Not retrying: let the hooks middleware end the attempt, and drop the body.
       if (!retryConfig.retryOn.includes(response.status)) {
-        cleanupBody();
+        bodyCache.delete(id);
         return response;
       }
 
-      // Extract current retry attempt from custom header
-      const attemptHeader = request.headers.get("X-Retry-Attempt");
-      const attempt = attemptHeader ? parseInt(attemptHeader, 10) : 0;
+      const failedAttempt = lifecycle.attemptOf(id);
 
-      // Check if we've exhausted retries (maxAttempts is total attempts, not retries)
-      // With maxAttempts=3: attempt 0 (initial), 1 (retry 1), 2 (retry 2) = 3 total
-      if (attempt >= retryConfig.maxAttempts - 1) {
-        cleanupBody();
+      // maxAttempts is a total attempt count, so attempt N is terminal when it
+      // equals the cap. TypeScript additionally chains at most one retry, since
+      // the retry below leaves the middleware chain (SPEC waiver 2B.1).
+      if (failedAttempt >= retryConfig.maxAttempts) {
+        bodyCache.delete(id);
         return response;
       }
 
-      // Calculate delay
+      // For 429, respect Retry-After; otherwise back off.
       let delay: number;
-
-      // For 429, respect Retry-After header
-      if (response.status === 429) {
-        const retryAfter = response.headers.get("Retry-After");
-        if (retryAfter) {
-          const seconds = parseInt(retryAfter, 10);
-          if (!isNaN(seconds)) {
-            delay = seconds * 1000;
-          } else {
-            delay = calculateBackoffDelay(retryConfig, attempt);
-          }
-        } else {
-          delay = calculateBackoffDelay(retryConfig, attempt);
-        }
+      const retryAfter =
+        response.status === 429 ? response.headers.get("Retry-After") : null;
+      const retryAfterSeconds = retryAfter ? parseInt(retryAfter, 10) : NaN;
+      if (!isNaN(retryAfterSeconds)) {
+        delay = retryAfterSeconds * 1000;
       } else {
-        delay = calculateBackoffDelay(retryConfig, attempt);
+        delay = calculateBackoffDelay(retryConfig, failedAttempt - 1);
       }
 
-      // Notify hooks of retry
-      if (hooks?.onRetry) {
-        const info: RequestInfo = {
-          method: request.method,
-          url: request.url,
-          attempt: attempt + 1,
-        };
-        const error = new Error(`HTTP ${response.status}: ${response.statusText || "Request failed"}`);
+      const statusError = new Error(
+        `HTTP ${response.status}: ${response.statusText || "Request failed"}`,
+      );
+
+      try {
+        // End the failed attempt before sleeping, so a slow backoff cannot leave
+        // an attempt open, then announce the upcoming one.
+        lifecycle.finalize(id, method, url, { statusCode: response.status });
+        lifecycle.retrying(id, method, url, failedAttempt, statusError, delay);
+
+        await sleep(delay);
+
+        const body = bodyCache.get(id) ?? null;
+
+        const retryRequest = new Request(url, {
+          method,
+          headers: new Headers(request.headers),
+          body,
+          signal: request.signal,
+        });
+
+        // Refresh auth header for retry (token may have been refreshed since initial request)
+        if (authStrategy) {
+          await authStrategy.authenticate(retryRequest.headers);
+        }
+
+        // This raw fetch bypasses the middleware chain, so nothing downstream will
+        // observe it — this middleware owns the whole lifecycle of the retry.
+        lifecycle.begin(id, method, url, failedAttempt + 1);
         try {
-          hooks.onRetry(info, attempt + 1, error, delay);
-        } catch {
-          // Hooks should not interrupt the retry
+          const retryResponse = await fetch(retryRequest);
+          lifecycle.finalize(id, method, url, { statusCode: retryResponse.status });
+          return retryResponse;
+        } catch (error) {
+          // openapi-fetch only routes the INITIAL fetch through onError, so a
+          // failed retry would otherwise escape unobserved. End it here and
+          // rethrow the original error unchanged.
+          lifecycle.finalize(id, method, url, {
+            statusCode: 0,
+            error: error instanceof Error ? error : new Error(String(error)),
+          });
+          lifecycle.release(id);
+          throw error;
         }
+      } finally {
+        bodyCache.delete(id);
       }
+    },
 
-      // Wait before retry
-      await sleep(delay);
-
-      // Get cached body for methods that may have one
-      let body: ArrayBuffer | null = null;
-      if (requestId && bodyCache.has(requestId)) {
-        const cachedBody = bodyCache.get(requestId);
-        if (cachedBody) {
-          body = cachedBody;
-        }
-      }
-
-      // Create retry request with fresh body
-      const retryRequest = new Request(request.url, {
-        method: request.method,
-        headers: new Headers(request.headers),
-        body,
-        signal: request.signal,
-      });
-      retryRequest.headers.set("X-Retry-Attempt", String(attempt + 1));
-
-      // Refresh auth header for retry (token may have been refreshed since initial request)
-      if (authStrategy) {
-        await authStrategy.authenticate(retryRequest.headers);
-      }
-
-      // Retry using native fetch
-      return fetch(retryRequest);
+    async onError({ id }) {
+      // The initial fetch rejected, so onResponse never ran and the cached body
+      // would leak. The hooks middleware owns ending the attempt.
+      bodyCache.delete(id);
+      return undefined;
     },
   };
 }

--- a/typescript/src/hooks.ts
+++ b/typescript/src/hooks.ts
@@ -286,8 +286,11 @@ export function consoleHooks(options: ConsoleHooksOptions = {}): BasecampHooks {
 
     onRetry: logRetries
       ? (info, attempt, error, delayMs) => {
+          // `attempt` is already the UPCOMING attempt per SPEC section 7 — print it
+          // as given. It used to be incremented here, which happened to read
+          // correctly only because the callers passed the failed attempt instead.
           logger.warn(
-            `[Basecamp] Retrying ${info.method} ${info.url} (attempt ${attempt + 1}, waiting ${delayMs}ms): ${error.message}`
+            `[Basecamp] Retrying ${info.method} ${info.url} (attempt ${attempt}, waiting ${delayMs}ms): ${error.message}`
           );
         }
       : undefined,

--- a/typescript/src/services/base.ts
+++ b/typescript/src/services/base.ts
@@ -214,9 +214,11 @@ export abstract class BaseService {
 
         try {
           const retryError = new Error(`${response.status} ${response.statusText}`);
+          // SPEC section 7: RequestInfo.attempt is the attempt that just failed
+          // (1-based), while the standalone argument is the UPCOMING attempt.
           this.hooks?.onRetry?.(
             { method, url, attempt: attempt + 1 },
-            attempt + 1,
+            attempt + 2,
             retryError,
             delay,
           );

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -616,8 +616,9 @@ describe("BasecampClient", () => {
         expect.objectContaining({
           method: "GET",
           url: expect.stringContaining("/projects.json"),
+          attempt: 1, // the attempt that just failed
         }),
-        1,
+        2, // SPEC section 7: the UPCOMING attempt
         expect.any(Error),
         expect.any(Number)
       );

--- a/typescript/tests/hooks.test.ts
+++ b/typescript/tests/hooks.test.ts
@@ -386,10 +386,11 @@ describe("consoleHooks", () => {
       };
       const error = new Error("Rate limited");
 
+      // 2 is the upcoming attempt (SPEC section 7), so it is logged verbatim.
       hooks.onRetry?.(info, 2, error, 2000);
 
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        "[Basecamp] Retrying GET https://api.example.com/todos.json (attempt 3, waiting 2000ms): Rate limited"
+        "[Basecamp] Retrying GET https://api.example.com/todos.json (attempt 2, waiting 2000ms): Rate limited"
       );
     });
 

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -95,15 +95,20 @@ describe("Integration", () => {
 
       await client.GET("/projects.json");
 
-      // onRequestStart fires for the initial request going through the middleware stack.
-      // The retry uses raw fetch, so it bypasses the hooks middleware.
-      expect(hooks.onRequestStart).toHaveBeenCalledTimes(1);
-      expect(hooks.onRequestStart).toHaveBeenCalledWith(
+      // Both attempts are observed. The retry leaves the middleware chain, so the
+      // retry middleware emits that attempt's start/end itself.
+      expect(hooks.onRequestStart).toHaveBeenCalledTimes(2);
+      expect(hooks.onRequestStart).toHaveBeenNthCalledWith(
+        1,
         expect.objectContaining({
           method: "GET",
           url: expect.stringContaining("/projects.json"),
           attempt: 1,
         })
+      );
+      expect(hooks.onRequestStart).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ attempt: 2 })
       );
 
       // onRetry fires from the retry middleware when it decides to retry.
@@ -112,19 +117,26 @@ describe("Integration", () => {
         expect.objectContaining({
           method: "GET",
           url: expect.stringContaining("/projects.json"),
+          attempt: 1, // the attempt that just failed
         }),
-        1, // attempt number
+        2, // SPEC section 7: the UPCOMING attempt
         expect.any(Error),
         expect.any(Number) // delay
       );
 
-      // onRequestEnd fires once — for the final response that propagates back
-      // through the middleware stack (the 200 returned by the retry's raw fetch).
-      expect(hooks.onRequestEnd).toHaveBeenCalledTimes(1);
-      expect(hooks.onRequestEnd).toHaveBeenCalledWith(
+      // One end per attempt: the failed 429, then the 200 from the retry.
+      expect(hooks.onRequestEnd).toHaveBeenCalledTimes(2);
+      expect(hooks.onRequestEnd).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ attempt: 1 }),
+        expect.objectContaining({ statusCode: 429, durationMs: expect.any(Number) })
+      );
+      expect(hooks.onRequestEnd).toHaveBeenNthCalledWith(
+        2,
         expect.objectContaining({
           method: "GET",
           url: expect.stringContaining("/projects.json"),
+          attempt: 2,
         }),
         expect.objectContaining({
           statusCode: 200,

--- a/typescript/tests/middleware-lifecycle.test.ts
+++ b/typescript/tests/middleware-lifecycle.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Request lifecycle regressions for the client middleware.
+ *
+ * Four defects motivated these, all in createRetryMiddleware/createHooksMiddleware:
+ *
+ *   1. bodyCache was keyed on `${method}:${url}:${Date.now()}`, so two concurrent
+ *      mutations to the same URL in the same millisecond shared one cache slot —
+ *      a retry replayed the other request's body, or none at all.
+ *   2. onRequestEnd never fired when the initial fetch rejected (network error or
+ *      timeout), because openapi-fetch skips onResponse entirely on that path and
+ *      no middleware implemented onError.
+ *   3. bodyCache/timings were pruned only in onResponse, so retried and
+ *      network-failed requests leaked their serialized bodies for the process
+ *      lifetime.
+ *   4. The raw `fetch(retryRequest)` retry bypassed middleware, so attempt 2 got
+ *      no onRequestStart/onRequestEnd at all, and onRetry reported the attempt
+ *      that just failed (1) where SPEC section 7 requires the upcoming one (2).
+ *
+ * SPEC section 7 attempt semantics, which these pin:
+ *   - RequestInfo.attempt  — the failed/current attempt, 1-based
+ *   - onRetry's 2nd arg    — the UPCOMING attempt, so 2 on the first retry
+ * Go, Python, Ruby and Kotlin all pass (1, 2); TypeScript passed (1, 1).
+ *
+ * Note TypeScript caps at one retry by design (SPEC waiver 2B.1), so attempt 2 is
+ * terminal here. These tests assert the two-attempt lifecycle, not three.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { http, HttpResponse } from "msw";
+import { server } from "./setup.js";
+import { createBasecampClient } from "../src/client.js";
+import type { BasecampHooks, RequestInfo, RequestResult } from "../src/hooks.js";
+
+const BASE_URL = "https://3.basecampapi.com/12345";
+
+/** Records every lifecycle callback in order, so we can assert balance and args. */
+function recordingHooks() {
+  const events: Array<{
+    kind: "start" | "end" | "retry";
+    attempt: number;
+    statusCode?: number;
+    error?: unknown;
+  }> = [];
+  const hooks: BasecampHooks = {
+    onRequestStart(info: RequestInfo) {
+      events.push({ kind: "start", attempt: info.attempt });
+    },
+    onRequestEnd(info: RequestInfo, result: RequestResult) {
+      events.push({
+        kind: "end",
+        attempt: info.attempt,
+        statusCode: result.statusCode,
+        error: (result as { error?: unknown }).error,
+      });
+    },
+    onRetry(_info: RequestInfo, upcomingAttempt: number, error: Error) {
+      events.push({ kind: "retry", attempt: upcomingAttempt, error });
+    },
+  };
+  return { hooks, events };
+}
+
+const starts = (e: ReturnType<typeof recordingHooks>["events"]) =>
+  e.filter((x) => x.kind === "start");
+const ends = (e: ReturnType<typeof recordingHooks>["events"]) =>
+  e.filter((x) => x.kind === "end");
+
+describe("middleware request lifecycle", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Defect 1. Two concurrent same-method/same-URL mutations with Date.now()
+  // pinned. Under the old timestamp key both computed the SAME cache key, so one
+  // body overwrote the other and at least one retry replayed the wrong bytes.
+  it("replays each concurrent same-URL mutation's own body on retry", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+
+    const seen: Array<{ phase: "initial" | "retry"; body: string }> = [];
+    let release: (() => void) | undefined;
+    const barrier = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let arrived = 0;
+
+    server.use(
+      http.put(`${BASE_URL}/buckets/1/todos/2.json`, async ({ request }) => {
+        const body = await request.text();
+        const n = ++arrived;
+
+        // The first two arrivals are the initial attempts. The barrier holds both
+        // of them until both have arrived, so their onRequest handlers provably
+        // interleave — and it makes the initial/retry split deterministic without
+        // relying on any wire header.
+        if (n <= 2) {
+          seen.push({ phase: "initial", body });
+          if (n === 2) release?.();
+          await barrier;
+          // Retry-After: 0 keeps the test off the real backoff clock.
+          return new HttpResponse(null, {
+            status: 429,
+            headers: { "Retry-After": "0" },
+          });
+        }
+
+        seen.push({ phase: "retry", body });
+        return HttpResponse.json({ ok: true });
+      })
+    );
+
+    const client = createBasecampClient({
+      accountId: "12345",
+      accessToken: "test-token",
+    });
+
+    await Promise.all([
+      client.PUT("/buckets/{bucketId}/todos/{todoId}.json", {
+        params: { path: { bucketId: 1, todoId: 2 } },
+        body: { content: "AAA" },
+      } as never),
+      client.PUT("/buckets/{bucketId}/todos/{todoId}.json", {
+        params: { path: { bucketId: 1, todoId: 2 } },
+        body: { content: "BBB" },
+      } as never),
+    ]);
+
+    const firstBodies = seen.filter((s) => s.phase === "initial").map((s) => s.body).sort();
+    const retryBodies = seen.filter((s) => s.phase === "retry").map((s) => s.body).sort();
+
+    expect(firstBodies).toHaveLength(2);
+    expect(retryBodies).toHaveLength(2);
+    // The retries must carry the same multiset of bodies as the originals.
+    // The old key made both retries send one request's body (or an empty one).
+    expect(retryBodies).toEqual(firstBodies);
+  });
+
+  // Defect 2. A rejected initial fetch must still produce a balanced
+  // start/end pair, with statusCode 0 and the original error preserved.
+  it("fires a balanced start/end with statusCode 0 when the initial fetch fails", async () => {
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, () => HttpResponse.error())
+    );
+
+    const { hooks, events } = recordingHooks();
+    const client = createBasecampClient({
+      accountId: "12345",
+      accessToken: "test-token",
+      hooks,
+    });
+
+    await expect(client.GET("/projects.json")).rejects.toBeTruthy();
+
+    expect(starts(events)).toHaveLength(1);
+    expect(ends(events)).toHaveLength(1);
+    const end = ends(events)[0]!;
+    expect(end.attempt).toBe(1);
+    expect(end.statusCode).toBe(0);
+    expect(end.error).toBeInstanceOf(Error);
+  });
+
+  // Defect 2, timeout variant. The auth middleware installs
+  // AbortSignal.timeout, so a stalled request rejects the same way.
+  it("fires a balanced start/end with statusCode 0 when the request times out", async () => {
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, async () => {
+        await new Promise((r) => setTimeout(r, 200));
+        return HttpResponse.json([]);
+      })
+    );
+
+    const { hooks, events } = recordingHooks();
+    const client = createBasecampClient({
+      accountId: "12345",
+      accessToken: "test-token",
+      hooks,
+      requestTimeoutMs: 20,
+    });
+
+    await expect(client.GET("/projects.json")).rejects.toBeTruthy();
+
+    expect(starts(events)).toHaveLength(1);
+    expect(ends(events)).toHaveLength(1);
+    const end = ends(events)[0]!;
+    expect(end.statusCode).toBe(0);
+    expect(end.error).toBeInstanceOf(Error);
+  });
+
+  // Defect 4. Both attempts get balanced hooks even when the RETRY fetch
+  // itself fails at the network level, and all state is finalized.
+  it("fires balanced lifecycle hooks for both attempts when the retry fetch fails", async () => {
+    let attempts = 0;
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, () => {
+        attempts++;
+        if (attempts === 1) {
+          return new HttpResponse(null, {
+            status: 503,
+            headers: { "Retry-After": "0" },
+          });
+        }
+        return HttpResponse.error();
+      })
+    );
+
+    const { hooks, events } = recordingHooks();
+    const client = createBasecampClient({
+      accountId: "12345",
+      accessToken: "test-token",
+      hooks,
+    });
+
+    await expect(client.GET("/projects.json")).rejects.toBeTruthy();
+
+    expect(attempts).toBe(2);
+    // One start and one end per attempt — nothing dangling.
+    expect(starts(events).map((e) => e.attempt)).toEqual([1, 2]);
+    expect(ends(events).map((e) => e.attempt)).toEqual([1, 2]);
+    expect(ends(events)[0]!.statusCode).toBe(503);
+    expect(ends(events)[1]!.statusCode).toBe(0);
+    expect(ends(events)[1]!.error).toBeInstanceOf(Error);
+  });
+
+  // Defect 4, attempt numbering. SPEC section 7: RequestInfo.attempt is the
+  // attempt that just failed (1); onRetry's second argument is the UPCOMING
+  // attempt (2). TypeScript passed 1 for both.
+  it("reports the failed attempt in RequestInfo and the upcoming attempt to onRetry", async () => {
+    let attempts = 0;
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, () => {
+        attempts++;
+        if (attempts === 1) {
+          return new HttpResponse(null, {
+            status: 503,
+            headers: { "Retry-After": "0" },
+          });
+        }
+        return HttpResponse.json([]);
+      })
+    );
+
+    const seen: Array<{ infoAttempt: number; upcoming: number }> = [];
+    const hooks: BasecampHooks = {
+      onRetry(info: RequestInfo, upcoming: number) {
+        seen.push({ infoAttempt: info.attempt, upcoming });
+      },
+    };
+    const client = createBasecampClient({
+      accountId: "12345",
+      accessToken: "test-token",
+      hooks,
+    });
+
+    await client.GET("/projects.json");
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.infoAttempt).toBe(1);
+    expect(seen[0]!.upcoming).toBe(2);
+  });
+
+  // Defect 3. A successful retry must leave no per-request state behind. We
+  // cannot read the private maps, so assert the observable consequence: many
+  // retried requests in sequence stay balanced and never mis-attribute an
+  // attempt number, which a leaking/colliding key would break.
+  it("finalizes state so repeated retried requests stay balanced", async () => {
+    let attempts = 0;
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, () => {
+        attempts++;
+        if (attempts % 2 === 1) {
+          // 429 rather than 503: Retry-After is honoured only for 429, so this
+          // keeps the loop off the real exponential-backoff clock.
+          return new HttpResponse(null, {
+            status: 429,
+            headers: { "Retry-After": "0" },
+          });
+        }
+        return HttpResponse.json([]);
+      })
+    );
+
+    const { hooks, events } = recordingHooks();
+    const client = createBasecampClient({
+      accountId: "12345",
+      accessToken: "test-token",
+      hooks,
+    });
+
+    for (let i = 0; i < 5; i++) {
+      await client.GET("/projects.json");
+    }
+
+    // 5 logical requests x 2 attempts each.
+    expect(starts(events)).toHaveLength(10);
+    expect(ends(events)).toHaveLength(10);
+    expect(starts(events).map((e) => e.attempt)).toEqual([1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);
+    expect(ends(events).map((e) => e.attempt)).toEqual([1, 2, 1, 2, 1, 2, 1, 2, 1, 2]);
+  });
+});

--- a/typescript/tests/middleware-lifecycle.test.ts
+++ b/typescript/tests/middleware-lifecycle.test.ts
@@ -38,6 +38,7 @@ function recordingHooks() {
     kind: "start" | "end" | "retry";
     attempt: number;
     statusCode?: number;
+    fromCache?: boolean;
     error?: unknown;
   }> = [];
   const hooks: BasecampHooks = {
@@ -49,6 +50,7 @@ function recordingHooks() {
         kind: "end",
         attempt: info.attempt,
         statusCode: result.statusCode,
+        fromCache: result.fromCache,
         error: (result as { error?: unknown }).error,
       });
     },
@@ -260,7 +262,7 @@ describe("middleware request lifecycle", () => {
   // configured, because it owns releasing per-request state and the retry
   // middleware records an attempt regardless of whether anyone is listening.
   // Without it, every retried request stranded one entry for the client's life.
-  it("does not retain per-request state when no hooks are configured", async () => {
+  it("retries correctly when no hooks are configured", async () => {
     let attempts = 0;
     server.use(
       http.get(`${BASE_URL}/projects.json`, () => {
@@ -328,16 +330,23 @@ describe("middleware request lifecycle", () => {
     await client.GET("/projects.json"); // populates the cache
     await client.GET("/projects.json"); // 429 -> retry -> 304 -> cached 200
 
+    // Asserted as one object so BOTH halves of the transformation are proven:
+    // eager finalization froze the status at 304 *and* fromCache at false, and a
+    // sequence of separate expects would stop at the first and leave the second
+    // unproven.
     const last = ends(events).at(-1)!;
-    expect(last.attempt).toBe(2);
-    expect(last.statusCode).toBe(200);
+    expect({
+      attempt: last.attempt,
+      statusCode: last.statusCode,
+      fromCache: last.fromCache,
+    }).toEqual({ attempt: 2, statusCode: 200, fromCache: true });
   });
 
-  // Defect 3. A successful retry must leave no per-request state behind. We
-  // cannot read the private maps, so assert the observable consequence: many
-  // retried requests in sequence stay balanced and never mis-attribute an
-  // attempt number, which a leaking/colliding key would break.
-  it("finalizes state so repeated retried requests stay balanced", async () => {
+  // Repeated retried requests each report their own two attempts, in order, with
+  // no cross-talk between logical requests. This says nothing about state being
+  // released — that is not observable from here — only that attempt attribution
+  // stays correct across many sequential retries.
+  it("attributes attempts correctly across repeated retried requests", async () => {
     let attempts = 0;
     server.use(
       http.get(`${BASE_URL}/projects.json`, () => {

--- a/typescript/tests/middleware-lifecycle.test.ts
+++ b/typescript/tests/middleware-lifecycle.test.ts
@@ -256,6 +256,83 @@ describe("middleware request lifecycle", () => {
     expect(seen[0]!.upcoming).toBe(2);
   });
 
+  // Review follow-up. The lifecycle middleware is registered even with no hooks
+  // configured, because it owns releasing per-request state and the retry
+  // middleware records an attempt regardless of whether anyone is listening.
+  // Without it, every retried request stranded one entry for the client's life.
+  it("does not retain per-request state when no hooks are configured", async () => {
+    let attempts = 0;
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, () => {
+        attempts++;
+        if (attempts % 2 === 1) {
+          return new HttpResponse(null, {
+            status: 429,
+            headers: { "Retry-After": "0" },
+          });
+        }
+        return HttpResponse.json([]);
+      })
+    );
+
+    // No `hooks` option at all — the path where state was stranded, because the
+    // middleware that releases it used to be registered only when hooks existed.
+    const client = createBasecampClient({
+      accountId: "12345",
+      accessToken: "test-token",
+    });
+
+    // Exercises the no-hooks retry path end to end. The release itself is
+    // structural (the lifecycle middleware is now unconditional) and not directly
+    // observable through the public API, so this pins the behaviour around it:
+    // retries still work, and each logical request completes.
+    for (let i = 0; i < 3; i++) {
+      const { data } = await client.GET("/projects.json");
+      expect(data).toEqual([]);
+    }
+    expect(attempts).toBe(6);
+  });
+
+  // Review follow-up. A cached conditional GET whose retry returns 304 must be
+  // reported as the cache middleware finally resolved it (200, fromCache), not as
+  // the raw 304 the retry saw — the retry deliberately leaves finalization to the
+  // downstream hooks pass so the cache can transform the response first.
+  it("reports the post-cache outcome when a retried conditional GET returns 304", async () => {
+    let attempts = 0;
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, ({ request }) => {
+        attempts++;
+        if (attempts === 1) {
+          return HttpResponse.json([{ id: 1 }], { headers: { ETag: 'W/"v1"' } });
+        }
+        if (attempts === 2) {
+          return new HttpResponse(null, {
+            status: 429,
+            headers: { "Retry-After": "0" },
+          });
+        }
+        // The retry carries the conditional header and the server confirms.
+        expect(request.headers.get("If-None-Match")).toBe('W/"v1"');
+        return new HttpResponse(null, { status: 304 });
+      })
+    );
+
+    const { hooks, events } = recordingHooks();
+    const client = createBasecampClient({
+      accountId: "12345",
+      accessToken: "test-token",
+      hooks,
+      enableCache: true,
+    });
+
+    await client.GET("/projects.json"); // populates the cache
+    await client.GET("/projects.json"); // 429 -> retry -> 304 -> cached 200
+
+    const last = ends(events).at(-1)!;
+    expect(last.attempt).toBe(2);
+    expect(last.statusCode).toBe(200);
+  });
+
   // Defect 3. A successful retry must leave no per-request state behind. We
   // cannot read the private maps, so assert the observable consequence: many
   // retried requests in sequence stay balanced and never mis-attribute an

--- a/typescript/tests/middleware-lifecycle.test.ts
+++ b/typescript/tests/middleware-lifecycle.test.ts
@@ -389,9 +389,13 @@ describe("middleware request lifecycle", () => {
   // Review follow-up. A failed response carrying a body has its stream cancelled
   // before the backoff, so a throttled client does not hold a connection per
   // in-flight retry. The other retry tests all use null-body responses, so this is
-  // the only one that reaches that branch — it pins that cancelling cannot break
-  // the retry itself. (Connection reuse is not observable from here.)
-  it("retries successfully when the failed response carries a body", async () => {
+  // the only one that reaches that branch.
+  //
+  // Connection reuse is not observable here, but the cancellation itself is:
+  // without the spy this test passed unchanged when the cancel was deleted, which
+  // made it no regression at all.
+  it("cancels the failed response's stream before retrying", async () => {
+    const cancelSpy = vi.spyOn(ReadableStream.prototype, "cancel");
     let attempts = 0;
     server.use(
       http.get(`${BASE_URL}/projects.json`, () => {
@@ -419,6 +423,8 @@ describe("middleware request lifecycle", () => {
     expect(attempts).toBe(2);
     expect(data).toEqual([{ id: 1 }]);
     expect(ends(events).map((e) => e.statusCode)).toEqual([429, 200]);
+    // The point of the test: the discarded body's stream was actually cancelled.
+    expect(cancelSpy).toHaveBeenCalled();
   });
 
   // Repeated retried requests each report their own two attempts, in order, with

--- a/typescript/tests/middleware-lifecycle.test.ts
+++ b/typescript/tests/middleware-lifecycle.test.ts
@@ -342,6 +342,50 @@ describe("middleware request lifecycle", () => {
     }).toEqual({ attempt: 2, statusCode: 200, fromCache: true });
   });
 
+  // Review follow-up. Attempt 2 begins before the auth refresh, so a throw from
+  // that refresh still lands on a live attempt. Otherwise onRetry announces the
+  // upcoming attempt and nothing ever accounts for it — the same blind spot this
+  // PR exists to close, just moved one step later.
+  it("accounts for attempt 2 when the retry's auth refresh throws", async () => {
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, () =>
+        new HttpResponse(null, { status: 429, headers: { "Retry-After": "0" } })
+      )
+    );
+
+    // Succeeds for the initial request, fails when the retry refreshes.
+    let calls = 0;
+    const failingAuth = {
+      async authenticate(headers: Headers) {
+        calls += 1;
+        if (calls > 1) throw new Error("token refresh failed");
+        headers.set("Authorization", "Bearer test-token");
+      },
+    };
+
+    const { hooks, events } = recordingHooks();
+    const client = createBasecampClient({
+      accountId: "12345",
+      auth: failingAuth,
+      hooks,
+    });
+
+    await expect(client.GET("/projects.json")).rejects.toThrow("token refresh failed");
+
+    // A retry to attempt 2 was announced...
+    const retries = events.filter((e) => e.kind === "retry");
+    expect(retries.map((r) => r.attempt)).toEqual([2]);
+
+    // ...and attempt 2 is accounted for, not silently dropped.
+    expect(starts(events).map((e) => e.attempt)).toEqual([1, 2]);
+    const last = ends(events).at(-1)!;
+    expect({ attempt: last.attempt, statusCode: last.statusCode }).toEqual({
+      attempt: 2,
+      statusCode: 0,
+    });
+    expect(last.error).toBeInstanceOf(Error);
+  });
+
   // Review follow-up. A failed response carrying a body has its stream cancelled
   // before the backoff, so a throttled client does not hold a connection per
   // in-flight retry. The other retry tests all use null-body responses, so this is

--- a/typescript/tests/middleware-lifecycle.test.ts
+++ b/typescript/tests/middleware-lifecycle.test.ts
@@ -342,6 +342,41 @@ describe("middleware request lifecycle", () => {
     }).toEqual({ attempt: 2, statusCode: 200, fromCache: true });
   });
 
+  // Review follow-up. A failed response carrying a body has its stream cancelled
+  // before the backoff, so a throttled client does not hold a connection per
+  // in-flight retry. The other retry tests all use null-body responses, so this is
+  // the only one that reaches that branch — it pins that cancelling cannot break
+  // the retry itself. (Connection reuse is not observable from here.)
+  it("retries successfully when the failed response carries a body", async () => {
+    let attempts = 0;
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, () => {
+        attempts++;
+        if (attempts === 1) {
+          // A body, unlike the null-body 429s used elsewhere in this file.
+          return HttpResponse.json(
+            { error: "Rate limited", details: "x".repeat(2048) },
+            { status: 429, headers: { "Retry-After": "0" } }
+          );
+        }
+        return HttpResponse.json([{ id: 1 }]);
+      })
+    );
+
+    const { hooks, events } = recordingHooks();
+    const client = createBasecampClient({
+      accountId: "12345",
+      accessToken: "test-token",
+      hooks,
+    });
+
+    const { data } = await client.GET("/projects.json");
+
+    expect(attempts).toBe(2);
+    expect(data).toEqual([{ id: 1 }]);
+    expect(ends(events).map((e) => e.statusCode)).toEqual([429, 200]);
+  });
+
   // Repeated retried requests each report their own two attempts, in order, with
   // no cross-talk between logical requests. This says nothing about state being
   // released — that is not observable from here — only that attempt attribution


### PR DESCRIPTION
Four defects in the client middleware, all rooted in the same thing: the retry loop re-issues through raw `fetch()`, which leaves the middleware chain, and nothing owned the lifecycle across that boundary.

## The defects

**1. The retry replayed the wrong body.** The body cache was keyed on `` `${method}:${url}:${Date.now()}` ``. Two concurrent mutations to the same URL land in the same millisecond routinely — a `Promise.all` batch, two workers on one record — and shared one cache slot. Whichever response arrived first deleted it, so the other request's retry replayed the wrong bytes or an empty body. That is silent data corruption on a retry, not a bookkeeping error.

**2. `onRequestEnd` never fired on a rejected initial fetch.** openapi-fetch skips `onResponse` entirely on that path and routes only to `onError`, which no middleware implemented. During a DNS outage or a stall, every request fired a start and no end: in-flight climbs, error rate reads zero — the opposite of what the hook was wired up for.

**3. Body and timing state leaked** on the retry and error paths, pruned only in `onResponse`.

**4. The raw retry got no hooks at all**, so attempt 2 was invisible; and `onRetry` reported the attempt that had just *failed* where SPEC §7 asks for the *upcoming* one. Go, Python, Ruby and Kotlin all pass `(failed, failed + 1)`; TypeScript passed `(1, 1)` — in **both** call sites, `client.ts` and the multipart loop in `services/base.ts`.

## The design

One `RequestLifecycle` keyed on openapi-fetch's per-request `id`, replacing two independent state maps. That id is minted once per logical request and threaded unchanged through `onRequest`/`onResponse`/`onError`, so it survives the auth middleware swapping the `Request` object, and it never touches the wire.

Two correlation headers go away with it. `X-SDK-Request-Id`, and `X-Request-Id` — the latter mattering because **SPEC reserves that name for the BC3 *response* header** feeding `error.request_id` (read at `services/base.ts:506`), so sending an SDK-internal value under it was a collision. Verified nothing in any SDK, spec, or conformance fixture referenced either header.

`finalize()` is idempotent, which is what makes split ownership safe:

- the retry middleware ends the failed attempt **before sleeping**, so a slow backoff can't leave an attempt open
- it announces the upcoming attempt, begins it, and finalizes its own raw fetch directly
- the hooks middleware's `onResponse` runs later for the same logical request and becomes a harmless no-op
- a failed retry fetch is caught, finalized with `statusCode: 0`, and **rethrown with its identity intact** — necessary because `onError` only covers the initial fetch
- body state is dropped in `finally`, plus in an `onError`, since a rejected initial fetch never reaches `onResponse`

`id` deliberately does *not* distinguish attempts, so per-attempt data nests under it.

**Kept the one-retry cap** (SPEC waiver 2B.1, `SPEC.md:444`/`468`/`472`). Lifting it is a real behavior change — 429/503 would start producing three attempts where fixtures assume two — and belongs in its own PR.

## Verification

All six new regressions were confirmed **red against the unfixed code first**:

| Regression | Failure before the fix |
|---|---|
| Concurrent same-URL bodies (with `Date.now()` pinned, both held at a barrier) | `['{"content":"BBB"}', …] to deeply equal ['{"content":"AAA"}', …]` |
| Initial network error → balanced start/end | `expected [] to have a length of 1` |
| Timeout → balanced start/end | `expected [] to have a length of 1` |
| Retry fetch fails → both attempts balanced | `expected [ 1 ] to deeply equal [ 1, 2 ]` |
| `onRetry` upcoming attempt | `expected 1 to be 2` |
| Repeated retried requests stay balanced | `length of 10 but got 5` |

I rewrote the body test partway through — it had keyed on `X-Retry-Attempt`, which this PR removes — and **re-proved it red** afterwards rather than assuming it still bit.

Then: **825 tests pass**; `make ts-check` clean; `check-retry-metadata-parity` still recognises `base.ts` under criterion 2; `check-idempotency-parity` 10/10; TypeScript drift gate clean.

## Two existing tests were changed, deliberately

Both asserted the defective behavior, so I want these visible rather than buried in the diff:

- `integration.test.ts` expected `onRequestStart` exactly once, with the comment *"The retry uses raw fetch, so it bypasses the hooks middleware."* It now asserts one start and one end per attempt, with `429` then `200`.
- `client.test.ts` pinned `onRetry`'s second argument to `1`. Now `2`, with `info.attempt: 1`.

## Not in scope

Swift has the same `(1, 1)` numbering and should be tracked separately — deliberately not touched here to keep this PR one language.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the request lifecycle so each attempt is observed exactly once. Fixes leaks when no hooks are set, reports retried conditional GETs as cached 200s with `fromCache`, cancels failed response streams before backoff, and accounts for auth refresh failures during retries.

- **Bug Fixes**
  - Retries replay the correct body for concurrent same-URL mutations.
  - `onRequestEnd` now fires on initial network errors/timeouts (statusCode 0 with the original error).
  - Lifecycle middleware is registered even with no hooks; per-request state is always released.
  - Cached conditional GET retries that return 304 are finalized after cache transformation and reported as 200 with `fromCache`.
  - Failed 429/503 responses cancel their body stream before sleeping, so throttled clients don’t hold open connections during backoff.
  - Attempt 2 begins before the auth refresh; if the refresh throws, the attempt is finalized with statusCode 0 and released so announced retries are always accounted.

- **Refactors**
  - Introduced a shared `RequestLifecycle` keyed by `openapi-fetch` request `id`; removes `X-SDK-Request-Id` and `X-Request-Id`.
  - Retry middleware begins and announces attempts; successful retries finalize downstream so cache transforms are reflected. Errors during the retry block finalize and release state.
  - Aligned attempt semantics with the spec: `RequestInfo.attempt` = failed attempt; `onRetry` arg = upcoming. `consoleHooks` logs the upcoming attempt verbatim.
  - Renamed and updated comments: lifecycle middleware replaces the old hooks middleware; comments now reflect the lifecycle and order.

<sup>Written for commit 194faf32ce8f34617a35e48bbae0ae5f8d96916f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

