### PR TITLE
fromCache means served from the ETag cache, so require the header that proves it

### DIFF
--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -506,9 +506,17 @@ function createAuthMiddleware(authStrategy: AuthStrategy, userAgent: string, req
  * Per-attempt observability state for one logical request.
  *
  * `attempt` is the 1-based attempt currently in flight. `finalized` makes
- * onRequestEnd idempotent: the retry middleware ends an attempt as soon as it
- * knows its outcome, and the lifecycle middleware's onResponse then runs later
- * for the same logical request and must not emit a second end.
+ * onRequestEnd idempotent per attempt: two terminal paths can reach the same
+ * attempt, and only the first may emit an end.
+ *
+ * Each attempt gets fresh state — begin() replaces this record — so the flag
+ * guards one attempt against a double end, not the request. The retry middleware
+ * ends the attempt it is abandoning before it backs off, and separately ends its
+ * own raw fetch when that throws; the lifecycle middleware's onResponse ends
+ * whichever attempt is in flight when a response comes back. On a successful
+ * retry those are different attempts, which is why the retry deliberately does
+ * not finalize a successful fetch: onResponse must be free to record the outcome
+ * the cache middleware has since transformed.
  */
 interface AttemptState {
   startTime: number;

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -624,11 +624,17 @@ function createLifecycleMiddleware(lifecycle: RequestLifecycle): Middleware {
     },
 
     async onResponse({ request, response, id }) {
-      // Runs after the retry middleware, which has already ended the final
-      // attempt whenever it retried — finalize is idempotent, so this is a no-op
-      // in that case and the authoritative end for a single-attempt request.
-      const fromCacheHeader = response.headers.get("X-From-Cache");
-      const fromCache = fromCacheHeader === "1" || response.status === 304;
+      // The authoritative end for whichever attempt is in flight: attempt 1 for a
+      // single-attempt request, or attempt 2 after a retry — the retry middleware
+      // deliberately does not finalize a successful attempt, so that the cache
+      // middleware (which runs between the two) can transform the response first.
+      // finalize stays idempotent as a backstop.
+      //
+      // fromCache means "served out of the ETag cache", and only the header the
+      // cache middleware sets proves that. A bare 304 does NOT: it reaches here
+      // when the cache is disabled, or is enabled but holds no entry for this key,
+      // and in both cases the caller's own conditional request went to the server.
+      const fromCache = response.headers.get("X-From-Cache") === "1";
 
       lifecycle.finalize(id, request.method, request.url, {
         statusCode: response.status,

--- a/typescript/tests/middleware-lifecycle.test.ts
+++ b/typescript/tests/middleware-lifecycle.test.ts
@@ -295,15 +295,12 @@ describe("middleware request lifecycle", () => {
     expect(attempts).toBe(6);
   });
 
-  // Review follow-up. A cached conditional GET whose retry returns 304 must be
-  // reported as the cache middleware finally resolved it (200, fromCache), not as
-  // the raw 304 the retry saw — the retry deliberately leaves finalization to the
-  // downstream hooks pass so the cache can transform the response first.
-  // Review follow-up. fromCache means "served out of the ETag cache". A bare 304
-  // does not prove that — it reaches the lifecycle when the cache is disabled, or
-  // is enabled but holds no entry, and in both cases the caller's own conditional
-  // request went to the server and got a real network round trip. Reporting it as
-  // a cache hit overstates the cache's effectiveness in anyone's metrics.
+  // The two 304 paths, as a pair. Here: fromCache means "served out of the ETag
+  // cache", and a bare 304 does not prove that — it reaches the lifecycle when the
+  // cache is disabled, or is enabled but holds no entry, and in both cases the
+  // caller's own conditional request went to the server for a real round trip.
+  // Reporting it as a cache hit overstates the cache's effectiveness in anyone's
+  // metrics. The test below covers the opposite path, where the cache does serve.
   it("does not report a bare 304 as served from cache", async () => {
     server.use(
       http.get(`${BASE_URL}/projects.json`, () => new HttpResponse(null, { status: 304 }))
@@ -327,6 +324,10 @@ describe("middleware request lifecycle", () => {
     });
   });
 
+  // The other 304 path. A cached conditional GET whose retry returns 304 must be
+  // reported as the cache middleware finally resolved it — 200 and fromCache true,
+  // not the raw 304 the retry saw. The retry deliberately leaves finalization to
+  // the downstream lifecycle pass so the cache can transform the response first.
   it("reports the post-cache outcome when a retried conditional GET returns 304", async () => {
     let attempts = 0;
     server.use(

--- a/typescript/tests/middleware-lifecycle.test.ts
+++ b/typescript/tests/middleware-lifecycle.test.ts
@@ -299,6 +299,34 @@ describe("middleware request lifecycle", () => {
   // reported as the cache middleware finally resolved it (200, fromCache), not as
   // the raw 304 the retry saw — the retry deliberately leaves finalization to the
   // downstream hooks pass so the cache can transform the response first.
+  // Review follow-up. fromCache means "served out of the ETag cache". A bare 304
+  // does not prove that — it reaches the lifecycle when the cache is disabled, or
+  // is enabled but holds no entry, and in both cases the caller's own conditional
+  // request went to the server and got a real network round trip. Reporting it as
+  // a cache hit overstates the cache's effectiveness in anyone's metrics.
+  it("does not report a bare 304 as served from cache", async () => {
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, () => new HttpResponse(null, { status: 304 }))
+    );
+
+    const { hooks, events } = recordingHooks();
+    // Cache disabled, so nothing can rewrite the 304 and no X-From-Cache is set.
+    const client = createBasecampClient({
+      accountId: "12345",
+      accessToken: "test-token",
+      hooks,
+      enableCache: false,
+    });
+
+    await client.GET("/projects.json");
+
+    const last = ends(events).at(-1)!;
+    expect({ statusCode: last.statusCode, fromCache: last.fromCache }).toEqual({
+      statusCode: 304,
+      fromCache: false,
+    });
+  });
+
   it("reports the post-cache outcome when a retried conditional GET returns 304", async () => {
     let attempts = 0;
     server.use(

--- a/typescript/tests/middleware-lifecycle.test.ts
+++ b/typescript/tests/middleware-lifecycle.test.ts
@@ -302,8 +302,19 @@ describe("middleware request lifecycle", () => {
   // Reporting it as a cache hit overstates the cache's effectiveness in anyone's
   // metrics. The test below covers the opposite path, where the cache does serve.
   it("does not report a bare 304 as served from cache", async () => {
+    // Reproduce the real path rather than just the status: the CALLER owns the
+    // conditional request. The server only answers 304 because it received their
+    // If-None-Match, which is what makes this a genuine round trip and not a
+    // cache hit.
+    let sawConditional = false;
     server.use(
-      http.get(`${BASE_URL}/projects.json`, () => new HttpResponse(null, { status: 304 }))
+      http.get(`${BASE_URL}/projects.json`, ({ request }) => {
+        if (request.headers.get("If-None-Match") === 'W/"caller-etag"') {
+          sawConditional = true;
+          return new HttpResponse(null, { status: 304 });
+        }
+        return HttpResponse.json([{ id: 1 }]);
+      })
     );
 
     const { hooks, events } = recordingHooks();
@@ -315,7 +326,12 @@ describe("middleware request lifecycle", () => {
       enableCache: false,
     });
 
-    await client.GET("/projects.json");
+    await client.GET("/projects.json", {
+      headers: { "If-None-Match": 'W/"caller-etag"' },
+    } as never);
+
+    // The 304 was earned by the caller's own conditional request.
+    expect(sawConditional).toBe(true);
 
     const last = ends(events).at(-1)!;
     expect({ statusCode: last.statusCode, fromCache: last.fromCache }).toEqual({


### PR DESCRIPTION
The lifecycle treated any 304 as a cache hit:

```ts
const fromCache = fromCacheHeader === "1" || response.status === 304;
```

SPEC defines `fromCache` as *served out of the ETag cache*, and only the `X-From-Cache: 1` header the cache middleware sets establishes that. A bare 304 reaches the lifecycle in two cases the flag then misreports:

- the cache is **disabled**, and the caller sent their own `If-None-Match`
- the cache is enabled but holds **no entry** for that key

In both, a real conditional round trip went to the server. Anyone measuring cache effectiveness from these hooks was told the cache served requests it never saw.

**Predates #503** — the condition was carried forward unchanged from the middleware that one replaced. Metrics only, not request correctness, which is why it isn't a rollback.

## The two 304 paths are genuinely distinct

Worth being explicit, since it would be easy to "fix" one by breaking the other:

| Path | X-From-Cache | Reported |
|---|---|---|
| Cache holds an entry — middleware rewrites 304 → 200 | set | `200`, `fromCache: true` |
| Bare 304 (cache off, or no entry) | absent | `304`, `fromCache: false` |

The new bare-304 regression is red against `3c268ef4` with `{statusCode: 304, fromCache: true}` vs `{…, fromCache: false}`. I also confirmed the **existing** cached-304 test still passes against merged main, so this adds a case rather than trading one assertion for another.

## Also fixed: a stale comment

The comment above this code still claimed the retry middleware "has already ended the final attempt whenever it retried — finalize is idempotent, so this is a no-op in that case". That stopped being true in #503's review round, when the retry stopped finalizing successful attempts precisely so the cache could transform the response first. This callback is now the authoritative end for attempt 2 as well; the idempotence is a backstop, not the mechanism.

CI reports **979 TypeScript tests passing** across 71 files on this head, plus the conformance suite at 117 passed / 6 skipped; `ts-check` clean.

(My local `vitest run` reports 981 on the same 71 files, same command, same Node major. I could not identify the 2-test delta, so the CI figure — the reproducible one — is what this cites.)

## Provenance

Copilot flagged this in a **suppressed low-confidence** comment on #503's final head. It sat there for 21h43m and I merged without reading the suppressed block — despite having recorded, in that same PR, that suppressed comments are review findings stored outside the thread ledger and that a zero unresolved count is not a review gate here. The rule was written and not applied. This PR is the result of applying it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `fromCache` semantics: we only mark a response as from cache when the `X-From-Cache: 1` header is present. Bare 304s no longer count as cache hits, improving cache metrics accuracy without changing request behavior.

- **Bug Fixes**
  - Derive `fromCache` solely from `X-From-Cache: 1`; `304` without the header reports `fromCache: false`.
  - Updated the bare-304 test to send `If-None-Match` so the 304 is caller-earned; placed each 304 test’s comment with its test.
  - Clarified lifecycle docs: `finalized` guards duplicate ends per attempt; `onResponse` is the authoritative end after cache transformation.

<sup>Written for commit 3a769a681d631ee58a09b8c540976f49dacbf1e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

