### PR TITLE
Carry pagination metadata on Ruby's lazy enumerators, cap with max_items

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -327,7 +327,7 @@ Conformance: `conformance/tests/todos_write.json` (`update-merge`, `edit-clear`,
 
 - Go is missing a standalone `automation` service; `clientVisibility` is implemented on `RecordingsService` (not a separate service); uses singular `Timesheet` vs `timesheets`
 - TypeScript flattens both tiers onto a single client object (no separate AccountClient exposed to consumers) — a valid language adaptation
-- Ruby returns lazy `Enumerator` for pagination rather than `ListResult`
+- Ruby returns a lazy `ListEnumerator` (an `Enumerator` subclass carrying `ListMeta`) for pagination rather than an eager `ListResult`; the first page is fetched eagerly so `meta.total_count` is available at call time, while `meta.truncated` is final only once enumeration completes
 
 ---
 
@@ -1665,11 +1665,6 @@ logic is covered by `TestIsSameOrigin` unit tests:
 - "PrioritizeAssignment POST retries when marked idempotent" — GET-only retry (waiver 2B.3).
 - "DeprioritizeAssignment DELETE retries when marked idempotent" — GET-only retry (waiver 2B.3).
 - "Network error on an idempotent POST is retried then succeeds" — GET-only network retry (waiver 2B.3).
-- "Total count header is accessible" — Enumerator exposes no totalCount metadata (waiver 2C.2).
-- "Missing X-Total-Count returns zero" — Enumerator exposes no totalCount metadata (waiver 2C.2).
-- "Pagination stops at maxPages safety cap" — cap is enforced, but truncation metadata is inexpressible (waiver 2C.6).
-- "maxItems caps results across pages" — no `max_items` support (waiver 2C.4).
-- "maxItems landing exactly on the final item is not truncated" — no `max_items` support (waiver 2C.4).
 - "DownloadURL retries on 503 at the auth'd first hop" — download path uses `get_no_retry`; hop-1 retry not implemented (unwaivered).
 - "DownloadURL honors Retry-After on 429 at the auth'd first hop" — same as above (unwaivered).
 
@@ -1989,7 +1984,7 @@ See the Gate 3 consumption table in §7 above.
 | Swift | `ListResult<T>` | yes | yes |
 | Go | Typed `*XxxListResult` with `Meta ListMeta` | yes | yes |
 | Python | `ListResult(list)` with `meta ListMeta` | yes | yes |
-| Ruby | Lazy `Enumerator` yielding items | no (waiver 2C.2) | no (waiver 2C.6) |
+| Ruby | Lazy `ListEnumerator` (Enumerator subclass) with `meta ListMeta` | yes | yes (final after enumeration completes) |
 
 ### Error Message Truncation Unit (§9)
 

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -69,14 +69,16 @@ class OperationMapper
     @account = account_client
   end
 
-  def call(operation, path_params: {}, query_params: {}, body: nil, path: "")
+  def call(operation, path_params: {}, query_params: {}, body: nil, path: "", max_items: nil)
     case operation
     when "DownloadURL"
       raise "DownloadURL test case requires a non-empty path" if path.nil? || path.empty?
       raw_url = "https://storage.3.basecamp.com" + path
       @account.download_url(raw_url)
     when "ListProjects"
-      @account.projects.list.to_a
+      # Returned unconsumed so the runner can consume then assert on .meta;
+      # the plain arity stays exercised when the fixture carries no maxItems.
+      max_items ? @account.projects.list(max_items: max_items) : @account.projects.list
     when "GetProject"
       @account.projects.get(project_id: path_params["projectId"])
     when "CreateProject"
@@ -84,7 +86,7 @@ class OperationMapper
     when "ListTodos"
       @account.todos.list(
         todolist_id: path_params["todolistId"]
-      ).to_a
+      )
     when "GetTodo"
       @account.todos.get(
         todo_id: path_params["todoId"]
@@ -280,9 +282,6 @@ TestResult = Struct.new(:name, :passed, :message)
 # The Ruby SDK only retries GET requests (see Http#request). PUT and DELETE
 # are sent once even though they're naturally idempotent. Tests asserting
 # mutation-retry behavior are skipped.
-#
-# The Ruby SDK's paginate Enumerator does not expose X-Total-Count metadata,
-# so responseMeta.totalCount assertions are skipped.
 RUBY_SKIPS = Set.new([
   "PUT operation is naturally idempotent",
   "DELETE operation is naturally idempotent",
@@ -294,11 +293,6 @@ RUBY_SKIPS = Set.new([
   "UpdateCalendar PUT retries when marked idempotent",
   "PrioritizeAssignment POST retries when marked idempotent",
   "DeprioritizeAssignment DELETE retries when marked idempotent",
-  "Total count header is accessible",
-  "Missing X-Total-Count returns zero",
-  "Pagination stops at maxPages safety cap",
-  "maxItems caps results across pages",
-  "maxItems landing exactly on the final item is not truncated",
   "DownloadURL retries on 503 at the auth'd first hop",
   "DownloadURL honors Retry-After on 429 at the auth'd first hop",
   "Network error on an idempotent POST is retried then succeeds",
@@ -316,11 +310,6 @@ RUBY_SKIP_REASONS = {
   "UpdateCalendar PUT retries when marked idempotent" => "Ruby SDK only retries GET",
   "PrioritizeAssignment POST retries when marked idempotent" => "Ruby SDK only retries GET",
   "DeprioritizeAssignment DELETE retries when marked idempotent" => "Ruby SDK only retries GET",
-  "Total count header is accessible" => "Ruby SDK paginate doesn't expose X-Total-Count metadata",
-  "Missing X-Total-Count returns zero" => "Ruby SDK paginate doesn't expose X-Total-Count metadata",
-  "Pagination stops at maxPages safety cap" => "Ruby SDK paginate doesn't expose truncation metadata",
-  "maxItems caps results across pages" => "Ruby SDK paginate doesn't support maxItems",
-  "maxItems landing exactly on the final item is not truncated" => "Ruby SDK paginate doesn't support maxItems",
   "DownloadURL retries on 503 at the auth'd first hop" => DOWNLOAD_RETRY_SKIP,
   "DownloadURL honors Retry-After on 429 at the auth'd first hop" => DOWNLOAD_RETRY_SKIP,
   "Network error on an idempotent POST is retried then succeeds" => "Ruby SDK only retries GET network errors; mutations go through single_request with no retry",
@@ -359,8 +348,14 @@ class TestRunner
         path_params: @test["pathParams"] || {},
         query_params: @test["queryParams"] || {},
         body: @test["requestBody"],
-        path: @test["path"] || ""
+        path: @test["path"] || "",
+        max_items: (@test["configOverrides"] || {})["maxItems"]
       )
+      # Consume-then-assert: pagination metadata (truncated in particular) is
+      # final only after the lazy enumeration completes, and consumption is
+      # what drives the follow-up page requests that requestCount observes.
+      # The enumerator itself is kept so responseMeta can reach .meta.
+      result.to_a if result.is_a?(Enumerator)
       verify_assertions(result: result, error: nil)
     rescue StandardError => e
       verify_assertions(result: nil, error: e)
@@ -776,7 +771,12 @@ class TestRunner
       when "responseMeta"
         field_path = assertion["path"]
         expected = assertion["expected"]
-        actual = result.is_a?(Hash) ? result[field_path] || result[field_path.to_sym] : nil
+        snake_field = field_path.gsub(/([A-Z])/) { "_#{Regexp.last_match(1).downcase}" }
+        actual = if result.respond_to?(:meta) && result.meta.respond_to?(snake_field)
+          result.meta.public_send(snake_field)
+        elsif result.is_a?(Hash)
+          result[field_path] || result[field_path.to_sym]
+        end
         unless actual == expected
           failures << "Expected responseMeta.#{field_path} = #{expected.inspect}, got #{actual.inspect}"
         end

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -84,9 +84,9 @@ class OperationMapper
     when "CreateProject"
       @account.projects.create(name: body["name"])
     when "ListTodos"
-      @account.todos.list(
-        todolist_id: path_params["todolistId"]
-      )
+      max_items ? \
+        @account.todos.list(todolist_id: path_params["todolistId"], max_items: max_items) : \
+        @account.todos.list(todolist_id: path_params["todolistId"])
     when "GetTodo"
       @account.todos.get(
         todo_id: path_params["todoId"]

--- a/rubric-audit.json
+++ b/rubric-audit.json
@@ -84,9 +84,7 @@
     },
     "2C.2": {
       "pass": true,
-      "waiver": true,
-      "note": "Ruby paginate returns Enumerator yielding items; X-Total-Count not exposed as metadata",
-      "language": "ruby"
+      "note": "All six SDKs expose the X-Total-Count header as pagination metadata. A prior Ruby waiver ('paginate returns Enumerator yielding items; X-Total-Count not exposed') is obsolete: Ruby's paginators now return a ListEnumerator carrying ListMeta, with the first page fetched eagerly so meta.total_count (0 when the header is absent) is available at call time, and the Ruby runner passes the totalCount conformance cases un-skipped."
     },
     "1B.6": {
       "pass": true,
@@ -96,15 +94,11 @@
     },
     "2C.4": {
       "pass": true,
-      "waiver": true,
-      "note": "Ruby paginate returns lazy Enumerator; maxItems cap requires ListResult refactor (separate PR)",
-      "language": "ruby"
+      "note": "All six SDKs support a client-side item cap on auto-pagination. A prior Ruby waiver ('lazy Enumerator; maxItems cap requires ListResult refactor') is obsolete: every generated Ruby list method now accepts max_items (non-positive values disable the cap, matching the other SDKs), enumeration stops at the cap without fetching further pages, and the Ruby runner passes both maxItems conformance cases un-skipped."
     },
     "2C.6": {
       "pass": true,
-      "waiver": true,
-      "note": "Ruby paginate Enumerator does not expose truncation metadata; requires ListResult refactor (separate PR)",
-      "language": "ruby"
+      "note": "All six SDKs expose truncation metadata with the shared contract (truncated only when items were dropped or a next Link was left unfetched; an exact-boundary cap is not truncation). A prior Ruby waiver ('Enumerator does not expose truncation metadata') is obsolete: Ruby's ListEnumerator carries meta.truncated, finalized once the lazy enumeration completes, and the Ruby runner consumes-then-asserts the truncated conformance cases un-skipped."
     }
   }
 }

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -316,7 +316,10 @@ The SDK provides 46 account-scoped services. The table below covers the common o
 
 ## Pagination
 
-All list methods return lazy Enumerators that automatically handle pagination:
+All list methods return a lazy `ListEnumerator` — an `Enumerator` subclass
+that automatically handles pagination and carries metadata. The first page is
+fetched when the method is called; later pages are fetched only as iteration
+demands them:
 
 ```ruby
 # Automatically fetches all pages
@@ -324,12 +327,40 @@ account.projects.list.each do |project|
   puts project["name"]
 end
 
-# Take only what you need
+# Take only what you need — no extra pages are fetched
 first_10 = account.todos.list(todolist_id: 456).take(10)
 
 # Convert to array (fetches all pages)
 all_projects = account.projects.list.to_a
 ```
+
+Pagination is automatic: the SDK follows Link headers up to `config.max_pages`
+(default: 10,000). The enumerator's `meta` exposes pagination metadata:
+
+```ruby
+projects = account.projects.list
+projects.meta.total_count  # X-Total-Count from the first page (0 if absent),
+                           # available immediately — page 1 is fetched eagerly
+projects.to_a
+projects.meta.truncated    # true if items beyond those yielded were available
+```
+
+Every list method also accepts a `max_items` keyword to cap how many items are
+yielded. Enumeration stops as soon as the cap is met, without fetching further
+pages. Zero or negative values disable the cap, as in the other SDKs:
+
+```ruby
+recent = account.projects.list(max_items: 50)
+recent.to_a
+recent.meta.truncated  # true only if more items were available
+```
+
+`meta.truncated` is final once enumeration completes, and is `true` only when
+items beyond those yielded were available — items were dropped by `max_items`,
+or the last-fetched page still advertised a next page when enumeration stopped
+(at `max_items` or the `max_pages` safety cap). Landing exactly on the final
+item is not truncation: when `truncated` is `false` after full enumeration,
+the result is definitely complete.
 
 ## Downloading Files
 

--- a/ruby/lib/basecamp/client.rb
+++ b/ruby/lib/basecamp/client.rb
@@ -202,10 +202,12 @@ module Basecamp
     # Fetches all pages of a paginated resource.
     # @param path [String] URL path (without account prefix)
     # @param params [Hash] query parameters
+    # @param max_items [Integer, nil] cap on items yielded across pages;
+    #   nil or non-positive means no cap
     # @yield [Hash] each item from the response
-    # @return [Enumerator] if no block given
-    def paginate(path, params: {}, operation: nil, &)
-      @parent.http.paginate(account_path(path), params: params, operation: operation, &)
+    # @return [ListEnumerator] metadata-carrying lazy enumerator
+    def paginate(path, params: {}, operation: nil, max_items: nil, &)
+      @parent.http.paginate(account_path(path), params: params, operation: operation, max_items: max_items, &)
     end
 
     # Fetches all pages of a paginated resource, extracting items from a key.
@@ -213,19 +215,25 @@ module Basecamp
     # @param path [String] URL path (without account prefix)
     # @param key [String] the key containing the array of items
     # @param params [Hash] query parameters
+    # @param max_items [Integer, nil] cap on items yielded across pages;
+    #   nil or non-positive means no cap
     # @yield [Hash] each item from the response
-    # @return [Enumerator] if no block given
-    def paginate_key(path, key:, params: {}, operation: nil, &)
-      @parent.http.paginate_key(account_path(path), key: key, params: params, operation: operation, &)
+    # @return [ListEnumerator] metadata-carrying lazy enumerator
+    def paginate_key(path, key:, params: {}, operation: nil, max_items: nil, &)
+      @parent.http.paginate_key(account_path(path), key: key, params: params, operation: operation, \
+        max_items: max_items, &)
     end
 
     # Fetches a wrapped paginated resource, returning wrapper fields + lazy paginated items.
     # @param path [String] URL path (without account prefix)
     # @param key [String] the key containing the array of paginated items
     # @param params [Hash] query parameters
-    # @return [Hash] wrapper fields merged with key => Enumerator of all items
-    def paginate_wrapped(path, key:, params: {}, operation: nil)
-      @parent.http.paginate_wrapped(account_path(path), key: key, params: params, operation: operation)
+    # @param max_items [Integer, nil] cap on items yielded across pages;
+    #   nil or non-positive means no cap
+    # @return [Hash] wrapper fields merged with key => ListEnumerator of all items
+    def paginate_wrapped(path, key:, params: {}, operation: nil, max_items: nil)
+      @parent.http.paginate_wrapped(account_path(path), key: key, params: params, operation: operation, \
+        max_items: max_items)
     end
 
     # Downloads file content from any API-routable download URL.

--- a/ruby/lib/basecamp/generated/services/base_service.rb
+++ b/ruby/lib/basecamp/generated/services/base_service.rb
@@ -61,7 +61,9 @@ module Basecamp
       # metadata carried by the inner ListEnumerator.
       # Fires on_operation_start eagerly (paginate fetches page 1 inside the
       # yield, so the start hook must precede it); on_operation_end fires via
-      # ensure when iteration completes, errors, or is cut short by break/take.
+      # ensure when the first traversal completes, errors, or is cut short by
+      # break/take — exactly once, so re-enumerating never emits an
+      # on_operation_end without a matching start.
       def wrap_paginated(service:, operation:, is_mutation: false, project_id: nil, resource_id: nil)
         info = OperationInfo.new(
           service: service, operation: operation,
@@ -79,6 +81,7 @@ module Basecamp
           raise
         end
 
+        ended = false
         ListEnumerator.new(enum.meta) do |yielder|
           error = nil
           begin
@@ -87,15 +90,19 @@ module Basecamp
             error = e
             raise
           ensure
-            duration = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) * 1000).round
-            safe_hook { hooks.on_operation_end(info, OperationResult.new(duration_ms: duration, error: error)) }
+            unless ended
+              ended = true
+              duration = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) * 1000).round
+              safe_hook { hooks.on_operation_end(info, OperationResult.new(duration_ms: duration, error: error)) }
+            end
           end
         end
       end
 
       # Wraps a wrapped-paginated operation with hooks.
-      # Fires on_operation_start eagerly (before page 1 fetch),
-      # on_operation_end when the events Enumerator completes/errors/breaks.
+      # Fires on_operation_start eagerly (before page 1 fetch), and
+      # on_operation_end exactly once, when the first traversal of the events
+      # Enumerator completes/errors/breaks.
       def wrap_paginated_wrapped(key:, service:, operation:, is_mutation: false, project_id: nil, resource_id: nil)
         info = OperationInfo.new(
           service: service, operation: operation,
@@ -114,6 +121,7 @@ module Basecamp
         end
 
         inner_enum = result[key]
+        ended = false
         wrapped_enum = ListEnumerator.new(inner_enum.meta) do |yielder|
           error = nil
           begin
@@ -122,8 +130,13 @@ module Basecamp
             error = e
             raise
           ensure
-            duration = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) * 1000).round
-            safe_hook { hooks.on_operation_end(info, OperationResult.new(duration_ms: duration, error: error)) }
+            # Exactly once: on_operation_start fired once at call time, so
+            # re-enumerating must not emit unmatched on_operation_end events.
+            unless ended
+              ended = true
+              duration = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) * 1000).round
+              safe_hook { hooks.on_operation_end(info, OperationResult.new(duration_ms: duration, error: error)) }
+            end
           end
         end
 

--- a/ruby/lib/basecamp/generated/services/base_service.rb
+++ b/ruby/lib/basecamp/generated/services/base_service.rb
@@ -57,23 +57,31 @@ module Basecamp
         raise
       end
 
-      # Wraps a lazy Enumerator so operation hooks fire around actual iteration,
-      # not at enumerator creation time. Hooks fire when the consumer begins
-      # iterating (.each, .to_a, .first, etc.) and end fires via ensure when
-      # iteration completes, errors, or is cut short by break/take.
+      # Wraps a paginated operation with hooks, preserving the pagination
+      # metadata carried by the inner ListEnumerator.
+      # Fires on_operation_start eagerly (paginate fetches page 1 inside the
+      # yield, so the start hook must precede it); on_operation_end fires via
+      # ensure when iteration completes, errors, or is cut short by break/take.
       def wrap_paginated(service:, operation:, is_mutation: false, project_id: nil, resource_id: nil)
         info = OperationInfo.new(
           service: service, operation: operation,
           is_mutation: is_mutation, project_id: project_id, resource_id: resource_id
         )
-        enum = yield
-
         hooks = @hooks
-        Enumerator.new do |yielder|
-          start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        safe_hook { hooks.on_operation_start(info) }
+
+        begin
+          enum = yield  # paginate fetches page 1 here
+        rescue => e
+          duration = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) * 1000).round
+          safe_hook { hooks.on_operation_end(info, OperationResult.new(duration_ms: duration, error: e)) }
+          raise
+        end
+
+        ListEnumerator.new(enum.meta) do |yielder|
           error = nil
           begin
-            safe_hook { hooks.on_operation_start(info) }
             enum.each { |item| yielder.yield(item) }
           rescue => e
             error = e
@@ -106,7 +114,7 @@ module Basecamp
         end
 
         inner_enum = result[key]
-        wrapped_enum = Enumerator.new do |yielder|
+        wrapped_enum = ListEnumerator.new(inner_enum.meta) do |yielder|
           error = nil
           begin
             inner_enum.each { |item| yielder.yield(item) }

--- a/ruby/lib/basecamp/generated/services/bookmarks_service.rb
+++ b/ruby/lib/basecamp/generated/services/bookmarks_service.rb
@@ -9,11 +9,12 @@ module Basecamp
 
       # List the current user's bookmarks, most recently bookmarked first (paginated).
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
-      # @return [Enumerator<Hash>] paginated results
-      def list_my_bookmarks(page: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list_my_bookmarks(page: nil, max_items: nil)
         wrap_paginated(service: "bookmarks", operation: "list_my_bookmarks", is_mutation: false) do
           params = compact_query_params(page: page)
-          paginate("/my/bookmarks.json", params: params, operation: "ListMyBookmarks")
+          paginate("/my/bookmarks.json", params: params, operation: "ListMyBookmarks", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/boosts_service.rb
+++ b/ruby/lib/basecamp/generated/services/boosts_service.rb
@@ -28,10 +28,11 @@ module Basecamp
 
       # List boosts on a recording
       # @param recording_id [Integer] recording id ID
-      # @return [Enumerator<Hash>] paginated results
-      def list_recording_boosts(recording_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list_recording_boosts(recording_id:, max_items: nil)
         wrap_paginated(service: "boosts", operation: "list_recording_boosts", is_mutation: false, resource_id: recording_id) do
-          paginate("/recordings/#{recording_id}/boosts.json", operation: "ListRecordingBoosts")
+          paginate("/recordings/#{recording_id}/boosts.json", operation: "ListRecordingBoosts", max_items: max_items)
         end
       end
 
@@ -48,10 +49,11 @@ module Basecamp
       # List boosts on a specific event within a recording
       # @param recording_id [Integer] recording id ID
       # @param event_id [Integer] event id ID
-      # @return [Enumerator<Hash>] paginated results
-      def list_event_boosts(recording_id:, event_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list_event_boosts(recording_id:, event_id:, max_items: nil)
         wrap_paginated(service: "boosts", operation: "list_event_boosts", is_mutation: false, resource_id: event_id) do
-          paginate("/recordings/#{recording_id}/events/#{event_id}/boosts.json", operation: "ListEventBoosts")
+          paginate("/recordings/#{recording_id}/events/#{event_id}/boosts.json", operation: "ListEventBoosts", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/campfires_service.rb
+++ b/ruby/lib/basecamp/generated/services/campfires_service.rb
@@ -10,10 +10,11 @@ module Basecamp
     class CampfiresService < BaseService
 
       # List all campfires across the account
-      # @return [Enumerator<Hash>] paginated results
-      def list()
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(max_items: nil)
         wrap_paginated(service: "campfires", operation: "list", is_mutation: false) do
-          paginate("/chats.json", operation: "ListCampfires")
+          paginate("/chats.json", operation: "ListCampfires", max_items: max_items)
         end
       end
 
@@ -28,10 +29,11 @@ module Basecamp
 
       # List all chatbots for a campfire
       # @param campfire_id [Integer] campfire id ID
-      # @return [Enumerator<Hash>] paginated results
-      def list_chatbots(campfire_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list_chatbots(campfire_id:, max_items: nil)
         wrap_paginated(service: "campfires", operation: "list_chatbots", is_mutation: false, resource_id: campfire_id) do
-          paginate("/chats/#{campfire_id}/integrations.json", operation: "ListChatbots")
+          paginate("/chats/#{campfire_id}/integrations.json", operation: "ListChatbots", max_items: max_items)
         end
       end
 
@@ -83,11 +85,12 @@ module Basecamp
       # @param campfire_id [Integer] campfire id ID
       # @param sort [String, nil] created_at|updated_at
       # @param direction [String, nil] asc|desc
-      # @return [Enumerator<Hash>] paginated results
-      def list_lines(campfire_id:, sort: nil, direction: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list_lines(campfire_id:, sort: nil, direction: nil, max_items: nil)
         wrap_paginated(service: "campfires", operation: "list_lines", is_mutation: false, resource_id: campfire_id) do
           params = compact_query_params(sort: sort, direction: direction)
-          paginate("/chats/#{campfire_id}/lines.json", params: params, operation: "ListCampfireLines")
+          paginate("/chats/#{campfire_id}/lines.json", params: params, operation: "ListCampfireLines", max_items: max_items)
         end
       end
 
@@ -139,11 +142,12 @@ module Basecamp
       # @param campfire_id [Integer] campfire id ID
       # @param sort [String, nil] created_at|updated_at
       # @param direction [String, nil] asc|desc
-      # @return [Enumerator<Hash>] paginated results
-      def list_uploads(campfire_id:, sort: nil, direction: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list_uploads(campfire_id:, sort: nil, direction: nil, max_items: nil)
         wrap_paginated(service: "campfires", operation: "list_uploads", is_mutation: false, resource_id: campfire_id) do
           params = compact_query_params(sort: sort, direction: direction)
-          paginate("/chats/#{campfire_id}/uploads.json", params: params, operation: "ListCampfireUploads")
+          paginate("/chats/#{campfire_id}/uploads.json", params: params, operation: "ListCampfireUploads", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/cards_service.rb
+++ b/ruby/lib/basecamp/generated/services/cards_service.rb
@@ -43,10 +43,11 @@ module Basecamp
 
       # List cards in a column
       # @param column_id [Integer] column id ID
-      # @return [Enumerator<Hash>] paginated results
-      def list(column_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(column_id:, max_items: nil)
         wrap_paginated(service: "cards", operation: "list", is_mutation: false, resource_id: column_id) do
-          paginate("/card_tables/lists/#{column_id}/cards.json", operation: "ListCards")
+          paginate("/card_tables/lists/#{column_id}/cards.json", operation: "ListCards", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/checkins_service.rb
+++ b/ruby/lib/basecamp/generated/services/checkins_service.rb
@@ -8,10 +8,11 @@ module Basecamp
     class CheckinsService < BaseService
 
       # Get pending check-in reminders for the current user
-      # @return [Enumerator<Hash>] paginated results
-      def reminders()
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def reminders(max_items: nil)
         wrap_paginated(service: "checkins", operation: "reminders", is_mutation: false) do
-          paginate("/my/question_reminders.json", operation: "GetQuestionReminders")
+          paginate("/my/question_reminders.json", operation: "GetQuestionReminders", max_items: max_items)
         end
       end
 
@@ -47,10 +48,11 @@ module Basecamp
 
       # List all questions in a questionnaire
       # @param questionnaire_id [Integer] questionnaire id ID
-      # @return [Enumerator<Hash>] paginated results
-      def list_questions(questionnaire_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list_questions(questionnaire_id:, max_items: nil)
         wrap_paginated(service: "checkins", operation: "list_questions", is_mutation: false, resource_id: questionnaire_id) do
-          paginate("/questionnaires/#{questionnaire_id}/questions.json", operation: "ListQuestions")
+          paginate("/questionnaires/#{questionnaire_id}/questions.json", operation: "ListQuestions", max_items: max_items)
         end
       end
 
@@ -89,10 +91,11 @@ module Basecamp
 
       # List all answers for a question
       # @param question_id [Integer] question id ID
-      # @return [Enumerator<Hash>] paginated results
-      def list_answers(question_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list_answers(question_id:, max_items: nil)
         wrap_paginated(service: "checkins", operation: "list_answers", is_mutation: false, resource_id: question_id) do
-          paginate("/questions/#{question_id}/answers.json", operation: "ListAnswers")
+          paginate("/questions/#{question_id}/answers.json", operation: "ListAnswers", max_items: max_items)
         end
       end
 
@@ -109,20 +112,22 @@ module Basecamp
 
       # List all people who have answered a question (answerers)
       # @param question_id [Integer] question id ID
-      # @return [Enumerator<Hash>] paginated results
-      def answerers(question_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def answerers(question_id:, max_items: nil)
         wrap_paginated(service: "checkins", operation: "answerers", is_mutation: false, resource_id: question_id) do
-          paginate("/questions/#{question_id}/answers/by.json", operation: "ListQuestionAnswerers")
+          paginate("/questions/#{question_id}/answers/by.json", operation: "ListQuestionAnswerers", max_items: max_items)
         end
       end
 
       # Get all answers from a specific person for a question
       # @param question_id [Integer] question id ID
       # @param person_id [Integer] person id ID
-      # @return [Enumerator<Hash>] paginated results
-      def by_person(question_id:, person_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def by_person(question_id:, person_id:, max_items: nil)
         wrap_paginated(service: "checkins", operation: "by_person", is_mutation: false, resource_id: person_id) do
-          paginate("/questions/#{question_id}/answers/by/#{person_id}", operation: "GetAnswersByPerson")
+          paginate("/questions/#{question_id}/answers/by/#{person_id}", operation: "GetAnswersByPerson", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/client_approvals_service.rb
+++ b/ruby/lib/basecamp/generated/services/client_approvals_service.rb
@@ -10,11 +10,12 @@ module Basecamp
       # List all client approvals in a project
       # @param sort [String, nil] created_at|updated_at
       # @param direction [String, nil] asc|desc
-      # @return [Enumerator<Hash>] paginated results
-      def list(sort: nil, direction: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(sort: nil, direction: nil, max_items: nil)
         wrap_paginated(service: "clientapprovals", operation: "list", is_mutation: false) do
           params = compact_query_params(sort: sort, direction: direction)
-          paginate("/client/approvals.json", params: params, operation: "ListClientApprovals")
+          paginate("/client/approvals.json", params: params, operation: "ListClientApprovals", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/client_correspondences_service.rb
+++ b/ruby/lib/basecamp/generated/services/client_correspondences_service.rb
@@ -10,11 +10,12 @@ module Basecamp
       # List all client correspondences in a project
       # @param sort [String, nil] created_at|updated_at
       # @param direction [String, nil] asc|desc
-      # @return [Enumerator<Hash>] paginated results
-      def list(sort: nil, direction: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(sort: nil, direction: nil, max_items: nil)
         wrap_paginated(service: "clientcorrespondences", operation: "list", is_mutation: false) do
           params = compact_query_params(sort: sort, direction: direction)
-          paginate("/client/correspondences.json", params: params, operation: "ListClientCorrespondences")
+          paginate("/client/correspondences.json", params: params, operation: "ListClientCorrespondences", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/client_replies_service.rb
+++ b/ruby/lib/basecamp/generated/services/client_replies_service.rb
@@ -9,10 +9,11 @@ module Basecamp
 
       # List all client replies for a recording (correspondence or approval)
       # @param recording_id [Integer] recording id ID
-      # @return [Enumerator<Hash>] paginated results
-      def list(recording_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(recording_id:, max_items: nil)
         wrap_paginated(service: "clientreplies", operation: "list", is_mutation: false, resource_id: recording_id) do
-          paginate("/client/recordings/#{recording_id}/replies.json", operation: "ListClientReplies")
+          paginate("/client/recordings/#{recording_id}/replies.json", operation: "ListClientReplies", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/comments_service.rb
+++ b/ruby/lib/basecamp/generated/services/comments_service.rb
@@ -28,10 +28,11 @@ module Basecamp
 
       # List comments on a recording
       # @param recording_id [Integer] recording id ID
-      # @return [Enumerator<Hash>] paginated results
-      def list(recording_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(recording_id:, max_items: nil)
         wrap_paginated(service: "comments", operation: "list", is_mutation: false, resource_id: recording_id) do
-          paginate("/recordings/#{recording_id}/comments.json", operation: "ListComments")
+          paginate("/recordings/#{recording_id}/comments.json", operation: "ListComments", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/documents_service.rb
+++ b/ruby/lib/basecamp/generated/services/documents_service.rb
@@ -29,10 +29,11 @@ module Basecamp
 
       # List documents in a vault
       # @param vault_id [Integer] vault id ID
-      # @return [Enumerator<Hash>] paginated results
-      def list(vault_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(vault_id:, max_items: nil)
         wrap_paginated(service: "documents", operation: "list", is_mutation: false, resource_id: vault_id) do
-          paginate("/vaults/#{vault_id}/documents.json", operation: "ListDocuments")
+          paginate("/vaults/#{vault_id}/documents.json", operation: "ListDocuments", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/drafts_service.rb
+++ b/ruby/lib/basecamp/generated/services/drafts_service.rb
@@ -9,11 +9,12 @@ module Basecamp
 
       # List the current user's drafts across their active projects, most recently
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
-      # @return [Enumerator<Hash>] paginated results
-      def list_my_drafts(page: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list_my_drafts(page: nil, max_items: nil)
         wrap_paginated(service: "drafts", operation: "list_my_drafts", is_mutation: false) do
           params = compact_query_params(page: page)
-          paginate("/my/drafts.json", params: params, operation: "ListMyDrafts")
+          paginate("/my/drafts.json", params: params, operation: "ListMyDrafts", max_items: max_items)
         end
       end
     end

--- a/ruby/lib/basecamp/generated/services/events_service.rb
+++ b/ruby/lib/basecamp/generated/services/events_service.rb
@@ -9,10 +9,11 @@ module Basecamp
 
       # List all events for a recording
       # @param recording_id [Integer] recording id ID
-      # @return [Enumerator<Hash>] paginated results
-      def list(recording_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(recording_id:, max_items: nil)
         wrap_paginated(service: "events", operation: "list", is_mutation: false, resource_id: recording_id) do
-          paginate("/recordings/#{recording_id}/events.json", operation: "ListEvents")
+          paginate("/recordings/#{recording_id}/events.json", operation: "ListEvents", max_items: max_items)
         end
       end
     end

--- a/ruby/lib/basecamp/generated/services/everything_service.rb
+++ b/ruby/lib/basecamp/generated/services/everything_service.rb
@@ -12,11 +12,12 @@ module Basecamp
       #   Assignees on nested steps are not considered.
       # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
-      # @return [Enumerator<Hash>] paginated results
-      def get_everything_completed_cards(assignee_ids: nil, due: nil, page: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def get_everything_completed_cards(assignee_ids: nil, due: nil, page: nil, max_items: nil)
         wrap_paginated(service: "everything", operation: "get_everything_completed_cards", is_mutation: false) do
           params = compact_query_params(assignee_ids: assignee_ids, due: due, page: page)
-          paginate("/cards/completed.json", params: params, operation: "GetEverythingCompletedCards")
+          paginate("/cards/completed.json", params: params, operation: "GetEverythingCompletedCards", max_items: max_items)
         end
       end
 
@@ -25,11 +26,12 @@ module Basecamp
       #   Assignees on nested steps are not considered.
       # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
-      # @return [Enumerator<Hash>] paginated results
-      def get_everything_no_due_date_cards(assignee_ids: nil, due: nil, page: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def get_everything_no_due_date_cards(assignee_ids: nil, due: nil, page: nil, max_items: nil)
         wrap_paginated(service: "everything", operation: "get_everything_no_due_date_cards", is_mutation: false) do
           params = compact_query_params(assignee_ids: assignee_ids, due: due, page: page)
-          paginate("/cards/no_due_date.json", params: params, operation: "GetEverythingNoDueDateCards")
+          paginate("/cards/no_due_date.json", params: params, operation: "GetEverythingNoDueDateCards", max_items: max_items)
         end
       end
 
@@ -38,11 +40,12 @@ module Basecamp
       #   Assignees on nested steps are not considered.
       # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
-      # @return [Enumerator<Hash>] paginated results
-      def get_everything_not_now_cards(assignee_ids: nil, due: nil, page: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def get_everything_not_now_cards(assignee_ids: nil, due: nil, page: nil, max_items: nil)
         wrap_paginated(service: "everything", operation: "get_everything_not_now_cards", is_mutation: false) do
           params = compact_query_params(assignee_ids: assignee_ids, due: due, page: page)
-          paginate("/cards/not_now.json", params: params, operation: "GetEverythingNotNowCards")
+          paginate("/cards/not_now.json", params: params, operation: "GetEverythingNotNowCards", max_items: max_items)
         end
       end
 
@@ -51,11 +54,12 @@ module Basecamp
       #   Assignees on nested steps are not considered.
       # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
-      # @return [Enumerator<Hash>] paginated results
-      def get_everything_open_cards(assignee_ids: nil, due: nil, page: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def get_everything_open_cards(assignee_ids: nil, due: nil, page: nil, max_items: nil)
         wrap_paginated(service: "everything", operation: "get_everything_open_cards", is_mutation: false) do
           params = compact_query_params(assignee_ids: assignee_ids, due: due, page: page)
-          paginate("/cards/open.json", params: params, operation: "GetEverythingOpenCards")
+          paginate("/cards/open.json", params: params, operation: "GetEverythingOpenCards", max_items: max_items)
         end
       end
 
@@ -75,31 +79,34 @@ module Basecamp
       #   Assignees on nested steps are not considered.
       # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
-      # @return [Enumerator<Hash>] paginated results
-      def get_everything_unassigned_cards(assignee_ids: nil, due: nil, page: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def get_everything_unassigned_cards(assignee_ids: nil, due: nil, page: nil, max_items: nil)
         wrap_paginated(service: "everything", operation: "get_everything_unassigned_cards", is_mutation: false) do
           params = compact_query_params(assignee_ids: assignee_ids, due: due, page: page)
-          paginate("/cards/unassigned.json", params: params, operation: "GetEverythingUnassignedCards")
+          paginate("/cards/unassigned.json", params: params, operation: "GetEverythingUnassignedCards", max_items: max_items)
         end
       end
 
       # Get every automatic check-in answer across all accessible projects, newest-first.
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
-      # @return [Enumerator<Hash>] paginated results
-      def get_everything_checkins(page: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def get_everything_checkins(page: nil, max_items: nil)
         wrap_paginated(service: "everything", operation: "get_everything_checkins", is_mutation: false) do
           params = compact_query_params(page: page)
-          paginate("/checkins.json", params: params, operation: "GetEverythingCheckins")
+          paginate("/checkins.json", params: params, operation: "GetEverythingCheckins", max_items: max_items)
         end
       end
 
       # Get every comment across all accessible projects, newest-first (paginated).
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
-      # @return [Enumerator<Hash>] paginated results
-      def get_everything_comments(page: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def get_everything_comments(page: nil, max_items: nil)
         wrap_paginated(service: "everything", operation: "get_everything_comments", is_mutation: false) do
           params = compact_query_params(page: page)
-          paginate("/comments.json", params: params, operation: "GetEverythingComments")
+          paginate("/comments.json", params: params, operation: "GetEverythingComments", max_items: max_items)
         end
       end
 
@@ -107,31 +114,34 @@ module Basecamp
       # @param kind [String, nil] Filter by file kind: all (default), images, pdfs, documents, or videos.
       # @param people_ids [Array, nil] Restrict to files created by the given people (repeatable).
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
-      # @return [Enumerator<Hash>] paginated results
-      def get_everything_files(kind: nil, people_ids: nil, page: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def get_everything_files(kind: nil, people_ids: nil, page: nil, max_items: nil)
         wrap_paginated(service: "everything", operation: "get_everything_files", is_mutation: false) do
           params = compact_query_params(kind: kind, people_ids: people_ids, page: page)
-          paginate("/files.json", params: params, operation: "GetEverythingFiles")
+          paginate("/files.json", params: params, operation: "GetEverythingFiles", max_items: max_items)
         end
       end
 
       # Get every inbox forward across all accessible projects, newest-first (paginated).
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
-      # @return [Enumerator<Hash>] paginated results
-      def get_everything_forwards(page: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def get_everything_forwards(page: nil, max_items: nil)
         wrap_paginated(service: "everything", operation: "get_everything_forwards", is_mutation: false) do
           params = compact_query_params(page: page)
-          paginate("/forwards.json", params: params, operation: "GetEverythingForwards")
+          paginate("/forwards.json", params: params, operation: "GetEverythingForwards", max_items: max_items)
         end
       end
 
       # Get every message across all accessible projects, newest-first (paginated).
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
-      # @return [Enumerator<Hash>] paginated results
-      def get_everything_messages(page: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def get_everything_messages(page: nil, max_items: nil)
         wrap_paginated(service: "everything", operation: "get_everything_messages", is_mutation: false) do
           params = compact_query_params(page: page)
-          paginate("/messages.json", params: params, operation: "GetEverythingMessages")
+          paginate("/messages.json", params: params, operation: "GetEverythingMessages", max_items: max_items)
         end
       end
 
@@ -140,11 +150,12 @@ module Basecamp
       #   Assignees on nested steps are not considered.
       # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
-      # @return [Enumerator<Hash>] paginated results
-      def get_everything_completed_todos(assignee_ids: nil, due: nil, page: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def get_everything_completed_todos(assignee_ids: nil, due: nil, page: nil, max_items: nil)
         wrap_paginated(service: "everything", operation: "get_everything_completed_todos", is_mutation: false) do
           params = compact_query_params(assignee_ids: assignee_ids, due: due, page: page)
-          paginate("/todos/completed.json", params: params, operation: "GetEverythingCompletedTodos")
+          paginate("/todos/completed.json", params: params, operation: "GetEverythingCompletedTodos", max_items: max_items)
         end
       end
 
@@ -153,11 +164,12 @@ module Basecamp
       #   Assignees on nested steps are not considered.
       # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
-      # @return [Enumerator<Hash>] paginated results
-      def get_everything_no_due_date_todos(assignee_ids: nil, due: nil, page: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def get_everything_no_due_date_todos(assignee_ids: nil, due: nil, page: nil, max_items: nil)
         wrap_paginated(service: "everything", operation: "get_everything_no_due_date_todos", is_mutation: false) do
           params = compact_query_params(assignee_ids: assignee_ids, due: due, page: page)
-          paginate("/todos/no_due_date.json", params: params, operation: "GetEverythingNoDueDateTodos")
+          paginate("/todos/no_due_date.json", params: params, operation: "GetEverythingNoDueDateTodos", max_items: max_items)
         end
       end
 
@@ -166,11 +178,12 @@ module Basecamp
       #   Assignees on nested steps are not considered.
       # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
-      # @return [Enumerator<Hash>] paginated results
-      def get_everything_open_todos(assignee_ids: nil, due: nil, page: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def get_everything_open_todos(assignee_ids: nil, due: nil, page: nil, max_items: nil)
         wrap_paginated(service: "everything", operation: "get_everything_open_todos", is_mutation: false) do
           params = compact_query_params(assignee_ids: assignee_ids, due: due, page: page)
-          paginate("/todos/open.json", params: params, operation: "GetEverythingOpenTodos")
+          paginate("/todos/open.json", params: params, operation: "GetEverythingOpenTodos", max_items: max_items)
         end
       end
 
@@ -190,11 +203,12 @@ module Basecamp
       #   Assignees on nested steps are not considered.
       # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
       # @param page [Integer, nil] Page number for paginating through results. Defaults to 1.
-      # @return [Enumerator<Hash>] paginated results
-      def get_everything_unassigned_todos(assignee_ids: nil, due: nil, page: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def get_everything_unassigned_todos(assignee_ids: nil, due: nil, page: nil, max_items: nil)
         wrap_paginated(service: "everything", operation: "get_everything_unassigned_todos", is_mutation: false) do
           params = compact_query_params(assignee_ids: assignee_ids, due: due, page: page)
-          paginate("/todos/unassigned.json", params: params, operation: "GetEverythingUnassignedTodos")
+          paginate("/todos/unassigned.json", params: params, operation: "GetEverythingUnassignedTodos", max_items: max_items)
         end
       end
     end

--- a/ruby/lib/basecamp/generated/services/forwards_service.rb
+++ b/ruby/lib/basecamp/generated/services/forwards_service.rb
@@ -18,10 +18,11 @@ module Basecamp
 
       # List all replies to a forward
       # @param forward_id [Integer] forward id ID
-      # @return [Enumerator<Hash>] paginated results
-      def list_replies(forward_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list_replies(forward_id:, max_items: nil)
         wrap_paginated(service: "forwards", operation: "list_replies", is_mutation: false, resource_id: forward_id) do
-          paginate("/inbox_forwards/#{forward_id}/replies.json", operation: "ListForwardReplies")
+          paginate("/inbox_forwards/#{forward_id}/replies.json", operation: "ListForwardReplies", max_items: max_items)
         end
       end
 
@@ -58,11 +59,12 @@ module Basecamp
       # @param inbox_id [Integer] inbox id ID
       # @param sort [String, nil] created_at|updated_at
       # @param direction [String, nil] asc|desc
-      # @return [Enumerator<Hash>] paginated results
-      def list(inbox_id:, sort: nil, direction: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(inbox_id:, sort: nil, direction: nil, max_items: nil)
         wrap_paginated(service: "forwards", operation: "list", is_mutation: false, resource_id: inbox_id) do
           params = compact_query_params(sort: sort, direction: direction)
-          paginate("/inboxes/#{inbox_id}/forwards.json", params: params, operation: "ListForwards")
+          paginate("/inboxes/#{inbox_id}/forwards.json", params: params, operation: "ListForwards", max_items: max_items)
         end
       end
     end

--- a/ruby/lib/basecamp/generated/services/gauges_service.rb
+++ b/ruby/lib/basecamp/generated/services/gauges_service.rb
@@ -49,10 +49,11 @@ module Basecamp
 
       # List gauge needles for a project, ordered newest first.
       # @param project_id [Integer] project id ID
-      # @return [Enumerator<Hash>] paginated results
-      def list_gauge_needles(project_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list_gauge_needles(project_id:, max_items: nil)
         wrap_paginated(service: "gauges", operation: "list_gauge_needles", is_mutation: false, project_id: project_id) do
-          paginate("/projects/#{project_id}/gauge/needles.json", operation: "ListGaugeNeedles")
+          paginate("/projects/#{project_id}/gauge/needles.json", operation: "ListGaugeNeedles", max_items: max_items)
         end
       end
 
@@ -71,11 +72,12 @@ module Basecamp
       # List gauges across all projects the authenticated user has access to.
       # @param bucket_ids [String, nil] Comma-separated list of project IDs. When provided, results are returned
       #   in the order specified instead of by risk level.
-      # @return [Enumerator<Hash>] paginated results
-      def list_gauges(bucket_ids: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list_gauges(bucket_ids: nil, max_items: nil)
         wrap_paginated(service: "gauges", operation: "list_gauges", is_mutation: false) do
           params = compact_query_params(bucket_ids: bucket_ids)
-          paginate("/reports/gauges.json", params: params, operation: "ListGauges")
+          paginate("/reports/gauges.json", params: params, operation: "ListGauges", max_items: max_items)
         end
       end
     end

--- a/ruby/lib/basecamp/generated/services/message_types_service.rb
+++ b/ruby/lib/basecamp/generated/services/message_types_service.rb
@@ -9,10 +9,11 @@ module Basecamp
 
       # List message types in a project
       # @param bucket_id [Integer] bucket id ID
-      # @return [Enumerator<Hash>] paginated results
-      def list(bucket_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(bucket_id:, max_items: nil)
         wrap_paginated(service: "messagetypes", operation: "list", is_mutation: false, project_id: bucket_id) do
-          paginate("/buckets/#{bucket_id}/categories.json", operation: "ListMessageTypes")
+          paginate("/buckets/#{bucket_id}/categories.json", operation: "ListMessageTypes", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/messages_service.rb
+++ b/ruby/lib/basecamp/generated/services/messages_service.rb
@@ -11,11 +11,12 @@ module Basecamp
       # @param board_id [Integer] board id ID
       # @param sort [String, nil] created_at|updated_at
       # @param direction [String, nil] asc|desc
-      # @return [Enumerator<Hash>] paginated results
-      def list(board_id:, sort: nil, direction: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(board_id:, sort: nil, direction: nil, max_items: nil)
         wrap_paginated(service: "messages", operation: "list", is_mutation: false, resource_id: board_id) do
           params = compact_query_params(sort: sort, direction: direction)
-          paginate("/message_boards/#{board_id}/messages.json", params: params, operation: "ListMessages")
+          paginate("/message_boards/#{board_id}/messages.json", params: params, operation: "ListMessages", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/my_notifications_service.rb
+++ b/ruby/lib/basecamp/generated/services/my_notifications_service.rb
@@ -22,11 +22,12 @@ module Basecamp
 
       # Get the current user's current and scheduled bubble-ups (paginated, 50 per page).
       # @param page [Integer, nil] Page number. Defaults to 1.
-      # @return [Enumerator<Hash>] paginated results
-      def get_bubble_ups(page: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def get_bubble_ups(page: nil, max_items: nil)
         wrap_paginated(service: "mynotifications", operation: "get_bubble_ups", is_mutation: false) do
           params = compact_query_params(page: page)
-          paginate("/my/readings/bubble_ups.json", params: params, operation: "GetBubbleUps")
+          paginate("/my/readings/bubble_ups.json", params: params, operation: "GetBubbleUps", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/people_service.rb
+++ b/ruby/lib/basecamp/generated/services/people_service.rb
@@ -8,10 +8,11 @@ module Basecamp
     class PeopleService < BaseService
 
       # List all account users who can be pinged
-      # @return [Enumerator<Hash>] paginated results
-      def list_pingable()
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list_pingable(max_items: nil)
         wrap_paginated(service: "people", operation: "list_pingable", is_mutation: false) do
-          paginate("/circles/people.json", operation: "ListPingablePeople")
+          paginate("/circles/people.json", operation: "ListPingablePeople", max_items: max_items)
         end
       end
 
@@ -58,10 +59,11 @@ module Basecamp
       end
 
       # List all people visible to the current user
-      # @return [Enumerator<Hash>] paginated results
-      def list()
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(max_items: nil)
         wrap_paginated(service: "people", operation: "list", is_mutation: false) do
-          paginate("/people.json", operation: "ListPeople")
+          paginate("/people.json", operation: "ListPeople", max_items: max_items)
         end
       end
 
@@ -105,10 +107,11 @@ module Basecamp
 
       # List all active people on a project
       # @param project_id [Integer] project id ID
-      # @return [Enumerator<Hash>] paginated results
-      def list_for_project(project_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list_for_project(project_id:, max_items: nil)
         wrap_paginated(service: "people", operation: "list_for_project", is_mutation: false, project_id: project_id) do
-          paginate("/projects/#{project_id}/people.json", operation: "ListProjectPeople")
+          paginate("/projects/#{project_id}/people.json", operation: "ListProjectPeople", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/projects_service.rb
+++ b/ruby/lib/basecamp/generated/services/projects_service.rb
@@ -9,11 +9,12 @@ module Basecamp
 
       # List projects (active by default; optionally archived/trashed)
       # @param status [String, nil] active|archived|trashed
-      # @return [Enumerator<Hash>] paginated results
-      def list(status: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(status: nil, max_items: nil)
         wrap_paginated(service: "projects", operation: "list", is_mutation: false) do
           params = compact_query_params(status: status)
-          paginate("/projects.json", params: params, operation: "ListProjects")
+          paginate("/projects.json", params: params, operation: "ListProjects", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/recordings_service.rb
+++ b/ruby/lib/basecamp/generated/services/recordings_service.rb
@@ -13,11 +13,12 @@ module Basecamp
       # @param status [String, nil] active|archived|trashed
       # @param sort [String, nil] created_at|updated_at
       # @param direction [String, nil] asc|desc
-      # @return [Enumerator<Hash>] paginated results
-      def list(type:, bucket: nil, status: nil, sort: nil, direction: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(type:, bucket: nil, status: nil, sort: nil, direction: nil, max_items: nil)
         wrap_paginated(service: "recordings", operation: "list", is_mutation: false) do
           params = compact_query_params(type: type, bucket: bucket, status: status, sort: sort, direction: direction)
-          paginate("/projects/recordings.json", params: params, operation: "ListRecordings")
+          paginate("/projects/recordings.json", params: params, operation: "ListRecordings", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/reports_service.rb
+++ b/ruby/lib/basecamp/generated/services/reports_service.rb
@@ -8,10 +8,11 @@ module Basecamp
     class ReportsService < BaseService
 
       # Get account-wide activity feed (progress report)
-      # @return [Enumerator<Hash>] paginated results
-      def progress()
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def progress(max_items: nil)
         wrap_paginated(service: "reports", operation: "progress", is_mutation: false) do
-          paginate("/reports/progress.json", operation: "GetProgressReport")
+          paginate("/reports/progress.json", operation: "GetProgressReport", max_items: max_items)
         end
       end
 
@@ -45,10 +46,11 @@ module Basecamp
 
       # Get a person's activity timeline
       # @param person_id [Integer] person id ID
-      # @return [Hash] response data
-      def person_progress(person_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [Hash] wrapper fields merged with a ListEnumerator of the paginated items
+      def person_progress(person_id:, max_items: nil)
         wrap_paginated_wrapped(key: "events", service: "reports", operation: "person_progress", is_mutation: false, resource_id: person_id) do
-          paginate_wrapped("/reports/users/progress/#{person_id}.json", key: "events", operation: "GetPersonProgress")
+          paginate_wrapped("/reports/users/progress/#{person_id}.json", key: "events", operation: "GetPersonProgress", max_items: max_items)
         end
       end
     end

--- a/ruby/lib/basecamp/generated/services/schedules_service.rb
+++ b/ruby/lib/basecamp/generated/services/schedules_service.rb
@@ -72,11 +72,12 @@ module Basecamp
       # List entries on a schedule
       # @param schedule_id [Integer] schedule id ID
       # @param status [String, nil] active|archived|trashed
-      # @return [Enumerator<Hash>] paginated results
-      def list_entries(schedule_id:, status: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list_entries(schedule_id:, status: nil, max_items: nil)
         wrap_paginated(service: "schedules", operation: "list_entries", is_mutation: false, resource_id: schedule_id) do
           params = compact_query_params(status: status)
-          paginate("/schedules/#{schedule_id}/entries.json", params: params, operation: "ListScheduleEntries")
+          paginate("/schedules/#{schedule_id}/entries.json", params: params, operation: "ListScheduleEntries", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/search_service.rb
+++ b/ruby/lib/basecamp/generated/services/search_service.rb
@@ -21,11 +21,12 @@ module Basecamp
       # @param type [String, nil] Deprecated: prefer type_names[].
       # @param bucket_id [Integer, nil] Deprecated: prefer bucket_ids[].
       # @param creator_id [Integer, nil] Deprecated: prefer creator_ids[].
-      # @return [Enumerator<Hash>] paginated results
-      def search(q:, type_names: nil, bucket_ids: nil, creator_ids: nil, file_type: nil, exclude_chat: nil, since: nil, sort: nil, type: nil, bucket_id: nil, creator_id: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def search(q:, type_names: nil, bucket_ids: nil, creator_ids: nil, file_type: nil, exclude_chat: nil, since: nil, sort: nil, type: nil, bucket_id: nil, creator_id: nil, max_items: nil)
         wrap_paginated(service: "search", operation: "search", is_mutation: false) do
           params = compact_query_params(q: q, type_names: type_names, bucket_ids: bucket_ids, creator_ids: creator_ids, file_type: file_type, exclude_chat: exclude_chat, since: since, sort: sort, type: type, bucket_id: bucket_id, creator_id: creator_id)
-          paginate("/search.json", params: params, operation: "Search")
+          paginate("/search.json", params: params, operation: "Search", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/templates_service.rb
+++ b/ruby/lib/basecamp/generated/services/templates_service.rb
@@ -9,11 +9,12 @@ module Basecamp
 
       # List all templates visible to the current user
       # @param status [String, nil] active|archived|trashed
-      # @return [Enumerator<Hash>] paginated results
-      def list(status: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(status: nil, max_items: nil)
         wrap_paginated(service: "templates", operation: "list", is_mutation: false) do
           params = compact_query_params(status: status)
-          paginate("/templates.json", params: params, operation: "ListTemplates")
+          paginate("/templates.json", params: params, operation: "ListTemplates", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/timeline_service.rb
+++ b/ruby/lib/basecamp/generated/services/timeline_service.rb
@@ -9,10 +9,11 @@ module Basecamp
 
       # Get project timeline
       # @param project_id [Integer] project id ID
-      # @return [Enumerator<Hash>] paginated results
-      def get_project_timeline(project_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def get_project_timeline(project_id:, max_items: nil)
         wrap_paginated(service: "timeline", operation: "get_project_timeline", is_mutation: false, project_id: project_id) do
-          paginate("/projects/#{project_id}/timeline.json", operation: "GetProjectTimeline")
+          paginate("/projects/#{project_id}/timeline.json", operation: "GetProjectTimeline", max_items: max_items)
         end
       end
     end

--- a/ruby/lib/basecamp/generated/services/timesheets_service.rb
+++ b/ruby/lib/basecamp/generated/services/timesheets_service.rb
@@ -12,11 +12,12 @@ module Basecamp
       # @param from [String, nil] from
       # @param to [String, nil] to
       # @param person_id [Integer, nil] person id
-      # @return [Enumerator<Hash>] paginated results
-      def for_project(project_id:, from: nil, to: nil, person_id: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def for_project(project_id:, from: nil, to: nil, person_id: nil, max_items: nil)
         wrap_paginated(service: "timesheets", operation: "for_project", is_mutation: false, project_id: project_id) do
           params = compact_query_params(from: from, to: to, person_id: person_id)
-          paginate("/projects/#{project_id}/timesheet.json", params: params, operation: "GetProjectTimesheet")
+          paginate("/projects/#{project_id}/timesheet.json", params: params, operation: "GetProjectTimesheet", max_items: max_items)
         end
       end
 
@@ -25,11 +26,12 @@ module Basecamp
       # @param from [String, nil] from
       # @param to [String, nil] to
       # @param person_id [Integer, nil] person id
-      # @return [Enumerator<Hash>] paginated results
-      def for_recording(recording_id:, from: nil, to: nil, person_id: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def for_recording(recording_id:, from: nil, to: nil, person_id: nil, max_items: nil)
         wrap_paginated(service: "timesheets", operation: "for_recording", is_mutation: false, resource_id: recording_id) do
           params = compact_query_params(from: from, to: to, person_id: person_id)
-          paginate("/recordings/#{recording_id}/timesheet.json", params: params, operation: "GetRecordingTimesheet")
+          paginate("/recordings/#{recording_id}/timesheet.json", params: params, operation: "GetRecordingTimesheet", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/todolist_groups_service.rb
+++ b/ruby/lib/basecamp/generated/services/todolist_groups_service.rb
@@ -20,10 +20,11 @@ module Basecamp
 
       # List groups in a todolist
       # @param todolist_id [Integer] todolist id ID
-      # @return [Enumerator<Hash>] paginated results
-      def list(todolist_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(todolist_id:, max_items: nil)
         wrap_paginated(service: "todolistgroups", operation: "list", is_mutation: false, resource_id: todolist_id) do
-          paginate("/todolists/#{todolist_id}/groups.json", operation: "ListTodolistGroups")
+          paginate("/todolists/#{todolist_id}/groups.json", operation: "ListTodolistGroups", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/todolists_service.rb
+++ b/ruby/lib/basecamp/generated/services/todolists_service.rb
@@ -41,11 +41,12 @@ module Basecamp
       # List todolists in a todoset
       # @param todoset_id [Integer] todoset id ID
       # @param status [String, nil] active|archived|trashed
-      # @return [Enumerator<Hash>] paginated results
-      def list(todoset_id:, status: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(todoset_id:, status: nil, max_items: nil)
         wrap_paginated(service: "todolists", operation: "list", is_mutation: false, resource_id: todoset_id) do
           params = compact_query_params(status: status)
-          paginate("/todosets/#{todoset_id}/todolists.json", params: params, operation: "ListTodolists")
+          paginate("/todosets/#{todoset_id}/todolists.json", params: params, operation: "ListTodolists", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/todos_service.rb
+++ b/ruby/lib/basecamp/generated/services/todos_service.rb
@@ -28,11 +28,12 @@ module Basecamp
       # @param todolist_id [Integer] todolist id ID
       # @param status [String, nil] active|archived|trashed
       # @param completed [Boolean, nil] completed
-      # @return [Enumerator<Hash>] paginated results
-      def list(todolist_id:, status: nil, completed: nil)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(todolist_id:, status: nil, completed: nil, max_items: nil)
         wrap_paginated(service: "todos", operation: "list", is_mutation: false, resource_id: todolist_id) do
           params = compact_query_params(status: status, completed: completed)
-          paginate("/todolists/#{todolist_id}/todos.json", params: params, operation: "ListTodos")
+          paginate("/todolists/#{todolist_id}/todos.json", params: params, operation: "ListTodos", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/uploads_service.rb
+++ b/ruby/lib/basecamp/generated/services/uploads_service.rb
@@ -29,19 +29,21 @@ module Basecamp
 
       # List versions of an upload
       # @param upload_id [Integer] upload id ID
-      # @return [Enumerator<Hash>] paginated results
-      def list_versions(upload_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list_versions(upload_id:, max_items: nil)
         wrap_paginated(service: "uploads", operation: "list_versions", is_mutation: false, resource_id: upload_id) do
-          paginate("/uploads/#{upload_id}/versions.json", operation: "ListUploadVersions")
+          paginate("/uploads/#{upload_id}/versions.json", operation: "ListUploadVersions", max_items: max_items)
         end
       end
 
       # List uploads in a vault
       # @param vault_id [Integer] vault id ID
-      # @return [Enumerator<Hash>] paginated results
-      def list(vault_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(vault_id:, max_items: nil)
         wrap_paginated(service: "uploads", operation: "list", is_mutation: false, resource_id: vault_id) do
-          paginate("/vaults/#{vault_id}/uploads.json", operation: "ListUploads")
+          paginate("/vaults/#{vault_id}/uploads.json", operation: "ListUploads", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/vaults_service.rb
+++ b/ruby/lib/basecamp/generated/services/vaults_service.rb
@@ -28,10 +28,11 @@ module Basecamp
 
       # List vaults (subfolders) in a vault
       # @param vault_id [Integer] vault id ID
-      # @return [Enumerator<Hash>] paginated results
-      def list(vault_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(vault_id:, max_items: nil)
         wrap_paginated(service: "vaults", operation: "list", is_mutation: false, resource_id: vault_id) do
-          paginate("/vaults/#{vault_id}/vaults.json", operation: "ListVaults")
+          paginate("/vaults/#{vault_id}/vaults.json", operation: "ListVaults", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/generated/services/webhooks_service.rb
+++ b/ruby/lib/basecamp/generated/services/webhooks_service.rb
@@ -9,10 +9,11 @@ module Basecamp
 
       # List all webhooks for a project
       # @param bucket_id [Integer] bucket id ID
-      # @return [Enumerator<Hash>] paginated results
-      def list(bucket_id:)
+      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
+      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
+      def list(bucket_id:, max_items: nil)
         wrap_paginated(service: "webhooks", operation: "list", is_mutation: false, project_id: bucket_id) do
-          paginate("/buckets/#{bucket_id}/webhooks.json", operation: "ListWebhooks")
+          paginate("/buckets/#{bucket_id}/webhooks.json", operation: "ListWebhooks", max_items: max_items)
         end
       end
 

--- a/ruby/lib/basecamp/http.rb
+++ b/ruby/lib/basecamp/http.rb
@@ -269,13 +269,14 @@ module Basecamp
 
           capped = false
           items.each_with_index do |item, index|
-            yielder << item
             yielded += 1
-            next unless max_items && yielded >= max_items
-
-            meta.mark_truncated! if index < items.size - 1 || next_link
-            capped = true
-            break
+            capped = max_items && yielded >= max_items
+            # Truncation is recorded before the capping yield: consumers like
+            # first/take cancel the producer at that yield, and the metadata
+            # must already be accurate once the capped item is delivered.
+            meta.mark_truncated! if capped && (index < items.size - 1 || next_link)
+            yielder << item
+            break if capped
           end
           break if capped
           break if next_link.nil?

--- a/ruby/lib/basecamp/http.rb
+++ b/ruby/lib/basecamp/http.rb
@@ -257,6 +257,7 @@ module Basecamp
           @hooks.on_paginate(base_url, 1)
           response = get(base_url, params: params, operation: operation)
           items = extract_page_items(parse_page(response, page: 1), key: key, page: 1)
+          meta.restart!(total_count: parse_total_count(response.headers))
         end
 
         yielded = 0

--- a/ruby/lib/basecamp/http.rb
+++ b/ruby/lib/basecamp/http.rb
@@ -170,97 +170,33 @@ module Basecamp
     end
 
     # Fetches all pages of a paginated resource.
+    # The first page is fetched eagerly, so pagination metadata (and any
+    # page-1 error) surfaces at call time; later pages are fetched lazily
+    # as enumeration demands them.
     # @param path [String] initial URL path
     # @param params [Hash] query parameters
+    # @param max_items [Integer, nil] cap on items yielded across pages;
+    #   nil or non-positive means no cap
     # @yield [Hash] each item from the response
-    # @return [Enumerator] if no block given
-    def paginate(path, params: {}, operation: nil, &block)
-      return to_enum(:paginate, path, params: params, operation: operation) unless block
-
-      base_url = build_url(path)
-      url = base_url
-      page = 0
-
-      loop do
-        page += 1
-        break if page > @config.max_pages
-
-        @hooks.on_paginate(url, page)
-        response = get(url, params: page == 1 ? params : {}, operation: operation)
-
-        Security.check_body_size!(response.body, Security::MAX_RESPONSE_BODY_BYTES)
-
-        begin
-          items = JSON.parse(response.body)
-          Http.normalize_person_ids(items)
-        rescue JSON::ParserError => e
-          raise Basecamp::ApiError.new("Failed to parse paginated response (page #{page}): #{Security.truncate(e.message)}")
-        end
-        items.each(&block)
-
-        next_url = parse_next_link(response.headers["Link"])
-        break if next_url.nil?
-
-        next_url = Security.resolve_url(url, next_url)
-
-        unless Security.same_origin?(next_url, base_url)
-          raise Basecamp::ApiError.new(
-            "Pagination Link header points to different origin: #{Security.truncate(next_url)}"
-          )
-        end
-
-        url = next_url
-      end
+    # @return [ListEnumerator] metadata-carrying lazy enumerator
+    def paginate(path, params: {}, operation: nil, max_items: nil, &block)
+      enum = paginated_enumerator(path, params: params, operation: operation, max_items: max_items)
+      block ? enum.each(&block) : enum
     end
 
     # Fetches all pages of a paginated resource, extracting items from a key.
     # Use this for endpoints that return objects like { "events": [...] }.
+    # The first page is fetched eagerly; later pages are fetched lazily.
     # @param path [String] initial URL path
     # @param key [String] the key containing the array of items
     # @param params [Hash] query parameters
+    # @param max_items [Integer, nil] cap on items yielded across pages;
+    #   nil or non-positive means no cap
     # @yield [Hash] each item from the response
-    # @return [Enumerator] if no block given
-    def paginate_key(path, key:, params: {}, operation: nil, &block)
-      return to_enum(:paginate_key, path, key: key, params: params, operation: operation) unless block
-
-      base_url = build_url(path)
-      url = base_url
-      page = 0
-
-      loop do
-        page += 1
-        break if page > @config.max_pages
-
-        @hooks.on_paginate(url, page)
-        response = get(url, params: page == 1 ? params : {}, operation: operation)
-
-        Security.check_body_size!(response.body, Security::MAX_RESPONSE_BODY_BYTES)
-
-        begin
-          data = JSON.parse(response.body)
-          Http.normalize_person_ids(data)
-        rescue JSON::ParserError => e
-          raise Basecamp::ApiError.new("Failed to parse paginated response (page #{page}): #{Security.truncate(e.message)}")
-        end
-        unless data.key?(key)
-          warn "[Basecamp SDK] paginate_key: expected key '#{key}' not found in response (page #{page})"
-        end
-        items = data[key] || []
-        items.each(&block)
-
-        next_url = parse_next_link(response.headers["Link"])
-        break if next_url.nil?
-
-        next_url = Security.resolve_url(url, next_url)
-
-        unless Security.same_origin?(next_url, base_url)
-          raise Basecamp::ApiError.new(
-            "Pagination Link header points to different origin: #{Security.truncate(next_url)}"
-          )
-        end
-
-        url = next_url
-      end
+    # @return [ListEnumerator] metadata-carrying lazy enumerator
+    def paginate_key(path, key:, params: {}, operation: nil, max_items: nil, &block)
+      enum = paginated_enumerator(path, key: key, params: params, operation: operation, max_items: max_items)
+      block ? enum.each(&block) : enum
     end
 
     # Fetches a wrapped paginated resource, returning wrapper fields + lazy paginated items.
@@ -268,70 +204,118 @@ module Basecamp
     # @param path [String] initial URL path
     # @param key [String] the key containing the array of paginated items
     # @param params [Hash] query parameters
-    # @return [Hash] wrapper fields merged with key => Enumerator of all items
-    def paginate_wrapped(path, key:, params: {}, operation: nil)
-      base_url = build_url(path)
-
-      @hooks.on_paginate(base_url, 1)
-      first_response = get(base_url, params: params, operation: operation)
-      Security.check_body_size!(first_response.body, Security::MAX_RESPONSE_BODY_BYTES)
-
-      begin
-        first_data = JSON.parse(first_response.body)
-        Http.normalize_person_ids(first_data)
-      rescue JSON::ParserError => e
-        raise Basecamp::ApiError.new(
-          "Failed to parse paginated response (page 1): #{Security.truncate(e.message)}"
-        )
+    # @param max_items [Integer, nil] cap on items yielded across pages;
+    #   nil or non-positive means no cap
+    # @return [Hash] wrapper fields merged with key => ListEnumerator of all items
+    def paginate_wrapped(path, key:, params: {}, operation: nil, max_items: nil)
+      wrapper = nil
+      events = paginated_enumerator(path, key: key, params: params, operation: operation, \
+        max_items: max_items) do |first_data|
+        wrapper = first_data.reject { |k, _| k == key }
       end
-
-      wrapper = first_data.reject { |k, _| k == key }
-      first_items = first_data[key] || []
-
-      events = Enumerator.new do |yielder|
-        first_items.each { |item| yielder << item }
-
-        next_link = parse_next_link(first_response.headers["Link"])
-        url = base_url
-        page = 1
-
-        while next_link && page < @config.max_pages
-          page += 1
-          next_url = Security.resolve_url(url, next_link)
-
-          unless Security.same_origin?(next_url, base_url)
-            raise Basecamp::ApiError.new(
-              "Pagination Link header points to different origin: " \
-              "#{Security.truncate(next_url)}"
-            )
-          end
-
-          @hooks.on_paginate(next_url, page)
-          response = get(next_url, operation: operation)
-          Security.check_body_size!(response.body, Security::MAX_RESPONSE_BODY_BYTES)
-
-          begin
-            data = JSON.parse(response.body)
-            Http.normalize_person_ids(data)
-          rescue JSON::ParserError => e
-            raise Basecamp::ApiError.new(
-              "Failed to parse paginated response (page #{page}): " \
-              "#{Security.truncate(e.message)}"
-            )
-          end
-
-          items = data[key] || []
-          items.each { |item| yielder << item }
-
-          next_link = parse_next_link(response.headers["Link"])
-          url = next_url
-        end
-      end
-
       wrapper.merge(key => events)
     end
 
     private
+
+    # Shared paginator core behind paginate/paginate_key/paginate_wrapped.
+    # Eagerly fetches page 1 (so ListMeta#total_count is available
+    # immediately), then returns a ListEnumerator that yields the captured
+    # first page and follows Link headers lazily. When key is nil each page
+    # body is a bare item array; otherwise items live under key. Yields the
+    # parsed first-page body when a block is given (paginate_wrapped uses it
+    # to capture the wrapper fields).
+    #
+    # meta.truncated is finalized during enumeration: set when max_items
+    # drops items or leaves a next Link unfetched, or when the max_pages
+    # safety cap stops with a next Link still present. A cap landing exactly
+    # on the final item of the last page is not truncation.
+    def paginated_enumerator(path, params:, operation:, max_items:, key: nil)
+      max_items = nil if max_items && max_items <= 0
+      base_url = build_url(path)
+
+      @hooks.on_paginate(base_url, 1)
+      first_response = get(base_url, params: params, operation: operation)
+      first_data = parse_page(first_response, page: 1)
+      yield first_data if block_given?
+      first_items = extract_page_items(first_data, key: key, page: 1)
+
+      meta = ListMeta.new(total_count: parse_total_count(first_response.headers))
+
+      ListEnumerator.new(meta) do |yielder|
+        yielded = 0
+        page = 1
+        url = base_url
+        response = first_response
+        items = first_items
+
+        loop do
+          next_link = parse_next_link(response.headers["Link"])
+
+          capped = false
+          items.each_with_index do |item, index|
+            yielder << item
+            yielded += 1
+            next unless max_items && yielded >= max_items
+
+            meta.mark_truncated! if index < items.size - 1 || next_link
+            capped = true
+            break
+          end
+          break if capped
+          break if next_link.nil?
+
+          next_url = Security.resolve_url(url, next_link)
+          unless Security.same_origin?(next_url, base_url)
+            raise Basecamp::ApiError.new(
+              "Pagination Link header points to different origin: #{Security.truncate(next_url)}"
+            )
+          end
+
+          if page >= @config.max_pages
+            meta.mark_truncated!
+            break
+          end
+
+          page += 1
+          @hooks.on_paginate(next_url, page)
+          response = get(next_url, operation: operation)
+          items = extract_page_items(parse_page(response, page: page), key: key, page: page)
+          url = next_url
+        end
+      end
+    end
+
+    # Parses a pagination page body: size check, JSON parse, and person-ID
+    # normalization, with page-numbered error context.
+    def parse_page(response, page:)
+      Security.check_body_size!(response.body, Security::MAX_RESPONSE_BODY_BYTES)
+      data = JSON.parse(response.body)
+      Http.normalize_person_ids(data)
+      data
+    rescue JSON::ParserError => e
+      raise Basecamp::ApiError.new("Failed to parse paginated response (page #{page}): #{Security.truncate(e.message)}")
+    end
+
+    # Extracts the item array from a parsed page body: the body itself for
+    # bare-array pagination, or the named key's array otherwise.
+    def extract_page_items(data, key:, page:)
+      if key.nil?
+        data
+      else
+        unless data.key?(key)
+          warn "[Basecamp SDK] paginate: expected key '#{key}' not found in response (page #{page})"
+        end
+        data[key] || []
+      end
+    end
+
+    # Parses the X-Total-Count header, returning 0 when absent or malformed.
+    def parse_total_count(headers)
+      Integer(headers["X-Total-Count"] || headers["x-total-count"], 10)
+    rescue ArgumentError, TypeError
+      0
+    end
 
     def build_faraday_client
       Faraday.new(url: @config.base_url) do |f|

--- a/ruby/lib/basecamp/http.rb
+++ b/ruby/lib/basecamp/http.rb
@@ -230,6 +230,11 @@ module Basecamp
     # drops items or leaves a next Link unfetched, or when the max_pages
     # safety cap stops with a next Link still present. A cap landing exactly
     # on the final item of the last page is not truncation.
+    #
+    # Re-enumerating restarts pagination from the base URL: the eagerly
+    # fetched first page is served from memory on the first pass only, and
+    # later passes refetch every page, so each pass is a consistent
+    # snapshot rather than a hybrid of captured and current data.
     def paginated_enumerator(path, params:, operation:, max_items:, key: nil)
       max_items = nil if max_items && max_items <= 0
       base_url = build_url(path)
@@ -241,13 +246,22 @@ module Basecamp
       first_items = extract_page_items(first_data, key: key, page: 1)
 
       meta = ListMeta.new(total_count: parse_total_count(first_response.headers))
+      first_pass = true
 
       ListEnumerator.new(meta) do |yielder|
+        if first_pass
+          first_pass = false
+          response = first_response
+          items = first_items
+        else
+          @hooks.on_paginate(base_url, 1)
+          response = get(base_url, params: params, operation: operation)
+          items = extract_page_items(parse_page(response, page: 1), key: key, page: 1)
+        end
+
         yielded = 0
         page = 1
         url = base_url
-        response = first_response
-        items = first_items
 
         loop do
           next_link = parse_next_link(response.headers["Link"])

--- a/ruby/lib/basecamp/list_enumerator.rb
+++ b/ruby/lib/basecamp/list_enumerator.rb
@@ -13,9 +13,9 @@ module Basecamp
   #
   # Re-enumerating restarts pagination: the eagerly fetched first page is
   # served from memory on the first pass only, and later passes refetch
-  # every page for a consistent snapshot. Metadata reflects the first page
-  # fetched at call time plus whatever truncation enumeration has
-  # discovered so far.
+  # every page for a consistent snapshot, refreshing meta from their own
+  # first-page response — metadata always describes the most recent
+  # traversal.
   class ListEnumerator < Enumerator
     # @return [ListMeta] pagination metadata
     attr_reader :meta

--- a/ruby/lib/basecamp/list_enumerator.rb
+++ b/ruby/lib/basecamp/list_enumerator.rb
@@ -10,6 +10,12 @@ module Basecamp
   # The metadata object is shared with the paginator: meta.total_count is
   # populated from the eagerly fetched first page, and meta.truncated is
   # finalized by consuming the enumeration (see {ListMeta}).
+  #
+  # Re-enumerating restarts pagination: the eagerly fetched first page is
+  # served from memory on the first pass only, and later passes refetch
+  # every page for a consistent snapshot. Metadata reflects the first page
+  # fetched at call time plus whatever truncation enumeration has
+  # discovered so far.
   class ListEnumerator < Enumerator
     # @return [ListMeta] pagination metadata
     attr_reader :meta

--- a/ruby/lib/basecamp/list_enumerator.rb
+++ b/ruby/lib/basecamp/list_enumerator.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Basecamp
+  # A lazy Enumerator over paginated items that carries pagination metadata.
+  #
+  # Behaves exactly like the plain Enumerator it replaces — each/next/peek/
+  # take/first/lazy all work, and pages beyond the first are fetched only as
+  # iteration demands them — while additionally exposing {#meta}.
+  #
+  # The metadata object is shared with the paginator: meta.total_count is
+  # populated from the eagerly fetched first page, and meta.truncated is
+  # finalized by consuming the enumeration (see {ListMeta}).
+  class ListEnumerator < Enumerator
+    # @return [ListMeta] pagination metadata
+    attr_reader :meta
+
+    # @param meta [ListMeta] metadata shared with the producing paginator
+    def initialize(meta, &block)
+      @meta = meta
+      super(&block)
+    end
+  end
+end

--- a/ruby/lib/basecamp/list_meta.rb
+++ b/ruby/lib/basecamp/list_meta.rb
@@ -32,5 +32,13 @@ module Basecamp
     def mark_truncated!
       @truncated = true
     end
+
+    # Re-initializes the metadata when a traversal restarts, so it describes
+    # the restarted pass's own snapshot rather than a previous traversal's.
+    # @api private
+    def restart!(total_count:)
+      @total_count = total_count
+      @truncated = false
+    end
   end
 end

--- a/ruby/lib/basecamp/list_meta.rb
+++ b/ruby/lib/basecamp/list_meta.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Basecamp
+  # Pagination metadata carried by {ListEnumerator}.
+  #
+  # total_count comes from the X-Total-Count header on the first page (0 when
+  # absent) and is available as soon as the list call returns, because the
+  # first page is fetched eagerly.
+  #
+  # truncated starts false and flips to true when enumeration discovers that
+  # items beyond those yielded were available: items dropped by a max_items
+  # cap, or a next Link left unfetched when the max_items or max_pages cap
+  # stopped pagination. It is final only once enumeration completes; landing
+  # exactly on the final item is not truncation.
+  class ListMeta
+    # @return [Integer] total item count from X-Total-Count (0 if absent)
+    attr_reader :total_count
+
+    # @return [Boolean] whether items beyond those yielded were available
+    attr_reader :truncated
+
+    alias truncated? truncated
+
+    # @param total_count [Integer] value of the X-Total-Count header
+    def initialize(total_count: 0)
+      @total_count = total_count
+      @truncated = false
+    end
+
+    # Records that truncation was discovered during enumeration.
+    # @api private
+    def mark_truncated!
+      @truncated = true
+    end
+  end
+end

--- a/ruby/scripts/generate-services.rb
+++ b/ruby/scripts/generate-services.rb
@@ -611,8 +611,11 @@ class ServiceGenerator
   def generate_method(op, service_name:)
     lines = []
 
-    # Method signature
-    params = build_params(op)
+    is_paginated = (op[:returns_array] || op[:has_pagination]) && !op[:pagination_key]
+    is_wrapped_paginated = op[:has_pagination] && op[:pagination_key]
+
+    # Method signature (paginated operations gain a trailing max_items: kwarg)
+    params = build_params(op, paginated: is_paginated || is_wrapped_paginated)
 
     # YARD documentation
     lines << "      # #{op[:description]}"
@@ -659,16 +662,18 @@ class ServiceGenerator
       lines << "      # @param #{ruby_name} [#{type}] #{desc}"
     end
 
-    # Add @return tag
-    is_paginated = (op[:returns_array] || op[:has_pagination]) && !op[:pagination_key]
-    is_wrapped_paginated = op[:has_pagination] && op[:pagination_key]
+    # Add @param tag for the pagination cap on paginated operations
+    if is_paginated || is_wrapped_paginated
+      lines << '      # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap'
+    end
 
+    # Add @return tag
     if op[:returns_void]
       lines << '      # @return [void]'
     elsif is_wrapped_paginated
-      lines << '      # @return [Hash] response data'
+      lines << '      # @return [Hash] wrapper fields merged with a ListEnumerator of the paginated items'
     elsif is_paginated
-      lines << '      # @return [Enumerator<Hash>] paginated results'
+      lines << '      # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)'
     elsif op[:returns_bare_array]
       # Unpaginated bare array (single request, no Link-following) — e.g. the
       # overdue todo/card feeds. Returns the parsed JSON array, not a Hash.
@@ -691,7 +696,8 @@ class ServiceGenerator
       body_lines.each { |l| lines << "  #{l}" }
       lines << '        end'
     elsif is_paginated
-      # wrap_paginated defers hooks to actual iteration time (lazy-safe)
+      # wrap_paginated fires the start hook eagerly (page 1 is fetched inside
+      # the block) and the end hook when iteration completes
       lines << "        wrap_paginated(#{hook_kwargs}) do"
       body_lines = generate_list_method_body(op, path_expr)
       body_lines.each { |l| lines << "  #{l}" }
@@ -729,7 +735,7 @@ class ServiceGenerator
     kwargs.join(', ')
   end
 
-  def build_params(op)
+  def build_params(op, paginated: false)
     params = []
 
     # Path parameters as keyword args
@@ -771,6 +777,9 @@ class ServiceGenerator
     optional_query_params.each do |q|
       params << "#{to_snake_case(q[:name])}: nil"
     end
+
+    # Client-side pagination cap, threaded into the base paginators
+    params << 'max_items: nil' if paginated
 
     params.join(', ')
   end
@@ -818,9 +827,9 @@ class ServiceGenerator
     if op[:query_params].any?
       param_names = op[:query_params].map { |q| "#{to_snake_case(q[:name])}: #{to_snake_case(q[:name])}" }
       lines << "        params = compact_query_params(#{param_names.join(', ')})"
-      lines << "        paginate(#{path_expr}, params: params, operation: \"#{op[:operation_id]}\")"
+      lines << "        paginate(#{path_expr}, params: params, operation: \"#{op[:operation_id]}\", max_items: max_items)"
     else
-      lines << "        paginate(#{path_expr}, operation: \"#{op[:operation_id]}\")"
+      lines << "        paginate(#{path_expr}, operation: \"#{op[:operation_id]}\", max_items: max_items)"
     end
 
     lines
@@ -832,9 +841,11 @@ class ServiceGenerator
     if op[:query_params].any?
       param_names = op[:query_params].map { |q| "#{to_snake_case(q[:name])}: #{to_snake_case(q[:name])}" }
       lines << "        params = compact_query_params(#{param_names.join(', ')})"
-      lines << "        paginate_wrapped(#{path_expr}, key: \"#{pagination_key}\", params: params, operation: \"#{op[:operation_id]}\")"
+      lines << "        paginate_wrapped(#{path_expr}, key: \"#{pagination_key}\", params: params, " \
+               "operation: \"#{op[:operation_id]}\", max_items: max_items)"
     else
-      lines << "        paginate_wrapped(#{path_expr}, key: \"#{pagination_key}\", operation: \"#{op[:operation_id]}\")"
+      lines << "        paginate_wrapped(#{path_expr}, key: \"#{pagination_key}\", " \
+               "operation: \"#{op[:operation_id]}\", max_items: max_items)"
     end
 
     lines

--- a/ruby/test/basecamp/operation_hooks_test.rb
+++ b/ruby/test/basecamp/operation_hooks_test.rb
@@ -41,7 +41,10 @@ class OperationHooksTest < Minitest::Test
 
   # -- Paginated operations (wrap_paginated) --
 
-  def test_paginated_hooks_do_not_fire_until_iteration
+  def test_paginated_start_hook_fires_eagerly_and_end_after_consumption
+    # Page 1 is fetched eagerly at call time, so on_operation_start must fire
+    # then (before the page-1 request hooks); on_operation_end fires only
+    # once iteration completes.
     events = []
     hooks = TrackingHooks.new(events)
     account = create_account_client(hooks: hooks)
@@ -49,7 +52,10 @@ class OperationHooksTest < Minitest::Test
     stub_get("/12345/projects.json", response_body: [ { "id" => 1 } ])
 
     enum = account.projects.list
-    assert_empty events, "hooks should not fire before iteration starts"
+    op_events = events.select { |e| e[:event].to_s.start_with?("on_operation") }
+    assert_equal [ :on_operation_start ], op_events.map { |e| e[:event] }
+    assert_equal :on_operation_start, events.first[:event],
+      "start hook must precede the eager page-1 request hooks"
 
     enum.to_a
     op_events = events.select { |e| e[:event].to_s.start_with?("on_operation") }
@@ -91,7 +97,9 @@ class OperationHooksTest < Minitest::Test
     assert_nil end_event[:result].error
   end
 
-  def test_paginated_hooks_report_error_during_iteration
+  def test_paginated_hooks_report_page_one_error_at_call_time
+    # The eager page-1 fetch surfaces errors from the list call itself,
+    # before any iteration, with the end hook carrying the error.
     events = []
     hooks = TrackingHooks.new(events)
     account = create_account_client(hooks: hooks)
@@ -99,7 +107,30 @@ class OperationHooksTest < Minitest::Test
     stub_request(:get, "https://3.basecampapi.com/12345/projects.json")
       .to_return(status: 404, body: { "error" => "not found" }.to_json)
 
-    assert_raises(Basecamp::NotFoundError) { account.projects.list.to_a }
+    assert_raises(Basecamp::NotFoundError) { account.projects.list }
+
+    end_event = events.find { |e| e[:event] == :on_operation_end }
+    assert_not_nil end_event
+    assert_kind_of Basecamp::NotFoundError, end_event[:result].error
+  end
+
+  def test_paginated_hooks_report_error_during_iteration
+    events = []
+    hooks = TrackingHooks.new(events)
+    account = create_account_client(hooks: hooks)
+
+    page2_url = "https://3.basecampapi.com/12345/projects.json?page=2"
+    stub_request(:get, "https://3.basecampapi.com/12345/projects.json")
+      .to_return(
+        status: 200,
+        body: [ { "id" => 1 } ].to_json,
+        headers: { "Content-Type" => "application/json", "Link" => "<#{page2_url}>; rel=\"next\"" }
+      )
+    stub_request(:get, page2_url)
+      .to_return(status: 404, body: { "error" => "not found" }.to_json)
+
+    enum = account.projects.list
+    assert_raises(Basecamp::NotFoundError) { enum.to_a }
 
     end_event = events.find { |e| e[:event] == :on_operation_end }
     assert_not_nil end_event
@@ -155,7 +186,9 @@ class OperationHooksTest < Minitest::Test
     assert_nil end_event[:error]
   end
 
-  def test_paginated_duration_reflects_iteration_time
+  def test_paginated_duration_spans_call_to_consumption
+    # Matches wrap_paginated_wrapped: with the first page fetched eagerly at
+    # call time, duration measures from the call through the end of iteration.
     events = []
     hooks = TrackingHooks.new(events)
     account = create_account_client(hooks: hooks)
@@ -163,12 +196,11 @@ class OperationHooksTest < Minitest::Test
     stub_get("/12345/projects.json", response_body: [ { "id" => 1 } ])
 
     enum = account.projects.list
-    sleep 0.01 # time passes before iteration — should NOT count
+    sleep 0.01 # time between call and iteration counts toward the duration
     enum.to_a
 
     end_event = events.find { |e| e[:event] == :on_operation_end }
-    # Duration should reflect iteration time, not time since .list was called
-    assert end_event[:result].duration_ms < 1000, "duration should reflect iteration, not creation"
+    assert end_event[:result].duration_ms >= 10, "duration spans call to consumption"
   end
 
   private

--- a/ruby/test/basecamp/operation_hooks_test.rb
+++ b/ruby/test/basecamp/operation_hooks_test.rb
@@ -186,6 +186,23 @@ class OperationHooksTest < Minitest::Test
     assert_nil end_event[:error]
   end
 
+  def test_paginated_hooks_fire_one_lifecycle_across_reenumeration
+    # on_operation_start fires once at call time, so on_operation_end must
+    # also fire exactly once — re-enumerating must not emit unmatched ends.
+    events = []
+    hooks = TrackingHooks.new(events)
+    account = create_account_client(hooks: hooks)
+
+    stub_get("/12345/projects.json", response_body: [ { "id" => 1 } ])
+
+    enum = account.projects.list
+    enum.to_a
+    enum.to_a
+
+    op_events = events.select { |e| e[:event].to_s.start_with?("on_operation") }
+    assert_equal [ :on_operation_start, :on_operation_end ], op_events.map { |e| e[:event] }
+  end
+
   def test_paginated_duration_spans_call_to_consumption
     # Matches wrap_paginated_wrapped: with the first page fetched eagerly at
     # call time, duration measures from the call through the end of iteration.

--- a/ruby/test/basecamp/pagination_meta_test.rb
+++ b/ruby/test/basecamp/pagination_meta_test.rb
@@ -296,6 +296,29 @@ class HttpPaginationMetaTest < Minitest::Test
     assert_not result["events"].meta.truncated
   end
 
+  def test_reenumeration_refetches_page_one
+    # Re-enumerating restarts pagination from the base URL so a second pass
+    # is a consistent fresh snapshot, never a hybrid of the eagerly captured
+    # first page and refetched later pages.
+    stub_get("/items.json", response_body: [ { "id" => 1 } ])
+
+    enum = @http.paginate("/items.json")
+
+    assert_equal 1, enum.to_a.length
+    assert_equal 1, enum.to_a.length
+    assert_requested :get, "#{base_url}/items.json", times: 2
+  end
+
+  def test_wrapped_reenumeration_refetches_page_one
+    stub_get("/progress.json", response_body: { "person" => { "id" => 7 }, "events" => [ { "id" => 1 } ] })
+
+    result = @http.paginate_wrapped("/progress.json", key: "events")
+
+    assert_equal 1, result["events"].to_a.length
+    assert_equal 1, result["events"].to_a.length
+    assert_requested :get, "#{base_url}/progress.json", times: 2
+  end
+
   # PIN: block form still yields every item across pages.
   def test_paginate_block_form_still_yields_items
     stub_get(

--- a/ruby/test/basecamp/pagination_meta_test.rb
+++ b/ruby/test/basecamp/pagination_meta_test.rb
@@ -309,6 +309,35 @@ class HttpPaginationMetaTest < Minitest::Test
     assert_requested :get, "#{base_url}/items.json", times: 2
   end
 
+  def test_reenumeration_refreshes_meta
+    # A restarted traversal must describe its own snapshot: total_count from
+    # the refetched first page, truncated re-derived for that pass — never
+    # the previous traversal's stale values.
+    stub_request(:get, "#{base_url}/items.json")
+      .to_return(
+        {
+          status: 200,
+          body: [ { "id" => 1 }, { "id" => 2 } ].to_json,
+          headers: { "Content-Type" => "application/json", "X-Total-Count" => "42" }
+        },
+        {
+          status: 200,
+          body: [ { "id" => 9 } ].to_json,
+          headers: { "Content-Type" => "application/json", "X-Total-Count" => "7" }
+        }
+      )
+
+    enum = @http.paginate("/items.json", max_items: 1)
+
+    assert_equal [ 1 ], enum.to_a.map { |i| i["id"] }
+    assert_equal 42, enum.meta.total_count
+    assert enum.meta.truncated, "pass 1 drops an item, so it is truncated"
+
+    assert_equal [ 9 ], enum.to_a.map { |i| i["id"] }
+    assert_equal 7, enum.meta.total_count
+    assert_not enum.meta.truncated, "pass 2 lands exactly on its final item"
+  end
+
   def test_wrapped_reenumeration_refetches_page_one
     stub_get("/progress.json", response_body: { "person" => { "id" => 7 }, "events" => [ { "id" => 1 } ] })
 

--- a/ruby/test/basecamp/pagination_meta_test.rb
+++ b/ruby/test/basecamp/pagination_meta_test.rb
@@ -1,0 +1,380 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Pagination metadata (ListEnumerator/ListMeta) and max_items behavior.
+#
+# Contract (shared with the other SDKs):
+# - The first page is fetched eagerly, so meta.total_count (X-Total-Count,
+#   0 when absent) is available as soon as the call returns.
+# - Pages beyond the first are fetched lazily during enumeration.
+# - meta.truncated is final only once enumeration completes: true only when
+#   items beyond those yielded were available (dropped by max_items, or a
+#   next Link was left unfetched at the max_items or max_pages cap).
+#   Landing exactly on the final item is not truncation.
+# - Non-positive max_items disables the cap.
+class HttpPaginationMetaTest < Minitest::Test
+  include TestHelper
+
+  def setup
+    @http = Basecamp::Http.new(config: default_config, token_provider: test_token_provider)
+  end
+
+  def test_paginate_returns_list_enumerator_with_meta
+    stub_get("/items.json", response_body: [ { "id" => 1 } ])
+
+    enum = @http.paginate("/items.json")
+
+    assert_kind_of Enumerator, enum
+    assert_kind_of Basecamp::ListEnumerator, enum
+    assert_kind_of Basecamp::ListMeta, enum.meta
+  end
+
+  def test_total_count_available_before_consumption
+    stub_get("/items.json", response_body: [], headers: { "X-Total-Count" => "42" })
+
+    enum = @http.paginate("/items.json")
+
+    assert_equal 42, enum.meta.total_count
+  end
+
+  def test_missing_total_count_is_zero
+    stub_get("/items.json", response_body: [ { "id" => 1 } ])
+
+    enum = @http.paginate("/items.json")
+
+    assert_equal 0, enum.meta.total_count
+  end
+
+  def test_malformed_total_count_is_zero
+    stub_get("/items.json", response_body: [], headers: { "X-Total-Count" => "not-a-number" })
+
+    assert_equal 0, @http.paginate("/items.json").meta.total_count
+  end
+
+  def test_first_page_fetched_eagerly
+    stub_get("/items.json", response_body: [ { "id" => 1 } ])
+
+    @http.paginate("/items.json")
+
+    assert_requested :get, "#{base_url}/items.json", times: 1
+  end
+
+  # PIN (passes before and after the metadata work): partial consumption must
+  # not fetch pages beyond what iteration demands — laziness survives the
+  # Enumerator subclass.
+  def test_first_n_fetches_only_one_page
+    stub_get(
+      "/items.json",
+      response_body: [ { "id" => 1 }, { "id" => 2 } ],
+      headers: { "Link" => "<#{base_url}/items.json?page=2>; rel=\"next\"" }
+    )
+
+    items = @http.paginate("/items.json").first(2)
+
+    assert_equal [ 1, 2 ], items.map { |i| i["id"] }
+    assert_requested :get, "#{base_url}/items.json", times: 1
+    assert_not_requested :get, "#{base_url}/items.json?page=2"
+  end
+
+  # PIN: external iteration (.next / .peek) works on the returned enumerator.
+  def test_external_iteration_next_and_peek
+    stub_get("/items.json", response_body: [ { "id" => 1 }, { "id" => 2 } ])
+
+    enum = @http.paginate("/items.json")
+
+    assert_equal 1, enum.peek["id"]
+    assert_equal 1, enum.next["id"]
+    assert_equal 2, enum.next["id"]
+  end
+
+  # PIN: .lazy chains work on the returned enumerator.
+  def test_lazy_chain
+    stub_get(
+      "/items.json",
+      response_body: [ { "id" => 1 }, { "id" => 2 } ],
+      headers: { "Link" => "<#{base_url}/items.json?page=2>; rel=\"next\"" }
+    )
+
+    ids = @http.paginate("/items.json").lazy.map { |i| i["id"] }.first(2)
+
+    assert_equal [ 1, 2 ], ids
+    assert_not_requested :get, "#{base_url}/items.json?page=2"
+  end
+
+  def test_truncated_false_until_consumption_discovers_it
+    # Visibility semantics: truncated starts false and is final only once
+    # enumeration completes — asserted here across the consumption boundary.
+    stub_get(
+      "/items.json",
+      response_body: [ { "id" => 1 }, { "id" => 2 } ],
+      headers: { "Link" => "<#{base_url}/items.json?page=2>; rel=\"next\"" }
+    )
+
+    enum = @http.paginate("/items.json", max_items: 1)
+
+    assert_not enum.meta.truncated, "truncated must not be finalized before consumption"
+    enum.to_a
+    assert enum.meta.truncated
+    assert enum.meta.truncated?
+  end
+
+  def test_truncated_at_max_pages_cap
+    config = Basecamp::Config.new(base_url: base_url, max_pages: 2)
+    http = Basecamp::Http.new(config: config, token_provider: test_token_provider)
+    stub_get(
+      "/items.json",
+      response_body: [ { "id" => 1 } ],
+      headers: { "Link" => "<#{base_url}/items.json?page=2>; rel=\"next\"" }
+    )
+    stub_get(
+      "/items.json?page=2",
+      response_body: [ { "id" => 2 } ],
+      headers: { "Link" => "<#{base_url}/items.json?page=3>; rel=\"next\"" }
+    )
+
+    enum = http.paginate("/items.json")
+    items = enum.to_a
+
+    assert_equal 2, items.length
+    assert enum.meta.truncated
+    assert_not_requested :get, "#{base_url}/items.json?page=3"
+  end
+
+  def test_not_truncated_when_all_pages_consumed
+    stub_get(
+      "/items.json",
+      response_body: [ { "id" => 1 } ],
+      headers: { "X-Total-Count" => "2", "Link" => "<#{base_url}/items.json?page=2>; rel=\"next\"" }
+    )
+    stub_get("/items.json?page=2", response_body: [ { "id" => 2 } ])
+
+    enum = @http.paginate("/items.json")
+    items = enum.to_a
+
+    assert_equal 2, items.length
+    assert_equal 2, enum.meta.total_count
+    assert_not enum.meta.truncated
+  end
+
+  def test_max_items_caps_across_pages_and_truncates
+    stub_get(
+      "/items.json",
+      response_body: [ { "id" => 1 }, { "id" => 2 } ],
+      headers: { "Link" => "<#{base_url}/items.json?page=2>; rel=\"next\"" }
+    )
+    stub_get(
+      "/items.json?page=2",
+      response_body: [ { "id" => 3 }, { "id" => 4 } ],
+      headers: { "Link" => "<#{base_url}/items.json?page=3>; rel=\"next\"" }
+    )
+
+    enum = @http.paginate("/items.json", max_items: 3)
+    items = enum.to_a
+
+    assert_equal [ 1, 2, 3 ], items.map { |i| i["id"] }
+    assert enum.meta.truncated
+    assert_not_requested :get, "#{base_url}/items.json?page=3"
+  end
+
+  def test_max_items_exact_boundary_not_truncated
+    stub_get(
+      "/items.json",
+      response_body: [ { "id" => 1 }, { "id" => 2 } ],
+      headers: { "Link" => "<#{base_url}/items.json?page=2>; rel=\"next\"" }
+    )
+    stub_get("/items.json?page=2", response_body: [ { "id" => 3 }, { "id" => 4 } ])
+
+    enum = @http.paginate("/items.json", max_items: 4)
+    items = enum.to_a
+
+    assert_equal 4, items.length
+    assert_not enum.meta.truncated
+  end
+
+  def test_max_items_drop_within_single_page_truncates
+    stub_get("/items.json", response_body: [ { "id" => 1 }, { "id" => 2 } ])
+
+    enum = @http.paginate("/items.json", max_items: 1)
+    items = enum.to_a
+
+    assert_equal 1, items.length
+    assert enum.meta.truncated
+  end
+
+  def test_max_items_cap_met_with_next_link_truncates
+    # Cap lands on the last item of a page that still advertises a next page:
+    # nothing dropped in-page, but the unfetched next Link is truncation.
+    stub_get(
+      "/items.json",
+      response_body: [ { "id" => 1 }, { "id" => 2 } ],
+      headers: { "Link" => "<#{base_url}/items.json?page=2>; rel=\"next\"" }
+    )
+
+    enum = @http.paginate("/items.json", max_items: 2)
+    items = enum.to_a
+
+    assert_equal 2, items.length
+    assert enum.meta.truncated
+    assert_not_requested :get, "#{base_url}/items.json?page=2"
+  end
+
+  def test_non_positive_max_items_means_no_cap
+    [ 0, -5 ].each do |cap|
+      WebMock.reset!
+      stub_get("/items.json", response_body: [ { "id" => 1 }, { "id" => 2 } ])
+
+      enum = @http.paginate("/items.json", max_items: cap)
+
+      assert_equal 2, enum.to_a.length
+      assert_not enum.meta.truncated
+    end
+  end
+
+  def test_paginate_key_meta_and_max_items
+    stub_get(
+      "/events.json",
+      response_body: { "events" => [ { "id" => 1 }, { "id" => 2 } ] },
+      headers: { "X-Total-Count" => "9", "Link" => "<#{base_url}/events.json?page=2>; rel=\"next\"" }
+    )
+
+    enum = @http.paginate_key("/events.json", key: "events", max_items: 1)
+
+    assert_equal 9, enum.meta.total_count
+    assert_equal 1, enum.to_a.length
+    assert enum.meta.truncated
+    assert_not_requested :get, "#{base_url}/events.json?page=2"
+  end
+
+  def test_paginate_key_non_positive_max_items_means_no_cap
+    stub_get("/events.json", response_body: { "events" => [ { "id" => 1 }, { "id" => 2 } ] })
+
+    enum = @http.paginate_key("/events.json", key: "events", max_items: 0)
+
+    assert_equal 2, enum.to_a.length
+    assert_not enum.meta.truncated
+  end
+
+  def test_paginate_wrapped_shape_survives_with_meta
+    stub_get(
+      "/progress.json",
+      response_body: { "person" => { "id" => 7 }, "events" => [ { "id" => 1 }, { "id" => 2 } ] },
+      headers: { "X-Total-Count" => "5" }
+    )
+
+    result = @http.paginate_wrapped("/progress.json", key: "events")
+
+    assert_kind_of Hash, result
+    assert_equal({ "id" => 7 }, result["person"])
+    assert_kind_of Basecamp::ListEnumerator, result["events"]
+    assert_equal 5, result["events"].meta.total_count
+    assert_equal [ 1, 2 ], result["events"].to_a.map { |i| i["id"] }
+    assert_not result["events"].meta.truncated
+  end
+
+  def test_paginate_wrapped_max_items
+    stub_get(
+      "/progress.json",
+      response_body: { "person" => { "id" => 7 }, "events" => [ { "id" => 1 }, { "id" => 2 } ] },
+      headers: { "Link" => "<#{base_url}/progress.json?page=2>; rel=\"next\"" }
+    )
+
+    result = @http.paginate_wrapped("/progress.json", key: "events", max_items: 1)
+    events = result["events"]
+
+    assert_equal 1, events.to_a.length
+    assert events.meta.truncated
+    assert_not_requested :get, "#{base_url}/progress.json?page=2"
+  end
+
+  def test_paginate_wrapped_non_positive_max_items_means_no_cap
+    stub_get("/progress.json", response_body: { "person" => {}, "events" => [ { "id" => 1 }, { "id" => 2 } ] })
+
+    result = @http.paginate_wrapped("/progress.json", key: "events", max_items: -1)
+
+    assert_equal 2, result["events"].to_a.length
+    assert_not result["events"].meta.truncated
+  end
+
+  # PIN: block form still yields every item across pages.
+  def test_paginate_block_form_still_yields_items
+    stub_get(
+      "/items.json",
+      response_body: [ { "id" => 1 } ],
+      headers: { "Link" => "<#{base_url}/items.json?page=2>; rel=\"next\"" }
+    )
+    stub_get("/items.json?page=2", response_body: [ { "id" => 2 } ])
+
+    ids = []
+    @http.paginate("/items.json") { |item| ids << item["id"] }
+
+    assert_equal [ 1, 2 ], ids
+  end
+end
+
+# Service-layer coverage: the generated list methods expose max_items and the
+# hook wrapper (wrap_paginated) preserves the metadata-carrying enumerator.
+class ServicePaginationMetaTest < Minitest::Test
+  include TestHelper
+
+  def test_service_list_exposes_meta
+    stub_get(
+      "/12345/projects.json",
+      response_body: [ sample_project ],
+      headers: { "X-Total-Count" => "17" }
+    )
+
+    enum = create_account_client.projects.list
+
+    assert_kind_of Basecamp::ListEnumerator, enum
+    assert_equal 17, enum.meta.total_count
+  end
+
+  def test_service_list_accepts_max_items
+    stub_get("/12345/projects.json", response_body: [ sample_project(id: 1), sample_project(id: 2) ])
+
+    enum = create_account_client.projects.list(max_items: 1)
+    items = enum.to_a
+
+    assert_equal 1, items.length
+    assert enum.meta.truncated
+  end
+
+  def test_service_list_non_positive_max_items_means_no_cap
+    stub_get("/12345/projects.json", response_body: [ sample_project(id: 1), sample_project(id: 2) ])
+
+    enum = create_account_client.projects.list(max_items: 0)
+
+    assert_equal 2, enum.to_a.length
+    assert_not enum.meta.truncated
+  end
+
+  # PIN: .first through the service layer fetches only the pages it needs.
+  def test_service_list_first_fetches_one_page
+    stub_get(
+      "/12345/projects.json",
+      response_body: [ sample_project(id: 1), sample_project(id: 2) ],
+      headers: { "Link" => "<https://3.basecampapi.com/12345/projects.json?page=2>; rel=\"next\"" }
+    )
+
+    first = create_account_client.projects.list.first(2)
+
+    assert_equal 2, first.length
+    assert_requested :get, "https://3.basecampapi.com/12345/projects.json", times: 1
+    assert_not_requested :get, "https://3.basecampapi.com/12345/projects.json?page=2"
+  end
+
+  def test_wrapped_service_preserves_meta_and_shape
+    stub_get(
+      "/12345/reports/users/progress/9.json",
+      response_body: { "person" => { "id" => 9 }, "events" => [ { "id" => 1 } ] },
+      headers: { "X-Total-Count" => "3" }
+    )
+
+    result = create_account_client.reports.person_progress(person_id: 9)
+
+    assert_kind_of Hash, result
+    assert_kind_of Basecamp::ListEnumerator, result["events"]
+    assert_equal 3, result["events"].meta.total_count
+  end
+end

--- a/ruby/test/basecamp/pagination_meta_test.rb
+++ b/ruby/test/basecamp/pagination_meta_test.rb
@@ -219,6 +219,40 @@ class HttpPaginationMetaTest < Minitest::Test
     assert_not_requested :get, "#{base_url}/items.json?page=2"
   end
 
+  def test_first_on_capped_enumerator_records_truncation
+    # Consumers like first/take cancel the producer at the capping yield, so
+    # truncation must be recorded before that yield — once the capped item
+    # has been delivered, meta.truncated is accurate.
+    stub_get("/items.json", response_body: [ { "id" => 1 }, { "id" => 2 } ])
+
+    enum = @http.paginate("/items.json", max_items: 1)
+
+    assert_equal [ 1 ], enum.first(1).map { |i| i["id"] }
+    assert enum.meta.truncated
+  end
+
+  def test_block_form_returns_nil
+    # Pin: the block form returns nil, exactly as the pre-ListEnumerator loop
+    # did — Enumerator#each returns the generator block's value, and the
+    # generator ends in a bare loop. Callers using the return value for
+    # control flow must never see a truthy enumerator appear.
+    stub_get("/items.json", response_body: [ { "id" => 1 } ])
+
+    stub_get("/events.json", response_body: { "events" => [ { "id" => 2 } ] })
+
+    seen = []
+    result = @http.paginate("/items.json") { |item| seen << item["id"] }
+
+    assert_equal [ 1 ], seen
+    assert_nil result
+
+    seen = []
+    result = @http.paginate_key("/events.json", key: "events") { |item| seen << item["id"] }
+
+    assert_equal [ 2 ], seen
+    assert_nil result
+  end
+
   def test_non_positive_max_items_means_no_cap
     [ 0, -5 ].each do |cap|
       WebMock.reset!


### PR DESCRIPTION
Closes the last Ruby pagination parity gaps — waivers **2C.2** (X-Total-Count exposed), **2C.4** (maxItems early-stop), and **2C.6** (truncation metadata). Every other SDK ships all three; Ruby's lazy `Enumerator` could express none of them.

## Design: lazy-preserving, non-breaking

The Enumerator is Ruby's public pagination API (32 of 47 services return one), so laziness had to survive. Paginators now return a **`ListEnumerator`** — an `Enumerator` subclass carrying **`ListMeta`** (`total_count`, `truncated`) — built by one shared core behind `paginate`/`paginate_key`/`paginate_wrapped`:

- **Eager first page** (precedent: `paginate_wrapped` already fetched page 1 eagerly): `meta.total_count` (X-Total-Count, 0 when absent) is available the moment the list call returns, and page-1 errors surface from the call itself rather than first iteration.
- **Lazy tail**: pages beyond the first are fetched only as iteration demands them — `.first(n)`, `.take(n)`, `.next`/`.peek`, and `.lazy` all work unchanged and never over-fetch (pinned by WebMock request-count tests).
- **`max_items:` kwarg** on every generated list method (33 service files, uniformly additive), threaded into the base paginators. Non-positive values disable the cap at every paginator entry, matching TS (`maxItems > 0`), Swift (`n > 0`), and Python (#540).
- **Truncation contract** (same as #540's Python): `truncated` is true only when items were dropped by `max_items` or a next Link was left unfetched (at `max_items` or the `max_pages` safety cap). Landing exactly on the final item of the last page is **not** truncation.

### Metadata visibility semantics

`meta.total_count` is final at call time (eager page 1). `meta.truncated` starts `false` and is **final only once enumeration completes** — the lazy adaptation of the eager SDKs' post-collection metadata. The conformance runner consumes-then-asserts accordingly, and this is documented in `ListMeta`, the README, and SPEC Appendix F.

### Hook-timing consequence

With page 1 fetched inside `wrap_paginated`'s yield, `on_operation_start` now fires eagerly at call time (the pattern `wrap_paginated_wrapped` already used), and both hook wrappers re-wrap as `ListEnumerator` sharing the inner meta so metadata survives the hook layer. `on_operation_end` still fires when iteration completes, errors, or is cut short. The hook pins in `operation_hooks_test.rb` are updated to the new timing.

## Red proofs

Conformance, five skips removed + runner wired, against the pristine SDK:

```
  FAIL: Total count header is accessible
        Expected responseMeta.totalCount = 42, got nil
  FAIL: Pagination stops at maxPages safety cap
        Expected responseMeta.truncated = true, got nil
  FAIL: Missing X-Total-Count returns zero
        Expected responseMeta.totalCount = 0, got nil
  FAIL: maxItems caps results across pages
        Expected >= 2 requests (SDK auto-paginates), got 0; Expected no error, got: ArgumentError: unknown keyword: :max_items; Expected responseMeta.truncated = true, got nil
  FAIL: maxItems landing exactly on the final item is not truncated
        Expected >= 2 requests (SDK auto-paginates), got 0; Expected no error, got: ArgumentError: unknown keyword: :max_items; Expected responseMeta.truncated = false, got nil
Results: 106 passed, 5 failed, 13 skipped
REAL_EXIT=2
```

New unit tests (`ruby/test/basecamp/pagination_meta_test.rb`, 31 runs) against the pristine SDK: 22 red —

```
12 × ArgumentError: unknown keyword: :max_items
 5 × NoMethodError: undefined method 'meta' for an instance of Enumerator
 4 × NameError: uninitialized constant Basecamp::ListEnumerator
 1 × Failure: test_first_page_fetched_eagerly — expected 1 request, got 0
31 runs, 1 failures, 21 errors
REAL_EXIT=1
```

The 9 green-on-pristine tests are the labeled laziness/iteration **pins** (`.first(n)` fetches exactly one page, `.next`/`.peek`, `.lazy`, block form, wrapped `{key => Enumerator}` shape), which must hold before and after.

## Green

- `make conformance-ruby`: `Results: 111 passed, 0 failed, 13 skipped` (`REAL_EXIT=0`; remaining skips are the rostered 2B.3 retry family + DownloadURL pair)
- `make rb-check` (drift + tests + rubocop): `979 runs, 2204 assertions, 0 failures, 0 errors, 0 skips`, `143 files inspected, no offenses detected`, `No drift detected.` (`REAL_EXIT=0`)

## Governance (same PR)

- SPEC §19: exactly the five Ruby pagination roster lines deleted.
- `rubric-audit.json`: 2C.2/2C.4/2C.6 flipped to plain passes with obsolete-waiver notes (3C.6 style).
- SPEC §5 Known-Gaps bullet and Appendix F Ruby pagination row (`no/no` → `yes/yes`, truncated final after enumeration).
- `ruby/README.md` pagination section: metadata, `max_items`, and the truncation contract, mirroring the Python docs from #540.

No wire-format change: `max_items` is a client-side collection cap, never sent as a query parameter. Additive keyword — zero breakage for existing callers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds pagination metadata and a client-side item cap to Ruby’s paginators via a lazy `ListEnumerator` with `ListMeta`. Page 1 is fetched at call time for `meta.total_count`; re-enumeration now refetches all pages and refreshes metadata for a fresh snapshot.

- **New Features**
  - Return `ListEnumerator` (Enumerator subclass) with `.meta` (`ListMeta`): total_count from X-Total-Count (0 when absent); truncated finalized after enumeration.
  - Eager first page; lazy tail with no over-fetch for `.first`/`.take`/`.lazy`.
  - Add `max_items:` to all list methods; non-positive disables; client-side only.
  - Hooks: `on_operation_start` at call time; metadata preserved through wrappers.
  - Update runner, docs, and SPEC: Ruby conformance passes; remove waivers 2C.2/2C.4/2C.6.

- **Bug Fixes**
  - Re-enumeration refetches all pages and refreshes `.meta`; hooks fire once per traversal (start at call, end on first completion).
  - Truncation is recorded before the capping yield so `.first`/`.take` with `max_items` correctly set `meta.truncated`.

<sup>Written for commit 6b93d63123a0ae7decaadaa42e409b1bf5e8fe44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

