### PR TITLE
Run the TypeScript retry loop beneath the middleware chain

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -436,7 +436,7 @@ If `behavior-model.json` marks an operation with `idempotent: true`, the POST be
 The error must be retryable. Two categories qualify:
 
 - **HTTP status retry:** Response status is in the operation's **declared** retryable set. `behavior-model.json` specifies `retry_on: [429, 503]` for all operations. The declared set is **exhaustive**: a status outside it — including 500, 502, and 504 — is not retried and is surfaced to the caller on the first attempt. An implementation may still *classify* those statuses as retryable in its error taxonomy (§6); that is a caller-facing hint and must not widen the transport's gate.
-- **Network error retry:** Connection failures, timeouts, and DNS errors (no HTTP response received) are retryable. These correspond to `BasecampError(code: "network", retryable: true)` in §6. **Divergence:** **Go, Python, and Swift** retry network errors for retry-eligible operations — including idempotent mutations — with Swift and Go gating on operation idempotency, so a non-idempotent POST is attempted once. **Ruby** retries network errors too, but only on GET: its transport routes every non-GET to a single-attempt path, so no mutation ever sees a network retry. **TypeScript** retries only after receiving an HTTP response; **Kotlin** surfaces network errors immediately without retry. The spec prescribes network error retry as the target behavior.
+- **Network error retry:** Connection failures, timeouts, and DNS errors (no HTTP response received) are retryable. These correspond to `BasecampError(code: "network", retryable: true)` in §6. **Divergence:** **Go, Python, Swift, and TypeScript** retry network errors for retry-eligible operations — including idempotent mutations — with Swift, Go, and TypeScript gating on operation idempotency, so a non-idempotent POST is attempted once (TypeScript additionally treats caller aborts and request timeouts as terminal). **Ruby** retries network errors too, but only on GET: its transport routes every non-GET to a single-attempt path, so no mutation ever sees a network retry. **Kotlin** surfaces network errors immediately without retry. The spec prescribes network error retry as the target behavior.
 
 **Non-retryable statuses (never retry regardless of method):** 401, 403, 404, 400, 422.
 
@@ -447,7 +447,7 @@ are consumed unevenly:
 |---|---|---|
 | Go | yes | yes — `min(caller_cap, operation_max)` |
 | Python | yes | yes — `min(caller_cap, operation_max)` |
-| TypeScript | yes | n/a — exposes no numeric cap (only `enableRetry`), so the operation value is the only input. Additionally caps at one retry (waiver 2B.1) |
+| TypeScript | yes | n/a — exposes no numeric cap (only `enableRetry`), so the operation value is the only input |
 | Swift | yes | n/a — exposes no numeric cap (only `enableRetry`) |
 | Kotlin | yes | yes — `min(caller cap, operation max)`, with the cap coerced to at least one attempt |
 | Ruby | yes for governed GETs — a status-bearing error retries exactly when the declared `retryOn` says so; the error taxonomy's 500/502/504 classification neither widens nor vetoes the declared set. Status-less network errors keep the taxonomy's judgment | yes — governed GETs are bounded by `min(caller cap, operation max)`; Ruby's transport is GET-only, so mutations never reach the retry loop |
@@ -464,17 +464,17 @@ policy ever reaches OAuth traffic.
 
 **Enforcement.** `scripts/check-retry-metadata-parity.py` asserts every SDK's emitted per-operation
 retry metadata equals `behavior-model.json`, and records which fields each SDK actually consumes at
-runtime. It deliberately does not assert *effective behavior* parity, since TypeScript's one-retry
-cap and Ruby's GET-only transport are intentional. Effective Gate 3 behavior is pinned by tests in
-Go, Python, Kotlin, and Ruby.
+runtime. It deliberately does not assert *effective behavior* parity, since Ruby's GET-only
+transport is intentional. Effective Gate 3 behavior is pinned by tests in Go, Python, TypeScript,
+Kotlin, and Ruby.
 
 ### Cross-SDK Divergence `[CONFLICT]`
 
-- **TypeScript** implements the three-gate algorithm but chains at most 1 retry — on a retryable status, TS returns `fetch(retryRequest)` which bypasses middleware after the first retry (waiver 2B.1 in `rubric-audit.json`). **Kotlin** implements the three-gate algorithm for HTTP status retries (POST retries only when `idempotent: true`, full exponential backoff) but does not retry on network errors — transport exceptions are returned immediately as `BasecampException.Network`.
+- **TypeScript** implements the three-gate algorithm with the retry loop beneath the openapi-fetch middleware chain (the client's custom `fetch`), so attempts run to each operation's declared `retry.max` and network errors retry under the same idempotency gate; caller aborts and request timeouts are terminal. **Kotlin** implements the three-gate algorithm for HTTP status retries (POST retries only when `idempotent: true`, full exponential backoff) but does not retry on network errors — transport exceptions are returned immediately as `BasecampException.Network`.
 - **Go** implements the three-gate on its generated operation path: it retries operations classified idempotent at generation time — GET/HEAD by method, plus any operation carrying `x-basecamp-idempotent` (the naturally-idempotent PUT/DELETE mutations like `UpdateProject`/`TrashProject`, and the flagged-idempotent POSTs like `CompleteTodo`) — with exponential backoff; non-idempotent operations (e.g. `CreateTodo`) are single-attempt. The separate hand-written `doRequestURL` helper remains GET-only for ordinary retries, with a mutation-specific single re-attempt after successful 401 token refresh.
 - **Ruby** is stricter: only GET retries; all non-GET methods do not retry. Governed GETs (those carrying their canonical operation ID) are bounded by the per-op ceiling and status-gated on the declared `retryOn`; ungoverned GETs (`get_absolute`, OAuth discovery) keep the taxonomy-driven pre-metadata contract. Ruby is acceptably conservative.
-- **Swift** implements the three-gate algorithm: the transport retries only when the method is naturally idempotent (GET/HEAD/PUT/DELETE) **or** the operation is marked `idempotent: true`, so non-idempotent POSTs like `CreateProject` are attempted exactly once while the seven idempotent POSTs (`CompleteTodo`, `CreateBookmark`, `EnableCardColumnOnHold`, `PauseQuestion`, `PrioritizeAssignment`, `Subscribe`, `SubscribeToCardColumn`) keep retrying. The gate covers both retry paths — HTTP status (`429`/`503`) and network errors — so Swift retries network errors (unlike Kotlin/TS) but only for retry-eligible operations. `BaseService` threads the per-operation flag from generated `Metadata` into the transport; the naturally-idempotent method set is allowlisted so PATCH/OPTIONS and future methods stay fail-closed.
-- The spec prescribes the three-gate algorithm. **TS note:** TS retry returns `fetch(retryRequest)` which bypasses middleware after the first retry, so TS effectively caps at 1 retry per request regardless of `max_attempts`. This is a known limitation (waiver 2B.1).
+- **Swift** implements the three-gate algorithm: the transport retries only when the method is naturally idempotent (GET/HEAD/PUT/DELETE) **or** the operation is marked `idempotent: true`, so non-idempotent POSTs like `CreateProject` are attempted exactly once while the seven idempotent POSTs (`CompleteTodo`, `CreateBookmark`, `EnableCardColumnOnHold`, `PauseQuestion`, `PrioritizeAssignment`, `Subscribe`, `SubscribeToCardColumn`) keep retrying. The gate covers both retry paths — HTTP status (`429`/`503`) and network errors — so Swift retries network errors (unlike Kotlin) but only for retry-eligible operations. `BaseService` threads the per-operation flag from generated `Metadata` into the transport; the naturally-idempotent method set is allowlisted so PATCH/OPTIONS and future methods stay fail-closed.
+- The spec prescribes the three-gate algorithm.
 
 ### Retry Algorithm
 
@@ -1675,11 +1675,9 @@ logic is covered by `TestIsSameOrigin` unit tests:
 - "DownloadURL honors Retry-After on 429 at the auth'd first hop" — same as above (unwaivered).
 
 **TypeScript** (`conformance/runner/typescript/runner.test.ts` `TS_SDK_SKIPS`):
-- "GET operation retries on 503" — retry middleware chains at most 1 retry (waiver 2B.1).
 - "Large integer IDs preserved without precision loss" — `Number` is 53-bit (waiver 1B.6).
 - "DownloadURL retries on 503 at the auth'd first hop" — `downloadURL` uses raw fetch bypassing retry (unwaivered).
 - "DownloadURL honors Retry-After on 429 at the auth'd first hop" — same as above (unwaivered).
-- "Network error on an idempotent POST is retried then succeeds" — only HTTP-status retries are implemented (unwaivered).
 
 **Kotlin** (`kotlin/conformance/.../Main.kt` — `KOTLIN_SKIPS` plus one tag-based
 branch ahead of it):
@@ -1966,12 +1964,12 @@ Every operation has a `retry` block, including non-idempotent POSTs. For non-ide
 
 | SDK | Retry behavior |
 |-----|---------------|
-| TypeScript | Three-gate: POST retries only when `idempotent: true`. Retries on `retry_on` set from metadata. Chains at most 1 retry via `fetch(retryRequest)` which bypasses middleware (waiver 2B.1). |
+| TypeScript | Three-gate: POST retries only when `idempotent: true`. Retries on `retry_on` set from metadata to each operation's declared `max`, with the retry loop beneath the openapi-fetch middleware chain as the client's custom `fetch`. Network errors retry under the same idempotency gate; caller aborts and request timeouts are terminal. |
 | Kotlin | Three-gate for HTTP status retries: POST retries only when `idempotent: true`, full exponential backoff. Does not retry network errors (transport exceptions returned immediately). |
 | Go | Generated operation path retries operations classified idempotent at generation time — GET/HEAD by method, plus any operation carrying `x-basecamp-idempotent` (naturally-idempotent PUT/DELETE mutations like `UpdateProject`/`TrashProject`, and flagged-idempotent POSTs like `CompleteTodo`) — with exponential backoff; non-idempotent operations (e.g. `CreateTodo`) are single-attempt. The separate hand-written `doRequestURL` helper remains GET-only for ordinary retries, with a mutation-specific single re-attempt after successful 401 token refresh. |
 | Ruby | Simplified: only GET retries. All non-GET methods never retry. Governed GETs gate status retries on the declared `retryOn` and bound attempts by `min(config.max_retries, operation max)`; ungoverned traffic (no operation ID: `get_absolute`, OAuth) keeps the taxonomy-driven contract. |
 | Python | Three-gate, sync and async: `_mutation()` retries only when `behavior-model` metadata classifies the operation retryable, so non-idempotent POSTs are single-attempt; GETs always retry. Gate 3 uses the operation's declared `retry_on` and `max`. Non-Smithy traffic (`get_absolute()`, Launchpad authorization) passes no operation id and keeps the pre-Smithy contract. |
-| Swift | Three-gate: retries when the method is naturally idempotent (GET/HEAD/PUT/DELETE) or the operation is marked `idempotent: true`; non-idempotent POSTs make a single attempt. Gate covers both HTTP status and network-error retries, so Swift *does* retry network errors (unlike Kotlin/TS), gated by idempotency. |
+| Swift | Three-gate: retries when the method is naturally idempotent (GET/HEAD/PUT/DELETE) or the operation is marked `idempotent: true`; non-idempotent POSTs make a single attempt. Gate covers both HTTP status and network-error retries, so Swift *does* retry network errors (unlike Kotlin), gated by idempotency. |
 
 The table above describes **Gate 1 and Gate 2** — *whether* an operation retries. Gate 3's parameters
 are tracked separately: all six SDKs gate status retry on the declared `retryOn` (Ruby for governed

--- a/conformance/runner/typescript/runner.test.ts
+++ b/conformance/runner/typescript/runner.test.ts
@@ -83,8 +83,6 @@ const TS_SDK_SKIPS: Record<string, string> = {
     "TS SDK downloadURL uses raw fetch bypassing the retry middleware; 5xx / Retry-After retry is not implemented",
   "DownloadURL honors Retry-After on 429 at the auth'd first hop":
     "TS SDK downloadURL uses raw fetch bypassing the retry middleware; 5xx / Retry-After retry is not implemented",
-  "Network error on an idempotent POST is retried then succeeds":
-    "TS SDK retry middleware does not retry fetch rejections (network errors); only HTTP-status retries are implemented",
 };
 
 /**

--- a/conformance/runner/typescript/runner.test.ts
+++ b/conformance/runner/typescript/runner.test.ts
@@ -73,16 +73,10 @@ const TIMER_SLACK_MS = 2;
 const TEST_ACCOUNT_ID = "999";
 
 /**
- * Tests where the TS SDK's retry middleware architecture limits chained retries.
- *
- * The TS SDK retry middleware uses native fetch() for retry requests, which
- * bypasses the middleware stack. This means each middleware pass yields at most
- * 1 retry. A test expecting 3 total requests (initial + 2 retries) will only
- * see 2 (initial + 1 retry).
+ * Tests the TS SDK cannot pass, each with its reason. Kept per-line in sync
+ * with SPEC §19's zero-skip roster.
  */
 const TS_SDK_SKIPS: Record<string, string> = {
-  "GET operation retries on 503":
-    "TS SDK retry middleware yields at most 1 retry per middleware pass",
   "Large integer IDs preserved without precision loss":
     "JavaScript loses precision on integers > Number.MAX_SAFE_INTEGER (2^53)",
   "DownloadURL retries on 503 at the auth'd first hop":

--- a/rubric-audit.json
+++ b/rubric-audit.json
@@ -74,9 +74,7 @@
     },
     "2B.1": {
       "pass": true,
-      "waiver": true,
-      "note": "TS retry middleware uses native fetch for retries, limiting chained retry count to 1; initial + 1 retry still provides resilience",
-      "language": "typescript"
+      "note": "Retry driven by per-operation metadata exists in all six SDKs. A prior TypeScript waiver ('retry middleware uses native fetch for retries, limiting chained retry count to 1') is obsolete: the TS retry loop now runs beneath the openapi-fetch middleware chain as the client's custom fetch, so status retries run to each operation's declared retry.max and network errors retry under the idempotency gate (caller aborts and request timeouts are terminal). The TS runner passes the 503 multi-retry and idempotent-POST network-retry conformance cases un-skipped."
     },
     "2B.3": {
       "pass": true,

--- a/scripts/check-retry-metadata-parity.py
+++ b/scripts/check-retry-metadata-parity.py
@@ -229,11 +229,15 @@ def check_max_only(name: str, emitted: dict[str, int], model: dict[str, tuple]) 
 # a consumption site but cannot prove the field governs a retry decision (a token
 # surviving in a comment would pass). Behavioral proof lives in each SDK's own
 # retry test suite (go generated_*retry_test.go, python tests/test_http.py,
-# swift RetryTests.swift, the conformance runners).
+# swift RetryTests.swift, typescript tests/client.test.ts +
+# tests/middleware-lifecycle.test.ts, the conformance runners).
 RUNTIME_CONSUMPTION = [
     ("TypeScript", "full tuple", "typescript/src/services/base.ts",
      ["retryOn.includes", "maxAttempts", "baseDelayMs ??"], [],
      "base.ts: retryOn.includes(status), attempt vs maxAttempts, baseDelayMs backoff"),
+    ("TypeScript", "full tuple", "typescript/src/client.ts",
+     ["retryOn.includes", "attempt >= maxAttempts", "calculateBackoffDelay", "config.baseDelayMs"], [],
+     "client.ts createRetryingFetch: retryOn.includes(status), attempt >= maxAttempts, backoff from baseDelayMs"),
     ("Swift", "full tuple", "swift/Sources/Basecamp/HTTP/HTTPClient.swift",
      ["retryOn.contains", "< maxAttempts", "baseDelayMs"], [],
      "HTTPClient.swift: retryOn.contains(status), attempt < maxAttempts, baseDelayMs"),

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -1061,9 +1061,41 @@ function createRetryingFetch(
         await authStrategy.authenticate(attemptRequest.headers);
       }
 
-      // globalThis.fetch resolved per attempt rather than captured at client
-      // creation, so test interceptors that patch it (MSW) are honored.
-      const response = await globalThis.fetch(attemptRequest);
+      let response: Response;
+      try {
+        // globalThis.fetch resolved per attempt rather than captured at client
+        // creation, so test interceptors that patch it (MSW) are honored.
+        response = await globalThis.fetch(attemptRequest);
+      } catch (error) {
+        // An abort is terminal no matter what the budget says: a caller
+        // cancellation must not re-send, and the per-request timeout is one
+        // budget shared by every attempt and backoff — once it fires, a retry
+        // would instantly re-reject. Terminal errors are rethrown as-is so
+        // their identity survives to the lifecycle middleware's onError (and
+        // to the caller).
+        const isAbort =
+          error instanceof DOMException &&
+          (error.name === "AbortError" || error.name === "TimeoutError");
+        if (isAbort || attempt >= maxAttempts) {
+          throw error;
+        }
+
+        // Network-error retry rides the same per-operation gate as status
+        // retry: a non-idempotent POST resolves NO_RETRY_CONFIG (maxAttempts
+        // 1), so it is rethrown above after its single attempt.
+        const cause = error instanceof Error ? error : new Error(String(error));
+        const delay = calculateBackoffDelay(retryConfig, attempt - 1);
+
+        lifecycle.finalize(request, method, url, { statusCode: 0, error: cause });
+        lifecycle.retrying(method, url, attempt, cause, delay);
+
+        await sleep(delay);
+
+        // Same placement rationale as the status path below.
+        attempt += 1;
+        lifecycle.begin(request, method, url, attempt);
+        continue;
+      }
 
       // Terminal: a status outside the operation's declared retryOn set, or a
       // spent budget — maxAttempts is a total attempt count, so attempt N is

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -1096,7 +1096,7 @@ function createRetryingFetch(
         lifecycle.finalize(request, method, url, { statusCode: 0, error: cause });
         lifecycle.retrying(method, url, attempt, cause, delay);
 
-        await sleep(delay);
+        await sleep(delay, request.signal);
 
         // Same placement rationale as the status path below.
         attempt += 1;
@@ -1138,7 +1138,7 @@ function createRetryingFetch(
       // Errors are ignored: the body may already be consumed or closed.
       void response.body?.cancel().catch(() => {});
 
-      await sleep(delay);
+      await sleep(delay, request.signal);
 
       // Begun after the backoff but before any work that can throw. After, so
       // the attempt's duration measures the request rather than the sleep;
@@ -1173,8 +1173,29 @@ function calculateBackoffDelay(config: RetryConfig, attempt: number): number {
   return delay + jitter;
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+/**
+ * Signal-aware sleep for backoff waits: resolves after `ms`, or rejects with
+ * the signal's abort reason the moment it fires. Without this, a caller abort
+ * or the request-timeout budget expiring during a backoff would leave the
+ * request pending for the full delay and then start another attempt — begin,
+ * auth refresh, fetch — against an already-aborted signal.
+ */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason as Error);
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal!.reason as Error);
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 // =============================================================================

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -1073,9 +1073,16 @@ function createRetryingFetch(
         // would instantly re-reject. Terminal errors are rethrown as-is so
         // their identity survives to the lifecycle middleware's onError (and
         // to the caller).
+        //
+        // The signal is the authoritative abort test: a caller can abort with
+        // a CUSTOM reason — AbortController.abort(reason) — and fetch then
+        // rejects with that reason, not a DOMException named AbortError. The
+        // DOMException check remains for abort-shaped rejections that arrive
+        // without an aborted request signal.
         const isAbort =
-          error instanceof DOMException &&
-          (error.name === "AbortError" || error.name === "TimeoutError");
+          request.signal?.aborted === true ||
+          (error instanceof DOMException &&
+            (error.name === "AbortError" || error.name === "TimeoutError"));
         if (isAbort || attempt >= maxAttempts) {
           throw error;
         }

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -326,32 +326,34 @@ export function createBasecampClient(options: BasecampClientOptions): BasecampCl
     }
   }
 
-  const client = createClient<paths>({ baseUrl });
-
-  // Apply middleware in order: auth, lifecycle, cache, retry.
-  // onRequest runs in this order; onResponse and onError run in reverse, so the
-  // retry middleware sees a response first and the lifecycle middleware last.
-  client.use(createAuthMiddleware(authStrategy, userAgent, requestTimeoutMs, baseUrl));
-
-  // One lifecycle, shared with the retry middleware: the retry loop lives inside a
-  // single middleware callback, so per-attempt hooks have to be emitted from there
-  // rather than by a middleware that is only visited once per request.
+  // One lifecycle, shared between the retrying fetch and the lifecycle
+  // middleware: the fetch owns every attempt's start and each abandoned
+  // attempt's end; the middleware finalizes the terminal outcome.
   const lifecycle = new RequestLifecycle(hooks);
 
+  // The retry loop lives BENEATH the middleware chain, as the client's custom
+  // fetch: openapi-fetch calls it exactly once per logical request, after every
+  // onRequest middleware and before every onError/onResponse. Installed
+  // unconditionally — with retry disabled it degenerates to a single attempt —
+  // so hook emission is single-sourced regardless of config.
+  const client = createClient<paths>({
+    baseUrl,
+    fetch: createRetryingFetch(lifecycle, authStrategy, enableRetry),
+  });
+
+  // Apply middleware in order: auth, lifecycle, cache.
+  // onRequest runs in this order; onResponse and onError run in reverse, so the
+  // lifecycle middleware finalizes the terminal attempt only after the cache
+  // middleware has had its chance to transform the response.
+  client.use(createAuthMiddleware(authStrategy, userAgent, requestTimeoutMs, baseUrl));
+
   // Registered even when no hooks are configured. It emits nothing in that case
-  // (every call is optional-chained), but it still owns releasing per-request
-  // state — and the retry middleware records an attempt whether or not anyone is
-  // listening, so skipping this would strand one map entry per retried request.
+  // (every call is optional-chained), but registering it unconditionally keeps
+  // the finalize path identical whether or not anyone is listening.
   client.use(createLifecycleMiddleware(lifecycle));
 
   if (enableCache) {
     client.use(createCacheMiddleware());
-  }
-
-  // Registered last so that on the reverse-order response pass it runs first,
-  // before the cache and lifecycle middleware see the response.
-  if (enableRetry) {
-    client.use(createRetryMiddleware(lifecycle, authStrategy));
   }
 
   // Create enhanced client with additional properties
@@ -530,13 +532,11 @@ function createAuthMiddleware(authStrategy: AuthStrategy, userAgent: string, req
  * attempt, and only the first may emit an end.
  *
  * Each attempt gets fresh state — begin() replaces this record — so the flag
- * guards one attempt against a double end, not the request. The retry middleware
- * ends the attempt it is abandoning before it backs off, and separately ends its
- * own raw fetch when that throws; the lifecycle middleware's onResponse ends
- * whichever attempt is in flight when a response comes back. On a successful
- * retry those are different attempts, which is why the retry deliberately does
- * not finalize a successful fetch: onResponse must be free to record the outcome
- * the cache middleware has since transformed.
+ * guards one attempt against a double end, not the request. The retrying fetch
+ * ends every attempt it abandons before it backs off; the lifecycle middleware
+ * ends the terminal attempt. The fetch deliberately does not finalize the
+ * response it returns, so that onResponse is free to record the outcome the
+ * cache middleware has since transformed.
  */
 interface AttemptState {
   startTime: number;
@@ -545,36 +545,31 @@ interface AttemptState {
 }
 
 /**
- * Owns the onRequestStart / onRequestEnd / onRetry lifecycle for every attempt of
- * every in-flight request, keyed by openapi-fetch's per-request `id`.
+ * Owns the onRequestStart / onRequestEnd / onRetry lifecycle for every attempt
+ * of every in-flight request, keyed by the final Request object openapi-fetch
+ * hands to its custom fetch.
  *
- * The id is minted once per logical request (one client.GET/POST/... call) and is
- * passed unchanged to onRequest, onResponse and onError, so it survives a
- * middleware replacing the Request object. It deliberately does NOT distinguish
- * attempts — per-attempt data lives nested under it here — and it never goes on
- * the wire, which is why this replaces the old `X-SDK-Request-Id` and
- * `X-Request-Id` correlation headers. (`X-Request-Id` in particular is a
- * spec-reserved BC3 *response* header; sending an SDK-internal value under that
- * name was a collision.)
+ * openapi-fetch passes that same object to onResponse and onError, so identity
+ * holds from the retrying fetch (which begins every attempt) through to the
+ * lifecycle middleware (which finalizes the terminal one). Nothing ever goes on
+ * the wire — this keying replaced the old `X-SDK-Request-Id` and `X-Request-Id`
+ * correlation headers. (`X-Request-Id` in particular is a spec-reserved BC3
+ * *response* header; sending an SDK-internal value under that name was a
+ * collision.)
  *
- * Shared with the retry middleware because the retry loop lives inside
- * one middleware callback: openapi-fetch visits each middleware once per request,
- * so per-attempt hooks cannot be emitted by a separate middleware.
+ * A WeakMap makes the release bookkeeping structural: once a request settles
+ * and its Request is unreachable, the state is collectable — there is no
+ * release() to forget.
  */
 class RequestLifecycle {
-  private readonly states = new Map<string, AttemptState>();
+  private readonly states = new WeakMap<Request, AttemptState>();
 
   constructor(private readonly hooks: BasecampHooks | undefined) {}
 
   /** Begin an attempt and fire onRequestStart for it. */
-  begin(id: string, method: string, url: string, attempt: number): void {
-    this.states.set(id, { startTime: performance.now(), attempt, finalized: false });
+  begin(request: Request, method: string, url: string, attempt: number): void {
+    this.states.set(request, { startTime: performance.now(), attempt, finalized: false });
     this.emit(() => this.hooks?.onRequestStart?.({ method, url, attempt }));
-  }
-
-  /** The attempt currently in flight, or 1 if we have no record. */
-  attemptOf(id: string): number {
-    return this.states.get(id)?.attempt ?? 1;
   }
 
   /**
@@ -584,12 +579,12 @@ class RequestLifecycle {
    * matching the multipart transport in services/base.ts and SPEC section 7.
    */
   finalize(
-    id: string,
+    request: Request,
     method: string,
     url: string,
     outcome: { statusCode: number; fromCache?: boolean; error?: Error },
   ): void {
-    const state = this.states.get(id);
+    const state = this.states.get(request);
     if (!state || state.finalized) return;
     state.finalized = true;
 
@@ -613,7 +608,6 @@ class RequestLifecycle {
    * Python, Ruby and Kotlin all pass (failed, failed + 1).
    */
   retrying(
-    id: string,
     method: string,
     url: string,
     failedAttempt: number,
@@ -630,11 +624,6 @@ class RequestLifecycle {
     );
   }
 
-  /** Drop all state for a logical request. Safe to call more than once. */
-  release(id: string): void {
-    this.states.delete(id);
-  }
-
   private emit(fn: () => void): void {
     try {
       fn();
@@ -646,17 +635,12 @@ class RequestLifecycle {
 
 function createLifecycleMiddleware(lifecycle: RequestLifecycle): Middleware {
   return {
-    async onRequest({ request, id }) {
-      lifecycle.begin(id, request.method, request.url, 1);
-      return request;
-    },
-
-    async onResponse({ request, response, id }) {
-      // The authoritative end for whichever attempt is in flight: attempt 1 for a
-      // single-attempt request, or attempt 2 after a retry — the retry middleware
-      // deliberately does not finalize a successful attempt, so that the cache
-      // middleware (which runs between the two) can transform the response first.
-      // finalize stays idempotent as a backstop.
+    async onResponse({ request, response }) {
+      // The authoritative end for the terminal attempt: the retrying fetch
+      // begins every attempt but deliberately does not finalize the response it
+      // returns, so that this pass can record the outcome the cache middleware
+      // has since transformed (a 304 rewritten into a cached 200). finalize
+      // stays idempotent as a backstop.
       //
       // fromCache means "served out of the ETag cache", and only the header the
       // cache middleware sets proves that. A bare 304 does NOT: it reaches here
@@ -664,23 +648,22 @@ function createLifecycleMiddleware(lifecycle: RequestLifecycle): Middleware {
       // and in both cases the caller's own conditional request went to the server.
       const fromCache = response.headers.get("X-From-Cache") === "1";
 
-      lifecycle.finalize(id, request.method, request.url, {
+      lifecycle.finalize(request, request.method, request.url, {
         statusCode: response.status,
         fromCache,
       });
-      lifecycle.release(id);
 
       return response;
     },
 
-    async onError({ request, error, id }) {
-      // openapi-fetch skips onResponse entirely when the initial fetch rejects,
-      // so this is the only place a network error or timeout can be observed.
-      lifecycle.finalize(id, request.method, request.url, {
+    async onError({ request, error }) {
+      // A terminal throw from the retrying fetch — a network error, a timeout,
+      // or a retry's auth refresh — skips onResponse entirely, so this is the
+      // only place it can be observed.
+      lifecycle.finalize(request, request.method, request.url, {
         statusCode: 0,
         error: error instanceof Error ? error : new Error(String(error)),
       });
-      lifecycle.release(id);
 
       // Returning nothing preserves the original error's identity and rethrows it.
       return undefined;
@@ -825,7 +808,7 @@ function getCacheKey(url: string, tokenHash: string): string {
 }
 
 // =============================================================================
-// Retry Middleware
+// Retrying Fetch (the retry loop, beneath the middleware chain)
 // =============================================================================
 
 /**
@@ -1010,52 +993,82 @@ function getRetryConfigForRequest(method: string, url: string): RetryConfig {
   return DEFAULT_RETRY_CONFIG;
 }
 
-function createRetryMiddleware(
+/**
+ * The retry loop, installed beneath the middleware chain as the client's custom
+ * fetch (createClient's `fetch` option). openapi-fetch calls it exactly once
+ * per logical request, after every onRequest middleware and before every
+ * onError/onResponse — so the loop runs to the operation's full declared
+ * maxAttempts, and no attempt ever leaves the chain, because the chain sits
+ * above the loop.
+ *
+ * Division of labor with the lifecycle middleware: the loop begins EVERY
+ * attempt and finalizes the attempts it abandons (before the backoff sleep);
+ * the terminal outcome — the response it returns, or the error it throws — is
+ * deliberately NOT finalized here. It flows up through the cache middleware,
+ * which may rewrite a 304 into a cached 200 + X-From-Cache, to the lifecycle
+ * middleware, which records the post-transform result. Finalizing in the loop
+ * would freeze the pre-transformation status, and the idempotent finalize
+ * would keep the hooks pass from correcting it.
+ *
+ * With retry disabled the loop degenerates to a single attempt but still owns
+ * hook emission, so start/end events are single-sourced regardless of config.
+ */
+function createRetryingFetch(
   lifecycle: RequestLifecycle,
-  authStrategy?: AuthStrategy,
-): Middleware {
-  // Serialized request bodies, keyed by openapi-fetch's per-request id, because
-  // Request.body can only be read once and the retry needs to replay it. Keyed on
-  // the id rather than method+url+timestamp: two concurrent mutations to the same
-  // URL used to collide on one slot and replay each other's bytes.
-  const bodyCache = new Map<string, ArrayBuffer | null>();
+  authStrategy: AuthStrategy,
+  enableRetry: boolean,
+): (input: Request) => Promise<Response> {
+  return async (request) => {
+    const { method, url } = request;
+    const retryConfig = getRetryConfigForRequest(method, url);
+    const maxAttempts = enableRetry ? retryConfig.maxAttempts : 1;
 
-  return {
-    async onRequest({ request, id }) {
-      // For methods that may have a body, clone it before the initial fetch
-      // so we can use it for retries. Request.body can only be consumed once.
-      const method = request.method.toUpperCase();
-      if (method === "POST" || method === "PUT" || method === "PATCH") {
-        if (request.body) {
-          // Clone the body before it gets consumed
-          const cloned = request.clone();
-          bodyCache.set(id, await cloned.arrayBuffer());
-        } else {
-          bodyCache.set(id, null);
-        }
+    // Serialize the body once, before the first send, because Request.body is
+    // a stream that can only be consumed once and a retry needs to replay it.
+    // clone() tees the stream, so attempt 1 sends the original untouched and
+    // replays read from this buffer. Requests that can never retry — including
+    // every non-idempotent POST, via NO_RETRY_CONFIG — skip the buffering.
+    const upperMethod = method.toUpperCase();
+    let bodyBuffer: ArrayBuffer | null = null;
+    if (
+      maxAttempts > 1 &&
+      (upperMethod === "POST" || upperMethod === "PUT" || upperMethod === "PATCH") &&
+      request.body
+    ) {
+      bodyBuffer = await request.clone().arrayBuffer();
+    }
+
+    let attempt = 1;
+    let attemptRequest = request;
+    lifecycle.begin(request, method, url, attempt);
+
+    for (;;) {
+      if (attempt > 1) {
+        // Rebuild from the original request: the headers carry everything the
+        // onRequest middleware attached (auth, User-Agent, If-None-Match), and
+        // the signal keeps the caller's cancellation and the per-request
+        // timeout — one budget shared by all attempts and backoffs.
+        attemptRequest = new Request(url, {
+          method,
+          headers: new Headers(request.headers),
+          body: bodyBuffer,
+          signal: request.signal,
+        });
+
+        // Refresh auth (the token may have rotated since the last attempt).
+        // The attempt is already begun, so a throwing refresh lands on a live
+        // attempt and propagates to the lifecycle middleware's onError.
+        await authStrategy.authenticate(attemptRequest.headers);
       }
 
-      return request;
-    },
+      // globalThis.fetch resolved per attempt rather than captured at client
+      // creation, so test interceptors that patch it (MSW) are honored.
+      const response = await globalThis.fetch(attemptRequest);
 
-    async onResponse({ request, response, id }) {
-      const { method, url } = request;
-      // Get operation-specific retry config from metadata
-      const retryConfig = getRetryConfigForRequest(method, url);
-
-      // Not retrying: let the lifecycle middleware end the attempt, and drop the body.
-      if (!retryConfig.retryOn.includes(response.status)) {
-        bodyCache.delete(id);
-        return response;
-      }
-
-      const failedAttempt = lifecycle.attemptOf(id);
-
-      // maxAttempts is a total attempt count, so attempt N is terminal when it
-      // equals the cap. TypeScript additionally chains at most one retry, since
-      // the retry below leaves the middleware chain (SPEC waiver 2B.1).
-      if (failedAttempt >= retryConfig.maxAttempts) {
-        bodyCache.delete(id);
+      // Terminal: a status outside the operation's declared retryOn set, or a
+      // spent budget — maxAttempts is a total attempt count, so attempt N is
+      // terminal when it equals the cap.
+      if (!retryConfig.retryOn.includes(response.status) || attempt >= maxAttempts) {
         return response;
       }
 
@@ -1067,81 +1080,36 @@ function createRetryMiddleware(
       if (!isNaN(retryAfterSeconds)) {
         delay = retryAfterSeconds * 1000;
       } else {
-        delay = calculateBackoffDelay(retryConfig, failedAttempt - 1);
+        delay = calculateBackoffDelay(retryConfig, attempt - 1);
       }
 
       const statusError = new Error(
         `HTTP ${response.status}: ${response.statusText || "Request failed"}`,
       );
 
-      try {
-        // End the failed attempt before sleeping, so a slow backoff cannot leave
-        // an attempt open, then announce the upcoming one.
-        lifecycle.finalize(id, method, url, { statusCode: response.status });
-        lifecycle.retrying(id, method, url, failedAttempt, statusError, delay);
+      // End the failed attempt before sleeping, so a slow backoff cannot leave
+      // an attempt open, then announce the upcoming one.
+      lifecycle.finalize(request, method, url, { statusCode: response.status });
+      lifecycle.retrying(method, url, attempt, statusError, delay);
 
-        // This response is being discarded, so release its stream before we sleep
-        // rather than leaving it open across the backoff — otherwise a throttled
-        // client holds a connection per in-flight retry and cannot reuse any of
-        // them. The multipart transport in services/base.ts already does this.
-        // Errors are ignored: the body may already be consumed or closed.
-        void response.body?.cancel().catch(() => {});
+      // This response is being discarded, so release its stream before we sleep
+      // rather than leaving it open across the backoff — otherwise a throttled
+      // client holds a connection per in-flight retry and cannot reuse any of
+      // them. The multipart transport in services/base.ts already does this.
+      // Errors are ignored: the body may already be consumed or closed.
+      void response.body?.cancel().catch(() => {});
 
-        await sleep(delay);
+      await sleep(delay);
 
-        // The raw fetch below bypasses the middleware chain, so no downstream
-        // middleware sees this attempt begin — start it here.
-        //
-        // Started after the backoff but before any work that can throw. After, so
-        // the attempt's duration measures the request rather than the sleep;
-        // before, so that if the auth refresh or the fetch throws, the catch has a
-        // live attempt to finalize. Starting it later would let onRetry announce
-        // attempt 2 and then never account for it.
-        lifecycle.begin(id, method, url, failedAttempt + 1);
-
-        const body = bodyCache.get(id) ?? null;
-
-        const retryRequest = new Request(url, {
-          method,
-          headers: new Headers(request.headers),
-          body,
-          signal: request.signal,
-        });
-
-        // Refresh auth header for retry (token may have been refreshed since initial request)
-        if (authStrategy) {
-          await authStrategy.authenticate(retryRequest.headers);
-        }
-
-        // Deliberately NOT finalized here. The returned response still flows
-        // through the cache middleware, which may rewrite a 304 into a cached 200;
-        // finalizing now would freeze the pre-transformation status and
-        // fromCache: false, and an idempotent finalize means the hooks pass could
-        // not correct it. The lifecycle middleware ends this attempt instead, reading
-        // attempt 2 from the state begun above.
-        return await fetch(retryRequest);
-      } catch (error) {
-        // openapi-fetch routes only the INITIAL fetch through onError, so anything
-        // thrown in here — the retry fetch, the auth refresh, the sleep — would
-        // otherwise escape with the attempt still open and its state stranded.
-        lifecycle.finalize(id, method, url, {
-          statusCode: 0,
-          error: error instanceof Error ? error : new Error(String(error)),
-        });
-        lifecycle.release(id);
-        // Rethrow the original value so its identity survives.
-        throw error;
-      } finally {
-        bodyCache.delete(id);
-      }
-    },
-
-    async onError({ id }) {
-      // The initial fetch rejected, so onResponse never ran and the cached body
-      // would leak. The lifecycle middleware owns ending the attempt.
-      bodyCache.delete(id);
-      return undefined;
-    },
+      // Begun after the backoff but before any work that can throw. After, so
+      // the attempt's duration measures the request rather than the sleep;
+      // before, so that if the auth refresh or the fetch throws, the lifecycle
+      // middleware's onError still finds a live attempt to finalize. Starting
+      // it later would let onRetry announce an attempt and then never account
+      // for it.
+      attempt += 1;
+      lifecycle.begin(request, method, url, attempt);
+    }
   };
 }
 

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -306,6 +306,69 @@ describe("BasecampClient", () => {
       expect(member).toBe("/{accountId}/buckets/{bucketId}/categories/{typeId}");
     });
 
+    it("should not retry a network error on a non-idempotent POST and preserve the error's identity", async () => {
+      // The sentinel must surface unwrapped: the conformance runner (and any
+      // caller) classifies transport failures by the raw error, so wrapping or
+      // rethrowing a copy would break that contract.
+      const sentinel = new TypeError("Failed to fetch");
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockRejectedValue(sentinel);
+
+      try {
+        const client = createBasecampClient({
+          accountId: "12345",
+          accessToken: "test-token",
+        });
+
+        const err = await client
+          .POST("/todolists/{todolistId}/todos.json", {
+            params: { path: { todolistId: 456 } },
+            body: { content: "Test todo" },
+          })
+          .then(
+            () => undefined,
+            (e: unknown) => e
+          );
+
+        // CreateTodo is not idempotent, so exactly one attempt goes out.
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(err).toBe(sentinel);
+      } finally {
+        fetchSpy.mockRestore();
+      }
+    });
+
+    it("should retry a network error on an idempotent POST", async () => {
+      // CompleteTodo is flagged idempotent.natural in metadata, so a transport
+      // failure is retried under the same gate as a status retry.
+      let attempts = 0;
+
+      server.use(
+        http.post(`${BASE_URL}/todos/456/completion.json`, () => {
+          attempts++;
+          if (attempts === 1) {
+            return HttpResponse.error();
+          }
+          return new HttpResponse(null, { status: 204 });
+        })
+      );
+
+      const client = createBasecampClient({
+        accountId: "12345",
+        accessToken: "test-token",
+      });
+
+      const { error, response } = await client.POST(
+        "/todos/{todoId}/completion.json",
+        { params: { path: { todoId: 456 } } }
+      );
+
+      expect(attempts).toBe(2);
+      expect(error).toBeUndefined();
+      expect(response.status).toBe(204);
+    }, 10_000);
+
     it("should refresh auth token on retry", async () => {
       let attempts = 0;
       const capturedTokens: string[] = [];

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -220,6 +220,56 @@ describe("BasecampClient", () => {
       expect(error).toBeDefined();
     });
 
+    it("should exhaust the operation's maxAttempts and surface the final 503", async () => {
+      let attempts = 0;
+
+      server.use(
+        http.get(`${BASE_URL}/projects.json`, () => {
+          attempts++;
+          return new HttpResponse(null, { status: 503 });
+        })
+      );
+
+      const client = createBasecampClient({
+        accountId: "12345",
+        accessToken: "test-token",
+      });
+
+      const { error, response } = await client.GET("/projects.json");
+
+      // The declared maxAttempts (3) is a total attempt count — and a ceiling,
+      // so no fourth request goes out.
+      expect(attempts).toBe(3);
+      expect(error).toBeDefined();
+      expect(response.status).toBe(503);
+    }, 10_000);
+
+    it("should honor a per-operation maxAttempts below the default", async () => {
+      // UpdateAccountName declares maxAttempts: 2 in behavior-model metadata,
+      // so the loop must stop below the default of 3.
+      let attempts = 0;
+
+      server.use(
+        http.put(`${BASE_URL}/account/name.json`, () => {
+          attempts++;
+          return new HttpResponse(null, { status: 503 });
+        })
+      );
+
+      const client = createBasecampClient({
+        accountId: "12345",
+        accessToken: "test-token",
+      });
+
+      const { error, response } = await client.PUT("/account/name.json", {
+        body: { name: "Renamed" },
+      } as never);
+
+      expect(attempts).toBe(2);
+      expect(error).toBeDefined();
+      expect(response.status).toBe(503);
+    }, 10_000);
+
     it("should resolve retry config for timesheet_entries paths", () => {
       // Regression test: normalizeUrlPath must map timesheet_entries/{id} → {entryId}
       // so PATH_TO_OPERATION lookup finds GetTimesheetEntry/UpdateTimesheetEntry.

--- a/typescript/tests/integration.test.ts
+++ b/typescript/tests/integration.test.ts
@@ -1,6 +1,6 @@
 /**
- * Integration smoke tests — verify the full middleware stack works in concert:
- * auth → hooks → cache → retry all interacting together.
+ * Integration smoke tests — verify the full transport works in concert:
+ * auth → hooks → cache middleware, with the retrying fetch beneath them.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { http, HttpResponse } from "msw";
@@ -45,9 +45,9 @@ describe("Integration", () => {
         enableRetry: true,
       });
 
-      // Call 1: middleware pipeline sees 429 → retry middleware does raw fetch → 200 with ETag.
-      // The retry's raw-fetch response flows back through the middleware stack in reverse,
-      // so the cache middleware's onResponse sees the 200 + ETag and stores it.
+      // Call 1: the retrying fetch sees the 429 beneath the chain and re-sends → 200
+      // with ETag. The terminal response flows up through the middleware stack in
+      // reverse, so the cache middleware's onResponse sees the 200 + ETag and stores it.
       const result1 = await client.GET("/projects.json");
       expect(result1.data).toHaveLength(1);
 
@@ -57,7 +57,7 @@ describe("Integration", () => {
 
       // Breakdown:
       //   callCount 1 = initial request, 429
-      //   callCount 2 = retry (raw fetch, bypasses cache onRequest — no If-None-Match), 200
+      //   callCount 2 = retry attempt (replays the original headers; nothing cached yet, so no If-None-Match), 200
       //   callCount 3 = second client.GET, cache attaches If-None-Match → 304
       expect(callCount).toBe(3);
     });
@@ -95,8 +95,8 @@ describe("Integration", () => {
 
       await client.GET("/projects.json");
 
-      // Both attempts are observed. The retry leaves the middleware chain, so the
-      // retry middleware emits that attempt's start/end itself.
+      // Both attempts are observed. The retrying fetch beneath the chain emits
+      // every attempt's start and each abandoned attempt's end.
       expect(hooks.onRequestStart).toHaveBeenCalledTimes(2);
       expect(hooks.onRequestStart).toHaveBeenNthCalledWith(
         1,
@@ -111,7 +111,7 @@ describe("Integration", () => {
         expect.objectContaining({ attempt: 2 })
       );
 
-      // onRetry fires from the retry middleware when it decides to retry.
+      // onRetry fires from the retrying fetch when it decides to retry.
       expect(hooks.onRetry).toHaveBeenCalledTimes(1);
       expect(hooks.onRetry).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/typescript/tests/middleware-lifecycle.test.ts
+++ b/typescript/tests/middleware-lifecycle.test.ts
@@ -219,6 +219,48 @@ describe("middleware request lifecycle", () => {
     expect(end.error).toBeInstanceOf(Error);
   });
 
+  // Review follow-up (Codex). A caller can abort with a CUSTOM reason —
+  // AbortController.abort(reason) — and fetch then rejects with that reason,
+  // not a DOMException named AbortError. Cancellation must stay terminal on
+  // that path too: no retry, no backoff, and the caller's reason surfaces
+  // untouched.
+  it("treats a caller abort with a custom reason as terminal", async () => {
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, async () => {
+        await new Promise((r) => setTimeout(r, 1000));
+        return HttpResponse.json([]);
+      })
+    );
+
+    const { hooks, events } = recordingHooks();
+    const client = createBasecampClient({
+      accountId: "12345",
+      accessToken: "test-token",
+      hooks,
+    });
+
+    const reason = new Error("caller cancelled");
+    const controller = new AbortController();
+    const abortTimer = setTimeout(() => controller.abort(reason), 50);
+
+    try {
+      const err = await client
+        .GET("/projects.json", { signal: controller.signal } as never)
+        .then(
+          () => undefined,
+          (e: unknown) => e
+        );
+
+      expect(err).toBe(reason);
+      // Terminal on attempt 1: no retry started, no onRetry announced.
+      expect(starts(events).map((e) => e.attempt)).toEqual([1]);
+      expect(ends(events).map((e) => e.attempt)).toEqual([1]);
+      expect(events.filter((e) => e.kind === "retry")).toHaveLength(0);
+    } finally {
+      clearTimeout(abortTimer);
+    }
+  }, 10_000);
+
   // Defect 4, updated for network-error retry. A 503 followed by fetch
   // rejections keeps retrying to maxAttempts, with balanced hooks per attempt
   // and nothing dangling.

--- a/typescript/tests/middleware-lifecycle.test.ts
+++ b/typescript/tests/middleware-lifecycle.test.ts
@@ -135,9 +135,10 @@ describe("middleware request lifecycle", () => {
     expect(retryBodies).toEqual(firstBodies);
   });
 
-  // Defect 2. A rejected initial fetch must still produce a balanced
-  // start/end pair, with statusCode 0 and the original error preserved.
-  it("fires a balanced start/end with statusCode 0 when the initial fetch fails", async () => {
+  // Defect 2, updated for network-error retry. A GET whose fetch keeps
+  // rejecting is retried to the operation's maxAttempts, and every attempt gets
+  // a balanced start/end pair with statusCode 0 and the error preserved.
+  it("retries a GET whose fetch fails, with balanced hooks for every attempt", async () => {
     server.use(
       http.get(`${BASE_URL}/projects.json`, () => HttpResponse.error())
     );
@@ -151,13 +152,41 @@ describe("middleware request lifecycle", () => {
 
     await expect(client.GET("/projects.json")).rejects.toBeTruthy();
 
-    expect(starts(events)).toHaveLength(1);
-    expect(ends(events)).toHaveLength(1);
-    const end = ends(events)[0]!;
-    expect(end.attempt).toBe(1);
-    expect(end.statusCode).toBe(0);
-    expect(end.error).toBeInstanceOf(Error);
-  });
+    expect(starts(events).map((e) => e.attempt)).toEqual([1, 2, 3]);
+    expect(ends(events).map((e) => e.attempt)).toEqual([1, 2, 3]);
+    for (const end of ends(events)) {
+      expect(end.statusCode).toBe(0);
+      expect(end.error).toBeInstanceOf(Error);
+    }
+  }, 10_000);
+
+  // Network-error retry's success path: two fetch rejections, then a 200.
+  it("recovers when a retried GET's network error clears", async () => {
+    let attempts = 0;
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, () => {
+        attempts++;
+        if (attempts <= 2) {
+          return HttpResponse.error();
+        }
+        return HttpResponse.json([{ id: 1 }]);
+      })
+    );
+
+    const { hooks, events } = recordingHooks();
+    const client = createBasecampClient({
+      accountId: "12345",
+      accessToken: "test-token",
+      hooks,
+    });
+
+    const { data } = await client.GET("/projects.json");
+
+    expect(attempts).toBe(3);
+    expect(data).toEqual([{ id: 1 }]);
+    expect(starts(events).map((e) => e.attempt)).toEqual([1, 2, 3]);
+    expect(ends(events).map((e) => e.statusCode)).toEqual([0, 0, 200]);
+  }, 10_000);
 
   // Defect 2, timeout variant. The auth middleware installs
   // AbortSignal.timeout, so a stalled request rejects the same way.
@@ -186,9 +215,10 @@ describe("middleware request lifecycle", () => {
     expect(end.error).toBeInstanceOf(Error);
   });
 
-  // Defect 4. Both attempts get balanced hooks even when the RETRY fetch
-  // itself fails at the network level, and all state is finalized.
-  it("fires balanced lifecycle hooks for both attempts when the retry fetch fails", async () => {
+  // Defect 4, updated for network-error retry. A 503 followed by fetch
+  // rejections keeps retrying to maxAttempts, with balanced hooks per attempt
+  // and nothing dangling.
+  it("fires balanced lifecycle hooks for every attempt when retry fetches fail", async () => {
     let attempts = 0;
     server.use(
       http.get(`${BASE_URL}/projects.json`, () => {
@@ -212,14 +242,13 @@ describe("middleware request lifecycle", () => {
 
     await expect(client.GET("/projects.json")).rejects.toBeTruthy();
 
-    expect(attempts).toBe(2);
+    expect(attempts).toBe(3);
     // One start and one end per attempt — nothing dangling.
-    expect(starts(events).map((e) => e.attempt)).toEqual([1, 2]);
-    expect(ends(events).map((e) => e.attempt)).toEqual([1, 2]);
-    expect(ends(events)[0]!.statusCode).toBe(503);
-    expect(ends(events)[1]!.statusCode).toBe(0);
-    expect(ends(events)[1]!.error).toBeInstanceOf(Error);
-  });
+    expect(starts(events).map((e) => e.attempt)).toEqual([1, 2, 3]);
+    expect(ends(events).map((e) => e.attempt)).toEqual([1, 2, 3]);
+    expect(ends(events).map((e) => e.statusCode)).toEqual([503, 0, 0]);
+    expect(ends(events)[2]!.error).toBeInstanceOf(Error);
+  }, 10_000);
 
   // Defect 4, attempt numbering. SPEC section 7: RequestInfo.attempt is the
   // attempt that just failed (1); onRetry's second argument is the UPCOMING

--- a/typescript/tests/middleware-lifecycle.test.ts
+++ b/typescript/tests/middleware-lifecycle.test.ts
@@ -1,7 +1,8 @@
 /**
  * Request lifecycle regressions for the client middleware.
  *
- * Four defects motivated these, all in createRetryMiddleware/createHooksMiddleware:
+ * Four defects motivated these, all in the since-replaced retry/hooks middleware
+ * (the retry loop now lives in createRetryingFetch, beneath the chain):
  *
  *   1. bodyCache was keyed on `${method}:${url}:${Date.now()}`, so two concurrent
  *      mutations to the same URL in the same millisecond shared one cache slot —
@@ -21,8 +22,11 @@
  *   - onRetry's 2nd arg    — the UPCOMING attempt, so 2 on the first retry
  * Go, Python, Ruby and Kotlin all pass (1, 2); TypeScript passed (1, 1).
  *
- * Note TypeScript caps at one retry by design (SPEC waiver 2B.1), so attempt 2 is
- * terminal here. These tests assert the two-attempt lifecycle, not three.
+ * The retry loop now runs beneath the middleware chain as the client's custom
+ * fetch (closing SPEC waiver 2B.1), so attempts run to each operation's
+ * declared maxAttempts and network errors retry under the idempotency gate.
+ * The multi-attempt tests below pin that; the two-attempt tests remain as the
+ * minimal shape of each original defect.
  */
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { http, HttpResponse } from "msw";

--- a/typescript/tests/middleware-lifecycle.test.ts
+++ b/typescript/tests/middleware-lifecycle.test.ts
@@ -472,6 +472,96 @@ describe("middleware request lifecycle", () => {
     expect(cancelSpy).toHaveBeenCalled();
   });
 
+  // Waiver 2B.1's kill shot. The retry loop lives beneath the middleware chain
+  // as the client's custom fetch, so a second 503 no longer exhausts the
+  // architecture — attempts run to the operation's declared maxAttempts (3 by
+  // default), each with balanced hooks and an onRetry announcing the next.
+  it("chains status retries to the operation's full maxAttempts", async () => {
+    let attempts = 0;
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, () => {
+        attempts++;
+        if (attempts <= 2) {
+          return new HttpResponse(null, { status: 503 });
+        }
+        return HttpResponse.json([{ id: 1 }]);
+      })
+    );
+
+    const events: Array<{
+      kind: "start" | "end" | "retry";
+      attempt: number;
+      statusCode?: number;
+      upcoming?: number;
+    }> = [];
+    const hooks: BasecampHooks = {
+      onRequestStart(info: RequestInfo) {
+        events.push({ kind: "start", attempt: info.attempt });
+      },
+      onRequestEnd(info: RequestInfo, result: RequestResult) {
+        events.push({ kind: "end", attempt: info.attempt, statusCode: result.statusCode });
+      },
+      onRetry(info: RequestInfo, upcoming: number) {
+        events.push({ kind: "retry", attempt: info.attempt, upcoming });
+      },
+    };
+    const client = createBasecampClient({
+      accountId: "12345",
+      accessToken: "test-token",
+      hooks,
+    });
+
+    const { data } = await client.GET("/projects.json");
+
+    expect(attempts).toBe(3);
+    expect(data).toEqual([{ id: 1 }]);
+    expect(starts(events).map((e) => e.attempt)).toEqual([1, 2, 3]);
+    expect(ends(events).map((e) => e.attempt)).toEqual([1, 2, 3]);
+    expect(ends(events).map((e) => e.statusCode)).toEqual([503, 503, 200]);
+    // SPEC section 7 pairs: (failed attempt, upcoming attempt).
+    const retries = events.filter((e) => e.kind === "retry");
+    expect(retries.map((r) => [r.attempt, r.upcoming])).toEqual([
+      [1, 2],
+      [2, 3],
+    ]);
+  }, 10_000);
+
+  // Body replay across MULTIPLE retries: the buffer captured before attempt 1
+  // must feed every subsequent attempt, byte-identical. The concurrency test
+  // above only exercises one retry per request.
+  it("replays the same body bytes on every retry attempt", async () => {
+    const bodies: string[] = [];
+    let attempts = 0;
+    server.use(
+      http.put(`${BASE_URL}/buckets/1/todos/2.json`, async ({ request }) => {
+        attempts++;
+        bodies.push(await request.text());
+        if (attempts <= 2) {
+          return new HttpResponse(null, {
+            status: 429,
+            headers: { "Retry-After": "0" },
+          });
+        }
+        return HttpResponse.json({ ok: true });
+      })
+    );
+
+    const client = createBasecampClient({
+      accountId: "12345",
+      accessToken: "test-token",
+    });
+
+    await client.PUT("/buckets/{bucketId}/todos/{todoId}.json", {
+      params: { path: { bucketId: 1, todoId: 2 } },
+      body: { content: "same-bytes" },
+    } as never);
+
+    expect(attempts).toBe(3);
+    expect(bodies).toHaveLength(3);
+    expect(new Set(bodies).size).toBe(1);
+    expect(bodies[0]).toContain("same-bytes");
+  });
+
   // Repeated retried requests each report their own two attempts, in order, with
   // no cross-talk between logical requests. This says nothing about state being
   // released — that is not observable from here — only that attempt attribution

--- a/typescript/tests/middleware-lifecycle.test.ts
+++ b/typescript/tests/middleware-lifecycle.test.ts
@@ -261,6 +261,54 @@ describe("middleware request lifecycle", () => {
     }
   }, 10_000);
 
+  // Review follow-up (Codex, round 2). An abort that fires DURING the backoff
+  // sleep must be terminal immediately: without a signal-aware sleep the
+  // request stays pending for the full delay, then begins another attempt
+  // (start + auth refresh) against an already-aborted signal. The same seam
+  // guards the request-timeout budget, which shares this signal.
+  it("rejects promptly when the caller aborts during a retry backoff", async () => {
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, () =>
+        // Retry-After: 2 puts the loop into a 2s backoff we can abort inside.
+        new HttpResponse(null, { status: 429, headers: { "Retry-After": "2" } })
+      )
+    );
+
+    const { hooks, events } = recordingHooks();
+    const client = createBasecampClient({
+      accountId: "12345",
+      accessToken: "test-token",
+      hooks,
+    });
+
+    const reason = new Error("caller cancelled during backoff");
+    const controller = new AbortController();
+    const abortTimer = setTimeout(() => controller.abort(reason), 100);
+
+    try {
+      const startedAt = Date.now();
+      const err = await client
+        .GET("/projects.json", { signal: controller.signal } as never)
+        .then(
+          () => undefined,
+          (e: unknown) => e
+        );
+
+      expect(err).toBe(reason);
+      // Prompt: nowhere near the 2s Retry-After backoff.
+      expect(Date.now() - startedAt).toBeLessThan(1000);
+      // Attempt 1 was started and ended (429) before the backoff; attempt 2
+      // must never start. onRetry had already announced it — that is the
+      // inherent race of cancelling between announce and begin — but starts
+      // and ends stay balanced.
+      expect(starts(events).map((e) => e.attempt)).toEqual([1]);
+      expect(ends(events).map((e) => e.attempt)).toEqual([1]);
+      expect(ends(events)[0]!.statusCode).toBe(429);
+    } finally {
+      clearTimeout(abortTimer);
+    }
+  }, 10_000);
+
   // Defect 4, updated for network-error retry. A 503 followed by fetch
   // rejections keeps retrying to maxAttempts, with balanced hooks per attempt
   // and nothing dangling.


### PR DESCRIPTION
Closes SPEC waiver 2B.1 and the TS network-error divergence in one architectural move: the retry loop now runs **beneath** the openapi-fetch middleware chain, as the client's custom `fetch` (Swift's #517 directive-loop is the model).

## What changed

**Commit 1 — the loop beneath the chain.** `createRetryMiddleware` is deleted and replaced by `createRetryingFetch(lifecycle, authStrategy, enableRetry)`, passed to `createClient({ fetch })`. openapi-fetch calls it exactly once per logical request, after every `onRequest` middleware and before every `onResponse`/`onError`, so:

- Status retries run to each operation's declared `retry.max` (per-op metadata via the existing `getRetryConfigForRequest` URL+method lookup — no request annotation, avoiding the #503 wire-leak class).
- The stack becomes auth → lifecycle(finalize-only) → cache. The loop owns every attempt's `onRequestStart` and each abandoned attempt's `onRequestEnd`/`onRetry`; the lifecycle middleware finalizes only the terminal attempt, after the cache middleware's 304 → cached-200 transform (the #505 crown-jewel test passes unmodified).
- `RequestLifecycle` re-keys from openapi-fetch's `id` to a `WeakMap<Request, AttemptState>` (identity holds from custom fetch to `onResponse`/`onError`); `release()` becomes structural and `attemptOf()` gives way to a loop-local counter. The `(failed, upcoming)` onRetry pair is untouched.
- Body replay is a closure-local buffer captured via `request.clone()` before attempt 1, gated on `maxAttempts > 1` — the id-keyed `bodyCache` dies, and never-retryable POSTs no longer buffer at all.

**Commit 2 — network-error retry, idempotency-gated.** A rejected fetch is retried under the same per-operation gate as status retries: GETs and idempotent mutations re-send with backoff; a non-idempotent POST (`NO_RETRY_CONFIG`) makes one attempt and surfaces its **original** error object (identity pinned by test — the conformance runner classifies transport failures by the raw error). `AbortError`/`TimeoutError` are terminal regardless of budget: caller cancellation must not re-send, and the request timeout is one budget shared by all attempts and backoffs.

**Commit 3 — doc sweep.** SPEC §7 (network-retry grouping, Gate 3 table, divergence bullets, enforcement paragraph), Appendix F TS+Swift rows, the §19 zero-skip roster (exactly the two TS lines this PR closes), rubric-audit 2B.1 → plain pass (same shape as the 3C.6 flip), and a `client.ts` token row in `check-retry-metadata-parity.py`.

## Conformance

Two `TS_SDK_SKIPS` entries removed, both proven red first against the old build:

- "GET operation retries on 503" — was `expected 3 requests, got 2`; now passes with real backoff (`delayBetweenRequests >= 1000`).
- "Network error on an idempotent POST is retried then succeeds" — was `expected 2 requests, got 1`; now passes (CompleteTodo re-sends, succeeds on 204).

TS skips drop 5 → 3 (integer precision waiver 1B.6 + two DownloadURL lines, a different gap — see below).

## Red proofs (unit)

- New kill shots failed against the old code before each implementation commit: full-maxAttempts chaining (2≠3), multi-retry body replay (2≠3), 503 exhaustion (2≠3), idempotent-POST network retry, GET network-error retry ×2.
- Two guard tests that pass coincidentally against old code were proven red against deliberately broken variants: the per-op ceiling test fails `expected 2, got 3` when the loop ignores per-op `max`, and the non-idempotent-POST identity test fails `called 1 times, but got 3` when the network catch ignores the idempotency gate.
- Two lifecycle tests flip deliberately (GET network errors now retry): all-rejections now runs to `[1,2,3]` all statusCode 0, and 503-then-rejections ends `[503, 0, 0]`. Both shown red before commit 2. The timeout test does NOT flip — it pins abort-is-terminal at exactly one attempt.

## Accepted behavior deltas (outside SDK-used surface)

1. A per-request `fetchOptions.fetch` override now bypasses retry and request-level hooks entirely (previously it got middleware retry).
2. A user middleware short-circuiting `onRequest` with a `Response` now produces zero start/end events (previously start+end); openapi-fetch skips both the custom fetch and `onResponse` on that path.
3. Attempt 1's `onRequestStart` now fires after ALL `onRequest` middleware rather than between auth and cache.

## Deliberately untouched

- `downloadURL`'s raw-fetch path and its two conformance skips (a different gap). The loop body is structured so a later rock can extract `executeWithRetry` — a pure function of request/config/hook seams — and let `download.ts` hop 1 adopt it.
- Coordination: the Kotlin lane also rewrites SPEC §7's network-error sentence; second-to-merge rebases that one sentence preserving both halves.

## Verification

- TS unit suite and conformance runner green at each commit (REAL_EXIT grep-back); CI is authoritative for counts.
- `check-retry-metadata-parity.py` green, now including the `client.ts` consumption row.
- `2B.1` grep gate: remaining references are the §20 rubric table row (criterion still met), the rubric-audit historical note, and two test comments describing the closed waiver.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs the TypeScript retry loop beneath the `openapi-fetch` middleware via a custom fetch. Retries now go to each operation’s max, include idempotency-gated network-error retries, and aborts/timeouts are terminal — even during backoff.

- **New Features**
  - Full per-operation retries using metadata (`retry_on`, `maxAttempts`) with backoff and `Retry-After`.
  - Network errors retry for GET and idempotent mutations; non-idempotent POSTs make one attempt. Aborts/timeouts are terminal, and the backoff sleep is signal-aware so mid-backoff aborts reject promptly with the original reason.
  - Lifecycle: the retrying fetch starts every attempt and ends abandoned ones; the lifecycle middleware finalizes only the terminal attempt after cache transforms.
  - Conformance: un-skips “GET operation retries on 503” and “Network error on an idempotent POST is retried then succeeds”; closes SPEC waiver 2B.1 and updates SPEC to reflect TS’s model.

- **Refactors**
  - Replaced retry middleware with `createRetryingFetch(lifecycle, authStrategy, enableRetry)` passed via `createClient({ fetch })`.
  - `RequestLifecycle` now keys state by `Request` via `WeakMap`; removes `release()` and `attemptOf()`.
  - Body replay captured once via `request.clone()` when retries are possible; removes the id-keyed body cache.
  - Behavior deltas: per-request `fetchOptions.fetch` bypasses retry and hooks; `onRequest` short-circuits emit no start/end; attempt 1 start fires after all `onRequest` middleware.

<sup>Written for commit 32e70873d9b112260da8b3412398dc73179a999b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

