### PR TITLE
Expose max_items on Python paginated list methods

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1649,8 +1649,6 @@ logic is covered by `TestIsSameOrigin` unit tests:
 - "Bracketed IPv6 loopback origin stays on the mocked origin" — same as above.
 
 **Python** (`conformance/runner/python/runner.py` `SKIPS`) — unwaivered:
-- "maxItems caps results across pages" — list methods don't expose a public `max_items` parameter.
-- "maxItems landing exactly on the final item is not truncated" — same as above.
 - "DownloadURL retries on 503 at the auth'd first hop" — download path uses `get_no_retry`; hop-1 retry not implemented.
 - "DownloadURL honors Retry-After on 429 at the auth'd first hop" — same as above.
 

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -77,7 +77,7 @@ class OperationMapper:
     def __init__(self, account_client):
         self._account = account_client
 
-    def __call__(self, operation: str, *, path_params: dict, query_params: dict, body: dict | None, path: str = "") -> Any:
+    def __call__(self, operation: str, *, path_params: dict, query_params: dict, body: dict | None, path: str = "", max_items: int | None = None) -> Any:
         match operation:
             case "DownloadURL":
                 if not path:
@@ -85,6 +85,8 @@ class OperationMapper:
                 raw_url = "https://storage.3.basecamp.com" + path
                 return self._account.download_url(raw_url)
             case "ListProjects":
+                if max_items:
+                    return self._account.projects.list(max_items=max_items)
                 return self._account.projects.list()
             case "GetProject":
                 return self._account.projects.get(project_id=path_params["projectId"])
@@ -290,6 +292,7 @@ class TestRunner:
                     query_params=self._test.get("queryParams", {}),
                     body=self._test.get("requestBody"),
                     path=self._test.get("path", ""),
+                    max_items=(self._test.get("configOverrides") or {}).get("maxItems"),
                 )
                 return self._verify_assertions(result=result, error=None)
             except Exception as e:
@@ -672,14 +675,10 @@ def _get_error_field(error: Exception, field_path: str) -> Any:
 class ConformanceRunner:
     _DOWNLOAD_RETRY_SKIP = "Python SDK download path uses get_no_retry; retry on 5xx / Retry-After is not implemented"
     SKIPS: set[str] = {
-        "maxItems caps results across pages",
-        "maxItems landing exactly on the final item is not truncated",
         "DownloadURL retries on 503 at the auth'd first hop",
         "DownloadURL honors Retry-After on 429 at the auth'd first hop",
     }
     SKIP_REASONS: dict[str, str] = {
-        "maxItems caps results across pages": "Python SDK list methods don't expose a public max_items parameter",
-        "maxItems landing exactly on the final item is not truncated": "Python SDK list methods don't expose a public max_items parameter",
         "DownloadURL retries on 503 at the auth'd first hop": _DOWNLOAD_RETRY_SKIP,
         "DownloadURL honors Retry-After on 429 at the auth'd first hop": _DOWNLOAD_RETRY_SKIP,
     }

--- a/python/README.md
+++ b/python/README.md
@@ -503,7 +503,7 @@ for project in projects:
 
 # Access pagination metadata
 print(projects.meta.total_count)   # total items across all pages
-print(projects.meta.truncated)     # True if max_pages was reached
+print(projects.meta.truncated)     # True if items beyond those returned were available
 
 # Standard list operations work
 print(len(projects))
@@ -512,6 +512,15 @@ sliced = projects[:5]
 ```
 
 Pagination is automatic. The SDK follows Link headers and collects all pages up to `config.max_pages` (default: 10,000).
+
+Every paginated method also accepts a `max_items` keyword to cap how many items are collected. Collection stops as soon as the cap is met, without fetching further pages:
+
+```python
+recent = account.projects.list(max_items=50)
+print(recent.meta.truncated)  # True only if more items were available
+```
+
+`meta.truncated` is `True` only when items beyond those returned were available — items were dropped by `max_items`, or the last-fetched page still advertised a next page when collection stopped (at `max_items` or the `max_pages` safety cap). When it is `False`, the result is definitely complete.
 
 ## Error Handling
 

--- a/python/README.md
+++ b/python/README.md
@@ -513,7 +513,7 @@ sliced = projects[:5]
 
 Pagination is automatic. The SDK follows Link headers and collects all pages up to `config.max_pages` (default: 10,000).
 
-Every paginated method also accepts a `max_items` keyword to cap how many items are collected. Collection stops as soon as the cap is met, without fetching further pages:
+Every paginated method also accepts a `max_items` keyword to cap how many items are collected. Collection stops as soon as the cap is met, without fetching further pages. Zero or negative values disable the cap, as in the other SDKs:
 
 ```python
 recent = account.projects.list(max_items=50)

--- a/python/scripts/generate_services.py
+++ b/python/scripts/generate_services.py
@@ -583,6 +583,11 @@ def build_params(op: dict) -> list[str]:
         hint = python_type_hint(q["type"])
         params.append(f"{q['python_name']}: {hint} | None = None")
 
+    # Paginated operations take a client-side cap on collected items,
+    # matching the maxItems pagination option in the other SDKs.
+    if op["has_pagination"]:
+        params.append("max_items: int | None = None")
+
     return params
 
 
@@ -702,18 +707,18 @@ def generate_method_body(op: dict, service_name: str, *, is_async: bool) -> list
         if op["query_params"]:
             lines.append(f"        return {_await(is_async)}self._request_paginated_wrapped(")
             lines.append(f'            OperationInfo({info_kwargs}), {path_expr}, "{key}",')
-            lines.append(f"            params={build_query_params_expr(op)}{operation_kwarg(op)},")
+            lines.append(f"            params={build_query_params_expr(op)}, max_items=max_items{operation_kwarg(op)},")
             lines.append("        )")
         else:
-            lines.append(f'        return {_await(is_async)}self._request_paginated_wrapped(OperationInfo({info_kwargs}), {path_expr}, "{key}"{operation_kwarg(op)})')
+            lines.append(f'        return {_await(is_async)}self._request_paginated_wrapped(OperationInfo({info_kwargs}), {path_expr}, "{key}", max_items=max_items{operation_kwarg(op)})')
     elif is_paginated_list(op):
         if op["query_params"]:
             lines.append(f"        return {_await(is_async)}self._request_paginated(")
             lines.append(f"            OperationInfo({info_kwargs}), {path_expr},")
-            lines.append(f"            params={build_query_params_expr(op)}{operation_kwarg(op)},")
+            lines.append(f"            params={build_query_params_expr(op)}, max_items=max_items{operation_kwarg(op)},")
             lines.append("        )")
         else:
-            lines.append(f"        return {_await(is_async)}self._request_paginated(OperationInfo({info_kwargs}), {path_expr}{operation_kwarg(op)})")
+            lines.append(f"        return {_await(is_async)}self._request_paginated(OperationInfo({info_kwargs}), {path_expr}, max_items=max_items{operation_kwarg(op)})")
     elif is_unpaginated_array(op):
         if op["query_params"]:
             lines.append(f"        return {_await(is_async)}self._request_list(")

--- a/python/src/basecamp/generated/services/_async_base.py
+++ b/python/src/basecamp/generated/services/_async_base.py
@@ -228,12 +228,13 @@ class AsyncBaseService:
         key: str,
         *,
         params: dict | None = None,
+        max_items: int | None = None,
         operation: str | None = None,
     ) -> ListResult:
         start = time.monotonic()
         safe_hook(self._hooks.on_operation_start, info)
         try:
-            result = await self._paginate_key(path, key, params=params, operation=operation)
+            result = await self._paginate_key(path, key, params=params, max_items=max_items, operation=operation)
             duration_ms = int((time.monotonic() - start) * 1000)
             safe_hook(self._hooks.on_operation_end, info, OperationResult(duration_ms=duration_ms))
             return result
@@ -249,12 +250,13 @@ class AsyncBaseService:
         key: str,
         *,
         params: dict | None = None,
+        max_items: int | None = None,
         operation: str | None = None,
     ) -> dict:
         start = time.monotonic()
         safe_hook(self._hooks.on_operation_start, info)
         try:
-            result = await self._paginate_wrapped(path, key, params=params, operation=operation)
+            result = await self._paginate_wrapped(path, key, params=params, max_items=max_items, operation=operation)
             duration_ms = int((time.monotonic() - start) * 1000)
             safe_hook(self._hooks.on_operation_end, info, OperationResult(duration_ms=duration_ms))
             return result
@@ -313,7 +315,13 @@ class AsyncBaseService:
         return ListResult(all_items, ListMeta(total_count=total_count, truncated=truncated))
 
     async def _paginate_key(
-        self, path: str, key: str, *, params: dict | None = None, operation: str | None = None
+        self,
+        path: str,
+        key: str,
+        *,
+        params: dict | None = None,
+        max_items: int | None = None,
+        operation: str | None = None,
     ) -> ListResult:
         base_url = self._client.http._build_url(self._client.account_path(path))
         url = base_url
@@ -338,6 +346,11 @@ class AsyncBaseService:
             items = data.get(key, [])
             all_items.extend(items)
 
+            if max_items and len(all_items) >= max_items:
+                truncated = len(all_items) > max_items or parse_next_link(response.headers.get("link")) is not None
+                all_items = all_items[:max_items]
+                break
+
             next_url = parse_next_link(response.headers.get("link"))
             if not next_url:
                 break
@@ -353,7 +366,13 @@ class AsyncBaseService:
         return ListResult(all_items, ListMeta(total_count=total_count, truncated=truncated))
 
     async def _paginate_wrapped(
-        self, path: str, key: str, *, params: dict | None = None, operation: str | None = None
+        self,
+        path: str,
+        key: str,
+        *,
+        params: dict | None = None,
+        max_items: int | None = None,
+        operation: str | None = None,
     ) -> dict:
         base_url = self._client.http._build_url(self._client.account_path(path))
 
@@ -377,6 +396,9 @@ class AsyncBaseService:
         page = 1
 
         while next_link and page < self._client.config.max_pages:
+            if max_items and len(all_items) >= max_items:
+                break
+
             page += 1
             next_url = _security.resolve_url(url, next_link)
             if not _security.same_origin(next_url, base_url):
@@ -396,7 +418,12 @@ class AsyncBaseService:
             next_link = parse_next_link(response.headers.get("link"))
             url = next_url
 
-        wrapper[key] = ListResult(all_items, ListMeta(total_count=total_count, truncated=next_link is not None))
+        truncated = next_link is not None
+        if max_items and len(all_items) >= max_items:
+            truncated = len(all_items) > max_items or next_link is not None
+            all_items = all_items[:max_items]
+
+        wrapper[key] = ListResult(all_items, ListMeta(total_count=total_count, truncated=truncated))
         return wrapper
 
     def _compact(self, **kwargs: Any) -> dict:

--- a/python/src/basecamp/generated/services/_async_base.py
+++ b/python/src/basecamp/generated/services/_async_base.py
@@ -273,6 +273,8 @@ class AsyncBaseService:
         max_items: int | None = None,
         operation: str | None = None,
     ) -> ListResult:
+        if max_items is not None and max_items <= 0:
+            max_items = None  # Non-positive caps disable the cap, matching the other SDKs.
         base_url = self._client.http._build_url(self._client.account_path(path))
         url = base_url
         all_items: list = []
@@ -323,6 +325,8 @@ class AsyncBaseService:
         max_items: int | None = None,
         operation: str | None = None,
     ) -> ListResult:
+        if max_items is not None and max_items <= 0:
+            max_items = None  # Non-positive caps disable the cap, matching the other SDKs.
         base_url = self._client.http._build_url(self._client.account_path(path))
         url = base_url
         all_items: list = []
@@ -374,6 +378,8 @@ class AsyncBaseService:
         max_items: int | None = None,
         operation: str | None = None,
     ) -> dict:
+        if max_items is not None and max_items <= 0:
+            max_items = None  # Non-positive caps disable the cap, matching the other SDKs.
         base_url = self._client.http._build_url(self._client.account_path(path))
 
         safe_hook(self._hooks.on_paginate, base_url, 1)

--- a/python/src/basecamp/generated/services/_base.py
+++ b/python/src/basecamp/generated/services/_base.py
@@ -278,6 +278,8 @@ class BaseService:
         max_items: int | None = None,
         operation: str | None = None,
     ) -> ListResult:
+        if max_items is not None and max_items <= 0:
+            max_items = None  # Non-positive caps disable the cap, matching the other SDKs.
         base_url = self._client.http._build_url(self._client.account_path(path))
         url = base_url
         all_items: list = []
@@ -328,6 +330,8 @@ class BaseService:
         max_items: int | None = None,
         operation: str | None = None,
     ) -> ListResult:
+        if max_items is not None and max_items <= 0:
+            max_items = None  # Non-positive caps disable the cap, matching the other SDKs.
         base_url = self._client.http._build_url(self._client.account_path(path))
         url = base_url
         all_items: list = []
@@ -379,6 +383,8 @@ class BaseService:
         max_items: int | None = None,
         operation: str | None = None,
     ) -> dict:
+        if max_items is not None and max_items <= 0:
+            max_items = None  # Non-positive caps disable the cap, matching the other SDKs.
         base_url = self._client.http._build_url(self._client.account_path(path))
 
         safe_hook(self._hooks.on_paginate, base_url, 1)

--- a/python/src/basecamp/generated/services/_base.py
+++ b/python/src/basecamp/generated/services/_base.py
@@ -233,12 +233,13 @@ class BaseService:
         key: str,
         *,
         params: dict | None = None,
+        max_items: int | None = None,
         operation: str | None = None,
     ) -> ListResult:
         start = time.monotonic()
         safe_hook(self._hooks.on_operation_start, info)
         try:
-            result = self._paginate_key(path, key, params=params, operation=operation)
+            result = self._paginate_key(path, key, params=params, max_items=max_items, operation=operation)
             duration_ms = int((time.monotonic() - start) * 1000)
             safe_hook(self._hooks.on_operation_end, info, OperationResult(duration_ms=duration_ms))
             return result
@@ -254,12 +255,13 @@ class BaseService:
         key: str,
         *,
         params: dict | None = None,
+        max_items: int | None = None,
         operation: str | None = None,
     ) -> dict:
         start = time.monotonic()
         safe_hook(self._hooks.on_operation_start, info)
         try:
-            result = self._paginate_wrapped(path, key, params=params, operation=operation)
+            result = self._paginate_wrapped(path, key, params=params, max_items=max_items, operation=operation)
             duration_ms = int((time.monotonic() - start) * 1000)
             safe_hook(self._hooks.on_operation_end, info, OperationResult(duration_ms=duration_ms))
             return result
@@ -318,7 +320,13 @@ class BaseService:
         return ListResult(all_items, ListMeta(total_count=total_count, truncated=truncated))
 
     def _paginate_key(
-        self, path: str, key: str, *, params: dict | None = None, operation: str | None = None
+        self,
+        path: str,
+        key: str,
+        *,
+        params: dict | None = None,
+        max_items: int | None = None,
+        operation: str | None = None,
     ) -> ListResult:
         base_url = self._client.http._build_url(self._client.account_path(path))
         url = base_url
@@ -343,6 +351,11 @@ class BaseService:
             items = data.get(key, [])
             all_items.extend(items)
 
+            if max_items and len(all_items) >= max_items:
+                truncated = len(all_items) > max_items or parse_next_link(response.headers.get("link")) is not None
+                all_items = all_items[:max_items]
+                break
+
             next_url = parse_next_link(response.headers.get("link"))
             if not next_url:
                 break
@@ -358,7 +371,13 @@ class BaseService:
         return ListResult(all_items, ListMeta(total_count=total_count, truncated=truncated))
 
     def _paginate_wrapped(
-        self, path: str, key: str, *, params: dict | None = None, operation: str | None = None
+        self,
+        path: str,
+        key: str,
+        *,
+        params: dict | None = None,
+        max_items: int | None = None,
+        operation: str | None = None,
     ) -> dict:
         base_url = self._client.http._build_url(self._client.account_path(path))
 
@@ -382,6 +401,9 @@ class BaseService:
         page = 1
 
         while next_link and page < self._client.config.max_pages:
+            if max_items and len(all_items) >= max_items:
+                break
+
             page += 1
             next_url = _security.resolve_url(url, next_link)
             if not _security.same_origin(next_url, base_url):
@@ -401,7 +423,12 @@ class BaseService:
             next_link = parse_next_link(response.headers.get("link"))
             url = next_url
 
-        wrapper[key] = ListResult(all_items, ListMeta(total_count=total_count, truncated=next_link is not None))
+        truncated = next_link is not None
+        if max_items and len(all_items) >= max_items:
+            truncated = len(all_items) > max_items or next_link is not None
+            all_items = all_items[:max_items]
+
+        wrapper[key] = ListResult(all_items, ListMeta(total_count=total_count, truncated=truncated))
         return wrapper
 
     def _compact(self, **kwargs: Any) -> dict:

--- a/python/src/basecamp/generated/services/bookmarks.py
+++ b/python/src/basecamp/generated/services/bookmarks.py
@@ -11,11 +11,12 @@ from basecamp.hooks import OperationInfo
 
 
 class BookmarksService(BaseService):
-    def list_my_bookmarks(self, *, page: int | None = None) -> ListResult:
+    def list_my_bookmarks(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="bookmarks", operation="list_my_bookmarks", is_mutation=False),
             "/my/bookmarks.json",
             params=self._compact(page=page),
+            max_items=max_items,
             operation="ListMyBookmarks",
         )
 
@@ -45,11 +46,12 @@ class BookmarksService(BaseService):
 
 
 class AsyncBookmarksService(AsyncBaseService):
-    async def list_my_bookmarks(self, *, page: int | None = None) -> ListResult:
+    async def list_my_bookmarks(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="bookmarks", operation="list_my_bookmarks", is_mutation=False),
             "/my/bookmarks.json",
             params=self._compact(page=page),
+            max_items=max_items,
             operation="ListMyBookmarks",
         )
 

--- a/python/src/basecamp/generated/services/boosts.py
+++ b/python/src/basecamp/generated/services/boosts.py
@@ -27,12 +27,13 @@ class BoostsService(BaseService):
             operation="DeleteBoost",
         )
 
-    def list_recording_boosts(self, *, recording_id: int) -> ListResult:
+    def list_recording_boosts(self, *, recording_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(
                 service="boosts", operation="list_recording_boosts", is_mutation=False, resource_id=recording_id
             ),
             f"/recordings/{recording_id}/boosts.json",
+            max_items=max_items,
             operation="ListRecordingBoosts",
         )
 
@@ -47,10 +48,11 @@ class BoostsService(BaseService):
             operation="CreateRecordingBoost",
         )
 
-    def list_event_boosts(self, *, recording_id: int, event_id: int) -> ListResult:
+    def list_event_boosts(self, *, recording_id: int, event_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="boosts", operation="list_event_boosts", is_mutation=False, resource_id=event_id),
             f"/recordings/{recording_id}/events/{event_id}/boosts.json",
+            max_items=max_items,
             operation="ListEventBoosts",
         )
 
@@ -81,12 +83,13 @@ class AsyncBoostsService(AsyncBaseService):
             operation="DeleteBoost",
         )
 
-    async def list_recording_boosts(self, *, recording_id: int) -> ListResult:
+    async def list_recording_boosts(self, *, recording_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(
                 service="boosts", operation="list_recording_boosts", is_mutation=False, resource_id=recording_id
             ),
             f"/recordings/{recording_id}/boosts.json",
+            max_items=max_items,
             operation="ListRecordingBoosts",
         )
 
@@ -101,10 +104,11 @@ class AsyncBoostsService(AsyncBaseService):
             operation="CreateRecordingBoost",
         )
 
-    async def list_event_boosts(self, *, recording_id: int, event_id: int) -> ListResult:
+    async def list_event_boosts(self, *, recording_id: int, event_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="boosts", operation="list_event_boosts", is_mutation=False, resource_id=event_id),
             f"/recordings/{recording_id}/events/{event_id}/boosts.json",
+            max_items=max_items,
             operation="ListEventBoosts",
         )
 

--- a/python/src/basecamp/generated/services/campfires.py
+++ b/python/src/basecamp/generated/services/campfires.py
@@ -11,10 +11,11 @@ from basecamp.hooks import OperationInfo
 
 
 class CampfiresService(BaseService):
-    def list(self) -> ListResult:
+    def list(self, *, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="campfires", operation="list", is_mutation=False),
             "/chats.json",
+            max_items=max_items,
             operation="ListCampfires",
         )
 
@@ -26,10 +27,11 @@ class CampfiresService(BaseService):
             operation="GetCampfire",
         )
 
-    def list_chatbots(self, *, campfire_id: int) -> ListResult:
+    def list_chatbots(self, *, campfire_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="campfires", operation="list_chatbots", is_mutation=False, resource_id=campfire_id),
             f"/chats/{campfire_id}/integrations.json",
+            max_items=max_items,
             operation="ListChatbots",
         )
 
@@ -69,11 +71,14 @@ class CampfiresService(BaseService):
             operation="DeleteChatbot",
         )
 
-    def list_lines(self, *, campfire_id: int, sort: str | None = None, direction: str | None = None) -> ListResult:
+    def list_lines(
+        self, *, campfire_id: int, sort: str | None = None, direction: str | None = None, max_items: int | None = None
+    ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="campfires", operation="list_lines", is_mutation=False, resource_id=campfire_id),
             f"/chats/{campfire_id}/lines.json",
             params=self._compact(sort=sort, direction=direction),
+            max_items=max_items,
             operation="ListCampfireLines",
         )
 
@@ -111,11 +116,14 @@ class CampfiresService(BaseService):
             operation="DeleteCampfireLine",
         )
 
-    def list_uploads(self, *, campfire_id: int, sort: str | None = None, direction: str | None = None) -> ListResult:
+    def list_uploads(
+        self, *, campfire_id: int, sort: str | None = None, direction: str | None = None, max_items: int | None = None
+    ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="campfires", operation="list_uploads", is_mutation=False, resource_id=campfire_id),
             f"/chats/{campfire_id}/uploads.json",
             params=self._compact(sort=sort, direction=direction),
+            max_items=max_items,
             operation="ListCampfireUploads",
         )
 
@@ -131,10 +139,11 @@ class CampfiresService(BaseService):
 
 
 class AsyncCampfiresService(AsyncBaseService):
-    async def list(self) -> ListResult:
+    async def list(self, *, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="campfires", operation="list", is_mutation=False),
             "/chats.json",
+            max_items=max_items,
             operation="ListCampfires",
         )
 
@@ -146,10 +155,11 @@ class AsyncCampfiresService(AsyncBaseService):
             operation="GetCampfire",
         )
 
-    async def list_chatbots(self, *, campfire_id: int) -> ListResult:
+    async def list_chatbots(self, *, campfire_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="campfires", operation="list_chatbots", is_mutation=False, resource_id=campfire_id),
             f"/chats/{campfire_id}/integrations.json",
+            max_items=max_items,
             operation="ListChatbots",
         )
 
@@ -192,12 +202,13 @@ class AsyncCampfiresService(AsyncBaseService):
         )
 
     async def list_lines(
-        self, *, campfire_id: int, sort: str | None = None, direction: str | None = None
+        self, *, campfire_id: int, sort: str | None = None, direction: str | None = None, max_items: int | None = None
     ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="campfires", operation="list_lines", is_mutation=False, resource_id=campfire_id),
             f"/chats/{campfire_id}/lines.json",
             params=self._compact(sort=sort, direction=direction),
+            max_items=max_items,
             operation="ListCampfireLines",
         )
 
@@ -236,12 +247,13 @@ class AsyncCampfiresService(AsyncBaseService):
         )
 
     async def list_uploads(
-        self, *, campfire_id: int, sort: str | None = None, direction: str | None = None
+        self, *, campfire_id: int, sort: str | None = None, direction: str | None = None, max_items: int | None = None
     ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="campfires", operation="list_uploads", is_mutation=False, resource_id=campfire_id),
             f"/chats/{campfire_id}/uploads.json",
             params=self._compact(sort=sort, direction=direction),
+            max_items=max_items,
             operation="ListCampfireUploads",
         )
 

--- a/python/src/basecamp/generated/services/cards.py
+++ b/python/src/basecamp/generated/services/cards.py
@@ -45,10 +45,11 @@ class CardsService(BaseService):
             operation="MoveCard",
         )
 
-    def list(self, *, column_id: int) -> ListResult:
+    def list(self, *, column_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="cards", operation="list", is_mutation=False, resource_id=column_id),
             f"/card_tables/lists/{column_id}/cards.json",
+            max_items=max_items,
             operation="ListCards",
         )
 
@@ -105,10 +106,11 @@ class AsyncCardsService(AsyncBaseService):
             operation="MoveCard",
         )
 
-    async def list(self, *, column_id: int) -> ListResult:
+    async def list(self, *, column_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="cards", operation="list", is_mutation=False, resource_id=column_id),
             f"/card_tables/lists/{column_id}/cards.json",
+            max_items=max_items,
             operation="ListCards",
         )
 

--- a/python/src/basecamp/generated/services/checkins.py
+++ b/python/src/basecamp/generated/services/checkins.py
@@ -11,10 +11,11 @@ from basecamp.hooks import OperationInfo
 
 
 class CheckinsService(BaseService):
-    def reminders(self) -> ListResult:
+    def reminders(self, *, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="checkins", operation="reminders", is_mutation=False),
             "/my/question_reminders.json",
+            max_items=max_items,
             operation="GetQuestionReminders",
         )
 
@@ -45,12 +46,13 @@ class CheckinsService(BaseService):
             operation="GetQuestionnaire",
         )
 
-    def list_questions(self, *, questionnaire_id: int) -> ListResult:
+    def list_questions(self, *, questionnaire_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(
                 service="checkins", operation="list_questions", is_mutation=False, resource_id=questionnaire_id
             ),
             f"/questionnaires/{questionnaire_id}/questions.json",
+            max_items=max_items,
             operation="ListQuestions",
         )
 
@@ -86,10 +88,11 @@ class CheckinsService(BaseService):
             operation="UpdateQuestion",
         )
 
-    def list_answers(self, *, question_id: int) -> ListResult:
+    def list_answers(self, *, question_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="checkins", operation="list_answers", is_mutation=False, resource_id=question_id),
             f"/questions/{question_id}/answers.json",
+            max_items=max_items,
             operation="ListAnswers",
         )
 
@@ -102,17 +105,19 @@ class CheckinsService(BaseService):
             operation="CreateAnswer",
         )
 
-    def answerers(self, *, question_id: int) -> ListResult:
+    def answerers(self, *, question_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="checkins", operation="answerers", is_mutation=False, resource_id=question_id),
             f"/questions/{question_id}/answers/by.json",
+            max_items=max_items,
             operation="ListQuestionAnswerers",
         )
 
-    def by_person(self, *, question_id: int, person_id: int) -> ListResult:
+    def by_person(self, *, question_id: int, person_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="checkins", operation="by_person", is_mutation=False, resource_id=person_id),
             f"/questions/{question_id}/answers/by/{person_id}",
+            max_items=max_items,
             operation="GetAnswersByPerson",
         )
 
@@ -149,10 +154,11 @@ class CheckinsService(BaseService):
 
 
 class AsyncCheckinsService(AsyncBaseService):
-    async def reminders(self) -> ListResult:
+    async def reminders(self, *, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="checkins", operation="reminders", is_mutation=False),
             "/my/question_reminders.json",
+            max_items=max_items,
             operation="GetQuestionReminders",
         )
 
@@ -183,12 +189,13 @@ class AsyncCheckinsService(AsyncBaseService):
             operation="GetQuestionnaire",
         )
 
-    async def list_questions(self, *, questionnaire_id: int) -> ListResult:
+    async def list_questions(self, *, questionnaire_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(
                 service="checkins", operation="list_questions", is_mutation=False, resource_id=questionnaire_id
             ),
             f"/questionnaires/{questionnaire_id}/questions.json",
+            max_items=max_items,
             operation="ListQuestions",
         )
 
@@ -224,10 +231,11 @@ class AsyncCheckinsService(AsyncBaseService):
             operation="UpdateQuestion",
         )
 
-    async def list_answers(self, *, question_id: int) -> ListResult:
+    async def list_answers(self, *, question_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="checkins", operation="list_answers", is_mutation=False, resource_id=question_id),
             f"/questions/{question_id}/answers.json",
+            max_items=max_items,
             operation="ListAnswers",
         )
 
@@ -240,17 +248,19 @@ class AsyncCheckinsService(AsyncBaseService):
             operation="CreateAnswer",
         )
 
-    async def answerers(self, *, question_id: int) -> ListResult:
+    async def answerers(self, *, question_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="checkins", operation="answerers", is_mutation=False, resource_id=question_id),
             f"/questions/{question_id}/answers/by.json",
+            max_items=max_items,
             operation="ListQuestionAnswerers",
         )
 
-    async def by_person(self, *, question_id: int, person_id: int) -> ListResult:
+    async def by_person(self, *, question_id: int, person_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="checkins", operation="by_person", is_mutation=False, resource_id=person_id),
             f"/questions/{question_id}/answers/by/{person_id}",
+            max_items=max_items,
             operation="GetAnswersByPerson",
         )
 

--- a/python/src/basecamp/generated/services/client_approvals.py
+++ b/python/src/basecamp/generated/services/client_approvals.py
@@ -11,11 +11,14 @@ from basecamp.hooks import OperationInfo
 
 
 class ClientApprovalsService(BaseService):
-    def list(self, *, sort: str | None = None, direction: str | None = None) -> ListResult:
+    def list(
+        self, *, sort: str | None = None, direction: str | None = None, max_items: int | None = None
+    ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="clientapprovals", operation="list", is_mutation=False),
             "/client/approvals.json",
             params=self._compact(sort=sort, direction=direction),
+            max_items=max_items,
             operation="ListClientApprovals",
         )
 
@@ -29,11 +32,14 @@ class ClientApprovalsService(BaseService):
 
 
 class AsyncClientApprovalsService(AsyncBaseService):
-    async def list(self, *, sort: str | None = None, direction: str | None = None) -> ListResult:
+    async def list(
+        self, *, sort: str | None = None, direction: str | None = None, max_items: int | None = None
+    ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="clientapprovals", operation="list", is_mutation=False),
             "/client/approvals.json",
             params=self._compact(sort=sort, direction=direction),
+            max_items=max_items,
             operation="ListClientApprovals",
         )
 

--- a/python/src/basecamp/generated/services/client_correspondences.py
+++ b/python/src/basecamp/generated/services/client_correspondences.py
@@ -11,11 +11,14 @@ from basecamp.hooks import OperationInfo
 
 
 class ClientCorrespondencesService(BaseService):
-    def list(self, *, sort: str | None = None, direction: str | None = None) -> ListResult:
+    def list(
+        self, *, sort: str | None = None, direction: str | None = None, max_items: int | None = None
+    ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="clientcorrespondences", operation="list", is_mutation=False),
             "/client/correspondences.json",
             params=self._compact(sort=sort, direction=direction),
+            max_items=max_items,
             operation="ListClientCorrespondences",
         )
 
@@ -31,11 +34,14 @@ class ClientCorrespondencesService(BaseService):
 
 
 class AsyncClientCorrespondencesService(AsyncBaseService):
-    async def list(self, *, sort: str | None = None, direction: str | None = None) -> ListResult:
+    async def list(
+        self, *, sort: str | None = None, direction: str | None = None, max_items: int | None = None
+    ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="clientcorrespondences", operation="list", is_mutation=False),
             "/client/correspondences.json",
             params=self._compact(sort=sort, direction=direction),
+            max_items=max_items,
             operation="ListClientCorrespondences",
         )
 

--- a/python/src/basecamp/generated/services/client_replies.py
+++ b/python/src/basecamp/generated/services/client_replies.py
@@ -11,10 +11,11 @@ from basecamp.hooks import OperationInfo
 
 
 class ClientRepliesService(BaseService):
-    def list(self, *, recording_id: int) -> ListResult:
+    def list(self, *, recording_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="clientreplies", operation="list", is_mutation=False, resource_id=recording_id),
             f"/client/recordings/{recording_id}/replies.json",
+            max_items=max_items,
             operation="ListClientReplies",
         )
 
@@ -28,10 +29,11 @@ class ClientRepliesService(BaseService):
 
 
 class AsyncClientRepliesService(AsyncBaseService):
-    async def list(self, *, recording_id: int) -> ListResult:
+    async def list(self, *, recording_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="clientreplies", operation="list", is_mutation=False, resource_id=recording_id),
             f"/client/recordings/{recording_id}/replies.json",
+            max_items=max_items,
             operation="ListClientReplies",
         )
 

--- a/python/src/basecamp/generated/services/comments.py
+++ b/python/src/basecamp/generated/services/comments.py
@@ -28,10 +28,11 @@ class CommentsService(BaseService):
             operation="UpdateComment",
         )
 
-    def list(self, *, recording_id: int) -> ListResult:
+    def list(self, *, recording_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="comments", operation="list", is_mutation=False, resource_id=recording_id),
             f"/recordings/{recording_id}/comments.json",
+            max_items=max_items,
             operation="ListComments",
         )
 
@@ -63,10 +64,11 @@ class AsyncCommentsService(AsyncBaseService):
             operation="UpdateComment",
         )
 
-    async def list(self, *, recording_id: int) -> ListResult:
+    async def list(self, *, recording_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="comments", operation="list", is_mutation=False, resource_id=recording_id),
             f"/recordings/{recording_id}/comments.json",
+            max_items=max_items,
             operation="ListComments",
         )
 

--- a/python/src/basecamp/generated/services/documents.py
+++ b/python/src/basecamp/generated/services/documents.py
@@ -28,10 +28,11 @@ class DocumentsService(BaseService):
             operation="UpdateDocument",
         )
 
-    def list(self, *, vault_id: int) -> ListResult:
+    def list(self, *, vault_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="documents", operation="list", is_mutation=False, resource_id=vault_id),
             f"/vaults/{vault_id}/documents.json",
+            max_items=max_items,
             operation="ListDocuments",
         )
 
@@ -78,10 +79,11 @@ class AsyncDocumentsService(AsyncBaseService):
             operation="UpdateDocument",
         )
 
-    async def list(self, *, vault_id: int) -> ListResult:
+    async def list(self, *, vault_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="documents", operation="list", is_mutation=False, resource_id=vault_id),
             f"/vaults/{vault_id}/documents.json",
+            max_items=max_items,
             operation="ListDocuments",
         )
 

--- a/python/src/basecamp/generated/services/drafts.py
+++ b/python/src/basecamp/generated/services/drafts.py
@@ -11,20 +11,22 @@ from basecamp.hooks import OperationInfo
 
 
 class DraftsService(BaseService):
-    def list_my_drafts(self, *, page: int | None = None) -> ListResult:
+    def list_my_drafts(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="drafts", operation="list_my_drafts", is_mutation=False),
             "/my/drafts.json",
             params=self._compact(page=page),
+            max_items=max_items,
             operation="ListMyDrafts",
         )
 
 
 class AsyncDraftsService(AsyncBaseService):
-    async def list_my_drafts(self, *, page: int | None = None) -> ListResult:
+    async def list_my_drafts(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="drafts", operation="list_my_drafts", is_mutation=False),
             "/my/drafts.json",
             params=self._compact(page=page),
+            max_items=max_items,
             operation="ListMyDrafts",
         )

--- a/python/src/basecamp/generated/services/events.py
+++ b/python/src/basecamp/generated/services/events.py
@@ -11,18 +11,20 @@ from basecamp.hooks import OperationInfo
 
 
 class EventsService(BaseService):
-    def list(self, *, recording_id: int) -> ListResult:
+    def list(self, *, recording_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="events", operation="list", is_mutation=False, resource_id=recording_id),
             f"/recordings/{recording_id}/events.json",
+            max_items=max_items,
             operation="ListEvents",
         )
 
 
 class AsyncEventsService(AsyncBaseService):
-    async def list(self, *, recording_id: int) -> ListResult:
+    async def list(self, *, recording_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="events", operation="list", is_mutation=False, resource_id=recording_id),
             f"/recordings/{recording_id}/events.json",
+            max_items=max_items,
             operation="ListEvents",
         )

--- a/python/src/basecamp/generated/services/everything.py
+++ b/python/src/basecamp/generated/services/everything.py
@@ -12,7 +12,12 @@ from basecamp.hooks import OperationInfo
 
 class EverythingService(BaseService):
     def get_everything_completed_cards(
-        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+        self,
+        *,
+        assignee_ids: list[int] | None = None,
+        due: str | None = None,
+        page: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_completed_cards", is_mutation=False),
@@ -20,11 +25,17 @@ class EverythingService(BaseService):
             params={
                 k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
             },
+            max_items=max_items,
             operation="GetEverythingCompletedCards",
         )
 
     def get_everything_no_due_date_cards(
-        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+        self,
+        *,
+        assignee_ids: list[int] | None = None,
+        due: str | None = None,
+        page: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_no_due_date_cards", is_mutation=False),
@@ -32,11 +43,17 @@ class EverythingService(BaseService):
             params={
                 k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
             },
+            max_items=max_items,
             operation="GetEverythingNoDueDateCards",
         )
 
     def get_everything_not_now_cards(
-        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+        self,
+        *,
+        assignee_ids: list[int] | None = None,
+        due: str | None = None,
+        page: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_not_now_cards", is_mutation=False),
@@ -44,11 +61,17 @@ class EverythingService(BaseService):
             params={
                 k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
             },
+            max_items=max_items,
             operation="GetEverythingNotNowCards",
         )
 
     def get_everything_open_cards(
-        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+        self,
+        *,
+        assignee_ids: list[int] | None = None,
+        due: str | None = None,
+        page: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_open_cards", is_mutation=False),
@@ -56,6 +79,7 @@ class EverythingService(BaseService):
             params={
                 k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
             },
+            max_items=max_items,
             operation="GetEverythingOpenCards",
         )
 
@@ -70,7 +94,12 @@ class EverythingService(BaseService):
         )
 
     def get_everything_unassigned_cards(
-        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+        self,
+        *,
+        assignee_ids: list[int] | None = None,
+        due: str | None = None,
+        page: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_unassigned_cards", is_mutation=False),
@@ -78,53 +107,69 @@ class EverythingService(BaseService):
             params={
                 k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
             },
+            max_items=max_items,
             operation="GetEverythingUnassignedCards",
         )
 
-    def get_everything_checkins(self, *, page: int | None = None) -> ListResult:
+    def get_everything_checkins(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_checkins", is_mutation=False),
             "/checkins.json",
             params=self._compact(page=page),
+            max_items=max_items,
             operation="GetEverythingCheckins",
         )
 
-    def get_everything_comments(self, *, page: int | None = None) -> ListResult:
+    def get_everything_comments(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_comments", is_mutation=False),
             "/comments.json",
             params=self._compact(page=page),
+            max_items=max_items,
             operation="GetEverythingComments",
         )
 
     def get_everything_files(
-        self, *, kind: str | None = None, people_ids: list[int] | None = None, page: int | None = None
+        self,
+        *,
+        kind: str | None = None,
+        people_ids: list[int] | None = None,
+        page: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_files", is_mutation=False),
             "/files.json",
             params={k: v for k, v in {"kind": kind, "people_ids[]": people_ids, "page": page}.items() if v is not None},
+            max_items=max_items,
             operation="GetEverythingFiles",
         )
 
-    def get_everything_forwards(self, *, page: int | None = None) -> ListResult:
+    def get_everything_forwards(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_forwards", is_mutation=False),
             "/forwards.json",
             params=self._compact(page=page),
+            max_items=max_items,
             operation="GetEverythingForwards",
         )
 
-    def get_everything_messages(self, *, page: int | None = None) -> ListResult:
+    def get_everything_messages(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_messages", is_mutation=False),
             "/messages.json",
             params=self._compact(page=page),
+            max_items=max_items,
             operation="GetEverythingMessages",
         )
 
     def get_everything_completed_todos(
-        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+        self,
+        *,
+        assignee_ids: list[int] | None = None,
+        due: str | None = None,
+        page: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_completed_todos", is_mutation=False),
@@ -132,11 +177,17 @@ class EverythingService(BaseService):
             params={
                 k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
             },
+            max_items=max_items,
             operation="GetEverythingCompletedTodos",
         )
 
     def get_everything_no_due_date_todos(
-        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+        self,
+        *,
+        assignee_ids: list[int] | None = None,
+        due: str | None = None,
+        page: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_no_due_date_todos", is_mutation=False),
@@ -144,11 +195,17 @@ class EverythingService(BaseService):
             params={
                 k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
             },
+            max_items=max_items,
             operation="GetEverythingNoDueDateTodos",
         )
 
     def get_everything_open_todos(
-        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+        self,
+        *,
+        assignee_ids: list[int] | None = None,
+        due: str | None = None,
+        page: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_open_todos", is_mutation=False),
@@ -156,6 +213,7 @@ class EverythingService(BaseService):
             params={
                 k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
             },
+            max_items=max_items,
             operation="GetEverythingOpenTodos",
         )
 
@@ -170,7 +228,12 @@ class EverythingService(BaseService):
         )
 
     def get_everything_unassigned_todos(
-        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+        self,
+        *,
+        assignee_ids: list[int] | None = None,
+        due: str | None = None,
+        page: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_unassigned_todos", is_mutation=False),
@@ -178,13 +241,19 @@ class EverythingService(BaseService):
             params={
                 k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
             },
+            max_items=max_items,
             operation="GetEverythingUnassignedTodos",
         )
 
 
 class AsyncEverythingService(AsyncBaseService):
     async def get_everything_completed_cards(
-        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+        self,
+        *,
+        assignee_ids: list[int] | None = None,
+        due: str | None = None,
+        page: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_completed_cards", is_mutation=False),
@@ -192,11 +261,17 @@ class AsyncEverythingService(AsyncBaseService):
             params={
                 k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
             },
+            max_items=max_items,
             operation="GetEverythingCompletedCards",
         )
 
     async def get_everything_no_due_date_cards(
-        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+        self,
+        *,
+        assignee_ids: list[int] | None = None,
+        due: str | None = None,
+        page: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_no_due_date_cards", is_mutation=False),
@@ -204,11 +279,17 @@ class AsyncEverythingService(AsyncBaseService):
             params={
                 k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
             },
+            max_items=max_items,
             operation="GetEverythingNoDueDateCards",
         )
 
     async def get_everything_not_now_cards(
-        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+        self,
+        *,
+        assignee_ids: list[int] | None = None,
+        due: str | None = None,
+        page: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_not_now_cards", is_mutation=False),
@@ -216,11 +297,17 @@ class AsyncEverythingService(AsyncBaseService):
             params={
                 k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
             },
+            max_items=max_items,
             operation="GetEverythingNotNowCards",
         )
 
     async def get_everything_open_cards(
-        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+        self,
+        *,
+        assignee_ids: list[int] | None = None,
+        due: str | None = None,
+        page: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_open_cards", is_mutation=False),
@@ -228,6 +315,7 @@ class AsyncEverythingService(AsyncBaseService):
             params={
                 k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
             },
+            max_items=max_items,
             operation="GetEverythingOpenCards",
         )
 
@@ -242,7 +330,12 @@ class AsyncEverythingService(AsyncBaseService):
         )
 
     async def get_everything_unassigned_cards(
-        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+        self,
+        *,
+        assignee_ids: list[int] | None = None,
+        due: str | None = None,
+        page: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_unassigned_cards", is_mutation=False),
@@ -250,53 +343,69 @@ class AsyncEverythingService(AsyncBaseService):
             params={
                 k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
             },
+            max_items=max_items,
             operation="GetEverythingUnassignedCards",
         )
 
-    async def get_everything_checkins(self, *, page: int | None = None) -> ListResult:
+    async def get_everything_checkins(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_checkins", is_mutation=False),
             "/checkins.json",
             params=self._compact(page=page),
+            max_items=max_items,
             operation="GetEverythingCheckins",
         )
 
-    async def get_everything_comments(self, *, page: int | None = None) -> ListResult:
+    async def get_everything_comments(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_comments", is_mutation=False),
             "/comments.json",
             params=self._compact(page=page),
+            max_items=max_items,
             operation="GetEverythingComments",
         )
 
     async def get_everything_files(
-        self, *, kind: str | None = None, people_ids: list[int] | None = None, page: int | None = None
+        self,
+        *,
+        kind: str | None = None,
+        people_ids: list[int] | None = None,
+        page: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_files", is_mutation=False),
             "/files.json",
             params={k: v for k, v in {"kind": kind, "people_ids[]": people_ids, "page": page}.items() if v is not None},
+            max_items=max_items,
             operation="GetEverythingFiles",
         )
 
-    async def get_everything_forwards(self, *, page: int | None = None) -> ListResult:
+    async def get_everything_forwards(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_forwards", is_mutation=False),
             "/forwards.json",
             params=self._compact(page=page),
+            max_items=max_items,
             operation="GetEverythingForwards",
         )
 
-    async def get_everything_messages(self, *, page: int | None = None) -> ListResult:
+    async def get_everything_messages(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_messages", is_mutation=False),
             "/messages.json",
             params=self._compact(page=page),
+            max_items=max_items,
             operation="GetEverythingMessages",
         )
 
     async def get_everything_completed_todos(
-        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+        self,
+        *,
+        assignee_ids: list[int] | None = None,
+        due: str | None = None,
+        page: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_completed_todos", is_mutation=False),
@@ -304,11 +413,17 @@ class AsyncEverythingService(AsyncBaseService):
             params={
                 k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
             },
+            max_items=max_items,
             operation="GetEverythingCompletedTodos",
         )
 
     async def get_everything_no_due_date_todos(
-        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+        self,
+        *,
+        assignee_ids: list[int] | None = None,
+        due: str | None = None,
+        page: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_no_due_date_todos", is_mutation=False),
@@ -316,11 +431,17 @@ class AsyncEverythingService(AsyncBaseService):
             params={
                 k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
             },
+            max_items=max_items,
             operation="GetEverythingNoDueDateTodos",
         )
 
     async def get_everything_open_todos(
-        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+        self,
+        *,
+        assignee_ids: list[int] | None = None,
+        due: str | None = None,
+        page: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_open_todos", is_mutation=False),
@@ -328,6 +449,7 @@ class AsyncEverythingService(AsyncBaseService):
             params={
                 k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
             },
+            max_items=max_items,
             operation="GetEverythingOpenTodos",
         )
 
@@ -342,7 +464,12 @@ class AsyncEverythingService(AsyncBaseService):
         )
 
     async def get_everything_unassigned_todos(
-        self, *, assignee_ids: list[int] | None = None, due: str | None = None, page: int | None = None
+        self,
+        *,
+        assignee_ids: list[int] | None = None,
+        due: str | None = None,
+        page: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_unassigned_todos", is_mutation=False),
@@ -350,5 +477,6 @@ class AsyncEverythingService(AsyncBaseService):
             params={
                 k: v for k, v in {"assignee_ids[]": assignee_ids, "due": due, "page": page}.items() if v is not None
             },
+            max_items=max_items,
             operation="GetEverythingUnassignedTodos",
         )

--- a/python/src/basecamp/generated/services/forwards.py
+++ b/python/src/basecamp/generated/services/forwards.py
@@ -19,10 +19,11 @@ class ForwardsService(BaseService):
             operation="GetForward",
         )
 
-    def list_replies(self, *, forward_id: int) -> ListResult:
+    def list_replies(self, *, forward_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="forwards", operation="list_replies", is_mutation=False, resource_id=forward_id),
             f"/inbox_forwards/{forward_id}/replies.json",
+            max_items=max_items,
             operation="ListForwardReplies",
         )
 
@@ -51,11 +52,14 @@ class ForwardsService(BaseService):
             operation="GetInbox",
         )
 
-    def list(self, *, inbox_id: int, sort: str | None = None, direction: str | None = None) -> ListResult:
+    def list(
+        self, *, inbox_id: int, sort: str | None = None, direction: str | None = None, max_items: int | None = None
+    ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="forwards", operation="list", is_mutation=False, resource_id=inbox_id),
             f"/inboxes/{inbox_id}/forwards.json",
             params=self._compact(sort=sort, direction=direction),
+            max_items=max_items,
             operation="ListForwards",
         )
 
@@ -69,10 +73,11 @@ class AsyncForwardsService(AsyncBaseService):
             operation="GetForward",
         )
 
-    async def list_replies(self, *, forward_id: int) -> ListResult:
+    async def list_replies(self, *, forward_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="forwards", operation="list_replies", is_mutation=False, resource_id=forward_id),
             f"/inbox_forwards/{forward_id}/replies.json",
+            max_items=max_items,
             operation="ListForwardReplies",
         )
 
@@ -101,10 +106,13 @@ class AsyncForwardsService(AsyncBaseService):
             operation="GetInbox",
         )
 
-    async def list(self, *, inbox_id: int, sort: str | None = None, direction: str | None = None) -> ListResult:
+    async def list(
+        self, *, inbox_id: int, sort: str | None = None, direction: str | None = None, max_items: int | None = None
+    ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="forwards", operation="list", is_mutation=False, resource_id=inbox_id),
             f"/inboxes/{inbox_id}/forwards.json",
             params=self._compact(sort=sort, direction=direction),
+            max_items=max_items,
             operation="ListForwards",
         )

--- a/python/src/basecamp/generated/services/gauges.py
+++ b/python/src/basecamp/generated/services/gauges.py
@@ -45,10 +45,11 @@ class GaugesService(BaseService):
             operation="ToggleGauge",
         )
 
-    def list_gauge_needles(self, *, project_id: int) -> ListResult:
+    def list_gauge_needles(self, *, project_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="gauges", operation="list_gauge_needles", is_mutation=False, project_id=project_id),
             f"/projects/{project_id}/gauge/needles.json",
+            max_items=max_items,
             operation="ListGaugeNeedles",
         )
 
@@ -63,11 +64,12 @@ class GaugesService(BaseService):
             operation="CreateGaugeNeedle",
         )
 
-    def list_gauges(self, *, bucket_ids: str | None = None) -> ListResult:
+    def list_gauges(self, *, bucket_ids: str | None = None, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="gauges", operation="list_gauges", is_mutation=False),
             "/reports/gauges.json",
             params=self._compact(bucket_ids=bucket_ids),
+            max_items=max_items,
             operation="ListGauges",
         )
 
@@ -107,10 +109,11 @@ class AsyncGaugesService(AsyncBaseService):
             operation="ToggleGauge",
         )
 
-    async def list_gauge_needles(self, *, project_id: int) -> ListResult:
+    async def list_gauge_needles(self, *, project_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="gauges", operation="list_gauge_needles", is_mutation=False, project_id=project_id),
             f"/projects/{project_id}/gauge/needles.json",
+            max_items=max_items,
             operation="ListGaugeNeedles",
         )
 
@@ -125,10 +128,11 @@ class AsyncGaugesService(AsyncBaseService):
             operation="CreateGaugeNeedle",
         )
 
-    async def list_gauges(self, *, bucket_ids: str | None = None) -> ListResult:
+    async def list_gauges(self, *, bucket_ids: str | None = None, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="gauges", operation="list_gauges", is_mutation=False),
             "/reports/gauges.json",
             params=self._compact(bucket_ids=bucket_ids),
+            max_items=max_items,
             operation="ListGauges",
         )

--- a/python/src/basecamp/generated/services/message_types.py
+++ b/python/src/basecamp/generated/services/message_types.py
@@ -11,10 +11,11 @@ from basecamp.hooks import OperationInfo
 
 
 class MessageTypesService(BaseService):
-    def list(self, *, bucket_id: int) -> ListResult:
+    def list(self, *, bucket_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="messagetypes", operation="list", is_mutation=False, project_id=bucket_id),
             f"/buckets/{bucket_id}/categories.json",
+            max_items=max_items,
             operation="ListMessageTypes",
         )
 
@@ -62,10 +63,11 @@ class MessageTypesService(BaseService):
 
 
 class AsyncMessageTypesService(AsyncBaseService):
-    async def list(self, *, bucket_id: int) -> ListResult:
+    async def list(self, *, bucket_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="messagetypes", operation="list", is_mutation=False, project_id=bucket_id),
             f"/buckets/{bucket_id}/categories.json",
+            max_items=max_items,
             operation="ListMessageTypes",
         )
 

--- a/python/src/basecamp/generated/services/messages.py
+++ b/python/src/basecamp/generated/services/messages.py
@@ -11,11 +11,14 @@ from basecamp.hooks import OperationInfo
 
 
 class MessagesService(BaseService):
-    def list(self, *, board_id: int, sort: str | None = None, direction: str | None = None) -> ListResult:
+    def list(
+        self, *, board_id: int, sort: str | None = None, direction: str | None = None, max_items: int | None = None
+    ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="messages", operation="list", is_mutation=False, resource_id=board_id),
             f"/message_boards/{board_id}/messages.json",
             params=self._compact(sort=sort, direction=direction),
+            max_items=max_items,
             operation="ListMessages",
         )
 
@@ -88,11 +91,14 @@ class MessagesService(BaseService):
 
 
 class AsyncMessagesService(AsyncBaseService):
-    async def list(self, *, board_id: int, sort: str | None = None, direction: str | None = None) -> ListResult:
+    async def list(
+        self, *, board_id: int, sort: str | None = None, direction: str | None = None, max_items: int | None = None
+    ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="messages", operation="list", is_mutation=False, resource_id=board_id),
             f"/message_boards/{board_id}/messages.json",
             params=self._compact(sort=sort, direction=direction),
+            max_items=max_items,
             operation="ListMessages",
         )
 

--- a/python/src/basecamp/generated/services/my_notifications.py
+++ b/python/src/basecamp/generated/services/my_notifications.py
@@ -20,11 +20,12 @@ class MyNotificationsService(BaseService):
             operation="GetMyNotifications",
         )
 
-    def get_bubble_ups(self, *, page: int | None = None) -> ListResult:
+    def get_bubble_ups(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="mynotifications", operation="get_bubble_ups", is_mutation=False),
             "/my/readings/bubble_ups.json",
             params=self._compact(page=page),
+            max_items=max_items,
             operation="GetBubbleUps",
         )
 
@@ -50,11 +51,12 @@ class AsyncMyNotificationsService(AsyncBaseService):
             operation="GetMyNotifications",
         )
 
-    async def get_bubble_ups(self, *, page: int | None = None) -> ListResult:
+    async def get_bubble_ups(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="mynotifications", operation="get_bubble_ups", is_mutation=False),
             "/my/readings/bubble_ups.json",
             params=self._compact(page=page),
+            max_items=max_items,
             operation="GetBubbleUps",
         )
 

--- a/python/src/basecamp/generated/services/people.py
+++ b/python/src/basecamp/generated/services/people.py
@@ -11,10 +11,11 @@ from basecamp.hooks import OperationInfo
 
 
 class PeopleService(BaseService):
-    def list_pingable(self) -> ListResult:
+    def list_pingable(self, *, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="people", operation="list_pingable", is_mutation=False),
             "/circles/people.json",
+            max_items=max_items,
             operation="ListPingablePeople",
         )
 
@@ -72,9 +73,12 @@ class PeopleService(BaseService):
             operation="UpdateMyProfile",
         )
 
-    def list(self) -> ListResult:
+    def list(self, *, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
-            OperationInfo(service="people", operation="list", is_mutation=False), "/people.json", operation="ListPeople"
+            OperationInfo(service="people", operation="list", is_mutation=False),
+            "/people.json",
+            max_items=max_items,
+            operation="ListPeople",
         )
 
     def get(self, *, person_id: int) -> dict[str, Any]:
@@ -110,10 +114,11 @@ class PeopleService(BaseService):
             operation="DisableOutOfOffice",
         )
 
-    def list_for_project(self, *, project_id: int) -> ListResult:
+    def list_for_project(self, *, project_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="people", operation="list_for_project", is_mutation=False, project_id=project_id),
             f"/projects/{project_id}/people.json",
+            max_items=max_items,
             operation="ListProjectPeople",
         )
 
@@ -142,10 +147,11 @@ class PeopleService(BaseService):
 
 
 class AsyncPeopleService(AsyncBaseService):
-    async def list_pingable(self) -> ListResult:
+    async def list_pingable(self, *, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="people", operation="list_pingable", is_mutation=False),
             "/circles/people.json",
+            max_items=max_items,
             operation="ListPingablePeople",
         )
 
@@ -203,9 +209,12 @@ class AsyncPeopleService(AsyncBaseService):
             operation="UpdateMyProfile",
         )
 
-    async def list(self) -> ListResult:
+    async def list(self, *, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
-            OperationInfo(service="people", operation="list", is_mutation=False), "/people.json", operation="ListPeople"
+            OperationInfo(service="people", operation="list", is_mutation=False),
+            "/people.json",
+            max_items=max_items,
+            operation="ListPeople",
         )
 
     async def get(self, *, person_id: int) -> dict[str, Any]:
@@ -241,10 +250,11 @@ class AsyncPeopleService(AsyncBaseService):
             operation="DisableOutOfOffice",
         )
 
-    async def list_for_project(self, *, project_id: int) -> ListResult:
+    async def list_for_project(self, *, project_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="people", operation="list_for_project", is_mutation=False, project_id=project_id),
             f"/projects/{project_id}/people.json",
+            max_items=max_items,
             operation="ListProjectPeople",
         )
 

--- a/python/src/basecamp/generated/services/projects.py
+++ b/python/src/basecamp/generated/services/projects.py
@@ -11,11 +11,12 @@ from basecamp.hooks import OperationInfo
 
 
 class ProjectsService(BaseService):
-    def list(self, *, status: str | None = None) -> ListResult:
+    def list(self, *, status: str | None = None, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="projects", operation="list", is_mutation=False),
             "/projects.json",
             params=self._compact(status=status),
+            max_items=max_items,
             operation="ListProjects",
         )
 
@@ -65,11 +66,12 @@ class ProjectsService(BaseService):
 
 
 class AsyncProjectsService(AsyncBaseService):
-    async def list(self, *, status: str | None = None) -> ListResult:
+    async def list(self, *, status: str | None = None, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="projects", operation="list", is_mutation=False),
             "/projects.json",
             params=self._compact(status=status),
+            max_items=max_items,
             operation="ListProjects",
         )
 

--- a/python/src/basecamp/generated/services/recordings.py
+++ b/python/src/basecamp/generated/services/recordings.py
@@ -19,11 +19,13 @@ class RecordingsService(BaseService):
         status: str | None = None,
         sort: str | None = None,
         direction: str | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="recordings", operation="list", is_mutation=False),
             "/projects/recordings.json",
             params=self._compact(type=type, bucket=bucket, status=status, sort=sort, direction=direction),
+            max_items=max_items,
             operation="ListRecordings",
         )
 
@@ -69,11 +71,13 @@ class AsyncRecordingsService(AsyncBaseService):
         status: str | None = None,
         sort: str | None = None,
         direction: str | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="recordings", operation="list", is_mutation=False),
             "/projects/recordings.json",
             params=self._compact(type=type, bucket=bucket, status=status, sort=sort, direction=direction),
+            max_items=max_items,
             operation="ListRecordings",
         )
 

--- a/python/src/basecamp/generated/services/reports.py
+++ b/python/src/basecamp/generated/services/reports.py
@@ -11,10 +11,11 @@ from basecamp.hooks import OperationInfo
 
 
 class ReportsService(BaseService):
-    def progress(self) -> ListResult:
+    def progress(self, *, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="reports", operation="progress", is_mutation=False),
             "/reports/progress.json",
+            max_items=max_items,
             operation="GetProgressReport",
         )
 
@@ -44,20 +45,22 @@ class ReportsService(BaseService):
             operation="GetOverdueTodos",
         )
 
-    def person_progress(self, *, person_id: int) -> dict[str, Any]:
+    def person_progress(self, *, person_id: int, max_items: int | None = None) -> dict[str, Any]:
         return self._request_paginated_wrapped(
             OperationInfo(service="reports", operation="person_progress", is_mutation=False, resource_id=person_id),
             f"/reports/users/progress/{person_id}.json",
             "events",
+            max_items=max_items,
             operation="GetPersonProgress",
         )
 
 
 class AsyncReportsService(AsyncBaseService):
-    async def progress(self) -> ListResult:
+    async def progress(self, *, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="reports", operation="progress", is_mutation=False),
             "/reports/progress.json",
+            max_items=max_items,
             operation="GetProgressReport",
         )
 
@@ -89,10 +92,11 @@ class AsyncReportsService(AsyncBaseService):
             operation="GetOverdueTodos",
         )
 
-    async def person_progress(self, *, person_id: int) -> dict[str, Any]:
+    async def person_progress(self, *, person_id: int, max_items: int | None = None) -> dict[str, Any]:
         return await self._request_paginated_wrapped(
             OperationInfo(service="reports", operation="person_progress", is_mutation=False, resource_id=person_id),
             f"/reports/users/progress/{person_id}.json",
             "events",
+            max_items=max_items,
             operation="GetPersonProgress",
         )

--- a/python/src/basecamp/generated/services/schedules.py
+++ b/python/src/basecamp/generated/services/schedules.py
@@ -74,11 +74,12 @@ class SchedulesService(BaseService):
             operation="UpdateScheduleSettings",
         )
 
-    def list_entries(self, *, schedule_id: int, status: str | None = None) -> ListResult:
+    def list_entries(self, *, schedule_id: int, status: str | None = None, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="schedules", operation="list_entries", is_mutation=False, resource_id=schedule_id),
             f"/schedules/{schedule_id}/entries.json",
             params=self._compact(status=status),
+            max_items=max_items,
             operation="ListScheduleEntries",
         )
 
@@ -179,11 +180,14 @@ class AsyncSchedulesService(AsyncBaseService):
             operation="UpdateScheduleSettings",
         )
 
-    async def list_entries(self, *, schedule_id: int, status: str | None = None) -> ListResult:
+    async def list_entries(
+        self, *, schedule_id: int, status: str | None = None, max_items: int | None = None
+    ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="schedules", operation="list_entries", is_mutation=False, resource_id=schedule_id),
             f"/schedules/{schedule_id}/entries.json",
             params=self._compact(status=status),
+            max_items=max_items,
             operation="ListScheduleEntries",
         )
 

--- a/python/src/basecamp/generated/services/search.py
+++ b/python/src/basecamp/generated/services/search.py
@@ -25,6 +25,7 @@ class SearchService(BaseService):
         type: str | None = None,
         bucket_id: int | None = None,
         creator_id: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         """Deprecated parameters (prefer the replacement):
 
@@ -52,6 +53,7 @@ class SearchService(BaseService):
                 }.items()
                 if v is not None
             },
+            max_items=max_items,
             operation="Search",
         )
 
@@ -79,6 +81,7 @@ class AsyncSearchService(AsyncBaseService):
         type: str | None = None,
         bucket_id: int | None = None,
         creator_id: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         """Deprecated parameters (prefer the replacement):
 
@@ -106,6 +109,7 @@ class AsyncSearchService(AsyncBaseService):
                 }.items()
                 if v is not None
             },
+            max_items=max_items,
             operation="Search",
         )
 

--- a/python/src/basecamp/generated/services/templates.py
+++ b/python/src/basecamp/generated/services/templates.py
@@ -11,11 +11,12 @@ from basecamp.hooks import OperationInfo
 
 
 class TemplatesService(BaseService):
-    def list(self, *, status: str | None = None) -> ListResult:
+    def list(self, *, status: str | None = None, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="templates", operation="list", is_mutation=False),
             "/templates.json",
             params=self._compact(status=status),
+            max_items=max_items,
             operation="ListTemplates",
         )
 
@@ -74,11 +75,12 @@ class TemplatesService(BaseService):
 
 
 class AsyncTemplatesService(AsyncBaseService):
-    async def list(self, *, status: str | None = None) -> ListResult:
+    async def list(self, *, status: str | None = None, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="templates", operation="list", is_mutation=False),
             "/templates.json",
             params=self._compact(status=status),
+            max_items=max_items,
             operation="ListTemplates",
         )
 

--- a/python/src/basecamp/generated/services/timeline.py
+++ b/python/src/basecamp/generated/services/timeline.py
@@ -11,22 +11,24 @@ from basecamp.hooks import OperationInfo
 
 
 class TimelineService(BaseService):
-    def get_project_timeline(self, *, project_id: int) -> ListResult:
+    def get_project_timeline(self, *, project_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(
                 service="timeline", operation="get_project_timeline", is_mutation=False, project_id=project_id
             ),
             f"/projects/{project_id}/timeline.json",
+            max_items=max_items,
             operation="GetProjectTimeline",
         )
 
 
 class AsyncTimelineService(AsyncBaseService):
-    async def get_project_timeline(self, *, project_id: int) -> ListResult:
+    async def get_project_timeline(self, *, project_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(
                 service="timeline", operation="get_project_timeline", is_mutation=False, project_id=project_id
             ),
             f"/projects/{project_id}/timeline.json",
+            max_items=max_items,
             operation="GetProjectTimeline",
         )

--- a/python/src/basecamp/generated/services/timesheets.py
+++ b/python/src/basecamp/generated/services/timesheets.py
@@ -12,22 +12,36 @@ from basecamp.hooks import OperationInfo
 
 class TimesheetsService(BaseService):
     def for_project(
-        self, *, project_id: int, from_: str | None = None, to: str | None = None, person_id: int | None = None
+        self,
+        *,
+        project_id: int,
+        from_: str | None = None,
+        to: str | None = None,
+        person_id: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="timesheets", operation="for_project", is_mutation=False, project_id=project_id),
             f"/projects/{project_id}/timesheet.json",
             params={k: v for k, v in {"from": from_, "to": to, "person_id": person_id}.items() if v is not None},
+            max_items=max_items,
             operation="GetProjectTimesheet",
         )
 
     def for_recording(
-        self, *, recording_id: int, from_: str | None = None, to: str | None = None, person_id: int | None = None
+        self,
+        *,
+        recording_id: int,
+        from_: str | None = None,
+        to: str | None = None,
+        person_id: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="timesheets", operation="for_recording", is_mutation=False, resource_id=recording_id),
             f"/recordings/{recording_id}/timesheet.json",
             params={k: v for k, v in {"from": from_, "to": to, "person_id": person_id}.items() if v is not None},
+            max_items=max_items,
             operation="GetRecordingTimesheet",
         )
 
@@ -78,22 +92,36 @@ class TimesheetsService(BaseService):
 
 class AsyncTimesheetsService(AsyncBaseService):
     async def for_project(
-        self, *, project_id: int, from_: str | None = None, to: str | None = None, person_id: int | None = None
+        self,
+        *,
+        project_id: int,
+        from_: str | None = None,
+        to: str | None = None,
+        person_id: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="timesheets", operation="for_project", is_mutation=False, project_id=project_id),
             f"/projects/{project_id}/timesheet.json",
             params={k: v for k, v in {"from": from_, "to": to, "person_id": person_id}.items() if v is not None},
+            max_items=max_items,
             operation="GetProjectTimesheet",
         )
 
     async def for_recording(
-        self, *, recording_id: int, from_: str | None = None, to: str | None = None, person_id: int | None = None
+        self,
+        *,
+        recording_id: int,
+        from_: str | None = None,
+        to: str | None = None,
+        person_id: int | None = None,
+        max_items: int | None = None,
     ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="timesheets", operation="for_recording", is_mutation=False, resource_id=recording_id),
             f"/recordings/{recording_id}/timesheet.json",
             params={k: v for k, v in {"from": from_, "to": to, "person_id": person_id}.items() if v is not None},
+            max_items=max_items,
             operation="GetRecordingTimesheet",
         )
 

--- a/python/src/basecamp/generated/services/todolist_groups.py
+++ b/python/src/basecamp/generated/services/todolist_groups.py
@@ -20,10 +20,11 @@ class TodolistGroupsService(BaseService):
             operation="RepositionTodolistGroup",
         )
 
-    def list(self, *, todolist_id: int) -> ListResult:
+    def list(self, *, todolist_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="todolistgroups", operation="list", is_mutation=False, resource_id=todolist_id),
             f"/todolists/{todolist_id}/groups.json",
+            max_items=max_items,
             operation="ListTodolistGroups",
         )
 
@@ -47,10 +48,11 @@ class AsyncTodolistGroupsService(AsyncBaseService):
             operation="RepositionTodolistGroup",
         )
 
-    async def list(self, *, todolist_id: int) -> ListResult:
+    async def list(self, *, todolist_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="todolistgroups", operation="list", is_mutation=False, resource_id=todolist_id),
             f"/todolists/{todolist_id}/groups.json",
+            max_items=max_items,
             operation="ListTodolistGroups",
         )
 

--- a/python/src/basecamp/generated/services/todolists.py
+++ b/python/src/basecamp/generated/services/todolists.py
@@ -37,11 +37,12 @@ class TodolistsService(BaseService):
             operation="RepositionTodolist",
         )
 
-    def list(self, *, todoset_id: int, status: str | None = None) -> ListResult:
+    def list(self, *, todoset_id: int, status: str | None = None, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="todolists", operation="list", is_mutation=False, resource_id=todoset_id),
             f"/todosets/{todoset_id}/todolists.json",
             params=self._compact(status=status),
+            max_items=max_items,
             operation="ListTodolists",
         )
 
@@ -84,11 +85,12 @@ class AsyncTodolistsService(AsyncBaseService):
             operation="RepositionTodolist",
         )
 
-    async def list(self, *, todoset_id: int, status: str | None = None) -> ListResult:
+    async def list(self, *, todoset_id: int, status: str | None = None, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="todolists", operation="list", is_mutation=False, resource_id=todoset_id),
             f"/todosets/{todoset_id}/todolists.json",
             params=self._compact(status=status),
+            max_items=max_items,
             operation="ListTodolists",
         )
 

--- a/python/src/basecamp/generated/services/todos.py
+++ b/python/src/basecamp/generated/services/todos.py
@@ -46,11 +46,19 @@ class TodosService(BaseService):
             operation="CreateTodosetTodo",
         )
 
-    def list(self, *, todolist_id: int, status: str | None = None, completed: bool | None = None) -> ListResult:
+    def list(
+        self,
+        *,
+        todolist_id: int,
+        status: str | None = None,
+        completed: bool | None = None,
+        max_items: int | None = None,
+    ) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="todos", operation="list", is_mutation=False, resource_id=todolist_id),
             f"/todolists/{todolist_id}/todos.json",
             params=self._compact(status=status, completed=completed),
+            max_items=max_items,
             operation="ListTodos",
         )
 
@@ -188,11 +196,19 @@ class AsyncTodosService(AsyncBaseService):
             operation="CreateTodosetTodo",
         )
 
-    async def list(self, *, todolist_id: int, status: str | None = None, completed: bool | None = None) -> ListResult:
+    async def list(
+        self,
+        *,
+        todolist_id: int,
+        status: str | None = None,
+        completed: bool | None = None,
+        max_items: int | None = None,
+    ) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="todos", operation="list", is_mutation=False, resource_id=todolist_id),
             f"/todolists/{todolist_id}/todos.json",
             params=self._compact(status=status, completed=completed),
+            max_items=max_items,
             operation="ListTodos",
         )
 

--- a/python/src/basecamp/generated/services/uploads.py
+++ b/python/src/basecamp/generated/services/uploads.py
@@ -28,17 +28,19 @@ class UploadsService(BaseService):
             operation="UpdateUpload",
         )
 
-    def list_versions(self, *, upload_id: int) -> ListResult:
+    def list_versions(self, *, upload_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="uploads", operation="list_versions", is_mutation=False, resource_id=upload_id),
             f"/uploads/{upload_id}/versions.json",
+            max_items=max_items,
             operation="ListUploadVersions",
         )
 
-    def list(self, *, vault_id: int) -> ListResult:
+    def list(self, *, vault_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="uploads", operation="list", is_mutation=False, resource_id=vault_id),
             f"/vaults/{vault_id}/uploads.json",
+            max_items=max_items,
             operation="ListUploads",
         )
 
@@ -87,17 +89,19 @@ class AsyncUploadsService(AsyncBaseService):
             operation="UpdateUpload",
         )
 
-    async def list_versions(self, *, upload_id: int) -> ListResult:
+    async def list_versions(self, *, upload_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="uploads", operation="list_versions", is_mutation=False, resource_id=upload_id),
             f"/uploads/{upload_id}/versions.json",
+            max_items=max_items,
             operation="ListUploadVersions",
         )
 
-    async def list(self, *, vault_id: int) -> ListResult:
+    async def list(self, *, vault_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="uploads", operation="list", is_mutation=False, resource_id=vault_id),
             f"/vaults/{vault_id}/uploads.json",
+            max_items=max_items,
             operation="ListUploads",
         )
 

--- a/python/src/basecamp/generated/services/vaults.py
+++ b/python/src/basecamp/generated/services/vaults.py
@@ -28,10 +28,11 @@ class VaultsService(BaseService):
             operation="UpdateVault",
         )
 
-    def list(self, *, vault_id: int) -> ListResult:
+    def list(self, *, vault_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="vaults", operation="list", is_mutation=False, resource_id=vault_id),
             f"/vaults/{vault_id}/vaults.json",
+            max_items=max_items,
             operation="ListVaults",
         )
 
@@ -63,10 +64,11 @@ class AsyncVaultsService(AsyncBaseService):
             operation="UpdateVault",
         )
 
-    async def list(self, *, vault_id: int) -> ListResult:
+    async def list(self, *, vault_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="vaults", operation="list", is_mutation=False, resource_id=vault_id),
             f"/vaults/{vault_id}/vaults.json",
+            max_items=max_items,
             operation="ListVaults",
         )
 

--- a/python/src/basecamp/generated/services/webhooks_service.py
+++ b/python/src/basecamp/generated/services/webhooks_service.py
@@ -11,10 +11,11 @@ from basecamp.hooks import OperationInfo
 
 
 class WebhooksService(BaseService):
-    def list(self, *, bucket_id: int) -> ListResult:
+    def list(self, *, bucket_id: int, max_items: int | None = None) -> ListResult:
         return self._request_paginated(
             OperationInfo(service="webhooks", operation="list", is_mutation=False, project_id=bucket_id),
             f"/buckets/{bucket_id}/webhooks.json",
+            max_items=max_items,
             operation="ListWebhooks",
         )
 
@@ -63,10 +64,11 @@ class WebhooksService(BaseService):
 
 
 class AsyncWebhooksService(AsyncBaseService):
-    async def list(self, *, bucket_id: int) -> ListResult:
+    async def list(self, *, bucket_id: int, max_items: int | None = None) -> ListResult:
         return await self._request_paginated(
             OperationInfo(service="webhooks", operation="list", is_mutation=False, project_id=bucket_id),
             f"/buckets/{bucket_id}/webhooks.json",
+            max_items=max_items,
             operation="ListWebhooks",
         )
 

--- a/python/tests/test_max_items_public.py
+++ b/python/tests/test_max_items_public.py
@@ -111,6 +111,51 @@ class TestAsyncPlainListMaxItems:
         assert result.meta.truncated is False
 
 
+class TestNonPositiveMaxItems:
+    """Non-positive caps disable the cap, matching the other SDKs.
+
+    TypeScript guards ``maxItems && maxItems > 0`` and Swift ``ln > 0``: zero
+    and negative values mean "no cap", never a negative slice or an early stop.
+    """
+
+    @respx.mock
+    def test_zero_collects_everything(self):
+        page1, page2 = _mount_two_pages(_PROJECTS_URL, _items(1, 2), _items(3))
+
+        account = Client(access_token="test-token").for_account("12345")
+        result = account.projects.list(max_items=0)
+
+        assert page1.call_count == 1
+        assert page2.call_count == 1
+        assert [p["id"] for p in result] == [1, 2, 3]
+        assert result.meta.truncated is False
+
+    @respx.mock
+    def test_negative_collects_everything(self):
+        page1, page2 = _mount_two_pages(_PROJECTS_URL, _items(1, 2), _items(3))
+
+        account = Client(access_token="test-token").for_account("12345")
+        result = account.projects.list(max_items=-1)
+
+        assert page1.call_count == 1
+        assert page2.call_count == 1
+        assert [p["id"] for p in result] == [1, 2, 3]
+        assert result.meta.truncated is False
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_negative_collects_everything_async(self):
+        page1, page2 = _mount_two_pages(_PROJECTS_URL, _items(1, 2), _items(3))
+
+        account = AsyncClient(access_token="test-token").for_account("12345")
+        result = await account.projects.list(max_items=-1)
+
+        assert page1.call_count == 1
+        assert page2.call_count == 1
+        assert [p["id"] for p in result] == [1, 2, 3]
+        assert result.meta.truncated is False
+
+
 class TestKeyPaginateMaxItems:
     @respx.mock
     def test_cap_drops_items_and_stops_before_next_page(self):

--- a/python/tests/test_max_items_public.py
+++ b/python/tests/test_max_items_public.py
@@ -1,0 +1,249 @@
+"""Public ``max_items`` coverage across the three paginator families.
+
+Every paginated list method now exposes a keyword-only ``max_items`` cap,
+matching the ``maxItems`` pagination option in the other SDKs. These tests
+drive the cap through the public generated surface where one exists:
+
+- plain (bare-array pages): ``projects.list(max_items=...)``
+- wrapped (envelope + item key): ``reports.person_progress(..., max_items=...)``
+
+The key family (``_paginate_key``) has no generated public caller today, so
+its cap semantics are pinned on the private helper directly, as
+test_paginate_truncated.py does for its page-cap cases.
+
+Semantics under test (SPEC.md steps 4a/6g): collection stops as soon as the
+cap is met — no further pages are fetched — and ``truncated`` is True only
+when items were actually dropped or a next Link was left unfetched. A cap
+landing exactly on the final item of a Link-less last page is NOT truncated.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from basecamp import AsyncClient, Client
+
+_ACCOUNT_URL = "https://3.basecampapi.com/12345"
+
+
+def _items(*ids: int) -> list[dict]:
+    return [{"id": i, "title": f"Item {i}"} for i in ids]
+
+
+def _link_to(url: str) -> dict[str, str]:
+    return {"Link": f'<{url}>; rel="next"'}
+
+
+def _mount_two_pages(url: str, page1_json, page2_json, *, page2_link: bool = False):
+    """Mount page 1 (with a next Link to ?page=2) and page 2 on the same path.
+
+    The ``?page=2`` route must be registered first so it wins for the follow-up
+    request; the bare route then catches the initial (query-less) request.
+    """
+    page2_headers = _link_to(f"{url}?page=3") if page2_link else {}
+    page2 = respx.get(url, params={"page": "2"}).mock(
+        return_value=httpx.Response(200, json=page2_json, headers=page2_headers)
+    )
+    page1 = respx.get(url).mock(return_value=httpx.Response(200, json=page1_json, headers=_link_to(f"{url}?page=2")))
+    return page1, page2
+
+
+_PROJECTS_URL = f"{_ACCOUNT_URL}/projects.json"
+_PROGRESS_PATH = "/reports/users/progress/1.json"
+_PROGRESS_URL = f"{_ACCOUNT_URL}{_PROGRESS_PATH}"
+
+
+class TestPlainListMaxItems:
+    @respx.mock
+    def test_cap_stops_pagination_early_and_truncates(self):
+        # Page 2 links onward to an unmounted page 3: reaching the cap there
+        # must stop collection without following the link.
+        page1, page2 = _mount_two_pages(_PROJECTS_URL, _items(1, 2), _items(3, 4), page2_link=True)
+
+        account = Client(access_token="test-token").for_account("12345")
+        result = account.projects.list(max_items=3)
+
+        assert page1.call_count == 1
+        assert page2.call_count == 1
+        assert [p["id"] for p in result] == [1, 2, 3]
+        assert result.meta.truncated is True
+
+    @respx.mock
+    def test_cap_on_exact_final_item_is_not_truncated(self):
+        page1, page2 = _mount_two_pages(_PROJECTS_URL, _items(1, 2), _items(3))
+
+        account = Client(access_token="test-token").for_account("12345")
+        result = account.projects.list(max_items=3)
+
+        assert page1.call_count == 1
+        assert page2.call_count == 1
+        assert len(result) == 3
+        assert result.meta.truncated is False
+
+
+class TestAsyncPlainListMaxItems:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_cap_stops_pagination_early_and_truncates(self):
+        page1, page2 = _mount_two_pages(_PROJECTS_URL, _items(1, 2), _items(3, 4), page2_link=True)
+
+        account = AsyncClient(access_token="test-token").for_account("12345")
+        result = await account.projects.list(max_items=3)
+
+        assert page1.call_count == 1
+        assert page2.call_count == 1
+        assert [p["id"] for p in result] == [1, 2, 3]
+        assert result.meta.truncated is True
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_cap_on_exact_final_item_is_not_truncated(self):
+        page1, page2 = _mount_two_pages(_PROJECTS_URL, _items(1, 2), _items(3))
+
+        account = AsyncClient(access_token="test-token").for_account("12345")
+        result = await account.projects.list(max_items=3)
+
+        assert page1.call_count == 1
+        assert page2.call_count == 1
+        assert len(result) == 3
+        assert result.meta.truncated is False
+
+
+class TestKeyPaginateMaxItems:
+    @respx.mock
+    def test_cap_drops_items_and_stops_before_next_page(self):
+        # Page 2 links onward to an unmounted page 3: the cap must break the
+        # loop there, dropping the fourth item and never fetching page 3.
+        page1, page2 = _mount_two_pages(
+            _PROGRESS_URL, {"events": _items(1, 2)}, {"events": _items(3, 4)}, page2_link=True
+        )
+
+        account = Client(access_token="test-token").for_account("12345")
+        result = account.reports._paginate_key(_PROGRESS_PATH, "events", max_items=3)
+
+        assert page1.call_count == 1
+        assert page2.call_count == 1
+        assert [e["id"] for e in result] == [1, 2, 3]
+        assert result.meta.truncated is True
+
+    @respx.mock
+    def test_cap_on_exact_final_item_is_not_truncated(self):
+        page1, page2 = _mount_two_pages(_PROGRESS_URL, {"events": _items(1, 2)}, {"events": _items(3)})
+
+        account = Client(access_token="test-token").for_account("12345")
+        result = account.reports._paginate_key(_PROGRESS_PATH, "events", max_items=3)
+
+        assert page1.call_count == 1
+        assert page2.call_count == 1
+        assert len(result) == 3
+        assert result.meta.truncated is False
+
+
+class TestAsyncKeyPaginateMaxItems:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_cap_drops_items_and_stops_before_next_page(self):
+        page1, page2 = _mount_two_pages(
+            _PROGRESS_URL, {"events": _items(1, 2)}, {"events": _items(3, 4)}, page2_link=True
+        )
+
+        account = AsyncClient(access_token="test-token").for_account("12345")
+        result = await account.reports._paginate_key(_PROGRESS_PATH, "events", max_items=3)
+
+        assert page1.call_count == 1
+        assert page2.call_count == 1
+        assert [e["id"] for e in result] == [1, 2, 3]
+        assert result.meta.truncated is True
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_cap_on_exact_final_item_is_not_truncated(self):
+        page1, page2 = _mount_two_pages(_PROGRESS_URL, {"events": _items(1, 2)}, {"events": _items(3)})
+
+        account = AsyncClient(access_token="test-token").for_account("12345")
+        result = await account.reports._paginate_key(_PROGRESS_PATH, "events", max_items=3)
+
+        assert page1.call_count == 1
+        assert page2.call_count == 1
+        assert len(result) == 3
+        assert result.meta.truncated is False
+
+
+class TestWrappedMaxItems:
+    @respx.mock
+    def test_cap_met_on_first_page_stops_before_next_page(self):
+        # The first page alone satisfies the cap; its next Link must be left
+        # unfetched and the surplus item dropped.
+        page1, page2 = _mount_two_pages(
+            _PROGRESS_URL,
+            {"person": {"id": 7, "name": "Victor Cooper"}, "events": _items(1, 2, 3, 4)},
+            {"events": _items(5)},
+        )
+
+        account = Client(access_token="test-token").for_account("12345")
+        result = account.reports.person_progress(person_id=1, max_items=3)
+
+        assert page1.call_count == 1
+        assert page2.call_count == 0
+        assert result["person"]["id"] == 7
+        events = result["events"]
+        assert [e["id"] for e in events] == [1, 2, 3]
+        assert events.meta.truncated is True
+
+    @respx.mock
+    def test_cap_on_exact_final_item_is_not_truncated(self):
+        page1, page2 = _mount_two_pages(
+            _PROGRESS_URL,
+            {"person": {"id": 7, "name": "Victor Cooper"}, "events": _items(1, 2)},
+            {"events": _items(3)},
+        )
+
+        account = Client(access_token="test-token").for_account("12345")
+        result = account.reports.person_progress(person_id=1, max_items=3)
+
+        assert page1.call_count == 1
+        assert page2.call_count == 1
+        events = result["events"]
+        assert len(events) == 3
+        assert events.meta.truncated is False
+
+
+class TestAsyncWrappedMaxItems:
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_cap_met_on_first_page_stops_before_next_page(self):
+        page1, page2 = _mount_two_pages(
+            _PROGRESS_URL,
+            {"person": {"id": 7, "name": "Victor Cooper"}, "events": _items(1, 2, 3, 4)},
+            {"events": _items(5)},
+        )
+
+        account = AsyncClient(access_token="test-token").for_account("12345")
+        result = await account.reports.person_progress(person_id=1, max_items=3)
+
+        assert page1.call_count == 1
+        assert page2.call_count == 0
+        assert result["person"]["id"] == 7
+        events = result["events"]
+        assert [e["id"] for e in events] == [1, 2, 3]
+        assert events.meta.truncated is True
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_cap_on_exact_final_item_is_not_truncated(self):
+        page1, page2 = _mount_two_pages(
+            _PROGRESS_URL,
+            {"person": {"id": 7, "name": "Victor Cooper"}, "events": _items(1, 2)},
+            {"events": _items(3)},
+        )
+
+        account = AsyncClient(access_token="test-token").for_account("12345")
+        result = await account.reports.person_progress(person_id=1, max_items=3)
+
+        assert page1.call_count == 1
+        assert page2.call_count == 1
+        events = result["events"]
+        assert len(events) == 3
+        assert events.meta.truncated is False

--- a/python/tests/test_paginate_truncated.py
+++ b/python/tests/test_paginate_truncated.py
@@ -13,8 +13,9 @@ Two defects pinned here (SPEC.md steps 4a/6g mandate the precise form
    a live next Link on the final fetched page still reported
    ``truncated=False``.
 
-No public list method exposes ``max_items`` today, so the boundary cases
-exercise the private helpers directly on a concrete service.
+These regression pins exercise the private helpers directly on a concrete
+service; the public ``max_items`` surface across all three paginator families
+is covered in test_max_items_public.py.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Closes the last Python parity gap on pagination control: every other SDK exposes a public cap on auto-pagination (`maxItems` in TypeScript/Kotlin/Swift, `ListOptions.Limit` in Go), but Python's cap died at the private `_request_paginated` plumbing — external developers had no way to stop a 10,000-page collection early.

## What changed

- **Generator** (`python/scripts/generate_services.py`): every paginated operation now emits a keyword-only `max_items: int | None = None` and threads it into the base paginators. Regen touched all 36 service modules — uniformly additive (122 signature additions + 122 call-site threadings across sync and async, remainder is ruff line-wrap of those same signatures; no other content changed, no types.py/metadata.json churn).
- **Base paginators** (`_base.py` / `_async_base.py`, the sanctioned hand-written exceptions under `generated/`): the key and wrapped families now accept `max_items` with the same exact-boundary `truncated` semantics the plain family already had (SPEC steps 4a/6g) — `truncated` only when items were dropped or a next Link was left unfetched; a cap landing exactly on the final item of a Link-less last page is complete, not truncated. Collection stops as soon as the cap is met, without fetching further pages.
- **Conformance runner**: the two `maxItems` skips are removed and `configOverrides.maxItems` is wired through the `ListProjects` dispatch (mirroring the Kotlin runner).
- **SPEC §Zero-Skip roster**: the two Python lines are deleted — exactly its own lines, per the roster contract. Ruby's waiver-backed (2C.4) lines remain.
- **Tests**: `python/tests/test_max_items_public.py` — 12 cases covering plain (`projects.list`), key (`_paginate_key`; no generated operation uses this family publicly), and wrapped (`reports.person_progress`) in sync and async, including early-stop-with-drop and exact-boundary-not-truncated.
- **Docs**: `python/README.md` pagination section documents `max_items` and the truncation contract (wording aligned with the Kotlin README).

## Red proofs

Conformance, skips removed, against the pristine SDK:

```
  FAIL: maxItems caps results across pages
        Expected >= 2 requests, got 0; Expected no error, got: TypeError: ProjectsService.list() got an unexpected keyword argument 'max_items'; Expected responseMeta.truncated = True, got None
  FAIL: maxItems landing exactly on the final item is not truncated
        Expected >= 2 requests, got 0; Expected no error, got: TypeError: ProjectsService.list() got an unexpected keyword argument 'max_items'; Expected responseMeta.truncated = False, got None
Results: 120 passed, 2 failed, 2 skipped
REAL_EXIT=2
```

New unit tests against the pristine SDK (base files + generated services swapped back to `origin/main` via `git show`): all 12 fail —

```
FAILED tests/test_max_items_public.py::TestPlainListMaxItems::test_cap_stops_pagination_early_and_truncates
FAILED tests/test_max_items_public.py::TestPlainListMaxItems::test_cap_on_exact_final_item_is_not_truncated
FAILED tests/test_max_items_public.py::TestAsyncPlainListMaxItems::test_cap_stops_pagination_early_and_truncates
FAILED tests/test_max_items_public.py::TestAsyncPlainListMaxItems::test_cap_on_exact_final_item_is_not_truncated
FAILED tests/test_max_items_public.py::TestKeyPaginateMaxItems::test_cap_drops_items_and_stops_before_next_page
FAILED tests/test_max_items_public.py::TestKeyPaginateMaxItems::test_cap_on_exact_final_item_is_not_truncated
FAILED tests/test_max_items_public.py::TestAsyncKeyPaginateMaxItems::test_cap_drops_items_and_stops_before_next_page
FAILED tests/test_max_items_public.py::TestAsyncKeyPaginateMaxItems::test_cap_on_exact_final_item_is_not_truncated
FAILED tests/test_max_items_public.py::TestWrappedMaxItems::test_cap_met_on_first_page_stops_before_next_page
FAILED tests/test_max_items_public.py::TestWrappedMaxItems::test_cap_on_exact_final_item_is_not_truncated
FAILED tests/test_max_items_public.py::TestAsyncWrappedMaxItems::test_cap_met_on_first_page_stops_before_next_page
FAILED tests/test_max_items_public.py::TestAsyncWrappedMaxItems::test_cap_on_exact_final_item_is_not_truncated
12 failed in 2.88s
REAL_EXIT=1
```

## Green

- `make conformance-python`: `Results: 122 passed, 0 failed, 2 skipped` (`REAL_EXIT=0`; remaining 2 are the rostered DownloadURL pair)
- `make py-check` (drift + tests + mypy + ruff): `722 passed`, `REAL_EXIT=0`

No wire-format change: `max_items` is a client-side collection cap, never sent as a query parameter. Additive keyword-only parameter — zero breakage for existing callers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `max_items` to all Python paginated list methods to cap auto-pagination and report accurate `meta.truncated`, matching other SDKs. Non‑positive caps are treated as no cap, and the two Python maxItems conformance skips are removed.

- New Features
  - Generator emits keyword-only `max_items` for every paginated operation (sync/async) and threads it into the base paginators.
  - Pagination honors the cap: stop before fetching more pages; `meta.truncated` is True only when items were dropped or a next Link was left unfetched (exact-boundary caps are not truncated).
  - Conformance runner passes `configOverrides.maxItems` through `ListProjects`; SPEC roster lines removed; README updated; tests cover plain/key/wrapped paginators; Python conformance passes.
  - Backward-compatible: additive keyword-only arg; no wire-format change.

- Bug Fixes
  - Normalize non‑positive `max_items` (<= 0) to “no cap,” matching other SDKs; tests pin the behavior.

<sup>Written for commit 4f2227206f99d00751c56458301158becf79e6aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

