### PR TITLE
Run the wrapper field-level drift gate in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,14 @@ jobs:
       - name: Check service layer drift
         run: ../scripts/check-service-drift.sh
 
+      - name: Check wrapper field-level drift
+        # Pure-Go AST check (stdlib-only module in go.work) comparing wrapper
+        # structs in go/pkg/basecamp/ against generated structs in
+        # go/pkg/generated/client.gen.go; writes nothing to the tree. Runs
+        # from repo root regardless of this job's `working-directory: go`.
+        working-directory: .
+        run: make go-check-wrapper-drift
+
       - name: Check generated client drift
         run: ../scripts/check-go-generated-drift.sh
 


### PR DESCRIPTION
## Gap

`make go-check-wrapper-drift` — the only field-level gate comparing hand-written wrappers in `go/pkg/basecamp/` against generated structs in `go/pkg/generated/client.gen.go` — is reachable only through the root `check:` prereq list, and no workflow runs `make check`. This is exactly the gap #500 closed for `check-retry-metadata-parity`: wrapper drift could reach main unnoticed.

## Change

One file. Insert a step into `test-go` between "Check service layer drift" and "Check generated client drift", mirroring the `check:` prereq order (`go-check-drift go-check-wrapper-drift go-check-generated-drift`).

- `working-directory: .` is required: the job defaults to `go/`, and the checker module (`scripts/check-wrapper-drift`, stdlib-only, in `go.work`) only resolves from the repo root.
- No new actions → no new SHA pins. The job already has `permissions: contents: read`, pinned checkout with `persist-credentials: false`, and setup-go from `go/go.mod` (1.26, matching the checker's `go.mod`). No `cache-dependency-path` addition — the module has no `go.sum`.
- No temp-only conversion needed: the #456/#460 law covers regenerate-and-diff gates; this one regenerates nothing and writes nothing (statically: no `os.WriteFile/Create/Remove/MkdirAll/os/exec` in `main.go`; tests write only under `t.TempDir()`).

## Verification

**Green** (pristine `git archive` of this branch): the gate's own 28-test suite passed, then

```
Wrapper drift check: 82 pairs walked, 1118 generated fields verified (966 field assignments verified at tier-1 *FromGenerated bodies + tier-3 composite literals)
REAL_EXIT=0
```

SHA-256 digests over every file in the tree, taken before and after the run, are identical — the gate provably writes nothing.

**Red** (scratch copy, deleted `Content string `json:"content"`` from `go/pkg/basecamp/boosts.go`):

```
=== DRIFT DETECTED ===
wrapper drift: 1 issue(s)
REAL_EXIT=2
```

(The checker exits 1; make surfaces 2 — nonzero either way, so the step fails.)

**Lint**: `make lint-actions` clean (actionlint + zizmor, "No findings to report").

Note: this touches `.github/workflows/`, so the sensitive-change gate will comment — informational shadow mode.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the wrapper field-level drift check in CI to catch drift between `go/pkg/basecamp` wrappers and `go/pkg/generated/client.gen.go` structs. Adds a `make go-check-wrapper-drift` step to `test-go`, executed from the repo root.

<sup>Written for commit a4acb6d551324b0f888cbefc955b2a1dcc9bc40a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

