### PR TITLE
Measure retry delays with monotonic clocks in the Python and Ruby conformance runners

### DIFF
--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -37,8 +37,8 @@ _MISSING = object()
 class TestTracker:
     requests: list[dict] = field(default_factory=list)
 
-    def record_request(self, *, time: float, method: str, url: str, headers: dict, body: Any = None) -> None:
-        self.requests.append({"time": time, "method": method, "url": url, "headers": headers, "body": body})
+    def record_request(self, *, monotonic_time: float, method: str, url: str, headers: dict, body: Any = None) -> None:
+        self.requests.append({"monotonic_time": monotonic_time, "method": method, "url": url, "headers": headers, "body": body})
 
     def reset(self) -> None:
         self.requests.clear()
@@ -49,10 +49,14 @@ class TestTracker:
 
     @property
     def delays_between_requests(self) -> list[int]:
+        # Elapsed ms between consecutive requests, from monotonic captures.
+        # Wall-clock (time.time) can step or slew mid-test and read a sleep
+        # as shorter than it was — the delay-flake class from #496. Monotonic
+        # deltas mirror the Go runner's time.Time subtraction.
         if len(self.requests) < 2:
             return []
         return [
-            int((b["time"] - a["time"]) * 1000)
+            int((b["monotonic_time"] - a["monotonic_time"]) * 1000)
             for a, b in zip(self.requests, self.requests[1:])
         ]
 
@@ -306,7 +310,7 @@ class TestRunner:
             except ValueError:
                 request_body = None
             self._tracker.record_request(
-                time=time.time(),
+                monotonic_time=time.monotonic(),
                 method=str(request.method),
                 url=str(request.url),
                 headers=dict(request.headers),

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -11,7 +11,6 @@ require "basecamp"
 require "webmock"
 require "json"
 require "set"
-require "time"
 
 WebMock.enable!
 WebMock.disable_net_connect!
@@ -25,9 +24,9 @@ class TestTracker
     @mutex = Mutex.new
   end
 
-  def record_request(time:, method:, uri:, headers: {}, body: nil)
+  def record_request(monotonic_time:, method:, uri:, headers: {}, body: nil)
     @mutex.synchronize do
-      @requests << { time: time, method: method, uri: uri.to_s, headers: headers, body: body }
+      @requests << { monotonic_time: monotonic_time, method: method, uri: uri.to_s, headers: headers, body: body }
     end
   end
 
@@ -39,11 +38,15 @@ class TestTracker
     @requests.size
   end
 
+  # Elapsed ms between consecutive requests, from monotonic captures.
+  # Wall-clock (Time.now) can step or slew mid-test and read a sleep as
+  # shorter than it was — the delay-flake class from #496. Monotonic
+  # deltas mirror the Go runner's time.Time subtraction.
   def delays_between_requests
     return [] if @requests.size < 2
 
     @requests.each_cons(2).map do |a, b|
-      ((b[:time] - a[:time]) * 1000).to_i # milliseconds
+      ((b[:monotonic_time] - a[:monotonic_time]) * 1000).to_i # milliseconds
     end
   end
 end
@@ -395,7 +398,7 @@ class TestRunner
     call_count = 0
     stub.to_return do |request|
       @tracker.record_request(
-        time: Time.now,
+        monotonic_time: Process.clock_gettime(Process::CLOCK_MONOTONIC),
         method: request.method,
         uri: request.uri,
         headers: request.headers,


### PR DESCRIPTION
## The flake class

`delayBetweenRequests` assertions compare captured request timestamps against an exact minimum-delay bound. When the capture uses a **wall clock**, any NTP step or slew between two captures can make a real sleep of `min_delay` read marginally short, failing the assertion — a nondeterministic flake unrelated to SDK behavior.

#496 reported exactly this in the TypeScript runner; 058fd1172 (#488) patched it there with a `TIMER_SLACK_MS = 2` tolerance (a libuv early-fire workaround). The same class remained latent in two other runners:

- **Python** (`conformance/runner/python/runner.py`): captured `time.time()`, asserted `d < min_delay`
- **Ruby** (`conformance/runner/ruby/runner.rb`): captured `Time.now`, same exact bound

## The fix: Go's approach, not TS's

The Go runner never had this problem — `main.go` subtracts `time.Time` values, which is monotonic in Go. This PR applies the same principle rather than copying the slack-constant hack:

- Python captures `time.monotonic()`
- Ruby captures `Process.clock_gettime(Process::CLOCK_MONOTONIC)`

Both SDKs' retry sleeps wait against the monotonic clock, so measuring on the same clock makes the elapsed delta a true lower bound on the sleep — no tolerance constant needed, and the assertion stays exact.

## Consumer audit

The captured timestamp's **only consumer** in both runners is the delay-delta math (`delays_between_requests`). Nothing exports or reports it as an absolute time — other assertions read `method`/`url`/`headers`/`body`, and reports carry name/pass/fail only. So the field swaps wholesale, renamed `time` → `monotonic_time` so it can't be mistaken for a wall-clock reading. Ruby's now-unused `require "time"` is dropped.

Replay runners capture no timestamps; Kotlin/Swift runners don't implement `delayBetweenRequests`. Go and TS are untouched.

## Evidence

Both runners green with the change, exit codes pinned:

- `make conformance-python` → `REAL_EXIT=0`, 0 failed
- `make conformance-ruby` → `REAL_EXIT=0`, 0 failed

The delay-assertion fixtures (`GET operation retries on 503`, `GET operation retries on 429 with Retry-After`) PASS through the monotonic path in both; the two DownloadURL delay fixtures remain pre-existing intentional skips in both runners.

Closes the Python/Ruby residual of #496 (TS half already fixed by 058fd1172).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Python and Ruby conformance runners to monotonic clocks for measuring retry delays to eliminate flaky failures from wall-clock adjustments. Keeps exact minimum-delay assertions without adding tolerance.

- **Bug Fixes**
  - Python: replace `time.time()` with `time.monotonic()` and compute delays from `monotonic_time`.
  - Ruby: replace `Time.now` with `Process.clock_gettime(Process::CLOCK_MONOTONIC)` and compute delays from `monotonic_time`.
  - Rename captured field `time` → `monotonic_time`; remove unused `require "time"` in Ruby.

<sup>Written for commit 22b1241450982b9fe206a9f1bc3f7587393a40cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

