### PR TITLE
Date the rubric audit for the day it was last changed

### DIFF
--- a/rubric-audit.json
+++ b/rubric-audit.json
@@ -1,6 +1,6 @@
 {
   "profile": "full-sdk",
-  "date": "2026-07-31",
+  "date": "2026-08-01",
   "reviewer": "agent:conformance-runner",
   "criteria": {
     "1A.6": {


### PR DESCRIPTION
Six waivers were resolved on 2026-08-01 — 1B.4, 2B.1, 2C.2, 2C.4, 2C.6 and 3C.6 — while `rubric-audit.json`'s top-level date still read `2026-07-31`. One-character provenance fix; the file's whole purpose is being an accurate record of when the audit reflected reality.

Caught during the full-menu program's closeout audit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected the top-level audit date in `rubric-audit.json` to 2026-08-01. This matches the day six waivers were resolved (1B.4, 2B.1, 2C.2, 2C.4, 2C.6, 3C.6).

<sup>Written for commit 4bb8f6a58215e5471d442b832b5e044843c8107a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

