### PR TITLE
Go wrappers: complete the ergonomic surface for questions and card-column subscriptions

### DIFF
--- a/go/pkg/basecamp/cards.go
+++ b/go/pkg/basecamp/cards.go
@@ -988,6 +988,64 @@ func (s *CardColumnsService) Unwatch(ctx context.Context, columnID int64) (err e
 	return checkResponse(resp.HTTPResponse, resp.Body)
 }
 
+// Subscribe subscribes the current user to the column, watching it for changes.
+//
+// Subscribe uses the card-table-specific subscription endpoint
+// (card_tables/lists/{columnID}/subscription), which returns no content.
+// Watch is the same action through the generic recording subscription
+// endpoint and returns the resulting subscription details.
+// Returns nil on success (204 No Content).
+func (s *CardColumnsService) Subscribe(ctx context.Context, columnID int64) (err error) {
+	op := OperationInfo{
+		Service: "CardColumns", Operation: "Subscribe",
+		ResourceType: "card_column", IsMutation: true,
+		ResourceID: columnID,
+	}
+	if gater, ok := s.client.parent.hooks.(GatingHooks); ok {
+		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
+			return
+		}
+	}
+	start := time.Now()
+	ctx = s.client.parent.hooks.OnOperationStart(ctx, op)
+	defer func() { s.client.parent.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
+
+	resp, err := s.client.parent.gen.SubscribeToCardColumnWithResponse(ctx, s.client.accountID, columnID)
+	if err != nil {
+		return err
+	}
+	return checkResponse(resp.HTTPResponse, resp.Body)
+}
+
+// Unsubscribe unsubscribes the current user from the column, no longer
+// watching it for changes.
+//
+// Unsubscribe uses the card-table-specific subscription endpoint
+// (card_tables/lists/{columnID}/subscription); Unwatch is the same action
+// through the generic recording subscription endpoint.
+// Returns nil on success (204 No Content).
+func (s *CardColumnsService) Unsubscribe(ctx context.Context, columnID int64) (err error) {
+	op := OperationInfo{
+		Service: "CardColumns", Operation: "Unsubscribe",
+		ResourceType: "card_column", IsMutation: true,
+		ResourceID: columnID,
+	}
+	if gater, ok := s.client.parent.hooks.(GatingHooks); ok {
+		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
+			return
+		}
+	}
+	start := time.Now()
+	ctx = s.client.parent.hooks.OnOperationStart(ctx, op)
+	defer func() { s.client.parent.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
+
+	resp, err := s.client.parent.gen.UnsubscribeFromCardColumnWithResponse(ctx, s.client.accountID, columnID)
+	if err != nil {
+		return err
+	}
+	return checkResponse(resp.HTTPResponse, resp.Body)
+}
+
 // CardStepsService handles card step operations.
 type CardStepsService struct {
 	client *AccountClient

--- a/go/pkg/basecamp/cards_test.go
+++ b/go/pkg/basecamp/cards_test.go
@@ -1163,3 +1163,64 @@ func TestCardsService_UpdateSendsExplicitEmptyAssignees(t *testing.T) {
 		t.Errorf("assignee_ids = %v, want []", ids)
 	}
 }
+
+func TestCardColumnsService_Subscribe(t *testing.T) {
+	wantPath := "/99999/card_tables/lists/1069479347/subscription.json"
+
+	var requestedMethod, requestedPath string
+	svc := testCardColumnsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestedMethod = r.Method
+		requestedPath = r.URL.Path
+		w.WriteHeader(204)
+	})
+
+	if err := svc.Subscribe(context.Background(), cardColumnsTestColumnID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if requestedMethod != "POST" {
+		t.Errorf("expected POST, got %s", requestedMethod)
+	}
+	if requestedPath != wantPath {
+		t.Errorf("path = %q, want %q", requestedPath, wantPath)
+	}
+}
+
+func TestCardColumnsService_Unsubscribe(t *testing.T) {
+	wantPath := "/99999/card_tables/lists/1069479347/subscription.json"
+
+	var requestedMethod, requestedPath string
+	svc := testCardColumnsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestedMethod = r.Method
+		requestedPath = r.URL.Path
+		w.WriteHeader(204)
+	})
+
+	if err := svc.Unsubscribe(context.Background(), cardColumnsTestColumnID); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if requestedMethod != "DELETE" {
+		t.Errorf("expected DELETE, got %s", requestedMethod)
+	}
+	if requestedPath != wantPath {
+		t.Errorf("path = %q, want %q", requestedPath, wantPath)
+	}
+}
+
+func TestCardColumnsService_SubscribeError(t *testing.T) {
+	svc := testCardColumnsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(404)
+		w.Write([]byte(`{"error":"not found"}`))
+	})
+
+	err := svc.Subscribe(context.Background(), cardColumnsTestColumnID)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	apiErr, ok := err.(*Error)
+	if !ok || apiErr.Code != CodeNotFound {
+		t.Fatalf("expected not-found error, got %v", err)
+	}
+}

--- a/go/pkg/basecamp/checkins.go
+++ b/go/pkg/basecamp/checkins.go
@@ -34,6 +34,18 @@ type AnswerListOptions struct {
 	Page int
 }
 
+// QuestionReminderListOptions specifies options for listing question reminders.
+type QuestionReminderListOptions struct {
+	// Limit is the maximum number of reminders to return.
+	// If 0 (default), returns all reminders. Use a positive value to cap results.
+	Limit int
+
+	// Page, if non-zero, disables pagination and returns only the first page.
+	// NOTE: The page number itself is not yet honored due to OpenAPI client
+	// limitations. Use 0 to paginate through all results up to Limit.
+	Page int
+}
+
 // Questionnaire represents a Basecamp automatic check-in questionnaire.
 type Questionnaire struct {
 	ID               int64     `json:"id"`
@@ -127,6 +139,21 @@ type QuestionAnswer struct {
 	Creator            *Person              `json:"creator,omitempty"`
 }
 
+// QuestionReminder represents a pending check-in reminder for the current user.
+type QuestionReminder struct {
+	GroupOn    string    `json:"group_on,omitempty"`
+	Question   Question  `json:"question"`
+	RemindAt   time.Time `json:"remind_at"`
+	ReminderID *int64    `json:"reminder_id,omitempty"`
+}
+
+// QuestionNotificationSettings represents the current user's notification
+// settings for a check-in question.
+type QuestionNotificationSettings struct {
+	Responding bool `json:"responding"`
+	Subscribed bool `json:"subscribed"`
+}
+
 // CreateQuestionRequest specifies the parameters for creating a question.
 type CreateQuestionRequest struct {
 	// Title is the question text (required).
@@ -167,6 +194,20 @@ type UpdateAnswerRequest struct {
 	GroupOn string `json:"group_on,omitempty"`
 }
 
+// UpdateQuestionNotificationSettingsRequest specifies the parameters for
+// updating the current user's notification settings for a question.
+//
+// Both fields are optional and tri-state: nil omits the field so the server
+// leaves that setting unchanged; a non-nil value is sent verbatim, and an
+// explicit false reaches the wire (the pointer distinguishes unset from false).
+type UpdateQuestionNotificationSettingsRequest struct {
+	// NotifyOnAnswer controls whether the user is notified when someone answers.
+	NotifyOnAnswer *bool `json:"notify_on_answer,omitempty"`
+	// DigestIncludeUnanswered controls whether unanswered questions are
+	// included in the digest.
+	DigestIncludeUnanswered *bool `json:"digest_include_unanswered,omitempty"`
+}
+
 // QuestionListResult contains the results from listing questions.
 type QuestionListResult struct {
 	// Questions is the list of questions returned.
@@ -179,6 +220,14 @@ type QuestionListResult struct {
 type AnswerListResult struct {
 	// Answers is the list of answers returned.
 	Answers []QuestionAnswer
+	// Meta contains pagination metadata (total count, etc.).
+	Meta ListMeta
+}
+
+// QuestionReminderListResult contains the results from listing question reminders.
+type QuestionReminderListResult struct {
+	// Reminders is the list of question reminders returned.
+	Reminders []QuestionReminder
 	// Meta contains pagination metadata (total count, etc.).
 	Meta ListMeta
 }
@@ -446,6 +495,98 @@ func (s *CheckinsService) UpdateQuestion(ctx context.Context, questionID int64, 
 	return &question, nil
 }
 
+// PauseQuestion pauses a check-in question, stopping its reminders.
+// Returns nil on success.
+func (s *CheckinsService) PauseQuestion(ctx context.Context, questionID int64) (err error) {
+	op := OperationInfo{
+		Service: "Checkins", Operation: "PauseQuestion",
+		ResourceType: "question", IsMutation: true,
+		ResourceID: questionID,
+	}
+	if gater, ok := s.client.parent.hooks.(GatingHooks); ok {
+		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
+			return
+		}
+	}
+	start := time.Now()
+	ctx = s.client.parent.hooks.OnOperationStart(ctx, op)
+	defer func() { s.client.parent.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
+
+	resp, err := s.client.parent.gen.PauseQuestionWithResponse(ctx, s.client.accountID, questionID)
+	if err != nil {
+		return err
+	}
+	return checkResponse(resp.HTTPResponse, resp.Body)
+}
+
+// ResumeQuestion resumes a paused check-in question, restarting its reminders.
+// Returns nil on success.
+func (s *CheckinsService) ResumeQuestion(ctx context.Context, questionID int64) (err error) {
+	op := OperationInfo{
+		Service: "Checkins", Operation: "ResumeQuestion",
+		ResourceType: "question", IsMutation: true,
+		ResourceID: questionID,
+	}
+	if gater, ok := s.client.parent.hooks.(GatingHooks); ok {
+		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
+			return
+		}
+	}
+	start := time.Now()
+	ctx = s.client.parent.hooks.OnOperationStart(ctx, op)
+	defer func() { s.client.parent.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
+
+	resp, err := s.client.parent.gen.ResumeQuestionWithResponse(ctx, s.client.accountID, questionID)
+	if err != nil {
+		return err
+	}
+	return checkResponse(resp.HTTPResponse, resp.Body)
+}
+
+// UpdateQuestionNotificationSettings updates the current user's notification
+// settings for a question.
+// Returns the updated settings.
+func (s *CheckinsService) UpdateQuestionNotificationSettings(ctx context.Context, questionID int64, req *UpdateQuestionNotificationSettingsRequest) (result *QuestionNotificationSettings, err error) {
+	op := OperationInfo{
+		Service: "Checkins", Operation: "UpdateQuestionNotificationSettings",
+		ResourceType: "question", IsMutation: true,
+		ResourceID: questionID,
+	}
+	if gater, ok := s.client.parent.hooks.(GatingHooks); ok {
+		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
+			return
+		}
+	}
+	start := time.Now()
+	ctx = s.client.parent.hooks.OnOperationStart(ctx, op)
+	defer func() { s.client.parent.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
+
+	if req == nil {
+		err = ErrUsage("update request is required")
+		return nil, err
+	}
+
+	body := generated.UpdateQuestionNotificationSettingsJSONRequestBody{
+		NotifyOnAnswer:          req.NotifyOnAnswer,
+		DigestIncludeUnanswered: req.DigestIncludeUnanswered,
+	}
+
+	resp, err := s.client.parent.gen.UpdateQuestionNotificationSettingsWithResponse(ctx, s.client.accountID, questionID, body)
+	if err != nil {
+		return nil, err
+	}
+	if err = checkResponse(resp.HTTPResponse, resp.Body); err != nil {
+		return nil, err
+	}
+	if resp.JSON200 == nil {
+		err = fmt.Errorf("unexpected empty response")
+		return nil, err
+	}
+
+	settings := questionNotificationSettingsFromGenerated(*resp.JSON200)
+	return &settings, nil
+}
+
 // ListAnswers returns all answers for a question.
 //
 // By default, returns all answers (no limit). Use Limit to cap results.
@@ -597,6 +738,79 @@ func (s *CheckinsService) ListAnswersByPerson(ctx context.Context, questionID, p
 	return &AnswerListResult{Answers: answers, Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 }
 
+// ListAnswerers returns all people who have answered a question.
+//
+// By default, returns all answerers (no limit). Use Limit to cap results.
+//
+// Pagination options:
+//   - Limit: maximum number of people to return (0 = all)
+//   - Page: if non-zero, disables pagination and returns first page only.
+//     NOTE: The page number itself is not yet honored due to OpenAPI client
+//     limitations. Use 0 to paginate through all results up to Limit.
+//
+// The returned PeopleListResult includes pagination metadata (TotalCount from
+// X-Total-Count header) when available.
+func (s *CheckinsService) ListAnswerers(ctx context.Context, questionID int64, opts *PeopleListOptions) (result *PeopleListResult, err error) {
+	op := OperationInfo{
+		Service: "Checkins", Operation: "ListAnswerers",
+		ResourceType: "person", IsMutation: false,
+		ResourceID: questionID,
+	}
+	if gater, ok := s.client.parent.hooks.(GatingHooks); ok {
+		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
+			return
+		}
+	}
+	start := time.Now()
+	ctx = s.client.parent.hooks.OnOperationStart(ctx, op)
+	defer func() { s.client.parent.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
+
+	resp, err := s.client.parent.gen.ListQuestionAnswerersWithResponse(ctx, s.client.accountID, questionID)
+	if err != nil {
+		return nil, err
+	}
+	if err = checkResponse(resp.HTTPResponse, resp.Body); err != nil {
+		return nil, err
+	}
+
+	totalCount := parseTotalCount(resp.HTTPResponse)
+
+	var people []Person
+	if resp.JSON200 != nil {
+		for _, gp := range *resp.JSON200 {
+			people = append(people, personFromGenerated(gp))
+		}
+	}
+
+	if opts != nil && opts.Page > 0 {
+		return &PeopleListResult{People: people, Meta: ListMeta{TotalCount: totalCount}}, nil
+	}
+
+	limit := 0
+	if opts != nil && opts.Limit > 0 {
+		limit = opts.Limit
+	}
+
+	if limit > 0 && len(people) >= limit {
+		return &PeopleListResult{People: people[:limit], Meta: ListMeta{TotalCount: totalCount, Truncated: isFirstPageTruncated(resp.HTTPResponse, len(people), limit)}}, nil
+	}
+
+	rawMore, truncated, err := s.client.parent.followPagination(ctx, resp.HTTPResponse, len(people), limit)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, raw := range rawMore {
+		var gp generated.Person
+		if err := json.Unmarshal(raw, &gp); err != nil {
+			return nil, fmt.Errorf("failed to parse person: %w", err)
+		}
+		people = append(people, personFromGenerated(gp))
+	}
+
+	return &PeopleListResult{People: people, Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
+}
+
 // GetAnswer returns a question answer by ID.
 func (s *CheckinsService) GetAnswer(ctx context.Context, answerID int64) (result *QuestionAnswer, err error) {
 	op := OperationInfo{
@@ -730,6 +944,81 @@ func (s *CheckinsService) UpdateAnswer(ctx context.Context, answerID int64, req 
 		return err
 	}
 	return checkResponse(resp.HTTPResponse, resp.Body)
+}
+
+// ListQuestionReminders returns pending check-in reminders for the current user.
+//
+// Reminders cover questions that are awaiting a response from the
+// authenticated user, across all projects in the account.
+//
+// By default, returns all reminders (no limit). Use Limit to cap results.
+//
+// Pagination options:
+//   - Limit: maximum number of reminders to return (0 = all)
+//   - Page: if non-zero, disables pagination and returns first page only.
+//     NOTE: The page number itself is not yet honored due to OpenAPI client
+//     limitations. Use 0 to paginate through all results up to Limit.
+//
+// The returned QuestionReminderListResult includes pagination metadata
+// (TotalCount from X-Total-Count header) when available.
+func (s *CheckinsService) ListQuestionReminders(ctx context.Context, opts *QuestionReminderListOptions) (result *QuestionReminderListResult, err error) {
+	op := OperationInfo{
+		Service: "Checkins", Operation: "ListQuestionReminders",
+		ResourceType: "question_reminder", IsMutation: false,
+	}
+	if gater, ok := s.client.parent.hooks.(GatingHooks); ok {
+		if ctx, err = gater.OnOperationGate(ctx, op); err != nil {
+			return
+		}
+	}
+	start := time.Now()
+	ctx = s.client.parent.hooks.OnOperationStart(ctx, op)
+	defer func() { s.client.parent.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
+
+	resp, err := s.client.parent.gen.GetQuestionRemindersWithResponse(ctx, s.client.accountID)
+	if err != nil {
+		return nil, err
+	}
+	if err = checkResponse(resp.HTTPResponse, resp.Body); err != nil {
+		return nil, err
+	}
+
+	totalCount := parseTotalCount(resp.HTTPResponse)
+
+	var reminders []QuestionReminder
+	if resp.JSON200 != nil {
+		for _, gr := range *resp.JSON200 {
+			reminders = append(reminders, questionReminderFromGenerated(gr))
+		}
+	}
+
+	if opts != nil && opts.Page > 0 {
+		return &QuestionReminderListResult{Reminders: reminders, Meta: ListMeta{TotalCount: totalCount}}, nil
+	}
+
+	limit := 0
+	if opts != nil && opts.Limit > 0 {
+		limit = opts.Limit
+	}
+
+	if limit > 0 && len(reminders) >= limit {
+		return &QuestionReminderListResult{Reminders: reminders[:limit], Meta: ListMeta{TotalCount: totalCount, Truncated: isFirstPageTruncated(resp.HTTPResponse, len(reminders), limit)}}, nil
+	}
+
+	rawMore, truncated, err := s.client.parent.followPagination(ctx, resp.HTTPResponse, len(reminders), limit)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, raw := range rawMore {
+		var gr generated.QuestionReminder
+		if err := json.Unmarshal(raw, &gr); err != nil {
+			return nil, fmt.Errorf("failed to parse question reminder: %w", err)
+		}
+		reminders = append(reminders, questionReminderFromGenerated(gr))
+	}
+
+	return &QuestionReminderListResult{Reminders: reminders, Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 }
 
 // questionnaireFromGenerated converts a generated Questionnaire to our clean type.
@@ -904,6 +1193,31 @@ func questionAnswerFromGenerated(ga generated.QuestionAnswer) QuestionAnswer {
 	a.ContentAttachments = richTextAttachmentsFromGenerated(ga.ContentAttachments)
 
 	return a
+}
+
+// questionReminderFromGenerated converts a generated QuestionReminder to our clean type.
+func questionReminderFromGenerated(gr generated.QuestionReminder) QuestionReminder {
+	r := QuestionReminder{
+		Question:   questionFromGenerated(gr.Question),
+		RemindAt:   gr.RemindAt,
+		ReminderID: gr.ReminderId,
+	}
+
+	// Convert date fields to strings
+	if !gr.GroupOn.IsZero() {
+		r.GroupOn = gr.GroupOn.String()
+	}
+
+	return r
+}
+
+// questionNotificationSettingsFromGenerated converts a generated
+// UpdateQuestionNotificationSettingsResponseContent to our clean type.
+func questionNotificationSettingsFromGenerated(gs generated.UpdateQuestionNotificationSettingsResponseContent) QuestionNotificationSettings {
+	return QuestionNotificationSettings{
+		Responding: gs.Responding,
+		Subscribed: gs.Subscribed,
+	}
 }
 
 // questionScheduleToMap converts a QuestionSchedule to a map for JSON marshaling.

--- a/go/pkg/basecamp/checkins_test.go
+++ b/go/pkg/basecamp/checkins_test.go
@@ -1099,3 +1099,336 @@ func TestCheckinsService_CreateQuestionVisibleToClients(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckinsService_PauseQuestion(t *testing.T) {
+	var requestedMethod, requestedPath string
+	svc := testCheckinsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestedMethod = r.Method
+		requestedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"paused":true}`))
+	})
+
+	if err := svc.PauseQuestion(context.Background(), 1069479410); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if requestedMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", requestedMethod)
+	}
+	if requestedPath != "/99999/questions/1069479410/pause.json" {
+		t.Errorf("expected path /99999/questions/1069479410/pause.json, got %q", requestedPath)
+	}
+}
+
+func TestCheckinsService_ResumeQuestion(t *testing.T) {
+	var requestedMethod, requestedPath string
+	svc := testCheckinsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestedMethod = r.Method
+		requestedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"paused":false}`))
+	})
+
+	if err := svc.ResumeQuestion(context.Background(), 1069479410); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if requestedMethod != http.MethodDelete {
+		t.Errorf("expected DELETE, got %s", requestedMethod)
+	}
+	if requestedPath != "/99999/questions/1069479410/pause.json" {
+		t.Errorf("expected path /99999/questions/1069479410/pause.json, got %q", requestedPath)
+	}
+}
+
+func TestCheckinsService_PauseQuestionError(t *testing.T) {
+	svc := testCheckinsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(404)
+		w.Write([]byte(`{"error":"not found"}`))
+	})
+
+	err := svc.PauseQuestion(context.Background(), 1069479410)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	apiErr, ok := err.(*Error)
+	if !ok || apiErr.Code != CodeNotFound {
+		t.Fatalf("expected not-found error, got %v", err)
+	}
+}
+
+// TestCheckinsService_UpdateQuestionNotificationSettings verifies the wire
+// shape (PUT to notification_settings.json) and the tri-state request fields:
+// nil omits a key, and an explicit false is sent (not dropped).
+func TestCheckinsService_UpdateQuestionNotificationSettings(t *testing.T) {
+	fls := false
+
+	var requestedMethod, requestedPath string
+	var receivedBody map[string]any
+	svc := testCheckinsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestedMethod = r.Method
+		requestedPath = r.URL.Path
+		receivedBody = decodeRequestBody(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`{"responding":true,"subscribed":false}`))
+	})
+
+	settings, err := svc.UpdateQuestionNotificationSettings(context.Background(), 1069479410, &UpdateQuestionNotificationSettingsRequest{
+		NotifyOnAnswer: &fls,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if requestedMethod != http.MethodPut {
+		t.Errorf("expected PUT, got %s", requestedMethod)
+	}
+	if requestedPath != "/99999/questions/1069479410/notification_settings.json" {
+		t.Errorf("expected path /99999/questions/1069479410/notification_settings.json, got %q", requestedPath)
+	}
+
+	if got, ok := receivedBody["notify_on_answer"]; !ok || got != false {
+		t.Errorf("expected notify_on_answer false to reach the wire, got %v (present=%v)", got, ok)
+	}
+	if _, ok := receivedBody["digest_include_unanswered"]; ok {
+		t.Errorf("expected digest_include_unanswered to be omitted when nil, but it was present: %v", receivedBody["digest_include_unanswered"])
+	}
+
+	if !settings.Responding {
+		t.Error("expected Responding true")
+	}
+	if settings.Subscribed {
+		t.Error("expected Subscribed false")
+	}
+}
+
+func TestCheckinsService_UpdateQuestionNotificationSettingsRequiresRequest(t *testing.T) {
+	var requestCount int
+	svc := testCheckinsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+	})
+
+	_, err := svc.UpdateQuestionNotificationSettings(context.Background(), 1069479410, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	apiErr, ok := err.(*Error)
+	if !ok || apiErr.Code != CodeUsage {
+		t.Fatalf("expected usage error, got %v", err)
+	}
+	if requestCount != 0 {
+		t.Fatalf("expected 0 requests, got %d", requestCount)
+	}
+}
+
+func TestCheckinsService_ListAnswerers(t *testing.T) {
+	var requestedMethod, requestedPath string
+	svc := testCheckinsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestedMethod = r.Method
+		requestedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-Total-Count", "2")
+		w.WriteHeader(200)
+		w.Write([]byte(`[
+			{"id":1049715914,"name":"Victor Cooper","email_address":"victor@honchodesign.com"},
+			{"id":1049715915,"name":"Annie Bryan","email_address":"annie@honchodesign.com"}
+		]`))
+	})
+
+	result, err := svc.ListAnswerers(context.Background(), 1069479410, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if requestedMethod != http.MethodGet {
+		t.Errorf("expected GET, got %s", requestedMethod)
+	}
+	if requestedPath != "/99999/questions/1069479410/answers/by.json" {
+		t.Errorf("expected path /99999/questions/1069479410/answers/by.json, got %q", requestedPath)
+	}
+
+	if len(result.People) != 2 {
+		t.Fatalf("expected 2 people, got %d", len(result.People))
+	}
+	if result.People[0].ID != 1049715914 || result.People[0].Name != "Victor Cooper" {
+		t.Errorf("unexpected first person: %+v", result.People[0])
+	}
+	if result.People[1].EmailAddress != "annie@honchodesign.com" {
+		t.Errorf("unexpected second person email: %q", result.People[1].EmailAddress)
+	}
+	if result.Meta.TotalCount != 2 {
+		t.Errorf("expected TotalCount 2, got %d", result.Meta.TotalCount)
+	}
+}
+
+func TestCheckinsService_ListAnswerers_Pagination(t *testing.T) {
+	page1Body := `[{"id":1,"name":"A"},{"id":2,"name":"B"}]`
+	page2Body := `[{"id":3,"name":"C"},{"id":4,"name":"D"}]`
+
+	cases := []struct {
+		name          string
+		opts          *PeopleListOptions
+		wantPeople    int
+		wantRequests  int
+		wantTruncated bool
+	}{
+		{"collects across pages when no limit", nil, 4, 2, false},
+		{"Page option returns first page and skips Link follow", &PeopleListOptions{Page: 1}, 2, 1, false},
+		{"Limit smaller than first page truncates without follow", &PeopleListOptions{Limit: 1}, 1, 1, true},
+		{"Limit straddling page boundary trims second page", &PeopleListOptions{Limit: 3}, 3, 2, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var requestCount int
+			svc := testCheckinsServer(t, func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+				w.Header().Set("Content-Type", "application/json")
+				if requestCount == 1 {
+					w.Header().Set("Link", fmt.Sprintf(`<http://%s/99999/questions/1069479410/answers/by.json?page=2>; rel="next"`, r.Host))
+					w.WriteHeader(200)
+					w.Write([]byte(page1Body))
+					return
+				}
+				w.WriteHeader(200)
+				w.Write([]byte(page2Body))
+			})
+
+			result, err := svc.ListAnswerers(context.Background(), 1069479410, tc.opts)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(result.People) != tc.wantPeople {
+				t.Errorf("expected %d people, got %d", tc.wantPeople, len(result.People))
+			}
+			if requestCount != tc.wantRequests {
+				t.Errorf("expected %d HTTP requests, got %d", tc.wantRequests, requestCount)
+			}
+			if result.Meta.Truncated != tc.wantTruncated {
+				t.Errorf("expected Truncated=%v, got %v", tc.wantTruncated, result.Meta.Truncated)
+			}
+		})
+	}
+}
+
+func TestCheckinsService_ListQuestionReminders(t *testing.T) {
+	var requestedMethod, requestedPath string
+	svc := testCheckinsServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestedMethod = r.Method
+		requestedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`[
+			{
+				"group_on": "2022-10-28",
+				"remind_at": "2022-10-28T09:00:00.000Z",
+				"reminder_id": 123,
+				"question": {"id": 1069479410, "title": "What did you work on today?", "type": "Question", "paused": false}
+			},
+			{
+				"remind_at": "2022-10-29T09:00:00.000Z",
+				"question": {"id": 1069479411, "title": "Any blockers?", "type": "Question", "paused": false}
+			}
+		]`))
+	})
+
+	result, err := svc.ListQuestionReminders(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if requestedMethod != http.MethodGet {
+		t.Errorf("expected GET, got %s", requestedMethod)
+	}
+	if requestedPath != "/99999/my/question_reminders.json" {
+		t.Errorf("expected path /99999/my/question_reminders.json, got %q", requestedPath)
+	}
+
+	if len(result.Reminders) != 2 {
+		t.Fatalf("expected 2 reminders, got %d", len(result.Reminders))
+	}
+
+	r1 := result.Reminders[0]
+	if r1.GroupOn != "2022-10-28" {
+		t.Errorf("expected GroupOn '2022-10-28', got %q", r1.GroupOn)
+	}
+	if r1.RemindAt.IsZero() {
+		t.Error("expected RemindAt to be non-zero")
+	}
+	if r1.ReminderID == nil || *r1.ReminderID != 123 {
+		t.Errorf("expected ReminderID 123, got %v", r1.ReminderID)
+	}
+	if r1.Question.ID != 1069479410 {
+		t.Errorf("expected Question.ID 1069479410, got %d", r1.Question.ID)
+	}
+	if r1.Question.Title != "What did you work on today?" {
+		t.Errorf("unexpected Question.Title: %q", r1.Question.Title)
+	}
+
+	r2 := result.Reminders[1]
+	if r2.GroupOn != "" {
+		t.Errorf("expected empty GroupOn when absent, got %q", r2.GroupOn)
+	}
+	if r2.ReminderID != nil {
+		t.Errorf("expected nil ReminderID when absent, got %v", r2.ReminderID)
+	}
+	if r2.Question.ID != 1069479411 {
+		t.Errorf("expected Question.ID 1069479411, got %d", r2.Question.ID)
+	}
+}
+
+func TestCheckinsService_ListQuestionReminders_Pagination(t *testing.T) {
+	page1Body := `[{"remind_at":"2022-10-28T09:00:00.000Z","question":{"id":1}},{"remind_at":"2022-10-28T09:00:00.000Z","question":{"id":2}}]`
+	page2Body := `[{"remind_at":"2022-10-28T09:00:00.000Z","question":{"id":3}},{"remind_at":"2022-10-28T09:00:00.000Z","question":{"id":4}}]`
+
+	cases := []struct {
+		name          string
+		opts          *QuestionReminderListOptions
+		wantReminders int
+		wantRequests  int
+		wantTruncated bool
+	}{
+		{"collects across pages when no limit", nil, 4, 2, false},
+		{"Page option returns first page and skips Link follow", &QuestionReminderListOptions{Page: 1}, 2, 1, false},
+		{"Limit smaller than first page truncates without follow", &QuestionReminderListOptions{Limit: 1}, 1, 1, true},
+		{"Limit straddling page boundary trims second page", &QuestionReminderListOptions{Limit: 3}, 3, 2, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var requestCount int
+			svc := testCheckinsServer(t, func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+				w.Header().Set("Content-Type", "application/json")
+				if requestCount == 1 {
+					w.Header().Set("Link", fmt.Sprintf(`<http://%s/99999/my/question_reminders.json?page=2>; rel="next"`, r.Host))
+					w.WriteHeader(200)
+					w.Write([]byte(page1Body))
+					return
+				}
+				w.WriteHeader(200)
+				w.Write([]byte(page2Body))
+			})
+
+			result, err := svc.ListQuestionReminders(context.Background(), tc.opts)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(result.Reminders) != tc.wantReminders {
+				t.Errorf("expected %d reminders, got %d", tc.wantReminders, len(result.Reminders))
+			}
+			if requestCount != tc.wantRequests {
+				t.Errorf("expected %d HTTP requests, got %d", tc.wantRequests, requestCount)
+			}
+			if result.Meta.Truncated != tc.wantTruncated {
+				t.Errorf("expected Truncated=%v, got %v", tc.wantTruncated, result.Meta.Truncated)
+			}
+		})
+	}
+}

--- a/scripts/check-service-drift.sh
+++ b/scripts/check-service-drift.sh
@@ -17,16 +17,9 @@ SDK_DIR="$(dirname "$SCRIPT_DIR")/go"
 GENERATED_FILE="$SDK_DIR/pkg/generated/client.gen.go"
 SERVICE_DIR="$SDK_DIR/pkg/basecamp"
 
-# Operations intentionally not yet wrapped (tracked for Go service generator work)
-EXCLUDED_OPS=(
-  GetQuestionReminders
-  ListQuestionAnswerers
-  PauseQuestion
-  ResumeQuestion
-  SubscribeToCardColumn
-  UnsubscribeFromCardColumn
-  UpdateQuestionNotificationSettings
-)
+# Operations intentionally not yet wrapped. Keep this empty: every generated
+# operation must have an ergonomic wrapper in go/pkg/basecamp/.
+EXCLUDED_OPS=()
 
 # Temporary files
 GEN_OPS=$(mktemp)


### PR DESCRIPTION
Closes the last gap in Go's ergonomic layer: seven generated operations were callable from every other SDK but excluded from `go/pkg/basecamp`, parked on `check-service-drift.sh`'s exclusion list. This PR wraps all seven and empties the list, so the drift gate now enforces 238/238 (100%) operation coverage with zero exclusions.

## The seven operations

| Operation | Wrapper | Route |
|---|---|---|
| `GetQuestionReminders` | `Checkins().ListQuestionReminders(ctx, opts)` | `GET /my/question_reminders.json` |
| `ListQuestionAnswerers` | `Checkins().ListAnswerers(ctx, questionID, opts)` | `GET /questions/{id}/answers/by.json` |
| `PauseQuestion` | `Checkins().PauseQuestion(ctx, questionID)` | `POST /questions/{id}/pause.json` |
| `ResumeQuestion` | `Checkins().ResumeQuestion(ctx, questionID)` | `DELETE /questions/{id}/pause.json` |
| `UpdateQuestionNotificationSettings` | `Checkins().UpdateQuestionNotificationSettings(ctx, questionID, req)` | `PUT /questions/{id}/notification_settings.json` |
| `SubscribeToCardColumn` | `CardColumns().Subscribe(ctx, columnID)` | `POST /card_tables/lists/{id}/subscription.json` |
| `UnsubscribeFromCardColumn` | `CardColumns().Unsubscribe(ctx, columnID)` | `DELETE /card_tables/lists/{id}/subscription.json` |

Naming follows each file's existing idiom: `ListAnswersByPerson` already wraps `GetAnswersByPerson`, so list-returning wrappers take `List*` names; `ListAnswerers` reuses the `PeopleListOptions`/`PeopleListResult` types since it returns people. `CardColumns().Subscribe/Unsubscribe` sit alongside the existing `Watch/Unwatch` pair, which ride the **generic recording** subscription endpoint (`gen.Subscribe`/`gen.Unsubscribe`) — the new pair covers the dedicated card-table route, and the doc comments cross-reference the two.

Both paginated list wrappers (`ListQuestionReminders`, `ListAnswerers`) follow the standard Link-header pagination idiom (`followPagination`, `X-Total-Count`, Limit/Page options). `PauseQuestion`/`ResumeQuestion` return err-only: the 200 body (`{"paused": bool}`) carries no information beyond success. New `QuestionReminder` and `QuestionNotificationSettings` wrapper types come with `*FromGenerated` converters, so `check-wrapper-drift` discovers and verifies them (88 pairs walked, up from 86).

## Red proof

With `EXCLUDED_OPS=()` and no wrappers, `scripts/check-service-drift.sh` fails listing exactly the seven:

```
Generated client operations: 238
Service layer wrapped operations: 231

=== ERROR: Generated operations NOT wrapped by service layer (7) ===
GetQuestionReminders
ListQuestionAnswerers
PauseQuestion
ResumeQuestion
SubscribeToCardColumn
UnsubscribeFromCardColumn
UpdateQuestionNotificationSettings

Every generated operation must have a service wrapper in go/pkg/basecamp/.
Add wrappers for these operations or update this check if they are intentionally excluded.
Coverage: 231 / 238 operations (97%)

DRIFT DETECTED - Fix the issues above before proceeding.
REAL_EXIT=1
```

After the wrappers: `Coverage: 238 / 238 operations (100%)`, `No critical drift detected.`, exit 0.

## Retry-metadata verification

`PauseQuestion` and `SubscribeToCardColumn` are two of the idempotent POSTs named in SPEC.md §7. Verified the wrappers leave the generated transport's retry gating untouched:

- `ClientWithResponses.PauseQuestionWithResponse` delegates to `Client.PauseQuestion`, which calls `doWithRetry(ctx, build, true, "PauseQuestion", ...)` — the idempotent call-site boolean and the `operationRetryMetadata["PauseQuestion"] = {Idempotent: true}` entry are generated and unchanged.
- Same shape for `SubscribeToCardColumnWithResponse` → `Client.SubscribeToCardColumn` → `doWithRetry(..., true, "SubscribeToCardColumn", ...)`.
- The wrappers call only `s.client.parent.gen.<Op>WithResponse` (no raw transport, no manual paths), so the retry loop, per-op `x-basecamp-retry` ceiling, and body-replay machinery in `go/pkg/generated` all apply exactly as before. No retry code was touched.

## Verification

- `scripts/check-service-drift.sh` — green, zero exclusions (exit 0)
- `make go-check-wrapper-drift` — green: 88 pairs walked, 1155 generated fields verified (both new `*FromGenerated` pairs discovered)
- `go test ./...` in `go/` — green (exit 0)
- `golangci-lint run ./...` — 0 issues
- Unit tests per wrapper follow the existing `httptest` idiom: method + path + body assertions, response decode, pagination table tests for both list wrappers, usage-error and 404-mapping cases


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the Go ergonomic layer by wrapping the last seven question and card-column operations in `go/pkg/basecamp`. This brings wrapper coverage to 238/238 and removes all exclusions from the drift check.

- **New Features**
  - Checkins: `PauseQuestion`, `ResumeQuestion`, `UpdateQuestionNotificationSettings`, `ListAnswerers`, `ListQuestionReminders`. Reuses People list types; adds `QuestionReminder` and `QuestionNotificationSettings` with converters.
  - CardColumns: `Subscribe`, `Unsubscribe` over the card-table route, complementing existing `Watch`/`Unwatch`.
  - Pagination for reminders/answerers via Link headers with `Limit` and `Page`; returns `X-Total-Count` and `Truncated`.

- **Refactors**
  - Emptied exclusions in `scripts/check-service-drift.sh`; drift gate enforces 100% wrapper coverage.
  - Wrappers call generated `ClientWithResponses` methods, preserving idempotent retry behavior for `PauseQuestion` and `SubscribeToCardColumn`.

<sup>Written for commit 0f20a97f75958edd273a7af746a21cd8ad675b9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

