### PR TITLE
Add the GetCalendar live canary with an env-var-only fixture

### DIFF
--- a/conformance/runner/go/replay_runner.go
+++ b/conformance/runner/go/replay_runner.go
@@ -75,6 +75,10 @@ var decoders = map[string]func(bodyText string) error{
 		var v generated.ListTodosResponseContent
 		return json.Unmarshal([]byte(bt), &v)
 	},
+	"GetCalendar": func(bt string) error {
+		var v generated.GetCalendarResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
 }
 
 var safeNameRE = regexp.MustCompile(`(?i)[^a-z0-9_-]+`)
@@ -98,6 +102,11 @@ type ReplayResult struct {
 	SchemaVersion int          `json:"schema_version"`
 	Operation     string       `json:"operation"`
 	Pages         []ReplayPage `json:"pages"`
+	// Skipped mirrors a skip-marker snapshot (a live test that skipped
+	// before wire capture, e.g. an unset env-var-only fixture ID). Omitted
+	// on decoded results so existing outputs stay byte-identical.
+	Skipped    bool   `json:"skipped,omitempty"`
+	SkipReason string `json:"skip_reason,omitempty"`
 }
 
 type fixtureTest struct {
@@ -135,6 +144,12 @@ type wireSnapshot struct {
 	Operation  string     `json:"operation"`
 	Pages      []wirePage `json:"pages"`
 	PagesCount int        `json:"pages_count"`
+	// Skip marker: the TS live runner writes {skipped: true, skip_reason,
+	// pages: [], pages_count: 0} when a test skips before wire capture, so
+	// the snapshot-completeness gate can distinguish a deliberate skip from
+	// a missing capture.
+	Skipped    bool   `json:"skipped"`
+	SkipReason string `json:"skip_reason"`
 }
 
 type ReplayRunner struct {
@@ -274,7 +289,21 @@ func (r *ReplayRunner) Run() int {
 			failures++
 			continue
 		}
-		result := r.decodeSnapshot(snap)
+		var result ReplayResult
+		if snap.Skipped {
+			// Nothing to decode; record the skip so downstream consumers
+			// see an explicit marker rather than a missing decode result.
+			result = ReplayResult{
+				SchemaVersion: ReplaySchemaVersion,
+				Operation:     snap.Operation,
+				Pages:         []ReplayPage{},
+				Skipped:       true,
+				SkipReason:    snap.SkipReason,
+			}
+			fmt.Printf("skip %s: %s\n", snap.Operation, snap.SkipReason)
+		} else {
+			result = r.decodeSnapshot(snap)
+		}
 		out, err := json.MarshalIndent(result, "", "  ")
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
@@ -310,6 +339,15 @@ func (r *ReplayRunner) readSnapshot(testName string) (*wireSnapshot, error) {
 	var snap wireSnapshot
 	if err := json.Unmarshal(raw, &snap); err != nil {
 		return nil, err
+	}
+	// A skip-marker snapshot legitimately has zero pages — but ONLY zero
+	// pages; a skipped marker carrying pages would mean the TS runner's
+	// contract drifted.
+	if snap.Skipped {
+		if len(snap.Pages) != 0 || snap.PagesCount != 0 {
+			return nil, fmt.Errorf("snapshot %s is marked skipped but carries %d pages (pages_count %d); a skip marker must be empty", path, len(snap.Pages), snap.PagesCount)
+		}
+		return &snap, nil
 	}
 	// A snapshot like `{"operation":"GetProject"}` unmarshals cleanly with
 	// Pages == nil; decodeSnapshot would then loop zero times and Run()

--- a/conformance/runner/go/replay_runner_test.go
+++ b/conformance/runner/go/replay_runner_test.go
@@ -127,3 +127,28 @@ func TestReadSnapshot_AcceptsMatchingPagesCount(t *testing.T) {
 		t.Fatalf("readSnapshot should accept matching pages_count; got %v", err)
 	}
 }
+
+func TestReadSnapshot_AcceptsEmptySkipMarker(t *testing.T) {
+	// A skip marker (live test skipped before wire capture — e.g. an unset
+	// env-var-only fixture ID) legitimately has zero pages. Without the
+	// skipped branch this would be rejected by the empty-pages guard.
+	r := readSnapshotFixture(t, "Test",
+		`{"operation":"GetCalendar","skipped":true,"skip_reason":"Fixture ID for ${CALENDAR_ID} not available","pages":[],"pages_count":0}`)
+	snap, err := r.readSnapshot("Test")
+	if err != nil {
+		t.Fatalf("readSnapshot should accept an empty skip marker; got %v", err)
+	}
+	if !snap.Skipped || snap.SkipReason == "" {
+		t.Fatalf("skip marker fields should round-trip; got skipped=%v reason=%q", snap.Skipped, snap.SkipReason)
+	}
+}
+
+func TestReadSnapshot_RejectsSkipMarkerWithPages(t *testing.T) {
+	// A skipped marker carrying pages means the TS runner's contract
+	// drifted — refuse it rather than silently ignoring captured data.
+	r := readSnapshotFixture(t, "Test",
+		`{"operation":"GetCalendar","skipped":true,"pages":[{"status":200,"bodyText":"{}"}],"pages_count":1}`)
+	if _, err := r.readSnapshot("Test"); err == nil {
+		t.Fatal("readSnapshot should reject a skip marker that carries pages; got nil")
+	}
+}

--- a/conformance/runner/python/replay_runner.py
+++ b/conformance/runner/python/replay_runner.py
@@ -68,6 +68,7 @@ DECODERS: dict[str, Callable[[str], None]] = {
     "GetTodoset": _decode,
     "ListTodolists": _decode,
     "ListTodos": _decode,
+    "GetCalendar": _decode,
 }
 
 
@@ -157,6 +158,16 @@ class ReplayRunner:
                 # matching `pages_count` so the gate fails fast with a
                 # deterministic message.
                 pages = snap.get("pages")
+                if snap.get("skipped") is True:
+                    # Skip markers (written by the TS runner when a live test
+                    # skips before wire capture) legitimately carry zero
+                    # pages — but ONLY zero pages.
+                    if pages or snap.get("pages_count") != 0:
+                        msgs.append(
+                            f"Snapshot {f.name} is marked skipped but carries pages; "
+                            "a skip marker must be empty."
+                        )
+                    continue
                 if not isinstance(pages, list) or not pages:
                     msgs.append(
                         f"Snapshot {f.name} has no pages; expected at least one wire response."
@@ -182,7 +193,19 @@ class ReplayRunner:
         failures = 0
         for t in self._fixture:
             snapshot = self._read_snapshot(t["name"])
-            result = self._decode_snapshot(snapshot)
+            if snapshot.get("skipped") is True:
+                # Nothing to decode; record the skip explicitly so downstream
+                # consumers see a marker rather than a missing decode result.
+                result = {
+                    "schema_version": SCHEMA_VERSION,
+                    "operation": snapshot["operation"],
+                    "pages": [],
+                    "skipped": True,
+                    "skip_reason": snapshot.get("skip_reason", ""),
+                }
+                print(f"skip {snapshot['operation']}: {result['skip_reason']}")
+            else:
+                result = self._decode_snapshot(snapshot)
             (out_dir / f"{_safe_name(t['name'])}.json").write_text(
                 json.dumps(result, indent=2)
             )

--- a/conformance/runner/python/replay_runner.py
+++ b/conformance/runner/python/replay_runner.py
@@ -161,8 +161,10 @@ class ReplayRunner:
                 if snap.get("skipped") is True:
                     # Skip markers (written by the TS runner when a live test
                     # skips before wire capture) legitimately carry zero
-                    # pages — but ONLY zero pages.
-                    if pages or snap.get("pages_count") != 0:
+                    # pages — but ONLY zero pages, as an actual (or absent)
+                    # array. A wrong-typed `pages` means contract drift.
+                    pages_ok = pages is None or (isinstance(pages, list) and not pages)
+                    if not pages_ok or snap.get("pages_count") != 0:
                         msgs.append(
                             f"Snapshot {f.name} is marked skipped but carries pages; "
                             "a skip marker must be empty."

--- a/conformance/runner/ruby/replay-runner.rb
+++ b/conformance/runner/ruby/replay-runner.rb
@@ -51,6 +51,7 @@ class ReplayRunner
     "GetTodoset"                => SDK_DECODE,
     "ListTodolists"             => SDK_DECODE,
     "ListTodos"                 => SDK_DECODE,
+    "GetCalendar"               => SDK_DECODE,
   }.freeze
 
   def initialize(replay_dir, backend, fixture_path, openapi_path)
@@ -74,7 +75,16 @@ class ReplayRunner
     failures = 0
     @fixture.each do |test|
       snapshot = read_snapshot(test["name"])
-      result = decode_snapshot(snapshot)
+      result = \
+        if snapshot["skipped"] == true
+          # Nothing to decode; record the skip explicitly so downstream
+          # consumers see a marker rather than a missing decode result.
+          puts "skip #{snapshot["operation"]}: #{snapshot["skip_reason"]}"
+          { schema_version: SCHEMA_VERSION, operation: snapshot["operation"], pages: [],
+            skipped: true, skip_reason: snapshot["skip_reason"].to_s }
+        else
+          decode_snapshot(snapshot)
+        end
       File.write(File.join(out_dir, "#{safe_name(test["name"])}.json"), JSON.pretty_generate(result))
       failures += 1 if result[:pages].any? { |p| !p[:decoded] || p[:missing_required].any? }
     end
@@ -101,8 +111,9 @@ class ReplayRunner
       f = File.join(wire_dir, "#{safe_name(t["name"])}.json")
       next if File.exist?(f)
 
-      # Per-test skipReason files are not part of the PR2 contract today;
-      # treat missing snapshots as runner failure with a clear pointer.
+      # A deliberately skipped test still leaves a skip-marker snapshot
+      # (see live-runner.test.ts persistSkipMarker), so a genuinely missing
+      # file always means the capture didn't run.
       msgs << "Snapshot missing for operation #{t["operation"]} (test #{t["name"]}); " \
               "expected at #{f}. Re-run TS live capture or check skip status."
     end
@@ -130,6 +141,17 @@ class ReplayRunner
         unless fixture_ops.include?(op)
           msgs << "Unknown operation #{op.inspect} in snapshot #{File.basename(f)}; " \
                   "TS dispatch table appears to have drifted from live-my-surface.json."
+        end
+
+        # Skip markers (written by the TS runner when a live test skips
+        # before wire capture) legitimately carry zero pages — but ONLY
+        # zero pages.
+        if snap["skipped"] == true
+          unless (snap["pages"] || []).empty? && snap["pages_count"] == 0
+            msgs << "Snapshot #{File.basename(f)} is marked skipped but carries pages; " \
+                    "a skip marker must be empty."
+          end
+          next
         end
 
         # A snapshot like `{"operation": "GetProject"}` would pass the gates

--- a/conformance/runner/ruby/replay-runner.rb
+++ b/conformance/runner/ruby/replay-runner.rb
@@ -147,7 +147,8 @@ class ReplayRunner
         # before wire capture) legitimately carry zero pages — but ONLY
         # zero pages.
         if snap["skipped"] == true
-          unless (snap["pages"] || []).empty? && snap["pages_count"] == 0
+          pages_ok = snap["pages"].nil? || (snap["pages"].is_a?(Array) && snap["pages"].empty?)
+          unless pages_ok && snap["pages_count"] == 0
             msgs << "Snapshot #{File.basename(f)} is marked skipped but carries pages; " \
                     "a skip marker must be empty."
           end

--- a/conformance/runner/typescript/fixtures.ts
+++ b/conformance/runner/typescript/fixtures.ts
@@ -45,6 +45,11 @@ function fromEnv(backend: Backend, name: string): string | undefined {
  *   TODOSET_ID    → walk dock of resolved project, pick first todoset tool
  *   TODOLIST_ID   → ListTodolists for resolved todoset, pick first
  *   TODO_ID       → ListTodos for resolved todolist, pick first
+ *
+ * CALENDAR_ID is env-var-only (BASECAMP_BC5_CALENDAR_ID → BASECAMP_CALENDAR_ID
+ * → skip): no modeled endpoint returns a calendar bucket id — the dock has no
+ * calendar tool and bucket `type` never says "Calendar" — so there is no
+ * discovery branch to write until upstream exposes one.
  */
 export async function resolveFixtureId(
   ctx: FixtureContext,

--- a/conformance/runner/typescript/live-dispatch.ts
+++ b/conformance/runner/typescript/live-dispatch.ts
@@ -190,6 +190,17 @@ export const LIVE_OPERATIONS: Record<string, DispatchSpec> = {
     call: async (ctx) => ({ resolvedIds: {}, result: await ctx.client.everything.everythingNotNowCards({ maxItems: 5 }) }),
   },
 
+  GetCalendar: {
+    // CALENDAR_ID resolves via env vars only (BASECAMP_BC5_CALENDAR_ID →
+    // BASECAMP_CALENDAR_ID); unconfigured runs skip through the fixture
+    // ladder. See fixtures.ts — no discovery path exists for calendar ids.
+    fixtures: ["CALENDAR_ID"],
+    call: async (ctx, ids) => {
+      const result = await ctx.client.calendars.getCalendar(Number(ids.CALENDAR_ID));
+      return { resolvedIds: ids, result };
+    },
+  },
+
   GetMyProfile: {
     fixtures: [],
     call: async (ctx) => {

--- a/conformance/runner/typescript/live-runner.test.ts
+++ b/conformance/runner/typescript/live-runner.test.ts
@@ -116,6 +116,28 @@ function persistSnapshot(testName: string, operation: string, snapshot: WireSnap
   fs.writeFileSync(file, JSON.stringify(payload, null, 2));
 }
 
+/**
+ * Persist a skip-marker snapshot for a test that skipped before wire capture
+ * (fixture-ID not resolvable). Downstream replay runners require a snapshot
+ * file for every live fixture entry; the marker satisfies that completeness
+ * gate while recording — machine-readably — that there is nothing to decode.
+ */
+function persistSkipMarker(testName: string, operation: string, reason: string): void {
+  if (!RECORD_DIR) return;
+  const wireDir = path.join(RECORD_DIR, BACKEND, "wire");
+  fs.mkdirSync(wireDir, { recursive: true });
+  const safeName = testName.replace(/[^a-z0-9_-]+/gi, "_");
+  const file = path.join(wireDir, `${safeName}.json`);
+  const payload: PersistedWireSnapshot = {
+    operation,
+    skipped: true,
+    skip_reason: reason,
+    pages: [],
+    pages_count: 0,
+  };
+  fs.writeFileSync(file, JSON.stringify(payload, null, 2));
+}
+
 function checkRequiredFields(page: WirePage, fields: string[]): string[] {
   const errors: string[] = [];
   const body = page.body;
@@ -206,7 +228,12 @@ LIVE_DESCRIBE("conformance live runner", () => {
           for (const fixture of spec.fixtures) {
             const value = await resolveFixtureId(ctx, fixture);
             if (!value) {
-              testCtx.skip(`Fixture ID for \${${fixture}} not available`);
+              const reason = `Fixture ID for \${${fixture}} not available`;
+              // Replay runners require a snapshot file per live fixture
+              // entry; leave a skip marker so a fixture-level skip doesn't
+              // read as a capture failure downstream.
+              persistSkipMarker(tc.name, tc.operation, reason);
+              testCtx.skip(reason);
               return;
             }
             resolvedIds[fixture] = value;

--- a/conformance/runner/typescript/wire-capture.ts
+++ b/conformance/runner/typescript/wire-capture.ts
@@ -39,6 +39,16 @@ export interface WireSnapshot {
 /** Snapshot as persisted to disk: WireSnapshot plus the operation that produced it. */
 export interface PersistedWireSnapshot extends WireSnapshot {
   operation: string;
+  /**
+   * Skip marker: set (true) when the live runner skipped this test before
+   * wire capture (e.g. an env-var-only fixture-ID was not provided). A
+   * skipped snapshot has zero pages; replay runners record the skip and
+   * exempt it from decode instead of failing their snapshot-completeness
+   * gate. Absent on captured snapshots.
+   */
+  skipped?: true;
+  /** Human-readable reason accompanying `skipped`. */
+  skip_reason?: string;
 }
 
 export interface WireCaptureSession {

--- a/conformance/tests/live-my-surface.json
+++ b/conformance/tests/live-my-surface.json
@@ -99,6 +99,46 @@
   },
   {
     "mode": "live",
+    "name": "GetCalendar decodes the spec-required fields",
+    "description": "Live canary for the BC5-only Calendar resource (C8 follow-up). CALENDAR_ID is env-var-only (BASECAMP_BC5_CALENDAR_ID → BASECAMP_CALENDAR_ID): no modeled endpoint returns a calendar bucket id, so unconfigured runs skip via the fixture ladder.",
+    "operation": "GetCalendar",
+    "method": "GET",
+    "path": "/calendars/${CALENDAR_ID}.json",
+    "fixtureIds": {
+      "CALENDAR_ID": "CALENDAR_ID"
+    },
+    "pathParams": {
+      "calendarId": "${CALENDAR_ID}"
+    },
+    "tags": [
+      "live",
+      "read-only"
+    ],
+    "liveAssertions": [
+      {
+        "type": "liveCallSucceeds"
+      },
+      {
+        "type": "liveSchemaValidate"
+      },
+      {
+        "type": "liveResponseFieldsRequired",
+        "fields": [
+          "id",
+          "type",
+          "name",
+          "color",
+          "created_at",
+          "updated_at",
+          "url",
+          "app_url",
+          "schedule_url"
+        ]
+      }
+    ]
+  },
+  {
+    "mode": "live",
     "name": "GetMyAssignments decodes priorities + non_priorities",
     "description": "Verifies MyAssignment.bucket JSON-key compat \u2014 the field is preserved despite route renames.",
     "operation": "GetMyAssignments",

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/ReplayRunner.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/ReplayRunner.kt
@@ -194,11 +194,11 @@ class ReplayRunner(
                 // Skip markers (written by the TS runner when a live test
                 // skips before wire capture) legitimately carry zero pages —
                 // but ONLY zero pages.
-                val skipped = (snap["skipped"] as? JsonPrimitive)?.contentOrNull == "true"
-                if (skipped) {
-                    val markerPages = snap["pages"] as? JsonArray
+                if (isSkipMarker(snap)) {
+                    val pagesEl = snap["pages"]
+                    val pagesOk = pagesEl == null || (pagesEl is JsonArray && pagesEl.isEmpty())
                     val markerCount = (snap["pages_count"] as? JsonPrimitive)?.contentOrNull?.toIntOrNull()
-                    if (!(markerPages == null || markerPages.isEmpty()) || markerCount != 0) {
+                    if (!pagesOk || markerCount != 0) {
                         msgs += "Snapshot ${f.name} is marked skipped but carries pages; " +
                             "a skip marker must be empty."
                     }
@@ -234,7 +234,7 @@ class ReplayRunner(
         for (t in fixture) {
             val name = t["name"]!!.jsonPrimitive.content
             val snap = readSnapshot(name)
-            val result = if ((snap["skipped"] as? JsonPrimitive)?.contentOrNull == "true") {
+            val result = if (isSkipMarker(snap)) {
                 // Nothing to decode; record the skip explicitly so downstream
                 // consumers see a marker rather than a missing decode result.
                 val reason = (snap["skip_reason"] as? JsonPrimitive)?.contentOrNull ?: ""
@@ -255,6 +255,17 @@ class ReplayRunner(
             if (result.pages.any { !it.decoded || it.missing_required.isNotEmpty() }) failures++
         }
         return if (failures == 0) 0 else 1
+    }
+
+    /**
+     * True only for a JSON boolean `"skipped": true`. A string `"true"`
+     * (or any other type) is NOT a skip marker — the marker is written by
+     * our own TS runner, so a wrong-typed field means contract drift and
+     * must fall through to the strict non-skipped checks.
+     */
+    private fun isSkipMarker(snap: JsonObject): Boolean {
+        val prim = snap["skipped"] as? JsonPrimitive ?: return false
+        return !prim.isString && prim.contentOrNull == "true"
     }
 
     private fun readSnapshot(testName: String): JsonObject {

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/ReplayRunner.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/ReplayRunner.kt
@@ -1,5 +1,6 @@
 package com.basecamp.sdk.conformance
 
+import com.basecamp.sdk.generated.models.Calendar
 import com.basecamp.sdk.generated.models.Person
 import com.basecamp.sdk.generated.models.Project
 import com.basecamp.sdk.generated.models.Todo
@@ -83,6 +84,7 @@ private val decoders: Map<String, (String) -> Unit> = mapOf(
     "GetTodoset" to { bt -> replayJson.decodeFromString(Todoset.serializer(), bt) },
     "ListTodolists" to { bt -> replayJson.decodeFromString(ListSerializer(Todolist.serializer()), bt) },
     "ListTodos" to { bt -> replayJson.decodeFromString(ListSerializer(Todo.serializer()), bt) },
+    "GetCalendar" to { bt -> replayJson.decodeFromString(Calendar.serializer(), bt) },
 )
 
 private val safeNameRegex = Regex("[^a-z0-9_-]+", RegexOption.IGNORE_CASE)
@@ -101,6 +103,11 @@ data class ReplayResult(
     val schema_version: Int,
     val operation: String,
     val pages: List<ReplayPageResult>,
+    // Skip marker passthrough (live test skipped before wire capture).
+    // Defaults are omitted on encode (encodeDefaults=false), so decoded
+    // results stay byte-identical to the pre-skip-marker output schema.
+    val skipped: Boolean = false,
+    val skip_reason: String? = null,
 )
 
 class ReplayRunner(
@@ -184,6 +191,19 @@ class ReplayRunner(
                 // with an opaque NPE. Mirror the Go runner's read-time checks:
                 // require a non-empty `pages` array and a matching `pages_count`
                 // so the gate fails fast with a deterministic message.
+                // Skip markers (written by the TS runner when a live test
+                // skips before wire capture) legitimately carry zero pages —
+                // but ONLY zero pages.
+                val skipped = (snap["skipped"] as? JsonPrimitive)?.contentOrNull == "true"
+                if (skipped) {
+                    val markerPages = snap["pages"] as? JsonArray
+                    val markerCount = (snap["pages_count"] as? JsonPrimitive)?.contentOrNull?.toIntOrNull()
+                    if (!(markerPages == null || markerPages.isEmpty()) || markerCount != 0) {
+                        msgs += "Snapshot ${f.name} is marked skipped but carries pages; " +
+                            "a skip marker must be empty."
+                    }
+                    return@forEach
+                }
                 val pages = snap["pages"] as? JsonArray
                 if (pages == null || pages.isEmpty()) {
                     msgs += "Snapshot ${f.name} has no pages; expected at least one wire response."
@@ -214,7 +234,21 @@ class ReplayRunner(
         for (t in fixture) {
             val name = t["name"]!!.jsonPrimitive.content
             val snap = readSnapshot(name)
-            val result = decodeSnapshot(snap)
+            val result = if ((snap["skipped"] as? JsonPrimitive)?.contentOrNull == "true") {
+                // Nothing to decode; record the skip explicitly so downstream
+                // consumers see a marker rather than a missing decode result.
+                val reason = (snap["skip_reason"] as? JsonPrimitive)?.contentOrNull ?: ""
+                println("skip ${snap["operation"]!!.jsonPrimitive.content}: $reason")
+                ReplayResult(
+                    schema_version = REPLAY_SCHEMA_VERSION,
+                    operation = snap["operation"]!!.jsonPrimitive.content,
+                    pages = emptyList(),
+                    skipped = true,
+                    skip_reason = reason,
+                )
+            } else {
+                decodeSnapshot(snap)
+            }
             File(outDir, "${safeName(name)}.json").writeText(
                 pretty.encodeToString(ReplayResult.serializer(), result)
             )

--- a/spec/api-gaps/calendar.md
+++ b/spec/api-gaps/calendar.md
@@ -65,5 +65,10 @@ required non-nullable. The update body is the nested `{calendar: {color}}`
 envelope; the pinned controller's 422 contract (`{"errors": {"color": ["is not
 a valid color"]}}`, rejected up front for unknown enum values) is documented on
 the operation and pinned in per-SDK 422 tests. `UpdateCalendar` is a flagged
-idempotent PUT with an idempotency conformance case. Live-canary fixture for
-`GetCalendar` remains a follow-up (needs a stable dock-walk fixture-id path).
+idempotent PUT with an idempotency conformance case. The `GetCalendar`
+live-canary case ships in `live-my-surface.json` with an **env-var-only**
+fixture (`BASECAMP_BC5_CALENDAR_ID` → `BASECAMP_CALENDAR_ID` → skip): no
+modeled endpoint returns a calendar bucket id (the dock has no calendar tool;
+bucket `type` never says "Calendar"), so SDK discovery is impossible until
+upstream exposes one — revisit the fixture ladder's discovery branch if that
+surface ever ships.


### PR DESCRIPTION
## Summary

Closes the C8 deferral: `GetCalendar` (the BC5-only Calendar resource absorbed in #526) gets a live-canary case, and — following review — the capture/replay contract learns to honor fixture-level skips so an env-var-only fixture is honest end to end.

**Canary case (commit 1):**
- **`conformance/tests/live-my-surface.json`** — new `GetCalendar` case (liveCallSucceeds + liveSchemaValidate + the nine spec-required fields from `doc/api/sections/calendars.md` at the pinned revision).
- **`live-dispatch.ts`** — `GetCalendar` DispatchSpec through the generated service.
- **`fixtures.ts`** — documents that `CALENDAR_ID` is **env-var-only**: `BASECAMP_BC5_CALENDAR_ID` → `BASECAMP_CALENDAR_ID` → skip. No discovery branch is possible — no modeled endpoint returns a calendar bucket id (the dock has no calendar tool; bucket `type` never says "Calendar").
- **`spec/api-gaps/calendar.md`** — follow-up note updated to the shipped shape.

**Skip-marker replay contract (commit 2, from review):** the four replay runners require a snapshot per live fixture entry, so a designed skip would have read as a capture failure downstream (Codex P1s — both real).
- TS live runner persists `{skipped: true, skip_reason, pages: [], pages_count: 0}` when a test skips before wire capture.
- All four replay runners (Go/Ruby/Python/Kotlin) accept an **empty** skip marker, emit an explicit skipped decode result (`skipped`/`skip_reason` omitted from decoded results, so existing output stays byte-identical), and reject a marker that carries pages.
- `GetCalendar` registered in all four replay decoder maps through each SDK's real decode boundary.
- **Pre-existing, not introduced here:** the decoder maps are missing ~15 live ops added since the original 10-op surface, so the replay gate already fails on main whenever it actually runs — filed as #553 (backfill + static parity guard).

## Verification

- Full TS conformance suite green; live suite skips without `BASECAMP_LIVE`.
- Discriminating pair with dummy credentials filtered to the new case: env var unset → fixture-ladder skip **and the marker file is written**; `BASECAMP_CALENDAR_ID=123` set → the SDK call dispatches to `/calendars/123.json`.
- Go: two new unit tests (accept empty marker / reject marker-with-pages), **red-proofed** — both fail with the `readSnapshot` skip branch stripped.
- Python + Ruby replay runners driven end-to-end against a single-case fixture: marker present → exit 0 + skipped decode result; marker removed → snapshot-completeness gate failure.
- Kotlin conformance module compiles.
- `make conformance-fixtures-check` and `scripts/validate-api-gaps.sh` clean.
- A true live **pass** still needs BC5 credentials plus a real calendar bucket id; that remains an operator-provisioned step by design (this PR makes it a one-env-var step and makes the unprovisioned state a recorded skip, not a failure).

🤖 _Authored with agent assistance by @jeremy._
