### PR TITLE
Ruby retry docs from ground truth; TS docstring examples typecheck

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -56,7 +56,7 @@ todo = account.todos.create(
 config = Basecamp::Config.new(
   base_url: "https://3.basecampapi.com",  # Default
   timeout: 30,                             # Request timeout in seconds
-  max_retries: 3,                          # Max retry attempts for GET requests
+  max_retries: 3,                          # Total request attempts for GET requests (including the initial request)
   base_delay: 1.0,                         # Base delay for exponential backoff
   max_pages: 10_000                         # Max pages for pagination
 )
@@ -71,7 +71,7 @@ client = Basecamp::Client.new(config: config, token_provider: token_provider)
 |--------|---------|-------------|
 | `base_url` | `https://3.basecampapi.com` | Basecamp API base URL |
 | `timeout` | `30` | HTTP request timeout (seconds) |
-| `max_retries` | `3` | Maximum retry attempts for GET requests |
+| `max_retries` | `3` | Total request attempts for GET requests (including the initial request) |
 | `base_delay` | `1.0` | Base delay for exponential backoff (seconds) |
 | `max_jitter` | `0.1` | Maximum random jitter added to delays |
 | `max_pages` | `10_000` | Maximum pages to fetch during pagination |
@@ -352,13 +352,15 @@ result = account.download_url(url)
 
 ## Retry Behavior
 
-GET requests automatically retry on transient failures with exponential backoff:
+Only plain GET requests retry — automatically, with exponential backoff. Mutation operations (POST, PUT, DELETE) do **not** retry to prevent data duplication, and the raw upload and download paths skip the retry loop entirely (the upload path is strictly one request; the download hop keeps only the one-shot 401 replay below).
 
-- **Retryable errors**: 429 (rate limit), 502, 503, 504 (gateway errors)
-- **Backoff**: Exponential with jitter (1s, 2s, 4s...)
-- **Rate limits**: Respects `Retry-After` header
-
-Mutation operations (POST, PUT, DELETE) do **not** retry to prevent data duplication.
+- **Which errors**: Retry keys off the error's `retryable?` classification, not a declared status list — 429 (rate limit), 500, 502, 503, 504, and any other 5xx all retry, as does `NetworkError` (connection failures, including DNS and connect-phase timeouts). Read timeouts are the exception: Faraday surfaces them as a status-less `ApiError` with `retryable? == false`, so a GET that times out mid-response fails on the first attempt. 400, 401, 403, 404, and 422 never retry.
+- **`max_retries`**: Total request attempts for GET requests, including the initial request — the default `3` means one initial attempt plus two retries. **`max_retries: 0` sends zero requests** and raises `Basecamp::ApiError` (`"Request failed after 0 attempts"`).
+- **Backoff**: Exponential with jitter — `base_delay * 2^(attempt - 1) + rand * max_jitter` — uncapped, bounded in practice by the attempt budget.
+- **Rate limits**: A 429's `Retry-After` header overrides the calculated backoff. Only 429 carries it: 5xx and network errors always use the exponential backoff.
+- **401 responses**: With a refresh-capable token provider, the SDK refreshes the token and replays the request **once** — for all methods, including mutations — outside the `max_retries` budget. A second 401 is surfaced. The raw upload path has no 401 replay.
+- **Per-operation metadata**: The retry policy operations declare (`retry_on` statuses, per-operation `max`) is inert in Ruby — every API GET issued through the client, including the Launchpad authorization fetch, rides the same classification-based loop bounded by `config.max_retries` alone. (The download flow's redirect hop and OAuth discovery use their own single-attempt transports.)
+- **`retryable?`**: Unlike SDKs where the error classification is only a hint for your own code, in Ruby an error's `retryable?` (and `retry_after`) is exactly what the transport acts on for GET requests.
 
 ## Error Handling
 
@@ -427,6 +429,8 @@ client = Basecamp::Client.new(
 | `BASECAMP_TOKEN` | OAuth access token |
 | `BASECAMP_ACCOUNT_ID` | Account ID |
 | `BASECAMP_BASE_URL` | API base URL (default: `https://3.basecampapi.com`) |
+| `BASECAMP_TIMEOUT` | Request timeout in seconds (default: `30`) |
+| `BASECAMP_MAX_RETRIES` | Total request attempts for GET requests, including the initial request (default: `3`) |
 
 ## Development
 

--- a/ruby/lib/basecamp/config.rb
+++ b/ruby/lib/basecamp/config.rb
@@ -24,7 +24,8 @@ module Basecamp
     # @return [Integer] request timeout in seconds
     attr_accessor :timeout
 
-    # @return [Integer] maximum retry attempts for GET requests
+    # @return [Integer] total request attempts for GET requests, including the
+    #   initial request (0 sends no requests at all and raises)
     attr_accessor :max_retries
 
     # @return [Float] initial backoff delay in seconds
@@ -48,7 +49,7 @@ module Basecamp
     #
     # @param base_url [String] API base URL
     # @param timeout [Integer] request timeout in seconds
-    # @param max_retries [Integer] maximum retry attempts
+    # @param max_retries [Integer] total request attempts for GET requests, including the initial request
     # @param base_delay [Float] initial backoff delay
     # @param max_jitter [Float] maximum jitter
     # @param max_pages [Integer] maximum pages to fetch
@@ -78,7 +79,7 @@ module Basecamp
     # Environment variables:
     # - BASECAMP_BASE_URL: API base URL
     # - BASECAMP_TIMEOUT: Request timeout in seconds
-    # - BASECAMP_MAX_RETRIES: Maximum retry attempts
+    # - BASECAMP_MAX_RETRIES: Total request attempts for GET requests, including the initial request
     #
     # @return [Config]
     def self.from_env

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -1164,7 +1164,7 @@ function sleep(ms: number): Promise<void> {
  *
  * const allProjects = await fetchAllPages(
  *   response.response,
- *   (r) => r.json()
+ *   (r) => r.json() as Promise<any[]>
  * );
  * ```
  */
@@ -1208,7 +1208,7 @@ export async function fetchAllPages<T>(
  *
  * @example
  * ```ts
- * for await (const page of paginateAll(response.response, (r) => r.json())) {
+ * for await (const page of paginateAll(response.response, (r) => r.json() as Promise<any[]>)) {
  *   console.log(`Processing ${page.length} items`);
  * }
  * ```


### PR DESCRIPTION
Fixes #510. Fixes #511.

## Ruby — Retry Behavior rewritten from the transport's ground truth

The old section was wrong twice over, both proven by driving the real `request_with_retry` loop with only `single_request` stubbed:

- "Retryable errors: 429, 502, 503, 504" — but the loop keys off `retryable?`, which is true for 500 and every other 5xx. Proof: a stubbed 500 on GET under `max_retries: 3` produced exactly **3 invocations**.
- `max_retries` documented as "max retry attempts" — it is the **total attempt budget**. Proof: `Config.new(max_retries: 0)` → **zero HTTP calls**, raising `Basecamp::ApiError: Request failed after 0 attempts`.

The rewrite also covers the contract corners the old text ignored: GET-only scope with the raw-path carve-outs; the **read-timeout exception** (Faraday maps read timeouts to `Faraday::TimeoutError < ServerError`, caught ahead of the `NetworkError` rescue and classified as a status-less, `retryable? == false` `ApiError` — proven empirically: stubbed read timeout → 1 attempt, no retry, vs `ConnectionFailed` → `NetworkError`, 3 attempts); uncapped exponential backoff; `Retry-After` only via 429; the one-shot 401 refresh replay for all methods outside the budget; per-operation retry metadata being inert in Ruby; and `retryable?` as the actual transport predicate (the inverse of Python's "classification is only a hint" framing). Config comment, options table, env-var table (adding the missing `BASECAMP_TIMEOUT`/`BASECAMP_MAX_RETRIES` rows), and the same misstatements in `config.rb`'s doc comments all aligned.

Ruby suite: 908 runs, 2079 assertions, 0 failures; rubocop clean.

## TypeScript — docstring examples pass strict typecheck

`fetchAllPages`/`paginateAll` `@example` blocks used bare `(r) => r.json()` — `Promise<unknown>` under Node fetch types, failing the parse callback's `Promise<T[]>` in any strict/NodeNext project configured like this repo (the defect #507 fixed in the README, still present in source). Red proof, the extracted examples verbatim under the repo-shaped harness:

```
error TS2322: Type 'Promise<unknown>' is not assignable to type 'Promise<unknown[]>'.
```

Green with the README's proven form `(r) => r.json() as Promise<any[]>`; `tsc --noEmit` clean; vitest 979 passed (local count).

These are the only two bare `r.json()` docstring sites in `typescript/src` (verified by grep — everything else is real code operating under the SDK's own types).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Ruby retry docs to match the actual transport behavior and fixes TypeScript pagination examples to pass strict typecheck. Clarifies `max_retries` semantics to prevent misleading guidance.

- **Bug Fixes**
  - Ruby docs: Rewrite Retry Behavior to reflect transport ground truth — GET-only; `retryable?`-based (429, all 5xx, network); no retry on read timeouts/4xx; `max_retries` = total attempts (0 sends none); exponential backoff with jitter and 429 `Retry-After`; one-shot 401 refresh; raw upload/download carve-outs; per-operation retry metadata ignored. Also align `config.rb` comments and README tables, adding `BASECAMP_TIMEOUT` and `BASECAMP_MAX_RETRIES`.
  - TypeScript: Make `fetchAllPages`/`paginateAll` `@example` blocks typecheck by casting `r.json()` to `Promise<any[]>`.

<sup>Written for commit 572bce95418e6028c66d9c78ba6649a09eb8202c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

