### PR TITLE
Everything to-do/card listings take assignee_ids[] and due filters (#12442)

### DIFF
--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -777,47 +777,47 @@ func executeOperation(ctx context.Context, account *basecamp.AccountClient, tc T
 		return operationResult{err: err}
 
 	case "GetEverythingOverdueTodos":
-		_, err := account.Everything().OverdueTodos(ctx)
+		_, err := account.Everything().OverdueTodos(ctx, nil)
 		return operationResult{err: err}
 
 	case "GetEverythingOverdueCards":
-		_, err := account.Everything().OverdueCards(ctx)
+		_, err := account.Everything().OverdueCards(ctx, nil)
 		return operationResult{err: err}
 
 	case "GetEverythingOpenTodos":
-		_, err := account.Everything().OpenTodos(ctx, 0)
+		_, err := account.Everything().OpenTodos(ctx, 0, nil)
 		return operationResult{err: err}
 
 	case "GetEverythingCompletedTodos":
-		_, err := account.Everything().CompletedTodos(ctx, 0)
+		_, err := account.Everything().CompletedTodos(ctx, 0, nil)
 		return operationResult{err: err}
 
 	case "GetEverythingUnassignedTodos":
-		_, err := account.Everything().UnassignedTodos(ctx, 0)
+		_, err := account.Everything().UnassignedTodos(ctx, 0, nil)
 		return operationResult{err: err}
 
 	case "GetEverythingNoDueDateTodos":
-		_, err := account.Everything().NoDueDateTodos(ctx, 0)
+		_, err := account.Everything().NoDueDateTodos(ctx, 0, nil)
 		return operationResult{err: err}
 
 	case "GetEverythingOpenCards":
-		_, err := account.Everything().OpenCards(ctx, 0)
+		_, err := account.Everything().OpenCards(ctx, 0, nil)
 		return operationResult{err: err}
 
 	case "GetEverythingCompletedCards":
-		_, err := account.Everything().CompletedCards(ctx, 0)
+		_, err := account.Everything().CompletedCards(ctx, 0, nil)
 		return operationResult{err: err}
 
 	case "GetEverythingUnassignedCards":
-		_, err := account.Everything().UnassignedCards(ctx, 0)
+		_, err := account.Everything().UnassignedCards(ctx, 0, nil)
 		return operationResult{err: err}
 
 	case "GetEverythingNoDueDateCards":
-		_, err := account.Everything().NoDueDateCards(ctx, 0)
+		_, err := account.Everything().NoDueDateCards(ctx, 0, nil)
 		return operationResult{err: err}
 
 	case "GetEverythingNotNowCards":
-		_, err := account.Everything().NotNowCards(ctx, 0)
+		_, err := account.Everything().NotNowCards(ctx, 0, nil)
 		return operationResult{err: err}
 
 	default:

--- a/go/pkg/basecamp/everything.go
+++ b/go/pkg/basecamp/everything.go
@@ -349,7 +349,7 @@ func decodeEverythingFiles(body []byte) ([]EverythingFile, error) {
 
 // OverdueTodos returns every overdue to-do across all accessible projects — a
 // complete, oldest-due-date-first array (unpaginated, no Link-following).
-func (s *EverythingService) OverdueTodos(ctx context.Context) (result []Todo, err error) {
+func (s *EverythingService) OverdueTodos(ctx context.Context, filters *EverythingTaskFilters) (result []Todo, err error) {
 	op := OperationInfo{Service: "Everything", Operation: "OverdueTodos", ResourceType: "todo", IsMutation: false}
 	ctx, done, err := s.begin(ctx, op)
 	if err != nil {
@@ -357,7 +357,11 @@ func (s *EverythingService) OverdueTodos(ctx context.Context) (result []Todo, er
 	}
 	defer done(&err)
 
-	resp, err := s.client.parent.gen.GetEverythingOverdueTodosWithResponse(ctx, s.client.accountID)
+	params := (*generated.GetEverythingOverdueTodosParams)(nil)
+	if !filters.empty() {
+		params = &generated.GetEverythingOverdueTodosParams{Due: filters.due(), AssigneeIds: filters.assigneeIDs()}
+	}
+	resp, err := s.client.parent.gen.GetEverythingOverdueTodosWithResponse(ctx, s.client.accountID, params)
 	if err != nil {
 		return nil, err
 	}
@@ -375,7 +379,7 @@ func (s *EverythingService) OverdueTodos(ctx context.Context) (result []Todo, er
 
 // OverdueCards returns every overdue card across all accessible projects — a
 // complete, oldest-due-date-first array (unpaginated, no Link-following).
-func (s *EverythingService) OverdueCards(ctx context.Context) (result []Card, err error) {
+func (s *EverythingService) OverdueCards(ctx context.Context, filters *EverythingTaskFilters) (result []Card, err error) {
 	op := OperationInfo{Service: "Everything", Operation: "OverdueCards", ResourceType: "card", IsMutation: false}
 	ctx, done, err := s.begin(ctx, op)
 	if err != nil {
@@ -383,7 +387,11 @@ func (s *EverythingService) OverdueCards(ctx context.Context) (result []Card, er
 	}
 	defer done(&err)
 
-	resp, err := s.client.parent.gen.GetEverythingOverdueCardsWithResponse(ctx, s.client.accountID)
+	params := (*generated.GetEverythingOverdueCardsParams)(nil)
+	if !filters.empty() {
+		params = &generated.GetEverythingOverdueCardsParams{Due: filters.due(), AssigneeIds: filters.assigneeIDs()}
+	}
+	resp, err := s.client.parent.gen.GetEverythingOverdueCardsWithResponse(ctx, s.client.accountID, params)
 	if err != nil {
 		return nil, err
 	}
@@ -397,6 +405,35 @@ func (s *EverythingService) OverdueCards(ctx context.Context) (result []Card, er
 		}
 	}
 	return cards, nil
+}
+
+// EverythingTaskFilters narrows the everything to-do/card listings (BC3 #12442).
+// Both filters apply to every method in the family and compose.
+type EverythingTaskFilters struct {
+	// AssigneeIDs restricts to tasks assigned to at least one of these people.
+	// Assignees on nested steps are not considered.
+	AssigneeIDs []int64
+	// Due filters by due date: "with", "without", or "overdue".
+	Due string
+}
+
+func (f *EverythingTaskFilters) empty() bool {
+	return f == nil || (len(f.AssigneeIDs) == 0 && f.Due == "")
+}
+
+func (f *EverythingTaskFilters) due() string {
+	if f == nil {
+		return ""
+	}
+	return f.Due
+}
+
+func (f *EverythingTaskFilters) assigneeIDs() *[]int64 {
+	if f == nil || len(f.AssigneeIDs) == 0 {
+		return nil
+	}
+	ids := append([]int64(nil), f.AssigneeIDs...)
+	return &ids
 }
 
 // ---- bucket-grouped todo/card filter family ----
@@ -451,15 +488,15 @@ func bucketCardsGroupFromGenerated(g generated.BucketCardsGroup) BucketCardsGrou
 // OpenTodos returns active, incomplete to-dos across all accessible projects,
 // grouped by project (paginated). Pass a positive page to return only that page;
 // page 0 follows the Link header across all pages.
-func (s *EverythingService) OpenTodos(ctx context.Context, page int32) (result *BucketTodosGroupsPage, err error) {
+func (s *EverythingService) OpenTodos(ctx context.Context, page int32, filters *EverythingTaskFilters) (result *BucketTodosGroupsPage, err error) {
 	ctx, done, err := s.begin(ctx, OperationInfo{Service: "Everything", Operation: "OpenTodos", ResourceType: "todo"})
 	if err != nil {
 		return nil, err
 	}
 	defer done(&err)
 	var params *generated.GetEverythingOpenTodosParams
-	if page > 0 {
-		params = &generated.GetEverythingOpenTodosParams{Page: page}
+	if page > 0 || !filters.empty() {
+		params = &generated.GetEverythingOpenTodosParams{Page: page, Due: filters.due(), AssigneeIds: filters.assigneeIDs()}
 	}
 	r, err := s.client.parent.gen.GetEverythingOpenTodosWithResponse(ctx, s.client.accountID, params)
 	if err != nil {
@@ -469,15 +506,15 @@ func (s *EverythingService) OpenTodos(ctx context.Context, page int32) (result *
 }
 
 // CompletedTodos returns completed to-dos, grouped by project (paginated).
-func (s *EverythingService) CompletedTodos(ctx context.Context, page int32) (result *BucketTodosGroupsPage, err error) {
+func (s *EverythingService) CompletedTodos(ctx context.Context, page int32, filters *EverythingTaskFilters) (result *BucketTodosGroupsPage, err error) {
 	ctx, done, err := s.begin(ctx, OperationInfo{Service: "Everything", Operation: "CompletedTodos", ResourceType: "todo"})
 	if err != nil {
 		return nil, err
 	}
 	defer done(&err)
 	var params *generated.GetEverythingCompletedTodosParams
-	if page > 0 {
-		params = &generated.GetEverythingCompletedTodosParams{Page: page}
+	if page > 0 || !filters.empty() {
+		params = &generated.GetEverythingCompletedTodosParams{Page: page, Due: filters.due(), AssigneeIds: filters.assigneeIDs()}
 	}
 	r, err := s.client.parent.gen.GetEverythingCompletedTodosWithResponse(ctx, s.client.accountID, params)
 	if err != nil {
@@ -487,15 +524,15 @@ func (s *EverythingService) CompletedTodos(ctx context.Context, page int32) (res
 }
 
 // UnassignedTodos returns open, unassigned to-dos, grouped by project (paginated).
-func (s *EverythingService) UnassignedTodos(ctx context.Context, page int32) (result *BucketTodosGroupsPage, err error) {
+func (s *EverythingService) UnassignedTodos(ctx context.Context, page int32, filters *EverythingTaskFilters) (result *BucketTodosGroupsPage, err error) {
 	ctx, done, err := s.begin(ctx, OperationInfo{Service: "Everything", Operation: "UnassignedTodos", ResourceType: "todo"})
 	if err != nil {
 		return nil, err
 	}
 	defer done(&err)
 	var params *generated.GetEverythingUnassignedTodosParams
-	if page > 0 {
-		params = &generated.GetEverythingUnassignedTodosParams{Page: page}
+	if page > 0 || !filters.empty() {
+		params = &generated.GetEverythingUnassignedTodosParams{Page: page, Due: filters.due(), AssigneeIds: filters.assigneeIDs()}
 	}
 	r, err := s.client.parent.gen.GetEverythingUnassignedTodosWithResponse(ctx, s.client.accountID, params)
 	if err != nil {
@@ -505,15 +542,15 @@ func (s *EverythingService) UnassignedTodos(ctx context.Context, page int32) (re
 }
 
 // NoDueDateTodos returns open to-dos with no due date, grouped by project (paginated).
-func (s *EverythingService) NoDueDateTodos(ctx context.Context, page int32) (result *BucketTodosGroupsPage, err error) {
+func (s *EverythingService) NoDueDateTodos(ctx context.Context, page int32, filters *EverythingTaskFilters) (result *BucketTodosGroupsPage, err error) {
 	ctx, done, err := s.begin(ctx, OperationInfo{Service: "Everything", Operation: "NoDueDateTodos", ResourceType: "todo"})
 	if err != nil {
 		return nil, err
 	}
 	defer done(&err)
 	var params *generated.GetEverythingNoDueDateTodosParams
-	if page > 0 {
-		params = &generated.GetEverythingNoDueDateTodosParams{Page: page}
+	if page > 0 || !filters.empty() {
+		params = &generated.GetEverythingNoDueDateTodosParams{Page: page, Due: filters.due(), AssigneeIds: filters.assigneeIDs()}
 	}
 	r, err := s.client.parent.gen.GetEverythingNoDueDateTodosWithResponse(ctx, s.client.accountID, params)
 	if err != nil {
@@ -523,15 +560,15 @@ func (s *EverythingService) NoDueDateTodos(ctx context.Context, page int32) (res
 }
 
 // OpenCards returns incomplete cards in active columns, grouped by project (paginated).
-func (s *EverythingService) OpenCards(ctx context.Context, page int32) (result *BucketCardsGroupsPage, err error) {
+func (s *EverythingService) OpenCards(ctx context.Context, page int32, filters *EverythingTaskFilters) (result *BucketCardsGroupsPage, err error) {
 	ctx, done, err := s.begin(ctx, OperationInfo{Service: "Everything", Operation: "OpenCards", ResourceType: "card"})
 	if err != nil {
 		return nil, err
 	}
 	defer done(&err)
 	var params *generated.GetEverythingOpenCardsParams
-	if page > 0 {
-		params = &generated.GetEverythingOpenCardsParams{Page: page}
+	if page > 0 || !filters.empty() {
+		params = &generated.GetEverythingOpenCardsParams{Page: page, Due: filters.due(), AssigneeIds: filters.assigneeIDs()}
 	}
 	r, err := s.client.parent.gen.GetEverythingOpenCardsWithResponse(ctx, s.client.accountID, params)
 	if err != nil {
@@ -541,15 +578,15 @@ func (s *EverythingService) OpenCards(ctx context.Context, page int32) (result *
 }
 
 // CompletedCards returns completed cards, grouped by project (paginated).
-func (s *EverythingService) CompletedCards(ctx context.Context, page int32) (result *BucketCardsGroupsPage, err error) {
+func (s *EverythingService) CompletedCards(ctx context.Context, page int32, filters *EverythingTaskFilters) (result *BucketCardsGroupsPage, err error) {
 	ctx, done, err := s.begin(ctx, OperationInfo{Service: "Everything", Operation: "CompletedCards", ResourceType: "card"})
 	if err != nil {
 		return nil, err
 	}
 	defer done(&err)
 	var params *generated.GetEverythingCompletedCardsParams
-	if page > 0 {
-		params = &generated.GetEverythingCompletedCardsParams{Page: page}
+	if page > 0 || !filters.empty() {
+		params = &generated.GetEverythingCompletedCardsParams{Page: page, Due: filters.due(), AssigneeIds: filters.assigneeIDs()}
 	}
 	r, err := s.client.parent.gen.GetEverythingCompletedCardsWithResponse(ctx, s.client.accountID, params)
 	if err != nil {
@@ -559,15 +596,15 @@ func (s *EverythingService) CompletedCards(ctx context.Context, page int32) (res
 }
 
 // UnassignedCards returns open, unassigned cards, grouped by project (paginated).
-func (s *EverythingService) UnassignedCards(ctx context.Context, page int32) (result *BucketCardsGroupsPage, err error) {
+func (s *EverythingService) UnassignedCards(ctx context.Context, page int32, filters *EverythingTaskFilters) (result *BucketCardsGroupsPage, err error) {
 	ctx, done, err := s.begin(ctx, OperationInfo{Service: "Everything", Operation: "UnassignedCards", ResourceType: "card"})
 	if err != nil {
 		return nil, err
 	}
 	defer done(&err)
 	var params *generated.GetEverythingUnassignedCardsParams
-	if page > 0 {
-		params = &generated.GetEverythingUnassignedCardsParams{Page: page}
+	if page > 0 || !filters.empty() {
+		params = &generated.GetEverythingUnassignedCardsParams{Page: page, Due: filters.due(), AssigneeIds: filters.assigneeIDs()}
 	}
 	r, err := s.client.parent.gen.GetEverythingUnassignedCardsWithResponse(ctx, s.client.accountID, params)
 	if err != nil {
@@ -577,15 +614,15 @@ func (s *EverythingService) UnassignedCards(ctx context.Context, page int32) (re
 }
 
 // NoDueDateCards returns open cards with no due date, grouped by project (paginated).
-func (s *EverythingService) NoDueDateCards(ctx context.Context, page int32) (result *BucketCardsGroupsPage, err error) {
+func (s *EverythingService) NoDueDateCards(ctx context.Context, page int32, filters *EverythingTaskFilters) (result *BucketCardsGroupsPage, err error) {
 	ctx, done, err := s.begin(ctx, OperationInfo{Service: "Everything", Operation: "NoDueDateCards", ResourceType: "card"})
 	if err != nil {
 		return nil, err
 	}
 	defer done(&err)
 	var params *generated.GetEverythingNoDueDateCardsParams
-	if page > 0 {
-		params = &generated.GetEverythingNoDueDateCardsParams{Page: page}
+	if page > 0 || !filters.empty() {
+		params = &generated.GetEverythingNoDueDateCardsParams{Page: page, Due: filters.due(), AssigneeIds: filters.assigneeIDs()}
 	}
 	r, err := s.client.parent.gen.GetEverythingNoDueDateCardsWithResponse(ctx, s.client.accountID, params)
 	if err != nil {
@@ -596,15 +633,15 @@ func (s *EverythingService) NoDueDateCards(ctx context.Context, page int32) (res
 
 // NotNowCards returns cards parked in a project's "Not now" column, grouped by
 // project (paginated).
-func (s *EverythingService) NotNowCards(ctx context.Context, page int32) (result *BucketCardsGroupsPage, err error) {
+func (s *EverythingService) NotNowCards(ctx context.Context, page int32, filters *EverythingTaskFilters) (result *BucketCardsGroupsPage, err error) {
 	ctx, done, err := s.begin(ctx, OperationInfo{Service: "Everything", Operation: "NotNowCards", ResourceType: "card"})
 	if err != nil {
 		return nil, err
 	}
 	defer done(&err)
 	var params *generated.GetEverythingNotNowCardsParams
-	if page > 0 {
-		params = &generated.GetEverythingNotNowCardsParams{Page: page}
+	if page > 0 || !filters.empty() {
+		params = &generated.GetEverythingNotNowCardsParams{Page: page, Due: filters.due(), AssigneeIds: filters.assigneeIDs()}
 	}
 	r, err := s.client.parent.gen.GetEverythingNotNowCardsWithResponse(ctx, s.client.accountID, params)
 	if err != nil {

--- a/go/pkg/basecamp/everything_test.go
+++ b/go/pkg/basecamp/everything_test.go
@@ -97,7 +97,7 @@ func TestEverythingService_OverdueTodos_Unpaginated(t *testing.T) {
 		]`))
 	})
 
-	todos, err := svc.OverdueTodos(context.Background())
+	todos, err := svc.OverdueTodos(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -202,6 +202,61 @@ func TestEverythingService_Files_Filters(t *testing.T) {
 	ids := q["people_ids[]"]
 	if len(ids) != 2 || ids[0] != "101" || ids[1] != "202" {
 		t.Errorf("expected people_ids[]=101,202, got %v (query %q)", ids, captured)
+	}
+}
+
+// TestEverythingService_TaskFilters verifies the assignee_ids[] and due query
+// parameters reach the wire on a grouped listing (#12442).
+func TestEverythingService_TaskFilters(t *testing.T) {
+	var captured string
+	svc, _ := everythingTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`[]`))
+	})
+
+	filters := &EverythingTaskFilters{AssigneeIDs: []int64{101, 202}, Due: "overdue"}
+	if _, err := svc.OpenTodos(context.Background(), 1, filters); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	q, _ := url.ParseQuery(captured)
+	if q.Get("due") != "overdue" {
+		t.Errorf("expected due=overdue, got query %q", captured)
+	}
+	ids := q["assignee_ids[]"]
+	if len(ids) != 2 || ids[0] != "101" || ids[1] != "202" {
+		t.Errorf("expected assignee_ids[]=101,202, got %v (query %q)", ids, captured)
+	}
+}
+
+// TestEverythingService_TaskFilters_Overdue verifies the filters also reach the
+// wire on the unpaginated overdue family, and that nil filters add no query.
+func TestEverythingService_TaskFilters_Overdue(t *testing.T) {
+	var captured string
+	svc, _ := everythingTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`[]`))
+	})
+
+	if _, err := svc.OverdueCards(context.Background(), &EverythingTaskFilters{AssigneeIDs: []int64{7}}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	q, _ := url.ParseQuery(captured)
+	if ids := q["assignee_ids[]"]; len(ids) != 1 || ids[0] != "7" {
+		t.Errorf("expected assignee_ids[]=7, got %v (query %q)", ids, captured)
+	}
+	if q.Has("due") {
+		t.Errorf("expected no due param when unset, got query %q", captured)
+	}
+
+	if _, err := svc.OverdueTodos(context.Background(), nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if captured != "" {
+		t.Errorf("expected no query params with nil filters, got %q", captured)
 	}
 }
 
@@ -351,7 +406,7 @@ func TestEverythingService_OpenTodos_BucketGrouped_MultiPage(t *testing.T) {
 	})
 	serverURL = url
 
-	result, err := svc.OpenTodos(context.Background(), 0)
+	result, err := svc.OpenTodos(context.Background(), 0, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -391,7 +446,7 @@ func TestEverythingService_NotNowCards_BucketGrouped(t *testing.T) {
 		_, _ = w.Write([]byte(`[{"bucket":{"id":30,"name":"Kanban Project","type":"Project"},"cards":[{"id":7,"title":"Parked card","completed":false,"steps":[{"id":200,"title":"Do later","completed":false}]}]}]`))
 	})
 
-	result, err := svc.NotNowCards(context.Background(), 1)
+	result, err := svc.NotNowCards(context.Background(), 1, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -420,7 +475,7 @@ func TestEverythingService_OpenTodos_PassesPageParam(t *testing.T) {
 		w.WriteHeader(200)
 		_, _ = w.Write([]byte(`[]`))
 	})
-	if _, err := svc.OpenTodos(context.Background(), 4); err != nil {
+	if _, err := svc.OpenTodos(context.Background(), 4, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if q, _ := url.ParseQuery(captured); q.Get("page") != "4" {
@@ -438,7 +493,7 @@ func TestEverythingService_BucketGroup_RequiredFieldsRoundTrip(t *testing.T) {
 		w.WriteHeader(200)
 		_, _ = w.Write([]byte(`[{"bucket":{"id":40,"name":"Empty Project","type":"Project"},"todos":[]}]`))
 	})
-	result, err := svc.OpenTodos(context.Background(), 1)
+	result, err := svc.OpenTodos(context.Background(), 1, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -3267,30 +3267,75 @@ type CreateAttachmentParams struct {
 
 // GetEverythingCompletedCardsParams defines parameters for GetEverythingCompletedCards.
 type GetEverythingCompletedCardsParams struct {
+	// AssigneeIds Restrict to tasks assigned to at least one of the given people (repeatable).
+	// Assignees on nested steps are not considered.
+	AssigneeIds *[]int64 `form:"assignee_ids[],omitempty" json:"assignee_ids[],omitempty"`
+
+	// Due Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+	Due string `form:"due,omitempty" json:"due,omitempty"`
+
 	// Page Page number for paginating through results. Defaults to 1.
 	Page int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetEverythingNoDueDateCardsParams defines parameters for GetEverythingNoDueDateCards.
 type GetEverythingNoDueDateCardsParams struct {
+	// AssigneeIds Restrict to tasks assigned to at least one of the given people (repeatable).
+	// Assignees on nested steps are not considered.
+	AssigneeIds *[]int64 `form:"assignee_ids[],omitempty" json:"assignee_ids[],omitempty"`
+
+	// Due Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+	Due string `form:"due,omitempty" json:"due,omitempty"`
+
 	// Page Page number for paginating through results. Defaults to 1.
 	Page int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetEverythingNotNowCardsParams defines parameters for GetEverythingNotNowCards.
 type GetEverythingNotNowCardsParams struct {
+	// AssigneeIds Restrict to tasks assigned to at least one of the given people (repeatable).
+	// Assignees on nested steps are not considered.
+	AssigneeIds *[]int64 `form:"assignee_ids[],omitempty" json:"assignee_ids[],omitempty"`
+
+	// Due Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+	Due string `form:"due,omitempty" json:"due,omitempty"`
+
 	// Page Page number for paginating through results. Defaults to 1.
 	Page int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetEverythingOpenCardsParams defines parameters for GetEverythingOpenCards.
 type GetEverythingOpenCardsParams struct {
+	// AssigneeIds Restrict to tasks assigned to at least one of the given people (repeatable).
+	// Assignees on nested steps are not considered.
+	AssigneeIds *[]int64 `form:"assignee_ids[],omitempty" json:"assignee_ids[],omitempty"`
+
+	// Due Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+	Due string `form:"due,omitempty" json:"due,omitempty"`
+
 	// Page Page number for paginating through results. Defaults to 1.
 	Page int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
+// GetEverythingOverdueCardsParams defines parameters for GetEverythingOverdueCards.
+type GetEverythingOverdueCardsParams struct {
+	// AssigneeIds Restrict to tasks assigned to at least one of the given people (repeatable).
+	// Assignees on nested steps are not considered.
+	AssigneeIds *[]int64 `form:"assignee_ids[],omitempty" json:"assignee_ids[],omitempty"`
+
+	// Due Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+	Due string `form:"due,omitempty" json:"due,omitempty"`
+}
+
 // GetEverythingUnassignedCardsParams defines parameters for GetEverythingUnassignedCards.
 type GetEverythingUnassignedCardsParams struct {
+	// AssigneeIds Restrict to tasks assigned to at least one of the given people (repeatable).
+	// Assignees on nested steps are not considered.
+	AssigneeIds *[]int64 `form:"assignee_ids[],omitempty" json:"assignee_ids[],omitempty"`
+
+	// Due Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+	Due string `form:"due,omitempty" json:"due,omitempty"`
+
 	// Page Page number for paginating through results. Defaults to 1.
 	Page int32 `form:"page,omitempty" json:"page,omitempty"`
 }
@@ -3542,24 +3587,62 @@ type ListTodosParams struct {
 
 // GetEverythingCompletedTodosParams defines parameters for GetEverythingCompletedTodos.
 type GetEverythingCompletedTodosParams struct {
+	// AssigneeIds Restrict to tasks assigned to at least one of the given people (repeatable).
+	// Assignees on nested steps are not considered.
+	AssigneeIds *[]int64 `form:"assignee_ids[],omitempty" json:"assignee_ids[],omitempty"`
+
+	// Due Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+	Due string `form:"due,omitempty" json:"due,omitempty"`
+
 	// Page Page number for paginating through results. Defaults to 1.
 	Page int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetEverythingNoDueDateTodosParams defines parameters for GetEverythingNoDueDateTodos.
 type GetEverythingNoDueDateTodosParams struct {
+	// AssigneeIds Restrict to tasks assigned to at least one of the given people (repeatable).
+	// Assignees on nested steps are not considered.
+	AssigneeIds *[]int64 `form:"assignee_ids[],omitempty" json:"assignee_ids[],omitempty"`
+
+	// Due Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+	Due string `form:"due,omitempty" json:"due,omitempty"`
+
 	// Page Page number for paginating through results. Defaults to 1.
 	Page int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetEverythingOpenTodosParams defines parameters for GetEverythingOpenTodos.
 type GetEverythingOpenTodosParams struct {
+	// AssigneeIds Restrict to tasks assigned to at least one of the given people (repeatable).
+	// Assignees on nested steps are not considered.
+	AssigneeIds *[]int64 `form:"assignee_ids[],omitempty" json:"assignee_ids[],omitempty"`
+
+	// Due Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+	Due string `form:"due,omitempty" json:"due,omitempty"`
+
 	// Page Page number for paginating through results. Defaults to 1.
 	Page int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
+// GetEverythingOverdueTodosParams defines parameters for GetEverythingOverdueTodos.
+type GetEverythingOverdueTodosParams struct {
+	// AssigneeIds Restrict to tasks assigned to at least one of the given people (repeatable).
+	// Assignees on nested steps are not considered.
+	AssigneeIds *[]int64 `form:"assignee_ids[],omitempty" json:"assignee_ids[],omitempty"`
+
+	// Due Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+	Due string `form:"due,omitempty" json:"due,omitempty"`
+}
+
 // GetEverythingUnassignedTodosParams defines parameters for GetEverythingUnassignedTodos.
 type GetEverythingUnassignedTodosParams struct {
+	// AssigneeIds Restrict to tasks assigned to at least one of the given people (repeatable).
+	// Assignees on nested steps are not considered.
+	AssigneeIds *[]int64 `form:"assignee_ids[],omitempty" json:"assignee_ids[],omitempty"`
+
+	// Due Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+	Due string `form:"due,omitempty" json:"due,omitempty"`
+
 	// Page Page number for paginating through results. Defaults to 1.
 	Page int32 `form:"page,omitempty" json:"page,omitempty"`
 }
@@ -4498,7 +4581,7 @@ type ClientInterface interface {
 	GetEverythingOpenCards(ctx context.Context, accountId string, params *GetEverythingOpenCardsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetEverythingOverdueCards request
-	GetEverythingOverdueCards(ctx context.Context, accountId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetEverythingOverdueCards(ctx context.Context, accountId string, params *GetEverythingOverdueCardsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetEverythingUnassignedCards request
 	GetEverythingUnassignedCards(ctx context.Context, accountId string, params *GetEverythingUnassignedCardsParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -5053,7 +5136,7 @@ type ClientInterface interface {
 	GetEverythingOpenTodos(ctx context.Context, accountId string, params *GetEverythingOpenTodosParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetEverythingOverdueTodos request
-	GetEverythingOverdueTodos(ctx context.Context, accountId string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	GetEverythingOverdueTodos(ctx context.Context, accountId string, params *GetEverythingOverdueTodosParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetEverythingUnassignedTodos request
 	GetEverythingUnassignedTodos(ctx context.Context, accountId string, params *GetEverythingUnassignedTodosParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -5851,10 +5934,10 @@ func (c *Client) GetEverythingOpenCards(ctx context.Context, accountId string, p
 
 // GetEverythingOverdueCards is marked as idempotent and will be retried on transient failures.
 
-func (c *Client) GetEverythingOverdueCards(ctx context.Context, accountId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+func (c *Client) GetEverythingOverdueCards(ctx context.Context, accountId string, params *GetEverythingOverdueCardsParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
-		return NewGetEverythingOverdueCardsRequest(c.Server, accountId)
+		return NewGetEverythingOverdueCardsRequest(c.Server, accountId, params)
 	}, true, "GetEverythingOverdueCards", reqEditors...)
 
 }
@@ -8007,10 +8090,10 @@ func (c *Client) GetEverythingOpenTodos(ctx context.Context, accountId string, p
 
 // GetEverythingOverdueTodos is marked as idempotent and will be retried on transient failures.
 
-func (c *Client) GetEverythingOverdueTodos(ctx context.Context, accountId string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+func (c *Client) GetEverythingOverdueTodos(ctx context.Context, accountId string, params *GetEverythingOverdueTodosParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 
 	return c.doWithRetry(ctx, func() (*http.Request, error) {
-		return NewGetEverythingOverdueTodosRequest(c.Server, accountId)
+		return NewGetEverythingOverdueTodosRequest(c.Server, accountId, params)
 	}, true, "GetEverythingOverdueTodos", reqEditors...)
 
 }
@@ -10292,6 +10375,38 @@ func NewGetEverythingCompletedCardsRequest(server string, accountId string, para
 	if params != nil {
 		queryValues := queryURL.Query()
 
+		if params.AssigneeIds != nil && len(*params.AssigneeIds) > 0 {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "assignee_ids[]", runtime.ParamLocationQuery, *params.AssigneeIds); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Due != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "due", runtime.ParamLocationQuery, params.Due); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		if params.Page != 0 {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
@@ -10347,6 +10462,38 @@ func NewGetEverythingNoDueDateCardsRequest(server string, accountId string, para
 
 	if params != nil {
 		queryValues := queryURL.Query()
+
+		if params.AssigneeIds != nil && len(*params.AssigneeIds) > 0 {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "assignee_ids[]", runtime.ParamLocationQuery, *params.AssigneeIds); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Due != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "due", runtime.ParamLocationQuery, params.Due); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
 
 		if params.Page != 0 {
 
@@ -10404,6 +10551,38 @@ func NewGetEverythingNotNowCardsRequest(server string, accountId string, params 
 	if params != nil {
 		queryValues := queryURL.Query()
 
+		if params.AssigneeIds != nil && len(*params.AssigneeIds) > 0 {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "assignee_ids[]", runtime.ParamLocationQuery, *params.AssigneeIds); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Due != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "due", runtime.ParamLocationQuery, params.Due); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		if params.Page != 0 {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
@@ -10460,6 +10639,38 @@ func NewGetEverythingOpenCardsRequest(server string, accountId string, params *G
 	if params != nil {
 		queryValues := queryURL.Query()
 
+		if params.AssigneeIds != nil && len(*params.AssigneeIds) > 0 {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "assignee_ids[]", runtime.ParamLocationQuery, *params.AssigneeIds); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Due != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "due", runtime.ParamLocationQuery, params.Due); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		if params.Page != 0 {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
@@ -10488,7 +10699,7 @@ func NewGetEverythingOpenCardsRequest(server string, accountId string, params *G
 }
 
 // NewGetEverythingOverdueCardsRequest generates requests for GetEverythingOverdueCards
-func NewGetEverythingOverdueCardsRequest(server string, accountId string) (*http.Request, error) {
+func NewGetEverythingOverdueCardsRequest(server string, accountId string, params *GetEverythingOverdueCardsParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -10511,6 +10722,44 @@ func NewGetEverythingOverdueCardsRequest(server string, accountId string) (*http
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.AssigneeIds != nil && len(*params.AssigneeIds) > 0 {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "assignee_ids[]", runtime.ParamLocationQuery, *params.AssigneeIds); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Due != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "due", runtime.ParamLocationQuery, params.Due); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -10549,6 +10798,38 @@ func NewGetEverythingUnassignedCardsRequest(server string, accountId string, par
 
 	if params != nil {
 		queryValues := queryURL.Query()
+
+		if params.AssigneeIds != nil && len(*params.AssigneeIds) > 0 {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "assignee_ids[]", runtime.ParamLocationQuery, *params.AssigneeIds); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Due != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "due", runtime.ParamLocationQuery, params.Due); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
 
 		if params.Page != 0 {
 
@@ -18260,6 +18541,38 @@ func NewGetEverythingCompletedTodosRequest(server string, accountId string, para
 	if params != nil {
 		queryValues := queryURL.Query()
 
+		if params.AssigneeIds != nil && len(*params.AssigneeIds) > 0 {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "assignee_ids[]", runtime.ParamLocationQuery, *params.AssigneeIds); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Due != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "due", runtime.ParamLocationQuery, params.Due); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		if params.Page != 0 {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
@@ -18315,6 +18628,38 @@ func NewGetEverythingNoDueDateTodosRequest(server string, accountId string, para
 
 	if params != nil {
 		queryValues := queryURL.Query()
+
+		if params.AssigneeIds != nil && len(*params.AssigneeIds) > 0 {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "assignee_ids[]", runtime.ParamLocationQuery, *params.AssigneeIds); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Due != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "due", runtime.ParamLocationQuery, params.Due); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
 
 		if params.Page != 0 {
 
@@ -18372,6 +18717,38 @@ func NewGetEverythingOpenTodosRequest(server string, accountId string, params *G
 	if params != nil {
 		queryValues := queryURL.Query()
 
+		if params.AssigneeIds != nil && len(*params.AssigneeIds) > 0 {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "assignee_ids[]", runtime.ParamLocationQuery, *params.AssigneeIds); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Due != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "due", runtime.ParamLocationQuery, params.Due); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
 		if params.Page != 0 {
 
 			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "page", runtime.ParamLocationQuery, params.Page); err != nil {
@@ -18400,7 +18777,7 @@ func NewGetEverythingOpenTodosRequest(server string, accountId string, params *G
 }
 
 // NewGetEverythingOverdueTodosRequest generates requests for GetEverythingOverdueTodos
-func NewGetEverythingOverdueTodosRequest(server string, accountId string) (*http.Request, error) {
+func NewGetEverythingOverdueTodosRequest(server string, accountId string, params *GetEverythingOverdueTodosParams) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -18423,6 +18800,44 @@ func NewGetEverythingOverdueTodosRequest(server string, accountId string) (*http
 	queryURL, err := serverURL.Parse(operationPath)
 	if err != nil {
 		return nil, err
+	}
+
+	if params != nil {
+		queryValues := queryURL.Query()
+
+		if params.AssigneeIds != nil && len(*params.AssigneeIds) > 0 {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "assignee_ids[]", runtime.ParamLocationQuery, *params.AssigneeIds); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Due != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "due", runtime.ParamLocationQuery, params.Due); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		queryURL.RawQuery = queryValues.Encode()
 	}
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
@@ -18461,6 +18876,38 @@ func NewGetEverythingUnassignedTodosRequest(server string, accountId string, par
 
 	if params != nil {
 		queryValues := queryURL.Query()
+
+		if params.AssigneeIds != nil && len(*params.AssigneeIds) > 0 {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "assignee_ids[]", runtime.ParamLocationQuery, *params.AssigneeIds); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
+
+		if params.Due != "" {
+
+			if queryFrag, err := runtime.StyleParamWithLocation("form", true, "due", runtime.ParamLocationQuery, params.Due); err != nil {
+				return nil, err
+			} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+				return nil, err
+			} else {
+				for k, v := range parsed {
+					for _, v2 := range v {
+						queryValues.Add(k, v2)
+					}
+				}
+			}
+
+		}
 
 		if params.Page != 0 {
 
@@ -21560,7 +22007,7 @@ type ClientWithResponsesInterface interface {
 	GetEverythingOpenCardsWithResponse(ctx context.Context, accountId string, params *GetEverythingOpenCardsParams, reqEditors ...RequestEditorFn) (*GetEverythingOpenCardsResponse, error)
 
 	// GetEverythingOverdueCardsWithResponse request
-	GetEverythingOverdueCardsWithResponse(ctx context.Context, accountId string, reqEditors ...RequestEditorFn) (*GetEverythingOverdueCardsResponse, error)
+	GetEverythingOverdueCardsWithResponse(ctx context.Context, accountId string, params *GetEverythingOverdueCardsParams, reqEditors ...RequestEditorFn) (*GetEverythingOverdueCardsResponse, error)
 
 	// GetEverythingUnassignedCardsWithResponse request
 	GetEverythingUnassignedCardsWithResponse(ctx context.Context, accountId string, params *GetEverythingUnassignedCardsParams, reqEditors ...RequestEditorFn) (*GetEverythingUnassignedCardsResponse, error)
@@ -22115,7 +22562,7 @@ type ClientWithResponsesInterface interface {
 	GetEverythingOpenTodosWithResponse(ctx context.Context, accountId string, params *GetEverythingOpenTodosParams, reqEditors ...RequestEditorFn) (*GetEverythingOpenTodosResponse, error)
 
 	// GetEverythingOverdueTodosWithResponse request
-	GetEverythingOverdueTodosWithResponse(ctx context.Context, accountId string, reqEditors ...RequestEditorFn) (*GetEverythingOverdueTodosResponse, error)
+	GetEverythingOverdueTodosWithResponse(ctx context.Context, accountId string, params *GetEverythingOverdueTodosParams, reqEditors ...RequestEditorFn) (*GetEverythingOverdueTodosResponse, error)
 
 	// GetEverythingUnassignedTodosWithResponse request
 	GetEverythingUnassignedTodosWithResponse(ctx context.Context, accountId string, params *GetEverythingUnassignedTodosParams, reqEditors ...RequestEditorFn) (*GetEverythingUnassignedTodosResponse, error)
@@ -30447,8 +30894,8 @@ func (c *ClientWithResponses) GetEverythingOpenCardsWithResponse(ctx context.Con
 }
 
 // GetEverythingOverdueCardsWithResponse request returning *GetEverythingOverdueCardsResponse
-func (c *ClientWithResponses) GetEverythingOverdueCardsWithResponse(ctx context.Context, accountId string, reqEditors ...RequestEditorFn) (*GetEverythingOverdueCardsResponse, error) {
-	rsp, err := c.GetEverythingOverdueCards(ctx, accountId, reqEditors...)
+func (c *ClientWithResponses) GetEverythingOverdueCardsWithResponse(ctx context.Context, accountId string, params *GetEverythingOverdueCardsParams, reqEditors ...RequestEditorFn) (*GetEverythingOverdueCardsResponse, error) {
+	rsp, err := c.GetEverythingOverdueCards(ctx, accountId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -32202,8 +32649,8 @@ func (c *ClientWithResponses) GetEverythingOpenTodosWithResponse(ctx context.Con
 }
 
 // GetEverythingOverdueTodosWithResponse request returning *GetEverythingOverdueTodosResponse
-func (c *ClientWithResponses) GetEverythingOverdueTodosWithResponse(ctx context.Context, accountId string, reqEditors ...RequestEditorFn) (*GetEverythingOverdueTodosResponse, error) {
-	rsp, err := c.GetEverythingOverdueTodos(ctx, accountId, reqEditors...)
+func (c *ClientWithResponses) GetEverythingOverdueTodosWithResponse(ctx context.Context, accountId string, params *GetEverythingOverdueTodosParams, reqEditors ...RequestEditorFn) (*GetEverythingOverdueTodosResponse, error) {
+	rsp, err := c.GetEverythingOverdueTodos(ctx, accountId, params, reqEditors...)
 	if err != nil {
 		return nil, err
 	}

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/Types.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/Types.kt
@@ -219,6 +219,8 @@ data class CreateDocumentBody(
 
 /** Options for GetEverythingCompletedCards. */
 data class GetEverythingCompletedCardsOptions(
+    val assigneeIds: List<Long>? = null,
+    val due: String? = null,
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -227,6 +229,8 @@ data class GetEverythingCompletedCardsOptions(
 
 /** Options for GetEverythingNoDueDateCards. */
 data class GetEverythingNoDueDateCardsOptions(
+    val assigneeIds: List<Long>? = null,
+    val due: String? = null,
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -235,6 +239,8 @@ data class GetEverythingNoDueDateCardsOptions(
 
 /** Options for GetEverythingNotNowCards. */
 data class GetEverythingNotNowCardsOptions(
+    val assigneeIds: List<Long>? = null,
+    val due: String? = null,
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -243,14 +249,25 @@ data class GetEverythingNotNowCardsOptions(
 
 /** Options for GetEverythingOpenCards. */
 data class GetEverythingOpenCardsOptions(
+    val assigneeIds: List<Long>? = null,
+    val due: String? = null,
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
     fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
 }
 
+/** Options for GetEverythingOverdueCards. */
+data class GetEverythingOverdueCardsOptions(
+    val assigneeIds: List<Long>? = null,
+    val due: String? = null
+) {
+}
+
 /** Options for GetEverythingUnassignedCards. */
 data class GetEverythingUnassignedCardsOptions(
+    val assigneeIds: List<Long>? = null,
+    val due: String? = null,
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -301,6 +318,8 @@ data class GetEverythingMessagesOptions(
 
 /** Options for GetEverythingCompletedTodos. */
 data class GetEverythingCompletedTodosOptions(
+    val assigneeIds: List<Long>? = null,
+    val due: String? = null,
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -309,6 +328,8 @@ data class GetEverythingCompletedTodosOptions(
 
 /** Options for GetEverythingNoDueDateTodos. */
 data class GetEverythingNoDueDateTodosOptions(
+    val assigneeIds: List<Long>? = null,
+    val due: String? = null,
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -317,14 +338,25 @@ data class GetEverythingNoDueDateTodosOptions(
 
 /** Options for GetEverythingOpenTodos. */
 data class GetEverythingOpenTodosOptions(
+    val assigneeIds: List<Long>? = null,
+    val due: String? = null,
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
     fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
 }
 
+/** Options for GetEverythingOverdueTodos. */
+data class GetEverythingOverdueTodosOptions(
+    val assigneeIds: List<Long>? = null,
+    val due: String? = null
+) {
+}
+
 /** Options for GetEverythingUnassignedTodos. */
 data class GetEverythingUnassignedTodosOptions(
+    val assigneeIds: List<Long>? = null,
+    val due: String? = null,
     val page: Long? = null,
     val maxItems: Int? = null
 ) {

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/everything.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/everything.kt
@@ -26,6 +26,8 @@ class EverythingService(client: AccountClient) : BaseService(client) {
             resourceId = null,
         )
         val qs = buildQueryString(
+            "assignee_ids[]" to options?.assigneeIds,
+            "due" to options?.due,
             "page" to options?.page,
         )
         return requestPaginated(info, options?.toPaginationOptions(), {
@@ -49,6 +51,8 @@ class EverythingService(client: AccountClient) : BaseService(client) {
             resourceId = null,
         )
         val qs = buildQueryString(
+            "assignee_ids[]" to options?.assigneeIds,
+            "due" to options?.due,
             "page" to options?.page,
         )
         return requestPaginated(info, options?.toPaginationOptions(), {
@@ -72,6 +76,8 @@ class EverythingService(client: AccountClient) : BaseService(client) {
             resourceId = null,
         )
         val qs = buildQueryString(
+            "assignee_ids[]" to options?.assigneeIds,
+            "due" to options?.due,
             "page" to options?.page,
         )
         return requestPaginated(info, options?.toPaginationOptions(), {
@@ -95,6 +101,8 @@ class EverythingService(client: AccountClient) : BaseService(client) {
             resourceId = null,
         )
         val qs = buildQueryString(
+            "assignee_ids[]" to options?.assigneeIds,
+            "due" to options?.due,
             "page" to options?.page,
         )
         return requestPaginated(info, options?.toPaginationOptions(), {
@@ -106,8 +114,9 @@ class EverythingService(client: AccountClient) : BaseService(client) {
 
     /**
      * Get every overdue card across all accessible projects, oldest-due-date-first.
+     * @param options Optional query parameters and pagination control
      */
-    suspend fun everythingOverdueCards(): List<Card> {
+    suspend fun everythingOverdueCards(options: GetEverythingOverdueCardsOptions? = null): List<Card> {
         val info = OperationInfo(
             service = "Everything",
             operation = "GetEverythingOverdueCards",
@@ -116,8 +125,12 @@ class EverythingService(client: AccountClient) : BaseService(client) {
             projectId = null,
             resourceId = null,
         )
+        val qs = buildQueryString(
+            "assignee_ids[]" to options?.assigneeIds,
+            "due" to options?.due,
+        )
         return request(info, {
-            httpGet("/cards/overdue.json", operationName = info.operation)
+            httpGet("/cards/overdue.json" + qs, operationName = info.operation)
         }) { body ->
             json.decodeFromString<List<Card>>(body)
         }
@@ -137,6 +150,8 @@ class EverythingService(client: AccountClient) : BaseService(client) {
             resourceId = null,
         )
         val qs = buildQueryString(
+            "assignee_ids[]" to options?.assigneeIds,
+            "due" to options?.due,
             "page" to options?.page,
         )
         return requestPaginated(info, options?.toPaginationOptions(), {
@@ -277,6 +292,8 @@ class EverythingService(client: AccountClient) : BaseService(client) {
             resourceId = null,
         )
         val qs = buildQueryString(
+            "assignee_ids[]" to options?.assigneeIds,
+            "due" to options?.due,
             "page" to options?.page,
         )
         return requestPaginated(info, options?.toPaginationOptions(), {
@@ -300,6 +317,8 @@ class EverythingService(client: AccountClient) : BaseService(client) {
             resourceId = null,
         )
         val qs = buildQueryString(
+            "assignee_ids[]" to options?.assigneeIds,
+            "due" to options?.due,
             "page" to options?.page,
         )
         return requestPaginated(info, options?.toPaginationOptions(), {
@@ -323,6 +342,8 @@ class EverythingService(client: AccountClient) : BaseService(client) {
             resourceId = null,
         )
         val qs = buildQueryString(
+            "assignee_ids[]" to options?.assigneeIds,
+            "due" to options?.due,
             "page" to options?.page,
         )
         return requestPaginated(info, options?.toPaginationOptions(), {
@@ -334,8 +355,9 @@ class EverythingService(client: AccountClient) : BaseService(client) {
 
     /**
      * Get every overdue to-do across all accessible projects, oldest-due-date-first.
+     * @param options Optional query parameters and pagination control
      */
-    suspend fun everythingOverdueTodos(): List<Todo> {
+    suspend fun everythingOverdueTodos(options: GetEverythingOverdueTodosOptions? = null): List<Todo> {
         val info = OperationInfo(
             service = "Everything",
             operation = "GetEverythingOverdueTodos",
@@ -344,8 +366,12 @@ class EverythingService(client: AccountClient) : BaseService(client) {
             projectId = null,
             resourceId = null,
         )
+        val qs = buildQueryString(
+            "assignee_ids[]" to options?.assigneeIds,
+            "due" to options?.due,
+        )
         return request(info, {
-            httpGet("/todos/overdue.json", operationName = info.operation)
+            httpGet("/todos/overdue.json" + qs, operationName = info.operation)
         }) { body ->
             json.decodeFromString<List<Todo>>(body)
         }
@@ -365,6 +391,8 @@ class EverythingService(client: AccountClient) : BaseService(client) {
             resourceId = null,
         )
         val qs = buildQueryString(
+            "assignee_ids[]" to options?.assigneeIds,
+            "due" to options?.due,
             "page" to options?.page,
         )
         return requestPaginated(info, options?.toPaginationOptions(), {

--- a/openapi.json
+++ b/openapi.json
@@ -3993,6 +3993,31 @@
             "required": true
           },
           {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
+          },
+          {
             "name": "page",
             "in": "query",
             "description": "Page number for paginating through results. Defaults to 1.",
@@ -4089,6 +4114,31 @@
               "description": "Basecamp account ID (numeric string)"
             },
             "required": true
+          },
+          {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
           },
           {
             "name": "page",
@@ -4189,6 +4239,31 @@
             "required": true
           },
           {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
+          },
+          {
             "name": "page",
             "in": "query",
             "description": "Page number for paginating through results. Defaults to 1.",
@@ -4287,6 +4362,31 @@
             "required": true
           },
           {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
+          },
+          {
             "name": "page",
             "in": "query",
             "description": "Page number for paginating through results. Defaults to 1.",
@@ -4383,6 +4483,31 @@
               "description": "Basecamp account ID (numeric string)"
             },
             "required": true
+          },
+          {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
           }
         ],
         "responses": {
@@ -4466,6 +4591,31 @@
               "description": "Basecamp account ID (numeric string)"
             },
             "required": true
+          },
+          {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
           },
           {
             "name": "page",
@@ -20046,6 +20196,31 @@
             "required": true
           },
           {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
+          },
+          {
             "name": "page",
             "in": "query",
             "description": "Page number for paginating through results. Defaults to 1.",
@@ -20142,6 +20317,31 @@
               "description": "Basecamp account ID (numeric string)"
             },
             "required": true
+          },
+          {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
           },
           {
             "name": "page",
@@ -20242,6 +20442,31 @@
             "required": true
           },
           {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
+          },
+          {
             "name": "page",
             "in": "query",
             "description": "Page number for paginating through results. Defaults to 1.",
@@ -20338,6 +20563,31 @@
               "description": "Basecamp account ID (numeric string)"
             },
             "required": true
+          },
+          {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
           }
         ],
         "responses": {
@@ -20421,6 +20671,31 @@
               "description": "Basecamp account ID (numeric string)"
             },
             "required": true
+          },
+          {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
           },
           {
             "name": "page",

--- a/python/src/basecamp/generated/services/everything.py
+++ b/python/src/basecamp/generated/services/everything.py
@@ -11,50 +11,73 @@ from basecamp.hooks import OperationInfo
 
 
 class EverythingService(BaseService):
-    def get_everything_completed_cards(self, *, page: int | None = None) -> ListResult:
+    def get_everything_completed_cards(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+    ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_completed_cards", is_mutation=False),
             "/cards/completed.json",
-            params=self._compact(page=page),
+            params={
+                k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
+            },
             operation="GetEverythingCompletedCards",
         )
 
-    def get_everything_no_due_date_cards(self, *, page: int | None = None) -> ListResult:
+    def get_everything_no_due_date_cards(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+    ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_no_due_date_cards", is_mutation=False),
             "/cards/no_due_date.json",
-            params=self._compact(page=page),
+            params={
+                k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
+            },
             operation="GetEverythingNoDueDateCards",
         )
 
-    def get_everything_not_now_cards(self, *, page: int | None = None) -> ListResult:
+    def get_everything_not_now_cards(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+    ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_not_now_cards", is_mutation=False),
             "/cards/not_now.json",
-            params=self._compact(page=page),
+            params={
+                k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
+            },
             operation="GetEverythingNotNowCards",
         )
 
-    def get_everything_open_cards(self, *, page: int | None = None) -> ListResult:
+    def get_everything_open_cards(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+    ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_open_cards", is_mutation=False),
             "/cards/open.json",
-            params=self._compact(page=page),
+            params={
+                k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
+            },
             operation="GetEverythingOpenCards",
         )
 
-    def get_everything_overdue_cards(self) -> ListResult:
+    def get_everything_overdue_cards(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None
+    ) -> ListResult:
         return self._request_list(
             OperationInfo(service="everything", operation="get_everything_overdue_cards", is_mutation=False),
             "/cards/overdue.json",
+            params={k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due}.items() if v is not None},
             operation="GetEverythingOverdueCards",
         )
 
-    def get_everything_unassigned_cards(self, *, page: int | None = None) -> ListResult:
+    def get_everything_unassigned_cards(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+    ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_unassigned_cards", is_mutation=False),
             "/cards/unassigned.json",
-            params=self._compact(page=page),
+            params={
+                k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
+            },
             operation="GetEverythingUnassignedCards",
         )
 
@@ -100,91 +123,133 @@ class EverythingService(BaseService):
             operation="GetEverythingMessages",
         )
 
-    def get_everything_completed_todos(self, *, page: int | None = None) -> ListResult:
+    def get_everything_completed_todos(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+    ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_completed_todos", is_mutation=False),
             "/todos/completed.json",
-            params=self._compact(page=page),
+            params={
+                k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
+            },
             operation="GetEverythingCompletedTodos",
         )
 
-    def get_everything_no_due_date_todos(self, *, page: int | None = None) -> ListResult:
+    def get_everything_no_due_date_todos(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+    ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_no_due_date_todos", is_mutation=False),
             "/todos/no_due_date.json",
-            params=self._compact(page=page),
+            params={
+                k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
+            },
             operation="GetEverythingNoDueDateTodos",
         )
 
-    def get_everything_open_todos(self, *, page: int | None = None) -> ListResult:
+    def get_everything_open_todos(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+    ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_open_todos", is_mutation=False),
             "/todos/open.json",
-            params=self._compact(page=page),
+            params={
+                k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
+            },
             operation="GetEverythingOpenTodos",
         )
 
-    def get_everything_overdue_todos(self) -> ListResult:
+    def get_everything_overdue_todos(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None
+    ) -> ListResult:
         return self._request_list(
             OperationInfo(service="everything", operation="get_everything_overdue_todos", is_mutation=False),
             "/todos/overdue.json",
+            params={k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due}.items() if v is not None},
             operation="GetEverythingOverdueTodos",
         )
 
-    def get_everything_unassigned_todos(self, *, page: int | None = None) -> ListResult:
+    def get_everything_unassigned_todos(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+    ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_unassigned_todos", is_mutation=False),
             "/todos/unassigned.json",
-            params=self._compact(page=page),
+            params={
+                k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
+            },
             operation="GetEverythingUnassignedTodos",
         )
 
 
 class AsyncEverythingService(AsyncBaseService):
-    async def get_everything_completed_cards(self, *, page: int | None = None) -> ListResult:
+    async def get_everything_completed_cards(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+    ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_completed_cards", is_mutation=False),
             "/cards/completed.json",
-            params=self._compact(page=page),
+            params={
+                k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
+            },
             operation="GetEverythingCompletedCards",
         )
 
-    async def get_everything_no_due_date_cards(self, *, page: int | None = None) -> ListResult:
+    async def get_everything_no_due_date_cards(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+    ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_no_due_date_cards", is_mutation=False),
             "/cards/no_due_date.json",
-            params=self._compact(page=page),
+            params={
+                k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
+            },
             operation="GetEverythingNoDueDateCards",
         )
 
-    async def get_everything_not_now_cards(self, *, page: int | None = None) -> ListResult:
+    async def get_everything_not_now_cards(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+    ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_not_now_cards", is_mutation=False),
             "/cards/not_now.json",
-            params=self._compact(page=page),
+            params={
+                k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
+            },
             operation="GetEverythingNotNowCards",
         )
 
-    async def get_everything_open_cards(self, *, page: int | None = None) -> ListResult:
+    async def get_everything_open_cards(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+    ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_open_cards", is_mutation=False),
             "/cards/open.json",
-            params=self._compact(page=page),
+            params={
+                k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
+            },
             operation="GetEverythingOpenCards",
         )
 
-    async def get_everything_overdue_cards(self) -> ListResult:
+    async def get_everything_overdue_cards(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None
+    ) -> ListResult:
         return await self._request_list(
             OperationInfo(service="everything", operation="get_everything_overdue_cards", is_mutation=False),
             "/cards/overdue.json",
+            params={k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due}.items() if v is not None},
             operation="GetEverythingOverdueCards",
         )
 
-    async def get_everything_unassigned_cards(self, *, page: int | None = None) -> ListResult:
+    async def get_everything_unassigned_cards(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+    ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_unassigned_cards", is_mutation=False),
             "/cards/unassigned.json",
-            params=self._compact(page=page),
+            params={
+                k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
+            },
             operation="GetEverythingUnassignedCards",
         )
 
@@ -230,41 +295,60 @@ class AsyncEverythingService(AsyncBaseService):
             operation="GetEverythingMessages",
         )
 
-    async def get_everything_completed_todos(self, *, page: int | None = None) -> ListResult:
+    async def get_everything_completed_todos(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+    ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_completed_todos", is_mutation=False),
             "/todos/completed.json",
-            params=self._compact(page=page),
+            params={
+                k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
+            },
             operation="GetEverythingCompletedTodos",
         )
 
-    async def get_everything_no_due_date_todos(self, *, page: int | None = None) -> ListResult:
+    async def get_everything_no_due_date_todos(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+    ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_no_due_date_todos", is_mutation=False),
             "/todos/no_due_date.json",
-            params=self._compact(page=page),
+            params={
+                k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
+            },
             operation="GetEverythingNoDueDateTodos",
         )
 
-    async def get_everything_open_todos(self, *, page: int | None = None) -> ListResult:
+    async def get_everything_open_todos(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+    ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_open_todos", is_mutation=False),
             "/todos/open.json",
-            params=self._compact(page=page),
+            params={
+                k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
+            },
             operation="GetEverythingOpenTodos",
         )
 
-    async def get_everything_overdue_todos(self) -> ListResult:
+    async def get_everything_overdue_todos(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None
+    ) -> ListResult:
         return await self._request_list(
             OperationInfo(service="everything", operation="get_everything_overdue_todos", is_mutation=False),
             "/todos/overdue.json",
+            params={k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due}.items() if v is not None},
             operation="GetEverythingOverdueTodos",
         )
 
-    async def get_everything_unassigned_todos(self, *, page: int | None = None) -> ListResult:
+    async def get_everything_unassigned_todos(
+        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+    ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_unassigned_todos", is_mutation=False),
             "/todos/unassigned.json",
-            params=self._compact(page=page),
+            params={
+                k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
+            },
             operation="GetEverythingUnassignedTodos",
         )

--- a/python/tests/services/test_everything.py
+++ b/python/tests/services/test_everything.py
@@ -221,6 +221,44 @@ _OVERDUE_CARDS_FEED = [
 ]
 
 
+class TestEverythingTaskFilters:
+    """assignee_ids[]/due filters on the everything to-do/card family (#12442)."""
+
+    @respx.mock
+    def test_grouped_listing_serializes_bracketed_assignee_ids_and_due(self):
+        def respond(request: httpx.Request) -> httpx.Response:
+            params = request.url.params
+            # Bracketed repeated keys — the only form Rails' permit accepts.
+            assert params.get_list("assignee_ids[]") == ["11", "22"]
+            assert "assignee_ids" not in params
+            assert params.get("due") == "overdue"
+            return httpx.Response(200, json=[])
+
+        route = respx.get("https://3.basecampapi.com/12345/todos/open.json").mock(side_effect=respond)
+
+        account = Client(access_token="test-token").for_account("12345")
+        result = account.everything.get_everything_open_todos(assignee_ids=[11, 22], due="overdue")
+
+        assert route.called
+        assert len(result) == 0
+
+    @respx.mock
+    def test_overdue_feed_accepts_the_filters(self):
+        def respond(request: httpx.Request) -> httpx.Response:
+            params = request.url.params
+            assert params.get_list("assignee_ids[]") == ["7"]
+            assert params.get("due") == "with"
+            return httpx.Response(200, json=[])
+
+        route = respx.get("https://3.basecampapi.com/12345/cards/overdue.json").mock(side_effect=respond)
+
+        account = Client(access_token="test-token").for_account("12345")
+        result = account.everything.get_everything_overdue_cards(assignee_ids=[7], due="with")
+
+        assert route.called
+        assert len(result) == 0
+
+
 class TestEverythingRecordingFeeds:
     @respx.mock
     def test_messages_feed_embeds_bucket_roots(self):

--- a/ruby/lib/basecamp/generated/services/everything_service.rb
+++ b/ruby/lib/basecamp/generated/services/everything_service.rb
@@ -8,59 +8,77 @@ module Basecamp
     class EverythingService < BaseService
 
       # Completed cards across all accessible projects, grouped by project (paginated).
+      # @param assignee_ids [Array, nil] Restrict to tasks assigned to at least one of the given people (repeatable).
+      #   Assignees on nested steps are not considered.
+      # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
       # @return [Enumerator<Hash>] paginated results
-      def get_everything_completed_cards(page: nil)
+      def get_everything_completed_cards(assignee_ids: nil, due: nil, page: nil)
         wrap_paginated(service: "everything", operation: "get_everything_completed_cards", is_mutation: false) do
-          params = compact_query_params(page: page)
+          params = compact_query_params(assignee_ids: assignee_ids, due: due, page: page)
           paginate("/cards/completed.json", params: params, operation: "GetEverythingCompletedCards")
         end
       end
 
       # Open cards with no due date across all accessible projects, grouped by project (paginated).
+      # @param assignee_ids [Array, nil] Restrict to tasks assigned to at least one of the given people (repeatable).
+      #   Assignees on nested steps are not considered.
+      # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
       # @return [Enumerator<Hash>] paginated results
-      def get_everything_no_due_date_cards(page: nil)
+      def get_everything_no_due_date_cards(assignee_ids: nil, due: nil, page: nil)
         wrap_paginated(service: "everything", operation: "get_everything_no_due_date_cards", is_mutation: false) do
-          params = compact_query_params(page: page)
+          params = compact_query_params(assignee_ids: assignee_ids, due: due, page: page)
           paginate("/cards/no_due_date.json", params: params, operation: "GetEverythingNoDueDateCards")
         end
       end
 
       # Cards parked in a project's "Not now" column across all accessible projects, grouped by project (paginated).
+      # @param assignee_ids [Array, nil] Restrict to tasks assigned to at least one of the given people (repeatable).
+      #   Assignees on nested steps are not considered.
+      # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
       # @return [Enumerator<Hash>] paginated results
-      def get_everything_not_now_cards(page: nil)
+      def get_everything_not_now_cards(assignee_ids: nil, due: nil, page: nil)
         wrap_paginated(service: "everything", operation: "get_everything_not_now_cards", is_mutation: false) do
-          params = compact_query_params(page: page)
+          params = compact_query_params(assignee_ids: assignee_ids, due: due, page: page)
           paginate("/cards/not_now.json", params: params, operation: "GetEverythingNotNowCards")
         end
       end
 
       # Incomplete cards in active columns across all accessible projects, grouped by project (paginated).
+      # @param assignee_ids [Array, nil] Restrict to tasks assigned to at least one of the given people (repeatable).
+      #   Assignees on nested steps are not considered.
+      # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
       # @return [Enumerator<Hash>] paginated results
-      def get_everything_open_cards(page: nil)
+      def get_everything_open_cards(assignee_ids: nil, due: nil, page: nil)
         wrap_paginated(service: "everything", operation: "get_everything_open_cards", is_mutation: false) do
-          params = compact_query_params(page: page)
+          params = compact_query_params(assignee_ids: assignee_ids, due: due, page: page)
           paginate("/cards/open.json", params: params, operation: "GetEverythingOpenCards")
         end
       end
 
       # Get every overdue card across all accessible projects, oldest-due-date-first.
+      # @param assignee_ids [Array, nil] Restrict to tasks assigned to at least one of the given people (repeatable).
+      #   Assignees on nested steps are not considered.
+      # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
       # @return [Array<Hash>] response data
-      def get_everything_overdue_cards()
+      def get_everything_overdue_cards(assignee_ids: nil, due: nil)
         with_operation(service: "everything", operation: "get_everything_overdue_cards", is_mutation: false) do
-          http_get("/cards/overdue.json", operation: "GetEverythingOverdueCards").json
+          http_get("/cards/overdue.json", params: compact_query_params(assignee_ids: assignee_ids, due: due), operation: "GetEverythingOverdueCards").json
         end
       end
 
       # Open, unassigned cards across all accessible projects, grouped by project (paginated).
+      # @param assignee_ids [Array, nil] Restrict to tasks assigned to at least one of the given people (repeatable).
+      #   Assignees on nested steps are not considered.
+      # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
       # @return [Enumerator<Hash>] paginated results
-      def get_everything_unassigned_cards(page: nil)
+      def get_everything_unassigned_cards(assignee_ids: nil, due: nil, page: nil)
         wrap_paginated(service: "everything", operation: "get_everything_unassigned_cards", is_mutation: false) do
-          params = compact_query_params(page: page)
+          params = compact_query_params(assignee_ids: assignee_ids, due: due, page: page)
           paginate("/cards/unassigned.json", params: params, operation: "GetEverythingUnassignedCards")
         end
       end
@@ -118,49 +136,64 @@ module Basecamp
       end
 
       # Completed to-dos across all accessible projects, grouped by project (paginated).
+      # @param assignee_ids [Array, nil] Restrict to tasks assigned to at least one of the given people (repeatable).
+      #   Assignees on nested steps are not considered.
+      # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
       # @return [Enumerator<Hash>] paginated results
-      def get_everything_completed_todos(page: nil)
+      def get_everything_completed_todos(assignee_ids: nil, due: nil, page: nil)
         wrap_paginated(service: "everything", operation: "get_everything_completed_todos", is_mutation: false) do
-          params = compact_query_params(page: page)
+          params = compact_query_params(assignee_ids: assignee_ids, due: due, page: page)
           paginate("/todos/completed.json", params: params, operation: "GetEverythingCompletedTodos")
         end
       end
 
       # Open to-dos with no due date across all accessible projects, grouped by project (paginated).
+      # @param assignee_ids [Array, nil] Restrict to tasks assigned to at least one of the given people (repeatable).
+      #   Assignees on nested steps are not considered.
+      # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
       # @return [Enumerator<Hash>] paginated results
-      def get_everything_no_due_date_todos(page: nil)
+      def get_everything_no_due_date_todos(assignee_ids: nil, due: nil, page: nil)
         wrap_paginated(service: "everything", operation: "get_everything_no_due_date_todos", is_mutation: false) do
-          params = compact_query_params(page: page)
+          params = compact_query_params(assignee_ids: assignee_ids, due: due, page: page)
           paginate("/todos/no_due_date.json", params: params, operation: "GetEverythingNoDueDateTodos")
         end
       end
 
       # Active, incomplete to-dos across all accessible projects, grouped by project (paginated).
+      # @param assignee_ids [Array, nil] Restrict to tasks assigned to at least one of the given people (repeatable).
+      #   Assignees on nested steps are not considered.
+      # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
       # @return [Enumerator<Hash>] paginated results
-      def get_everything_open_todos(page: nil)
+      def get_everything_open_todos(assignee_ids: nil, due: nil, page: nil)
         wrap_paginated(service: "everything", operation: "get_everything_open_todos", is_mutation: false) do
-          params = compact_query_params(page: page)
+          params = compact_query_params(assignee_ids: assignee_ids, due: due, page: page)
           paginate("/todos/open.json", params: params, operation: "GetEverythingOpenTodos")
         end
       end
 
       # Get every overdue to-do across all accessible projects, oldest-due-date-first.
+      # @param assignee_ids [Array, nil] Restrict to tasks assigned to at least one of the given people (repeatable).
+      #   Assignees on nested steps are not considered.
+      # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
       # @return [Array<Hash>] response data
-      def get_everything_overdue_todos()
+      def get_everything_overdue_todos(assignee_ids: nil, due: nil)
         with_operation(service: "everything", operation: "get_everything_overdue_todos", is_mutation: false) do
-          http_get("/todos/overdue.json", operation: "GetEverythingOverdueTodos").json
+          http_get("/todos/overdue.json", params: compact_query_params(assignee_ids: assignee_ids, due: due), operation: "GetEverythingOverdueTodos").json
         end
       end
 
       # Open, unassigned to-dos across all accessible projects, grouped by project (paginated).
+      # @param assignee_ids [Array, nil] Restrict to tasks assigned to at least one of the given people (repeatable).
+      #   Assignees on nested steps are not considered.
+      # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
       # @return [Enumerator<Hash>] paginated results
-      def get_everything_unassigned_todos(page: nil)
+      def get_everything_unassigned_todos(assignee_ids: nil, due: nil, page: nil)
         wrap_paginated(service: "everything", operation: "get_everything_unassigned_todos", is_mutation: false) do
-          params = compact_query_params(page: page)
+          params = compact_query_params(assignee_ids: assignee_ids, due: due, page: page)
           paginate("/todos/unassigned.json", params: params, operation: "GetEverythingUnassignedTodos")
         end
       end

--- a/ruby/test/basecamp/services/everything_service_test.rb
+++ b/ruby/test/basecamp/services/everything_service_test.rb
@@ -87,6 +87,30 @@ class EverythingServiceTest < Minitest::Test
     assert_nil result[2]["width"]
   end
 
+  # Faraday's NestedParamsEncoder serializes the assignee_ids array kwarg into
+  # the bracketed repeated form (assignee_ids[]=11&assignee_ids[]=22), the only
+  # form Rails' permit(assignee_ids: []) accepts. Exact query match proves no
+  # bare key leaks through and the due filter rides alongside (#12442).
+  def test_everything_todo_filters_encode_bracketed_assignee_ids_and_due
+    stub_request(:get, "https://3.basecampapi.com/12345/todos/open.json")
+      .with(query: { "assignee_ids" => %w[11 22], "due" => "overdue" })
+      .to_return(status: 200, body: [].to_json)
+
+    result = @account.everything.get_everything_open_todos(assignee_ids: [ 11, 22 ], due: "overdue").to_a
+
+    assert_equal 0, result.length
+  end
+
+  def test_everything_overdue_cards_accept_the_filters
+    stub_request(:get, "https://3.basecampapi.com/12345/cards/overdue.json")
+      .with(query: { "assignee_ids" => %w[7], "due" => "with" })
+      .to_return(status: 200, body: [].to_json)
+
+    result = @account.everything.get_everything_overdue_cards(assignee_ids: [ 7 ], due: "with")
+
+    assert_equal 0, result.length
+  end
+
   def test_get_everything_messages_decodes_recording_feed
     messages = [
       {

--- a/spec/api-gaps/README.md
+++ b/spec/api-gaps/README.md
@@ -64,7 +64,7 @@ making the absorption journey publicly auditable.
 | [card-table-wormholes](card-table-wormholes.md) | absorbed-in-sdk | post-train | medium |
 | [bubble-ups-surface](bubble-ups-surface.md) | absorbed-in-sdk | launch | high |
 | [everything-boosts-withdrawn](everything-boosts-withdrawn.md) | no-json-contract | post-train | medium |
-| [everything-todo-card-filters](everything-todo-card-filters.md) | addressed-in-bc3-pr-12442 | post-train | medium |
+| [everything-todo-card-filters](everything-todo-card-filters.md) | absorbed-in-sdk | post-train | medium |
 
 > Statuses reflect how BC3's **BC5 API train** actually shipped (8 PRs merged
 > to `master`, 2026-07-18..21); BC3 #10947 closed unmerged, superseded by the

--- a/spec/api-gaps/everything-todo-card-filters.md
+++ b/spec/api-gaps/everything-todo-card-filters.md
@@ -1,9 +1,18 @@
 ---
 gap: everything-todo-card-filters
-status: addressed-in-bc3-pr-12442
+status: absorbed-in-sdk
 detected: 2026-07-30
 sdk_demand: medium
 bc3_pr: 12442
+smithy_refs:
+  - "EverythingTodosFilterInput.assignee_ids member"
+  - "EverythingTodosFilterInput.due member"
+  - "EverythingCardsFilterInput.assignee_ids member"
+  - "EverythingCardsFilterInput.due member"
+  - "GetEverythingOverdueTodosInput.assignee_ids member"
+  - "GetEverythingOverdueTodosInput.due member"
+  - "GetEverythingOverdueCardsInput.assignee_ids member"
+  - "GetEverythingOverdueCardsInput.due member"
 bc3_refs:
   introduced_in: master
   routes:
@@ -45,8 +54,12 @@ family and the flat overdue lists alike. Per
   ignored.
 
 The SDK models the 11 affected operations (see
-[everything-aggregates.md](everything-aggregates.md)) but none of them carry
-these query parameters yet.
+[everything-aggregates.md](everything-aggregates.md)); **absorbed** — all 11
+now carry both query parameters (the nine grouped operations share the two
+`Everything*FilterInput` structures, the two overdue lists have their own
+inputs), regenerated across all six SDKs with Go options threading
+(`EverythingTaskFilters`) and per-SDK bracketed-serialization tests
+mirroring the `people_ids[]` precedent.
 
 ## Why it matters
 

--- a/spec/basecamp.smithy
+++ b/spec/basecamp.smithy
@@ -9050,6 +9050,15 @@ structure GetEverythingOverdueTodosInput {
   @required
   @httpLabel
   accountId: AccountId
+
+  /// Restrict to tasks assigned to at least one of the given people (repeatable).
+  /// Assignees on nested steps are not considered.
+  @httpQuery("assignee_ids[]")
+  assignee_ids: PersonIdList
+
+  /// Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+  @httpQuery("due")
+  due: String
 }
 
 structure GetEverythingOverdueTodosOutput {
@@ -9071,6 +9080,15 @@ structure GetEverythingOverdueCardsInput {
   @required
   @httpLabel
   accountId: AccountId
+
+  /// Restrict to tasks assigned to at least one of the given people (repeatable).
+  /// Assignees on nested steps are not considered.
+  @httpQuery("assignee_ids[]")
+  assignee_ids: PersonIdList
+
+  /// Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+  @httpQuery("due")
+  due: String
 }
 
 structure GetEverythingOverdueCardsOutput {
@@ -9254,6 +9272,15 @@ structure EverythingTodosFilterInput {
   @httpLabel
   accountId: AccountId
 
+  /// Restrict to tasks assigned to at least one of the given people (repeatable).
+  /// Assignees on nested steps are not considered.
+  @httpQuery("assignee_ids[]")
+  assignee_ids: PersonIdList
+
+  /// Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+  @httpQuery("due")
+  due: String
+
   /// Page number for paginating through results. Defaults to 1.
   @httpQuery("page")
   page: Integer
@@ -9267,6 +9294,15 @@ structure EverythingCardsFilterInput {
   @required
   @httpLabel
   accountId: AccountId
+
+  /// Restrict to tasks assigned to at least one of the given people (repeatable).
+  /// Assignees on nested steps are not considered.
+  @httpQuery("assignee_ids[]")
+  assignee_ids: PersonIdList
+
+  /// Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+  @httpQuery("due")
+  due: String
 
   /// Page number for paginating through results. Defaults to 1.
   @httpQuery("page")

--- a/swift/Sources/Basecamp/Generated/Services/EverythingService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/EverythingService.swift
@@ -22,20 +22,38 @@ public struct EverythingCommentsEverythingOptions: Sendable {
 }
 
 public struct EverythingCompletedCardsEverythingOptions: Sendable {
+    public var assigneeIds: [Int]?
+    public var due: String?
     public var page: Int?
     public var maxItems: Int?
 
-    public init(page: Int? = nil, maxItems: Int? = nil) {
+    public init(
+        assigneeIds: [Int]? = nil,
+        due: String? = nil,
+        page: Int? = nil,
+        maxItems: Int? = nil
+    ) {
+        self.assigneeIds = assigneeIds
+        self.due = due
         self.page = page
         self.maxItems = maxItems
     }
 }
 
 public struct EverythingCompletedTodosEverythingOptions: Sendable {
+    public var assigneeIds: [Int]?
+    public var due: String?
     public var page: Int?
     public var maxItems: Int?
 
-    public init(page: Int? = nil, maxItems: Int? = nil) {
+    public init(
+        assigneeIds: [Int]? = nil,
+        due: String? = nil,
+        page: Int? = nil,
+        maxItems: Int? = nil
+    ) {
+        self.assigneeIds = assigneeIds
+        self.due = due
         self.page = page
         self.maxItems = maxItems
     }
@@ -81,70 +99,153 @@ public struct EverythingMessagesEverythingOptions: Sendable {
 }
 
 public struct EverythingNoDueDateCardsEverythingOptions: Sendable {
+    public var assigneeIds: [Int]?
+    public var due: String?
     public var page: Int?
     public var maxItems: Int?
 
-    public init(page: Int? = nil, maxItems: Int? = nil) {
+    public init(
+        assigneeIds: [Int]? = nil,
+        due: String? = nil,
+        page: Int? = nil,
+        maxItems: Int? = nil
+    ) {
+        self.assigneeIds = assigneeIds
+        self.due = due
         self.page = page
         self.maxItems = maxItems
     }
 }
 
 public struct EverythingNoDueDateTodosEverythingOptions: Sendable {
+    public var assigneeIds: [Int]?
+    public var due: String?
     public var page: Int?
     public var maxItems: Int?
 
-    public init(page: Int? = nil, maxItems: Int? = nil) {
+    public init(
+        assigneeIds: [Int]? = nil,
+        due: String? = nil,
+        page: Int? = nil,
+        maxItems: Int? = nil
+    ) {
+        self.assigneeIds = assigneeIds
+        self.due = due
         self.page = page
         self.maxItems = maxItems
     }
 }
 
 public struct EverythingNotNowCardsEverythingOptions: Sendable {
+    public var assigneeIds: [Int]?
+    public var due: String?
     public var page: Int?
     public var maxItems: Int?
 
-    public init(page: Int? = nil, maxItems: Int? = nil) {
+    public init(
+        assigneeIds: [Int]? = nil,
+        due: String? = nil,
+        page: Int? = nil,
+        maxItems: Int? = nil
+    ) {
+        self.assigneeIds = assigneeIds
+        self.due = due
         self.page = page
         self.maxItems = maxItems
     }
 }
 
 public struct EverythingOpenCardsEverythingOptions: Sendable {
+    public var assigneeIds: [Int]?
+    public var due: String?
     public var page: Int?
     public var maxItems: Int?
 
-    public init(page: Int? = nil, maxItems: Int? = nil) {
+    public init(
+        assigneeIds: [Int]? = nil,
+        due: String? = nil,
+        page: Int? = nil,
+        maxItems: Int? = nil
+    ) {
+        self.assigneeIds = assigneeIds
+        self.due = due
         self.page = page
         self.maxItems = maxItems
     }
 }
 
 public struct EverythingOpenTodosEverythingOptions: Sendable {
+    public var assigneeIds: [Int]?
+    public var due: String?
     public var page: Int?
     public var maxItems: Int?
 
-    public init(page: Int? = nil, maxItems: Int? = nil) {
+    public init(
+        assigneeIds: [Int]? = nil,
+        due: String? = nil,
+        page: Int? = nil,
+        maxItems: Int? = nil
+    ) {
+        self.assigneeIds = assigneeIds
+        self.due = due
         self.page = page
         self.maxItems = maxItems
     }
 }
 
+public struct EverythingOverdueCardsEverythingOptions: Sendable {
+    public var assigneeIds: [Int]?
+    public var due: String?
+
+    public init(assigneeIds: [Int]? = nil, due: String? = nil) {
+        self.assigneeIds = assigneeIds
+        self.due = due
+    }
+}
+
+public struct EverythingOverdueTodosEverythingOptions: Sendable {
+    public var assigneeIds: [Int]?
+    public var due: String?
+
+    public init(assigneeIds: [Int]? = nil, due: String? = nil) {
+        self.assigneeIds = assigneeIds
+        self.due = due
+    }
+}
+
 public struct EverythingUnassignedCardsEverythingOptions: Sendable {
+    public var assigneeIds: [Int]?
+    public var due: String?
     public var page: Int?
     public var maxItems: Int?
 
-    public init(page: Int? = nil, maxItems: Int? = nil) {
+    public init(
+        assigneeIds: [Int]? = nil,
+        due: String? = nil,
+        page: Int? = nil,
+        maxItems: Int? = nil
+    ) {
+        self.assigneeIds = assigneeIds
+        self.due = due
         self.page = page
         self.maxItems = maxItems
     }
 }
 
 public struct EverythingUnassignedTodosEverythingOptions: Sendable {
+    public var assigneeIds: [Int]?
+    public var due: String?
     public var page: Int?
     public var maxItems: Int?
 
-    public init(page: Int? = nil, maxItems: Int? = nil) {
+    public init(
+        assigneeIds: [Int]? = nil,
+        due: String? = nil,
+        page: Int? = nil,
+        maxItems: Int? = nil
+    ) {
+        self.assigneeIds = assigneeIds
+        self.due = due
         self.page = page
         self.maxItems = maxItems
     }
@@ -182,6 +283,14 @@ public final class EverythingService: BaseService, @unchecked Sendable {
 
     public func everythingCompletedCards(options: EverythingCompletedCardsEverythingOptions? = nil) async throws -> ListResult<BucketCardsGroup> {
         var queryItems: [URLQueryItem] = []
+        if let assigneeIds = options?.assigneeIds {
+            for item in assigneeIds {
+                queryItems.append(URLQueryItem(name: "assignee_ids[]", value: String(item)))
+            }
+        }
+        if let due = options?.due {
+            queryItems.append(URLQueryItem(name: "due", value: due))
+        }
         if let page = options?.page {
             queryItems.append(URLQueryItem(name: "page", value: String(page)))
         }
@@ -196,6 +305,14 @@ public final class EverythingService: BaseService, @unchecked Sendable {
 
     public func everythingCompletedTodos(options: EverythingCompletedTodosEverythingOptions? = nil) async throws -> ListResult<BucketTodosGroup> {
         var queryItems: [URLQueryItem] = []
+        if let assigneeIds = options?.assigneeIds {
+            for item in assigneeIds {
+                queryItems.append(URLQueryItem(name: "assignee_ids[]", value: String(item)))
+            }
+        }
+        if let due = options?.due {
+            queryItems.append(URLQueryItem(name: "due", value: due))
+        }
         if let page = options?.page {
             queryItems.append(URLQueryItem(name: "page", value: String(page)))
         }
@@ -260,6 +377,14 @@ public final class EverythingService: BaseService, @unchecked Sendable {
 
     public func everythingNoDueDateCards(options: EverythingNoDueDateCardsEverythingOptions? = nil) async throws -> ListResult<BucketCardsGroup> {
         var queryItems: [URLQueryItem] = []
+        if let assigneeIds = options?.assigneeIds {
+            for item in assigneeIds {
+                queryItems.append(URLQueryItem(name: "assignee_ids[]", value: String(item)))
+            }
+        }
+        if let due = options?.due {
+            queryItems.append(URLQueryItem(name: "due", value: due))
+        }
         if let page = options?.page {
             queryItems.append(URLQueryItem(name: "page", value: String(page)))
         }
@@ -274,6 +399,14 @@ public final class EverythingService: BaseService, @unchecked Sendable {
 
     public func everythingNoDueDateTodos(options: EverythingNoDueDateTodosEverythingOptions? = nil) async throws -> ListResult<BucketTodosGroup> {
         var queryItems: [URLQueryItem] = []
+        if let assigneeIds = options?.assigneeIds {
+            for item in assigneeIds {
+                queryItems.append(URLQueryItem(name: "assignee_ids[]", value: String(item)))
+            }
+        }
+        if let due = options?.due {
+            queryItems.append(URLQueryItem(name: "due", value: due))
+        }
         if let page = options?.page {
             queryItems.append(URLQueryItem(name: "page", value: String(page)))
         }
@@ -288,6 +421,14 @@ public final class EverythingService: BaseService, @unchecked Sendable {
 
     public func everythingNotNowCards(options: EverythingNotNowCardsEverythingOptions? = nil) async throws -> ListResult<BucketCardsGroup> {
         var queryItems: [URLQueryItem] = []
+        if let assigneeIds = options?.assigneeIds {
+            for item in assigneeIds {
+                queryItems.append(URLQueryItem(name: "assignee_ids[]", value: String(item)))
+            }
+        }
+        if let due = options?.due {
+            queryItems.append(URLQueryItem(name: "due", value: due))
+        }
         if let page = options?.page {
             queryItems.append(URLQueryItem(name: "page", value: String(page)))
         }
@@ -302,6 +443,14 @@ public final class EverythingService: BaseService, @unchecked Sendable {
 
     public func everythingOpenCards(options: EverythingOpenCardsEverythingOptions? = nil) async throws -> ListResult<BucketCardsGroup> {
         var queryItems: [URLQueryItem] = []
+        if let assigneeIds = options?.assigneeIds {
+            for item in assigneeIds {
+                queryItems.append(URLQueryItem(name: "assignee_ids[]", value: String(item)))
+            }
+        }
+        if let due = options?.due {
+            queryItems.append(URLQueryItem(name: "due", value: due))
+        }
         if let page = options?.page {
             queryItems.append(URLQueryItem(name: "page", value: String(page)))
         }
@@ -316,6 +465,14 @@ public final class EverythingService: BaseService, @unchecked Sendable {
 
     public func everythingOpenTodos(options: EverythingOpenTodosEverythingOptions? = nil) async throws -> ListResult<BucketTodosGroup> {
         var queryItems: [URLQueryItem] = []
+        if let assigneeIds = options?.assigneeIds {
+            for item in assigneeIds {
+                queryItems.append(URLQueryItem(name: "assignee_ids[]", value: String(item)))
+            }
+        }
+        if let due = options?.due {
+            queryItems.append(URLQueryItem(name: "due", value: due))
+        }
         if let page = options?.page {
             queryItems.append(URLQueryItem(name: "page", value: String(page)))
         }
@@ -328,26 +485,52 @@ public final class EverythingService: BaseService, @unchecked Sendable {
         )
     }
 
-    public func everythingOverdueCards() async throws -> [Card] {
+    public func everythingOverdueCards(options: EverythingOverdueCardsEverythingOptions? = nil) async throws -> [Card] {
+        var queryItems: [URLQueryItem] = []
+        if let assigneeIds = options?.assigneeIds {
+            for item in assigneeIds {
+                queryItems.append(URLQueryItem(name: "assignee_ids[]", value: String(item)))
+            }
+        }
+        if let due = options?.due {
+            queryItems.append(URLQueryItem(name: "due", value: due))
+        }
         return try await request(
             OperationInfo(service: "Everything", operation: "GetEverythingOverdueCards", resourceType: "everything_overdue_card", isMutation: false),
             method: "GET",
-            path: "/cards/overdue.json",
+            path: "/cards/overdue.json" + queryString(queryItems),
             retryConfig: Metadata.retryConfig(for: "GetEverythingOverdueCards")
         )
     }
 
-    public func everythingOverdueTodos() async throws -> [Todo] {
+    public func everythingOverdueTodos(options: EverythingOverdueTodosEverythingOptions? = nil) async throws -> [Todo] {
+        var queryItems: [URLQueryItem] = []
+        if let assigneeIds = options?.assigneeIds {
+            for item in assigneeIds {
+                queryItems.append(URLQueryItem(name: "assignee_ids[]", value: String(item)))
+            }
+        }
+        if let due = options?.due {
+            queryItems.append(URLQueryItem(name: "due", value: due))
+        }
         return try await request(
             OperationInfo(service: "Everything", operation: "GetEverythingOverdueTodos", resourceType: "everything_overdue_todo", isMutation: false),
             method: "GET",
-            path: "/todos/overdue.json",
+            path: "/todos/overdue.json" + queryString(queryItems),
             retryConfig: Metadata.retryConfig(for: "GetEverythingOverdueTodos")
         )
     }
 
     public func everythingUnassignedCards(options: EverythingUnassignedCardsEverythingOptions? = nil) async throws -> ListResult<BucketCardsGroup> {
         var queryItems: [URLQueryItem] = []
+        if let assigneeIds = options?.assigneeIds {
+            for item in assigneeIds {
+                queryItems.append(URLQueryItem(name: "assignee_ids[]", value: String(item)))
+            }
+        }
+        if let due = options?.due {
+            queryItems.append(URLQueryItem(name: "due", value: due))
+        }
         if let page = options?.page {
             queryItems.append(URLQueryItem(name: "page", value: String(page)))
         }
@@ -362,6 +545,14 @@ public final class EverythingService: BaseService, @unchecked Sendable {
 
     public func everythingUnassignedTodos(options: EverythingUnassignedTodosEverythingOptions? = nil) async throws -> ListResult<BucketTodosGroup> {
         var queryItems: [URLQueryItem] = []
+        if let assigneeIds = options?.assigneeIds {
+            for item in assigneeIds {
+                queryItems.append(URLQueryItem(name: "assignee_ids[]", value: String(item)))
+            }
+        }
+        if let due = options?.due {
+            queryItems.append(URLQueryItem(name: "due", value: due))
+        }
         if let page = options?.page {
             queryItems.append(URLQueryItem(name: "page", value: String(page)))
         }

--- a/typescript/src/generated/openapi-stripped.json
+++ b/typescript/src/generated/openapi-stripped.json
@@ -3560,6 +3560,31 @@
         "operationId": "GetEverythingCompletedCards",
         "parameters": [
           {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
+          },
+          {
             "name": "page",
             "in": "query",
             "description": "Page number for paginating through results. Defaults to 1.",
@@ -3646,6 +3671,31 @@
         "description": "Open cards with no due date across all accessible projects, grouped by project (paginated).",
         "operationId": "GetEverythingNoDueDateCards",
         "parameters": [
+          {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
+          },
           {
             "name": "page",
             "in": "query",
@@ -3734,6 +3784,31 @@
         "operationId": "GetEverythingNotNowCards",
         "parameters": [
           {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
+          },
+          {
             "name": "page",
             "in": "query",
             "description": "Page number for paginating through results. Defaults to 1.",
@@ -3821,6 +3896,31 @@
         "operationId": "GetEverythingOpenCards",
         "parameters": [
           {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
+          },
+          {
             "name": "page",
             "in": "query",
             "description": "Page number for paginating through results. Defaults to 1.",
@@ -3906,7 +4006,33 @@
       "get": {
         "description": "Get every overdue card across all accessible projects, oldest-due-date-first.\nA complete, unpaginated array; each item embeds its `bucket`.",
         "operationId": "GetEverythingOverdueCards",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "GetEverythingOverdueCards 200 response",
@@ -3978,6 +4104,31 @@
         "description": "Open, unassigned cards across all accessible projects, grouped by project (paginated).",
         "operationId": "GetEverythingUnassignedCards",
         "parameters": [
+          {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
+          },
           {
             "name": "page",
             "in": "query",
@@ -17812,6 +17963,31 @@
         "operationId": "GetEverythingCompletedTodos",
         "parameters": [
           {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
+          },
+          {
             "name": "page",
             "in": "query",
             "description": "Page number for paginating through results. Defaults to 1.",
@@ -17898,6 +18074,31 @@
         "description": "Open to-dos with no due date across all accessible projects, grouped by project (paginated).",
         "operationId": "GetEverythingNoDueDateTodos",
         "parameters": [
+          {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
+          },
           {
             "name": "page",
             "in": "query",
@@ -17986,6 +18187,31 @@
         "operationId": "GetEverythingOpenTodos",
         "parameters": [
           {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
+          },
+          {
             "name": "page",
             "in": "query",
             "description": "Page number for paginating through results. Defaults to 1.",
@@ -18071,7 +18297,33 @@
       "get": {
         "description": "Get every overdue to-do across all accessible projects, oldest-due-date-first.\nA complete, unpaginated array; each item embeds its `bucket`.",
         "operationId": "GetEverythingOverdueTodos",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "GetEverythingOverdueTodos 200 response",
@@ -18143,6 +18395,31 @@
         "description": "Open, unassigned to-dos across all accessible projects, grouped by project (paginated).",
         "operationId": "GetEverythingUnassignedTodos",
         "parameters": [
+          {
+            "name": "assignee_ids[]",
+            "in": "query",
+            "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "description": "Restrict to tasks assigned to at least one of the given people (repeatable).\nAssignees on nested steps are not considered.",
+              "x-go-type-skip-optional-pointer": false
+            },
+            "explode": true
+          },
+          {
+            "name": "due",
+            "in": "query",
+            "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored.",
+            "schema": {
+              "type": "string",
+              "description": "Filter by due date: with, without, or overdue. Unrecognized values are ignored."
+            }
+          },
           {
             "name": "page",
             "in": "query",

--- a/typescript/src/generated/schema.d.ts
+++ b/typescript/src/generated/schema.d.ts
@@ -8103,6 +8103,13 @@ export interface operations {
     GetEverythingCompletedCards: {
         parameters: {
             query?: {
+                /**
+                 * @description Restrict to tasks assigned to at least one of the given people (repeatable).
+                 *     Assignees on nested steps are not considered.
+                 */
+                "assignee_ids[]"?: number[];
+                /** @description Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+                due?: string;
                 /** @description Page number for paginating through results. Defaults to 1. */
                 page?: number;
             };
@@ -8162,6 +8169,13 @@ export interface operations {
     GetEverythingNoDueDateCards: {
         parameters: {
             query?: {
+                /**
+                 * @description Restrict to tasks assigned to at least one of the given people (repeatable).
+                 *     Assignees on nested steps are not considered.
+                 */
+                "assignee_ids[]"?: number[];
+                /** @description Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+                due?: string;
                 /** @description Page number for paginating through results. Defaults to 1. */
                 page?: number;
             };
@@ -8221,6 +8235,13 @@ export interface operations {
     GetEverythingNotNowCards: {
         parameters: {
             query?: {
+                /**
+                 * @description Restrict to tasks assigned to at least one of the given people (repeatable).
+                 *     Assignees on nested steps are not considered.
+                 */
+                "assignee_ids[]"?: number[];
+                /** @description Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+                due?: string;
                 /** @description Page number for paginating through results. Defaults to 1. */
                 page?: number;
             };
@@ -8280,6 +8301,13 @@ export interface operations {
     GetEverythingOpenCards: {
         parameters: {
             query?: {
+                /**
+                 * @description Restrict to tasks assigned to at least one of the given people (repeatable).
+                 *     Assignees on nested steps are not considered.
+                 */
+                "assignee_ids[]"?: number[];
+                /** @description Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+                due?: string;
                 /** @description Page number for paginating through results. Defaults to 1. */
                 page?: number;
             };
@@ -8338,7 +8366,15 @@ export interface operations {
     };
     GetEverythingOverdueCards: {
         parameters: {
-            query?: never;
+            query?: {
+                /**
+                 * @description Restrict to tasks assigned to at least one of the given people (repeatable).
+                 *     Assignees on nested steps are not considered.
+                 */
+                "assignee_ids[]"?: number[];
+                /** @description Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+                due?: string;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -8395,6 +8431,13 @@ export interface operations {
     GetEverythingUnassignedCards: {
         parameters: {
             query?: {
+                /**
+                 * @description Restrict to tasks assigned to at least one of the given people (repeatable).
+                 *     Assignees on nested steps are not considered.
+                 */
+                "assignee_ids[]"?: number[];
+                /** @description Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+                due?: string;
                 /** @description Page number for paginating through results. Defaults to 1. */
                 page?: number;
             };
@@ -17888,6 +17931,13 @@ export interface operations {
     GetEverythingCompletedTodos: {
         parameters: {
             query?: {
+                /**
+                 * @description Restrict to tasks assigned to at least one of the given people (repeatable).
+                 *     Assignees on nested steps are not considered.
+                 */
+                "assignee_ids[]"?: number[];
+                /** @description Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+                due?: string;
                 /** @description Page number for paginating through results. Defaults to 1. */
                 page?: number;
             };
@@ -17947,6 +17997,13 @@ export interface operations {
     GetEverythingNoDueDateTodos: {
         parameters: {
             query?: {
+                /**
+                 * @description Restrict to tasks assigned to at least one of the given people (repeatable).
+                 *     Assignees on nested steps are not considered.
+                 */
+                "assignee_ids[]"?: number[];
+                /** @description Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+                due?: string;
                 /** @description Page number for paginating through results. Defaults to 1. */
                 page?: number;
             };
@@ -18006,6 +18063,13 @@ export interface operations {
     GetEverythingOpenTodos: {
         parameters: {
             query?: {
+                /**
+                 * @description Restrict to tasks assigned to at least one of the given people (repeatable).
+                 *     Assignees on nested steps are not considered.
+                 */
+                "assignee_ids[]"?: number[];
+                /** @description Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+                due?: string;
                 /** @description Page number for paginating through results. Defaults to 1. */
                 page?: number;
             };
@@ -18064,7 +18128,15 @@ export interface operations {
     };
     GetEverythingOverdueTodos: {
         parameters: {
-            query?: never;
+            query?: {
+                /**
+                 * @description Restrict to tasks assigned to at least one of the given people (repeatable).
+                 *     Assignees on nested steps are not considered.
+                 */
+                "assignee_ids[]"?: number[];
+                /** @description Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+                due?: string;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -18121,6 +18193,13 @@ export interface operations {
     GetEverythingUnassignedTodos: {
         parameters: {
             query?: {
+                /**
+                 * @description Restrict to tasks assigned to at least one of the given people (repeatable).
+                 *     Assignees on nested steps are not considered.
+                 */
+                "assignee_ids[]"?: number[];
+                /** @description Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+                due?: string;
                 /** @description Page number for paginating through results. Defaults to 1. */
                 page?: number;
             };

--- a/typescript/src/generated/services/everything.ts
+++ b/typescript/src/generated/services/everything.ts
@@ -30,6 +30,11 @@ export type Todo = components["schemas"]["Todo"];
  * Options for everythingCompletedCards.
  */
 export interface EverythingCompletedCardsEverythingOptions extends PaginationOptions {
+  /** Restrict to tasks assigned to at least one of the given people (repeatable).
+Assignees on nested steps are not considered. */
+  assigneeIds?: number[];
+  /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+  due?: string;
   /** Page number for paginating through results. Defaults to 1. */
   page?: number;
 }
@@ -38,6 +43,11 @@ export interface EverythingCompletedCardsEverythingOptions extends PaginationOpt
  * Options for everythingNoDueDateCards.
  */
 export interface EverythingNoDueDateCardsEverythingOptions extends PaginationOptions {
+  /** Restrict to tasks assigned to at least one of the given people (repeatable).
+Assignees on nested steps are not considered. */
+  assigneeIds?: number[];
+  /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+  due?: string;
   /** Page number for paginating through results. Defaults to 1. */
   page?: number;
 }
@@ -46,6 +56,11 @@ export interface EverythingNoDueDateCardsEverythingOptions extends PaginationOpt
  * Options for everythingNotNowCards.
  */
 export interface EverythingNotNowCardsEverythingOptions extends PaginationOptions {
+  /** Restrict to tasks assigned to at least one of the given people (repeatable).
+Assignees on nested steps are not considered. */
+  assigneeIds?: number[];
+  /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+  due?: string;
   /** Page number for paginating through results. Defaults to 1. */
   page?: number;
 }
@@ -54,14 +69,35 @@ export interface EverythingNotNowCardsEverythingOptions extends PaginationOption
  * Options for everythingOpenCards.
  */
 export interface EverythingOpenCardsEverythingOptions extends PaginationOptions {
+  /** Restrict to tasks assigned to at least one of the given people (repeatable).
+Assignees on nested steps are not considered. */
+  assigneeIds?: number[];
+  /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+  due?: string;
   /** Page number for paginating through results. Defaults to 1. */
   page?: number;
+}
+
+/**
+ * Options for everythingOverdueCards.
+ */
+export interface EverythingOverdueCardsEverythingOptions {
+  /** Restrict to tasks assigned to at least one of the given people (repeatable).
+Assignees on nested steps are not considered. */
+  assigneeIds?: number[];
+  /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+  due?: string;
 }
 
 /**
  * Options for everythingUnassignedCards.
  */
 export interface EverythingUnassignedCardsEverythingOptions extends PaginationOptions {
+  /** Restrict to tasks assigned to at least one of the given people (repeatable).
+Assignees on nested steps are not considered. */
+  assigneeIds?: number[];
+  /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+  due?: string;
   /** Page number for paginating through results. Defaults to 1. */
   page?: number;
 }
@@ -114,6 +150,11 @@ export interface EverythingMessagesEverythingOptions extends PaginationOptions {
  * Options for everythingCompletedTodos.
  */
 export interface EverythingCompletedTodosEverythingOptions extends PaginationOptions {
+  /** Restrict to tasks assigned to at least one of the given people (repeatable).
+Assignees on nested steps are not considered. */
+  assigneeIds?: number[];
+  /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+  due?: string;
   /** Page number for paginating through results. Defaults to 1. */
   page?: number;
 }
@@ -122,6 +163,11 @@ export interface EverythingCompletedTodosEverythingOptions extends PaginationOpt
  * Options for everythingNoDueDateTodos.
  */
 export interface EverythingNoDueDateTodosEverythingOptions extends PaginationOptions {
+  /** Restrict to tasks assigned to at least one of the given people (repeatable).
+Assignees on nested steps are not considered. */
+  assigneeIds?: number[];
+  /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+  due?: string;
   /** Page number for paginating through results. Defaults to 1. */
   page?: number;
 }
@@ -130,14 +176,35 @@ export interface EverythingNoDueDateTodosEverythingOptions extends PaginationOpt
  * Options for everythingOpenTodos.
  */
 export interface EverythingOpenTodosEverythingOptions extends PaginationOptions {
+  /** Restrict to tasks assigned to at least one of the given people (repeatable).
+Assignees on nested steps are not considered. */
+  assigneeIds?: number[];
+  /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+  due?: string;
   /** Page number for paginating through results. Defaults to 1. */
   page?: number;
+}
+
+/**
+ * Options for everythingOverdueTodos.
+ */
+export interface EverythingOverdueTodosEverythingOptions {
+  /** Restrict to tasks assigned to at least one of the given people (repeatable).
+Assignees on nested steps are not considered. */
+  assigneeIds?: number[];
+  /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+  due?: string;
 }
 
 /**
  * Options for everythingUnassignedTodos.
  */
 export interface EverythingUnassignedTodosEverythingOptions extends PaginationOptions {
+  /** Restrict to tasks assigned to at least one of the given people (repeatable).
+Assignees on nested steps are not considered. */
+  assigneeIds?: number[];
+  /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
+  due?: string;
   /** Page number for paginating through results. Defaults to 1. */
   page?: number;
 }
@@ -173,7 +240,7 @@ export class EverythingService extends BaseService {
       () =>
         this.client.GET("/cards/completed.json", {
           params: {
-            query: { page: options?.page },
+            query: { "assignee_ids[]": options?.assigneeIds, due: options?.due, page: options?.page },
           },
         })
       , options
@@ -201,7 +268,7 @@ export class EverythingService extends BaseService {
       () =>
         this.client.GET("/cards/no_due_date.json", {
           params: {
-            query: { page: options?.page },
+            query: { "assignee_ids[]": options?.assigneeIds, due: options?.due, page: options?.page },
           },
         })
       , options
@@ -229,7 +296,7 @@ export class EverythingService extends BaseService {
       () =>
         this.client.GET("/cards/not_now.json", {
           params: {
-            query: { page: options?.page },
+            query: { "assignee_ids[]": options?.assigneeIds, due: options?.due, page: options?.page },
           },
         })
       , options
@@ -257,7 +324,7 @@ export class EverythingService extends BaseService {
       () =>
         this.client.GET("/cards/open.json", {
           params: {
-            query: { page: options?.page },
+            query: { "assignee_ids[]": options?.assigneeIds, due: options?.due, page: options?.page },
           },
         })
       , options
@@ -266,6 +333,7 @@ export class EverythingService extends BaseService {
 
   /**
    * Get every overdue card across all accessible projects, oldest-due-date-first.
+   * @param options - Optional query parameters
    * @returns Array of Card
    *
    * @example
@@ -273,7 +341,7 @@ export class EverythingService extends BaseService {
    * const result = await client.everything.everythingOverdueCards();
    * ```
    */
-  async everythingOverdueCards(): Promise<Card[]> {
+  async everythingOverdueCards(options?: EverythingOverdueCardsEverythingOptions): Promise<Card[]> {
     const response = await this.request(
       {
         service: "Everything",
@@ -283,6 +351,9 @@ export class EverythingService extends BaseService {
       },
       () =>
         this.client.GET("/cards/overdue.json", {
+          params: {
+            query: { "assignee_ids[]": options?.assigneeIds, due: options?.due },
+          },
         })
     );
     return response ?? [];
@@ -309,7 +380,7 @@ export class EverythingService extends BaseService {
       () =>
         this.client.GET("/cards/unassigned.json", {
           params: {
-            query: { page: options?.page },
+            query: { "assignee_ids[]": options?.assigneeIds, due: options?.due, page: options?.page },
           },
         })
       , options
@@ -477,7 +548,7 @@ export class EverythingService extends BaseService {
       () =>
         this.client.GET("/todos/completed.json", {
           params: {
-            query: { page: options?.page },
+            query: { "assignee_ids[]": options?.assigneeIds, due: options?.due, page: options?.page },
           },
         })
       , options
@@ -505,7 +576,7 @@ export class EverythingService extends BaseService {
       () =>
         this.client.GET("/todos/no_due_date.json", {
           params: {
-            query: { page: options?.page },
+            query: { "assignee_ids[]": options?.assigneeIds, due: options?.due, page: options?.page },
           },
         })
       , options
@@ -533,7 +604,7 @@ export class EverythingService extends BaseService {
       () =>
         this.client.GET("/todos/open.json", {
           params: {
-            query: { page: options?.page },
+            query: { "assignee_ids[]": options?.assigneeIds, due: options?.due, page: options?.page },
           },
         })
       , options
@@ -542,6 +613,7 @@ export class EverythingService extends BaseService {
 
   /**
    * Get every overdue to-do across all accessible projects, oldest-due-date-first.
+   * @param options - Optional query parameters
    * @returns Array of Todo
    *
    * @example
@@ -549,7 +621,7 @@ export class EverythingService extends BaseService {
    * const result = await client.everything.everythingOverdueTodos();
    * ```
    */
-  async everythingOverdueTodos(): Promise<Todo[]> {
+  async everythingOverdueTodos(options?: EverythingOverdueTodosEverythingOptions): Promise<Todo[]> {
     const response = await this.request(
       {
         service: "Everything",
@@ -559,6 +631,9 @@ export class EverythingService extends BaseService {
       },
       () =>
         this.client.GET("/todos/overdue.json", {
+          params: {
+            query: { "assignee_ids[]": options?.assigneeIds, due: options?.due },
+          },
         })
     );
     return response ?? [];
@@ -585,7 +660,7 @@ export class EverythingService extends BaseService {
       () =>
         this.client.GET("/todos/unassigned.json", {
           params: {
-            query: { page: options?.page },
+            query: { "assignee_ids[]": options?.assigneeIds, due: options?.due, page: options?.page },
           },
         })
       , options

--- a/typescript/tests/services/everything.test.ts
+++ b/typescript/tests/services/everything.test.ts
@@ -346,6 +346,40 @@ describe("EverythingService", () => {
   });
 
   describe("everythingOpenTodos", () => {
+    it("encodes the due filter and repeatable assignee_ids[] in the query string", async () => {
+      let captured = "";
+      server.use(
+        http.get(`${BASE_URL}/todos/open.json`, ({ request }) => {
+          captured = new URL(request.url).search;
+          return HttpResponse.json([]);
+        })
+      );
+
+      await client.everything.everythingOpenTodos({ assigneeIds: [11, 22], due: "overdue" });
+
+      const params = new URLSearchParams(captured);
+      expect(params.get("due")).toBe("overdue");
+      // assignee_ids[] is a repeatable array param: both ids must appear under
+      // the bracketed key, not a single comma-joined value.
+      expect(params.getAll("assignee_ids[]")).toEqual(["11", "22"]);
+    });
+
+    it("encodes the filters on the unpaginated overdue feed too", async () => {
+      let captured = "";
+      server.use(
+        http.get(`${BASE_URL}/todos/overdue.json`, ({ request }) => {
+          captured = new URL(request.url).search;
+          return HttpResponse.json([]);
+        })
+      );
+
+      await client.everything.everythingOverdueTodos({ assigneeIds: [7], due: "with" });
+
+      const params = new URLSearchParams(captured);
+      expect(params.getAll("assignee_ids[]")).toEqual(["7"]);
+      expect(params.get("due")).toBe("with");
+    });
+
     it("should decode the /todos/open.json feed grouped by bucket, each to-do carrying its steps", async () => {
       const fixture = [
         {


### PR DESCRIPTION
C2 of the post-v0.11.0 absorption sprint.

BC3 #12442 added `assignee_ids[]` (repeatable) and `due` (`with`|`without`|`overdue`) to every everything to-do/card endpoint. The SDK modeled the 11 operations but carried neither filter — narrowing by assignee or due status meant fetching the full feed and filtering client-side.

## What

- **Spec**: four structures cover all 11 ops (nine grouped ops share `EverythingTodosFilterInput`/`EverythingCardsFilterInput`; the two overdue lists have their own inputs). `assignee_ids` follows the `people_ids[]` bracketed-array precedent on `GetEverythingFiles`; regenerated across all six SDKs.
- **Go**: shared `EverythingTaskFilters` options struct (the `EverythingFilesOptions` pattern) threaded through all 11 wrappers; grouped methods gain it alongside `page`, the overdue pair as their only option. Signature change is Go-breaking, staged for v0.12.0 like the rest of the sprint.
- **Tests**: Go/TS/Ruby/Python each pin the bracketed repeated wire form (`assignee_ids[]=11&assignee_ids[]=22`, no bare-key leak — the only form Rails' `permit` accepts) plus `due`, on both a grouped listing and the unpaginated overdue family; Go additionally pins that nil filters add no query. Kotlin/Swift serialize via their already-tested shared query builders.
- **Registry**: gap flipped to `absorbed-in-sdk` with eight member-level smithy_refs; README row; `make validate-api-gaps` clean.

## Notes

- No conformance fixture added: the mock harness asserts `requestPath` (path only) and has no query-assertion primitive; the wire-query pinning lives in the per-SDK tests above. (The live canary family is unaffected.)
- No operation-count movement — fields only; parity gates untouched and green.

## Verification

Full `make` green (exit 0) including all five conformance runners, drift gates, fixture coverage, and both parity gates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `assignee_ids[]` and `due` filters to all “Everything” to‑do/card endpoints, enabling server-side filtering and reducing client-side work. Specs and SDKs were regenerated; Go wrappers now accept filters.

- **New Features**
  - All 11 endpoints accept `assignee_ids[]` and `due` (`with` | `without` | `overdue`).
  - Bracketed repeatable array is used (`assignee_ids[]=11&assignee_ids[]=22`); tests in Go/TS/Ruby/Python pin wire format for grouped and overdue feeds. Kotlin/Swift serialize via shared query builders.
  - OpenAPI and `spec/basecamp.smithy` updated; API gap marked as absorbed in the registry.

- **Migration**
  - Go: method signatures change — grouped listings now take `(ctx, page, filters)`, overdue variants `(ctx, filters)`. Pass `nil` to omit filters; behavior unchanged.

<sup>Written for commit e5f1c71e867e306f7cbee7ba59685d1574e7daeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

