### PR TITLE
Stop auto-applying release-notes category labels by path

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -37,21 +37,8 @@ github-actions:
   - changed-files:
       - any-glob-to-any-file: ".github/**"
 
-documentation:
-  - changed-files:
-      - any-glob-to-any-file:
-          - "*.md"
-          - "docs/**"
-
-dependencies:
-  - changed-files:
-      - any-glob-to-any-file:
-          - "**/package.json"
-          - "**/package-lock.json"
-          - "**/go.mod"
-          - "**/go.sum"
-          - "**/Gemfile"
-          - "**/Gemfile.lock"
-          - "**/build.gradle.kts"
-          - "**/gradle.lockfile"
-          - "**/gradle/libs.versions.toml"
+# Deliberately absent: `documentation` and `dependencies`. Both are release-notes
+# categories in .github/release.yml, so auto-applying them by path misfiles any
+# feature or fix PR that happens to touch docs or a package manifest. Apply them
+# by hand when a PR really is docs-only or a dependency bump (Dependabot labels
+# its own PRs `dependencies`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,11 +248,15 @@ All SDKs are generated from a single Smithy specification. When adding support f
      | Documentation | `documentation` |
      | Other | anything else |
 
-     A PR may carry several — `breaking` plus `bug` is common — and language
-     labels (`go`, `python`, …) are applied automatically and don't affect
-     categorization. `ci` is configured in `.github/release.yml` but does not
-     yet exist as a repository label; use `github-actions` for workflow changes
-     until it does.
+     A PR may carry several — `breaking` plus `bug` is common. A PR lands in
+     the first matching section in the table's order, so an extra low-priority
+     label is harmless once the right one is applied. Language and area labels
+     (`go`, `python`, `spec`, `conformance`, …) are applied automatically from
+     changed paths and don't affect categorization; `github-actions` is the one
+     auto-applied label that does, filing otherwise-unlabeled workflow PRs
+     under CI & Infrastructure. `documentation` and `dependencies` are applied
+     by hand (Dependabot labels its own PRs), never by the path labeler — a
+     feature that touches docs or a manifest should read as a feature.
 
 ## Spec-shape lints
 


### PR DESCRIPTION
## The misfiling mechanism

Release notes are generated from PR labels at release time via `.github/release.yml`. The path labeler (`.github/labeler.yml`, actions/labeler) auto-applied two labels that are themselves release-notes categories:

- `documentation` — any PR touching `*.md` or `docs/**`
- `dependencies` — any PR touching a package manifest (`package.json`, `go.mod`, `Gemfile`, …)

A PR lands in the first category whose label it carries, so an otherwise-unlabeled feature PR that touches docs or a manifest gets filed under **Documentation** or **CI & Infrastructure** instead of falling to **Other** where it would at least look wrong. Concrete instance: #522–#526, five feature merges after v0.11.0, all auto-labeled `documentation` because they touch `docs/**` (since repaired by hand-applying `enhancement`, which outranks it).

## The fix

- **`.github/labeler.yml`**: drop the `documentation` and `dependencies` entries, with a comment explaining why they're deliberately absent. Language/area path labels stay, including `github-actions` — filing an otherwise-unlabeled workflow-only PR under CI & Infrastructure is the correct default, and a real category label still outranks it. Dependabot release notes are unaffected: Dependabot applies `dependencies` itself, and `release.yml` excludes dependabot authors from notes entirely.
- **`CONTRIBUTING.md`**: the claim that auto-applied labels "don't affect categorization" was false for `documentation`/`dependencies`; now it's accurate. Also retires the stale note that `ci` doesn't exist as a repo label — it does now.

No change to `.github/release.yml`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop auto-applying `documentation` and `dependencies` by path to prevent misfiled release notes. Updated `CONTRIBUTING.md` to match and clarify how labels affect categories.

- **Bug Fixes**
  - Removed `documentation` and `dependencies` from `.github/labeler.yml`. Apply these by hand for docs-only or dependency bumps; Dependabot still sets `dependencies`.
  - Kept language/area path labels, including `github-actions`. That one still files unlabeled workflow-only PRs under CI & Infrastructure; real category labels override it.
  - Updated `CONTRIBUTING.md` to clarify categorization order and auto-applied labels. Removed the outdated note about the `ci` label.

<sup>Written for commit 052100816f96246b142813777a9581ce42ae9e45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

