### PR TITLE
SPEC and waiver hygiene: per-line skip roster, current facts, doc-example and lint fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ When verifying API response shapes, check Go generated code in `go/pkg/generated
 
 ### Never Do These
 
-1. **NEVER edit files under `*/generated/`** — they get overwritten by generators
+1. **NEVER edit files under `*/generated/`** — they get overwritten by generators. Four files under `generated/` are not generator-emitted and are the ONLY exceptions: three hand-written base files, edited like any other infrastructure file — `python/src/basecamp/generated/services/_base.py`, `python/src/basecamp/generated/services/_async_base.py`, `ruby/lib/basecamp/generated/services/base_service.rb` — plus the empty package marker `python/src/basecamp/generated/__init__.py`. The `generated/services/__init__.py` next to the Python base files IS generated.
 2. **NEVER add hand-written service methods that touch the wire** — all wire operations come from generators. The sole exception is a conformance-tested composite that only calls generated wire methods and satisfies SPEC.md §18 "Hand-Written Composite Methods"
 3. **NEVER skip running `make smithy-build` after Smithy changes** — keeps OpenAPI in sync
 4. **NEVER construct API paths manually** — use the generated client methods

--- a/SPEC.md
+++ b/SPEC.md
@@ -473,7 +473,7 @@ Go, Python, Kotlin, and Ruby.
 - **TypeScript** implements the three-gate algorithm but chains at most 1 retry — on a retryable status, TS returns `fetch(retryRequest)` which bypasses middleware after the first retry (waiver 2B.1 in `rubric-audit.json`). **Kotlin** implements the three-gate algorithm for HTTP status retries (POST retries only when `idempotent: true`, full exponential backoff) but does not retry on network errors — transport exceptions are returned immediately as `BasecampException.Network`.
 - **Go** implements the three-gate on its generated operation path: it retries operations classified idempotent at generation time — GET/HEAD by method, plus any operation carrying `x-basecamp-idempotent` (the naturally-idempotent PUT/DELETE mutations like `UpdateProject`/`TrashProject`, and the flagged-idempotent POSTs like `CompleteTodo`) — with exponential backoff; non-idempotent operations (e.g. `CreateTodo`) are single-attempt. The separate hand-written `doRequestURL` helper remains GET-only for ordinary retries, with a mutation-specific single re-attempt after successful 401 token refresh.
 - **Ruby** is stricter: only GET retries; all non-GET methods do not retry. Governed GETs (those carrying their canonical operation ID) are bounded by the per-op ceiling and status-gated on the declared `retryOn`; ungoverned GETs (`get_absolute`, OAuth discovery) keep the taxonomy-driven pre-metadata contract. Ruby is acceptably conservative.
-- **Swift** implements the three-gate algorithm: the transport retries only when the method is naturally idempotent (GET/HEAD/PUT/DELETE) **or** the operation is marked `idempotent: true`, so non-idempotent POSTs like `CreateProject` are attempted exactly once while the five idempotent POSTs (`CompleteTodo`, `PauseQuestion`, `SubscribeToCardColumn`, `Subscribe`, `EnableCardColumnOnHold`) keep retrying. The gate covers both retry paths — HTTP status (`429`/`503`) and network errors — so Swift retries network errors (unlike Kotlin/TS) but only for retry-eligible operations. `BaseService` threads the per-operation flag from generated `Metadata` into the transport; the naturally-idempotent method set is allowlisted so PATCH/OPTIONS and future methods stay fail-closed.
+- **Swift** implements the three-gate algorithm: the transport retries only when the method is naturally idempotent (GET/HEAD/PUT/DELETE) **or** the operation is marked `idempotent: true`, so non-idempotent POSTs like `CreateProject` are attempted exactly once while the seven idempotent POSTs (`CompleteTodo`, `CreateBookmark`, `EnableCardColumnOnHold`, `PauseQuestion`, `PrioritizeAssignment`, `Subscribe`, `SubscribeToCardColumn`) keep retrying. The gate covers both retry paths — HTTP status (`429`/`503`) and network errors — so Swift retries network errors (unlike Kotlin/TS) but only for retry-eligible operations. `BaseService` threads the per-operation flag from generated `Metadata` into the transport; the naturally-idempotent method set is allowlisted so PATCH/OPTIONS and future methods stay fail-closed.
 - The spec prescribes the three-gate algorithm. **TS note:** TS retry returns `fetch(retryRequest)` which bypasses middleware after the first retry, so TS effectively caps at 1 retry per request regardless of `max_attempts`. This is a known limitation (waiver 2B.1).
 
 ### Retry Algorithm
@@ -524,7 +524,7 @@ FUNCTION executeWithRetry(request, retry_config) → Response
         --   (1 = initial request failed, 2 = first retry failed, etc.)
         -- Standalone attempt = attempt+2: the 1-based attempt about to happen
         --   (2 = about to do first retry, 3 = about to do second retry, etc.)
-        -- This matches shipped SDKs: Go/Ruby/Kotlin pass the failed attempt in
+        -- This matches shipped SDKs: all six pass the failed attempt in
         -- RequestInfo and the next attempt number as the standalone parameter.
      k. Sleep delay ms.
      l. Refresh auth headers (token may have been refreshed during sleep).
@@ -1605,14 +1605,21 @@ Enumerated from `conformance/schema.json`:
 | Category | Files | Owning Spec Section(s) |
 |----------|-------|----------------------|
 | auth | `auth.json` | §4 Authentication, §13 HTTP Transport |
+| cards-write | `cards_write.json` | §5 Merge-Safe Write Surface (Cards), §18 Hand-Written Composite Methods |
+| downloads | `downloads.json` | §14 Download |
 | error-mapping | `error-mapping.json` | §6 Error Taxonomy |
 | idempotency | `idempotency.json` | §7 Retry (Gate 2) |
 | integer-precision | `integer-precision.json` | §10 Type Fidelity |
+| live-my-surface | `live-my-surface.json` | External governance (CONTRIBUTING.md, live canary — opt-in via `BASECAMP_LIVE`) |
+| network-retry | `network-retry.json` | §7 Retry (network errors, Gate 2) |
 | pagination | `pagination.json` | §8 Pagination |
 | paths | `paths.json` | §3 Client Architecture (account path construction) |
 | retry | `retry.json` | §7 Retry |
+| schedule-entries-write | `schedule_entries_write.json` | §10 Type Fidelity (explicit-empty vs. omitted wire semantics) |
 | security | `security.json` | §9 Security |
 | status-codes | `status-codes.json` | §11 Response Semantics |
+| todos-write | `todos_write.json` | §5 Merge-Safe Write Surface (Todos), §18 Hand-Written Composite Methods |
+| uploads-download | `uploads_download.json` | §14 Download, §18 Hand-Written Composite Methods |
 
 ### Runner Pattern
 
@@ -1628,7 +1635,68 @@ Enumerated from `conformance/schema.json`:
 
 ### Zero-Skip Target `[manual]`
 
-All conformance tests should pass. Runners currently pass with documented waivers covering: retry depth (TS single-chained retry, waiver 2B.1), integer precision (TS Number, waiver 1B.6), retry scope (Ruby only-GET retry), and pagination metadata (Ruby Enumerator lacks totalCount/truncated/maxItems, waivers 2C.2/2C.4/2C.6). Waivers are documented in each runner's skip list and in `rubric-audit.json` with language-specific rationale.
+All conformance tests should pass. The roster below enumerates every skip a
+default (mock-mode) conformance run reports, one line per runner × test,
+verbatim from the runners' skip mechanisms. A skip is
+either **waiver-backed** (a `rubric-audit.json` waiver ID), **architectural**
+(runner mechanics, compensated by native tests), or **unwaivered** (a known gap
+with no rubric record — tracked work, not an accepted divergence). A PR that
+closes a gap deletes exactly its own lines.
+
+**Go** (`conformance/runner/go/main.go` `goSDKSkips`) — architectural; same-origin
+logic is covered by `TestIsSameOrigin` unit tests:
+- "Mixed-case host and explicit default port stay on the mocked origin" — Go runner dials `configOverrides.baseUrl` directly; its `httptest` mock owns its origin, so origin-interception normalization does not apply.
+- "Bracketed IPv6 loopback origin stays on the mocked origin" — same as above.
+
+**Python** (`conformance/runner/python/runner.py` `SKIPS`) — unwaivered:
+- "maxItems caps results across pages" — list methods don't expose a public `max_items` parameter.
+- "maxItems landing exactly on the final item is not truncated" — same as above.
+- "DownloadURL retries on 503 at the auth'd first hop" — download path uses `get_no_retry`; hop-1 retry not implemented.
+- "DownloadURL honors Retry-After on 429 at the auth'd first hop" — same as above.
+
+**Ruby** (`conformance/runner/ruby/runner.rb` `RUBY_SKIPS`):
+- "PUT operation is naturally idempotent" — GET-only retry (waiver 2B.3).
+- "DELETE operation is naturally idempotent" — GET-only retry (waiver 2B.3).
+- "POST operation retries when marked idempotent" — GET-only retry (waiver 2B.3).
+- "Subscribe POST retries when marked idempotent" — GET-only retry (waiver 2B.3).
+- "CreateBookmark POST retries when marked idempotent" — GET-only retry (waiver 2B.3).
+- "DeleteBookmark DELETE retries when marked idempotent" — GET-only retry (waiver 2B.3).
+- "UpdateMyNote PUT retries when marked idempotent" — GET-only retry (waiver 2B.3).
+- "UpdateCalendar PUT retries when marked idempotent" — GET-only retry (waiver 2B.3).
+- "PrioritizeAssignment POST retries when marked idempotent" — GET-only retry (waiver 2B.3).
+- "DeprioritizeAssignment DELETE retries when marked idempotent" — GET-only retry (waiver 2B.3).
+- "Network error on an idempotent POST is retried then succeeds" — GET-only network retry (waiver 2B.3).
+- "Total count header is accessible" — Enumerator exposes no totalCount metadata (waiver 2C.2).
+- "Missing X-Total-Count returns zero" — Enumerator exposes no totalCount metadata (waiver 2C.2).
+- "Pagination stops at maxPages safety cap" — cap is enforced, but truncation metadata is inexpressible (waiver 2C.6).
+- "maxItems caps results across pages" — no `max_items` support (waiver 2C.4).
+- "maxItems landing exactly on the final item is not truncated" — no `max_items` support (waiver 2C.4).
+- "DownloadURL retries on 503 at the auth'd first hop" — download path uses `get_no_retry`; hop-1 retry not implemented (unwaivered).
+- "DownloadURL honors Retry-After on 429 at the auth'd first hop" — same as above (unwaivered).
+
+**TypeScript** (`conformance/runner/typescript/runner.test.ts` `TS_SDK_SKIPS`):
+- "GET operation retries on 503" — retry middleware chains at most 1 retry (waiver 2B.1).
+- "Large integer IDs preserved without precision loss" — `Number` is 53-bit (waiver 1B.6).
+- "DownloadURL retries on 503 at the auth'd first hop" — `downloadURL` uses raw fetch bypassing retry (unwaivered).
+- "DownloadURL honors Retry-After on 429 at the auth'd first hop" — same as above (unwaivered).
+- "Network error on an idempotent POST is retried then succeeds" — only HTTP-status retries are implemented (unwaivered).
+
+**Kotlin** (`kotlin/conformance/.../Main.kt` — `KOTLIN_SKIPS` plus one tag-based
+branch ahead of it):
+- "List operation returns first page with Link header" — skipped via the `link-header` tag branch, not `KOTLIN_SKIPS`: Kotlin auto-paginates by design, so a first-page-only requestCount assertion is inapplicable (architectural).
+- "DownloadURL auth'd first hop 302s to signed URL" — runner does not yet dispatch DownloadURL (unwaivered).
+- "DownloadURL direct 2xx body" — same as above (unwaivered).
+- "DownloadURL retries on 503 at the auth'd first hop" — same as above (unwaivered).
+- "DownloadURL honors Retry-After on 429 at the auth'd first hop" — same as above (unwaivered).
+- "DownloadURL surfaces redirect with no Location" — same as above (unwaivered).
+- "UploadsDownload delegates through DownloadURL primitive" — SDK does not yet expose `uploads.download(id)` (unwaivered).
+- "UploadsDownload errors when upload has no download_url" — same as above (unwaivered).
+- "Network error on an idempotent POST is retried then succeeds" — network errors on mutations are surfaced immediately, not retried (unwaivered).
+
+The TypeScript live canary additionally reports one placeholder skip when
+`BASECAMP_LIVE` is unset (`live-runner.test.ts`) — that is the opt-in gate for
+`live-my-surface.json` documented in the category table above, not a
+conformance gap, and it is deliberately not rostered.
 
 ---
 
@@ -1670,7 +1738,7 @@ The following are must-pass criteria from the rubric. Each maps to a spec sectio
 | `rb-check` | Ruby: test + rubocop |
 | `kt-check` | Kotlin: build + test |
 | `swift-check` | Swift: build + test |
-| `conformance` | All conformance test categories pass with documented waivers (go, kotlin, typescript, ruby runners) |
+| `conformance` | All conformance test categories pass with documented waivers (go, kotlin, python, ruby, typescript runners) |
 
 Representative dependency chain (see the Makefile `check:` line for the authoritative, complete list): `check: … sync-api-version-check url-routes-check go-check-drift … kt-check-drift … go-check ts-check rb-check kt-check swift-check py-check conformance …`
 
@@ -1827,6 +1895,19 @@ account, attachments, automation, boosts, campfires, cardColumns, cardSteps, car
 | `status-codes.json` | Non-retryable not retried | §7, §11 |
 | `integer-precision.json` | Large integer IDs preserved | §10 |
 | `paths.json` | Path construction | §3 |
+| `downloads.json` | DownloadURL auth'd first hop 302s to signed URL | §14 |
+| `downloads.json` | DownloadURL direct 2xx body | §14 |
+| `downloads.json` | DownloadURL retries on 503 at the auth'd first hop | §14, §7 |
+| `downloads.json` | DownloadURL honors Retry-After on 429 at the auth'd first hop | §14, §7 |
+| `downloads.json` | DownloadURL surfaces redirect with no Location | §14 |
+| `network-retry.json` | Network error on a non-idempotent POST is not retried | §7 (Gate 2) |
+| `network-retry.json` | Network error on an idempotent POST is retried then succeeds | §7 (Gate 2) |
+| `uploads_download.json` | UploadsDownload delegates through DownloadURL primitive | §14, §18 |
+| `uploads_download.json` | UploadsDownload errors when upload has no download_url | §14, §18 |
+| `todos_write.json` | update-merge / edit-clear / replace-omission-clears | §5 (Todos), §18 |
+| `cards_write.json` | Merge-safe update composite (5 cases: due-on preservation, verbatim raw path, explicit clears/empties) | §5 (Cards), §18 |
+| `schedule_entries_write.json` | update-omits-participant-ids / update-empty-participant-ids | §10 |
+| `live-my-surface.json` | Live schema validation, 30 read-surface cases (opt-in via `BASECAMP_LIVE`) | External governance (CONTRIBUTING.md, live canary) |
 
 ---
 

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
@@ -34,7 +34,7 @@ data class PaginationOptions(
  * accessible via the [meta] property.
  *
  * ```kotlin
- * val todos = account.todos.list(projectId, todolistId)
+ * val todos = account.todos.list(todolistId)
  * println("Showing ${todos.size} of ${todos.meta.totalCount} todos")
  * todos.forEach { println(it.content) }
  * ```

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/BaseService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/BaseService.kt
@@ -19,7 +19,13 @@ import kotlinx.serialization.json.jsonPrimitive
  * Provides shared functionality for making API requests, handling errors,
  * and integrating with the hooks system. Generated service classes extend this.
  *
+ * The example below shows the shape the GENERATOR emits. Wire methods are never
+ * written by hand (see AGENTS.md — paths and verbs come from the generator; the
+ * only sanctioned hand-written methods are SPEC §18 composites over generated
+ * wire methods):
+ *
  * ```kotlin
+ * // Generator output (illustrative):
  * class TodosService(client: AccountClient) : BaseService(client) {
  *     suspend fun list(todolistId: Long): ListResult<Todo> =
  *         requestPaginated(
@@ -404,15 +410,20 @@ abstract class BaseService(
      * a cold [Flow] that fetches pages lazily as the collector consumes items.
      * Useful for processing large datasets without loading everything into memory.
      *
+     * No generated service currently emits a method on this primitive; it is
+     * reserved for a future generated streaming surface. If the generator gains
+     * one, its output would take this shape (wire methods are never written by
+     * hand — see AGENTS.md):
+     *
      * ```kotlin
-     * // In a service subclass:
+     * // Generator output (illustrative):
      * fun listAsFlow(todolistId: Long): Flow<Todo> =
      *     requestPaginatedAsFlow(
      *         OperationInfo("Todos", "ListTodos", "todo", false, resourceId = todolistId),
      *         { httpGet("/todolists/$todolistId/todos.json") },
      *     ) { body -> json.decodeFromString<List<Todo>>(body) }
      *
-     * // Collectors then consume pages lazily:
+     * // Collectors consume pages lazily:
      * service.listAsFlow(todolistId).collect { todo -> println(todo.content) }
      * ```
      *

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/BaseService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/BaseService.kt
@@ -21,12 +21,12 @@ import kotlinx.serialization.json.jsonPrimitive
  *
  * ```kotlin
  * class TodosService(client: AccountClient) : BaseService(client) {
- *     suspend fun list(projectId: Long, todolistId: Long): ListResult<Todo> =
+ *     suspend fun list(todolistId: Long): ListResult<Todo> =
  *         requestPaginated(
- *             OperationInfo("Todos", "ListTodos", "todo", false, projectId),
- *         ) {
- *             httpGet("/buckets/$projectId/todolists/$todolistId/todos.json")
- *         }
+ *             OperationInfo("Todos", "ListTodos", "todo", false, resourceId = todolistId),
+ *             null,
+ *             { httpGet("/todolists/$todolistId/todos.json") },
+ *         ) { body -> json.decodeFromString<List<Todo>>(body) }
  * }
  * ```
  */
@@ -405,8 +405,15 @@ abstract class BaseService(
      * Useful for processing large datasets without loading everything into memory.
      *
      * ```kotlin
-     * account.todos.listAsFlow(projectId, todolistId)
-     *     .collect { todo -> println(todo.content) }
+     * // In a service subclass:
+     * fun listAsFlow(todolistId: Long): Flow<Todo> =
+     *     requestPaginatedAsFlow(
+     *         OperationInfo("Todos", "ListTodos", "todo", false, resourceId = todolistId),
+     *         { httpGet("/todolists/$todolistId/todos.json") },
+     *     ) { body -> json.decodeFromString<List<Todo>>(body) }
+     *
+     * // Collectors then consume pages lazily:
+     * service.listAsFlow(todolistId).collect { todo -> println(todo.content) }
      * ```
      *
      * @param info Operation metadata for hooks.

--- a/rubric-audit.json
+++ b/rubric-audit.json
@@ -1,6 +1,6 @@
 {
   "profile": "full-sdk",
-  "date": "2026-03-06",
+  "date": "2026-07-31",
   "reviewer": "agent:conformance-runner",
   "criteria": {
     "1A.6": {
@@ -18,7 +18,7 @@
     },
     "1B.5": {
       "pass": true,
-      "note": "Date fields use time.Time (Go), Date (TS), Time (Ruby) per ISO 8601"
+      "note": "Temporal fields carry ISO 8601 on the wire in all six SDKs: Go decodes to time.Time and Ruby coerces via Time.parse; TypeScript, Python, Kotlin, and Swift preserve the ISO 8601 string verbatim (no lossy coercion)"
     },
     "1C.1": {
       "pass": true,
@@ -34,7 +34,7 @@
     },
     "2D.5": {
       "pass": true,
-      "note": "Resilience patterns scoped per service.operation in Go; Ruby/TS use per-client config"
+      "note": "All six SDKs consume per-operation retry metadata from behavior-model.json (declared retry_on status set and per-op max). The four SDKs with a public numeric caller cap compose the ceiling as min(caller cap, op max): Go and Python (per-op ceiling #483, retry_on gate #486), Ruby and Kotlin (#515). TypeScript and Swift expose only a boolean retry switch and apply the operation's declared parameters directly (TS since its middleware inception). Non-Smithy traffic (absolute-URL fetches, Launchpad authorization) carries no operation id and keeps per-client config."
     },
     "3A.4": {
       "pass": true,
@@ -42,7 +42,7 @@
     },
     "3A.5": {
       "pass": true,
-      "note": "OAuth PKCE code exchange implemented in all three SDKs"
+      "note": "OAuth PKCE code exchange implemented in five SDKs (Go, TypeScript, Python, Ruby, Kotlin); Swift ships token-provider injection only, with no OAuth utility surface"
     },
     "3A.6": {
       "pass": true,
@@ -70,9 +70,7 @@
     },
     "3C.6": {
       "pass": true,
-      "waiver": true,
-      "note": "Go SDK uses consumer-driven pagination; same-origin enforcement is caller responsibility",
-      "language": "go"
+      "note": "All six SDKs auto-paginate with same-origin enforcement before following Link headers. A prior Go waiver ('consumer-driven pagination; same-origin enforcement is caller responsibility') is obsolete: Go auto-paginates and enforces same-origin in client.go before following Link, and the Go runner passes all security.json pagination tests un-skipped (its two origin-normalization skips are runner mechanics — httptest owns its origin — compensated by TestIsSameOrigin unit coverage)."
     },
     "2B.1": {
       "pass": true,

--- a/rubric-audit.json
+++ b/rubric-audit.json
@@ -18,7 +18,7 @@
     },
     "1B.5": {
       "pass": true,
-      "note": "Temporal fields carry ISO 8601 on the wire in all six SDKs: Go decodes to time.Time and Ruby coerces via Time.parse; TypeScript, Python, Kotlin, and Swift preserve the ISO 8601 string verbatim (no lossy coercion)"
+      "note": "Temporal fields carry ISO 8601 on the wire in all six SDKs: Go decodes to time.Time; Ruby coerces via Time.parse for fields the schema marks x-go-type time.Time — nullable timestamps spelled *time.Time (currently MyNote.created_at/updated_at) pass through as strings because the generator's coercion condition matches the exact spelling, tracked in #537; TypeScript, Python, Kotlin, and Swift preserve the ISO 8601 string verbatim (no lossy coercion)"
     },
     "1C.1": {
       "pass": true,

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -10,7 +10,7 @@ import createClient, { type Middleware } from "openapi-fetch";
 import type { paths } from "./generated/schema.js";
 import metadata from "./generated/metadata.js";
 import { PATH_TO_OPERATION } from "./generated/path-mapping.js";
-import type { BasecampHooks, RequestInfo, RequestResult } from "./hooks.js";
+import type { BasecampHooks, RequestResult } from "./hooks.js";
 import { BasecampError } from "./errors.js";
 import { isLocalhost, requireSameOrigin } from "./security.js";
 import { parseNextLink, resolveURL, isSameOrigin } from "./pagination-utils.js";

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -9,7 +9,7 @@
  * import { BasecampError, Errors } from "@37signals/basecamp";
  *
  * try {
- *   await client.todos.get(projectId, todoId);
+ *   await client.todos.get(todoId);
  * } catch (err) {
  *   if (err instanceof BasecampError) {
  *     if (err.code === 'not_found') {

--- a/typescript/src/hooks/otel.ts
+++ b/typescript/src/hooks/otel.ts
@@ -178,7 +178,7 @@ function requestKey(): string {
  * });
  *
  * // Operations will create spans and record metrics
- * const todos = await client.todos.list(projectId, todolistId);
+ * const todos = await client.todos.list(todolistId);
  * ```
  */
 export function otelHooks(options: OtelHooksOptions = {}): BasecampHooks {

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -14,7 +14,7 @@
  *
  * // High-level service methods
  * const projects = await client.projects.list();
- * const todo = await client.todos.create(projectId, todolistId, {
+ * const todo = await client.todos.create(todolistId, {
  *   content: "Ship the feature",
  *   assigneeIds: [userId],
  * });

--- a/typescript/src/oauth/discovery.ts
+++ b/typescript/src/oauth/discovery.ts
@@ -17,7 +17,6 @@ import { isLocalhost } from "../security.js";
 import type {
   OAuthConfig,
   ProtectedResourceMetadata,
-  FallbackReason,
   DiscoverySelectionErrorReason,
   DiscoverFromResourceResult,
 } from "./types.js";
@@ -142,6 +141,7 @@ export function requireOriginRoot(raw: string, label = "origin"): string {
   // tabs/newlines/surrounding spaces and converts backslashes to forward slashes
   // for special schemes, so a malformed spelling ("https:\\host", "https://host\n")
   // would be cleaned and accepted. None is legitimate in an origin root.
+  // eslint-disable-next-line no-control-regex -- deliberate guard: rejects C0 controls/space/backslash the WHATWG URL parser would silently strip or rewrite
   if (/[\u0000-\u0020\\]/.test(raw)) {
     throw new BasecampError("usage", `${label} contains invalid characters: ${raw}`);
   }

--- a/typescript/src/pagination.ts
+++ b/typescript/src/pagination.ts
@@ -39,7 +39,7 @@ export interface PaginationOptions {
  *
  * @example
  * ```ts
- * const todos = await client.todos.list(projectId, todolistId);
+ * const todos = await client.todos.list(todolistId);
  * console.log(`Showing ${todos.length} of ${todos.meta.totalCount} todos`);
  * todos.forEach(todo => console.log(todo.content));
  * ```


### PR DESCRIPTION
Governance docs had drifted from the code across three fronts. This PR trues them up so later work (conformance-closure PRs in flight) can delete exactly its own roster lines instead of rebasing a prose paragraph.

## SPEC §19 + Appendix D

- The zero-skip roster is restructured from a summary paragraph into a per-line enumeration of all **38 skips a default mock-mode run reports** across the five runners, verbatim, each tagged **waiver-backed** (rubric ID), **architectural**, or **unwaivered**. Re-derived from the runners at head (includes the #528-era Ruby priority-mutation skips and Kotlin's tag-based `link-header` skip that lives *outside* `KOTLIN_SKIPS` — found by adversarial review running the Kotlin runner: 9 live skips, not the 8 in its skip map).
- §19 category table + Appendix D gain the 7 fixture files they omitted: `downloads`, `network-retry`, `uploads_download`, `todos_write`, `cards_write`, `schedule_entries_write`, `live-my-surface` (the last documented as opt-in via `BASECAMP_LIVE`, owned by CONTRIBUTING.md's live-canary machinery).
- The `conformance` gate line adds the python runner, which `make conformance` has run all along.
- §7: the idempotent-POST enumeration catches up to the current **seven** (verified by joining `behavior-model.json` `idempotent: true` with `openapi.json` methods): CompleteTodo, CreateBookmark, EnableCardColumnOnHold, PauseQuestion, PrioritizeAssignment, Subscribe, SubscribeToCardColumn. The on_retry pseudocode note now says all six SDKs ship the (failed, upcoming) pair (true since #517).

## rubric-audit.json

- **3C.6 (Go) waiver flipped to plain pass** — "consumer-driven pagination; same-origin enforcement is caller responsibility" has been false since Go gained auto-pagination with same-origin enforcement before following Link; the Go runner passes all security.json pagination tests un-skipped.
- **2D.5** rewritten: all six SDKs consume per-op retry metadata; the min(caller cap, op max) composition exists in exactly the four SDKs with a public numeric cap (Go/Python via #483+#486, Ruby/Kotlin via #515); TS/Swift expose only a boolean switch. (First draft said "#479" — adversarial review caught that no such PR exists.)
- **3A.5** corrected: PKCE code exchange ships in five SDKs; Swift has token-provider injection only.
- **1B.5** corrected to verified reality: Go decodes time.Time, Ruby coerces via Time.parse; TS/Python/Kotlin/Swift carry ISO 8601 strings verbatim.
- Audit date current.

## AGENTS.md

The "NEVER edit `*/generated/`" rule now names its four real exceptions (`_base.py`, `_async_base.py`, `base_service.rb`, and Python's empty package-root `__init__.py`) — the exact confusion behind #518's refuted review finding. Verified against both generators: none of the four is emitted; `generated/services/__init__.py` is.

## Source fixes riding along

- **Seven invalid doc examples fixed** (same defect class as #511), each verified against the real generated signatures: six used the stale two-ID `list(projectId, todolistId)` convention; `BaseService.kt`'s KDoc sketched a nonexistent `listAsFlow` and a `requestPaginated` call that could not compile. Valid examples untouched.
- **The three standing lint warnings** on every CI run are gone: two doc-only imports dropped (types remain publicly exported), and the deliberate control-character guard in `discovery.ts` gets an explicit `no-control-regex` disable with rationale (WHATWG URL silently strips/rewrites those characters).

Verification: TS lint (0 warnings), typecheck, build, tests green; Kotlin `compileKotlinJvm` green; edited KDoc examples manually re-verified against declarations (KDoc isn't compiled). Adversarial review (4 lenses) ran over the diff; its 5 findings (2 P1) are incorporated above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns SPEC, rubric, and governance docs with current SDK behavior and runner output. Makes future conformance-closure PRs remove exact skip lines instead of editing prose.

- **Refactors**
  - Restructured the zero-skip roster to a per-line list of 38 skips across Go, Kotlin, Python, Ruby, and TypeScript, each tagged waiver-backed, architectural, or unwaivered.
  - Added 7 missing conformance fixtures to §19 and Appendix D; updated idempotent POSTs to seven; Swift section reflects the full set; retry pseudocode notes all six SDKs pass attempt numbers consistently.
  - Added the Python runner to the `conformance` gate.
  - `rubric-audit.json`: flipped Go `3C.6` to a plain pass; corrected notes for `2D.5`, `3A.5`, `1B.5` (Ruby nullable `*time.Time` timestamps currently pass through as strings; tracked in #537); updated the audit date.
  - `AGENTS.md`: documented the four non-generated exceptions under `generated/`.

- **Bug Fixes**
  - Fixed seven invalid examples (single-ID todos surface; reframed `BaseService.kt` KDoc examples as illustrative generator output and corrected pagination examples).
  - Removed three lint warnings by dropping doc-only imports and adding an explicit `no-control-regex` disable with rationale in `typescript/src/oauth/discovery.ts`.

<sup>Written for commit 8f9fc215852169e69d28e030ae49c7cdfc383fb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/535?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

