### PR TITLE
READMEs: fix every sample that misstates the API

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -23,7 +23,7 @@ Official Go SDK for the [Basecamp API](https://github.com/basecamp/bc3-api).
 go get github.com/basecamp/basecamp-sdk/go
 ```
 
-Requires Go 1.25 or later.
+Requires Go 1.26 or later.
 
 ## Quick Start
 
@@ -60,12 +60,12 @@ func main() {
     account := client.ForAccount(accountID)
 
     // List all projects
-    projects, err := account.Projects().List(context.Background(), nil)
+    result, err := account.Projects().List(context.Background(), nil)
     if err != nil {
         log.Fatal(err)
     }
 
-    for _, p := range projects {
+    for _, p := range result.Projects {
         fmt.Printf("%d: %s\n", p.ID, p.Name)
     }
 }
@@ -102,14 +102,14 @@ func main() {
     account := client.ForAccount(fmt.Sprint(info.Accounts[0].ID))
 
     // List active projects
-    projects, err := account.Projects().List(context.Background(), &basecamp.ProjectListOptions{
+    result, err := account.Projects().List(context.Background(), &basecamp.ProjectListOptions{
         Status: basecamp.ProjectStatusActive,
     })
     if err != nil {
         log.Fatal(err)
     }
 
-    for _, p := range projects {
+    for _, p := range result.Projects {
         fmt.Printf("%s (%d)\n", p.Name, p.ID)
     }
 }
@@ -471,13 +471,13 @@ msg, err := account.Messages().Create(ctx, board.ID, &basecamp.CreateMessageRequ
 ctx := context.Background()
 
 // List all campfires
-campfires, err := account.Campfires().List(ctx)
+campfires, err := account.Campfires().List(ctx, nil)
 
 // Send a message
 line, err := account.Campfires().CreateLine(ctx, campfireID, "Hello, team!")
 
 // List recent messages
-lines, err := account.Campfires().ListLines(ctx, campfireID)
+lines, err := account.Campfires().ListLines(ctx, campfireID, nil)
 ```
 
 ## Working with Webhooks
@@ -493,7 +493,7 @@ webhook, err := account.Webhooks().Create(ctx, bucketID, &basecamp.CreateWebhook
 })
 
 // List webhooks
-webhooks, err := account.Webhooks().List(ctx, bucketID)
+webhooks, err := account.Webhooks().List(ctx, bucketID, nil)
 
 // Delete a webhook
 err = account.Webhooks().Delete(ctx, webhookID)
@@ -628,13 +628,14 @@ import (
 
 // Uses global TracerProvider/MeterProvider by default
 hooks := basecampotel.NewHooks()
-client := basecamp.NewClient(cfg, token, basecamp.WithHooks(hooks))
 
 // Or with custom providers
-hooks := basecampotel.NewHooks(
+hooks = basecampotel.NewHooks(
     basecampotel.WithTracerProvider(tp),
     basecampotel.WithMeterProvider(mp),
 )
+
+client := basecamp.NewClient(cfg, token, basecamp.WithHooks(hooks))
 ```
 
 Creates spans like:
@@ -675,6 +676,7 @@ import (
     "github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
     basecampotel "github.com/basecamp/basecamp-sdk/go/pkg/basecamp/otel"
     basecampprom "github.com/basecamp/basecamp-sdk/go/pkg/basecamp/prometheus"
+    "github.com/prometheus/client_golang/prometheus"
 )
 
 otelHooks := basecampotel.NewHooks()

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -10,7 +10,7 @@ Official Kotlin SDK for the [Basecamp API](https://github.com/basecamp/bc3-api).
 
 - Kotlin Multiplatform (JVM target)
 - Builder DSL for client configuration
-- 45 services covering the complete Basecamp API
+- 46 services covering the complete Basecamp API
 - OAuth 2.0 with PKCE support
 - Webhook signature verification (HMAC-SHA256)
 - ETag-based HTTP caching (opt-in)
@@ -190,9 +190,9 @@ val client = BasecampClient {
 | `enableRetry` | `true` | Automatic retry on 429/503 |
 | `enableCache` | `false` | ETag-based HTTP caching |
 | `timeout` | `30s` | Request timeout |
-| `maxRetries` | `3` | Maximum retry attempts |
+| `maxRetries` | `3` | Maximum retry attempts (fixed; not settable via the builder) |
 | `maxPages` | `10_000` | Maximum pages to follow during pagination |
-| `baseRetryDelay` | `1s` | Base delay for exponential backoff |
+| `baseRetryDelay` | `1s` | Base delay for exponential backoff (fixed; not settable via the builder) |
 
 ## OAuth 2.0
 
@@ -415,7 +415,7 @@ if (!isValid) {
 
 ## Services
 
-The SDK exposes 45 account-scoped services. The tables below group the common ones; see `com/basecamp/sdk/generated/services/` for the full set.
+The SDK exposes 46 account-scoped services. The tables below group the common ones; see `com/basecamp/sdk/generated/services/` for the full set.
 
 ### Projects & Organization
 
@@ -561,7 +561,7 @@ The SDK uses a `BasecampException` sealed class for exhaustive `when` matching:
 import com.basecamp.sdk.BasecampException
 
 try {
-    val todo = account.todos.get(projectId = 123, todoId = 456)
+    val todo = account.todos.get(todoId = 456)
 } catch (e: BasecampException) {
     when (e) {
         is BasecampException.Auth -> println("Token expired: ${e.message}")
@@ -573,6 +573,8 @@ try {
         is BasecampException.Network -> println("Network error: ${e.message}")
         is BasecampException.Api -> println("Server error (${e.httpStatus}): ${e.message}")
         is BasecampException.Usage -> println("Bad arguments: ${e.message}")
+        is BasecampException.DiscoverySelection -> println("OAuth discovery: ${e.reason}")
+        is BasecampException.DeviceFlow -> println("Device flow: ${e.reason}")
     }
 
     // Common properties available on all subclasses
@@ -597,6 +599,8 @@ try {
 | `Ambiguous` | - | 8 | Multiple matches found |
 | `Validation` | 400, 422 | 9 | Invalid request data |
 | `Usage` | - | 1 | Configuration or argument error |
+| `DiscoverySelection` | - | 7 or 9 | OAuth discovery selection failed (code derived from `reason`) |
+| `DeviceFlow` | - | 1, 3, 6, or 9 | Device authorization grant failed (code derived from `reason`) |
 
 ## Observability
 
@@ -617,8 +621,8 @@ val client = BasecampClient {
 
 Output:
 ```
-[Basecamp] Projects.List
-[Basecamp] Projects.List completed (147ms)
+[Basecamp] Projects.ListProjects
+[Basecamp] Projects.ListProjects completed (147ms)
 ```
 
 ### Custom Hooks

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampClient.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampClient.kt
@@ -205,7 +205,7 @@ class BasecampClient internal constructor(
  * ```kotlin
  * val account = client.forAccount("12345")
  * val projects = account.projects.list()
- * val todo = account.todos.get(projectId = 123, todoId = 456)
+ * val todo = account.todos.get(todoId = 456)
  * ```
  *
  * **Extensibility**: External modules can add services via Kotlin extension

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
@@ -6,7 +6,7 @@ package com.basecamp.sdk
  * Enables exhaustive `when` matching for error handling:
  * ```kotlin
  * try {
- *     account.todos.get(projectId, todoId)
+ *     account.todos.get(todoId)
  * } catch (e: BasecampException) {
  *     when (e) {
  *         is BasecampException.Auth -> println("Token expired")

--- a/python/README.md
+++ b/python/README.md
@@ -8,7 +8,7 @@ Official Python SDK for the [Basecamp API](https://github.com/basecamp/bc3-api).
 
 ## Features
 
-- **Full API coverage** — 45 generated services covering projects, todos, messages, schedules, campfires, card tables, and more
+- **Full API coverage** — 46 generated services covering projects, todos, messages, schedules, campfires, card tables, and more
 - **OAuth 2.0 authentication** — PKCE support, token refresh, resource-first (RFC 9728 + RFC 8414) discovery
 - **Static token authentication** — Simple setup for personal integrations
 - **Automatic retry with backoff** — Exponential backoff with jitter, respects `Retry-After` headers

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -42,7 +42,6 @@ project = account.projects.get(project_id: 12345)
 
 # Create a todo
 todo = account.todos.create(
-  project_id: 12345,
   todolist_id: 67890,
   content: "Review PR",
   due_on: "2024-12-31"
@@ -272,7 +271,7 @@ aborts before an oversized body is buffered.
 
 ## Services
 
-The SDK provides 45 account-scoped services. The table below covers the common ones; see `lib/basecamp/generated/services/` for the authoritative, complete set:
+The SDK provides 46 account-scoped services. The table below covers the common ones; see `lib/basecamp/generated/services/` for the authoritative, complete set:
 
 | Service | Description |
 |---------|-------------|

--- a/swift/README.md
+++ b/swift/README.md
@@ -9,7 +9,7 @@ Official Swift SDK for the [Basecamp API](https://github.com/basecamp/bc3-api).
 ## Features
 
 - Full Swift 6 concurrency support (strict `Sendable` throughout)
-- 45 services covering the complete Basecamp API
+- 46 services covering the complete Basecamp API
 - Async/await API with structured concurrency
 - ETag-based HTTP caching (opt-in)
 - Automatic retry with exponential backoff
@@ -123,7 +123,7 @@ let client = BasecampClient(
 
 ## Services
 
-The SDK exposes 45 account-scoped services. The tables below group the common ones; see `Sources/Basecamp/Generated/Services/` for the full set.
+The SDK exposes 46 account-scoped services. The tables below group the common ones; see `Sources/Basecamp/Generated/Services/` for the full set.
 
 ### Projects & Organization
 
@@ -283,7 +283,7 @@ The SDK uses a `BasecampError` enum with associated values for exhaustive `switc
 
 ```swift
 do {
-    let todo = try await account.todos.get(projectId: 123, todoId: 456)
+    let todo = try await account.todos.get(todoId: 456)
 } catch let error as BasecampError {
     switch error {
     case .auth(let message, let hint, _):
@@ -294,7 +294,7 @@ do {
         print("Not found: \(message)")
     case .rateLimit(_, let retryAfter, _, _):
         if let seconds = retryAfter {
-            try await Task.sleep(for: .seconds(seconds))
+            try await Task.sleep(nanoseconds: UInt64(seconds) * 1_000_000_000)
         }
     case .network(let message, _):
         print("Network error: \(message)")

--- a/swift/Sources/Basecamp/AccountClient.swift
+++ b/swift/Sources/Basecamp/AccountClient.swift
@@ -8,7 +8,7 @@ import Foundation
 /// ```swift
 /// let account = client.forAccount("12345")
 /// let projects = try await account.projects.list()
-/// let todo = try await account.todos.get(projectId: 123, todoId: 456)
+/// let todo = try await account.todos.get(todoId: 456)
 /// ```
 ///
 /// ## Extensibility

--- a/swift/Sources/Basecamp/BasecampError.swift
+++ b/swift/Sources/Basecamp/BasecampError.swift
@@ -7,14 +7,14 @@ import Foundation
 ///
 /// ```swift
 /// do {
-///     let todo = try await account.todos.get(projectId: 123, todoId: 456)
+///     let todo = try await account.todos.get(todoId: 456)
 /// } catch let error as BasecampError {
 ///     switch error {
 ///     case .notFound(let message, _, _):
 ///         print("Not found: \(message)")
 ///     case .rateLimit(_, let retryAfter, _, _):
 ///         if let seconds = retryAfter {
-///             try await Task.sleep(for: .seconds(seconds))
+///             try await Task.sleep(nanoseconds: UInt64(seconds) * 1_000_000_000)
 ///         }
 ///     default:
 ///         print(error.localizedDescription)

--- a/swift/Sources/Basecamp/Pagination.swift
+++ b/swift/Sources/Basecamp/Pagination.swift
@@ -31,7 +31,7 @@ public struct PaginationOptions: Sendable {
 /// property provides pagination metadata.
 ///
 /// ```swift
-/// let todos = try await account.todos.list(projectId: 123, todolistId: 456)
+/// let todos = try await account.todos.list(todolistId: 456)
 /// print("Showing \(todos.count) of \(todos.meta.totalCount) todos")
 /// for todo in todos { print(todo.content) }
 /// let titles = todos.map(\.content) // returns [String]

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -462,32 +462,43 @@ const result = await client.downloadURL(url);
 
 ## Pagination
 
-List methods return a single page of results by default. Use the pagination helpers with low-level API calls to fetch all pages:
+Service `list()` methods auto-paginate: they follow the API's `Link: rel="next"` headers and return every item across all pages (up to a 10,000-page safety cap).
+
+The result is a `ListResult<T>` — an `Array<T>` subclass that works with `for...of`, `.map()`, `.filter()`, spread, `.length`, indexing, and `Array.isArray()` — plus a `.meta` property with pagination metadata:
+
+```ts
+const projects = await client.projects.list();
+
+console.log(`${projects.length} of ${projects.meta.totalCount} projects`);
+if (projects.meta.truncated) console.warn("results may have been capped");
+projects.forEach(p => console.log(p.name));
+```
+
+`meta.totalCount` is parsed from the `X-Total-Count` response header (0 when the header is absent). `meta.truncated` is `true` when the result may have been cut short — by `maxItems` or by the page safety cap; when it is `false`, the result is definitely complete.
+
+To bound the work, pass `maxItems` — every list options type extends `PaginationOptions`. When `maxItems` is omitted or `0`, all pages are fetched:
+
+```ts
+const firstFifty = await client.projects.list({ maxItems: 50 });
+```
+
+For endpoints not covered by a service, drive pagination yourself over a raw `client.GET` response with `fetchAllPages` (collects all pages into one array) or `paginateAll` (async generator that yields one page at a time):
 
 ```ts
 import { fetchAllPages, paginateAll } from "@37signals/basecamp";
 
-// First, fetch the initial page using the low-level client
-const initialResponse = await client.GET("/projects.json");
+const initial = await client.GET("/projects.json");
 
 // Option 1: fetchAllPages - returns all results as an array
-const allProjects = await fetchAllPages(
-  initialResponse.response,
-  (response) => response.json()
-);
+const all = await fetchAllPages(initial.response, (r) => r.json() as Promise<any[]>);
 
 // Option 2: paginateAll - async generator for streaming large result sets
-for await (const page of paginateAll(
-  initialResponse.response,
-  (response) => response.json()
-)) {
+for await (const page of paginateAll(initial.response, (r) => r.json() as Promise<any[]>)) {
   for (const project of page) {
     console.log(project.name);
   }
 }
 ```
-
-Paginated endpoints include an `X-Total-Count` HTTP header when available. You can access this header via the `response.headers` field on low-level `client.GET`/`client.POST` calls.
 
 ## Low-Level API Access
 


### PR DESCRIPTION
Six commits, one per SDK. Every defect below was proven against the real SDK before editing, and every corrected snippet was re-proven green. Nothing here touches behavior — READMEs plus five doc comments in Kotlin/Swift source that showed the same phantom signatures.

## Ruby — `todos.create` takes `todolist_id:`, not `project_id:`

The Quick Start's documented call fails at argument binding, before any HTTP:

```
ArgumentError: unknown keyword: :project_id
```

The corrected call (with `http_post` stubbed on the service singleton) POSTs `/todolists/67890/todos.json`.

## Go — five fences didn't compile

Each reproduced offline as the exact compiler error (scratch module + `replace` directive, `GOPROXY=off`); all corrected snippets `go build` + `go vet` clean:

```
cannot range over projects (variable of type *basecamp.ProjectListResult)   [both Quick Start programs]

not enough arguments in call to account.Campfires().List
	have (context.Context)
	want (context.Context, *basecamp.CampfireListOptions)
not enough arguments in call to account.Campfires().ListLines
	have (context.Context, int64)
	want (context.Context, int64, *basecamp.CampfireLineListOptions)

not enough arguments in call to account.Webhooks().List
	have (context.Context, int64)
	want (context.Context, int64, *basecamp.WebhookListOptions)

no new variables on left side of :=                                          [OTel fence redeclares hooks]

undefined: prometheus                                                        [chain-hooks fence]
```

Also "Requires Go 1.25 or later" → 1.26, matching `go.mod`. The README's fragment conventions (undeclared `ctx`, `use()`, top-level `return err`) are established style and stay.

## Kotlin — error-handling sample didn't compile; tables lied

- `todos.get(projectId = 123, todoId = 456)` — the generated signature is `get(todoId: Long)` (`generated/services/todos.kt`).
- The `when` over sealed `BasecampException` covered 9 of 11 subclasses; a non-exhaustive `when` statement over a sealed subject is a compile error, and the SDK's own `ErrorTest.kt` pins all 11 branches ("This ensures all branches compile (exhaustive when)"). Added `DiscoverySelection`/`DeviceFlow` branches and their Error Types rows.
- Configuration Options documented `maxRetries`/`baseRetryDelay`, but `BasecampClientBuilder` has no setter for either and the client constructor is `internal` — marked as fixed defaults.
- `consoleHooks` sample output showed `Projects.List`; the generated `OperationInfo` emits `Projects.ListProjects`.
- Same phantom `todos.get` in `BasecampException`/`BasecampClient` doc comments.

## Swift — phantom arity plus an API that needs macOS 13

- `todos.get(projectId: 123, todoId: 456)` — the generated signature is `get(todoId: Int)`.
- The same fence used `Task.sleep(for: .seconds(...))` while `Package.swift` declares `.macOS(.v12)`. Proven under a macOS 12 target:

```
error: 'sleep(for:tolerance:clock:)' is only available in macOS 13.0 or newer
```

Replaced with the nanoseconds form the SDK's own retry path uses (green under the same target). Also fixed the phantom signatures in `BasecampError`/`AccountClient`/`Pagination` doc comments.

## TypeScript — `list()` auto-paginates; the docs claimed the opposite

"List methods return a single page of results by default" inverts reality. Behavioral proof against a stubbed `fetch` serving two pages:

```
HTTP calls: 2; items returned: 3; meta.totalCount: 3; Array.isArray: true
maxItems:2 -> items: 2; truncated: true
```

The Pagination section now leads with auto-pagination and `ListResult`/`.meta`, shows `maxItems`, and reframes `fetchAllPages`/`paginateAll` as the escape hatch for raw `client.GET` calls. The helper callbacks read `(r) => r.json() as Promise<any[]>` because bare `r.json()` is `Promise<unknown>` under the repo's strict/NodeNext config and fails `tsc --noEmit`; all three replacement blocks typecheck clean under that config.

## All six SDKs — "45 services" → 46

Stale since `EverythingService` landed. Verified per SDK: 46 Kotlin accessors, 46 Swift accessors, 46 Ruby service classes (47 files minus `base_service.rb`), 46 Python service modules (excluding `_base`/`_async_base`), matching SPEC.md's counts.

## Deliberately not touched

- Install sections stay version-less (#495).
- Root README — all six quick starts verified correct.
- `python/README.md` Retry Behavior — current #502 text.
- `ruby/README.md` Retry Behavior — defective but deserves the #502-style whole-section treatment; issue to follow.
- Kotlin "2.0+" floor — repeated verbatim in CONTRIBUTING.md, so changing it is a policy call, not a doc fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix incorrect README code samples and doc comments across all SDKs to match real API signatures, pagination behavior, and compile-time constraints. No runtime changes; updates service count references to 46.

- **Bug Fixes**
  - Ruby: `todos.create` uses `todolist_id`, not `project_id`.
  - Go: All snippets compile; iterate `result.Projects`, pass `nil` to Campfires/Webhooks list calls, fix OTel hooks reassignment (construct client after), add `prometheus` import; "Requires Go 1.26".
  - Kotlin: Use `todos.get(todoId)`, make `BasecampException` sample exhaustive with `DiscoverySelection`/`DeviceFlow`; mark `maxRetries`/`baseRetryDelay` as fixed defaults; console hooks show `Projects.ListProjects`; fix doc comments.
  - Swift: Use `todos.get(todoId)`, replace `Task.sleep(for:)` with `nanoseconds` for macOS 12; fix doc comments and the pagination example.
  - TypeScript: `list()` auto-paginates and returns a `ListResult` with `.meta.totalCount` and `.truncated`; show `maxItems`; update raw pagination examples using `fetchAllPages`/`paginateAll` from `@37signals/basecamp` with typed `r.json()`.
  - All SDKs: "45 services" → 46 to reflect `EverythingService`.

<sup>Written for commit 60be4683e95be99c1eef592208b3deadae2a4d72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

