### PR TITLE
Swift retry lifecycle: SPEC-correct onRetry numbering, re-auth on every retry path, no events from catch

### DIFF
--- a/swift/Sources/Basecamp/BasecampHooks.swift
+++ b/swift/Sources/Basecamp/BasecampHooks.swift
@@ -105,8 +105,9 @@ public protocol BasecampHooks: Sendable {
     /// Called before a retry attempt.
     ///
     /// - Parameters:
-    ///   - info: Request information.
-    ///   - attempt: The attempt number (1-based).
+    ///   - info: Request information; `info.attempt` is the attempt that just failed (1-based).
+    ///   - attempt: The upcoming attempt (1-based) — the retry about to be made,
+    ///     so the first retry reports attempt 2.
     ///   - error: The error that triggered the retry.
     ///   - delaySeconds: The delay before the retry, in seconds.
     func onRetry(_ info: RequestInfo, attempt: Int, error: any Error, delaySeconds: TimeInterval)

--- a/swift/Sources/Basecamp/HTTP/HTTPClient.swift
+++ b/swift/Sources/Basecamp/HTTP/HTTPClient.swift
@@ -91,6 +91,16 @@ package final class HTTPClient: Sendable {
         let retryable = Self.retryableMethods.contains(method.uppercased()) || idempotent
         let maxAttempts = max((config.enableRetry && retryable) ? effectiveConfig.maxAttempts : 1, 1)
 
+        /// Outcome of a single attempt. Computed inside the do/catch below —
+        /// which covers only the transport call and response classification —
+        /// and acted on at the loop tail, so retry side effects (onRetry,
+        /// backoff sleep, reauth) never run inside a catch clause.
+        enum AttemptDirective {
+            case done(Data, HTTPURLResponse)
+            case retry(error: any Error, delaySeconds: TimeInterval)
+            case fail(any Error)
+        }
+
         for attempt in 1...maxAttempts {
             let info = RequestInfo(method: method, url: url, attempt: attempt)
 
@@ -98,6 +108,7 @@ package final class HTTPClient: Sendable {
             safeInvokeHooks { $0.onRequestStart(info) }
 
             let startTime = CFAbsoluteTimeGetCurrent()
+            let directive: AttemptDirective
 
             do {
                 let (data, response) = try await transport.data(for: request)
@@ -121,48 +132,43 @@ package final class HTTPClient: Sendable {
                         httpVersion: "HTTP/1.1",
                         headerFields: httpResponse.allHeaderFields as? [String: String] ?? [:]
                     )!
-                    return (cached, syntheticResponse)
+                    directive = .done(cached, syntheticResponse)
+                } else {
+                    // Cache successful GET responses with ETag
+                    if method == "GET", httpResponse.statusCode == 200,
+                       let cache, let etag = httpResponse.value(forHTTPHeaderField: "ETag") {
+                        cache.store(url: url, data: data, etag: etag)
+                    }
+
+                    safeInvokeHooks {
+                        $0.onRequestEnd(info, result: RequestResult(
+                            statusCode: httpResponse.statusCode, durationMs: durationMs))
+                    }
+
+                    // Check if we should retry
+                    let statusCode = httpResponse.statusCode
+                    if effectiveConfig.retryOn.contains(statusCode), attempt < maxAttempts {
+                        let delaySeconds = calculateDelay(
+                            attempt: attempt,
+                            baseDelayMs: effectiveConfig.baseDelayMs,
+                            backoff: effectiveConfig.backoff,
+                            retryAfterHeader: httpResponse.value(forHTTPHeaderField: "Retry-After"),
+                            statusCode: statusCode
+                        )
+                        let error = BasecampError.fromHTTPResponse(
+                            status: statusCode, data: data,
+                            headers: httpResponse.allHeaderFields as? [String: String] ?? [:],
+                            requestId: httpResponse.value(forHTTPHeaderField: "X-Request-Id")
+                        )
+                        directive = .retry(error: error, delaySeconds: delaySeconds)
+                    } else {
+                        directive = .done(data, httpResponse)
+                    }
                 }
-
-                // Cache successful GET responses with ETag
-                if method == "GET", httpResponse.statusCode == 200,
-                   let cache, let etag = httpResponse.value(forHTTPHeaderField: "ETag") {
-                    cache.store(url: url, data: data, etag: etag)
-                }
-
-                safeInvokeHooks {
-                    $0.onRequestEnd(info, result: RequestResult(
-                        statusCode: httpResponse.statusCode, durationMs: durationMs))
-                }
-
-                // Check if we should retry
-                let statusCode = httpResponse.statusCode
-                if effectiveConfig.retryOn.contains(statusCode), attempt < maxAttempts {
-                    let delaySeconds = calculateDelay(
-                        attempt: attempt,
-                        baseDelayMs: effectiveConfig.baseDelayMs,
-                        backoff: effectiveConfig.backoff,
-                        retryAfterHeader: httpResponse.value(forHTTPHeaderField: "Retry-After"),
-                        statusCode: statusCode
-                    )
-                    let error = BasecampError.fromHTTPResponse(
-                        status: statusCode, data: data,
-                        headers: httpResponse.allHeaderFields as? [String: String] ?? [:],
-                        requestId: httpResponse.value(forHTTPHeaderField: "X-Request-Id")
-                    )
-                    safeInvokeHooks { $0.onRetry(info, attempt: attempt + 1, error: error, delaySeconds: delaySeconds) }
-
-                    try await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))
-
-                    // Re-authenticate for retry (e.g. refresh expired token)
-                    try await authStrategy.authenticate(&request)
-                    continue
-                }
-
-                return (data, httpResponse)
-
             } catch let error as BasecampError {
-                throw error
+                // A BasecampError thrown by the transport (or the response-type
+                // guard) is rethrown untouched, with no request-end event.
+                directive = .fail(error)
             } catch {
                 // Network-level error
                 let durationMs = Int((CFAbsoluteTimeGetCurrent() - startTime) * 1000)
@@ -178,14 +184,29 @@ package final class HTTPClient: Sendable {
                         retryAfterHeader: nil,
                         statusCode: nil
                     )
-                    safeInvokeHooks {
-                        $0.onRetry(info, attempt: attempt + 1, error: error, delaySeconds: delaySeconds)
-                    }
-                    try await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))
-                    continue
+                    directive = .retry(error: error, delaySeconds: delaySeconds)
+                } else {
+                    directive = .fail(BasecampError.network(message: "Network error", cause: error))
                 }
+            }
 
-                throw BasecampError.network(message: "Network error", cause: error)
+            // Loop tail — SPEC §7 steps 3.j (on_retry), 3.k (sleep), 3.l (refresh
+            // auth), shared by the status and network retry paths. These run
+            // outside any catch, so a CancellationError from the backoff sleep or
+            // an error from re-authentication propagates raw — no phantom request
+            // events for an attempt that already ended, no wrapping.
+            switch directive {
+            case .done(let data, let response):
+                return (data, response)
+            case .fail(let error):
+                throw error
+            case .retry(let error, let delaySeconds):
+                safeInvokeHooks { $0.onRetry(info, attempt: attempt + 1, error: error, delaySeconds: delaySeconds) }
+
+                try await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))
+
+                // Re-authenticate for retry (e.g. refresh expired token)
+                try await authStrategy.authenticate(&request)
             }
         }
 

--- a/swift/Sources/Basecamp/HTTP/HTTPClient.swift
+++ b/swift/Sources/Basecamp/HTTP/HTTPClient.swift
@@ -150,7 +150,7 @@ package final class HTTPClient: Sendable {
                         headers: httpResponse.allHeaderFields as? [String: String] ?? [:],
                         requestId: httpResponse.value(forHTTPHeaderField: "X-Request-Id")
                     )
-                    safeInvokeHooks { $0.onRetry(info, attempt: attempt, error: error, delaySeconds: delaySeconds) }
+                    safeInvokeHooks { $0.onRetry(info, attempt: attempt + 1, error: error, delaySeconds: delaySeconds) }
 
                     try await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))
 
@@ -179,7 +179,7 @@ package final class HTTPClient: Sendable {
                         statusCode: nil
                     )
                     safeInvokeHooks {
-                        $0.onRetry(info, attempt: attempt, error: error, delaySeconds: delaySeconds)
+                        $0.onRetry(info, attempt: attempt + 1, error: error, delaySeconds: delaySeconds)
                     }
                     try await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))
                     continue

--- a/swift/Tests/BasecampTests/HooksTests.swift
+++ b/swift/Tests/BasecampTests/HooksTests.swift
@@ -165,7 +165,8 @@ final class HooksTests: XCTestCase {
         )
 
         XCTAssertEqual(spy.retries.count, 1, "onRetry should fire once for one retry")
-        XCTAssertEqual(spy.retries.first?.attempt, 1, "First retry attempt number should be 1")
+        XCTAssertEqual(spy.retries.first?.attempt, 2, "Standalone attempt is the upcoming attempt: first retry = attempt 2")
+        XCTAssertEqual(spy.retries.first?.info.attempt, 1, "RequestInfo carries the attempt that just failed")
         XCTAssertGreaterThanOrEqual(spy.retries.first?.delaySeconds ?? -1, 0)
     }
 

--- a/swift/Tests/BasecampTests/RetryTests.swift
+++ b/swift/Tests/BasecampTests/RetryTests.swift
@@ -194,15 +194,63 @@ final class RetryTests: XCTestCase {
             )
         )
 
-        // The second request should have a different auth token than the first
+        // The second request should have a different auth token than the first:
+        // the retry re-authenticates and the provider rotates (SPEC §7 step 3.l).
         let requests = transport.requests
         XCTAssertEqual(requests.count, 2)
         let firstAuth = requests[0].request.value(forHTTPHeaderField: "Authorization")
         let secondAuth = requests[1].request.value(forHTTPHeaderField: "Authorization")
-        // Both get token from the provider; the retry re-authenticates
-        // The key thing is that authenticate() was called again
-        XCTAssertNotNil(firstAuth)
-        XCTAssertNotNil(secondAuth)
+        XCTAssertEqual(firstAuth, "Bearer token-1")
+        XCTAssertEqual(secondAuth, "Bearer token-2", "The retry after a retryable status must re-authenticate")
+    }
+
+    /// Network-path twin of `testAuthReauthenticatesOnRetry`: a retry after a
+    /// transport-level failure must also refresh auth before the next attempt
+    /// (SPEC §7 step 3.l applies to both retry paths).
+    func testAuthReauthenticatesOnRetryAfterNetworkError() async throws {
+        let requestCounter = Counter()
+
+        let tokenProvider = RotatingTokenProvider(tokens: ["token-1", "token-2", "token-3"])
+
+        let transport = MockTransport { request in
+            let count = requestCounter.increment()
+            if count == 1 {
+                throw URLError(.networkConnectionLost)
+            }
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 200,
+                httpVersion: "HTTP/1.1", headerFields: [:]
+            )!
+            return (Data("{}".utf8), response)
+        }
+
+        let client = BasecampClient(
+            tokenProvider: tokenProvider,
+            userAgent: "test-suite",
+            config: BasecampConfig(
+                baseURL: "https://3.basecampapi.com",
+                enableRetry: true,
+                enableCache: false
+            ),
+            transport: transport
+        )
+        let account = client.forAccount("999999999")
+
+        _ = try await account.httpClient.performRequest(
+            method: "GET",
+            url: "https://3.basecampapi.com/999999999/projects.json",
+            retryConfig: RetryConfig(
+                maxAttempts: 3, baseDelayMs: 1,
+                backoff: .constant, retryOn: [429, 503]
+            )
+        )
+
+        let requests = transport.requests
+        XCTAssertEqual(requests.count, 2)
+        let firstAuth = requests[0].request.value(forHTTPHeaderField: "Authorization")
+        let secondAuth = requests[1].request.value(forHTTPHeaderField: "Authorization")
+        XCTAssertEqual(firstAuth, "Bearer token-1")
+        XCTAssertEqual(secondAuth, "Bearer token-2", "The retry after a network error must re-authenticate")
     }
 
     // MARK: - Retry-After Header
@@ -308,6 +356,104 @@ final class RetryTests: XCTestCase {
         }
 
         XCTAssertEqual(counter.value, 2, "Should exhaust all retry attempts")
+    }
+
+    // MARK: - Retry Lifecycle (#509): backoff/reauth run outside the attempt's do/catch
+
+    /// A failing re-authentication before a retry must propagate its error raw:
+    /// no phantom onRequestEnd(statusCode: 0) for an attempt that already ended,
+    /// no second onRetry, and no further attempt with stale headers.
+    func testAuthFailureOnRetryPropagatesRaw() async throws {
+        let spy = RetrySpyHooks()
+        let counter = Counter()
+        let transport = MockTransport { request in
+            let count = counter.increment()
+            let statusCode = count == 1 ? 429 : 200
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: statusCode,
+                httpVersion: "HTTP/1.1", headerFields: [:]
+            )!
+            return (Data("{}".utf8), response)
+        }
+
+        let client = BasecampClient(
+            auth: FailingSecondAuth(),
+            userAgent: "test-suite",
+            config: BasecampConfig(
+                baseURL: "https://3.basecampapi.com",
+                enableRetry: true,
+                enableCache: false
+            ),
+            hooks: spy,
+            transport: transport
+        )
+        let account = client.forAccount("999999999")
+
+        do {
+            _ = try await account.httpClient.performRequest(
+                method: "GET",
+                url: "https://3.basecampapi.com/999999999/projects.json",
+                retryConfig: RetryConfig(
+                    maxAttempts: 3, baseDelayMs: 1,
+                    backoff: .constant, retryOn: [429, 503]
+                )
+            )
+            XCTFail("Expected RefreshError")
+        } catch is RefreshError {
+            // Expected: the authenticate error propagates untouched.
+        } catch {
+            XCTFail("Expected RefreshError, got \(error)")
+        }
+
+        XCTAssertEqual(spy.requestEnds.count, 1, "A failed reauth must not emit a phantom onRequestEnd")
+        XCTAssertEqual(spy.retries.count, 1, "A failed reauth must not emit a second onRetry")
+    }
+
+    /// Cancelling the task while it sleeps between attempts must propagate
+    /// CancellationError raw: no phantom onRequestEnd(statusCode: 0) and no
+    /// second onRetry for the attempt that already ended.
+    func testCancellationDuringBackoffPropagatesRaw() async throws {
+        let spy = RetrySpyHooks()
+        let transport = MockTransport { request in
+            let response = HTTPURLResponse(
+                url: request.url!, statusCode: 503,
+                httpVersion: "HTTP/1.1", headerFields: [:]
+            )!
+            return (Data(), response)
+        }
+
+        let client = makeTestClient(transport: transport, enableRetry: true, hooks: spy)
+        let httpClient = client.forAccount("999999999").httpClient
+
+        let task = Task {
+            _ = try await httpClient.performRequest(
+                method: "GET",
+                url: "https://3.basecampapi.com/999999999/projects.json",
+                retryConfig: RetryConfig(
+                    maxAttempts: 3, baseDelayMs: 5_000,
+                    backoff: .constant, retryOn: [429, 503]
+                )
+            )
+        }
+
+        // Wait until the first attempt's 503 has been served — the client is
+        // then headed into (or already inside) its ~5s backoff sleep — and cancel.
+        while transport.requests.isEmpty {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected CancellationError")
+        } catch is CancellationError {
+            // Expected: cooperative cancellation propagates raw.
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+
+        XCTAssertEqual(spy.requestEnds.count, 1, "A cancelled backoff must not emit a phantom onRequestEnd")
+        XCTAssertEqual(spy.retries.count, 1, "A cancelled backoff must not emit a second onRetry")
     }
 
     // MARK: - Idempotency Gate (Layer A: transport)
@@ -572,6 +718,67 @@ final class RetryTests: XCTestCase {
 }
 
 // MARK: - Test Helpers
+
+/// Error thrown by `FailingSecondAuth` to simulate a token-refresh failure.
+private struct RefreshError: Error {}
+
+/// An auth strategy whose second `authenticate` call throws `RefreshError`,
+/// simulating a token refresh that fails between retry attempts.
+private final class FailingSecondAuth: AuthStrategy, @unchecked Sendable {
+    private let lock = NSLock()
+    private var calls = 0
+
+    func authenticate(_ request: inout URLRequest) async throws {
+        let call: Int = lock.withLock {
+            calls += 1
+            return calls
+        }
+        if call >= 2 {
+            throw RefreshError()
+        }
+        request.setValue("Bearer token-\(call)", forHTTPHeaderField: "Authorization")
+    }
+}
+
+/// File-local spy recording request-level hook callbacks for the retry
+/// lifecycle tests. (HooksTests' SpyHooks is private to that file.)
+private final class RetrySpyHooks: BasecampHooks, @unchecked Sendable {
+    struct RetryRecord {
+        let info: RequestInfo
+        let attempt: Int
+        let error: any Error
+        let delaySeconds: TimeInterval
+    }
+
+    private let lock = NSLock()
+    private var _requestStarts: [RequestInfo] = []
+    private var _requestEnds: [(RequestInfo, RequestResult)] = []
+    private var _retries: [RetryRecord] = []
+
+    var requestStarts: [RequestInfo] {
+        lock.withLock { _requestStarts }
+    }
+
+    var requestEnds: [(RequestInfo, RequestResult)] {
+        lock.withLock { _requestEnds }
+    }
+
+    var retries: [RetryRecord] {
+        lock.withLock { _retries }
+    }
+
+    func onRequestStart(_ info: RequestInfo) {
+        lock.withLock { _requestStarts.append(info) }
+    }
+
+    func onRequestEnd(_ info: RequestInfo, result: RequestResult) {
+        lock.withLock { _requestEnds.append((info, result)) }
+    }
+
+    func onRetry(_ info: RequestInfo, attempt: Int, error: any Error, delaySeconds: TimeInterval) {
+        lock.withLock { _retries.append(RetryRecord(info: info, attempt: attempt, error: error, delaySeconds: delaySeconds)) }
+    }
+}
 
 /// A token provider that returns tokens from a list, cycling through them.
 private final class RotatingTokenProvider: TokenProvider, @unchecked Sendable {


### PR DESCRIPTION
Fixes #508. Fixes #509.

Two commits, both proven red-first against pristine `HTTPClient` (all new/changed tests written and run before any fix; 7 failing assertions across 4 tests, then 250/250 green after).

## Commit 1 — onRetry numbering (#508)

SPEC §7 step 3.j emits (failed attempt in `RequestInfo`, upcoming attempt standalone) — (1, 2) for the first retry. Swift passed bare `attempt` at both call sites, emitting (1, 1). Go/Ruby/Python/Kotlin/TS all emit the SPEC pair. Two-token fix + the hooks test now pins **both** halves (upcoming == 2, failed == 1 — the failed half was previously unasserted) + the ambiguous protocol doc now says "upcoming".

Red: `XCTAssertEqual failed: ("Optional(1)") is not equal to ("Optional(2)") - Standalone attempt is the upcoming attempt: first retry = attempt 2`

## Commit 2 — retry lifecycle (#509)

Three defects in the same loop:

1. **Network-path retries never re-authenticated.** The status path re-ran `authenticate(&request)` after backoff; the network path slept and `continue`d — SPEC §7 step 3.l requires the refresh on every retry path. Live for idempotent operations since #417.
   Red: `XCTAssertEqual failed: ("Optional("Bearer token-1")") is not equal to ("Optional("Bearer token-2")") - The retry after a network error must re-authenticate`
2. **The existing re-auth test was false proof** — rotating token-1/2/3 provider, a comment saying "should have a different auth token", and two `XCTAssertNotNil`s that pass even if re-auth never runs. It now asserts the actual header values.
3. **Sleep + re-auth ran inside the transport do/catch**, so `CancellationError` from the backoff or a non-`BasecampError` from a failing token refresh fell into the network-error catch: a second `onRequestEnd` (statusCode 0) and a second `onRetry` for an attempt that had already emitted both, then a retry with stale auth.
   Red: `XCTAssertEqual failed: ("3") is not equal to ("1") - A failed reauth must not emit a phantom onRequestEnd` / `("2") is not equal to ("1") - A cancelled backoff must not emit a second onRetry` / `failed - Expected RefreshError`

The restructure: the do/catch now only computes an `AttemptDirective` (done / retry / fail); the loop tail — outside any catch — performs SPEC steps 3.j/3.k/3.l in order (onRetry, sleep, re-authenticate), shared by both retry paths. Cancellation and auth failures propagate raw with no phantom events.

**Preserved exactly** (each pinned by an existing test): `BasecampError` from the transport rethrown untouched with no request-end event; network errors wrapped as `.network` only on exhaustion; the `maxAttempts >= 1` guard; 304/ETag cache behavior; one `onRequestStart`/`onRequestEnd` per attempt; both idempotency-gate layers.

**Behavior change worth a release-notes line:** an error thrown by `authenticate` during a retry now propagates raw instead of being swallowed into a stale-header retry — strictly a bug fix, but observable.

SPEC needed no edit — §7 already states the contract Swift now matches. `swift test`: 250 tests, 0 failures (commit 1 is independently green at 247/247).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes retry lifecycle in the Swift client: `onRetry` now reports the upcoming attempt, and re-auth runs on every retry path. Prevents duplicate hook events and stale auth, and lets cancellation/auth errors propagate cleanly.

- **Bug Fixes**
  - `onRetry` reports the upcoming attempt (first retry = 2); `RequestInfo.attempt` remains the attempt that just failed.
  - Re-authenticate before each retry, including after network errors.
  - Backoff sleep and re-auth moved outside the transport catch: no duplicate `onRequestEnd`/`onRetry`; cancellation and refresh errors propagate raw; no retries with stale headers.
  - Tests tightened to assert Authorization header values and cover the network retry path; hooks test pins both halves of the attempt pair.

<sup>Written for commit 03ae5de68c406600464d4535e62714be2d2339c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

