### PR TITLE
Fail, not skip, when a mock body flunks Kotlin's required-field validation

### DIFF
--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
@@ -66,7 +66,9 @@ fun main() {
             }
             // Note: MissingFieldException from kotlinx.serialization (when mock
             // bodies lack required model fields) is caught at runtime in runTest()
-            // and reported as SKIP, so no pre-flight filtering is needed.
+            // and reported as FAIL: Kotlin is the strictest fixture consumer, so
+            // an under-specified mock body is a fixture bug to fix, not a reason
+            // to silently shed coverage.
             val result = runTest(tc)
             when {
                 result.skipped -> {
@@ -281,8 +283,12 @@ private fun runTest(tc: TestCase): TestResult {
             caughtException = e
             httpStatusCode = e.httpStatus
         } catch (e: MissingFieldException) {
+            // A mock body that fails the model's required-field validation is a
+            // fixture bug, not a runner limitation: fail loudly so it gets fixed
+            // (canonical bodies live in spec/fixtures/) instead of silently
+            // degrading coverage. Was SKIP until every rider was repaired.
             client.close()
-            return TestResult(passed = false, message = "Mock body lacks required Kotlin model fields: ${e.message}", skipped = true)
+            return TestResult(passed = false, message = "Mock body lacks required Kotlin model fields: ${e.message}")
         } catch (e: Exception) {
             client.close()
             return TestResult(false, "Unexpected exception: ${e::class.simpleName}: ${e.message}")


### PR DESCRIPTION
Closes the Kotlin conformance runner's silent-degradation hole (wave 1, rock B6): a mock body that fails kotlinx.serialization's required-field validation now FAILS the suite instead of quietly skipping.

## The bug

The runner caught `MissingFieldException` and reported SKIP. Kotlin is the strictest fixture consumer — no other runner validates required fields at all — so this catch was the only place an under-specified fixture body could be detected, and it whispered: the test's coverage silently vanished and the suite still exited 0. Two real fixtures rode this path until #554 repaired them (the UploadsDownload metadata bodies), which is exactly how the hole hid — riders looked like clean SKIPs, not fixture bugs.

## The fix

One clause: `TestResult(passed = false, ...)` instead of `skipped = true`, with the message unchanged (`Mock body lacks required Kotlin model fields: ...`). A malformed body is a fixture bug to repair against the canonical `spec/fixtures/` shapes, not a runner limitation.

## Kill test (deliberate malformed-required-field proof, verbatim)

A scratch-only fixture (never committed) with a `GetProject` body stripped to `{"id": 1}` — the Kotlin `Project` model requires `status`, `created_at`, `updated_at`, `name`, `url`, `app_url`.

**Before the flip** — rides the SKIP path, suite exits 0 (`REAL_EXIT=0`):

```
  SKIP: KILL TEST: mock body missing required Kotlin model fields
        Mock body lacks required Kotlin model fields: Fields [status, created_at, updated_at, name, url, app_url] are required for type with serial name 'com.basecamp.sdk.generated.models.Project', but they were missing at path: $

Passed: 121, Failed: 0, Skipped: 4, Total: 125
```

**After the flip** — same fixture, hard failure, suite exits nonzero (`REAL_EXIT=2`):

```
  FAIL: KILL TEST: mock body missing required Kotlin model fields
        Mock body lacks required Kotlin model fields: Fields [status, created_at, updated_at, name, url, app_url] are required for type with serial name 'com.basecamp.sdk.generated.models.Project', but they were missing at path: $

Passed: 121, Failed: 1, Skipped: 3, Total: 125
```

## Real suite after the flip

No fixture rides the path anymore (#554 fixed the only two riders):

```
Passed: 121, Failed: 0, Skipped: 3, Total: 124
```

(`REAL_EXIT=0`; remaining skips: the link-header architectural case and the two B4 download-retry cases.)

No SPEC roster changes: the degradation was never rostered — it was invisible by construction, which is the point of this fix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail the Kotlin conformance test when a mock body is missing required model fields instead of skipping it. This surfaces fixture bugs and prevents silent coverage loss.

- **Bug Fixes**
  - Treat `kotlinx.serialization` `MissingFieldException` as FAIL in `runTest` (no longer SKIP).
  - Keep the same error message: “Mock body lacks required Kotlin model fields: ...”.
  - Suite now exits non-zero when such a fixture is present; current suite passes with no new failures.

<sup>Written for commit 8ae19b513b6521c127528c4377ff45a5a097b423. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

