### PR TITLE
Close out memories-emptied-regression: settled contract is fully modeled

### DIFF
--- a/spec/api-gaps/README.md
+++ b/spec/api-gaps/README.md
@@ -47,7 +47,7 @@ making the absorption journey publicly auditable.
 | [rich-text-project-attachable](rich-text-project-attachable.md) | no-json-contract | 3e | low |
 | [recording-bubbleupable-field](recording-bubbleupable-field.md) | no-json-contract | 3e | low |
 | [todoset-completed-list-visibility](todoset-completed-list-visibility.md) | ambiguous | 3a | low |
-| [memories-emptied-regression](memories-emptied-regression.md) | addressed-in-bc3-pr-11628 | launch | high |
+| [memories-emptied-regression](memories-emptied-regression.md) | absorbed-in-sdk | launch | high |
 | [campfire-line-edit](campfire-line-edit.md) | absorbed-in-sdk | post-train | medium |
 | [todoset-direct-todo-create](todoset-direct-todo-create.md) | addressed-in-bc3-pr-12359 | post-train | medium |
 | [schedule-recurrence-writes](schedule-recurrence-writes.md) | addressed-in-bc3-pr-12359 | post-train | medium |
@@ -71,8 +71,9 @@ making the absorption journey publicly auditable.
 > train. Entries with plan phase `post-train` track contracts documented
 > after the train (BC3 #12359, merged 2026-07-22). `memories-emptied-regression` is a *subtractive* delta (a field BC4
 > populates that BC5 emptied), settled as **permanently empty by documented
-> contract** — its `addressed-in-bc3-pr-11628` records the PR that codified
-> the empty-placeholder contract, not a repopulation; see the entry.
+> contract** (codified by BC3 #11628) and closed out `absorbed-in-sdk` —
+> `GetMyNotificationsOutput.memories` models the settled contract; the flip
+> was docs-only, no repopulation; see the entry.
 > `stack-doc-and-smithy` is retained as a `confirmed-not-api-resource`
 > classification record (Stacks — renamed Folders in the product — are
 > web-only on both `four` and `master`).

--- a/spec/api-gaps/memories-emptied-regression.md
+++ b/spec/api-gaps/memories-emptied-regression.md
@@ -1,9 +1,11 @@
 ---
 gap: memories-emptied-regression
-status: addressed-in-bc3-pr-11628
+status: absorbed-in-sdk
 detected: 2026-05-27
 sdk_demand: high
 bc3_pr: 11628
+smithy_refs:
+  - "GetMyNotificationsOutput.memories member"
 bc3_refs:
   introduced_in: master
   routes:
@@ -17,9 +19,18 @@ bc3_refs:
 > **Not an additive gap.** Every other entry in this registry tracks *new* BC5
 > surface awaiting JSON coverage. This entry tracked a *subtractive* delta —
 > a field BC4 populates that BC5 emptied — and records how it settled:
-> **permanently empty by documented contract**. `addressed-in-bc3-pr-11628`
-> here means BC3 shipped the *documented contract for the empty field*, not a
-> repopulation.
+> **permanently empty by documented contract**. BC3 #11628 shipped the
+> *documented contract for the empty field*, not a repopulation.
+>
+> **Closed out as `absorbed-in-sdk` (docs-only):** everything the settled
+> contract demands of the SDK already exists — `GetMyNotificationsOutput.memories`
+> is modeled in the Smithy spec with a doc comment stating the permanently-empty
+> BC5 contract, and the successor surface shipped separately under
+> [[bubble-ups-surface]] (which keeps this entry's status and explanation
+> deliberately separate). No code changed in the closeout; this flip records
+> that the entry's own obligation — model the field, document the contract —
+> is discharged. The pre-#12442 §Q sequencing queue this narrative once fed is
+> superseded by the post-#504 absorption program.
 
 ## What's missing
 


### PR DESCRIPTION
C1 of the post-v0.11.0 absorption sprint — **docs-only**.

The subtractive `memories: []` delta settled as a documented permanent contract (BC3 #11628), and everything that contract demands of the SDK already exists: `GetMyNotificationsOutput.memories` is modeled with a doc comment stating the permanently-empty BC5 semantics, and the successor bubble-ups surface was absorbed separately (`bubble-ups-surface`, which explicitly keeps this entry's status separate — so this flip cites the entry's **own** smithy_ref, not that one's).

- Status: `addressed-in-bc3-pr-11628` → `absorbed-in-sdk` + `smithy_refs: [GetMyNotificationsOutput.memories member]`
- README table row + explanatory note updated
- Notes the §Q queue supersession
- No code re-added (grep-verified the member exists in spec + all generated trees); `make validate-api-gaps` clean (30 entries)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closed out the `memories-emptied-regression` gap by marking it absorbed in the SDK and documenting that `GetMyNotificationsOutput.memories` is permanently empty. Docs-only: updated the gap entry (status and `smithy_refs`), refreshed the README row/note, and noted the §Q queue supersession; no code changes.

<sup>Written for commit 34a03947f784f55348dd222b78c76d1888b58a5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

