### PR TITLE
Count the 401 refresh replay against the attempt budget, and amend SPEC §4 to match

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -255,13 +255,35 @@ END
 ### 401 Refresh-and-Retry Algorithm
 
 1. Receive 401 response.
-2. If the token provider supports refresh (`refreshable() == true`) and refresh has not yet been attempted for this request:
+2. If the token provider supports refresh (`refreshable() == true`), refresh has not yet been attempted for this request, **and the attempt budget has another attempt left**:
    a. Call `refresh()`.
    b. If refresh succeeded, retry the request once with updated token.
    c. → response from retry.
 3. → `⊥ BasecampError(code: "auth_required", http_status: 401)`.
 
 Refresh is attempted at most once per request. Implementations track this with a boolean (e.g., `refresh_attempted`) rather than a counter.
+
+**The replay spends an attempt.** It puts a request on the wire, so it draws
+from the same total-attempt budget as a transient retry (§7): `max_retries`
+counts requests, not failure kinds, and a cap of one means one request no
+matter what would have caused the second. That is what makes §14's "disabling
+retry yields exactly ONE hop-1 attempt" literally true — refresh included —
+and it preserves the total-attempt semantics settled for observed attempts in
+#461.
+
+Step 2's budget gate is checked **before** `refresh()` is called, not after.
+Refreshing a token the SDK has no budget left to use would burn a rotation for
+nothing and still hand the caller the stale 401; declining to refresh at all is
+both cheaper and easier to reason about. The consequence is worth stating
+plainly: with a budget of one attempt, a refreshable 401 is NOT replayed and
+surfaces as `auth_required`. Callers who want the refresh replay must leave an
+attempt for it.
+
+This gate applies wherever a total-attempt budget governs the path. Go's
+hand-written mutation path has no such budget — mutations are deliberately
+single-attempt for transient failures — and keeps its documented
+mutation-specific single re-attempt after a successful refresh (see §7's
+Cross-SDK Divergence).
 
 ---
 

--- a/python/src/basecamp/_async_http.py
+++ b/python/src/basecamp/_async_http.py
@@ -163,6 +163,7 @@ class AsyncHttpClient:
         max_attempts = self._config.max_retries if self._config.max_retries > 0 else 1
         max_attempts = self._apply_operation_retry_max(operation, max_attempts)
         attempt = 0
+        refreshed_once = False
         last_error: BasecampError | None = None
 
         while True:
@@ -182,7 +183,26 @@ class AsyncHttpClient:
                     attempt=attempt,
                     allow_cross_origin=allow_cross_origin,
                     accept=accept,
+                    refresh_replay=False,
                 )
+            except AuthError as e:
+                # SPEC §4: the refresh replay is a request on the wire, so it
+                # spends an attempt from THIS budget rather than an uncounted
+                # one inside the single-request primitive. max_retries is a
+                # total attempt count (#461), and a cap of one means one
+                # request whatever would have caused the second.
+                #
+                # The budget is checked BEFORE refresh() so a rotation is never
+                # burned on an attempt the loop has no room to make. Await the
+                # refresh rather than truthy-testing the coroutine, which would
+                # pass the gate without ever rotating the token.
+                if refreshed_once or e.http_status != 401 or attempt >= max_attempts:
+                    raise
+                tp = getattr(self._auth, "token_provider", None)
+                if not (tp and getattr(tp, "refreshable", False) and await tp.refresh()):
+                    raise
+                refreshed_once = True
+                continue
             except (RateLimitError, NetworkError, ApiError) as e:
                 if not self._is_retryable_error(e, operation, retry_on=retry_on):
                     raise
@@ -218,6 +238,7 @@ class AsyncHttpClient:
         _retry_count: int = 0,
         allow_cross_origin: bool = False,
         accept: str | None = "application/json",
+        refresh_replay: bool = True,
     ) -> httpx.Response:
         if not allow_cross_origin and not (
             _security.is_localhost(url) or _security.same_origin(url, self._config.base_url)
@@ -247,8 +268,11 @@ class AsyncHttpClient:
 
             if response.status_code >= 400:
                 error = self._handle_error(response)
-                # 401 retry with async token refresh
-                if isinstance(error, AuthError) and error.http_status == 401 and _retry_count < 1:
+                # 401 replay for callers that come here directly (mutations),
+                # which have no retry loop to own it. _request_with_retry
+                # passes refresh_replay=False and replays from the loop so the
+                # extra request draws from the attempt budget (SPEC §4).
+                if refresh_replay and isinstance(error, AuthError) and error.http_status == 401 and _retry_count < 1:
                     tp = getattr(self._auth, "token_provider", None)
                     if tp and getattr(tp, "refreshable", False) and await tp.refresh():
                         return await self._single_request(
@@ -263,6 +287,7 @@ class AsyncHttpClient:
                             _retry_count=_retry_count + 1,
                             allow_cross_origin=allow_cross_origin,
                             accept=accept,
+                            refresh_replay=refresh_replay,
                         )
                 raise error
 

--- a/python/src/basecamp/_async_http.py
+++ b/python/src/basecamp/_async_http.py
@@ -171,6 +171,13 @@ class AsyncHttpClient:
             if attempt > max_attempts:
                 break
 
+            # Each except suite only CLASSIFIES the attempt; the retry side
+            # effects run below, outside every handler. An exception raised
+            # inside an except suite bypasses that try's sibling handlers, so
+            # refreshing there would let a NetworkError from the token endpoint
+            # escape the loop with budget still on the table.
+            error: BasecampError | None = None
+            stale_auth: AuthError | None = None
             try:
                 return await self._single_request(
                     method,
@@ -198,23 +205,40 @@ class AsyncHttpClient:
                 # pass the gate without ever rotating the token.
                 if refreshed_once or e.http_status != 401 or attempt >= max_attempts:
                     raise
-                tp = getattr(self._auth, "token_provider", None)
-                if not (tp and getattr(tp, "refreshable", False) and await tp.refresh()):
-                    raise
-                refreshed_once = True
-                continue
+                stale_auth = e
             except (RateLimitError, NetworkError, ApiError) as e:
-                if not self._is_retryable_error(e, operation, retry_on=retry_on):
-                    raise
-                last_error = e
+                error = e
+
+            if stale_auth is not None:
+                try:
+                    tp = getattr(self._auth, "token_provider", None)
+                    refreshed = bool(tp and getattr(tp, "refreshable", False) and await tp.refresh())
+                except (RateLimitError, NetworkError, ApiError) as e:
+                    # A token endpoint that times out is a transient failure of
+                    # this attempt, not a terminal auth fault: it retries under
+                    # the same budget, exactly as it did when the replay lived
+                    # inside _single_request.
+                    error = e
+                else:
+                    if not refreshed:
+                        raise stale_auth
+                    # No backoff: the token is fresh, and the server never asked
+                    # us to wait. The replay still costs the attempt counted above.
+                    refreshed_once = True
+                    continue
+
+            if error is not None:
+                if not self._is_retryable_error(error, operation, retry_on=retry_on):
+                    raise error
+                last_error = error
                 if attempt >= max_attempts:
                     break
-                delay = self._calculate_delay(attempt, e.retry_after)
+                delay = self._calculate_delay(attempt, error.retry_after)
                 safe_hook(
                     self._hooks.on_retry,
                     RequestInfo(method=method, url=url, attempt=attempt),
                     attempt + 1,
-                    e,
+                    error,
                     delay,
                 )
                 await asyncio.sleep(delay)

--- a/python/src/basecamp/_async_http.py
+++ b/python/src/basecamp/_async_http.py
@@ -210,6 +210,15 @@ class AsyncHttpClient:
                 error = e
 
             if stale_auth is not None:
+                # SPEC §4 tracks refresh with an "attempted" boolean, not a
+                # "succeeded" one, so mark it BEFORE invoking the provider: a
+                # refresh that throws still counts as the one attempt this
+                # request gets. Otherwise a transient token-endpoint failure
+                # lets the NEXT 401 in the same request call refresh() again —
+                # and if the first call reached the server and rotated the
+                # token before its response was lost, the second spends a
+                # refresh token that is already dead.
+                refreshed_once = True
                 try:
                     tp = getattr(self._auth, "token_provider", None)
                     refreshed = bool(tp and getattr(tp, "refreshable", False) and await tp.refresh())
@@ -224,7 +233,6 @@ class AsyncHttpClient:
                         raise stale_auth
                     # No backoff: the token is fresh, and the server never asked
                     # us to wait. The replay still costs the attempt counted above.
-                    refreshed_once = True
                     continue
 
             if error is not None:

--- a/python/src/basecamp/_http.py
+++ b/python/src/basecamp/_http.py
@@ -163,6 +163,7 @@ class HttpClient:
         max_attempts = self._config.max_retries if self._config.max_retries > 0 else 1
         max_attempts = self._apply_operation_retry_max(operation, max_attempts)
         attempt = 0
+        refreshed_once = False
         last_error: BasecampError | None = None
 
         while True:
@@ -182,7 +183,24 @@ class HttpClient:
                     attempt=attempt,
                     allow_cross_origin=allow_cross_origin,
                     accept=accept,
+                    refresh_replay=False,
                 )
+            except AuthError as e:
+                # SPEC §4: the refresh replay is a request on the wire, so it
+                # spends an attempt from THIS budget rather than an uncounted
+                # one inside the single-request primitive. max_retries is a
+                # total attempt count (#461), and a cap of one means one
+                # request whatever would have caused the second.
+                #
+                # The budget is checked BEFORE refresh() so a rotation is never
+                # burned on an attempt the loop has no room to make.
+                if refreshed_once or e.http_status != 401 or attempt >= max_attempts:
+                    raise
+                tp = getattr(self._auth, "token_provider", None)
+                if not (tp and getattr(tp, "refreshable", False) and tp.refresh()):
+                    raise
+                refreshed_once = True
+                continue
             except (RateLimitError, NetworkError, ApiError) as e:
                 if not self._is_retryable_error(e, operation, retry_on=retry_on):
                     raise
@@ -218,6 +236,7 @@ class HttpClient:
         _retry_count: int = 0,
         allow_cross_origin: bool = False,
         accept: str | None = "application/json",
+        refresh_replay: bool = True,
     ) -> httpx.Response:
         if not allow_cross_origin and not (
             _security.is_localhost(url) or _security.same_origin(url, self._config.base_url)
@@ -247,8 +266,11 @@ class HttpClient:
 
             if response.status_code >= 400:
                 error = self._handle_error(response)
-                # 401 retry with token refresh
-                if isinstance(error, AuthError) and error.http_status == 401 and _retry_count < 1:
+                # 401 replay for callers that come here directly (mutations),
+                # which have no retry loop to own it. _request_with_retry
+                # passes refresh_replay=False and replays from the loop so the
+                # extra request draws from the attempt budget (SPEC §4).
+                if refresh_replay and isinstance(error, AuthError) and error.http_status == 401 and _retry_count < 1:
                     tp = getattr(self._auth, "token_provider", None)
                     if tp and getattr(tp, "refreshable", False) and tp.refresh():
                         return self._single_request(
@@ -263,6 +285,7 @@ class HttpClient:
                             _retry_count=_retry_count + 1,
                             allow_cross_origin=allow_cross_origin,
                             accept=accept,
+                            refresh_replay=refresh_replay,
                         )
                 raise error
 

--- a/python/src/basecamp/_http.py
+++ b/python/src/basecamp/_http.py
@@ -208,6 +208,15 @@ class HttpClient:
                 error = e
 
             if stale_auth is not None:
+                # SPEC §4 tracks refresh with an "attempted" boolean, not a
+                # "succeeded" one, so mark it BEFORE invoking the provider: a
+                # refresh that throws still counts as the one attempt this
+                # request gets. Otherwise a transient token-endpoint failure
+                # lets the NEXT 401 in the same request call refresh() again —
+                # and if the first call reached the server and rotated the
+                # token before its response was lost, the second spends a
+                # refresh token that is already dead.
+                refreshed_once = True
                 try:
                     tp = getattr(self._auth, "token_provider", None)
                     refreshed = bool(tp and getattr(tp, "refreshable", False) and tp.refresh())
@@ -222,7 +231,6 @@ class HttpClient:
                         raise stale_auth
                     # No backoff: the token is fresh, and the server never asked
                     # us to wait. The replay still costs the attempt counted above.
-                    refreshed_once = True
                     continue
 
             if error is not None:

--- a/python/src/basecamp/_http.py
+++ b/python/src/basecamp/_http.py
@@ -171,6 +171,13 @@ class HttpClient:
             if attempt > max_attempts:
                 break
 
+            # Each except suite only CLASSIFIES the attempt; the retry side
+            # effects run below, outside every handler. An exception raised
+            # inside an except suite bypasses that try's sibling handlers, so
+            # refreshing there would let a NetworkError from the token endpoint
+            # escape the loop with budget still on the table.
+            error: BasecampError | None = None
+            stale_auth: AuthError | None = None
             try:
                 return self._single_request(
                     method,
@@ -196,23 +203,40 @@ class HttpClient:
                 # burned on an attempt the loop has no room to make.
                 if refreshed_once or e.http_status != 401 or attempt >= max_attempts:
                     raise
-                tp = getattr(self._auth, "token_provider", None)
-                if not (tp and getattr(tp, "refreshable", False) and tp.refresh()):
-                    raise
-                refreshed_once = True
-                continue
+                stale_auth = e
             except (RateLimitError, NetworkError, ApiError) as e:
-                if not self._is_retryable_error(e, operation, retry_on=retry_on):
-                    raise
-                last_error = e
+                error = e
+
+            if stale_auth is not None:
+                try:
+                    tp = getattr(self._auth, "token_provider", None)
+                    refreshed = bool(tp and getattr(tp, "refreshable", False) and tp.refresh())
+                except (RateLimitError, NetworkError, ApiError) as e:
+                    # A token endpoint that times out is a transient failure of
+                    # this attempt, not a terminal auth fault: it retries under
+                    # the same budget, exactly as it did when the replay lived
+                    # inside _single_request.
+                    error = e
+                else:
+                    if not refreshed:
+                        raise stale_auth
+                    # No backoff: the token is fresh, and the server never asked
+                    # us to wait. The replay still costs the attempt counted above.
+                    refreshed_once = True
+                    continue
+
+            if error is not None:
+                if not self._is_retryable_error(error, operation, retry_on=retry_on):
+                    raise error
+                last_error = error
                 if attempt >= max_attempts:
                     break
-                delay = self._calculate_delay(attempt, e.retry_after)
+                delay = self._calculate_delay(attempt, error.retry_after)
                 safe_hook(
                     self._hooks.on_retry,
                     RequestInfo(method=method, url=url, attempt=attempt),
                     attempt + 1,
-                    e,
+                    error,
                     delay,
                 )
                 time.sleep(delay)

--- a/python/tests/test_download.py
+++ b/python/tests/test_download.py
@@ -12,8 +12,34 @@ from basecamp.async_auth import AsyncBearerAuth, AsyncStaticTokenProvider
 from basecamp.auth import BearerAuth, StaticTokenProvider
 from basecamp.config import Config
 from basecamp.download import _rewrite_url, download_async, download_sync, filename_from_url
-from basecamp.errors import ApiError, BasecampError, UsageError
+from basecamp.errors import ApiError, AuthError, UsageError
 from basecamp.hooks import BasecampHooks
+
+
+class _RefreshableProvider(StaticTokenProvider):
+    """Counts refreshes so a test can tell "declined to refresh" from "refreshed"."""
+
+    refreshable = True
+
+    def __init__(self):
+        super().__init__("test-token")
+        self.refreshes = 0
+
+    def refresh(self):
+        self.refreshes += 1
+        return True
+
+
+class _AsyncRefreshableProvider(AsyncStaticTokenProvider):
+    refreshable = True
+
+    def __init__(self):
+        super().__init__("test-token")
+        self.refreshes = 0
+
+    async def refresh(self):
+        self.refreshes += 1
+        return True
 
 
 def make_config():
@@ -236,38 +262,65 @@ class TestHop1Retry:
         assert "Authorization" not in hop2.calls[0].request.headers
 
     @respx.mock
-    def test_refreshable_401_replays_once_independent_of_the_retry_cap(self):
-        """SPEC §4: refresh is attempted at most once PER REQUEST.
+    def test_refresh_replay_is_not_attempted_without_budget(self):
+        """SPEC §4/§14: with retry disabled, ONE request goes out — refresh included.
 
-        §4 tracks it with a boolean, not a counter, and does not subordinate
-        it to the transient-retry budget — so a refreshable 401 replays once
-        even with retries disabled. That is deliberately orthogonal to §14's
-        hop-1 attempt cap, which governs transient-failure retries. Whether
-        the two should be reconciled is tracked in #565; this pins what the
-        spec says today so a future change has to be a decision, not a drift.
+        The replay is a request on the wire, so it spends an attempt from the
+        same total-attempt budget as a transient retry. A cap of one means one
+        request no matter what would have caused the second (#565, #461).
+
+        The refresh itself must not fire either: §4 checks the budget BEFORE
+        calling refresh(), because rotating a token the SDK has no attempt left
+        to use burns it for nothing and still surfaces the stale 401.
         """
-
-        class RefreshableProvider(StaticTokenProvider):
-            refreshable = True
-
-            def __init__(self):
-                super().__init__("test-token")
-                self.refreshes = 0
-
-            def refresh(self):
-                self.refreshes += 1
-                return True
-
         hop1 = respx.get(self.HOP1).mock(return_value=httpx.Response(401))
 
-        provider = RefreshableProvider()
+        provider = _RefreshableProvider()
         config = make_fast_config(max_retries=0)
         http = HttpClient(config, BearerAuth(provider))
-        with pytest.raises(BasecampError):
+        with pytest.raises(AuthError):
             download_sync(self.RAW, http_client=http, config=config)
 
-        # One transient attempt, plus §4's single refresh replay.
+        assert hop1.call_count == 1
+        assert provider.refreshes == 0
+
+    @respx.mock
+    def test_refresh_replay_spends_an_attempt_from_the_budget(self):
+        """A budget of two allows the refresh replay, and it consumes attempt 2."""
+        hop1 = respx.get(self.HOP1).mock(return_value=httpx.Response(401))
+
+        provider = _RefreshableProvider()
+        config = make_fast_config(max_retries=2)
+        http = HttpClient(config, BearerAuth(provider))
+        with pytest.raises(AuthError):
+            download_sync(self.RAW, http_client=http, config=config)
+
+        # Two requests, not three: the replay drew from the same budget, and
+        # §4 allows only one refresh per request regardless.
         assert hop1.call_count == 2
+        assert provider.refreshes == 1
+
+    @respx.mock
+    def test_refresh_replay_succeeds_when_the_new_token_works(self):
+        """The refreshed request is actually SENT, not refreshed-then-discarded."""
+        hop1 = respx.get(self.HOP1).mock(
+            side_effect=[
+                httpx.Response(401),
+                httpx.Response(302, headers={"Location": self.SIGNED}),
+            ]
+        )
+        hop2 = respx.get(self.SIGNED).mock(
+            return_value=httpx.Response(200, content=b"data", headers={"content-type": "application/pdf"})
+        )
+
+        provider = _RefreshableProvider()
+        config = make_fast_config(max_retries=2)
+        http = HttpClient(config, BearerAuth(provider))
+        result = download_sync(self.RAW, http_client=http, config=config)
+
+        assert result.body == b"data"
+        assert hop1.call_count == 2
+        assert hop2.call_count == 1
         assert provider.refreshes == 1
 
     @respx.mock
@@ -478,3 +531,60 @@ class TestHop1RetryAsync:
             assert call.request.headers.get("Accept") != "application/json"
             assert "Content-Type" not in call.request.headers
             assert call.request.headers.get("User-Agent") is not None
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_refresh_replay_is_not_attempted_without_budget(self):
+        """SPEC §4/§14 budget gate, async transport (see the sync twin)."""
+        hop1 = respx.get(self.HOP1).mock(return_value=httpx.Response(401))
+
+        provider = _AsyncRefreshableProvider()
+        config = make_fast_config(max_retries=0)
+        http = AsyncHttpClient(config, AsyncBearerAuth(provider))
+        with pytest.raises(AuthError):
+            await download_async(self.RAW, http_client=http, config=config)
+
+        assert hop1.call_count == 1
+        assert provider.refreshes == 0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_refresh_replay_spends_an_attempt_from_the_budget(self):
+        hop1 = respx.get(self.HOP1).mock(return_value=httpx.Response(401))
+
+        provider = _AsyncRefreshableProvider()
+        config = make_fast_config(max_retries=2)
+        http = AsyncHttpClient(config, AsyncBearerAuth(provider))
+        with pytest.raises(AuthError):
+            await download_async(self.RAW, http_client=http, config=config)
+
+        assert hop1.call_count == 2
+        assert provider.refreshes == 1
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_refresh_replay_succeeds_when_the_new_token_works(self):
+        """The refreshed request is actually SENT, not awaited-then-discarded.
+
+        Pins the await too: a refresh coroutine truthy-tested without awaiting
+        would pass the gate and then never rotate the token (#563's de8c9255d).
+        """
+        hop1 = respx.get(self.HOP1).mock(
+            side_effect=[
+                httpx.Response(401),
+                httpx.Response(302, headers={"Location": self.SIGNED}),
+            ]
+        )
+        hop2 = respx.get(self.SIGNED).mock(
+            return_value=httpx.Response(200, content=b"data", headers={"content-type": "application/pdf"})
+        )
+
+        provider = _AsyncRefreshableProvider()
+        config = make_fast_config(max_retries=2)
+        http = AsyncHttpClient(config, AsyncBearerAuth(provider))
+        result = await download_async(self.RAW, http_client=http, config=config)
+
+        assert result.body == b"data"
+        assert hop1.call_count == 2
+        assert hop2.call_count == 1
+        assert provider.refreshes == 1

--- a/python/tests/test_http.py
+++ b/python/tests/test_http.py
@@ -758,6 +758,38 @@ class TestRefreshReplayAttemptBudget:
         assert provider.refreshes == 1
 
     @respx.mock
+    def test_refresh_network_failure_still_retries_under_the_budget(self):
+        """A token endpoint that fails is a transient failure of this attempt.
+
+        Performing the refresh inside the `except AuthError` suite would let
+        this NetworkError bypass the sibling transient handler entirely — an
+        exception raised inside an except suite is not offered to that try's
+        other handlers — ending the request with budget still unspent.
+        """
+        route = respx.get(self.URL).mock(side_effect=[httpx.Response(401), httpx.Response(200, json={"ok": True})])
+        config = Config(base_url="https://3.basecampapi.com", max_retries=3, base_delay=0.001, max_jitter=0.0)
+
+        class ExplodingProvider(StaticTokenProvider):
+            refreshable = True
+
+            def __init__(self):
+                super().__init__("test-token")
+                self.refreshes = 0
+
+            def refresh(self):
+                self.refreshes += 1
+                raise NetworkError("token endpoint timed out")
+
+        provider = ExplodingProvider()
+        client = HttpClient(config, BearerAuth(provider), BasecampHooks())
+
+        response = client.get("/thing")
+
+        assert response.status_code == 200
+        assert route.call_count == 2
+        assert provider.refreshes == 1
+
+    @respx.mock
     def test_mutations_keep_the_in_primitive_replay(self):
         # Mutations bypass the retry loop entirely (no transient budget), so
         # they keep the single-request primitive's own replay. SPEC §4's gate

--- a/python/tests/test_http.py
+++ b/python/tests/test_http.py
@@ -790,6 +790,40 @@ class TestRefreshReplayAttemptBudget:
         assert provider.refreshes == 1
 
     @respx.mock
+    def test_a_throwing_refresh_still_spends_the_one_allowed_refresh(self):
+        """SPEC §4 counts refresh ATTEMPTS, not successes.
+
+        The 401 recurs because the token never changed, so a flag set only on
+        success would let the same request call refresh() a second time — and
+        if the first call reached the server and rotated the token before its
+        response was lost, the second spends a refresh token already dead.
+        """
+        route = respx.get(self.URL).mock(return_value=httpx.Response(401))
+        config = Config(base_url="https://3.basecampapi.com", max_retries=3, base_delay=0.001, max_jitter=0.0)
+
+        class ExplodingProvider(StaticTokenProvider):
+            refreshable = True
+
+            def __init__(self):
+                super().__init__("test-token")
+                self.refreshes = 0
+
+            def refresh(self):
+                self.refreshes += 1
+                raise NetworkError("token endpoint timed out")
+
+        provider = ExplodingProvider()
+        client = HttpClient(config, BearerAuth(provider), BasecampHooks())
+
+        with pytest.raises(AuthError):
+            client.get("/thing")
+
+        # Attempt 1 401s and burns the one refresh; attempt 2 401s with the same
+        # token and must NOT refresh again, so the stale 401 surfaces.
+        assert provider.refreshes == 1
+        assert route.call_count == 2
+
+    @respx.mock
     def test_mutations_keep_the_in_primitive_replay(self):
         # Mutations bypass the retry loop entirely (no transient budget), so
         # they keep the single-request primitive's own replay. SPEC §4's gate

--- a/python/tests/test_http.py
+++ b/python/tests/test_http.py
@@ -697,3 +697,88 @@ class TestDeclaredSetIsAuthoritative:
         with pytest.raises(ApiError):
             await client.put("/thing", json_body={"x": 1}, operation="OptOutOp")
         assert route.call_count == 1
+
+
+class TestRefreshReplayAttemptBudget:
+    """SPEC §4: the 401 refresh replay draws from the total-attempt budget.
+
+    These pin the PLAIN GET path, not just the download hop — the "every GET
+    in Python and Ruby" case that the earlier, ungated attempt at this change
+    regressed (#563's aca2c481b, now superseded by §4's budget gate). #565.
+    """
+
+    URL = "https://3.basecampapi.com/thing"
+
+    def make_client(self, max_retries):
+        config = Config(
+            base_url="https://3.basecampapi.com",
+            max_retries=max_retries,
+            base_delay=0.001,
+            max_jitter=0.0,
+        )
+        provider = _RefreshableProvider()
+        return HttpClient(config, BearerAuth(provider), BasecampHooks()), provider
+
+    @respx.mock
+    def test_no_budget_means_one_request_and_no_refresh(self):
+        route = respx.get(self.URL).mock(return_value=httpx.Response(401))
+        client, provider = self.make_client(max_retries=0)
+
+        with pytest.raises(AuthError):
+            client.get("/thing")
+
+        assert route.call_count == 1
+        assert provider.refreshes == 0
+
+    @respx.mock
+    def test_replay_spends_an_attempt_and_is_actually_sent(self):
+        # The regression the ungated version caused: refresh, then rethrow the
+        # stale 401 WITHOUT ever sending the refreshed request. Two requests
+        # and a 200 body prove the replay reached the wire.
+        route = respx.get(self.URL).mock(side_effect=[httpx.Response(401), httpx.Response(200, json={"ok": True})])
+        client, provider = self.make_client(max_retries=2)
+
+        response = client.get("/thing")
+
+        assert response.status_code == 200
+        assert route.call_count == 2
+        assert provider.refreshes == 1
+
+    @respx.mock
+    def test_replay_and_transient_retries_share_one_budget(self):
+        # 401 (attempt 1, refresh) → 503 (attempt 2) → budget spent. Three
+        # requests would mean the replay rode outside the cap.
+        route = respx.get(self.URL).mock(side_effect=[httpx.Response(401), httpx.Response(503)])
+        client, provider = self.make_client(max_retries=2)
+
+        with pytest.raises(ApiError):
+            client.get("/thing")
+
+        assert route.call_count == 2
+        assert provider.refreshes == 1
+
+    @respx.mock
+    def test_mutations_keep_the_in_primitive_replay(self):
+        # Mutations bypass the retry loop entirely (no transient budget), so
+        # they keep the single-request primitive's own replay. SPEC §4's gate
+        # applies where a total-attempt budget governs the path.
+        route = respx.post(self.URL).mock(side_effect=[httpx.Response(401), httpx.Response(201, json={"ok": True})])
+        client, provider = self.make_client(max_retries=0)
+
+        response = client.post("/thing", json_body={"x": 1})
+
+        assert response.status_code == 201
+        assert route.call_count == 2
+        assert provider.refreshes == 1
+
+
+class _RefreshableProvider(StaticTokenProvider):
+    refreshable = True
+
+    def __init__(self):
+        super().__init__("test-token")
+        self.refreshes = 0
+
+    def refresh(self):
+        self.refreshes += 1
+        return True

--- a/ruby/lib/basecamp/http.rb
+++ b/ruby/lib/basecamp/http.rb
@@ -414,6 +414,15 @@ module Basecamp
         end
 
         if stale_auth
+          # SPEC §4 tracks refresh with an "attempted" boolean, not a
+          # "succeeded" one, so mark it BEFORE invoking the provider: a refresh
+          # that raises still counts as the one attempt this request gets.
+          # Otherwise a transient token-endpoint failure lets the NEXT 401 in
+          # the same request call refresh again — and if the first call reached
+          # the server and rotated the token before its response was lost, the
+          # second spends a refresh token that is already dead.
+          refreshed_once = true
+
           begin
             refreshed = @token_provider&.refreshable? && @token_provider.refresh
           rescue Basecamp::RateLimitError, Basecamp::NetworkError, Basecamp::ApiError => e
@@ -426,7 +435,6 @@ module Basecamp
 
             # No backoff: the token is fresh, and the server never asked us to
             # wait. The replay still costs the attempt counted above.
-            refreshed_once = true
             next
           end
         end

--- a/ruby/lib/basecamp/http.rb
+++ b/ruby/lib/basecamp/http.rb
@@ -380,6 +380,7 @@ module Basecamp
         @config.max_retries
       end
       attempt = 0
+      refreshed_once = false
       last_error = nil
 
       loop do
@@ -388,7 +389,21 @@ module Basecamp
 
         begin
           return single_request(method, url, params: params, body: nil, attempt: attempt,
-            allow_cross_origin: allow_cross_origin, accept: accept)
+            allow_cross_origin: allow_cross_origin, accept: accept, refresh_replay: false)
+        rescue Basecamp::AuthError => e
+          # SPEC §4: the refresh replay is a request on the wire, so it spends
+          # an attempt from THIS budget rather than an uncounted one inside
+          # single_request. max_retries is a total attempt count (#461), and a
+          # cap of one means one request whatever would have caused the second.
+          #
+          # The budget is checked BEFORE refresh so a rotation is never burned
+          # on an attempt the loop has no room to make — hence the ordering of
+          # these conditions, which short-circuit left to right.
+          replayable = !refreshed_once && e.http_status == 401 && attempt < max_attempts \
+            && @token_provider&.refreshable? && @token_provider.refresh
+          raise e unless replayable
+
+          refreshed_once = true
         rescue Basecamp::RateLimitError, Basecamp::NetworkError, Basecamp::ApiError => e
           raise e unless retry_eligible?(e, op_retry, retry_on)
 
@@ -434,7 +449,7 @@ module Basecamp
     end
 
     def single_request(method, url, params:, body:, attempt:, retry_count: 0, allow_cross_origin: false,
-      accept: "application/json")
+      accept: "application/json", refresh_replay: true)
       assert_credential_origin!(url, allow_cross_origin)
       info = RequestInfo.new(method: method.to_s.upcase, url: url, attempt: attempt)
       @hooks.on_request_start(info)
@@ -457,7 +472,7 @@ module Basecamp
         )
       rescue Faraday::ServerError, Faraday::ClientError => e
         duration = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
-        error = handle_error(e)
+        error = handle_error(e, refresh_on_401: refresh_replay)
         result = RequestResult.new(
           status_code: e.response&.dig(:status),
           duration: duration,
@@ -466,11 +481,15 @@ module Basecamp
         )
         @hooks.on_request_end(info, result)
 
-        # After a successful token refresh on 401, retry the request once
-        if error.is_a?(Basecamp::AuthError) && error.http_status == 401 && retry_count < 1 && @token_refreshed
+        # 401 replay for callers that come here directly (mutations), which
+        # have no retry loop to own it. request_with_retry passes
+        # refresh_replay: false and replays from the loop so the extra request
+        # draws from the attempt budget (SPEC §4).
+        if refresh_replay && error.is_a?(Basecamp::AuthError) && error.http_status == 401 && retry_count < 1 \
+            && @token_refreshed
           @token_refreshed = false
           return single_request(method, url, params: params, body: body, attempt: attempt, retry_count: retry_count + 1,
-            allow_cross_origin: allow_cross_origin, accept: accept)
+            allow_cross_origin: allow_cross_origin, accept: accept, refresh_replay: refresh_replay)
         end
 
         raise error
@@ -533,7 +552,10 @@ module Basecamp
       end
     end
 
-    def handle_error(error)
+    # refresh_on_401: false leaves the token alone — the caller (request_with_retry)
+    # owns the refresh so it can gate it on the attempt budget before spending a
+    # rotation. Classifying an error should not rotate credentials as a side effect.
+    def handle_error(error, refresh_on_401: true)
       status = error.response&.dig(:status)
       body = error.response&.dig(:body)
       headers = error.response&.dig(:headers) || {}
@@ -544,7 +566,7 @@ module Basecamp
       err = case status
       when 401
         # Try token refresh; flag for caller to retry
-        @token_refreshed = @token_provider&.refreshable? && @token_provider.refresh
+        @token_refreshed = refresh_on_401 && @token_provider&.refreshable? && @token_provider.refresh
         Basecamp::AuthError.new("Authentication failed")
       when 403
         Basecamp::ForbiddenError.new("Access denied")

--- a/ruby/lib/basecamp/http.rb
+++ b/ruby/lib/basecamp/http.rb
@@ -387,6 +387,14 @@ module Basecamp
         attempt += 1
         break if attempt > max_attempts
 
+        # Each rescue only CLASSIFIES the attempt; the retry side effects run
+        # below, outside every handler. An exception raised inside a rescue
+        # clause bypasses that begin's sibling rescues, so refreshing there
+        # would let a NetworkError from the token endpoint escape the loop
+        # with budget still on the table.
+        error = nil
+        stale_auth = nil
+
         begin
           return single_request(method, url, params: params, body: nil, attempt: attempt,
             allow_cross_origin: allow_cross_origin, accept: accept, refresh_replay: false)
@@ -397,24 +405,43 @@ module Basecamp
           # cap of one means one request whatever would have caused the second.
           #
           # The budget is checked BEFORE refresh so a rotation is never burned
-          # on an attempt the loop has no room to make — hence the ordering of
-          # these conditions, which short-circuit left to right.
-          replayable = !refreshed_once && e.http_status == 401 && attempt < max_attempts \
-            && @token_provider&.refreshable? && @token_provider.refresh
-          raise e unless replayable
+          # on an attempt the loop has no room to make.
+          raise e if refreshed_once || e.http_status != 401 || attempt >= max_attempts
 
-          refreshed_once = true
+          stale_auth = e
         rescue Basecamp::RateLimitError, Basecamp::NetworkError, Basecamp::ApiError => e
-          raise e unless retry_eligible?(e, op_retry, retry_on)
+          error = e
+        end
 
-          last_error = e
+        if stale_auth
+          begin
+            refreshed = @token_provider&.refreshable? && @token_provider.refresh
+          rescue Basecamp::RateLimitError, Basecamp::NetworkError, Basecamp::ApiError => e
+            # A token endpoint that times out is a transient failure of this
+            # attempt, not a terminal auth fault: it retries under the same
+            # budget, exactly as it did when the replay lived in single_request.
+            error = e
+          else
+            raise stale_auth unless refreshed
+
+            # No backoff: the token is fresh, and the server never asked us to
+            # wait. The replay still costs the attempt counted above.
+            refreshed_once = true
+            next
+          end
+        end
+
+        if error
+          raise error unless retry_eligible?(error, op_retry, retry_on)
+
+          last_error = error
 
           # Don't sleep if this was the last attempt
           break if attempt >= max_attempts
 
-          delay = calculate_delay(attempt, e.retry_after)
+          delay = calculate_delay(attempt, error.retry_after)
 
-          @hooks.on_retry(RequestInfo.new(method: method.to_s.upcase, url: url, attempt: attempt), attempt + 1, e,
+          @hooks.on_retry(RequestInfo.new(method: method.to_s.upcase, url: url, attempt: attempt), attempt + 1, error,
                           delay)
           sleep(delay)
         end

--- a/ruby/test/basecamp/download_test.rb
+++ b/ruby/test/basecamp/download_test.rb
@@ -438,13 +438,8 @@ class DownloadTest < Minitest::Test
     assert_requested(s3_stub)
   end
 
-  # SPEC §4: refresh is attempted at most once PER REQUEST — tracked with a
-  # boolean, not a counter, and not subordinate to the transient-retry budget.
-  # So a refreshable 401 replays once even with retries disabled, deliberately
-  # orthogonal to §14's hop-1 attempt cap. Whether the two should be
-  # reconciled is tracked in #565; this pins what the spec says today.
-  def test_download_url_refreshable_401_replays_once_independent_of_the_retry_cap
-    provider = Class.new do
+  def refreshable_provider
+    Class.new do
       attr_reader :refreshes
 
       def initialize = @refreshes = 0
@@ -456,14 +451,56 @@ class DownloadTest < Minitest::Test
         true
       end
     end.new
+  end
 
+  # SPEC §4/§14: with retry disabled ONE request goes out — refresh included.
+  # The replay is a request on the wire, so it spends an attempt from the same
+  # total-attempt budget as a transient retry (#565, #461).
+  #
+  # The refresh itself must not fire either: §4 checks the budget BEFORE
+  # refreshing, because rotating a token the SDK has no attempt left to use
+  # burns it for nothing and still surfaces the stale 401.
+  def test_download_url_refresh_replay_is_not_attempted_without_budget
+    provider = refreshable_provider
     stub_request(:get, "#{base_url}#{HOP1_PATH}").to_return(status: 401)
 
     account = create_account_client(config: fast_download_config(max_retries: 0), token_provider: provider)
-    assert_raises(Basecamp::Error) { account.download_url(HOP1_URL) }
+    assert_raises(Basecamp::AuthError) { account.download_url(HOP1_URL) }
 
-    # One transient attempt, plus §4's single refresh replay.
+    assert_requested(:get, "#{base_url}#{HOP1_PATH}", times: 1)
+    assert_equal 0, provider.refreshes
+  end
+
+  # A budget of two allows the replay, and it consumes attempt 2.
+  def test_download_url_refresh_replay_spends_an_attempt_from_the_budget
+    provider = refreshable_provider
+    stub_request(:get, "#{base_url}#{HOP1_PATH}").to_return(status: 401)
+
+    account = create_account_client(config: fast_download_config(max_retries: 2), token_provider: provider)
+    assert_raises(Basecamp::AuthError) { account.download_url(HOP1_URL) }
+
+    # Two requests, not three: the replay drew from the same budget, and §4
+    # allows only one refresh per request regardless.
     assert_requested(:get, "#{base_url}#{HOP1_PATH}", times: 2)
+    assert_equal 1, provider.refreshes
+  end
+
+  # The refreshed request is actually SENT, not refreshed-then-discarded.
+  def test_download_url_refresh_replay_succeeds_when_the_new_token_works
+    provider = refreshable_provider
+    stub_request(:get, "#{base_url}#{HOP1_PATH}")
+      .to_return(status: 401)
+      .then.to_return(status: 302, headers: { "Location" => SIGNED_URL })
+    s3_stub = stub_request(:get, SIGNED_URL)
+      .to_return(status: 200, body: "data", headers: { "Content-Type" => "application/octet-stream" })
+
+    account = create_account_client(config: fast_download_config(max_retries: 2), token_provider: provider)
+    result = account.download_url(HOP1_URL)
+
+    assert_equal "data", result.body
+    assert_requested(:get, "#{base_url}#{HOP1_PATH}", times: 2)
+    assert_requested(s3_stub)
+    assert_equal 1, provider.refreshes
   end
 
   # SPEC §14: hop 1 carries Authorization and User-Agent only. A binary

--- a/ruby/test/basecamp/http_test.rb
+++ b/ruby/test/basecamp/http_test.rb
@@ -209,6 +209,40 @@ class HTTPTest < Minitest::Test
     assert_equal 1, provider.refresh_count
   end
 
+  # A token endpoint that fails is a transient failure of THIS attempt.
+  # Performing the refresh inside the `rescue Basecamp::AuthError` clause would
+  # let this NetworkError bypass the sibling transient rescue entirely — an
+  # exception raised inside a rescue is not offered to that begin's other
+  # rescues — ending the request with budget still unspent.
+  def test_401_refresh_network_failure_still_retries_under_the_budget
+    provider = Class.new do
+      attr_reader :refresh_count
+
+      def initialize = @refresh_count = 0
+      def access_token = "old-token"
+      def refreshable? = true
+
+      def refresh
+        @refresh_count += 1
+        raise Basecamp::NetworkError.new("token endpoint timed out")
+      end
+    end.new
+
+    config = Basecamp::Config.new(base_url: "https://3.basecampapi.com", timeout: 5, max_retries: 3,
+      base_delay: 0.001, max_jitter: 0.0)
+    http = Basecamp::Http.new(config: config, token_provider: provider)
+
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 401, body: '{"error": "Unauthorized"}')
+      .then.to_return(status: 200, body: '{"ok": true}')
+
+    response = http.get("/test.json")
+
+    assert_equal 200, response.status
+    assert_requested(:get, "https://3.basecampapi.com/test.json", times: 2)
+    assert_equal 1, provider.refresh_count
+  end
+
   def test_401_no_retry_when_refresh_fails
     provider = RefreshableTokenProvider.new("old-token", refresh_result: false)
     http = Basecamp::Http.new(config: @config, token_provider: provider)

--- a/ruby/test/basecamp/http_test.rb
+++ b/ruby/test/basecamp/http_test.rb
@@ -243,6 +243,38 @@ class HTTPTest < Minitest::Test
     assert_equal 1, provider.refresh_count
   end
 
+  # SPEC §4 counts refresh ATTEMPTS, not successes. The 401 recurs because the
+  # token never changed, so a flag set only on success would let the same
+  # request call refresh a second time — and if the first call reached the
+  # server and rotated the token before its response was lost, the second
+  # spends a refresh token that is already dead.
+  def test_401_throwing_refresh_still_spends_the_one_allowed_refresh
+    provider = Class.new do
+      attr_reader :refresh_count
+
+      def initialize = @refresh_count = 0
+      def access_token = "old-token"
+      def refreshable? = true
+
+      def refresh
+        @refresh_count += 1
+        raise Basecamp::NetworkError.new("token endpoint timed out")
+      end
+    end.new
+
+    config = Basecamp::Config.new(base_url: "https://3.basecampapi.com", timeout: 5, max_retries: 3,
+      base_delay: 0.001, max_jitter: 0.0)
+    http = Basecamp::Http.new(config: config, token_provider: provider)
+
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 401, body: '{"error": "Unauthorized"}')
+
+    assert_raises(Basecamp::AuthError) { http.get("/test.json") }
+
+    assert_equal 1, provider.refresh_count
+    assert_requested(:get, "https://3.basecampapi.com/test.json", times: 2)
+  end
+
   def test_401_no_retry_when_refresh_fails
     provider = RefreshableTokenProvider.new("old-token", refresh_result: false)
     http = Basecamp::Http.new(config: @config, token_provider: provider)

--- a/ruby/test/basecamp/http_test.rb
+++ b/ruby/test/basecamp/http_test.rb
@@ -154,6 +154,61 @@ class HTTPTest < Minitest::Test
     assert_requested(:get, "https://3.basecampapi.com/test.json", times: 2)
   end
 
+  # SPEC §4: the refresh replay is a request on the wire, so it spends an
+  # attempt from the same total-attempt budget as a transient retry (#565,
+  # #461). These pin the PLAIN GET path — the "every GET in Python and Ruby"
+  # case that an earlier, ungated attempt at this change regressed.
+  def test_401_refresh_replay_is_not_attempted_without_budget
+    provider = RefreshableTokenProvider.new("old-token", refresh_result: true)
+    config = Basecamp::Config.new(base_url: "https://3.basecampapi.com", timeout: 5, max_retries: 1)
+    http = Basecamp::Http.new(config: config, token_provider: provider)
+
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 401, body: '{"error": "Unauthorized"}')
+
+    assert_raises(Basecamp::AuthError) { http.get("/test.json") }
+
+    # One request, and no rotation burned on an attempt the loop cannot make.
+    assert_requested(:get, "https://3.basecampapi.com/test.json", times: 1)
+    assert_equal 0, provider.refresh_count
+  end
+
+  def test_401_refresh_replay_shares_the_budget_with_transient_retries
+    provider = RefreshableTokenProvider.new("old-token", refresh_result: true)
+    config = Basecamp::Config.new(base_url: "https://3.basecampapi.com", timeout: 5, max_retries: 2,
+      base_delay: 0.001, max_jitter: 0.0)
+    http = Basecamp::Http.new(config: config, token_provider: provider)
+
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 401, body: '{"error": "Unauthorized"}')
+      .then.to_return(status: 503, body: '{"error": "Unavailable"}')
+
+    assert_raises(Basecamp::ApiError) { http.get("/test.json") }
+
+    # 401 (attempt 1, refresh) then 503 (attempt 2) exhausts the cap. Three
+    # requests would mean the replay rode outside it.
+    assert_requested(:get, "https://3.basecampapi.com/test.json", times: 2)
+    assert_equal 1, provider.refresh_count
+  end
+
+  def test_401_refresh_replay_is_actually_sent_not_discarded
+    # The regression an ungated version caused: refresh, then rethrow the stale
+    # 401 without ever sending the refreshed request. A 200 body proves it went.
+    provider = RefreshableTokenProvider.new("old-token", refresh_result: true)
+    config = Basecamp::Config.new(base_url: "https://3.basecampapi.com", timeout: 5, max_retries: 2)
+    http = Basecamp::Http.new(config: config, token_provider: provider)
+
+    stub_request(:get, "https://3.basecampapi.com/test.json")
+      .to_return(status: 401, body: '{"error": "Unauthorized"}')
+      .then.to_return(status: 200, body: '{"ok": true}')
+
+    response = http.get("/test.json")
+
+    assert_equal 200, response.status
+    assert_requested(:get, "https://3.basecampapi.com/test.json", times: 2)
+    assert_equal 1, provider.refresh_count
+  end
+
   def test_401_no_retry_when_refresh_fails
     provider = RefreshableTokenProvider.new("old-token", refresh_result: false)
     http = Basecamp::Http.new(config: @config, token_provider: provider)


### PR DESCRIPTION
Closes #565.

`max_retries: 0` documents exactly one attempt and sends two. A refreshable 401 puts a second request on the wire from inside Python's `_single_request` and Ruby's `single_request`, governed by its own `_retry_count` / `retry_count` rather than the caller's budget. SPEC §14 makes the same promise for the download hop — "disabling retry yields **exactly one** hop-1 attempt" — so the contradiction was written down in two places and shipping in both.

## Why this is a decision, not a re-application

Counting the replay was tried once on #563 (`b9662222d`) and reverted (`aca2c481b`). The revert was right. On its own, counting regresses SPEC §4, which says refresh is attempted once **per request**, tracked "with a boolean (e.g. `refresh_attempted`) rather than a counter". Gated only by "have we already refreshed", `max_retries: 1` refreshed the token and then rethrew the stale 401 without ever sending the refreshed request — for **every GET** in Python and Ruby, not just downloads. That is worse than the bug it fixed, and #565 was filed rather than smuggling the decision in.

The resolution needs both halves in the same change:

1. **The replayed wire request counts against the total-attempt budget**, preserving the total-attempt semantics #461 settled (observed attempts 4→3).
2. **SPEC §4 is amended** so the refresh is attempted once *only when another attempt remains*.

The second is what stops the first from regressing §4. With it, there is no state in which the SDK refreshes and then discards the result.

## The SPEC §4 wording

Step 2 gains a clause, and the section gains three paragraphs:

> 2. If the token provider supports refresh (`refreshable() == true`), refresh has not yet been attempted for this request, **and the attempt budget has another attempt left**:

> **The replay spends an attempt.** It puts a request on the wire, so it draws from the same total-attempt budget as a transient retry (§7): `max_retries` counts requests, not failure kinds, and a cap of one means one request no matter what would have caused the second. That is what makes §14's "disabling retry yields exactly ONE hop-1 attempt" literally true — refresh included — and it preserves the total-attempt semantics settled for observed attempts in #461.
>
> Step 2's budget gate is checked **before** `refresh()` is called, not after. Refreshing a token the SDK has no budget left to use would burn a rotation for nothing and still hand the caller the stale 401; declining to refresh at all is both cheaper and easier to reason about. The consequence is worth stating plainly: with a budget of one attempt, a refreshable 401 is NOT replayed and surfaces as `auth_required`. Callers who want the refresh replay must leave an attempt for it.
>
> This gate applies wherever a total-attempt budget governs the path. Go's hand-written mutation path has no such budget — mutations are deliberately single-attempt for transient failures — and keeps its documented mutation-specific single re-attempt after a successful refresh (see §7's Cross-SDK Divergence).

§14 needs no change: its per-SDK budget table already reads "`max_retries` as total attempts, floored at one (`max_retries: 0` still sends one attempt)". It is simply true now.

## Scope: which SDKs actually have this

Checked all six rather than assuming.

| SDK | 401 replay in the transport | Change |
|---|---|---|
| Python (sync + async) | in `_single_request`, own counter | **fixed** — replays from the retry loop |
| Ruby | in `single_request`, own counter | **fixed** — replays from the retry loop |
| Go | main GET loop **already counts it**: a 401 with a successful refresh returns a retryable error that the loop re-issues as the next attempt, bounded by `MaxRetries` | none |
| Go (mutations) | `doRequestURL`'s non-GET arm replays outside any budget | none — mutations have no transient-retry budget to draw from; §7's documented divergence, and §4's new gate binds only where a budget governs |
| TypeScript / Kotlin / Swift | none at all | none |

Direct single-request callers keep the in-primitive replay. Python's and Ruby's mutations bypass the retry loop entirely, so without a seam they would lose 401 refresh outright; a `refresh_replay:` parameter marks which side owns it. In Ruby that also stops `handle_error` from rotating credentials as a side effect of *classifying* an error — the refresh now happens where the budget is known.

## Red proofs

Against merged `main`, with `git show origin/main:<path>` swapped in. Both the plain GET path and the download hop, because the every-GET case is exactly what the earlier revert protected — it is covered by a test here rather than by absence.

**Python** — `uv run pytest tests/test_http.py -k RefreshReplay tests/test_download.py -k refresh_replay` against pristine `_http.py`:

```
>       assert route.call_count == 1
E       AssertionError: assert 2 == 1
>       assert hop1.call_count == 1
E       AssertionError: assert 2 == 1
FAILED tests/test_http.py::TestRefreshReplayAttemptBudget::test_no_budget_means_one_request_and_no_refresh
FAILED tests/test_http.py::TestRefreshReplayAttemptBudget::test_replay_and_transient_retries_share_one_budget
FAILED tests/test_download.py::TestHop1Retry::test_refresh_replay_is_not_attempted_without_budget
3 failed, 7 passed, 101 deselected
```

**Ruby** — against pristine `http.rb`:

```
The request GET https://3.basecampapi.com/test.json was expected to execute 1 time but it executed 2 times
The request GET https://3.basecampapi.com/test.json was expected to execute 2 times but it executed 3 times
3 runs, 7 assertions, 2 failures, 0 errors, 0 skips

The request GET .../12345/attachments/abc/download/file.txt was expected to execute 1 time but it executed 2 times
3 runs, 9 assertions, 2 failures, 0 errors, 0 skips
```

`test_401_refresh_replay_shares_the_budget_with_transient_retries` — "expected 2, executed 3" — is the load-bearing one: at `max_retries: 2` a 401 (attempt 1, refresh) followed by a 503 should exhaust the cap at two requests, and the replay used to ride outside it for three.

The remaining new tests pass against `main` by construction and pin the ceiling rather than the floor: that the refreshed request is actually **sent** (a 200 body, not a rethrown 401), that only one refresh happens per request, and that mutations keep their in-primitive replay.

## Review round

**Codex P2 — a refresh network failure escaped the retry loop.** Real, and a regression this branch introduced: an exception raised inside an `except` suite is not offered to that `try`'s sibling handlers (Ruby's `rescue` behaves the same), so calling `refresh()` from the `AuthError` handler put the token endpoint outside the loop's reach. A timing-out refresh ended the request with budget unspent, where before the move it landed in the transient handler and retried.

All three paths now use the directive shape the Swift and Kotlin download loops adopted in #517: the handlers only *classify* the attempt, and every side effect runs at the loop tail, outside any handler. A refresh that raises is a transient failure of that attempt and retries under the same budget; one that returns false surfaces the original 401; one that succeeds replays immediately with no backoff, since the token is fresh and the server never asked us to wait. Red-proofed in Python and Ruby against the previous commit — the `NetworkError` propagated raw out of `client.get(...)` with two attempts still available.

## Verification

`make check` green end to end (`REAL_EXIT=0`, grep-checked — one run reported "All checks passed!" mid-stream while exiting 2 on a later `ruff format` step):

| Suite | Result |
|---|---|
| Go | `ok` all packages |
| TypeScript | 1051 tests passed |
| Python | 792 passed |
| Ruby | 1023 runs, 2348 assertions, 0 failures, 0 errors |
| Kotlin | BUILD SUCCESSFUL |
| Swift | 285 tests, 0 failures |

Conformance: Go 135/0/2, Kotlin 136/0/1, TypeScript 157 passed / 2 skipped, Ruby 126/0/11, Python 137/0/0.

One flake seen locally and not reproducible: `tests/client.test.ts > request timeout > propagates a caller-supplied signal through the combined signal` failed once in a local `make check` and passed 3/3 on re-run. This branch changes no TypeScript files at all (`git diff origin/main...HEAD -- typescript/` is empty), and the TypeScript CI job is green. Cited numbers are the CI job's.

One aside for whoever hits it next: `make go-check` first failed here with 557 phantom issues in `../../validation-errors/go/pkg/generated/client.gen.go` — a golangci-lint cache shared across worktrees. `golangci-lint cache clean` cleared it; 0 issues after.
