### PR TITLE
Run the nine orphaned `make check` gates in CI, not just on developer machines

### DIFF
--- a/.github/workflows/smithy-verify.yml
+++ b/.github/workflows/smithy-verify.yml
@@ -42,6 +42,14 @@ jobs:
       - name: Build OpenAPI
         run: smithy build
 
+      # behavior-model-check consumes spec/build/smithy/source/model/model.json,
+      # which only exists after `smithy build` — so this is the one job that can
+      # run it. It was previously on the `make check` line but in no CI job.
+      # Runs from the repo root, overriding this workflow's `spec` default.
+      - name: Verify behavior model is up to date
+        working-directory: .
+        run: make behavior-model-check
+
       - name: Verify OpenAPI is up to date
         run: |
           cp build/smithy/openapi/openapi/Basecamp.openapi.json ../openapi.generated.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,63 @@ jobs:
         env:
           LC_ALL: C
 
+  # Toolchain-light repo-wide gates from the `make check` line that previously
+  # ran on developer machines only. `make check` membership is not enforcement:
+  # a gate nothing in CI invokes is discipline, not a guarantee. These eight
+  # need bash + jq + ruby and no SDK toolchain, so they get one fast job rather
+  # than riding along inside a language job (which is how
+  # check-idempotency-parity ended up coupled to test-go).
+  #
+  # kt-check-drift belongs here despite the kt- prefix: it is jq/grep with no
+  # JVM (see its Makefile comment). The authoritative regenerate-and-diff
+  # Kotlin gate, kt-check-generated-drift, already runs in test-kotlin.
+  #
+  # One sibling deliberately lives elsewhere: behavior-model-check is a step in
+  # smithy-verify.yml, because it consumes
+  # spec/build/smithy/source/model/model.json, which only exists after
+  # `smithy build`.
+  #
+  # Invoke via `make <target>` so the recipe has exactly one definition and CI
+  # cannot drift from the Makefile.
+  spec-gates:
+    name: Spec Gates
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
+        with:
+          ruby-version: "3.3"
+
+      - name: Spec version constants in sync with provenance
+        run: make sync-spec-version-check
+
+      - name: API version constants in sync with openapi.json
+        run: make sync-api-version-check
+
+      - name: Bucket-scoped vs flat operation parity
+        run: make check-bucket-flat-parity
+
+      - name: api-gaps registry frontmatter + allowlist schema
+        run: make validate-api-gaps
+
+      - name: Deprecation signal parity across six SDKs
+        run: make check-deprecation-parity
+
+      - name: Generated Go optional fields can represent absence
+        run: make go-check-optional-pointers
+
+      - name: Request-body enhancer reachability (synthetic specs)
+        run: make test-enhance-request-reachability
+
+      - name: Kotlin service drift (static; jq/grep, no JVM)
+        run: make kt-check-drift
+
   test-go:
     name: Go Tests
     runs-on: ubuntu-latest
@@ -460,23 +517,23 @@ jobs:
     # which includes its conformance step — did not succeed.
     name: Conformance Tests
     runs-on: ubuntu-latest
-    needs: [test-go, test-typescript, test-ruby, test-kotlin, test-python, test-swift]
+    needs: [test-go, test-typescript, test-ruby, test-kotlin, test-python, test-swift, spec-gates]
     if: always()
     permissions:
       contents: read
     steps:
-      - name: Verify per-language conformance results
+      - name: Verify per-language conformance and spec-gate results
         env:
           RESULTS: ${{ toJSON(needs) }}
         run: |
           echo "$RESULTS" | jq .
           NOT_GREEN=$(echo "$RESULTS" | jq -r 'to_entries[] | select(.value.result != "success") | "\(.key): \(.value.result)"')
           if [ -n "$NOT_GREEN" ]; then
-            echo "::error::Language test jobs (which run their own conformance suites) did not succeed:"
+            echo "::error::Required upstream jobs did not succeed (language test jobs run their own conformance suites; spec-gates runs the repo-wide gates):"
             echo "$NOT_GREEN"
             exit 1
           fi
-          echo "All per-language conformance suites green"
+          echo "All per-language conformance suites and spec gates green"
 
   lint:
     name: Lint


### PR DESCRIPTION
## The gap

`make check` membership was never enforcement. **Nine of the 29 targets on the `check:` line (`Makefile:955`) were invoked by no workflow at all** — directly or indirectly — so they only ran when someone remembered to run them locally.

I audited every target on that line against `.github/workflows/`, resolving each apparent miss against its actual recipe (several are covered *indirectly*, by CI running the underlying script rather than the make target — `go-check-drift` via `check-service-drift`, `rb-check` via `rubocop`, `py-check` via `ruff check`, and so on). What survives that check is genuinely uncovered:

| Gate | What it protects |
|---|---|
| `sync-spec-version-check` | Smithy version vs the provenance date |
| `sync-api-version-check` | `API_VERSION` constants vs `openapi.json` |
| `check-bucket-flat-parity` | bucket-scoped vs flat operation parity |
| `validate-api-gaps` | api-gaps frontmatter + allowlist schema |
| `check-deprecation-parity` | `@deprecated` signal class across six SDKs |
| `go-check-optional-pointers` | every `omitempty` Go field can represent absence |
| `test-enhance-request-reachability` | request-body enhancer, driven by synthetic specs |
| `kt-check-drift` | Kotlin service drift (static) |
| `behavior-model-check` | `behavior-model.json` freshness |

## The change

**Eight go into one new `spec-gates` job.** They need bash + jq + ruby and no SDK toolchain, so they get a fast standalone job rather than riding inside a language job — which is how `check-idempotency-parity` ended up coupled to `test-go` (`test.yml:126`). Modelled on the existing `fixture-coverage` job. Each step invokes `make <target>` so the recipe keeps exactly one definition and CI cannot drift from the Makefile.

`kt-check-drift` is in that light job despite the `kt-` prefix — it is jq/grep with no JVM, as [its own Makefile comment says](https://github.com/basecamp/basecamp-sdk/blob/main/Makefile). The authoritative regenerate-and-diff Kotlin gate, `kt-check-generated-drift`, already runs in `test-kotlin`.

**`behavior-model-check` is the one that cannot live there** — it consumes `spec/build/smithy/source/model/model.json`, which exists only after `smithy build`. It becomes a step in `smithy-verify.yml`, the job that already builds it.

**Enforcement without touching branch protection:** `spec-gates` joins the `conformance` fan-in `needs:` list, so it is covered by the existing required check (`Conformance Tests`). That job already fails on any non-success upstream result, so the wiring is the whole change. Its step name and error message are widened to stop claiming every failure came from a language job.

## Red proof

Corrupting a gate input, at this commit:

```console
$ make validate-api-gaps                       # pristine
REAL_EXIT=0

$ sed -i 's/status:/stat!us:/' spec/api-gaps/folders-api.md
$ make validate-api-gaps
==> API gap validation failed:
  spec/api-gaps/folders-api.md: missing required frontmatter field: status
  spec/api-gaps/folders-api.md: unknown frontmatter field: stat!us
    (schema declares additionalProperties: false)
make: *** [validate-api-gaps] Error 1
REAL_EXIT=2

$ # restored from a scratch copy — sha256 identical, tree clean
REAL_EXIT=0
```

**That corruption is invisible to CI on `main` today.** `git grep` over `c74709220:.github/workflows/` returns `NONE` for all nine target names; the same query on this branch returns `test.yml` / `smithy-verify.yml` for all nine.

## Cost

All eight light gates pass locally at `c74709220` in **~5.2s** total, so the job adds roughly that plus checkout. `actionlint` and `zizmor` are clean on both modified workflows.

## Notes for review

- This is deliberately **only** a coverage change — no gate logic is touched, and no gate is added or removed from the `check:` line.
- Labelled `bug`: nine gates that were believed to be enforced were not.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs nine previously orphaned `make check` gates in CI so they’re enforced, not just run locally. Adds a fast `spec-gates` job and wires it into the required Conformance Tests; moves `behavior-model-check` to `smithy-verify.yml` after `smithy build`.

- **Bug Fixes**
  - Added `spec-gates` job to run: `sync-spec-version-check`, `sync-api-version-check`, `check-bucket-flat-parity`, `validate-api-gaps`, `check-deprecation-parity`, `go-check-optional-pointers`, `test-enhance-request-reachability`, `kt-check-drift`.
  - Moved `behavior-model-check` into `smithy-verify.yml` (runs after `smithy build`).
  - Made `conformance` depend on `spec-gates` and clarified the failure message; no gate logic changed and no branch protection updates needed.

<sup>Written for commit 726685b30fa697b842486945f1361d817cb71686. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

