### PR TITLE
Make the conformance gap index bite in every runner, and catch URLSession's cancellation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,6 +143,13 @@ jobs:
             exit 1
           fi
 
+      - name: Run Go conformance runner unit tests
+        # Unit-tests the runner's own assertion helpers. Their bounds
+        # branches never execute against a fixture that passes, so a
+        # vacuous assertion (#563) survives a fully green conformance run.
+        working-directory: conformance/runner/go
+        run: go test ./...
+
       - name: Run Go conformance tests
         working-directory: conformance/runner/go
         run: |
@@ -261,6 +268,14 @@ jobs:
           bundle install
           ruby runner.rb
 
+      - name: Run Ruby conformance runner unit tests
+        # Unit-tests the runner's own assertion helpers. Their bounds
+        # branches never execute against a fixture that passes, so a
+        # vacuous assertion (#563) survives a fully green conformance run.
+        if: matrix.ruby == '3.3'
+        working-directory: conformance/runner/ruby
+        run: bundle exec ruby delay_gaps_test.rb
+
   test-python:
     name: Python ${{ matrix.python }}
     runs-on: ubuntu-latest
@@ -332,6 +347,14 @@ jobs:
           uv sync --python ${{ matrix.python }}
           uv run --python ${{ matrix.python }} python runner.py
 
+      - name: Run Python conformance runner unit tests
+        # Unit-tests the runner's own assertion helpers. Their bounds
+        # branches never execute against a fixture that passes, so a
+        # vacuous assertion (#563) survives a fully green conformance run.
+        if: matrix.python == '3.13'
+        working-directory: conformance/runner/python
+        run: uv run --python ${{ matrix.python }} python -m pytest -q test_delay_gaps.py
+
   test-swift:
     name: Swift Tests
     runs-on: macos-15
@@ -398,6 +421,12 @@ jobs:
 
       - name: Check optional array/scalar invariant
         run: ruby ../scripts/check-kotlin-optional-arrays-and-scalars.rb
+
+      - name: Run Kotlin conformance runner unit tests
+        # Unit-tests the runner's own assertion helpers. Their bounds
+        # branches never execute against a fixture that passes, so a
+        # vacuous assertion (#563) survives a fully green conformance run.
+        run: ./gradlew :conformance:test
 
       - name: Run Kotlin conformance tests
         run: ./gradlew :conformance:run

--- a/Makefile
+++ b/Makefile
@@ -408,7 +408,7 @@ py-clean:
 # Conformance Test targets
 #------------------------------------------------------------------------------
 
-.PHONY: conformance conformance-go conformance-go-replay conformance-kotlin conformance-kotlin-replay conformance-typescript conformance-typescript-live conformance-ruby conformance-ruby-replay conformance-python conformance-python-replay conformance-build conformance-live conformance-canary oauth-fixtures-check oauth-token-fixtures-check conformance-fixtures-check
+.PHONY: conformance conformance-runner-tests conformance-go conformance-go-replay conformance-kotlin conformance-kotlin-replay conformance-typescript conformance-typescript-live conformance-ruby conformance-ruby-replay conformance-python conformance-python-replay conformance-build conformance-live conformance-canary oauth-fixtures-check oauth-token-fixtures-check conformance-fixtures-check
 
 # Pinned validator for the data-only OAuth discovery fixtures. Run via uvx so the
 # version is reproducible without a global install; the schema is separate from
@@ -441,6 +441,20 @@ conformance-fixtures-check:
 	@echo "==> Validating conformance fixtures against schema.json..."
 	uvx --from 'check-jsonschema==$(CHECK_JSONSCHEMA_VERSION)' check-jsonschema \
 		--schemafile conformance/tests.schema.json conformance/tests/*.json
+
+# Unit-test the runners' own assertion helpers.
+#
+# The runners are test harnesses, but their assertion logic is code like any
+# other, and its bounds branches never execute against a fixture that passes.
+# #563 shipped a delayBetweenRequests check that vacuously passed when the gap
+# it named did not exist; nothing caught it because every committed fixture
+# supplied the gap. These pin the branches the fixtures cannot reach.
+conformance-runner-tests:
+	@echo "==> Running conformance runner unit tests..."
+	cd conformance/runner/go && go test ./...
+	cd conformance/runner/python && uv run python -m pytest -q test_delay_gaps.py
+	cd conformance/runner/ruby && bundle exec ruby delay_gaps_test.rb
+	cd kotlin && ./gradlew --quiet :conformance:test
 
 # Build conformance test runner
 conformance-build:
@@ -516,7 +530,7 @@ conformance-python-replay:
 	cd conformance/runner/python && uv sync && uv run python replay_runner.py
 
 # Run all conformance tests
-conformance: oauth-fixtures-check oauth-token-fixtures-check conformance-fixtures-check conformance-go conformance-kotlin conformance-typescript conformance-ruby conformance-python
+conformance: oauth-fixtures-check oauth-token-fixtures-check conformance-fixtures-check conformance-runner-tests conformance-go conformance-kotlin conformance-typescript conformance-ruby conformance-python
 	@echo "==> Conformance tests passed"
 
 # Orchestrate one canary pass against a single backend:

--- a/Makefile
+++ b/Makefile
@@ -453,7 +453,7 @@ conformance-runner-tests:
 	@echo "==> Running conformance runner unit tests..."
 	cd conformance/runner/go && go test ./...
 	cd conformance/runner/python && uv run python -m pytest -q test_delay_gaps.py
-	cd conformance/runner/ruby && bundle exec ruby delay_gaps_test.rb
+	cd conformance/runner/ruby && bundle install --quiet && bundle exec ruby delay_gaps_test.rb
 	cd kotlin && ./gradlew --quiet :conformance:test
 
 # Build conformance test runner

--- a/SPEC.md
+++ b/SPEC.md
@@ -1621,7 +1621,7 @@ Enumerated from `conformance/schema.json`:
 | Type | Description |
 |------|-------------|
 | `requestCount` | Number of HTTP requests made (verifies retry behavior) |
-| `delayBetweenRequests` | Minimum delay between requests in ms (verifies backoff) |
+| `delayBetweenRequests` | Minimum delay between requests in ms (verifies backoff). `index` names one inter-request gap; omitted, every gap must clear the minimum. Never passes vacuously: a named gap the run did not produce fails, an omitted index with no gaps fails, and a negative index is rejected. |
 | `statusCode` | HTTP status code of the response |
 | `responseStatus` | Response status category |
 | `responseBody` | Specific value in response body (by path) |

--- a/conformance/runner/go/delay_gaps.go
+++ b/conformance/runner/go/delay_gaps.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+// checkDelayGaps validates one `delayBetweenRequests` assertion against the
+// recorded request times, returning "" when it holds and a failure message
+// otherwise.
+//
+// Gap i is the interval between request i and request i+1, so N requests
+// yield N-1 gaps. The contract in conformance/schema.json:
+//
+//   - A NAMED index selects exactly that gap. It is bounds-checked
+//     unconditionally: a gap the run never produced is a failure, not a
+//     silent pass. The whole point of a timing pin is to catch a dropped
+//     backoff, and a dropped backoff is precisely what removes the gap.
+//   - An OMITTED index requires the minimum on EVERY gap. Zero gaps means
+//     nothing was measured, so an omitted-index assertion on a single-request
+//     run fails too — the same reasoning, one step further: if every retry
+//     were dropped, an "every gap" rule with no gaps left would otherwise
+//     wave the run through.
+//   - Negative indexes are rejected rather than wrapping to the end the way
+//     headerPresent and friends do. There is no sensible "last gap" when the
+//     point of naming one is to pin a specific backoff.
+//
+// The bounds test compares against the last valid gap rather than adding one
+// to the index: `index+1 >= len(requestTimes)` overflows for math.MaxInt and
+// wraps negative, sailing through the guard into an out-of-range read.
+func checkDelayGaps(requestTimes []time.Time, minDelay time.Duration, index *int) string {
+	gaps := len(requestTimes) - 1
+
+	if index != nil {
+		gap := *index
+		if gap < 0 {
+			return fmt.Sprintf("delayBetweenRequests gap index must be non-negative, got %d", gap)
+		}
+		if gap >= gaps {
+			return fmt.Sprintf("Expected a delay at gap %d, but only %d request(s) were made", gap, len(requestTimes))
+		}
+		if delay := requestTimes[gap+1].Sub(requestTimes[gap]); delay < minDelay {
+			return fmt.Sprintf("Expected delay >= %v at gap %d, got %v", minDelay, gap, delay)
+		}
+		return ""
+	}
+
+	if gaps < 1 {
+		return fmt.Sprintf("Expected a delay between requests, but only %d request(s) were made", len(requestTimes))
+	}
+	for i := 0; i < gaps; i++ {
+		if delay := requestTimes[i+1].Sub(requestTimes[i]); delay < minDelay {
+			return fmt.Sprintf("Expected delay >= %v at gap %d, got %v", minDelay, i, delay)
+		}
+	}
+	return ""
+}

--- a/conformance/runner/go/delay_gaps_test.go
+++ b/conformance/runner/go/delay_gaps_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"math"
+	"strings"
+	"testing"
+	"time"
+)
+
+// times builds request timestamps from successive gaps in milliseconds, so a
+// case reads as the gaps it is about rather than as absolute instants.
+func times(gapsMs ...int) []time.Time {
+	base := time.Unix(0, 0)
+	out := []time.Time{base}
+	for _, ms := range gapsMs {
+		base = base.Add(time.Duration(ms) * time.Millisecond)
+		out = append(out, base)
+	}
+	return out
+}
+
+func ptr(i int) *int { return &i }
+
+// The four bounds branches every runner must share, plus the every-gap rule.
+// Each case names the behavior that regressed on #563 and #568.
+func TestCheckDelayGaps(t *testing.T) {
+	cases := []struct {
+		name        string
+		requestTime []time.Time
+		min         time.Duration
+		index       *int
+		wantFail    bool
+		wantMsg     string
+	}{
+		{
+			// The #568 defect: three runners measured gap 0 and stopped, so a
+			// second backoff that never happened passed unnoticed.
+			name:        "omitted index catches a later failing gap",
+			requestTime: times(1000, 5),
+			min:         500 * time.Millisecond,
+			index:       nil,
+			wantFail:    true,
+			wantMsg:     "at gap 1",
+		},
+		{
+			name:        "omitted index passes when every gap clears the minimum",
+			requestTime: times(1000, 2000, 800),
+			min:         500 * time.Millisecond,
+			index:       nil,
+			wantFail:    false,
+		},
+		{
+			// The residual false-green: an "every gap" rule with no gaps must
+			// not wave the run through. A fully dropped retry lands here.
+			name:        "omitted index fails when there are no gaps at all",
+			requestTime: times(),
+			min:         500 * time.Millisecond,
+			index:       nil,
+			wantFail:    true,
+			wantMsg:     "only 1 request(s) were made",
+		},
+		{
+			name:        "named gap fails when the run never produced it",
+			requestTime: times(1000),
+			min:         500 * time.Millisecond,
+			index:       ptr(1),
+			wantFail:    true,
+			wantMsg:     "Expected a delay at gap 1, but only 2 request(s) were made",
+		},
+		{
+			name:        "named gap fails on a single-request run",
+			requestTime: times(),
+			min:         500 * time.Millisecond,
+			index:       ptr(0),
+			wantFail:    true,
+			wantMsg:     "Expected a delay at gap 0, but only 1 request(s) were made",
+		},
+		{
+			// Negative must be rejected categorically, not wrapped to the end
+			// the way headerPresent's index does.
+			name:        "negative gap index is rejected",
+			requestTime: times(1000, 2000),
+			min:         500 * time.Millisecond,
+			index:       ptr(-1),
+			wantFail:    true,
+			wantMsg:     "must be non-negative",
+		},
+		{
+			// gap+1 overflows to negative for MaxInt, sailing past a
+			// `gap+1 >= len` guard into an out-of-range read.
+			name:        "MaxInt gap index fails without overflowing",
+			requestTime: times(1000, 2000),
+			min:         500 * time.Millisecond,
+			index:       ptr(math.MaxInt),
+			wantFail:    true,
+			wantMsg:     "Expected a delay at gap",
+		},
+		{
+			// A zero minimum still requires the gap to EXIST. Runners that
+			// gate the check on a truthy min skip this case entirely.
+			name:        "zero minimum still asserts the gap exists",
+			requestTime: times(),
+			min:         0,
+			index:       nil,
+			wantFail:    true,
+			wantMsg:     "only 1 request(s) were made",
+		},
+		{
+			name:        "zero minimum passes once a gap exists",
+			requestTime: times(5),
+			min:         0,
+			index:       nil,
+			wantFail:    false,
+		},
+		{
+			name:        "named gap passes when it clears the minimum",
+			requestTime: times(5, 2000),
+			min:         500 * time.Millisecond,
+			index:       ptr(1),
+			wantFail:    false,
+		},
+		{
+			name:        "named gap fails when it is below the minimum",
+			requestTime: times(2000, 5),
+			min:         500 * time.Millisecond,
+			index:       ptr(1),
+			wantFail:    true,
+			wantMsg:     "at gap 1",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := checkDelayGaps(tc.requestTime, tc.min, tc.index)
+			if tc.wantFail {
+				if got == "" {
+					t.Fatalf("expected a failure message, got a pass")
+				}
+				if !strings.Contains(got, tc.wantMsg) {
+					t.Fatalf("expected message containing %q, got %q", tc.wantMsg, got)
+				}
+			} else if got != "" {
+				t.Fatalf("expected a pass, got failure %q", got)
+			}
+		})
+	}
+}

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -944,18 +944,23 @@ func checkAssertion(
 
 	case "delayBetweenRequests":
 		// index selects a single inter-request GAP (gap i is between request i
-		// and i+1); it defaults to the first. A named gap that does not exist
-		// is a failure, not a silent pass — otherwise a dropped retry makes the
-		// assertion vanish instead of firing.
-		if len(requestTimes) >= 2 {
-			gap := assertionIndex(assertion)
-			if gap+1 >= len(requestTimes) {
+		// and i+1). Omitted, every gap must clear the minimum. A NAMED gap is
+		// bounds-checked outside the "did we even get two requests" guard: a
+		// dropped retry must fail the assertion, not make it vanish.
+		minDelay := time.Duration(assertion.Min) * time.Millisecond
+		if assertion.Index != nil {
+			gap := *assertion.Index
+			if gap < 0 || gap+1 >= len(requestTimes) {
 				return fail(tc, fmt.Sprintf("Expected a delay at gap %d, but only %d request(s) were made", gap, len(requestTimes)))
 			}
-			delay := requestTimes[gap+1].Sub(requestTimes[gap])
-			minDelay := time.Duration(assertion.Min) * time.Millisecond
-			if delay < minDelay {
+			if delay := requestTimes[gap+1].Sub(requestTimes[gap]); delay < minDelay {
 				return fail(tc, fmt.Sprintf("Expected delay >= %v at gap %d, got %v", minDelay, gap, delay))
+			}
+		} else {
+			for i := 0; i+1 < len(requestTimes); i++ {
+				if delay := requestTimes[i+1].Sub(requestTimes[i]); delay < minDelay {
+					return fail(tc, fmt.Sprintf("Expected delay >= %v at gap %d, got %v", minDelay, i, delay))
+				}
 			}
 		}
 

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -943,25 +943,8 @@ func checkAssertion(
 		}
 
 	case "delayBetweenRequests":
-		// index selects a single inter-request GAP (gap i is between request i
-		// and i+1). Omitted, every gap must clear the minimum. A NAMED gap is
-		// bounds-checked outside the "did we even get two requests" guard: a
-		// dropped retry must fail the assertion, not make it vanish.
-		minDelay := time.Duration(assertion.Min) * time.Millisecond
-		if assertion.Index != nil {
-			gap := *assertion.Index
-			if gap < 0 || gap+1 >= len(requestTimes) {
-				return fail(tc, fmt.Sprintf("Expected a delay at gap %d, but only %d request(s) were made", gap, len(requestTimes)))
-			}
-			if delay := requestTimes[gap+1].Sub(requestTimes[gap]); delay < minDelay {
-				return fail(tc, fmt.Sprintf("Expected delay >= %v at gap %d, got %v", minDelay, gap, delay))
-			}
-		} else {
-			for i := 0; i+1 < len(requestTimes); i++ {
-				if delay := requestTimes[i+1].Sub(requestTimes[i]); delay < minDelay {
-					return fail(tc, fmt.Sprintf("Expected delay >= %v at gap %d, got %v", minDelay, i, delay))
-				}
-			}
+		if msg := checkDelayGaps(requestTimes, time.Duration(assertion.Min)*time.Millisecond, assertion.Index); msg != "" {
+			return fail(tc, msg)
 		}
 
 	case "noError":

--- a/conformance/runner/python/pyproject.toml
+++ b/conformance/runner/python/pyproject.toml
@@ -7,5 +7,12 @@ dependencies = [
     "basecamp-sdk",
 ]
 
+[dependency-groups]
+# The runner's own assertion helpers are unit-tested (test_delay_gaps.py):
+# a bounds branch that only ever runs against passing fixtures is not a guard.
+dev = [
+    "pytest>=8",
+]
+
 [tool.uv.sources]
 basecamp-sdk = { path = "../../../python", editable = true }

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -33,6 +33,48 @@ _CARD_WRITE_FIELDS = ("title", "content", "due_on", "assignee_ids")
 _MISSING = object()
 
 
+def check_delay_gaps(delays: list[float], min_delay: float | None, index: int | None) -> str | None:
+    """Validate one ``delayBetweenRequests`` assertion; None when it holds.
+
+    ``delays`` is the list of inter-request gaps, so N requests yield N-1
+    entries and gap i is the interval between request i and request i+1.
+    The contract in conformance/schema.json:
+
+    * A NAMED index selects exactly that gap, bounds-checked unconditionally.
+      A gap the run never produced is a failure, not a silent pass — the whole
+      point of a timing pin is to catch a dropped backoff, and a dropped
+      backoff is precisely what removes the gap.
+    * An OMITTED index requires the minimum on EVERY gap. Zero gaps means
+      nothing was measured, so that fails too: an "every gap" rule with no
+      gaps left would otherwise wave through a run that dropped every retry.
+    * Negative indexes are rejected rather than wrapping to the end the way
+      the per-request assertions do. There is no sensible "last gap" when the
+      point of naming one is to pin a specific backoff.
+
+    An absent or zero ``min_delay`` still asserts that the gap EXISTS. The
+    default is applied HERE rather than at the call site so a truthiness gate
+    (``if min_delay:``, which discards a legitimate ``min: 0``) cannot quietly
+    reduce the assertion to nothing — the false-green class this exists to kill.
+    """
+    min_delay = 0 if min_delay is None else min_delay
+
+    if index is not None:
+        if index < 0:
+            return f"delayBetweenRequests gap index must be non-negative, got {index}"
+        if index >= len(delays):
+            return f"Expected a delay at gap {index}, but only {len(delays) + 1} request(s) were made"
+        if delays[index] < min_delay:
+            return f"Expected minimum delay of {min_delay}ms at gap {index}, got {delays[index]}ms"
+        return None
+
+    if not delays:
+        return "Expected a delay between requests, but only 1 request(s) were made"
+    for i, delay in enumerate(delays):
+        if delay < min_delay:
+            return f"Expected minimum delay of {min_delay}ms at gap {i}, got {delay}ms"
+    return None
+
+
 @dataclass
 class TestTracker:
     requests: list[dict] = field(default_factory=list)
@@ -429,30 +471,22 @@ class TestRunner:
                         failures.append(f"Expected {expected} requests, got {actual}")
 
                 case "delayBetweenRequests":
-                    # Every inter-request gap must clear the minimum, unless the
-                    # fixture names one: not all gaps are retry gaps — the
-                    # download flow's final gap is the redirect hop to the
-                    # signed URL, which is deliberately un-delayed — so those
-                    # fixtures assert per-gap with an index.
-                    delays = self._tracker.delays_between_requests
-                    min_delay = assertion.get("min")
-                    index = assertion.get("index")
-                    if min_delay:
-                        if index is not None:
-                            # A named gap that does not exist fails: a dropped
-                            # retry must fire the assertion, not make it
-                            # vanish. Negative indexes are rejected rather than
-                            # wrapping like the per-request assertions do.
-                            if index < 0 or index >= len(delays):
-                                failures.append(
-                                    f"Expected a delay at gap {index}, but only {len(delays) + 1} request(s) were made"
-                                )
-                            elif delays[index] < min_delay:
-                                failures.append(
-                                    f"Expected minimum delay of {min_delay}ms at gap {index}, got {delays[index]}ms"
-                                )
-                        elif delays and any(d < min_delay for d in delays):
-                            failures.append(f"Expected minimum delay of {min_delay}ms, got {min(delays)}ms")
+                    # Not all gaps are retry gaps — the download flow's final
+                    # gap is the redirect hop to the signed URL, which is
+                    # deliberately un-delayed — so those fixtures name a gap
+                    # with an index. See check_delay_gaps for the contract.
+                    #
+                    # An absent or zero `min` still asserts that the gap EXISTS,
+                    # so it must not be truthiness-gated: `if min_delay:` skips
+                    # `min: 0` entirely, degrading the assertion to nothing —
+                    # the very false-green class this check exists to kill.
+                    failure = check_delay_gaps(
+                        self._tracker.delays_between_requests,
+                        assertion.get("min"),
+                        assertion.get("index"),
+                    )
+                    if failure:
+                        failures.append(failure)
 
                 case "noError":
                     if error:

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -33,7 +33,9 @@ _CARD_WRITE_FIELDS = ("title", "content", "due_on", "assignee_ids")
 _MISSING = object()
 
 
-def check_delay_gaps(delays: list[float], min_delay: float | None, index: int | None) -> str | None:
+def check_delay_gaps(
+    delays: list[float], min_delay: float | None, index: int | None, request_count: int
+) -> str | None:
     """Validate one ``delayBetweenRequests`` assertion; None when it holds.
 
     ``delays`` is the list of inter-request gaps, so N requests yield N-1
@@ -55,6 +57,10 @@ def check_delay_gaps(delays: list[float], min_delay: float | None, index: int | 
     default is applied HERE rather than at the call site so a truthiness gate
     (``if min_delay:``, which discards a legitimate ``min: 0``) cannot quietly
     reduce the assertion to nothing — the false-green class this exists to kill.
+
+    ``request_count`` is passed rather than inferred as ``len(delays) + 1``:
+    that inference assumes at least one request, so a run that failed before
+    dispatching anything would report "only 1 request(s) were made".
     """
     min_delay = 0 if min_delay is None else min_delay
 
@@ -62,13 +68,13 @@ def check_delay_gaps(delays: list[float], min_delay: float | None, index: int | 
         if index < 0:
             return f"delayBetweenRequests gap index must be non-negative, got {index}"
         if index >= len(delays):
-            return f"Expected a delay at gap {index}, but only {len(delays) + 1} request(s) were made"
+            return f"Expected a delay at gap {index}, but only {request_count} request(s) were made"
         if delays[index] < min_delay:
             return f"Expected minimum delay of {min_delay}ms at gap {index}, got {delays[index]}ms"
         return None
 
     if not delays:
-        return "Expected a delay between requests, but only 1 request(s) were made"
+        return f"Expected a delay between requests, but only {request_count} request(s) were made"
     for i, delay in enumerate(delays):
         if delay < min_delay:
             return f"Expected minimum delay of {min_delay}ms at gap {i}, got {delay}ms"
@@ -484,6 +490,7 @@ class TestRunner:
                         self._tracker.delays_between_requests,
                         assertion.get("min"),
                         assertion.get("index"),
+                        self._tracker.request_count,
                     )
                     if failure:
                         failures.append(failure)

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -437,13 +437,21 @@ class TestRunner:
                     delays = self._tracker.delays_between_requests
                     min_delay = assertion.get("min")
                     index = assertion.get("index")
-                    if min_delay and delays:
+                    if min_delay:
                         if index is not None:
-                            if index < len(delays) and delays[index] < min_delay:
+                            # A named gap that does not exist fails: a dropped
+                            # retry must fire the assertion, not make it
+                            # vanish. Negative indexes are rejected rather than
+                            # wrapping like the per-request assertions do.
+                            if index < 0 or index >= len(delays):
+                                failures.append(
+                                    f"Expected a delay at gap {index}, but only {len(delays) + 1} request(s) were made"
+                                )
+                            elif delays[index] < min_delay:
                                 failures.append(
                                     f"Expected minimum delay of {min_delay}ms at gap {index}, got {delays[index]}ms"
                                 )
-                        elif any(d < min_delay for d in delays):
+                        elif delays and any(d < min_delay for d in delays):
                             failures.append(f"Expected minimum delay of {min_delay}ms, got {min(delays)}ms")
 
                 case "noError":

--- a/conformance/runner/python/test_delay_gaps.py
+++ b/conformance/runner/python/test_delay_gaps.py
@@ -1,0 +1,79 @@
+"""Bounds and every-gap contract for the delayBetweenRequests assertion.
+
+Run: `uv run pytest test_delay_gaps.py`
+
+Each case names a behavior that regressed on #563/#568: an assertion that
+looked like it covered a timing gap and did not.
+"""
+from __future__ import annotations
+
+import pytest
+
+from runner import check_delay_gaps
+
+
+def test_omitted_index_catches_a_later_failing_gap():
+    # Three runners measured gap 0 and stopped, so a second backoff that never
+    # happened passed unnoticed.
+    failure = check_delay_gaps([1000.0, 5.0], 500, None)
+    assert failure is not None
+    assert "at gap 1" in failure
+
+
+def test_omitted_index_passes_when_every_gap_clears_the_minimum():
+    assert check_delay_gaps([1000.0, 2000.0, 800.0], 500, None) is None
+
+
+def test_omitted_index_fails_when_there_are_no_gaps_at_all():
+    # An "every gap" rule with no gaps left must not wave the run through: a
+    # fully dropped retry lands exactly here.
+    failure = check_delay_gaps([], 500, None)
+    assert failure == "Expected a delay between requests, but only 1 request(s) were made"
+
+
+def test_named_gap_fails_when_the_run_never_produced_it():
+    failure = check_delay_gaps([1000.0], 500, 1)
+    assert failure == "Expected a delay at gap 1, but only 2 request(s) were made"
+
+
+def test_named_gap_fails_on_a_single_request_run():
+    failure = check_delay_gaps([], 500, 0)
+    assert failure == "Expected a delay at gap 0, but only 1 request(s) were made"
+
+
+@pytest.mark.parametrize("index", [-1, -3])
+def test_negative_gap_index_is_rejected(index):
+    # Rejected categorically, not wrapped to the end the way headerPresent's
+    # index is: there is no sensible "last gap" when the point is to name one.
+    failure = check_delay_gaps([1000.0, 2000.0], 500, index)
+    assert failure == f"delayBetweenRequests gap index must be non-negative, got {index}"
+
+
+def test_enormous_gap_index_fails_rather_than_raising():
+    failure = check_delay_gaps([1000.0, 2000.0], 500, 2**63 - 1)
+    assert failure is not None
+    assert "Expected a delay at gap" in failure
+
+
+def test_named_gap_passes_when_it_clears_the_minimum():
+    assert check_delay_gaps([5.0, 2000.0], 500, 1) is None
+
+
+def test_named_gap_fails_when_it_is_below_the_minimum():
+    failure = check_delay_gaps([2000.0, 5.0], 500, 1)
+    assert failure is not None
+    assert "at gap 1" in failure
+
+
+def test_zero_minimum_still_asserts_that_the_gap_exists():
+    # `min: 0` is falsy in Python, so a truthiness gate would skip the whole
+    # assertion and pass a run with no gaps at all. The minimum is trivially
+    # met; the EXISTENCE requirement is not.
+    for missing in (0, None):
+        assert check_delay_gaps([], missing, None) == (
+            "Expected a delay between requests, but only 1 request(s) were made"
+        )
+        assert check_delay_gaps([], missing, 0) == (
+            "Expected a delay at gap 0, but only 1 request(s) were made"
+        )
+        assert check_delay_gaps([5.0], missing, None) is None

--- a/conformance/runner/python/test_delay_gaps.py
+++ b/conformance/runner/python/test_delay_gaps.py
@@ -15,29 +15,29 @@ from runner import check_delay_gaps
 def test_omitted_index_catches_a_later_failing_gap():
     # Three runners measured gap 0 and stopped, so a second backoff that never
     # happened passed unnoticed.
-    failure = check_delay_gaps([1000.0, 5.0], 500, None)
+    failure = check_delay_gaps([1000.0, 5.0], 500, None, 3)
     assert failure is not None
     assert "at gap 1" in failure
 
 
 def test_omitted_index_passes_when_every_gap_clears_the_minimum():
-    assert check_delay_gaps([1000.0, 2000.0, 800.0], 500, None) is None
+    assert check_delay_gaps([1000.0, 2000.0, 800.0], 500, None, 4) is None
 
 
 def test_omitted_index_fails_when_there_are_no_gaps_at_all():
     # An "every gap" rule with no gaps left must not wave the run through: a
     # fully dropped retry lands exactly here.
-    failure = check_delay_gaps([], 500, None)
+    failure = check_delay_gaps([], 500, None, 1)
     assert failure == "Expected a delay between requests, but only 1 request(s) were made"
 
 
 def test_named_gap_fails_when_the_run_never_produced_it():
-    failure = check_delay_gaps([1000.0], 500, 1)
+    failure = check_delay_gaps([1000.0], 500, 1, 2)
     assert failure == "Expected a delay at gap 1, but only 2 request(s) were made"
 
 
 def test_named_gap_fails_on_a_single_request_run():
-    failure = check_delay_gaps([], 500, 0)
+    failure = check_delay_gaps([], 500, 0, 1)
     assert failure == "Expected a delay at gap 0, but only 1 request(s) were made"
 
 
@@ -45,22 +45,22 @@ def test_named_gap_fails_on_a_single_request_run():
 def test_negative_gap_index_is_rejected(index):
     # Rejected categorically, not wrapped to the end the way headerPresent's
     # index is: there is no sensible "last gap" when the point is to name one.
-    failure = check_delay_gaps([1000.0, 2000.0], 500, index)
+    failure = check_delay_gaps([1000.0, 2000.0], 500, index, 3)
     assert failure == f"delayBetweenRequests gap index must be non-negative, got {index}"
 
 
 def test_enormous_gap_index_fails_rather_than_raising():
-    failure = check_delay_gaps([1000.0, 2000.0], 500, 2**63 - 1)
+    failure = check_delay_gaps([1000.0, 2000.0], 500, 2**63 - 1, 3)
     assert failure is not None
     assert "Expected a delay at gap" in failure
 
 
 def test_named_gap_passes_when_it_clears_the_minimum():
-    assert check_delay_gaps([5.0, 2000.0], 500, 1) is None
+    assert check_delay_gaps([5.0, 2000.0], 500, 1, 3) is None
 
 
 def test_named_gap_fails_when_it_is_below_the_minimum():
-    failure = check_delay_gaps([2000.0, 5.0], 500, 1)
+    failure = check_delay_gaps([2000.0, 5.0], 500, 1, 3)
     assert failure is not None
     assert "at gap 1" in failure
 
@@ -70,10 +70,21 @@ def test_zero_minimum_still_asserts_that_the_gap_exists():
     # assertion and pass a run with no gaps at all. The minimum is trivially
     # met; the EXISTENCE requirement is not.
     for missing in (0, None):
-        assert check_delay_gaps([], missing, None) == (
+        assert check_delay_gaps([], missing, None, 1) == (
             "Expected a delay between requests, but only 1 request(s) were made"
         )
-        assert check_delay_gaps([], missing, 0) == (
+        assert check_delay_gaps([], missing, 0, 1) == (
             "Expected a delay at gap 0, but only 1 request(s) were made"
         )
-        assert check_delay_gaps([5.0], missing, None) is None
+        assert check_delay_gaps([5.0], missing, None, 2) is None
+
+
+def test_zero_request_run_reports_zero_not_one():
+    # Inferring the count as len(delays) + 1 assumes at least one request, so a
+    # run that failed before dispatching anything reported "only 1 request(s)".
+    assert check_delay_gaps([], 500, None, 0) == (
+        "Expected a delay between requests, but only 0 request(s) were made"
+    )
+    assert check_delay_gaps([], 500, 0, 0) == (
+        "Expected a delay at gap 0, but only 0 request(s) were made"
+    )

--- a/conformance/runner/ruby/delay_gaps_test.rb
+++ b/conformance/runner/ruby/delay_gaps_test.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# Bounds and every-gap contract for the delayBetweenRequests assertion.
+#
+# Each case names a behavior that regressed on #563/#568: an assertion that
+# looked like it covered a timing gap and did not.
+#
+# Run: `bundle exec ruby delay_gaps_test.rb`
+
+require "minitest/autorun"
+require_relative "runner"
+
+class DelayGapsTest < Minitest::Test
+  def test_omitted_index_catches_a_later_failing_gap
+    # Three runners measured gap 0 and stopped, so a second backoff that never
+    # happened passed unnoticed.
+    failure = DelayGaps.check([ 1000, 5 ], 500, nil)
+
+    assert_includes failure, "at gap 1"
+  end
+
+  def test_omitted_index_passes_when_every_gap_clears_the_minimum
+    assert_nil DelayGaps.check([ 1000, 2000, 800 ], 500, nil)
+  end
+
+  def test_omitted_index_fails_when_there_are_no_gaps_at_all
+    # An "every gap" rule with no gaps left must not wave the run through: a
+    # fully dropped retry lands exactly here.
+    assert_equal "Expected a delay between requests, but only 1 request(s) were made",
+      DelayGaps.check([], 500, nil)
+  end
+
+  def test_named_gap_fails_when_the_run_never_produced_it
+    assert_equal "Expected a delay at gap 1, but only 2 request(s) were made",
+      DelayGaps.check([ 1000 ], 500, 1)
+  end
+
+  def test_named_gap_fails_on_a_single_request_run
+    assert_equal "Expected a delay at gap 0, but only 1 request(s) were made",
+      DelayGaps.check([], 500, 0)
+  end
+
+  def test_negative_gap_index_is_rejected
+    # Rejected categorically, not wrapped to the end the way headerPresent's
+    # index is: there is no sensible "last gap" when the point is to name one.
+    assert_equal "delayBetweenRequests gap index must be non-negative, got -1",
+      DelayGaps.check([ 1000, 2000 ], 500, -1)
+  end
+
+  def test_enormous_gap_index_fails_rather_than_raising
+    assert_includes DelayGaps.check([ 1000, 2000 ], 500, 2**63 - 1), "Expected a delay at gap"
+  end
+
+  def test_named_gap_passes_when_it_clears_the_minimum
+    assert_nil DelayGaps.check([ 5, 2000 ], 500, 1)
+  end
+
+  def test_named_gap_fails_when_it_is_below_the_minimum
+    assert_includes DelayGaps.check([ 2000, 5 ], 500, 1), "at gap 1"
+  end
+
+  def test_zero_minimum_still_asserts_that_the_gap_exists
+    # A `min` of zero (or an absent one, which the caller defaults to zero)
+    # still requires the gap to EXIST. Gating the call on the value's presence
+    # would degrade the assertion to nothing.
+    [ 0, nil ].each do |missing|
+      assert_equal "Expected a delay between requests, but only 1 request(s) were made",
+        DelayGaps.check([], missing, nil)
+      assert_equal "Expected a delay at gap 0, but only 1 request(s) were made",
+        DelayGaps.check([], missing, 0)
+      assert_nil DelayGaps.check([ 5 ], missing, nil)
+    end
+  end
+end

--- a/conformance/runner/ruby/delay_gaps_test.rb
+++ b/conformance/runner/ruby/delay_gaps_test.rb
@@ -14,49 +14,58 @@ class DelayGapsTest < Minitest::Test
   def test_omitted_index_catches_a_later_failing_gap
     # Three runners measured gap 0 and stopped, so a second backoff that never
     # happened passed unnoticed.
-    failure = DelayGaps.check([ 1000, 5 ], 500, nil)
+    failure = DelayGaps.check([ 1000, 5 ], 500, nil, 3)
 
     assert_includes failure, "at gap 1"
   end
 
   def test_omitted_index_passes_when_every_gap_clears_the_minimum
-    assert_nil DelayGaps.check([ 1000, 2000, 800 ], 500, nil)
+    assert_nil DelayGaps.check([ 1000, 2000, 800 ], 500, nil, 4)
   end
 
   def test_omitted_index_fails_when_there_are_no_gaps_at_all
     # An "every gap" rule with no gaps left must not wave the run through: a
     # fully dropped retry lands exactly here.
     assert_equal "Expected a delay between requests, but only 1 request(s) were made",
-      DelayGaps.check([], 500, nil)
+      DelayGaps.check([], 500, nil, 1)
   end
 
   def test_named_gap_fails_when_the_run_never_produced_it
     assert_equal "Expected a delay at gap 1, but only 2 request(s) were made",
-      DelayGaps.check([ 1000 ], 500, 1)
+      DelayGaps.check([ 1000 ], 500, 1, 2)
   end
 
   def test_named_gap_fails_on_a_single_request_run
     assert_equal "Expected a delay at gap 0, but only 1 request(s) were made",
-      DelayGaps.check([], 500, 0)
+      DelayGaps.check([], 500, 0, 1)
   end
 
   def test_negative_gap_index_is_rejected
     # Rejected categorically, not wrapped to the end the way headerPresent's
     # index is: there is no sensible "last gap" when the point is to name one.
     assert_equal "delayBetweenRequests gap index must be non-negative, got -1",
-      DelayGaps.check([ 1000, 2000 ], 500, -1)
+      DelayGaps.check([ 1000, 2000 ], 500, -1, 3)
   end
 
   def test_enormous_gap_index_fails_rather_than_raising
-    assert_includes DelayGaps.check([ 1000, 2000 ], 500, 2**63 - 1), "Expected a delay at gap"
+    assert_includes DelayGaps.check([ 1000, 2000 ], 500, 2**63 - 1, 3), "Expected a delay at gap"
   end
 
   def test_named_gap_passes_when_it_clears_the_minimum
-    assert_nil DelayGaps.check([ 5, 2000 ], 500, 1)
+    assert_nil DelayGaps.check([ 5, 2000 ], 500, 1, 3)
+  end
+
+  def test_zero_request_run_reports_zero_not_one
+    # Inferring the count as delays.length + 1 assumes at least one request, so
+    # a run that failed before dispatching anything reported "only 1 request(s)".
+    assert_equal "Expected a delay between requests, but only 0 request(s) were made",
+      DelayGaps.check([], 500, nil, 0)
+    assert_equal "Expected a delay at gap 0, but only 0 request(s) were made",
+      DelayGaps.check([], 500, 0, 0)
   end
 
   def test_named_gap_fails_when_it_is_below_the_minimum
-    assert_includes DelayGaps.check([ 2000, 5 ], 500, 1), "at gap 1"
+    assert_includes DelayGaps.check([ 2000, 5 ], 500, 1, 3), "at gap 1"
   end
 
   def test_zero_minimum_still_asserts_that_the_gap_exists
@@ -65,10 +74,10 @@ class DelayGapsTest < Minitest::Test
     # would degrade the assertion to nothing.
     [ 0, nil ].each do |missing|
       assert_equal "Expected a delay between requests, but only 1 request(s) were made",
-        DelayGaps.check([], missing, nil)
+        DelayGaps.check([], missing, nil, 1)
       assert_equal "Expected a delay at gap 0, but only 1 request(s) were made",
-        DelayGaps.check([], missing, 0)
-      assert_nil DelayGaps.check([ 5 ], missing, nil)
+        DelayGaps.check([], missing, 0, 1)
+      assert_nil DelayGaps.check([ 5 ], missing, nil, 2)
     end
   end
 end

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -15,6 +15,55 @@ require "set"
 WebMock.enable!
 WebMock.disable_net_connect!
 
+# The delayBetweenRequests assertion contract, kept apart from the runner so
+# its bounds branches are unit-testable (delay_gaps_test.rb).
+module DelayGaps
+  # Validates one assertion against the recorded inter-request gaps, returning
+  # nil when it holds and a failure message otherwise.
+  #
+  # +delays+ holds the inter-request gaps, so N requests yield N-1 entries and
+  # gap i is the interval between request i and request i+1. The contract in
+  # conformance/schema.json:
+  #
+  # * A NAMED index selects exactly that gap, bounds-checked unconditionally.
+  #   A gap the run never produced is a failure, not a silent pass — the whole
+  #   point of a timing pin is to catch a dropped backoff, and a dropped
+  #   backoff is precisely what removes the gap.
+  # * An OMITTED index requires the minimum on EVERY gap. Zero gaps means
+  #   nothing was measured, so that fails too: an "every gap" rule with no gaps
+  #   left would otherwise wave through a run that dropped every retry.
+  # * Negative indexes are rejected rather than wrapping to the end like the
+  #   per-request assertions. There is no sensible "last gap" when the point of
+  #   naming one is to pin a specific backoff.
+  #
+  # An absent or zero +min_delay+ still asserts that the gap EXISTS. The default
+  # is applied HERE rather than at the call site so gating on the value's
+  # presence cannot quietly reduce the assertion to nothing — the false-green
+  # class this exists to kill.
+  def self.check(delays, min_delay, index)
+    min_delay ||= 0
+
+    if index
+      named_gap_failure(delays, min_delay, index)
+    elsif delays.empty?
+      "Expected a delay between requests, but only 1 request(s) were made"
+    else
+      short = delays.each_with_index.find { |delay, _| delay < min_delay }
+      short && "Expected minimum delay of #{min_delay}ms at gap #{short.last}, got #{short.first}ms"
+    end
+  end
+
+  def self.named_gap_failure(delays, min_delay, index)
+    if index.negative?
+      "delayBetweenRequests gap index must be non-negative, got #{index}"
+    elsif index >= delays.length
+      "Expected a delay at gap #{index}, but only #{delays.length + 1} request(s) were made"
+    elsif delays[index] < min_delay
+      "Expected minimum delay of #{min_delay}ms at gap #{index}, got #{delays[index]}ms"
+    end
+  end
+end
+
 # Test execution tracking
 class TestTracker
   attr_reader :requests
@@ -526,27 +575,16 @@ class TestRunner
         end
 
       when "delayBetweenRequests"
-        # Every inter-request gap must clear the minimum, unless the fixture
-        # names one: not all gaps are retry gaps — the download flow's final
-        # gap is the redirect hop to the signed URL, which is deliberately
-        # un-delayed — so those fixtures assert per-gap with an index.
-        delays = @tracker.delays_between_requests
-        min_delay = assertion["min"]
-        index = assertion["index"]
-        if min_delay
-          if index
-            # A named gap that does not exist fails: a dropped retry must fire
-            # the assertion, not make it vanish. Negative indexes are rejected
-            # rather than wrapping to the end like the per-request assertions.
-            if index.negative? || index >= delays.length
-              failures << "Expected a delay at gap #{index}, but only #{delays.length + 1} request(s) were made"
-            elsif delays[index] < min_delay
-              failures << "Expected minimum delay of #{min_delay}ms at gap #{index}, got #{delays[index]}ms"
-            end
-          elsif delays.any? { |d| d < min_delay }
-            failures << "Expected minimum delay of #{min_delay}ms, got #{delays.min}ms"
-          end
-        end
+        # Not all gaps are retry gaps — the download flow's final gap is the
+        # redirect hop to the signed URL, which is deliberately un-delayed —
+        # so those fixtures name a gap with an index. See DelayGaps.check for
+        # the contract.
+        #
+        # An absent `min` still asserts that the gap EXISTS, so it defaults to
+        # zero rather than skipping the assertion: gating on presence degrades
+        # the check to nothing, the very false-green class this exists to kill.
+        failure = DelayGaps.check(@tracker.delays_between_requests, assertion["min"], assertion["index"])
+        failures << failure if failure
 
       when "noError"
         if error

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -533,11 +533,15 @@ class TestRunner
         delays = @tracker.delays_between_requests
         min_delay = assertion["min"]
         index = assertion["index"]
-        if min_delay && delays.any?
+        if min_delay
           if index
-            gap = delays[index]
-            if gap && gap < min_delay
-              failures << "Expected minimum delay of #{min_delay}ms at gap #{index}, got #{gap}ms"
+            # A named gap that does not exist fails: a dropped retry must fire
+            # the assertion, not make it vanish. Negative indexes are rejected
+            # rather than wrapping to the end like the per-request assertions.
+            if index.negative? || index >= delays.length
+              failures << "Expected a delay at gap #{index}, but only #{delays.length + 1} request(s) were made"
+            elsif delays[index] < min_delay
+              failures << "Expected minimum delay of #{min_delay}ms at gap #{index}, got #{delays[index]}ms"
             end
           elsif delays.any? { |d| d < min_delay }
             failures << "Expected minimum delay of #{min_delay}ms, got #{delays.min}ms"

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -40,24 +40,28 @@ module DelayGaps
   # is applied HERE rather than at the call site so gating on the value's
   # presence cannot quietly reduce the assertion to nothing — the false-green
   # class this exists to kill.
-  def self.check(delays, min_delay, index)
+  #
+  # +request_count+ is passed rather than inferred as +delays.length + 1+: that
+  # inference assumes at least one request, so a run that failed before
+  # dispatching anything would report "only 1 request(s) were made".
+  def self.check(delays, min_delay, index, request_count)
     min_delay ||= 0
 
     if index
-      named_gap_failure(delays, min_delay, index)
+      named_gap_failure(delays, min_delay, index, request_count)
     elsif delays.empty?
-      "Expected a delay between requests, but only 1 request(s) were made"
+      "Expected a delay between requests, but only #{request_count} request(s) were made"
     else
       short = delays.each_with_index.find { |delay, _| delay < min_delay }
       short && "Expected minimum delay of #{min_delay}ms at gap #{short.last}, got #{short.first}ms"
     end
   end
 
-  def self.named_gap_failure(delays, min_delay, index)
+  def self.named_gap_failure(delays, min_delay, index, request_count)
     if index.negative?
       "delayBetweenRequests gap index must be non-negative, got #{index}"
     elsif index >= delays.length
-      "Expected a delay at gap #{index}, but only #{delays.length + 1} request(s) were made"
+      "Expected a delay at gap #{index}, but only #{request_count} request(s) were made"
     elsif delays[index] < min_delay
       "Expected minimum delay of #{min_delay}ms at gap #{index}, got #{delays[index]}ms"
     end
@@ -583,7 +587,8 @@ class TestRunner
         # An absent `min` still asserts that the gap EXISTS, so it defaults to
         # zero rather than skipping the assertion: gating on presence degrades
         # the check to nothing, the very false-green class this exists to kill.
-        failure = DelayGaps.check(@tracker.delays_between_requests, assertion["min"], assertion["index"])
+        failure = DelayGaps.check(@tracker.delays_between_requests, assertion["min"], assertion["index"],
+          @tracker.request_count)
         failures << failure if failure
 
       when "noError"

--- a/conformance/runner/typescript/delay-gaps.test.ts
+++ b/conformance/runner/typescript/delay-gaps.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Bounds and every-gap contract for the delayBetweenRequests assertion.
+ *
+ * Each case names a behavior that regressed on #563/#568: an assertion that
+ * looked like it covered a timing gap and did not.
+ */
+import { describe, it, expect } from "vitest";
+import { checkDelayGaps } from "./delay-gaps.js";
+
+/** Builds request timestamps from successive gaps in milliseconds. */
+function times(...gapsMs: number[]): number[] {
+  const out = [0];
+  for (const ms of gapsMs) out.push(out[out.length - 1]! + ms);
+  return out;
+}
+
+describe("checkDelayGaps", () => {
+  it("catches a later failing gap when the index is omitted", () => {
+    // Three runners measured gap 0 and stopped, so a second backoff that never
+    // happened passed unnoticed.
+    expect(checkDelayGaps(times(1000, 5), 500, undefined)).toContain("at gap 1");
+  });
+
+  it("passes when every gap clears the minimum", () => {
+    expect(checkDelayGaps(times(1000, 2000, 800), 500, undefined)).toBeUndefined();
+  });
+
+  it("fails an omitted index when there are no gaps at all", () => {
+    // An "every gap" rule with no gaps left must not wave the run through: a
+    // fully dropped retry lands exactly here.
+    expect(checkDelayGaps(times(), 500, undefined)).toBe(
+      "expected a delay between requests, but only 1 request(s) were made",
+    );
+  });
+
+  it("fails a named gap the run never produced", () => {
+    expect(checkDelayGaps(times(1000), 500, 1)).toBe(
+      "expected a delay at gap 1, but only 2 request(s) were made",
+    );
+  });
+
+  it("fails a named gap on a single-request run", () => {
+    expect(checkDelayGaps(times(), 500, 0)).toBe(
+      "expected a delay at gap 0, but only 1 request(s) were made",
+    );
+  });
+
+  it("rejects a negative gap index rather than wrapping to the end", () => {
+    // The pre-fix guard was `toBeGreaterThan(index + 1)`, trivially satisfied
+    // by a negative index, which then read times[-1] and reported NaN.
+    expect(checkDelayGaps(times(1000, 2000), 500, -1)).toBe(
+      "delayBetweenRequests gap index must be non-negative, got -1",
+    );
+  });
+
+  it("fails an enormous gap index without arithmetic overflow", () => {
+    expect(checkDelayGaps(times(1000, 2000), 500, Number.MAX_SAFE_INTEGER)).toContain(
+      "expected a delay at gap",
+    );
+  });
+
+  it("passes a named gap that clears the minimum", () => {
+    expect(checkDelayGaps(times(5, 2000), 500, 1)).toBeUndefined();
+  });
+
+  it("fails a named gap below the minimum", () => {
+    expect(checkDelayGaps(times(2000, 5), 500, 1)).toContain("at gap 1");
+  });
+
+  it("still asserts the gap exists when the minimum is zero", () => {
+    // A zero minimum is trivially met; the EXISTENCE requirement is not.
+    for (const missing of [0, undefined]) {
+      expect(checkDelayGaps(times(), missing, undefined)).toBe(
+        "expected a delay between requests, but only 1 request(s) were made",
+      );
+      expect(checkDelayGaps(times(), missing, 0)).toBe(
+        "expected a delay at gap 0, but only 1 request(s) were made",
+      );
+      expect(checkDelayGaps(times(5), missing, undefined)).toBeUndefined();
+    }
+  });
+
+  it("allows timer slack but not a real miss", () => {
+    // libuv can fire a 2000ms sleep at 1999.87ms; that must not fail. A
+    // dropped Retry-After (1000ms instead of 2000ms) still must.
+    expect(checkDelayGaps(times(1999), 2000, undefined, 2)).toBeUndefined();
+    expect(checkDelayGaps(times(1000), 2000, undefined, 2)).toContain("at gap 0");
+  });
+});

--- a/conformance/runner/typescript/delay-gaps.ts
+++ b/conformance/runner/typescript/delay-gaps.ts
@@ -1,0 +1,71 @@
+/**
+ * The `delayBetweenRequests` assertion contract, kept apart from the runner so
+ * its bounds branches are unit-testable (delay-gaps.test.ts).
+ */
+
+/**
+ * Validates one assertion against the recorded request times, returning
+ * `undefined` when it holds and a failure message otherwise.
+ *
+ * Gap i is the interval between request i and request i+1, so N requests yield
+ * N-1 gaps. The contract in conformance/schema.json:
+ *
+ * - A NAMED index selects exactly that gap, bounds-checked unconditionally. A
+ *   gap the run never produced is a failure, not a silent pass — the whole
+ *   point of a timing pin is to catch a dropped backoff, and a dropped backoff
+ *   is precisely what removes the gap.
+ * - An OMITTED index requires the minimum on EVERY gap. Zero gaps means
+ *   nothing was measured, so that fails too: an "every gap" rule with no gaps
+ *   left would otherwise wave through a run that dropped every retry.
+ * - Negative indexes are rejected rather than wrapping to the end the way the
+ *   per-request assertions do. There is no sensible "last gap" when the point
+ *   of naming one is to pin a specific backoff.
+ *
+ * `slackMs` exists because Node's timers may fire marginally BEFORE the
+ * requested delay — libuv rounds the deadline down internally, so a 2000ms
+ * sleep can legitimately elapse in 1999.87ms. That is a runtime property, not
+ * an SDK behaviour: the SDK asked for the full interval. The Go runner never
+ * sees it because Go's timers do not fire early. A sub-millisecond allowance
+ * cannot mask a real regression, which would miss by hundreds of milliseconds
+ * (a dropped Retry-After means ~1000ms of backoff instead of 2000ms) or by the
+ * whole interval (no delay at all).
+ */
+export function checkDelayGaps(
+  requestTimes: number[],
+  minDelayMs: number | undefined,
+  index: number | undefined,
+  slackMs = 0,
+): string | undefined {
+  // An absent or zero minimum still asserts that the gap EXISTS. The default
+  // lands HERE rather than at the call site so a truthiness gate cannot
+  // quietly reduce the assertion to nothing.
+  const min = minDelayMs ?? 0;
+  const gaps = requestTimes.length - 1;
+  const floor = min - slackMs;
+
+  const short = (gap: number): string | undefined => {
+    const delay = requestTimes[gap + 1]! - requestTimes[gap]!;
+    return delay < floor
+      ? `expected delay >= ${min}ms at gap ${gap} (allowing ${slackMs}ms timer slack), got ${delay}ms`
+      : undefined;
+  };
+
+  if (index !== undefined) {
+    if (index < 0) {
+      return `delayBetweenRequests gap index must be non-negative, got ${index}`;
+    }
+    if (index >= gaps) {
+      return `expected a delay at gap ${index}, but only ${requestTimes.length} request(s) were made`;
+    }
+    return short(index);
+  }
+
+  if (gaps < 1) {
+    return `expected a delay between requests, but only ${requestTimes.length} request(s) were made`;
+  }
+  for (let i = 0; i < gaps; i++) {
+    const failure = short(i);
+    if (failure !== undefined) return failure;
+  }
+  return undefined;
+}

--- a/conformance/runner/typescript/runner.test.ts
+++ b/conformance/runner/typescript/runner.test.ts
@@ -799,17 +799,23 @@ function checkAssertions(
 
       case "delayBetweenRequests": {
         const times = tracker.requestTimes();
-        if (times.length >= 2) {
-          // index selects a single inter-request GAP (gap i is between request
-          // i and i+1), defaulting to the first. A named gap that does not
-          // exist fails rather than passing silently.
-          const gap = assertion.index ?? 0;
+        const minDelay = assertion.min ?? 0;
+        // index selects a single inter-request GAP (gap i is between request i
+        // and i+1). Omitted, every gap must clear the minimum. A NAMED gap is
+        // bounds-checked outside any "did we get two requests" guard: a
+        // dropped retry must fail the assertion, not make it vanish.
+        const gaps: number[] =
+          assertion.index !== undefined
+            ? [assertion.index]
+            : times.slice(0, -1).map((_, i) => i);
+        if (assertion.index !== undefined) {
           expect(
             times.length,
-            `[${tc.name}] expected a delay at gap ${gap}, but only ${times.length} request(s) were made`,
-          ).toBeGreaterThan(gap + 1);
+            `[${tc.name}] expected a delay at gap ${assertion.index}, but only ${times.length} request(s) were made`,
+          ).toBeGreaterThan(assertion.index + 1);
+        }
+        for (const gap of gaps) {
           const delay = times[gap + 1]! - times[gap]!;
-          const minDelay = assertion.min ?? 0;
           // Node's timers may fire marginally BEFORE the requested delay —
           // libuv rounds the deadline down internally, so a 2000ms sleep can
           // legitimately elapse in 1999.87ms. That is a runtime property, not

--- a/conformance/runner/typescript/runner.test.ts
+++ b/conformance/runner/typescript/runner.test.ts
@@ -15,6 +15,7 @@ import type { BasecampClient } from "@37signals/basecamp";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import { checkDelayGaps } from "./delay-gaps.js";
 
 // =============================================================================
 // Types mirroring conformance/schema.json
@@ -798,39 +799,17 @@ function checkAssertions(
       }
 
       case "delayBetweenRequests": {
-        const times = tracker.requestTimes();
-        const minDelay = assertion.min ?? 0;
-        // index selects a single inter-request GAP (gap i is between request i
-        // and i+1). Omitted, every gap must clear the minimum. A NAMED gap is
-        // bounds-checked outside any "did we get two requests" guard: a
-        // dropped retry must fail the assertion, not make it vanish.
-        const gaps: number[] =
-          assertion.index !== undefined
-            ? [assertion.index]
-            : times.slice(0, -1).map((_, i) => i);
-        if (assertion.index !== undefined) {
-          expect(
-            times.length,
-            `[${tc.name}] expected a delay at gap ${assertion.index}, but only ${times.length} request(s) were made`,
-          ).toBeGreaterThan(assertion.index + 1);
-        }
-        for (const gap of gaps) {
-          const delay = times[gap + 1]! - times[gap]!;
-          // Node's timers may fire marginally BEFORE the requested delay —
-          // libuv rounds the deadline down internally, so a 2000ms sleep can
-          // legitimately elapse in 1999.87ms. That is a runtime property, not
-          // an SDK behaviour: the SDK asked for the full interval. The Go
-          // runner never sees it because Go's timers do not fire early.
-          //
-          // A sub-millisecond allowance cannot mask a real regression, which
-          // would miss by hundreds of milliseconds (a dropped Retry-After
-          // means ~1000ms of backoff instead of 2000ms) or by the whole
-          // interval (no delay at all).
-          expect(
-            delay,
-            `[${tc.name}] expected delay >= ${minDelay}ms at gap ${gap} (allowing ${TIMER_SLACK_MS}ms timer slack), got ${delay}ms`,
-          ).toBeGreaterThanOrEqual(minDelay - TIMER_SLACK_MS);
-        }
+        // Not all gaps are retry gaps — the download flow's final gap is the
+        // redirect hop to the signed URL, which is deliberately un-delayed —
+        // so those fixtures name a gap with an index. See checkDelayGaps for
+        // the contract and for why timer slack exists.
+        const failure = checkDelayGaps(
+          tracker.requestTimes(),
+          assertion.min,
+          assertion.index,
+          TIMER_SLACK_MS,
+        );
+        expect(failure, `[${tc.name}] ${failure}`).toBeUndefined();
         break;
       }
 

--- a/conformance/schema.json
+++ b/conformance/schema.json
@@ -159,7 +159,7 @@
           },
           "index": {
             "type": "integer",
-            "description": "Request index for per-request assertions: headerPresent / headerAbsent / headerInjected / requestPath / requestMethod / requestBody / requestBodyAbsent (0-based; negative values index from the end, e.g. -1 = last request). Default 0. For delayBetweenRequests it selects a single inter-request GAP (gap i is between request i and i+1); omit it to require the minimum on every gap."
+            "description": "Request index for per-request assertions: headerPresent / headerAbsent / headerInjected / requestPath / requestMethod / requestBody / requestBodyAbsent (0-based; negative values index from the end, e.g. -1 = last request). Default 0. For delayBetweenRequests it selects a single inter-request GAP (gap i is between request i and i+1); omit it to require the minimum on every gap. A delayBetweenRequests assertion never passes vacuously: a named gap the run did not produce FAILS, an omitted index on a run with no gaps FAILS, and a negative gap index is rejected rather than wrapping to the end — a timing pin exists to catch a dropped backoff, and a dropped backoff is exactly what removes the gap."
           }
         }
       }

--- a/kotlin/conformance/build.gradle.kts
+++ b/kotlin/conformance/build.gradle.kts
@@ -34,4 +34,13 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.ktor.client.mock)
     implementation(libs.kotlinx.coroutines.core)
+
+    testImplementation(kotlin("test"))
+    testImplementation(libs.junit.jupiter)
+}
+
+// The runner's assertion helpers are unit-tested (DelayGapsTest): a bounds
+// branch that only ever runs against passing fixtures is not a guard.
+tasks.withType<Test> {
+    useJUnitPlatform()
 }

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/DelayGaps.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/DelayGaps.kt
@@ -1,0 +1,50 @@
+package com.basecamp.sdk.conformance
+
+/**
+ * Validates one `delayBetweenRequests` assertion against the recorded request
+ * times, returning `null` when it holds and a failure message otherwise.
+ *
+ * Gap i is the interval between request i and request i+1, so N requests yield
+ * N-1 gaps. The contract in conformance/schema.json:
+ *
+ * - A NAMED index selects exactly that gap, bounds-checked unconditionally. A
+ *   gap the run never produced is a failure, not a silent pass — the whole
+ *   point of a timing pin is to catch a dropped backoff, and a dropped backoff
+ *   is precisely what removes the gap.
+ * - An OMITTED index requires the minimum on EVERY gap. Zero gaps means
+ *   nothing was measured, so that fails too: an "every gap" rule with no gaps
+ *   left would otherwise wave through a run that dropped every retry.
+ * - Negative indexes are rejected rather than wrapping to the end the way the
+ *   per-request assertions do. There is no sensible "last gap" when the point
+ *   of naming one is to pin a specific backoff.
+ *
+ * The bounds test compares against the gap COUNT rather than adding one to the
+ * index: `gap + 1 >= requestTimes.size` overflows for [Int.MAX_VALUE] and wraps
+ * negative, sailing through the guard into an out-of-range read.
+ */
+fun checkDelayGaps(requestTimes: List<Long>, minDelay: Long, index: Int?): String? {
+    val gaps = requestTimes.size - 1
+
+    if (index != null) {
+        return when {
+            index < 0 ->
+                "delayBetweenRequests gap index must be non-negative, got $index"
+            index >= gaps ->
+                "Expected a delay at gap $index, but only ${requestTimes.size} request(s) were made"
+            else -> shortfall(requestTimes, minDelay, index)
+        }
+    }
+
+    if (gaps < 1) {
+        return "Expected a delay between requests, but only ${requestTimes.size} request(s) were made"
+    }
+    for (i in 0 until gaps) {
+        shortfall(requestTimes, minDelay, i)?.let { return it }
+    }
+    return null
+}
+
+private fun shortfall(requestTimes: List<Long>, minDelay: Long, gap: Int): String? {
+    val delay = requestTimes[gap + 1] - requestTimes[gap]
+    return if (delay < minDelay) "Expected delay >= ${minDelay}ms at gap $gap, got ${delay}ms" else null
+}

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
@@ -140,7 +140,7 @@ data class Assertion(
     val max: Double = 0.0,
     val path: String = "",
     /** Request index for per-request assertions (0-based; negative = from end). */
-    val index: Int = 0,
+    val index: Int? = null,
 )
 
 data class TestResult(
@@ -370,7 +370,7 @@ private fun runTest(tc: TestCase): TestResult {
             "requestPath" -> {
                 val expected = assertion.expected?.asString()
                     ?: return TestResult(false, "requestPath assertion missing expected value")
-                val idx = resolveRequestIndex(assertion.index, requestPaths.size)
+                val idx = resolveRequestIndex(assertion.index ?: 0, requestPaths.size)
                     ?: return TestResult(false, "requestPath[${assertion.index}]: no request recorded at that index (${requestPaths.size} requests)")
                 if (requestPaths[idx] != expected) {
                     return TestResult(false, "Expected request path \"$expected\" at index ${assertion.index}, got \"${requestPaths[idx]}\"")
@@ -380,7 +380,7 @@ private fun runTest(tc: TestCase): TestResult {
             "requestMethod" -> {
                 val expected = assertion.expected?.asString()?.uppercase()
                     ?: return TestResult(false, "requestMethod assertion missing expected value")
-                val idx = resolveRequestIndex(assertion.index, requestMethods.size)
+                val idx = resolveRequestIndex(assertion.index ?: 0, requestMethods.size)
                     ?: return TestResult(false, "requestMethod[${assertion.index}]: no request recorded at that index (${requestMethods.size} requests)")
                 if (requestMethods[idx] != expected) {
                     return TestResult(false, "Expected request method $expected at index ${assertion.index}, got ${requestMethods[idx]}")
@@ -389,7 +389,7 @@ private fun runTest(tc: TestCase): TestResult {
 
             "requestBody" -> {
                 val key = assertion.path
-                val idx = resolveRequestIndex(assertion.index, requestBodies.size)
+                val idx = resolveRequestIndex(assertion.index ?: 0, requestBodies.size)
                     ?: return TestResult(false, "requestBody.$key[${assertion.index}]: no request recorded at that index (${requestBodies.size} requests)")
                 val body = requestBodies[idx]
                     ?: return TestResult(false, "requestBody.$key[${assertion.index}]: request has no JSON body")
@@ -401,7 +401,7 @@ private fun runTest(tc: TestCase): TestResult {
 
             "requestBodyAbsent" -> {
                 val key = assertion.path
-                val idx = resolveRequestIndex(assertion.index, requestBodies.size)
+                val idx = resolveRequestIndex(assertion.index ?: 0, requestBodies.size)
                     ?: return TestResult(false, "requestBodyAbsent.$key[${assertion.index}]: no request recorded at that index (${requestBodies.size} requests)")
                 val body = requestBodies[idx]
                 if (body != null && navigateJsonPath(body, key) != null) {
@@ -410,19 +410,24 @@ private fun runTest(tc: TestCase): TestResult {
             }
 
             "delayBetweenRequests" -> {
-                if (requestTimes.size >= 2) {
-                    // index selects a single inter-request GAP (gap i is
-                    // between request i and i+1), defaulting to the first. A
-                    // named gap that does not exist fails rather than passing
-                    // silently.
-                    val gap = assertion.index
-                    if (gap + 1 >= requestTimes.size) {
-                        return TestResult(false, "Expected a delay at gap $gap, but only ${requestTimes.size} request(s) were made")
-                    }
-                    val delay = requestTimes[gap + 1] - requestTimes[gap]
+                run {
                     val minDelay = assertion.min.toLong()
-                    if (delay < minDelay) {
-                        return TestResult(false, "Expected delay >= ${minDelay}ms at gap $gap, got ${delay}ms")
+                    val gap = assertion.index
+                    if (gap != null) {
+                        if (gap < 0 || gap + 1 >= requestTimes.size) {
+                            return TestResult(false, "Expected a delay at gap $gap, but only ${requestTimes.size} request(s) were made")
+                        }
+                        val delay = requestTimes[gap + 1] - requestTimes[gap]
+                        if (delay < minDelay) {
+                            return TestResult(false, "Expected delay >= ${minDelay}ms at gap $gap, got ${delay}ms")
+                        }
+                    } else {
+                        for (i in 0 until requestTimes.size - 1) {
+                            val delay = requestTimes[i + 1] - requestTimes[i]
+                            if (delay < minDelay) {
+                                return TestResult(false, "Expected delay >= ${minDelay}ms at gap $i, got ${delay}ms")
+                            }
+                        }
                     }
                 }
             }
@@ -539,7 +544,7 @@ private fun runTest(tc: TestCase): TestResult {
 
             "headerPresent" -> {
                 val headerName = assertion.path
-                val idx = resolveRequestIndex(assertion.index, requestHeadersList.size)
+                val idx = resolveRequestIndex(assertion.index ?: 0, requestHeadersList.size)
                     ?: return TestResult(false, "headerPresent $headerName[${assertion.index}]: no request recorded at that index (${requestHeadersList.size} requests)")
                 val actual = requestHeadersList[idx][headerName]
                 if (actual.isNullOrEmpty()) {
@@ -549,7 +554,7 @@ private fun runTest(tc: TestCase): TestResult {
 
             "headerAbsent" -> {
                 val headerName = assertion.path
-                val idx = resolveRequestIndex(assertion.index, requestHeadersList.size)
+                val idx = resolveRequestIndex(assertion.index ?: 0, requestHeadersList.size)
                     ?: return TestResult(false, "headerAbsent $headerName[${assertion.index}]: no request recorded at that index (${requestHeadersList.size} requests)")
                 // Use getAll (not indexed get): a present-but-empty header must
                 // fail an absence assertion, same as the Go runner's Values check.

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
@@ -368,68 +368,58 @@ private fun runTest(tc: TestCase): TestResult {
             }
 
             "requestPath" -> {
+                val requestIndex = assertion.index ?: 0
                 val expected = assertion.expected?.asString()
                     ?: return TestResult(false, "requestPath assertion missing expected value")
-                val idx = resolveRequestIndex(assertion.index ?: 0, requestPaths.size)
-                    ?: return TestResult(false, "requestPath[${assertion.index}]: no request recorded at that index (${requestPaths.size} requests)")
+                val idx = resolveRequestIndex(requestIndex, requestPaths.size)
+                    ?: return TestResult(false, "requestPath[$requestIndex]: no request recorded at that index (${requestPaths.size} requests)")
                 if (requestPaths[idx] != expected) {
-                    return TestResult(false, "Expected request path \"$expected\" at index ${assertion.index}, got \"${requestPaths[idx]}\"")
+                    return TestResult(false, "Expected request path \"$expected\" at index $requestIndex, got \"${requestPaths[idx]}\"")
                 }
             }
 
             "requestMethod" -> {
+                val requestIndex = assertion.index ?: 0
                 val expected = assertion.expected?.asString()?.uppercase()
                     ?: return TestResult(false, "requestMethod assertion missing expected value")
-                val idx = resolveRequestIndex(assertion.index ?: 0, requestMethods.size)
-                    ?: return TestResult(false, "requestMethod[${assertion.index}]: no request recorded at that index (${requestMethods.size} requests)")
+                val idx = resolveRequestIndex(requestIndex, requestMethods.size)
+                    ?: return TestResult(false, "requestMethod[$requestIndex]: no request recorded at that index (${requestMethods.size} requests)")
                 if (requestMethods[idx] != expected) {
-                    return TestResult(false, "Expected request method $expected at index ${assertion.index}, got ${requestMethods[idx]}")
+                    return TestResult(false, "Expected request method $expected at index $requestIndex, got ${requestMethods[idx]}")
                 }
             }
 
             "requestBody" -> {
+                val requestIndex = assertion.index ?: 0
                 val key = assertion.path
-                val idx = resolveRequestIndex(assertion.index ?: 0, requestBodies.size)
-                    ?: return TestResult(false, "requestBody.$key[${assertion.index}]: no request recorded at that index (${requestBodies.size} requests)")
+                val idx = resolveRequestIndex(requestIndex, requestBodies.size)
+                    ?: return TestResult(false, "requestBody.$key[$requestIndex]: no request recorded at that index (${requestBodies.size} requests)")
                 val body = requestBodies[idx]
-                    ?: return TestResult(false, "requestBody.$key[${assertion.index}]: request has no JSON body")
+                    ?: return TestResult(false, "requestBody.$key[$requestIndex]: request has no JSON body")
                 val actual = navigateJsonPath(body, key)
-                    ?: return TestResult(false, "requestBody.$key[${assertion.index}]: key not present in request body")
-                val result = compareJsonValues("requestBody.$key[${assertion.index}]", assertion.expected, actual)
+                    ?: return TestResult(false, "requestBody.$key[$requestIndex]: key not present in request body")
+                val result = compareJsonValues("requestBody.$key[$requestIndex]", assertion.expected, actual)
                 if (result != null) return result
             }
 
             "requestBodyAbsent" -> {
+                val requestIndex = assertion.index ?: 0
                 val key = assertion.path
-                val idx = resolveRequestIndex(assertion.index ?: 0, requestBodies.size)
-                    ?: return TestResult(false, "requestBodyAbsent.$key[${assertion.index}]: no request recorded at that index (${requestBodies.size} requests)")
+                val idx = resolveRequestIndex(requestIndex, requestBodies.size)
+                    ?: return TestResult(false, "requestBodyAbsent.$key[$requestIndex]: no request recorded at that index (${requestBodies.size} requests)")
                 val body = requestBodies[idx]
                 if (body != null && navigateJsonPath(body, key) != null) {
-                    return TestResult(false, "requestBodyAbsent.$key[${assertion.index}]: key unexpectedly present in request body")
+                    return TestResult(false, "requestBodyAbsent.$key[$requestIndex]: key unexpectedly present in request body")
                 }
             }
 
             "delayBetweenRequests" -> {
-                run {
-                    val minDelay = assertion.min.toLong()
-                    val gap = assertion.index
-                    if (gap != null) {
-                        if (gap < 0 || gap + 1 >= requestTimes.size) {
-                            return TestResult(false, "Expected a delay at gap $gap, but only ${requestTimes.size} request(s) were made")
-                        }
-                        val delay = requestTimes[gap + 1] - requestTimes[gap]
-                        if (delay < minDelay) {
-                            return TestResult(false, "Expected delay >= ${minDelay}ms at gap $gap, got ${delay}ms")
-                        }
-                    } else {
-                        for (i in 0 until requestTimes.size - 1) {
-                            val delay = requestTimes[i + 1] - requestTimes[i]
-                            if (delay < minDelay) {
-                                return TestResult(false, "Expected delay >= ${minDelay}ms at gap $i, got ${delay}ms")
-                            }
-                        }
-                    }
-                }
+                // Not all gaps are retry gaps — the download flow's final gap
+                // is the redirect hop to the signed URL, which is deliberately
+                // un-delayed — so those fixtures name a gap with an index. See
+                // checkDelayGaps for the contract.
+                checkDelayGaps(requestTimes, assertion.min.toLong(), assertion.index)
+                    ?.let { return TestResult(false, it) }
             }
 
             "headerValue" -> {
@@ -543,9 +533,10 @@ private fun runTest(tc: TestCase): TestResult {
             }
 
             "headerPresent" -> {
+                val requestIndex = assertion.index ?: 0
                 val headerName = assertion.path
-                val idx = resolveRequestIndex(assertion.index ?: 0, requestHeadersList.size)
-                    ?: return TestResult(false, "headerPresent $headerName[${assertion.index}]: no request recorded at that index (${requestHeadersList.size} requests)")
+                val idx = resolveRequestIndex(requestIndex, requestHeadersList.size)
+                    ?: return TestResult(false, "headerPresent $headerName[$requestIndex]: no request recorded at that index (${requestHeadersList.size} requests)")
                 val actual = requestHeadersList[idx][headerName]
                 if (actual.isNullOrEmpty()) {
                     return TestResult(false, "Expected header $headerName present on request index $idx, but it was empty or missing")
@@ -553,9 +544,10 @@ private fun runTest(tc: TestCase): TestResult {
             }
 
             "headerAbsent" -> {
+                val requestIndex = assertion.index ?: 0
                 val headerName = assertion.path
-                val idx = resolveRequestIndex(assertion.index ?: 0, requestHeadersList.size)
-                    ?: return TestResult(false, "headerAbsent $headerName[${assertion.index}]: no request recorded at that index (${requestHeadersList.size} requests)")
+                val idx = resolveRequestIndex(requestIndex, requestHeadersList.size)
+                    ?: return TestResult(false, "headerAbsent $headerName[$requestIndex]: no request recorded at that index (${requestHeadersList.size} requests)")
                 // Use getAll (not indexed get): a present-but-empty header must
                 // fail an absence assertion, same as the Go runner's Values check.
                 val values = requestHeadersList[idx].getAll(headerName)

--- a/kotlin/conformance/src/test/kotlin/com/basecamp/sdk/conformance/DelayGapsTest.kt
+++ b/kotlin/conformance/src/test/kotlin/com/basecamp/sdk/conformance/DelayGapsTest.kt
@@ -1,0 +1,103 @@
+package com.basecamp.sdk.conformance
+
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Bounds and every-gap contract for the `delayBetweenRequests` assertion.
+ *
+ * Each case names a behavior that regressed on #563/#568: an assertion that
+ * looked like it covered a timing gap and did not.
+ */
+class DelayGapsTest {
+    /** Builds request timestamps from successive gaps in milliseconds. */
+    private fun times(vararg gapsMs: Long): List<Long> {
+        val out = mutableListOf(0L)
+        for (ms in gapsMs) out.add(out.last() + ms)
+        return out
+    }
+
+    @Test
+    fun `omitted index catches a later failing gap`() {
+        // Three runners measured gap 0 and stopped, so a second backoff that
+        // never happened passed unnoticed.
+        assertContains(checkDelayGaps(times(1000, 5), 500, null)!!, "at gap 1")
+    }
+
+    @Test
+    fun `omitted index passes when every gap clears the minimum`() {
+        assertNull(checkDelayGaps(times(1000, 2000, 800), 500, null))
+    }
+
+    @Test
+    fun `omitted index fails when there are no gaps at all`() {
+        // An "every gap" rule with no gaps left must not wave the run through:
+        // a fully dropped retry lands exactly here.
+        assertEquals(
+            "Expected a delay between requests, but only 1 request(s) were made",
+            checkDelayGaps(times(), 500, null),
+        )
+    }
+
+    @Test
+    fun `named gap fails when the run never produced it`() {
+        assertEquals(
+            "Expected a delay at gap 1, but only 2 request(s) were made",
+            checkDelayGaps(times(1000), 500, 1),
+        )
+    }
+
+    @Test
+    fun `named gap fails on a single-request run`() {
+        assertEquals(
+            "Expected a delay at gap 0, but only 1 request(s) were made",
+            checkDelayGaps(times(), 500, 0),
+        )
+    }
+
+    @Test
+    fun `negative gap index is rejected`() {
+        // Rejected categorically, not wrapped to the end the way
+        // headerPresent's index is.
+        assertEquals(
+            "delayBetweenRequests gap index must be non-negative, got -1",
+            checkDelayGaps(times(1000, 2000), 500, -1),
+        )
+    }
+
+    @Test
+    fun `Int MAX_VALUE gap index fails without overflowing`() {
+        // `gap + 1 >= size` computes the addition first, so Int.MAX_VALUE wraps
+        // negative and sails through the guard into an out-of-range read.
+        assertContains(
+            checkDelayGaps(times(1000, 2000), 500, Int.MAX_VALUE)!!,
+            "Expected a delay at gap",
+        )
+    }
+
+    @Test
+    fun `zero minimum still asserts that the gap exists`() {
+        // A zero minimum is trivially met; the EXISTENCE requirement is not.
+        assertEquals(
+            "Expected a delay between requests, but only 1 request(s) were made",
+            checkDelayGaps(times(), 0, null),
+        )
+        assertEquals(
+            "Expected a delay at gap 0, but only 1 request(s) were made",
+            checkDelayGaps(times(), 0, 0),
+        )
+        assertNull(checkDelayGaps(times(5), 0, null))
+    }
+
+    @Test
+    fun `named gap passes when it clears the minimum`() {
+        assertNull(checkDelayGaps(times(5, 2000), 500, 1))
+    }
+
+    @Test
+    fun `named gap fails when it is below the minimum`() {
+        assertContains(checkDelayGaps(times(2000, 5), 500, 1)!!, "at gap 1")
+    }
+}

--- a/swift/Sources/Basecamp/HTTP/HTTPClient.swift
+++ b/swift/Sources/Basecamp/HTTP/HTTPClient.swift
@@ -32,14 +32,6 @@ package final class HTTPClient: Sendable {
     private static let downloadMaxAttempts = 3
     private static let downloadRetryOn: Set<Int> = [429, 502, 503, 504]
 
-    /// Converts a backoff interval to nanoseconds without trapping.
-    ///
-    /// `UInt64(_:)` on an out-of-range `Double` is a runtime trap, not an
-    /// error, and a hostile or simply buggy `Retry-After` can name a delay
-    /// whose nanosecond product overflows `UInt64` — `Retry-After: 99999999999`
-    /// is 9.9e19 ns against a 1.8e19 ceiling. Clamp to a day instead: no SDK
-    /// retry is worth sleeping longer, and a crash is never the right answer
-    /// to a response header.
     /// Whether an error represents cooperative cancellation.
     ///
     /// Swift concurrency raises `CancellationError`, but `URLSession` reports a
@@ -51,6 +43,14 @@ package final class HTTPClient: Sendable {
         return (error as? URLError)?.code == .cancelled
     }
 
+    /// Converts a backoff interval to nanoseconds without trapping.
+    ///
+    /// `UInt64(_:)` on an out-of-range `Double` is a runtime trap, not an
+    /// error, and a hostile or simply buggy `Retry-After` can name a delay
+    /// whose nanosecond product overflows `UInt64` — `Retry-After: 99999999999`
+    /// is 9.9e19 ns against a 1.8e19 ceiling. Clamp to a day instead: no SDK
+    /// retry is worth sleeping longer, and a crash is never the right answer
+    /// to a response header.
     private static func sleepNanoseconds(_ seconds: TimeInterval) -> UInt64 {
         guard seconds.isFinite, seconds > 0 else { return 0 }
         return UInt64(min(seconds, 86_400) * 1_000_000_000)

--- a/swift/Sources/Basecamp/HTTP/HTTPClient.swift
+++ b/swift/Sources/Basecamp/HTTP/HTTPClient.swift
@@ -40,6 +40,17 @@ package final class HTTPClient: Sendable {
     /// is 9.9e19 ns against a 1.8e19 ceiling. Clamp to a day instead: no SDK
     /// retry is worth sleeping longer, and a crash is never the right answer
     /// to a response header.
+    /// Whether an error represents cooperative cancellation.
+    ///
+    /// Swift concurrency raises `CancellationError`, but `URLSession` reports a
+    /// cancelled task as `URLError(.cancelled)` — so checking only the former
+    /// would treat a real cancelled download as a retryable network blip and
+    /// spend the whole budget on a request the caller already abandoned.
+    private static func isCancellation(_ error: any Error) -> Bool {
+        if error is CancellationError { return true }
+        return (error as? URLError)?.code == .cancelled
+    }
+
     private static func sleepNanoseconds(_ seconds: TimeInterval) -> UInt64 {
         guard seconds.isFinite, seconds > 0 else { return 0 }
         return UInt64(min(seconds, 86_400) * 1_000_000_000)
@@ -198,7 +209,7 @@ package final class HTTPClient: Sendable {
                     $0.onRequestEnd(info, result: RequestResult(statusCode: 0, durationMs: durationMs))
                 }
 
-                if error is CancellationError {
+                if Self.isCancellation(error) {
                     // Cooperative cancellation is terminal, not a transport
                     // blip: retrying would announce and start an attempt the
                     // caller has already abandoned. It propagates raw rather
@@ -346,7 +357,7 @@ package final class HTTPClient: Sendable {
                     $0.onRequestEnd(info, result: RequestResult(statusCode: 0, durationMs: durationMs))
                 }
 
-                if error is CancellationError {
+                if Self.isCancellation(error) {
                     // Cooperative cancellation is terminal, not a transport
                     // blip: retrying would announce and start an attempt the
                     // caller has already abandoned. It propagates raw rather

--- a/swift/Tests/BasecampTests/DownloadTests.swift
+++ b/swift/Tests/BasecampTests/DownloadTests.swift
@@ -834,6 +834,31 @@ final class DownloadTests: XCTestCase {
         XCTAssertEqual(spy.ends, [1])
     }
 
+    /// `URLSession` reports a cancelled task as `URLError(.cancelled)`, not
+    /// `CancellationError` — so the real-world cancellation shape must be
+    /// terminal too, not just the Swift-concurrency one.
+    func testDownloadURL_urlErrorCancelledIsTerminal() async throws {
+        let spy = RetryHookSpy()
+        let counter = Counter()
+        let transport = MockTransport { _ in
+            counter.increment()
+            throw URLError(.cancelled)
+        }
+        let account = makeTestAccountClient(transport: transport, enableRetry: true, hooks: spy)
+
+        do {
+            _ = try await account.downloadURL(Self.hop1URL)
+            XCTFail("Expected the cancellation to surface")
+        } catch {
+            // Expected — terminal, whatever wrapper it arrives in.
+        }
+
+        XCTAssertEqual(counter.value, 1, "A cancelled URLSession task must not spend another attempt")
+        XCTAssertEqual(spy.retries, [], "A cancelled URLSession task must not announce a retry")
+        XCTAssertEqual(spy.starts, [1])
+        XCTAssertEqual(spy.ends, [1])
+    }
+
     /// A `Retry-After` large enough to overflow the nanosecond conversion must
     /// not trap the process. `UInt64(_:)` on an out-of-range `Double` is a
     /// runtime trap, so an unclamped conversion crashes here rather than

--- a/swift/Tests/BasecampTests/DownloadTests.swift
+++ b/swift/Tests/BasecampTests/DownloadTests.swift
@@ -849,8 +849,12 @@ final class DownloadTests: XCTestCase {
         do {
             _ = try await account.downloadURL(Self.hop1URL)
             XCTFail("Expected the cancellation to surface")
+        } catch let error as URLError {
+            // Terminal errors propagate raw, so the cancellation shape itself
+            // must arrive — not a BasecampError.network wrapping it.
+            XCTAssertEqual(error.code, .cancelled)
         } catch {
-            // Expected — terminal, whatever wrapper it arrives in.
+            XCTFail("Expected URLError(.cancelled) raw, got \(error)")
         }
 
         XCTAssertEqual(counter.value, 1, "A cancelled URLSession task must not spend another attempt")


### PR DESCRIPTION
Three review findings arrived on #563 after it had already merged. All three are on code #563 added, and all three are the same failure mode: an assertion or a classification that looks like it covers something and does not.

**An omitted `delayBetweenRequests` index was documented as "every gap" and implemented as "gap 0" in three runners.** #563 taught the assertion to take a gap index and updated `conformance/schema.json` to say that omitting it "require[s] the minimum on every gap". Ruby and Python did that. Go, TypeScript and Kotlin kept measuring `requestTimes[1] - requestTimes[0]` unconditionally, so every un-indexed timing fixture — `retry.json`'s multi-retry cases included — validated only its first backoff there. All five now iterate.

**A delay assertion could pass while checking nothing.** Two ways. A named gap that did not exist passed silently in all five, because the bounds check sat inside each runner's "did we record at least two requests" guard — so a *fully dropped* retry left one request, skipped the guard, and made the assertion evaporate rather than fire. And an omitted index over *zero* gaps passed everywhere, because "every gap must clear the minimum" is vacuously true when there are no gaps. Both are backwards: the case a timing pin most needs to catch is the one where the delay never happened. Neither can pass now.

**Swift only recognised Swift-concurrency cancellation.** #563 made cancellation terminal in both retry loops via `error is CancellationError`, tested with a `MockTransport` that throws exactly that. `URLSession` does not: a cancelled task surfaces as `URLError(.cancelled)`. So the shape that actually occurs in production still fell through to the generic catch, got classified a retryable network blip, and spent the entire attempt budget re-issuing a request the caller had abandoned — while firing `onRetry` for each one. Both loops now test for either shape through a shared `isCancellation`.

## The runners had no tests of their own

Every bounds branch above was written blind. The runners are test harnesses, but their assertion logic is code, and its bounds branches never execute against a fixture that *passes* — which is exactly how #563 shipped an assertion that vacuously passed, through a fully green five-runner conformance run.

So the contract is now one function per runner — `checkDelayGaps` / `DelayGaps.check` / `check_delay_gaps` — with a committed unit test beside it, wired into `make check` and into the four per-language CI jobs through a new `conformance-runner-tests` target. Eleven cases per runner, each named for a behavior that regressed here or on #563:

| Case | What it kills |
|---|---|
| omitted index catches a **later** failing gap | the gap-0-only bug |
| omitted index with **zero** gaps fails | the vacuous "every gap" pass |
| a named gap the run never produced fails | the dropped-retry evaporation |
| a negative index is rejected | wrapping to the end, which has no meaning for a gap |
| `Int.MAX_VALUE` / `MaxInt` fails without overflow | `gap + 1` wrapping past the guard |
| a **zero** minimum still requires the gap to exist | the truthiness gate |
| a zero-**request** run reports 0, not 1 | `len(delays) + 1` misattributing the failure |

## Proofs

The Swift pin fails five ways against the parent commit (`91f62074f`), with `git show 91f62074f:swift/Sources/Basecamp/HTTP/HTTPClient.swift` swapped in:

```
DownloadTests.swift:857: failed - Expected URLError(.cancelled) raw, got network(message: "Network error", cause: Optional(Error Domain=NSURLErrorDomain Code=-999 "(null)"))
DownloadTests.swift:860: XCTAssertEqual failed: ("3") is not equal to ("1") - A cancelled URLSession task must not spend another attempt
DownloadTests.swift:861: XCTAssertEqual failed: ("[2, 3]") is not equal to ("[]") - A cancelled URLSession task must not announce a retry
DownloadTests.swift:862: XCTAssertEqual failed: ("[1, 2, 3]") is not equal to ("[1]")
DownloadTests.swift:863: XCTAssertEqual failed: ("[1, 2, 3]") is not equal to ("[1]")
Executed 1 test, with 5 failures (0 unexpected)
```

Three attempts, two `onRetry`s, three start/end pairs — the #508/#509 lifecycle-imbalance class, on the transport shape that actually occurs.

The runner bounds tests fail three ways against the logic as committed at `07c356693`, lifted verbatim into the extracted signature:

```
--- FAIL: TestCheckDelayGaps/omitted_index_fails_when_there_are_no_gaps_at_all
    delay_gaps_test.go:120: expected a failure message, got a pass
--- FAIL: TestCheckDelayGaps/negative_gap_index_is_rejected
    delay_gaps_test.go:123: expected message containing "must be non-negative", got "Expected a delay at gap -1, but only 3 request(s) were made"
--- FAIL: TestCheckDelayGaps/MaxInt_gap_index_fails_without_overflowing
panic: runtime error: index out of range [-9223372036854775808]
```

The `MaxInt` case is a real panic, not a failed assertion — `gap + 1` wraps negative and sails through the guard into an out-of-range read.

The five-runner behavior was proven before the extraction with three probe fixtures. Expected-fail in all five; **actual**, on merged `main`:

| Probe | Go | TS | Kotlin | Python | Ruby |
|---|---|---|---|---|---|
| omitted index, a later gap below the minimum | PASS ✗ | PASS ✗ | PASS ✗ | FAIL ✓ | FAIL ✓ |
| named gap 9 on a 3-request flow | FAIL ✓ | FAIL ✓ | FAIL ✓ | PASS ✗ | PASS ✗ |
| delay assertion on a single-request flow | PASS ✗ | PASS ✗ | PASS ✗ | PASS ✗ | PASS ✗ |

Every cell now fails. The probes were scaffolding and are not committed; the unit tests above are their permanent form.

## Review rounds

Three rounds, ten threads, all resolved (Copilot errored on all three; cubic and Codex covered).

**Round 2** — cubic ×5: the Kotlin `Int.MAX_VALUE` overflow (Go had the identical shape); TypeScript never rejecting a negative index (`toBeGreaterThan(index + 1)` is trivially satisfied, then `times[-1]` produced NaN and a message about a delay); a Swift test whose catch-all asserted nothing about the error it caught; an orphaned doc comment left claiming `isCancellation` clamps `Retry-After`; and Ruby/Python collapsing two different failures into one misleading message.

**Round 2, B4 agent ×2** — a `min: 0` truthiness bug in Python and Ruby, which is this PR's own bug shape one layer up: `0` is falsy in Python and an absent `min` is nil in both, so a `min: 0` assertion silently degraded to no assertion at all. The default now lands *inside* the checked function, where no caller can gate it away. And the nullable Kotlin index regressing `requestPath`/`requestMethod`/`requestBody` diagnostics to `index null`.

**Round 3** — cubic ×1 and Codex ×2: the zero-request diagnostic; the helper tests not being invoked by required CI (an unrun test is not a guard — now wired into all four per-language jobs); and `bundle exec` running before anything installed the Ruby runner's gems.

## Verification

`make check` green end to end (`REAL_EXIT=0`): Go `ok`, TypeScript 1051, Python 763, Ruby 1011 runs / 2285 assertions, Kotlin BUILD SUCCESSFUL, Swift 278.

Conformance, from the same run — Go 131/0/2, Kotlin 132/0/1, TypeScript 164 passed / 2 skipped, Ruby 122/0/11, Python 133/0/0. Runner unit tests: Go 11, Python 12, Ruby 11 runs / 20 assertions, Kotlin 10, TypeScript 11.

Follow-ups from the #563 review that remain open and are deliberately not in here: #564 (`Retry-After`: HTTP-date form, the `> 0` guard, and which statuses honor it) and #567 (a `Transport` throwing `BasecampError.network` is classified terminal). **#565 is no longer among them** — the 401 refresh-replay budget is settled and lands in its own PR, since it changes SDK behavior in Python and Ruby rather than runner or Swift classification logic.
