### PR TITLE
docs(spec): clarify TypeScript integer waiver

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -732,7 +732,7 @@ Comparison is case-insensitive.
 
 All integer IDs must use at least 64 bits of precision (e.g., Go `int64`, Kotlin `Long`, Swift `Int` on 64-bit platforms). Note: Kotlin `Int` is 32-bit and must not be used for IDs — use `Long`. IDs up to 2^53 + 1 (`9007199254740993`) must survive JSON round-trip without precision loss.
 
-`[CONFLICT: JavaScript Number.MAX_SAFE_INTEGER is 2^53 - 1. The TypeScript SDK has a documented known gap — JSON.parse truncates integers beyond this value. The spec prescribes 64-bit precision; TypeScript implementations must document the limitation. See waiver 1B.6 in rubric-audit.json.]`
+`[CONFLICT: JavaScript Number.MAX_SAFE_INTEGER is 2^53 - 1. On the supported Node >=22.12 floor, JSON.parse reviver source access makes lossless bigint decoding feasible, but returning bigint would break the TypeScript SDK's number-typed API surface. The spec prescribes 64-bit precision; TypeScript implementations must document the retained limitation. See waiver 1B.6 in rubric-audit.json.]`
 
 ### Nullable Numeric Dimensions (rich-text attachment width/height)
 
@@ -1906,7 +1906,7 @@ See the Gate 3 consumption table in §7 above.
 | Ruby | Full arbitrary precision (Ruby Integer) |
 | Kotlin | Full 64-bit (`Long`) |
 | Swift | Platform-width `Int` (64-bit on all supported platforms). Generated models use `Int`, not `Int64`. |
-| TypeScript | 53-bit (`Number`). IDs > 2^53 - 1 lose precision. Documented known gap with waiver 1B.6. |
+| TypeScript | 53-bit (`Number`). Node >=22.12 can decode larger IDs losslessly as `bigint`, but that would break the number-typed API surface; waiver 1B.6 retains the limitation. |
 
 ### Pagination Metadata (§8)
 

--- a/conformance/tests/integer-precision.json
+++ b/conformance/tests/integer-precision.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Large integer IDs preserved without precision loss",
-    "description": "Verifies that integer IDs larger than 2^53 are preserved without floating-point precision loss (1B.6). This test documents a known gap in JavaScript/TypeScript where JSON.parse truncates integers beyond Number.MAX_SAFE_INTEGER.",
+    "description": "Verifies that integer IDs larger than 2^53 are preserved without floating-point precision loss (1B.6). TypeScript retains a known gap because returning bigint would break its number-typed API surface, although Node >=22.12 can decode the raw digits losslessly via JSON.parse reviver source access.",
     "operation": "GetProject",
     "method": "GET",
     "path": "/projects/{projectId}",

--- a/rubric-audit.json
+++ b/rubric-audit.json
@@ -95,7 +95,7 @@
     "1B.6": {
       "pass": true,
       "waiver": true,
-      "note": "JavaScript Number loses precision on integers > 2^53; no clean fix without breaking SDK API surface",
+      "note": "Lossless decode is feasible on Node >=22.12 via JSON.parse reviver source access, but emitting bigint would break the SDK's number-typed API surface",
       "language": "typescript"
     },
     "2C.4": {


### PR DESCRIPTION
## Summary

- clarify that Node 22 reviver source access makes lossless integer decoding technically feasible
- retain the TypeScript waiver because returning `bigint` would break the public `number`-typed API
- keep the rubric, specification, and conformance test description consistent

## Verification

- `python3 -m json.tool rubric-audit.json`
- `python3 -m json.tool conformance/tests/integer-precision.json`
- verified lossless `context.source` decoding on Node 22.22.0
- `git diff --check`

Release notes: Documentation

Closes #533


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the TypeScript integer precision waiver: Node >=22.12 can access raw digits in a JSON.parse reviver, making lossless bigint decoding feasible, but we retain the waiver because returning bigint would break the number-typed API. Syncs SPEC.md, the integer-precision conformance test description, and the rubric note.

<sup>Written for commit ff13a0986dbd02e225baad8658ca72fcadae0a34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

