### PR TITLE
Gate the three doc constants that had drifted from their sources

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,9 @@ jobs:
       # Prose restates three constants (API_VERSION, the bc3 provenance pin,
       # SPEC §19's assertion-type table). Marked spans only — spec/api-gaps/
       # legitimately cites historical SHAs — plus a committed marker floor so
-      # deleting a marker cannot silence the gate.
+      # deleting a marker cannot silence the gate. The target also runs
+      # scripts/test-doc-constants.rb, which asserts the gate rejects each
+      # failure mode; the live run alone only proves it can say yes.
       - name: Documentation constants in sync with their sources
         run: make doc-constants-check
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,9 +115,9 @@ jobs:
       # SPEC §19's assertion-type table). Marked spans only — spec/api-gaps/
       # legitimately cites historical SHAs — plus a committed exact marker
       # count, so neither deleting a marker nor adding an unrecorded one can
-      # silence the gate. The target also runs
-      # scripts/test-doc-constants.rb, which asserts the gate rejects each
-      # failure mode; the live run alone only proves it can say yes.
+      # silence the gate. The target also runs scripts/test-doc-constants.rb,
+      # which asserts the gate rejects each failure mode; the live run alone
+      # only proves it can say yes.
       - name: Documentation constants in sync with their sources
         run: make doc-constants-check
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,8 +113,9 @@ jobs:
 
       # Prose restates three constants (API_VERSION, the bc3 provenance pin,
       # SPEC §19's assertion-type table). Marked spans only — spec/api-gaps/
-      # legitimately cites historical SHAs — plus a committed marker floor so
-      # deleting a marker cannot silence the gate. The target also runs
+      # legitimately cites historical SHAs — plus a committed exact marker
+      # count, so neither deleting a marker nor adding an unrecorded one can
+      # silence the gate. The target also runs
       # scripts/test-doc-constants.rb, which asserts the gate rejects each
       # failure mode; the live run alone only proves it can say yes.
       - name: Documentation constants in sync with their sources

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,6 +111,13 @@ jobs:
       - name: API version constants in sync with openapi.json
         run: make sync-api-version-check
 
+      # Prose restates three constants (API_VERSION, the bc3 provenance pin,
+      # SPEC §19's assertion-type table). Marked spans only — spec/api-gaps/
+      # legitimately cites historical SHAs — plus a committed marker floor so
+      # deleting a marker cannot silence the gate.
+      - name: Documentation constants in sync with their sources
+        run: make doc-constants-check
+
       - name: Bucket-scoped vs flat operation parity
         run: make check-bucket-flat-parity
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,9 +185,10 @@ The Smithy service version is derived from the shared provenance date. Run `make
 `spec/api-gaps/README.md` each name the current pin in narrative, and both sat
 two repins stale before `make doc-constants-check` existed. A sentence that
 states the *current* pin carries an `<!-- @bc3-pin -->` marker at the end of its
-line; `make sync-api-version` rewrites every marked span from
-`spec/api-provenance.json` (SHA abbreviation length preserved) and the gate
-fails on any that drifted. Prose about *past* pins — "the pin has since advanced
+line and names both the revision and the sync date; `make sync-api-version`
+rewrites every marked span from `spec/api-provenance.json` (SHA abbreviation
+length preserved) and the gate fails on any that drifted — or on a span that
+dropped its SHA or its date, since the writer can only rewrite what it can see. Prose about *past* pins — "the pin has since advanced
 to X", "the `A..B` range contains…" — stays unmarked and is never rewritten:
 `spec/api-gaps/` cites ~30 historical SHAs on purpose, and a gate that rewrote
 them would convert settled triage into a claim nobody made. The same convention

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,6 +222,18 @@ that file still fails until someone reads it and restates the number. A SHA
 that is not the current pin is not checked at all — sorting those needs the
 pin's whole history, which CI's shallow clones do not have.
 
+Expect the range form to trip this, because a range written at a repin ends
+*at* the pin that repin set. An `` `A..B` `` whose `B` is today's revision
+names it as surely as a bare mention does, and the check reads inside compound
+code spans precisely so it cannot be smuggled past that way. A range is still
+an as-of fact — grant it and move on. `A` is not the current pin and is never
+flagged.
+
+(This paragraph deliberately says `A..B` rather than quoting the live range:
+documentation of the convention must not itself restate the constant, or it
+becomes the very class-A claim it is warning about — as this one did, and the
+gate caught it.)
+
 The same marker convention covers `<!-- @api-version -->` (from `openapi.json`
 `info.version`) and SPEC §19's `<!-- @assertion-types:begin/end -->` table
 (from `conformance/schema.json`). `spec/doc-constants.json` commits the exact

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,13 @@ everything else:
   `spec/api-gaps/` cites ~30 historical SHAs on purpose, and rewriting one
   would convert settled triage into a claim nobody made.
 
+There is a third form, and it is usually the right answer: **name the pin by
+reference instead of by value** — "the revision `spec/api-provenance.json`
+currently pins", "already inside the current pin". It means today's pin, stays
+true across every repin, and restates no constant, so nothing can drift and
+nothing needs marking. Reach for a literal SHA only when the sentence is
+genuinely about *which* revision.
+
 The failure to avoid is writing the second in the grammar of the first — "at
 the pinned revision", "the provenance pin (`X`)" — which is true the day it is
 written and silently false at the next repin. Name what binds the revision:
@@ -207,10 +214,13 @@ the PR that shipped it, or the verification it backs. `make
 doc-constants-check` enforces the boundary at the one moment it can see it
 without guessing at tense: an unmarked sentence naming **today's** pin fails,
 because that is the day such a sentence is born. If it is genuinely an as-of
-fact that happens to name the current pin, record the file in
-`spec/doc-constants.json` `.unmarkedPinCitations` with the reason. A SHA that
-is not the current pin is not checked at all — sorting those needs the pin's
-whole history, which CI's shallow clones do not have.
+fact that happens to name the current pin — a repin cites the commit it moved
+to, so `spec/api-gaps/README.md` hits this on every sync — record the file in
+`spec/doc-constants.json` `.unmarkedPinCitations` with a reason and an exact
+count. The count is what keeps the grant honest: the next unmarked citation in
+that file still fails until someone reads it and restates the number. A SHA
+that is not the current pin is not checked at all — sorting those needs the
+pin's whole history, which CI's shallow clones do not have.
 
 The same marker convention covers `<!-- @api-version -->` (from `openapi.json`
 `info.version`) and SPEC §19's `<!-- @assertion-types:begin/end -->` table

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,19 +183,44 @@ The Smithy service version is derived from the shared provenance date. Run `make
 
 **Prose restates the pin, and prose drifts.** `COORDINATION.md` and
 `spec/api-gaps/README.md` each name the current pin in narrative, and both sat
-two repins stale before `make doc-constants-check` existed. A sentence that
-states the *current* pin carries an `<!-- @bc3-pin -->` marker at the end of its
-line and names both the revision and the sync date; `make sync-api-version`
-rewrites every marked span from `spec/api-provenance.json` (SHA abbreviation
-length preserved) and the gate fails on any that drifted — or on a span that
-dropped its SHA or its date, since the writer can only rewrite what it can see. Prose about *past* pins — "the pin has since advanced
-to X", "the `A..B` range contains…" — stays unmarked and is never rewritten:
-`spec/api-gaps/` cites ~30 historical SHAs on purpose, and a gate that rewrote
-them would convert settled triage into a claim nobody made. The same convention
-covers `<!-- @api-version -->` (from `openapi.json` `info.version`) and SPEC §19's
-`<!-- @assertion-types:begin/end -->` table (from `conformance/schema.json`).
-`spec/doc-constants.json` commits a per-file floor on how many markers each file
-must carry, so deleting a marker fails the gate instead of silencing it.
+two repins stale before `make doc-constants-check` existed. Every bc3 revision
+you write into prose is one of exactly two things, and which one decides
+everything else:
+
+- **A current-value claim** — "the provenance pin is `X`". True only right now.
+  It carries an `<!-- @bc3-pin -->` marker at the end of its line and names
+  both the revision and the sync date. `make sync-api-version` rewrites every
+  marked span from `spec/api-provenance.json` (SHA abbreviation length
+  preserved), and the gate fails on any that drifted — or on a span that
+  dropped its SHA or its date, since the writer can only rewrite what it can
+  see.
+- **An as-of fact** — "verified against `X`", "shipped in BC3 #12380 (`X`)",
+  "the `A..B` range contains…". True forever, because the revision is bound to
+  a fixed observation. It stays unmarked and is never rewritten:
+  `spec/api-gaps/` cites ~30 historical SHAs on purpose, and rewriting one
+  would convert settled triage into a claim nobody made.
+
+The failure to avoid is writing the second in the grammar of the first — "at
+the pinned revision", "the provenance pin (`X`)" — which is true the day it is
+written and silently false at the next repin. Name what binds the revision:
+the PR that shipped it, or the verification it backs. `make
+doc-constants-check` enforces the boundary at the one moment it can see it
+without guessing at tense: an unmarked sentence naming **today's** pin fails,
+because that is the day such a sentence is born. If it is genuinely an as-of
+fact that happens to name the current pin, record the file in
+`spec/doc-constants.json` `.unmarkedPinCitations` with the reason. A SHA that
+is not the current pin is not checked at all — sorting those needs the pin's
+whole history, which CI's shallow clones do not have.
+
+The same marker convention covers `<!-- @api-version -->` (from `openapi.json`
+`info.version`) and SPEC §19's `<!-- @assertion-types:begin/end -->` table
+(from `conformance/schema.json`). `spec/doc-constants.json` commits a per-file
+floor on how many markers each file must carry, so deleting a marker fails the
+gate instead of silencing it, and a `.writerExcludes` list of files the writer
+must never touch — `spec/api-gaps/README.md` is on it, because its pin sentence
+heads the range triage and cannot advance without that triage advancing too.
+`scripts/test-doc-constants.rb` (run by `make doc-constants-check`) asserts the
+gate rejects each of these failure modes.
 
 **Pin semantics.** The pin is the conformance baseline as of the last sync — it asserts that all upstream drift up to that revision has been *triaged*, not that every contract in it has been *absorbed*. Upstream contracts shipped past the SDK's modeled surface are tracked in `spec/api-gaps/` (status `addressed-in-bc3-pr-N`) until an absorption PR lands. A repin is valid exactly when every drift item in `pin..HEAD` is either absorbed into the spec or registered in `spec/api-gaps/`; it is not blocked on absorption itself. The pin never moves backward. The `compatibility.*` pins mark the last **verified API-surface state** of their branch, not a last-glanced timestamp — refresh one only when re-verifying that branch's API surface, and record verification dates in the PR that did the checking.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,11 +214,13 @@ whole history, which CI's shallow clones do not have.
 
 The same marker convention covers `<!-- @api-version -->` (from `openapi.json`
 `info.version`) and SPEC §19's `<!-- @assertion-types:begin/end -->` table
-(from `conformance/schema.json`). `spec/doc-constants.json` commits a per-file
-floor on how many markers each file must carry, so deleting a marker fails the
-gate instead of silencing it, and a `.writerExcludes` list of files the writer
-must never touch — `spec/api-gaps/README.md` is on it, because its pin sentence
-heads the range triage and cannot advance without that triage advancing too.
+(from `conformance/schema.json`). `spec/doc-constants.json` commits the exact
+number of markers each file carries, so deleting one fails the gate instead of
+silencing it — and adding one fails too, until you record it, which is what
+makes the next deletion fail. It also carries `.writerExcludes`, the files the
+writer must never touch: `spec/api-gaps/README.md` is on it, because its pin
+sentence heads the range triage and cannot advance without that triage
+advancing too.
 `scripts/test-doc-constants.rb` (run by `make doc-constants-check`) asserts the
 gate rejects each of these failure modes.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,21 @@ Update the `revision` and `date` fields, then `make provenance-sync`. This is no
 
 The Smithy service version is derived from the shared provenance date. Run `make sync-spec-version` (or `make smithy-build`, which does this automatically) after updating provenance.
 
+**Prose restates the pin, and prose drifts.** `COORDINATION.md` and
+`spec/api-gaps/README.md` each name the current pin in narrative, and both sat
+two repins stale before `make doc-constants-check` existed. A sentence that
+states the *current* pin carries an `<!-- @bc3-pin -->` marker at the end of its
+line; `make sync-api-version` rewrites every marked span from
+`spec/api-provenance.json` (SHA abbreviation length preserved) and the gate
+fails on any that drifted. Prose about *past* pins — "the pin has since advanced
+to X", "the `A..B` range contains…" — stays unmarked and is never rewritten:
+`spec/api-gaps/` cites ~30 historical SHAs on purpose, and a gate that rewrote
+them would convert settled triage into a claim nobody made. The same convention
+covers `<!-- @api-version -->` (from `openapi.json` `info.version`) and SPEC §19's
+`<!-- @assertion-types:begin/end -->` table (from `conformance/schema.json`).
+`spec/doc-constants.json` commits a per-file floor on how many markers each file
+must carry, so deleting a marker fails the gate instead of silencing it.
+
 **Pin semantics.** The pin is the conformance baseline as of the last sync — it asserts that all upstream drift up to that revision has been *triaged*, not that every contract in it has been *absorbed*. Upstream contracts shipped past the SDK's modeled surface are tracked in `spec/api-gaps/` (status `addressed-in-bc3-pr-N`) until an absorption PR lands. A repin is valid exactly when every drift item in `pin..HEAD` is either absorbed into the spec or registered in `spec/api-gaps/`; it is not blocked on absorption itself. The pin never moves backward. The `compatibility.*` pins mark the last **verified API-surface state** of their branch, not a last-glanced timestamp — refresh one only when re-verifying that branch's API surface, and record verification dates in the PR that did the checking.
 
 ### Pre-sync
@@ -198,7 +213,10 @@ Use `make sync-status` to see upstream diffs since last sync.
 7. Update tests for any changed paths/signatures
 8. Update provenance, run `make provenance-sync`
 9. Run `make sync-spec-version` (or `make smithy-build`)
-10. `make` must pass clean
+10. Run `make sync-api-version` — it rewrites the SDK constants *and* the
+    `@bc3-pin` / `@api-version` marked spans in prose; record the new range's
+    triage in `spec/api-gaps/README.md` (unmarked, it is history)
+11. `make` must pass clean
 
 ---
 

--- a/COORDINATION.md
+++ b/COORDINATION.md
@@ -9,10 +9,13 @@ live BC5 by the #11629 tooling. The historical server-side audit lived on the
 
 The SDK's conformance baseline is the pin in
 [`spec/api-provenance.json`](spec/api-provenance.json) — `bc3` `master`
-`2c0dafba13` as of the 2026-08-02 sync. That file is the only authority;
-quote it here rather than a remembered SHA. Contracts documented past the
-SDK's modeled surface are registered in [`spec/api-gaps/`](spec/api-gaps/)
-until absorbed (see AGENTS.md §Provenance is Mandatory for the pin semantics).
+`2c0dafba13` as of the 2026-08-02 sync. <!-- @bc3-pin -->
+That file is the only authority; quote it here rather than a remembered SHA.
+`make sync-api-version` now rewrites the marked line above from it, and
+`make doc-constants-check` fails if the two disagree — this sentence sat two
+repins stale before that existed. Contracts documented past the SDK's modeled
+surface are registered in [`spec/api-gaps/`](spec/api-gaps/) until absorbed
+(see AGENTS.md §Provenance is Mandatory for the pin semantics).
 The `compatibility.bc3-four` pin stays at `9d73959a` (2026-06-12): the
 `four` branch was re-verified on 2026-07-22 with **zero API drift** since —
 no changes under `doc/api/` or the API controllers/views.

--- a/Makefile
+++ b/Makefile
@@ -245,9 +245,12 @@ sync-api-version-check:
 # SPEC §19's assertion-type table) against their machine-readable sources.
 # Only HTML-comment-marked spans are checked; spec/doc-constants.json commits
 # the per-file marker floor so deleting a marker cannot silence the gate.
+# The live run only ever proves the gate can say yes, so the self-test follows:
+# it crafts each failure mode and asserts the gate rejects it.
 doc-constants-check:
 	@echo "==> Checking documentation constants..."
 	@./scripts/check-doc-constants.sh
+	@ruby ./scripts/test-doc-constants.rb
 
 #------------------------------------------------------------------------------
 # Go SDK targets (delegates to go/Makefile)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #
 # Orchestrates both Smithy spec and Go SDK
 
-.PHONY: all check clean help setup tools provenance-sync provenance-check sync-status bump sync-spec-version sync-spec-version-check sync-api-version sync-api-version-check release
+.PHONY: all check clean help setup tools provenance-sync provenance-check sync-status bump sync-spec-version sync-spec-version-check sync-api-version sync-api-version-check doc-constants-check release
 
 # Default: run all checks
 all: check
@@ -240,6 +240,14 @@ sync-api-version-check:
 	grep -q "API_VERSION = \"$$API_VER\"" python/src/basecamp/_version.py || ok=false; \
 	if [ "$$ok" = false ]; then echo "ERROR: API_VERSION constants are out of date. Run 'make sync-api-version'"; exit 1; fi
 	@echo "API version constants are up to date"
+
+# Check the constants restated in prose (API_VERSION, bc3 provenance pin,
+# SPEC §19's assertion-type table) against their machine-readable sources.
+# Only HTML-comment-marked spans are checked; spec/doc-constants.json commits
+# the per-file marker floor so deleting a marker cannot silence the gate.
+doc-constants-check:
+	@echo "==> Checking documentation constants..."
+	@./scripts/check-doc-constants.sh
 
 #------------------------------------------------------------------------------
 # Go SDK targets (delegates to go/Makefile)
@@ -993,7 +1001,7 @@ generate:
 	@echo "==> Generation complete"
 
 # Run all checks (Smithy + Go + TypeScript + Ruby + Kotlin + Swift + Python + Behavior Model + Conformance + Provenance + Actions lint)
-check: lint-actions sync-spec-version-check smithy-check behavior-model-check provenance-check sync-api-version-check url-routes-check bc3-route-parity go-check-drift go-check-wrapper-drift go-check-generated-drift auth-routable-check kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity check-fixture-coverage kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-idempotency-parity check-retry-metadata-parity
+check: lint-actions sync-spec-version-check smithy-check behavior-model-check provenance-check sync-api-version-check doc-constants-check url-routes-check bc3-route-parity go-check-drift go-check-wrapper-drift go-check-generated-drift auth-routable-check kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity check-fixture-coverage kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-idempotency-parity check-retry-metadata-parity
 	@echo "==> All checks passed"
 
 # Clean all build artifacts
@@ -1104,6 +1112,7 @@ help:
 	@echo "  bump VERSION=x.y.z       Bump SDK version across all languages"
 	@echo "  sync-api-version         Sync API_VERSION from openapi.json"
 	@echo "  sync-api-version-check   Verify API_VERSION constants are up to date"
+	@echo "  doc-constants-check      Verify marked doc constants match their sources"
 	@echo "  release VERSION=x.y.z    Tag and push a global release (triggers all SDK releases)"
 	@echo ""
 	@echo "GitHub Actions:"

--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,8 @@ sync-api-version-check:
 # Check the constants restated in prose (API_VERSION, bc3 provenance pin,
 # SPEC §19's assertion-type table) against their machine-readable sources.
 # Only HTML-comment-marked spans are checked; spec/doc-constants.json commits
-# the per-file marker floor so deleting a marker cannot silence the gate.
+# the exact per-file marker count so neither deleting a marker nor quietly
+# adding an unrecorded one can silence the gate.
 # The live run only ever proves the gate can say yes, so the self-test follows:
 # it crafts each failure mode and asserts the gate rejects it.
 doc-constants-check:

--- a/SPEC.md
+++ b/SPEC.md
@@ -1058,7 +1058,7 @@ Every JSON API request must include all four headers below. Download requests (�
 Where:
 - `{lang}` is the language identifier: `go`, `ts`, `ruby`, `kotlin`, `swift`
 - `{VERSION}` is the SDK version (e.g., `0.6.0`)
-- `{API_VERSION}` is the API version from `openapi.json` `info.version` (currently `2026-03-23`), derived from the shared date in `spec/api-provenance.json`
+- `{API_VERSION}` is the API version from `openapi.json` `info.version` (currently `2026-03-23`), derived from the shared date in `spec/api-provenance.json` <!-- @api-version -->
 
 ### Redirect Handling
 
@@ -1711,7 +1711,11 @@ Test cases conform to `conformance/schema.json`. Each test specifies:
 
 ### Assertion Types
 
-Enumerated from `conformance/schema.json`:
+Enumerated from `conformance/schema.json` — the table below is gated against
+that enum by `make doc-constants-check`, so a new assertion type cannot ship
+undocumented:
+
+<!-- @assertion-types:begin -->
 
 | Type | Description |
 |------|-------------|
@@ -1732,6 +1736,8 @@ Enumerated from `conformance/schema.json`:
 | `requestScheme` | URL scheme (http/https) of request |
 | `urlOrigin` | Origin validation result (accepted/rejected) |
 | `responseMeta` | Metadata on paginated response (totalCount, truncated) |
+
+<!-- @assertion-types:end -->
 
 ### Test Categories and Owning Sections
 
@@ -1850,6 +1856,7 @@ The following are must-pass criteria from the rubric. Each maps to a spec sectio
 | `provenance-check` | Embedded provenance matches `spec/api-provenance.json` |
 | `sync-spec-version-check` | Smithy service version matches the shared date in `spec/api-provenance.json` |
 | `sync-api-version-check` | `API_VERSION` constants match `openapi.json` `info.version` across all SDKs |
+| `doc-constants-check` | Constants restated in prose match their sources: `@api-version`-marked spans vs. `openapi.json` `info.version`, `@bc3-pin`-marked spans vs. `spec/api-provenance.json`, and §19's `@assertion-types` table vs. `conformance/schema.json`. Only marked spans are checked — `spec/api-gaps/` cites historical bc3 SHAs on purpose — and `spec/doc-constants.json` commits a per-file marker floor so deleting a marker cannot silence the gate. `make sync-api-version` rewrites the two scalar constants |
 | `url-routes-check` | `go/pkg/basecamp/url-routes.json` (embedded via `//go:embed`) matches regeneration from `openapi.json` |
 | `go-check-drift` | Go generated services match current OpenAPI spec |
 | `kt-check-drift` | Kotlin generated services match current OpenAPI spec (operation-level coverage) |
@@ -1907,7 +1914,7 @@ All magic numbers in one place, derived from shipping SDK code (not `rubric-audi
 | `DEFAULT_MAX_PAGES` | 10,000 | — | All six SDKs |
 | `MAX_CACHE_ENTRIES` | 1000 | entries | `typescript/src/client.ts` |
 | `MAX_TOKEN_HASH_ENTRIES` | 100 | entries | `typescript/src/client.ts` |
-| `API_VERSION` | `2026-03-23` | — | `openapi.json` `info.version` |
+| `API_VERSION` | `2026-03-23` | — | `openapi.json` `info.version` <!-- @api-version --> |
 | `TOKEN_REFRESH_BUFFER` | 300 | seconds | Go OAuth token refresh threshold (5-minute buffer); Ruby refreshes only on expiry (no buffer); TS/Kotlin/Swift delegate expiry to caller |
 
 ---

--- a/SPEC.md
+++ b/SPEC.md
@@ -1058,7 +1058,7 @@ Every JSON API request must include all four headers below. Download requests (�
 Where:
 - `{lang}` is the language identifier: `go`, `ts`, `ruby`, `kotlin`, `swift`
 - `{VERSION}` is the SDK version (e.g., `0.6.0`)
-- `{API_VERSION}` is the API version from `openapi.json` `info.version` (currently `2026-03-23`), derived from the shared date in `spec/api-provenance.json` <!-- @api-version -->
+- `{API_VERSION}` is the API version from `openapi.json` `info.version` (currently `2026-07-31`), derived from the shared date in `spec/api-provenance.json` <!-- @api-version -->
 
 ### Redirect Handling
 
@@ -1725,10 +1725,14 @@ undocumented:
 | `responseStatus` | Response status category |
 | `responseBody` | Specific value in response body (by path) |
 | `headerPresent` | Named header exists on request |
+| `headerAbsent` | Named header does **not** exist on the request. Absence is decided on the header's value list, not a `get` that returns the empty string for both "missing" and "present but empty" — a present-but-empty header fails this assertion. |
 | `headerValue` | Named header has specific value |
 | `errorType` | Error type classification |
 | `noError` | Operation completed without error |
 | `requestPath` | URL path of the outgoing request |
+| `requestMethod` | HTTP method of the outgoing request |
+| `requestBody` | Value at `path` (dot-notation key) inside the captured JSON request body. A request that sent no JSON body fails, as does a body that omits the key. |
+| `requestBodyAbsent` | The `path` key is **not** present in the captured JSON request body — the assertion that pins omission-as-clear and body compaction (§18). A request with no JSON body at all satisfies it. |
 | `errorCode` | Error code in structured error |
 | `errorMessage` | Error message text |
 | `errorField` | Specific field value on the error object |
@@ -1738,6 +1742,12 @@ undocumented:
 | `responseMeta` | Metadata on paginated response (totalCount, truncated) |
 
 <!-- @assertion-types:end -->
+
+The per-request assertions — `headerPresent`, `headerAbsent`, `headerInjected`,
+`requestPath`, `requestMethod`, `requestBody`, `requestBodyAbsent` — take an
+optional `index` naming which recorded request to inspect (0-based; negative
+counts from the end, so `-1` is the last request). It defaults to `0`, and an
+index past the number of recorded requests fails rather than passing vacuously.
 
 ### Test Categories and Owning Sections
 
@@ -1914,7 +1924,7 @@ All magic numbers in one place, derived from shipping SDK code (not `rubric-audi
 | `DEFAULT_MAX_PAGES` | 10,000 | — | All six SDKs |
 | `MAX_CACHE_ENTRIES` | 1000 | entries | `typescript/src/client.ts` |
 | `MAX_TOKEN_HASH_ENTRIES` | 100 | entries | `typescript/src/client.ts` |
-| `API_VERSION` | `2026-03-23` | — | `openapi.json` `info.version` <!-- @api-version --> |
+| `API_VERSION` | `2026-07-31` | — | `openapi.json` `info.version` <!-- @api-version --> |
 | `TOKEN_REFRESH_BUFFER` | 300 | seconds | Go OAuth token refresh threshold (5-minute buffer); Ruby refreshes only on expiry (no buffer); TS/Kotlin/Swift delegate expiry to caller |
 
 ---

--- a/SPEC.md
+++ b/SPEC.md
@@ -1910,6 +1910,8 @@ The following are explicitly NOT part of this specification:
 
 All magic numbers in one place, derived from shipping SDK code (not `rubric-audit.json`).
 
+Only `API_VERSION` is gated (`<!-- @api-version -->`, checked by `make doc-constants-check`). The other 13 rows are hand-maintained and were verified against the cited sources on 2026-08-03 — all 13 matched. They are not gated because each is asserted of several SDKs at once in a different spelling per language (Go `1 * time.Second`, Python `1.0`, Ruby `1.0`, Kotlin `30.seconds`), so a checker would need a per-row, per-language extraction rule rather than the one-value-one-source substitution the marker convention is built on. If one of these starts moving, gate that row rather than the appendix.
+
 | Constant | Value | Unit | Source |
 |----------|-------|------|--------|
 | `MAX_RESPONSE_BODY_BYTES` | 52,428,800 (50 MiB) | bytes | `go/pkg/basecamp/security.go`, `ruby/lib/basecamp/security.rb`; Go/Ruby enforce; TS/Kotlin/Swift do not |

--- a/SPEC.md
+++ b/SPEC.md
@@ -1058,7 +1058,7 @@ Every JSON API request must include all four headers below. Download requests (�
 Where:
 - `{lang}` is the language identifier: `go`, `ts`, `ruby`, `kotlin`, `swift`
 - `{VERSION}` is the SDK version (e.g., `0.6.0`)
-- `{API_VERSION}` is the API version from `openapi.json` `info.version` (currently `2026-07-31`), derived from the shared date in `spec/api-provenance.json` <!-- @api-version -->
+- `{API_VERSION}` is the API version from `openapi.json` `info.version` (currently `2026-08-02`), derived from the shared date in `spec/api-provenance.json` <!-- @api-version -->
 
 ### Redirect Handling
 
@@ -1866,7 +1866,7 @@ The following are must-pass criteria from the rubric. Each maps to a spec sectio
 | `provenance-check` | Embedded provenance matches `spec/api-provenance.json` |
 | `sync-spec-version-check` | Smithy service version matches the shared date in `spec/api-provenance.json` |
 | `sync-api-version-check` | `API_VERSION` constants match `openapi.json` `info.version` across all SDKs |
-| `doc-constants-check` | Constants restated in prose match their sources: `@api-version`-marked spans vs. `openapi.json` `info.version`, `@bc3-pin`-marked spans vs. `spec/api-provenance.json`, and §19's `@assertion-types` table vs. `conformance/schema.json`. Only marked spans are checked — `spec/api-gaps/` cites historical bc3 SHAs on purpose — and `spec/doc-constants.json` commits a per-file marker floor so deleting a marker cannot silence the gate. `make sync-api-version` rewrites the two scalar constants |
+| `doc-constants-check` | Constants restated in prose match their sources: `@api-version`-marked spans vs. `openapi.json` `info.version`, `@bc3-pin`-marked spans vs. `spec/api-provenance.json`, and §19's `@assertion-types` table vs. `conformance/schema.json`. Only marked spans are checked — `spec/api-gaps/` cites historical bc3 SHAs on purpose — and `spec/doc-constants.json` commits the exact per-file marker count, so neither deleting a marker nor adding an unrecorded one can silence the gate. It also bounds, by count and with a reason, the files allowed to name today's pin unmarked. `make sync-api-version` rewrites the two scalar constants, except in files listed `.writerExcludes` |
 | `url-routes-check` | `go/pkg/basecamp/url-routes.json` (embedded via `//go:embed`) matches regeneration from `openapi.json` |
 | `go-check-drift` | Go generated services match current OpenAPI spec |
 | `kt-check-drift` | Kotlin generated services match current OpenAPI spec (operation-level coverage) |
@@ -1910,7 +1910,7 @@ The following are explicitly NOT part of this specification:
 
 All magic numbers in one place, derived from shipping SDK code (not `rubric-audit.json`).
 
-Only `API_VERSION` is gated (`<!-- @api-version -->`, checked by `make doc-constants-check`). The other 13 rows are hand-maintained and were verified against the cited sources on 2026-08-03 — all 13 matched. They are not gated because each is asserted of several SDKs at once in a different spelling per language (Go `1 * time.Second`, Python `1.0`, Ruby `1.0`, Kotlin `30.seconds`), so a checker would need a per-row, per-language extraction rule rather than the one-value-one-source substitution the marker convention is built on. If one of these starts moving, gate that row rather than the appendix.
+Only `API_VERSION` is gated (`<!-- @api-version -->`, checked by `make doc-constants-check`). The other 13 rows are hand-maintained and were read against their cited sources on 2026-08-03 — all 13 matched. They are not gated because each is asserted of several SDKs at once in a different spelling per language (Go `1 * time.Second`, Python `1.0`, Ruby `1.0`, Kotlin `30.seconds`, Swift `1_000`), so a checker would need a per-row, per-language extraction rule rather than the one-value-one-source substitution the marker convention is built on. The name in the table is the concept, not a symbol to grep: `MAX_ERROR_MESSAGE_LENGTH` is `MaxErrorMessageBytes` in Go and `MAX_ERROR_MESSAGE_BYTES` in Ruby, and `TOKEN_REFRESH_BUFFER` is the literal `300` in `creds.ExpiresAt-300` (`go/pkg/basecamp/auth.go`) rather than a named constant at all. If one of these starts moving, gate that row rather than the appendix.
 
 | Constant | Value | Unit | Source |
 |----------|-------|------|--------|
@@ -1926,7 +1926,7 @@ Only `API_VERSION` is gated (`<!-- @api-version -->`, checked by `make doc-const
 | `DEFAULT_MAX_PAGES` | 10,000 | — | All six SDKs |
 | `MAX_CACHE_ENTRIES` | 1000 | entries | `typescript/src/client.ts` |
 | `MAX_TOKEN_HASH_ENTRIES` | 100 | entries | `typescript/src/client.ts` |
-| `API_VERSION` | `2026-07-31` | — | `openapi.json` `info.version` <!-- @api-version --> |
+| `API_VERSION` | `2026-08-02` | — | `openapi.json` `info.version` <!-- @api-version --> |
 | `TOKEN_REFRESH_BUFFER` | 300 | seconds | Go OAuth token refresh threshold (5-minute buffer); Ruby refreshes only on expiry (no buffer); TS/Kotlin/Swift delegate expiry to caller |
 
 ---

--- a/scripts/check-doc-constants.sh
+++ b/scripts/check-doc-constants.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Verify prose doc constants (API_VERSION, the bc3 provenance pin, SPEC §19's
+# assertion-type table) still match their machine-readable sources.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! command -v ruby >/dev/null 2>&1; then
+  echo "ERROR: ruby is required for doc-constants-check" >&2
+  exit 2
+fi
+
+exec ruby "$SCRIPT_DIR/sync-doc-constants.rb" --check

--- a/scripts/sync-api-version.sh
+++ b/scripts/sync-api-version.sh
@@ -59,8 +59,11 @@ sedi "s/^API_VERSION = \".*\"/API_VERSION = \"$API_VERSION\"/" \
 # cited in spec/api-gaps/ narrative are left alone. Assertion-type table drift
 # is reported by `make doc-constants-check`, not fixed here — a new row needs a
 # human-written description, and failing here would break every `make generate`.
+# $OPENAPI is forwarded, not re-defaulted: a caller who passes their own spec
+# file must get the SDK constants AND the prose from that same file, or one
+# sync leaves the two disagreeing.
 if command -v ruby >/dev/null 2>&1; then
-  ruby "$SCRIPT_DIR/sync-doc-constants.rb" --write
+  ruby "$SCRIPT_DIR/sync-doc-constants.rb" --write --openapi "$OPENAPI"
 else
   echo "WARNING: ruby not found; skipped prose doc-constant sync (make doc-constants-check will fail)" >&2
 fi

--- a/scripts/sync-api-version.sh
+++ b/scripts/sync-api-version.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
-# Syncs API_VERSION constants across all SDKs from openapi.json info.version.
+# Syncs API_VERSION constants across all SDKs from openapi.json info.version,
+# then syncs the doc constants restated in prose (marked spans only) from the
+# same sources — see scripts/sync-doc-constants.rb.
 # Usage: scripts/sync-api-version.sh [openapi.json]
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 OPENAPI="${1:-openapi.json}"
 
@@ -49,5 +53,16 @@ sedi "s/public static let apiVersion = \".*\"/public static let apiVersion = \"$
 # Python
 sedi "s/^API_VERSION = \".*\"/API_VERSION = \"$API_VERSION\"/" \
   python/src/basecamp/_version.py
+
+# Prose: the same constants restated in SPEC.md / COORDINATION.md / api-gaps.
+# Only HTML-comment-marked spans are touched, so the ~20 historical bc3 SHAs
+# cited in spec/api-gaps/ narrative are left alone. Assertion-type table drift
+# is reported by `make doc-constants-check`, not fixed here — a new row needs a
+# human-written description, and failing here would break every `make generate`.
+if command -v ruby >/dev/null 2>&1; then
+  ruby "$SCRIPT_DIR/sync-doc-constants.rb" --write
+else
+  echo "WARNING: ruby not found; skipped prose doc-constant sync (make doc-constants-check will fail)" >&2
+fi
 
 echo "Done."

--- a/scripts/sync-api-version.sh
+++ b/scripts/sync-api-version.sh
@@ -59,6 +59,10 @@ sedi "s/^API_VERSION = \".*\"/API_VERSION = \"$API_VERSION\"/" \
 # cited in spec/api-gaps/ narrative are left alone. Assertion-type table drift
 # is reported by `make doc-constants-check`, not fixed here — a new row needs a
 # human-written description, and failing here would break every `make generate`.
+# Files in spec/doc-constants.json .writerExcludes are skipped with a warning
+# for the same reason in a different key: this runs inside `make generate`, and
+# a marked value that heads a narrative cannot advance on its own without the
+# narrative it heads becoming false.
 # $OPENAPI is forwarded, not re-defaulted: a caller who passes their own spec
 # file must get the SDK constants AND the prose from that same file, or one
 # sync leaves the two disagreeing.

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -40,7 +40,10 @@
 #                the span is the lines strictly between them.
 #
 # Deleting a marker to silence the gate is itself caught: spec/doc-constants.json
-# commits a per-file marker-count FLOOR, and dropping below it fails.
+# commits the EXACT per-file marker count, and any deviation fails — too few
+# (a claim was deleted or unmarked), too many (a claim was added without being
+# recorded, and so would not be missed if it went), or a marked file the
+# inventory does not mention at all.
 #
 # Modes
 #   --check (default)  Report drift; exit 1 on any error.
@@ -307,20 +310,30 @@ end
 # walking git log of spec/api-provenance.json — slow, and wrong under the
 # shallow clones CI uses. So this catches the claim as it is made, and AGENTS.md
 # governs the ones already settled.
-def check_unmarked_pin(file, prose, revision, allowed)
-  prose.filter_map do |line_no, line|
-    hits = line.scan(TICKED_HEX_RE).flatten.select { |h| revision.start_with?(h) }
-    next if hits.empty?
+#
+# Backticked and bare occurrences both count. Requiring backticks here would
+# leave "the provenance pin is d0edc128" as a one-character way around the
+# rule, and unlike the generic bare-SHA heuristic this match is the live
+# revision's own prefix, so it cannot collide with an ordinary number.
+def cites_current_pin?(line, revision)
+  ticked = line.scan(TICKED_HEX_RE).flatten.select { |h| revision.start_with?(h) }
+  return ticked.first unless ticked.empty?
 
-    if allowed.key?(file)
-      nil
-    else
-      "#{file}:#{line_no}: `#{hits.first}` is the current provenance pin, restated outside a " \
-        "@bc3-pin span. Either mark the line <!-- @bc3-pin --> (and name the sync date) so " \
-        "`make sync-api-version` keeps it current, or bind the SHA to what makes it permanently " \
-        "true — the PR that shipped it, the verification it backs — and record the file in " \
-        "spec/doc-constants.json .unmarkedPinCitations with that reason."
-    end
+  line.gsub(BACKTICKED_RE, " ")[/\b#{Regexp.escape(revision[0, 7])}[0-9a-f]{0,33}\b/]
+end
+
+def check_unmarked_pin(file, prose, revision, allowed)
+  return [] if allowed.key?(file)
+
+  prose.filter_map do |line_no, line|
+    hit = cites_current_pin?(line, revision)
+    next if hit.nil?
+
+    "#{file}:#{line_no}: `#{hit}` is the current provenance pin, restated outside a " \
+      "@bc3-pin span. Either mark the line <!-- @bc3-pin --> (and name the sync date) so " \
+      "`make sync-api-version` keeps it current, or bind the SHA to what makes it permanently " \
+      "true — the PR that shipped it, the verification it backs — and record the file in " \
+      "spec/doc-constants.json .unmarkedPinCitations with that reason."
   end
 end
 
@@ -385,7 +398,7 @@ def run(mode, openapi)
   end
 
   config = read_json("spec/doc-constants.json")
-  floors = dig!(config, "spec/doc-constants.json", "markerFloors")
+  declared = dig!(config, "spec/doc-constants.json", "markerCounts")
   writer_excludes = config.fetch("writerExcludes", {})
   pin_citations   = config.fetch("unmarkedPinCitations", {})
 
@@ -399,22 +412,49 @@ def run(mode, openapi)
     prose_by_file[file] = file_prose
   end
 
-  # Marker-count floor: deleting a marked claim to silence the gate fails here.
+  # Marker inventory: spec/doc-constants.json states EXACTLY how many marked
+  # claims each file carries, and every deviation fails.
+  #
+  # This was a floor — a minimum — which left a hole worth more than the
+  # convenience it bought. Under a minimum, a claim added to a file that
+  # already met its count is unprotected forever: add a third @api-version to
+  # SPEC.md against a floor of 2, delete it later, and two markers remain, so
+  # the gate passes while the value it used to guard drifts. The whole point of
+  # this section is that deleting a marked claim fails, so it has to hold for
+  # every claim, not just the first N. An exact count costs one line in the
+  # same commit that adds the marker, and buys an inventory that is true.
   counts = Hash.new(0)
   spans.each { |s| counts[[s.kind, s.file]] += 1 }
-  floors.each do |kind, per_file|
+
+  declared_pairs = []
+  declared.each do |kind, per_file|
     unless KNOWN_KINDS.include?(kind)
-      errors << "spec/doc-constants.json: floor declared for unknown marker @#{kind}"
+      errors << "spec/doc-constants.json: count declared for unknown marker @#{kind}"
       next
     end
-    per_file.each do |file, floor|
+    per_file.each do |file, expected|
+      declared_pairs << [kind, file]
       found = counts[[kind, file]]
-      next if found >= floor
+      next if found == expected
 
-      errors << "#{file}: marker floor violated — spec/doc-constants.json requires at least " \
-                "#{floor} @#{kind} marker(s), found #{found}. A current-value claim was deleted " \
-                "or unmarked; if it genuinely moved, move the floor in the same commit."
+      errors <<
+        if found < expected
+          "#{file}: spec/doc-constants.json declares #{expected} @#{kind} marker(s), found " \
+            "#{found}. A current-value claim was deleted or unmarked; if it genuinely moved, " \
+            "move the count in the same commit."
+        else
+          "#{file}: spec/doc-constants.json declares #{expected} @#{kind} marker(s), found " \
+            "#{found}. A marked claim was added without recording it — set the count to " \
+            "#{found} in the same commit, so deleting it later fails too."
+        end
     end
+  end
+
+  # A marker in a file nobody declared is equally unprotected: it could be
+  # removed with nothing to notice.
+  (counts.keys - declared_pairs).each do |kind, file|
+    errors << "#{file}: carries #{counts[[kind, file]]} @#{kind} marker(s) that " \
+              "spec/doc-constants.json does not declare — add the count so deleting them fails."
   end
 
   if mode == :write
@@ -499,9 +539,7 @@ def run(mode, openapi)
   # silently pre-authorize the next author to write an unmarked restatement
   # there.
   pin_citations.each_key do |file|
-    cited = prose_by_file.fetch(file, []).any? do |_, line|
-      line.scan(TICKED_HEX_RE).flatten.any? { |h| revision.start_with?(h) }
-    end
+    cited = prose_by_file.fetch(file, []).any? { |_, line| cites_current_pin?(line, revision) }
     next if cited
 
     errors << "spec/doc-constants.json: .unmarkedPinCitations lists #{file}, but it no longer " \

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -317,9 +317,12 @@ end
 # revision's own prefix, so it cannot collide with an ordinary number.
 def cites_current_pin?(line, revision)
   ticked = line.scan(TICKED_HEX_RE).flatten.select { |h| revision.start_with?(h) }
-  return ticked.first unless ticked.empty?
 
-  line.gsub(BACKTICKED_RE, " ")[/\b#{Regexp.escape(revision[0, 7])}[0-9a-f]{0,33}\b/]
+  if ticked.empty?
+    line.gsub(BACKTICKED_RE, " ")[/\b#{Regexp.escape(revision[0, 7])}[0-9a-f]{0,33}\b/]
+  else
+    ticked.first
+  end
 end
 
 # A grant is bounded by a COUNT, for the same reason markerFloors became
@@ -337,25 +340,23 @@ def check_unmarked_pin(file, prose, revision, allowed)
   end
 
   grant = allowed[file]
+
   if grant.nil?
-    return hits.map do |line_no, hit|
+    hits.map do |line_no, hit|
       "#{file}:#{line_no}: `#{hit}` is the current provenance pin, restated outside a " \
         "@bc3-pin span. Either mark the line <!-- @bc3-pin --> (and name the sync date) so " \
         "`make sync-api-version` keeps it current, or bind the SHA to what makes it permanently " \
         "true — the PR that shipped it, the verification it backs — and record the file in " \
         "spec/doc-constants.json .unmarkedPinCitations with that reason and a count."
     end
-  end
-
-  return [] if hits.length == grant["count"]
-
-  if hits.length > grant["count"]
-    lines = hits.map { |line_no, _| line_no }.join(", ")
+  elsif hits.length == grant["count"]
+    []
+  elsif hits.length > grant["count"]
     ["#{file}: spec/doc-constants.json grants #{grant['count']} unmarked citation(s) of the " \
-     "current pin, found #{hits.length} (lines #{lines}). The grant covers reviewed as-of " \
-     "facts, not whatever the file grows next — read the new one, confirm it binds the SHA to " \
-     "a fixed observation rather than claiming today's pin, and raise the count in the same " \
-     "commit."]
+     "current pin, found #{hits.length} (lines #{hits.map(&:first).join(', ')}). The grant " \
+     "covers reviewed as-of facts, not whatever the file grows next — read the new one, " \
+     "confirm it binds the SHA to a fixed observation rather than claiming today's pin, and " \
+     "raise the count in the same commit."]
   else
     # Fewer than granted: the entry has outlived what it described. Left alone
     # it is a standing permission nobody reviewed, pre-authorising the next
@@ -381,27 +382,22 @@ def validate_citation_grants(allowed)
   valid = {}
 
   allowed.each do |file, grant|
-    unless grant.is_a?(Hash)
-      errors << "spec/doc-constants.json: .unmarkedPinCitations[#{file.inspect}] must be an " \
-                "object with \"count\" and \"reason\", got #{grant.class}"
-      next
-    end
+    where = ".unmarkedPinCitations[#{file.inspect}]"
+    problem =
+      if !grant.is_a?(Hash)
+        "#{where} must be an object with \"count\" and \"reason\", got #{grant.class}"
+      elsif !grant["count"].is_a?(Integer) || !grant["count"].positive?
+        "#{where}.count must be a positive integer, got #{grant['count'].inspect}"
+      elsif !grant["reason"].is_a?(String) || grant["reason"].strip.empty?
+        "#{where} needs a non-empty \"reason\" — the reason is what a reviewer checks the " \
+          "citation against"
+      end
 
-    count = grant["count"]
-    unless count.is_a?(Integer) && count.positive?
-      errors << "spec/doc-constants.json: .unmarkedPinCitations[#{file.inspect}].count must be " \
-                "a positive integer, got #{count.inspect}"
-      next
+    if problem
+      errors << "spec/doc-constants.json: #{problem}"
+    else
+      valid[file] = grant
     end
-
-    reason = grant["reason"]
-    unless reason.is_a?(String) && !reason.strip.empty?
-      errors << "spec/doc-constants.json: .unmarkedPinCitations[#{file.inspect}] needs a " \
-                "non-empty \"reason\" — the reason is what a reviewer checks the citation against"
-      next
-    end
-
-    valid[file] = grant
   end
 
   [errors, valid]

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -322,19 +322,89 @@ def cites_current_pin?(line, revision)
   line.gsub(BACKTICKED_RE, " ")[/\b#{Regexp.escape(revision[0, 7])}[0-9a-f]{0,33}\b/]
 end
 
+# A grant is bounded by a COUNT, for the same reason markerFloors became
+# markerCounts. spec/api-gaps/README.md has to be granted — its job is
+# recording ranges, and a range's endpoint is by definition the pin that repin
+# set, so it names today's pin every time. But it is also the single likeliest
+# place for a genuine class-A sentence ("the provenance pin is X") to be
+# written, and an unbounded file grant would wave that through forever. The
+# count says "this file carries exactly N as-of citations of today's pin, all
+# reviewed"; the N+1th fails until someone looks at it and re-states the number.
 def check_unmarked_pin(file, prose, revision, allowed)
-  return [] if allowed.key?(file)
-
-  prose.filter_map do |line_no, line|
+  hits = prose.filter_map do |line_no, line|
     hit = cites_current_pin?(line, revision)
-    next if hit.nil?
-
-    "#{file}:#{line_no}: `#{hit}` is the current provenance pin, restated outside a " \
-      "@bc3-pin span. Either mark the line <!-- @bc3-pin --> (and name the sync date) so " \
-      "`make sync-api-version` keeps it current, or bind the SHA to what makes it permanently " \
-      "true — the PR that shipped it, the verification it backs — and record the file in " \
-      "spec/doc-constants.json .unmarkedPinCitations with that reason."
+    hit && [line_no, hit]
   end
+
+  grant = allowed[file]
+  if grant.nil?
+    return hits.map do |line_no, hit|
+      "#{file}:#{line_no}: `#{hit}` is the current provenance pin, restated outside a " \
+        "@bc3-pin span. Either mark the line <!-- @bc3-pin --> (and name the sync date) so " \
+        "`make sync-api-version` keeps it current, or bind the SHA to what makes it permanently " \
+        "true — the PR that shipped it, the verification it backs — and record the file in " \
+        "spec/doc-constants.json .unmarkedPinCitations with that reason and a count."
+    end
+  end
+
+  return [] if hits.length == grant["count"]
+
+  if hits.length > grant["count"]
+    lines = hits.map { |line_no, _| line_no }.join(", ")
+    ["#{file}: spec/doc-constants.json grants #{grant['count']} unmarked citation(s) of the " \
+     "current pin, found #{hits.length} (lines #{lines}). The grant covers reviewed as-of " \
+     "facts, not whatever the file grows next — read the new one, confirm it binds the SHA to " \
+     "a fixed observation rather than claiming today's pin, and raise the count in the same " \
+     "commit."]
+  else
+    # Fewer than granted: the entry has outlived what it described. Left alone
+    # it is a standing permission nobody reviewed, pre-authorising the next
+    # unmarked restatement in this file.
+    ["#{file}: spec/doc-constants.json grants #{grant['count']} unmarked citation(s) of the " \
+     "current pin, found #{hits.length} — the entry no longer describes the file. Lower the " \
+     "count, or drop the entry."]
+  end
+end
+
+# The grant shape is load-bearing: a bare string (the shape before counts) or a
+# missing count would otherwise read as "grant everything" — a silent hole in
+# exactly the check this list exists to bound.
+#
+# Returns [errors, well_formed_grants]. A malformed grant is reported and then
+# dropped rather than being handed to check_unmarked_pin, which would compare
+# a count against nil and die with a backtrace instead of the message that says
+# what to fix. Its file is skipped for the citation scan too: the shape error is
+# the actionable one, and also listing every citation in the file as unmarked
+# would bury it.
+def validate_citation_grants(allowed)
+  errors = []
+  valid = {}
+
+  allowed.each do |file, grant|
+    unless grant.is_a?(Hash)
+      errors << "spec/doc-constants.json: .unmarkedPinCitations[#{file.inspect}] must be an " \
+                "object with \"count\" and \"reason\", got #{grant.class}"
+      next
+    end
+
+    count = grant["count"]
+    unless count.is_a?(Integer) && count.positive?
+      errors << "spec/doc-constants.json: .unmarkedPinCitations[#{file.inspect}].count must be " \
+                "a positive integer, got #{count.inspect}"
+      next
+    end
+
+    reason = grant["reason"]
+    unless reason.is_a?(String) && !reason.strip.empty?
+      errors << "spec/doc-constants.json: .unmarkedPinCitations[#{file.inspect}] needs a " \
+                "non-empty \"reason\" — the reason is what a reviewer checks the citation against"
+      next
+    end
+
+    valid[file] = grant
+  end
+
+  [errors, valid]
 end
 
 def check_assertion_types(span, schema_types)
@@ -530,20 +600,15 @@ def run(mode, openapi)
     )
   end
 
-  prose_by_file.each do |file, prose|
-    errors.concat(check_unmarked_pin(file, prose, revision, pin_citations))
-  end
+  grant_errors, grants = validate_citation_grants(pin_citations)
+  errors.concat(grant_errors)
+  malformed = pin_citations.keys - grants.keys
 
-  # A citation exemption is a claim about a file, and claims rot. If the named
-  # file no longer cites the pin at all, the entry is dead weight that would
-  # silently pre-authorize the next author to write an unmarked restatement
-  # there.
-  pin_citations.each_key do |file|
-    cited = prose_by_file.fetch(file, []).any? { |_, line| cites_current_pin?(line, revision) }
-    next if cited
-
-    errors << "spec/doc-constants.json: .unmarkedPinCitations lists #{file}, but it no longer " \
-              "names the current pin outside a marked span — drop the entry."
+  # Every granted file is checked even if git no longer tracks it: a grant for
+  # a deleted file is dead weight that would spring back to life, unreviewed,
+  # the day someone recreates the path.
+  ((prose_by_file.keys | grants.keys) - malformed).each do |file|
+    errors.concat(check_unmarked_pin(file, prose_by_file.fetch(file, []), revision, grants))
   end
 
   if errors.empty?

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -17,6 +17,22 @@
 # history into a claim nobody verified. A marker means "this is a claim about
 # the CURRENT value" and nothing else.
 #
+# The two classes, stated once because everything below follows from them:
+#
+#   (A) A current-value claim — "the pin is X". True only right now. Carries a
+#       marker; the writer keeps it current.
+#   (B) An as-of fact — "verified at X", "shipped in X", "the A..B range".
+#       True forever, because the revision is bound to a fixed observation.
+#       Never marked; rewriting one would fabricate an observation.
+#
+# The gate cannot read tense, so it cannot sort an arbitrary sentence into A or
+# B. It enforces the one boundary it can see without guessing: a sentence
+# naming the CURRENT pin, unmarked, is rejected (see check_unmarked_pin
+# below). That is where every stale restatement in spec/api-gaps/ came from —
+# each was written when its SHA was current and correct. A SHA that was never
+# the pin, or that stopped being it before this gate existed, is out of reach
+# of any cheap check and is governed by the convention in AGENTS.md instead.
+#
 # Marker syntax
 #   Line span:   <!-- @api-version -->  or  <!-- @bc3-pin -->
 #                anywhere on the line; the span is exactly that line.
@@ -35,6 +51,15 @@
 #                      fails on it. `make doc-constants-check` is what catches
 #                      that one; keeping it out of the writer keeps a schema
 #                      edit from breaking every `make generate`.
+#                      Files listed in spec/doc-constants.json .writerExcludes
+#                      are never rewritten either: this script runs inside
+#                      `make generate`, and a document whose marked value is
+#                      the heading of a narrative cannot have that value
+#                      advanced without the narrative advancing too. Silently
+#                      doing it anyway would be the same unreviewed prose
+#                      rewrite this gate exists to prevent. The writer warns
+#                      and leaves them; --check then fails until a human
+#                      answers.
 #   --openapi PATH     Read the API version from PATH instead of ./openapi.json.
 #                      sync-api-version.sh forwards its own documented
 #                      [openapi.json] argument here; without that, one sync
@@ -46,8 +71,12 @@
 # CONTRIBUTING.md. Add a marked table there first if that changes.
 
 require "json"
+require "set"
 
-ROOT = File.expand_path("..", __dir__)
+# The repo this gate reads. DOC_CONSTANTS_ROOT exists so
+# scripts/test-doc-constants.rb can point the gate at a crafted tiny repo and
+# assert it rejects each failure mode; nothing in normal operation sets it.
+ROOT = File.expand_path(ENV["DOC_CONSTANTS_ROOT"] || File.expand_path("..", __dir__))
 
 # Every input here is UTF-8 by construction — openapi.json, the tracked
 # Markdown, and this script's own messages all contain non-ASCII. Ruby
@@ -66,6 +95,20 @@ MARKER_RE   = /<!--\s*@([a-z0-9][a-z0-9-]*)(?::(begin|end))?\s*-->/
 ISO_DATE_RE = /\b\d{4}-\d{2}-\d{2}\b/
 TICKED_HEX_RE = /`([0-9a-f]{7,40})`/
 BACKTICKED_RE = /`[^`]*`/
+
+# Bare (un-backticked) SHA detection, used only INSIDE a @bc3-pin span. A plain
+# /\b[0-9a-f]{7,40}\b/ also matches any run of 7+ digits, so a recording id or
+# an issue number sitting in a pin sentence was reported as a "bare SHA" —
+# fail-loud, never a false green, but a false alarm a human then has to
+# disprove. Requiring at least one a-f digit costs nothing real: an
+# abbreviation is only all-decimal by chance, and the one all-decimal
+# abbreviation that would actually matter is the pin's own, which is caught by
+# the second alternative built from the live revision.
+BARE_HEX_WITH_LETTER_RE = /\b(?=[0-9a-f]{7,40}\b)[0-9a-f]*[a-f][0-9a-f]*\b/
+
+def bare_sha_re(revision)
+  Regexp.union(BARE_HEX_WITH_LETTER_RE, /\b#{Regexp.escape(revision[0, 7])}[0-9a-f]{0,33}\b/)
+end
 
 class Failure < StandardError; end
 
@@ -116,11 +159,14 @@ Span = Struct.new(:kind, :file, :line_no, :lines, :block, keyword_init: true) do
   end
 end
 
-# Returns [spans, errors]. Line markers yield a one-line span; block markers
-# yield the lines strictly between :begin and :end.
+# Returns [spans, errors, prose_lines]. Line markers yield a one-line span;
+# block markers yield the lines strictly between :begin and :end. prose_lines
+# is every [line_no, text] pair that is neither fenced code nor inside a marked
+# span — i.e. the text check_unmarked_pin is entitled to judge.
 def scan_file(file)
   spans = []
   errors = []
+  prose = []
   lines = File.readlines(File.join(ROOT, file), chomp: true, encoding: UTF8)
   open_block = nil
   in_fence = false
@@ -133,6 +179,8 @@ def scan_file(file)
       next
     end
     next if in_fence
+
+    prose << [line_no, line]
 
     # A marker inside an inline code span (or a fenced block) is documentation
     # OF the convention — AGENTS.md explains it — not a use of it. Markdown
@@ -187,7 +235,11 @@ def scan_file(file)
     errors << "#{file}:#{open_block[:line_no]}: @#{open_block[:kind]}:begin never closed"
   end
 
-  [spans, errors]
+  covered = Set.new
+  spans.each { |s| (s.line_no...(s.line_no + s.lines.length)).each { |n| covered << n } }
+  prose.reject! { |line_no, _| covered.include?(line_no) }
+
+  [spans, errors, prose]
 end
 
 # --- per-kind checkers -------------------------------------------------------
@@ -215,11 +267,12 @@ def check_bc3_pin(span, revision, date)
     end
   end
 
-  # A SHA that lost its backticks is invisible to the writer's rewrite, so it
-  # would sit stale forever while the gate reported green. Reject it outright.
-  text.gsub(BACKTICKED_RE, " ").scan(/\b[0-9a-f]{7,40}\b/).uniq.each do |bare|
+  # A SHA that lost its backticks is invisible to both the check above and the
+  # writer's rewrite, so it would sit stale forever while the gate reported
+  # green. Reject it outright.
+  text.gsub(BACKTICKED_RE, " ").scan(bare_sha_re(revision)).flatten.compact.uniq.each do |bare|
     errors << "#{span.location}: bare SHA #{bare} in a @bc3-pin span — backtick it " \
-              "so `make sync-api-version` can rewrite it"
+              "so the gate can read it as part of the pin claim"
   end
 
   # A span that states no date is not "nothing to check" — the sync date is
@@ -237,6 +290,38 @@ def check_bc3_pin(span, revision, date)
   end
 
   errors
+end
+
+# Unmarked prose must not restate TODAY's pin.
+#
+# This is the birth-time half of the A/B rule at the top of the file. Every
+# stale pin restatement in spec/api-gaps/ — "the provenance pin (`c3086931`)",
+# "at the pinned `dffa7e11b3`" — was written on the day its SHA was the pin,
+# was true that day, and rotted at the next repin with nothing to notice. This
+# fires on exactly that sentence, on the day it is written, while the author is
+# still in the file and can say which kind of claim they meant.
+#
+# It deliberately does NOT fire on a SHA that is not the current pin. Deciding
+# whether an arbitrary revision is a stale class-A claim or a legitimate
+# class-B citation needs the pin's whole history, and reading that means
+# walking git log of spec/api-provenance.json — slow, and wrong under the
+# shallow clones CI uses. So this catches the claim as it is made, and AGENTS.md
+# governs the ones already settled.
+def check_unmarked_pin(file, prose, revision, allowed)
+  prose.filter_map do |line_no, line|
+    hits = line.scan(TICKED_HEX_RE).flatten.select { |h| revision.start_with?(h) }
+    next if hits.empty?
+
+    if allowed.key?(file)
+      nil
+    else
+      "#{file}:#{line_no}: `#{hits.first}` is the current provenance pin, restated outside a " \
+        "@bc3-pin span. Either mark the line <!-- @bc3-pin --> (and name the sync date) so " \
+        "`make sync-api-version` keeps it current, or bind the SHA to what makes it permanently " \
+        "true — the PR that shipped it, the verification it backs — and record the file in " \
+        "spec/doc-constants.json .unmarkedPinCitations with that reason."
+    end
+  end
 end
 
 def check_assertion_types(span, schema_types)
@@ -301,13 +386,17 @@ def run(mode, openapi)
 
   config = read_json("spec/doc-constants.json")
   floors = dig!(config, "spec/doc-constants.json", "markerFloors")
+  writer_excludes = config.fetch("writerExcludes", {})
+  pin_citations   = config.fetch("unmarkedPinCitations", {})
 
   errors = []
   spans = []
+  prose_by_file = {}
   tracked_markdown.each do |file|
-    file_spans, file_errors = scan_file(file)
+    file_spans, file_errors, file_prose = scan_file(file)
     spans.concat(file_spans)
     errors.concat(file_errors)
+    prose_by_file[file] = file_prose
   end
 
   # Marker-count floor: deleting a marked claim to silence the gate fails here.
@@ -330,6 +419,7 @@ def run(mode, openapi)
 
   if mode == :write
     written = []
+    declined = []
     spans.group_by(&:file).each do |file, file_spans|
       writable = file_spans.reject(&:block).select { |s| LINE_KINDS.include?(s.kind) }
       next if writable.empty?
@@ -347,6 +437,15 @@ def run(mode, openapi)
       updated = lines.join
       next if updated == original
 
+      # Excluded files are diffed but never written. Reaching here means the
+      # file IS stale, so say so loudly — this runs inside `make generate`, and
+      # a silent skip would read as "nothing to do" right up until `make check`
+      # failed for reasons the generate output never mentioned.
+      if writer_excludes.key?(file)
+        declined << file
+        next
+      end
+
       File.write(path, updated, encoding: UTF8)
       written << file
     end
@@ -355,6 +454,15 @@ def run(mode, openapi)
       puts "Doc constants already in sync (#{spans.count { |s| LINE_KINDS.include?(s.kind) }} marked spans)."
     else
       written.each { |file| puts "Rewrote marked doc constants in #{file}" }
+    end
+
+    declined.each do |file|
+      warn ""
+      warn "NOTE: #{file} has stale marked doc constants and was NOT rewritten."
+      warn "      Reason it is in spec/doc-constants.json .writerExcludes:"
+      warn "        #{writer_excludes[file]}"
+      warn "      Update it by hand, along with the prose that depends on it."
+      warn "      `make doc-constants-check` stays red until you do."
     end
 
     # Structural marker problems are still fatal in --write: they mean the
@@ -382,6 +490,24 @@ def run(mode, openapi)
     )
   end
 
+  prose_by_file.each do |file, prose|
+    errors.concat(check_unmarked_pin(file, prose, revision, pin_citations))
+  end
+
+  # A citation exemption is a claim about a file, and claims rot. If the named
+  # file no longer cites the pin at all, the entry is dead weight that would
+  # silently pre-authorize the next author to write an unmarked restatement
+  # there.
+  pin_citations.each_key do |file|
+    cited = prose_by_file.fetch(file, []).any? do |_, line|
+      line.scan(TICKED_HEX_RE).flatten.any? { |h| revision.start_with?(h) }
+    end
+    next if cited
+
+    errors << "spec/doc-constants.json: .unmarkedPinCitations lists #{file}, but it no longer " \
+              "names the current pin outside a marked span — drop the entry."
+  end
+
   if errors.empty?
     puts "Doc constants match their sources (#{spans.length} marked spans across " \
          "#{spans.map(&:file).uniq.length} files)."
@@ -394,8 +520,16 @@ def run(mode, openapi)
     errors.each { |e| warn "  #{e}" }
     warn ""
     warn "  Scalar constants: run `make sync-api-version` to rewrite marked spans."
+    # Naming the excluded files here matters: for those, "run make
+    # sync-api-version" is advice that silently does nothing, and a developer
+    # who follows it and sees no diff learns to distrust the gate.
+    writer_excludes.each do |file, reason|
+      warn "    — except #{file}, which the writer never edits (#{reason});"
+      warn "      fix it by hand."
+    end
     warn "  Assertion types:  edit SPEC.md §19's marked table by hand — a new row " \
          "needs a description only a human can write."
+    warn "  Unmarked pin:     see the A/B rule in AGENTS.md §Provenance is Mandatory."
     1
   end
 end

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -29,18 +29,17 @@
 # Modes
 #   --check (default)  Report drift; exit 1 on any error.
 #   --write            Rewrite marked spans in place from the sources.
-#
-#   --openapi PATH     Read the API version from PATH instead of ./openapi.json.
-#                      sync-api-version.sh forwards its own documented
-#                      [openapi.json] argument here; without that, one sync
-#                      could set the SDK constants from a caller-supplied file
-#                      and the prose from the repo's, leaving them disagreeing.
 #                      Only the two scalar constants are writable — an
 #                      assertion-type row needs a human-written description,
 #                      so --write never touches @assertion-types and never
 #                      fails on it. `make doc-constants-check` is what catches
 #                      that one; keeping it out of the writer keeps a schema
 #                      edit from breaking every `make generate`.
+#   --openapi PATH     Read the API version from PATH instead of ./openapi.json.
+#                      sync-api-version.sh forwards its own documented
+#                      [openapi.json] argument here; without that, one sync
+#                      could set the SDK constants from a caller-supplied file
+#                      and the prose from the repo's, leaving them disagreeing.
 #
 # liveAssertions (.properties.liveAssertions...) is deliberately NOT gated:
 # SPEC §19 does not tabulate it, and the live canary is governed by
@@ -49,6 +48,15 @@
 require "json"
 
 ROOT = File.expand_path("..", __dir__)
+
+# Every input here is UTF-8 by construction — openapi.json, the tracked
+# Markdown, and this script's own messages all contain non-ASCII. Ruby
+# otherwise reads and writes in the locale's encoding, so under LC_ALL=C the
+# gate died on the first byte of an em dash instead of checking anything.
+# Encodings are pinned explicitly rather than left to the environment.
+UTF8 = "UTF-8"
+$stdout.set_encoding(UTF8)
+$stderr.set_encoding(UTF8)
 
 LINE_KINDS  = %w[api-version bc3-pin].freeze
 BLOCK_KINDS = %w[assertion-types].freeze
@@ -64,7 +72,7 @@ class Failure < StandardError; end
 def read_json_at(path, label)
   raise Failure, "missing #{label}" unless File.exist?(path)
 
-  JSON.parse(File.read(path))
+  JSON.parse(File.read(path, encoding: UTF8))
 rescue JSON::ParserError => e
   raise Failure, "#{label} is not valid JSON: #{e.message}"
 end
@@ -91,7 +99,7 @@ end
 # Markdown files git actually tracks. `git ls-files` (not Dir.glob) so the
 # gitignored internal docs/ tree and vendored node_modules never get scanned.
 def tracked_markdown
-  out = IO.popen(["git", "-C", ROOT, "ls-files", "-z", "--", "*.md"], &:read)
+  out = IO.popen(["git", "-C", ROOT, "ls-files", "-z", "--", "*.md"], external_encoding: UTF8, &:read)
   raise Failure, "git ls-files failed (is #{ROOT} a git checkout?)" unless $?.success?
 
   out.split("\0").reject(&:empty?).sort
@@ -113,7 +121,7 @@ end
 def scan_file(file)
   spans = []
   errors = []
-  lines = File.readlines(File.join(ROOT, file), chomp: true)
+  lines = File.readlines(File.join(ROOT, file), chomp: true, encoding: UTF8)
   open_block = nil
   in_fence = false
 
@@ -327,7 +335,7 @@ def run(mode, openapi)
       next if writable.empty?
 
       path = File.join(ROOT, file)
-      original = File.read(path)
+      original = File.read(path, encoding: UTF8)
       lines = original.lines
       writable.each do |span|
         index = span.line_no - 1
@@ -339,7 +347,7 @@ def run(mode, openapi)
       updated = lines.join
       next if updated == original
 
-      File.write(path, updated)
+      File.write(path, updated, encoding: UTF8)
       written << file
     end
 

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -95,9 +95,25 @@ BLOCK_KINDS = %w[assertion-types].freeze
 KNOWN_KINDS = (LINE_KINDS + BLOCK_KINDS).freeze
 
 MARKER_RE   = /<!--\s*@([a-z0-9][a-z0-9-]*)(?::(begin|end))?\s*-->/
-# A fenced-code delimiter: 3+ backticks or 3+ tildes, optional leading space,
-# with whatever follows captured as the info string (a close must have none).
-FENCE_RE    = /\A\s*(?<delimiter>`{3,}|~{3,})(?<info>.*)\z/
+# A fenced-code delimiter: 3+ backticks or 3+ tildes, indented at most three
+# spaces, with whatever follows captured as the info string (a close must have
+# none).
+#
+# The three-space limit is load-bearing, not pedantry. At four spaces a line is
+# an INDENTED code block — "    ```ruby" is how you show a fence without opening
+# one — and a permissive \s* took that as an opening. Since the example it
+# quotes usually has no matching close, the fence stayed open and every line
+# after it was skipped, which is the same fail-open hole the delimiter matching
+# was added to close, re-entering through the indentation door. Tabs are
+# excluded for the same reason: a tab counts as four columns.
+#
+# Tracked Markdown indents fences 0, 2 or 3 spaces and never more, so this
+# rejects nothing that exists today. A 4-space-indented fence line now reads as
+# prose rather than as code, which over-scans rather than under-scans — the
+# safe direction, since the cost is a visible false alarm rather than a claim
+# nobody checked. Fences nested in deeply indented list items would need real
+# container tracking; none exist here, and the gate is not a Markdown parser.
+FENCE_RE    = /\A {0,3}(?<delimiter>`{3,}|~{3,})(?<info>.*)\z/
 ISO_DATE_RE = /\b\d{4}-\d{2}-\d{2}\b/
 TICKED_HEX_RE = /`([0-9a-f]{7,40})`/
 BACKTICKED_RE = /`[^`]*`/

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -433,8 +433,11 @@ def check_unmarked_pin(file, prose, revision, allowed)
   end
 
   grant = allowed[file]
+  claims = grant.nil? ? [] : class_a_claims(file, prose, revision)
 
-  if grant.nil?
+  if claims.any?
+    claims
+  elsif grant.nil?
     hits.map { |line_no, hit|
       "#{file}:#{line_no}: `#{hit}` is the current provenance pin, restated outside a " \
         "@bc3-pin span. Either mark the line <!-- @bc3-pin --> (and name the sync date) so " \
@@ -457,6 +460,42 @@ def check_unmarked_pin(file, prose, revision, allowed)
     ["#{file}: spec/doc-constants.json grants #{grant['count']} unmarked citation(s) of the " \
      "current pin, found #{hits.length} — the entry no longer describes the file. Lower the " \
      "count, or drop the entry."]
+  end
+end
+
+# The one thing a grant never covers: a sentence in the class-A grammar.
+#
+# A grant is a statement about KIND — "the citations in this file are as-of
+# facts" — enforced by a count, which is a statement about QUANTITY. Swap one
+# granted citation for "the provenance pin is X" in the same change and the
+# quantity is unchanged, so the count alone lets a current-value claim in under
+# a reason that does not describe it.
+#
+# Binding the grant to occurrence identity would close that completely, and it
+# was considered: line numbers churn on every unrelated edit, and hashing the
+# matched text churns on every rewording of the triage prose. Either way the
+# grant would need bumping constantly, and an inventory that gets bumped
+# reflexively is not an inventory — the same argument that makes markerCounts
+# work only because it moves when the number of claims moves, which is rare and
+# meaningful.
+#
+# So instead of identity, this checks for the one shape that is never an as-of
+# fact. AGENTS.md already names it as the failure to avoid — "writing the second
+# in the grammar of the first" — and a sentence in that grammar wants a marker
+# whether or not its file holds a grant. Deliberately narrow: it is a floor
+# under the grant, not a tense parser, and the residual is recorded in the PR.
+CLASS_A_GRAMMAR_RE = /\b(?:pin|revision)\s+is\b|\bat\s+the\s+pinned\b|\bprovenance\s+pin\s*\(/i
+
+def class_a_claims(file, prose, revision)
+  prose.filter_map do |line_no, line|
+    next if current_pin_citations(line, revision).empty?
+    next unless line.match?(CLASS_A_GRAMMAR_RE)
+
+    "#{file}:#{line_no}: names the current pin in the grammar of a current-value claim " \
+      "(\"the pin is X\", \"at the pinned X\"). spec/doc-constants.json .unmarkedPinCitations " \
+      "grants as-of FACTS, and never this shape — a grant cannot make a class-A sentence " \
+      "permanently true. Mark the line <!-- @bc3-pin --> (and name the sync date), or reword it " \
+      "to say what binds the revision."
   end
 end
 

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -311,18 +311,25 @@ end
 # shallow clones CI uses. So this catches the claim as it is made, and AGENTS.md
 # governs the ones already settled.
 #
-# Backticked and bare occurrences both count. Requiring backticks here would
-# leave "the provenance pin is d0edc128" as a one-character way around the
-# rule, and unlike the generic bare-SHA heuristic this match is the live
-# revision's own prefix, so it cannot collide with an ordinary number.
+# Every occurrence counts, wherever it sits. This match is built from the live
+# revision's own prefix, so unlike the generic bare-SHA heuristic it cannot
+# collide with an ordinary number, and that is what lets it read the raw line
+# instead of a filtered one.
+#
+# It got there in two steps, both of which were holes:
+#
+#   - Backticks-only missed "the provenance pin is d0edc128", a one-character
+#     way around the rule.
+#   - Masking code spans before the bare scan then missed the pin inside a
+#     COMPOUND span. `d0edc1283b..2c0dafba13` is not a lone SHA, so the
+#     backticked pattern skipped it, and blanking the span hid it from the
+#     bare pass too. Range notation is the single most common way this file
+#     names a revision, so that blind spot sat exactly where the traffic is.
+#
+# Scanning the raw line subsumes both. A marked span's line never reaches here
+# (scan_file drops it from prose), and neither does anything fenced.
 def cites_current_pin?(line, revision)
-  ticked = line.scan(TICKED_HEX_RE).flatten.select { |h| revision.start_with?(h) }
-
-  if ticked.empty?
-    line.gsub(BACKTICKED_RE, " ")[/\b#{Regexp.escape(revision[0, 7])}[0-9a-f]{0,33}\b/]
-  else
-    ticked.first
-  end
+  line[/\b#{Regexp.escape(revision[0, 7])}[0-9a-f]{0,33}\b/]
 end
 
 # A grant is bounded by a COUNT, for the same reason markerFloors became

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -55,6 +55,20 @@
 # recorded, and so would not be missed if it went), or a marked file the
 # inventory does not mention at all.
 #
+# Known residual, examined and accepted: a count is per file, not per claim, so
+# unmarking one @api-version sentence in SPEC.md while marking a different one
+# in the same change keeps the total at 2 and passes, leaving the first
+# unprotected. Closing it needs per-claim identity — named markers, say
+# <!-- @api-version#headers --> with the inventory listing names — which is a
+# real option and no more churn than counts, since both move only when claims
+# are added or removed. It is not done here because it changes the marker
+# grammar that AGENTS.md and SPEC.md document, and it collides with the
+# :begin/:end suffix; and because unlike everything else fixed in review, this
+# one cannot happen by ordinary authoring. It takes a deliberate relocation of
+# a marker within one file, which is a reviewed edit to marked spans by
+# definition. Cross-FILE relocation is already caught. If a third @api-version
+# claim ever appears, revisit: the argument weakens as the count grows.
+#
 # Modes
 #   --check (default)  Report drift; exit 1 on any error.
 #   --write            Rewrite marked spans in place from the sources.

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -29,6 +29,12 @@
 # Modes
 #   --check (default)  Report drift; exit 1 on any error.
 #   --write            Rewrite marked spans in place from the sources.
+#
+#   --openapi PATH     Read the API version from PATH instead of ./openapi.json.
+#                      sync-api-version.sh forwards its own documented
+#                      [openapi.json] argument here; without that, one sync
+#                      could set the SDK constants from a caller-supplied file
+#                      and the prose from the repo's, leaving them disagreeing.
 #                      Only the two scalar constants are writable — an
 #                      assertion-type row needs a human-written description,
 #                      so --write never touches @assertion-types and never
@@ -55,13 +61,24 @@ BACKTICKED_RE = /`[^`]*`/
 
 class Failure < StandardError; end
 
-def read_json(relative)
-  path = File.join(ROOT, relative)
-  raise Failure, "missing #{relative}" unless File.exist?(path)
+def read_json_at(path, label)
+  raise Failure, "missing #{label}" unless File.exist?(path)
 
   JSON.parse(File.read(path))
 rescue JSON::ParserError => e
-  raise Failure, "#{relative} is not valid JSON: #{e.message}"
+  raise Failure, "#{label} is not valid JSON: #{e.message}"
+end
+
+# Repo-owned inputs: always resolved against the repo root, never the cwd.
+def read_json(relative)
+  read_json_at(File.join(ROOT, relative), relative)
+end
+
+# The one caller-supplied input. Resolved against the cwd so the same string
+# means the same file to this script as it did to the shell that passed it,
+# absolute or relative.
+def read_openapi(path)
+  read_json_at(File.expand_path(path, Dir.pwd), path)
 end
 
 def dig!(doc, relative, *path)
@@ -167,12 +184,12 @@ end
 
 # --- per-kind checkers -------------------------------------------------------
 
-def check_api_version(span, api_version)
+def check_api_version(span, api_version, source)
   dates = span.text.scan(ISO_DATE_RE)
   return ["#{span.location}: @api-version span states no YYYY-MM-DD version"] if dates.empty?
 
   dates.uniq.reject { |d| d == api_version }.map do |bad|
-    "#{span.location}: @api-version says #{bad}, openapi.json .info.version is #{api_version}"
+    "#{span.location}: @api-version says #{bad}, #{source} .info.version is #{api_version}"
   end
 end
 
@@ -197,9 +214,18 @@ def check_bc3_pin(span, revision, date)
               "so `make sync-api-version` can rewrite it"
   end
 
-  text.scan(ISO_DATE_RE).uniq.reject { |d| d == date }.each do |bad|
-    errors << "#{span.location}: @bc3-pin says #{bad}, spec/api-provenance.json " \
-              ".bc3.date is #{date}"
+  # A span that states no date is not "nothing to check" — the sync date is
+  # half the pin claim, and the writer can only substitute dates it can see, so
+  # a dropped date would never come back. Same rule as the missing-SHA case.
+  dates = text.scan(ISO_DATE_RE)
+  if dates.empty?
+    errors << "#{span.location}: @bc3-pin span states no YYYY-MM-DD sync date; " \
+              "a pin claim names both the revision and #{date}"
+  else
+    dates.uniq.reject { |d| d == date }.each do |bad|
+      errors << "#{span.location}: @bc3-pin says #{bad}, spec/api-provenance.json " \
+                ".bc3.date is #{date}"
+    end
   end
 
   errors
@@ -254,8 +280,8 @@ end
 
 # --- main --------------------------------------------------------------------
 
-def run(mode)
-  api_version = dig!(read_json("openapi.json"), "openapi.json", "info", "version")
+def run(mode, openapi)
+  api_version = dig!(read_openapi(openapi), openapi, "info", "version")
 
   provenance = read_json("spec/api-provenance.json")
   revision = dig!(provenance, "spec/api-provenance.json", "bc3", "revision")
@@ -340,7 +366,7 @@ def run(mode)
   spans.each do |span|
     errors.concat(
       case span.kind
-      when "api-version"     then check_api_version(span, api_version)
+      when "api-version"     then check_api_version(span, api_version, openapi)
       when "bc3-pin"         then check_bc3_pin(span, revision, date)
       when "assertion-types" then check_assertion_types(span, schema_types)
       else []
@@ -366,17 +392,27 @@ def run(mode)
   end
 end
 
-mode = if ARGV.empty? || ARGV == ["--check"]
-         :check
-       elsif ARGV == ["--write"]
-         :write
-       else
-         warn "usage: #{$PROGRAM_NAME} [--check|--write]"
-         exit 2
-       end
+mode = :check
+openapi = "openapi.json"
+args = ARGV.dup
+until args.empty?
+  case args.shift
+  when "--check" then mode = :check
+  when "--write" then mode = :write
+  when "--openapi"
+    openapi = args.shift
+    if openapi.nil? || openapi.empty?
+      warn "ERROR: --openapi needs a path"
+      exit 2
+    end
+  else
+    warn "usage: #{$PROGRAM_NAME} [--check|--write] [--openapi PATH]"
+    exit 2
+  end
+end
 
 begin
-  exit run(mode)
+  exit run(mode, openapi)
 rescue Failure => e
   warn "ERROR: #{e.message}"
   exit 2

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -95,6 +95,9 @@ BLOCK_KINDS = %w[assertion-types].freeze
 KNOWN_KINDS = (LINE_KINDS + BLOCK_KINDS).freeze
 
 MARKER_RE   = /<!--\s*@([a-z0-9][a-z0-9-]*)(?::(begin|end))?\s*-->/
+# A fenced-code delimiter: 3+ backticks or 3+ tildes, optional leading space,
+# with whatever follows captured as the info string (a close must have none).
+FENCE_RE    = /\A\s*(?<delimiter>`{3,}|~{3,})(?<info>.*)\z/
 ISO_DATE_RE = /\b\d{4}-\d{2}-\d{2}\b/
 TICKED_HEX_RE = /`([0-9a-f]{7,40})`/
 BACKTICKED_RE = /`[^`]*`/
@@ -172,16 +175,34 @@ def scan_file(file)
   prose = []
   lines = File.readlines(File.join(ROOT, file), chomp: true, encoding: UTF8)
   open_block = nil
-  in_fence = false
+  open_fence = nil
 
   lines.each_with_index do |line, index|
     line_no = index + 1
 
-    if line.lstrip.start_with?("```", "~~~")
-      in_fence = !in_fence
+    # Fences are matched, not toggled. A fence closes only on the same
+    # character, at least as long, with nothing after it (CommonMark), so a
+    # ````-fence may quote a ```-fence — which is how you write a Markdown
+    # example about Markdown, and how AGENTS.md documents this convention.
+    #
+    # Toggling got this wrong in the direction that matters. Each inner fence
+    # flipped the flag, so a block containing an odd number of them ended with
+    # the flag still set and every following line silently treated as code —
+    # including an unmarked restatement of the pin, which the gate would then
+    # never see. Fail-open, and invisible: the check would report success.
+    if (fence = line.match(FENCE_RE))
+      delimiter = fence[:delimiter]
+
+      if open_fence.nil?
+        open_fence = [delimiter[0], delimiter.length]
+      elsif delimiter[0] == open_fence[0] &&
+            delimiter.length >= open_fence[1] &&
+            fence[:info].strip.empty?
+        open_fence = nil
+      end
       next
     end
-    next if in_fence
+    next if open_fence
 
     prose << [line_no, line]
 

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -124,6 +124,22 @@ MARKER_RE   = /<!--\s*@([a-z0-9][a-z0-9-]*)(?::(begin|end))?\s*-->/
 # nobody checked. Fences nested in deeply indented list items would need real
 # container tracking; none exist here, and the gate is not a Markdown parser.
 FENCE_RE    = /\A {0,3}(?<delimiter>`{3,}|~{3,})(?<info>.*)\z/
+
+# A fence opening, or nil when the line only looks like one.
+#
+# A backtick fence's info string may not itself contain a backtick, so
+# "```code``` is inline" is a paragraph holding an inline code span, not an
+# opening. Accepting it opened a fence that the line never closes, and the rest
+# of the file went unscanned — the same fail-open shape once more, so it lands
+# on the same side as everything else: not a fence, therefore prose.
+# Tilde fences have no such restriction; their info string may contain anything.
+def fence_at(line)
+  fence = line.match(FENCE_RE)
+  return nil if fence.nil?
+  return nil if fence[:delimiter].start_with?("`") && fence[:info].include?("`")
+
+  fence
+end
 ISO_DATE_RE = /\b\d{4}-\d{2}-\d{2}\b/
 TICKED_HEX_RE = /`([0-9a-f]{7,40})`/
 BACKTICKED_RE = /`[^`]*`/
@@ -216,7 +232,7 @@ def scan_file(file)
     # the flag still set and every following line silently treated as code —
     # including an unmarked restatement of the pin, which the gate would then
     # never see. Fail-open, and invisible: the check would report success.
-    if (fence = line.match(FENCE_RE))
+    if (fence = fence_at(line))
       delimiter = fence[:delimiter]
 
       if open_fence.nil?
@@ -381,8 +397,15 @@ end
 # provenance pin `X`" to a line that already ends a range at `X` and the line
 # now makes two, while a first-match-only scan would still report one and keep
 # the grant satisfied.
+#
+# Case-insensitive, because 2C0DAFBA and 2c0dafba are the same revision and a
+# lowercase-only scan would wave the first one through. Only this scan is
+# relaxed: a MARKED span is still required to spell the SHA in the lowercase
+# form the writer emits, and an uppercase one there is reported as "states no
+# backticked bc3 SHA" — actionable, and it keeps the writer from having to
+# guess which spelling to preserve.
 def current_pin_citations(line, revision)
-  line.scan(/\b#{Regexp.escape(revision[0, 7])}[0-9a-f]{0,33}\b/)
+  line.scan(/\b#{Regexp.escape(revision[0, 7])}[0-9a-f]{0,33}\b/i)
 end
 
 # "lines 103, 107" normally; "line 103 (x2)" when one line carries two claims,

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -1,0 +1,383 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Doc-constant drift gate + writer.
+#
+# Three constants are restated in prose and drift silently from their sources:
+#
+#   @api-version      openapi.json  .info.version
+#   @bc3-pin          spec/api-provenance.json  .bc3.revision / .bc3.date
+#   @assertion-types  conformance/schema.json
+#                       .properties.assertions.items.properties.type.enum
+#
+# Only spans MARKED with an HTML comment are checked. That is deliberate:
+# spec/api-gaps/ legitimately cites ~20 historical bc3 SHAs in narrative
+# ("the pin has since advanced to X", "the A..B range contains..."), and a
+# naive "every SHA must equal the current pin" gate would rewrite settled
+# history into a claim nobody verified. A marker means "this is a claim about
+# the CURRENT value" and nothing else.
+#
+# Marker syntax
+#   Line span:   <!-- @api-version -->  or  <!-- @bc3-pin -->
+#                anywhere on the line; the span is exactly that line.
+#   Block span:  <!-- @assertion-types:begin --> ... <!-- @assertion-types:end -->
+#                the span is the lines strictly between them.
+#
+# Deleting a marker to silence the gate is itself caught: spec/doc-constants.json
+# commits a per-file marker-count FLOOR, and dropping below it fails.
+#
+# Modes
+#   --check (default)  Report drift; exit 1 on any error.
+#   --write            Rewrite marked spans in place from the sources.
+#                      Only the two scalar constants are writable — an
+#                      assertion-type row needs a human-written description,
+#                      so --write never touches @assertion-types and never
+#                      fails on it. `make doc-constants-check` is what catches
+#                      that one; keeping it out of the writer keeps a schema
+#                      edit from breaking every `make generate`.
+#
+# liveAssertions (.properties.liveAssertions...) is deliberately NOT gated:
+# SPEC §19 does not tabulate it, and the live canary is governed by
+# CONTRIBUTING.md. Add a marked table there first if that changes.
+
+require "json"
+
+ROOT = File.expand_path("..", __dir__)
+
+LINE_KINDS  = %w[api-version bc3-pin].freeze
+BLOCK_KINDS = %w[assertion-types].freeze
+KNOWN_KINDS = (LINE_KINDS + BLOCK_KINDS).freeze
+
+MARKER_RE   = /<!--\s*@([a-z0-9][a-z0-9-]*)(?::(begin|end))?\s*-->/
+ISO_DATE_RE = /\b\d{4}-\d{2}-\d{2}\b/
+TICKED_HEX_RE = /`([0-9a-f]{7,40})`/
+BACKTICKED_RE = /`[^`]*`/
+
+class Failure < StandardError; end
+
+def read_json(relative)
+  path = File.join(ROOT, relative)
+  raise Failure, "missing #{relative}" unless File.exist?(path)
+
+  JSON.parse(File.read(path))
+rescue JSON::ParserError => e
+  raise Failure, "#{relative} is not valid JSON: #{e.message}"
+end
+
+def dig!(doc, relative, *path)
+  value = doc.dig(*path)
+  raise Failure, "#{relative}: expected a value at .#{path.join('.')} (schema moved?)" if value.nil?
+
+  value
+end
+
+# Markdown files git actually tracks. `git ls-files` (not Dir.glob) so the
+# gitignored internal docs/ tree and vendored node_modules never get scanned.
+def tracked_markdown
+  out = IO.popen(["git", "-C", ROOT, "ls-files", "-z", "--", "*.md"], &:read)
+  raise Failure, "git ls-files failed (is #{ROOT} a git checkout?)" unless $?.success?
+
+  out.split("\0").reject(&:empty?).sort
+end
+
+Span = Struct.new(:kind, :file, :line_no, :lines, :block, keyword_init: true) do
+  # 1-based inclusive range of content lines, for error messages.
+  def location
+    block ? "#{file}:#{line_no}-#{line_no + lines.length - 1}" : "#{file}:#{line_no}"
+  end
+
+  def text
+    lines.join("\n")
+  end
+end
+
+# Returns [spans, errors]. Line markers yield a one-line span; block markers
+# yield the lines strictly between :begin and :end.
+def scan_file(file)
+  spans = []
+  errors = []
+  lines = File.readlines(File.join(ROOT, file), chomp: true)
+  open_block = nil
+  in_fence = false
+
+  lines.each_with_index do |line, index|
+    line_no = index + 1
+
+    if line.lstrip.start_with?("```", "~~~")
+      in_fence = !in_fence
+      next
+    end
+    next if in_fence
+
+    # A marker inside an inline code span (or a fenced block) is documentation
+    # OF the convention — AGENTS.md explains it — not a use of it. Markdown
+    # renders it as literal text, so it is not an HTML comment at all. Mask
+    # code spans before looking for markers; value extraction still reads the
+    # raw line, where the backticked SHAs live.
+    line.gsub(BACKTICKED_RE, " ").scan(MARKER_RE) do
+      kind = Regexp.last_match(1)
+      form = Regexp.last_match(2)
+
+      unless KNOWN_KINDS.include?(kind)
+        errors << "#{file}:#{line_no}: unknown doc-constant marker @#{kind} " \
+                  "(known: #{KNOWN_KINDS.join(', ')})"
+        next
+      end
+
+      if form.nil?
+        unless LINE_KINDS.include?(kind)
+          errors << "#{file}:#{line_no}: @#{kind} is a block marker; use " \
+                    "<!-- @#{kind}:begin --> / <!-- @#{kind}:end -->"
+          next
+        end
+        spans << Span.new(kind: kind, file: file, line_no: line_no, lines: [line], block: false)
+      else
+        unless BLOCK_KINDS.include?(kind)
+          errors << "#{file}:#{line_no}: @#{kind} is a line marker; drop the :#{form} suffix"
+          next
+        end
+
+        if form == "begin"
+          if open_block
+            errors << "#{file}:#{line_no}: @#{kind}:begin inside an unclosed " \
+                      "@#{open_block[:kind]}:begin from line #{open_block[:line_no]}"
+            next
+          end
+          open_block = { kind: kind, line_no: line_no }
+        else
+          if open_block.nil? || open_block[:kind] != kind
+            errors << "#{file}:#{line_no}: @#{kind}:end without a matching :begin"
+            next
+          end
+          body_start = open_block[:line_no] + 1
+          body = lines[body_start - 1..line_no - 2] || []
+          spans << Span.new(kind: kind, file: file, line_no: body_start, lines: body, block: true)
+          open_block = nil
+        end
+      end
+    end
+  end
+
+  if open_block
+    errors << "#{file}:#{open_block[:line_no]}: @#{open_block[:kind]}:begin never closed"
+  end
+
+  [spans, errors]
+end
+
+# --- per-kind checkers -------------------------------------------------------
+
+def check_api_version(span, api_version)
+  dates = span.text.scan(ISO_DATE_RE)
+  return ["#{span.location}: @api-version span states no YYYY-MM-DD version"] if dates.empty?
+
+  dates.uniq.reject { |d| d == api_version }.map do |bad|
+    "#{span.location}: @api-version says #{bad}, openapi.json .info.version is #{api_version}"
+  end
+end
+
+def check_bc3_pin(span, revision, date)
+  errors = []
+  text = span.text
+
+  hexes = text.scan(TICKED_HEX_RE).flatten
+  if hexes.empty?
+    errors << "#{span.location}: @bc3-pin span states no backticked bc3 SHA"
+  else
+    hexes.uniq.reject { |h| revision.start_with?(h) }.each do |bad|
+      errors << "#{span.location}: @bc3-pin says `#{bad}`, spec/api-provenance.json " \
+                ".bc3.revision is #{revision}"
+    end
+  end
+
+  # A SHA that lost its backticks is invisible to the writer's rewrite, so it
+  # would sit stale forever while the gate reported green. Reject it outright.
+  text.gsub(BACKTICKED_RE, " ").scan(/\b[0-9a-f]{7,40}\b/).uniq.each do |bare|
+    errors << "#{span.location}: bare SHA #{bare} in a @bc3-pin span — backtick it " \
+              "so `make sync-api-version` can rewrite it"
+  end
+
+  text.scan(ISO_DATE_RE).uniq.reject { |d| d == date }.each do |bad|
+    errors << "#{span.location}: @bc3-pin says #{bad}, spec/api-provenance.json " \
+              ".bc3.date is #{date}"
+  end
+
+  errors
+end
+
+def check_assertion_types(span, schema_types)
+  documented = span.lines.filter_map do |line|
+    next unless line.lstrip.start_with?("|")
+
+    cell = line.split("|")[1]
+    next if cell.nil?
+
+    match = cell.strip.match(/\A`([A-Za-z][A-Za-z0-9_]*)`\z/)
+    match && match[1]
+  end
+
+  errors = []
+  duplicated = documented.tally.select { |_, n| n > 1 }.keys
+  duplicated.each { |name| errors << "#{span.location}: `#{name}` is tabulated twice" }
+
+  missing = schema_types - documented
+  extra   = documented - schema_types
+
+  unless missing.empty?
+    errors << "#{span.location}: conformance/schema.json defines #{schema_types.length} " \
+              "assertion types, the table documents #{documented.uniq.length}; missing: " \
+              "#{missing.map { |n| "`#{n}`" }.join(', ')}"
+  end
+  unless extra.empty?
+    errors << "#{span.location}: table documents assertion types absent from " \
+              "conformance/schema.json: #{extra.map { |n| "`#{n}`" }.join(', ')}"
+  end
+
+  errors
+end
+
+# --- writer ------------------------------------------------------------------
+
+def rewrite_line(kind, line, api_version:, revision:, date:)
+  case kind
+  when "api-version"
+    line.gsub(ISO_DATE_RE, api_version)
+  when "bc3-pin"
+    # Preserve the abbreviation length the prose already chose.
+    line
+      .gsub(TICKED_HEX_RE) { "`#{revision[0, Regexp.last_match(1).length]}`" }
+      .gsub(ISO_DATE_RE, date)
+  else
+    line
+  end
+end
+
+# --- main --------------------------------------------------------------------
+
+def run(mode)
+  api_version = dig!(read_json("openapi.json"), "openapi.json", "info", "version")
+
+  provenance = read_json("spec/api-provenance.json")
+  revision = dig!(provenance, "spec/api-provenance.json", "bc3", "revision")
+  date     = dig!(provenance, "spec/api-provenance.json", "bc3", "date")
+
+  unless revision.match?(/\A[0-9a-f]{40}\z/)
+    raise Failure, "spec/api-provenance.json .bc3.revision is not a full 40-char SHA: #{revision}"
+  end
+
+  config = read_json("spec/doc-constants.json")
+  floors = dig!(config, "spec/doc-constants.json", "markerFloors")
+
+  errors = []
+  spans = []
+  tracked_markdown.each do |file|
+    file_spans, file_errors = scan_file(file)
+    spans.concat(file_spans)
+    errors.concat(file_errors)
+  end
+
+  # Marker-count floor: deleting a marked claim to silence the gate fails here.
+  counts = Hash.new(0)
+  spans.each { |s| counts[[s.kind, s.file]] += 1 }
+  floors.each do |kind, per_file|
+    unless KNOWN_KINDS.include?(kind)
+      errors << "spec/doc-constants.json: floor declared for unknown marker @#{kind}"
+      next
+    end
+    per_file.each do |file, floor|
+      found = counts[[kind, file]]
+      next if found >= floor
+
+      errors << "#{file}: marker floor violated — spec/doc-constants.json requires at least " \
+                "#{floor} @#{kind} marker(s), found #{found}. A current-value claim was deleted " \
+                "or unmarked; if it genuinely moved, move the floor in the same commit."
+    end
+  end
+
+  if mode == :write
+    written = []
+    spans.group_by(&:file).each do |file, file_spans|
+      writable = file_spans.reject(&:block).select { |s| LINE_KINDS.include?(s.kind) }
+      next if writable.empty?
+
+      path = File.join(ROOT, file)
+      original = File.read(path)
+      lines = original.lines
+      writable.each do |span|
+        index = span.line_no - 1
+        body = lines[index].chomp("\n")
+        newline = lines[index].end_with?("\n") ? "\n" : ""
+        lines[index] = rewrite_line(span.kind, body,
+                                    api_version: api_version, revision: revision, date: date) + newline
+      end
+      updated = lines.join
+      next if updated == original
+
+      File.write(path, updated)
+      written << file
+    end
+
+    if written.empty?
+      puts "Doc constants already in sync (#{spans.count { |s| LINE_KINDS.include?(s.kind) }} marked spans)."
+    else
+      written.each { |file| puts "Rewrote marked doc constants in #{file}" }
+    end
+
+    # Structural marker problems are still fatal in --write: they mean the
+    # writer could not see a span it was supposed to maintain.
+    unless errors.empty?
+      warn "ERROR: doc-constant markers are malformed; nothing could be synced for these:"
+      errors.each { |e| warn "  #{e}" }
+      return 1
+    end
+    return 0
+  end
+
+  schema = read_json("conformance/schema.json")
+  schema_types = dig!(schema, "conformance/schema.json",
+                      "properties", "assertions", "items", "properties", "type", "enum")
+
+  spans.each do |span|
+    errors.concat(
+      case span.kind
+      when "api-version"     then check_api_version(span, api_version)
+      when "bc3-pin"         then check_bc3_pin(span, revision, date)
+      when "assertion-types" then check_assertion_types(span, schema_types)
+      else []
+      end
+    )
+  end
+
+  if errors.empty?
+    puts "Doc constants match their sources (#{spans.length} marked spans across " \
+         "#{spans.map(&:file).uniq.length} files)."
+    puts "  api-version      #{api_version}"
+    puts "  bc3-pin          #{revision[0, 8]} (#{date})"
+    puts "  assertion-types  #{schema_types.length}"
+    0
+  else
+    warn "ERROR: documentation constants have drifted from their sources."
+    errors.each { |e| warn "  #{e}" }
+    warn ""
+    warn "  Scalar constants: run `make sync-api-version` to rewrite marked spans."
+    warn "  Assertion types:  edit SPEC.md §19's marked table by hand — a new row " \
+         "needs a description only a human can write."
+    1
+  end
+end
+
+mode = if ARGV.empty? || ARGV == ["--check"]
+         :check
+       elsif ARGV == ["--write"]
+         :write
+       else
+         warn "usage: #{$PROGRAM_NAME} [--check|--write]"
+         exit 2
+       end
+
+begin
+  exit run(mode)
+rescue Failure => e
+  warn "ERROR: #{e.message}"
+  exit 2
+end

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -328,8 +328,25 @@ end
 #
 # Scanning the raw line subsumes both. A marked span's line never reaches here
 # (scan_file drops it from prose), and neither does anything fenced.
-def cites_current_pin?(line, revision)
-  line[/\b#{Regexp.escape(revision[0, 7])}[0-9a-f]{0,33}\b/]
+#
+# It returns EVERY occurrence, not the first. The count that bounds a grant is
+# a count of claims, and claims are not one per line: append "…, which is the
+# provenance pin `X`" to a line that already ends a range at `X` and the line
+# now makes two, while a first-match-only scan would still report one and keep
+# the grant satisfied.
+def current_pin_citations(line, revision)
+  line.scan(/\b#{Regexp.escape(revision[0, 7])}[0-9a-f]{0,33}\b/)
+end
+
+# "lines 103, 107" normally; "line 103 (x2)" when one line carries two claims,
+# because a bare repeated line number reads as a bug in the message rather than
+# the thing it is reporting.
+def citation_locations(hits)
+  tallied = hits.map(&:first).tally
+  label = tallied.length == 1 ? "line" : "lines"
+  listed = tallied.map { |line_no, n| n > 1 ? "#{line_no} (x#{n})" : line_no.to_s }
+
+  "#{label} #{listed.join(', ')}"
 end
 
 # A grant is bounded by a COUNT, for the same reason markerFloors became
@@ -341,29 +358,28 @@ end
 # count says "this file carries exactly N as-of citations of today's pin, all
 # reviewed"; the N+1th fails until someone looks at it and re-states the number.
 def check_unmarked_pin(file, prose, revision, allowed)
-  hits = prose.filter_map do |line_no, line|
-    hit = cites_current_pin?(line, revision)
-    hit && [line_no, hit]
+  hits = prose.flat_map do |line_no, line|
+    current_pin_citations(line, revision).map { |hit| [line_no, hit] }
   end
 
   grant = allowed[file]
 
   if grant.nil?
-    hits.map do |line_no, hit|
+    hits.map { |line_no, hit|
       "#{file}:#{line_no}: `#{hit}` is the current provenance pin, restated outside a " \
         "@bc3-pin span. Either mark the line <!-- @bc3-pin --> (and name the sync date) so " \
         "`make sync-api-version` keeps it current, or bind the SHA to what makes it permanently " \
         "true — the PR that shipped it, the verification it backs — and record the file in " \
         "spec/doc-constants.json .unmarkedPinCitations with that reason and a count."
-    end
+    }.uniq
   elsif hits.length == grant["count"]
     []
   elsif hits.length > grant["count"]
     ["#{file}: spec/doc-constants.json grants #{grant['count']} unmarked citation(s) of the " \
-     "current pin, found #{hits.length} (lines #{hits.map(&:first).join(', ')}). The grant " \
-     "covers reviewed as-of facts, not whatever the file grows next — read the new one, " \
-     "confirm it binds the SHA to a fixed observation rather than claiming today's pin, and " \
-     "raise the count in the same commit."]
+     "current pin, found #{hits.length} (#{citation_locations(hits)}). The grant covers " \
+     "reviewed as-of facts, not whatever the file grows next — read the new one, confirm it " \
+     "binds the SHA to a fixed observation rather than claiming today's pin, and raise the " \
+     "count in the same commit."]
   else
     # Fewer than granted: the entry has outlived what it described. Left alone
     # it is a standing permission nobody reviewed, pre-authorising the next

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -33,6 +33,16 @@
 # the pin, or that stopped being it before this gate existed, is out of reach
 # of any cheap check and is governed by the convention in AGENTS.md instead.
 #
+# WHICH WAY TO BE WRONG. Deciding what counts as prose means approximating
+# Markdown, and every approximation is wrong somewhere. Resolve every such
+# ambiguity toward treating a line AS PROSE. Over-scanning costs a false alarm:
+# loud, in front of the author, disproved in a minute. Under-scanning costs a
+# claim nobody ever looked at, reported as success — which is the exact failure
+# this gate exists to prevent, now wearing the gate's own green tick. Three
+# separate review findings here were all the same bug in that light: a line the
+# scanner could not see was a line it silently vouched for. This is a drift
+# gate, not a Markdown parser; when the two disagree, prefer the false alarm.
+#
 # Marker syntax
 #   Line span:   <!-- @api-version -->  or  <!-- @bc3-pin -->
 #                anywhere on the line; the span is exactly that line.

--- a/scripts/test-doc-constants.rb
+++ b/scripts/test-doc-constants.rb
@@ -349,6 +349,69 @@ out, status = gate lambda { |f|
 }
 expect_pass(failures, "fenced pin restatement is not prose", out, status)
 
+# ...but the fence must CLOSE. A ````-fence may quote a ```-fence, which is how
+# you write a Markdown example about Markdown. Toggling on every fence line left
+# an odd number of inner fences flipping the flag on for good, so everything
+# after the block read as code — a restatement there was never even looked at,
+# and the gate reported success. Fail-open, so this case must FAIL.
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = <<~MD
+    # An entry
+
+    ````
+    ```
+    ````
+
+    The provenance pin is `#{SHORT}`.
+  MD
+}
+expect_fail(failures, "prose after a nested fence is still prose", out, status,
+            "is the current provenance pin, restated outside a @bc3-pin span")
+
+# The same, one delimiter swapped: a ``` line inside a ~~~ block is content,
+# not a close, because closing requires the same character.
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = <<~MD
+    # An entry
+
+    ~~~
+    ```
+    ~~~
+
+    The provenance pin is `#{SHORT}`.
+  MD
+}
+expect_fail(failures, "a mismatched delimiter does not close a fence", out, status,
+            "is the current provenance pin, restated outside a @bc3-pin span")
+
+# And the inner fence really is inside: a restatement between ```` and ```` is
+# code even though a bare ``` sits between them.
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = <<~MD
+    # An entry
+
+    ````
+    ```
+    The provenance pin is `#{SHORT}`.
+    ```
+    ````
+  MD
+}
+expect_pass(failures, "a nested fence keeps its contents fenced", out, status)
+
+# An info string closes nothing — ```ruby inside a ``` block is content.
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = <<~MD
+    # An entry
+
+    ```
+    ```ruby
+    The provenance pin is `#{SHORT}`.
+    ```
+  MD
+}
+expect_pass(failures, "a fence with an info string does not close", out, status)
+
 # --- @assertion-types ----------------------------------------------------------
 
 out, status = gate ->(f) { f["SPEC.md"] = f["SPEC.md"].sub("| `jsonPath` | a JSON path |\n", "") }

--- a/scripts/test-doc-constants.rb
+++ b/scripts/test-doc-constants.rb
@@ -399,6 +399,40 @@ out, status = gate lambda { |f|
 }
 expect_pass(failures, "a nested fence keeps its contents fenced", out, status)
 
+# Four spaces is an INDENTED code block, not a fence opener. Showing a fence by
+# indenting it is common, the quoted example rarely has a matching close, and a
+# permissive indent took it as an opening that then swallowed the rest of the
+# file — the fail-open hole again, through the indentation door. So this must
+# FAIL: the restatement below is still prose.
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = <<~MD
+    # An entry
+
+    To open a code block, write:
+
+        ```ruby
+
+    The provenance pin is `#{SHORT}`.
+  MD
+}
+expect_fail(failures, "a 4-space-indented fence does not open one", out, status,
+            "is the current provenance pin, restated outside a @bc3-pin span")
+
+# Three spaces is still a fence (CONTRIBUTING.md indents fences inside numbered
+# list items exactly this way), so its contents stay code.
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = <<~MD
+    # An entry
+
+    1. Step one:
+
+       ```
+       The provenance pin is `#{SHORT}`.
+       ```
+  MD
+}
+expect_pass(failures, "a 3-space-indented fence still fences", out, status)
+
 # An info string closes nothing — ```ruby inside a ``` block is content.
 out, status = gate lambda { |f|
   f["spec/api-gaps/entry.md"] = <<~MD

--- a/scripts/test-doc-constants.rb
+++ b/scripts/test-doc-constants.rb
@@ -280,12 +280,43 @@ out, status = gate lambda { |f|
 }
 expect_pass(failures, "granted pin citation passes", out, status)
 
+# A grant covers as-of FACTS, never the class-A grammar. Swapping one granted
+# citation for "the provenance pin is X" leaves the count untouched, so the
+# count alone would wave a current-value claim through under a reason that does
+# not describe it.
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = "# An entry\n\nThe provenance pin is `#{SHORT}`.\n"
+  grant.call(f, "count" => 1, "reason" => "as-of fact about SDK #528")
+}
+expect_fail(failures, "a grant does not cover a class-A claim", out, status,
+            "names the current pin in the grammar of a current-value claim")
+
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = "# An entry\n\nVerified at the pinned #{SHORT} today.\n"
+  grant.call(f, "count" => 1, "reason" => "as-of fact about SDK #528")
+}
+expect_fail(failures, "a grant does not cover \"at the pinned X\"", out, status,
+            "names the current pin in the grammar of a current-value claim")
+
+# The grammar check only fires on lines that actually name today's pin, so
+# an as-of citation in a granted file is still fine.
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = "# An entry\n\nThe pin is `dffa7e11b3` in that old note.\n"
+  grant.call(f, "count" => 1, "reason" => "as-of fact about SDK #528")
+  cfg = JSON.parse(f["spec/doc-constants.json"])
+  cfg["unmarkedPinCitations"] = {}
+  f["spec/doc-constants.json"] = JSON.pretty_generate(cfg)
+}
+expect_pass(failures, "class-A grammar about a HISTORICAL sha is not flagged", out, status)
+
 # The grant is bounded. A SECOND unmarked citation appearing in an already-
 # granted file is the hole an unbounded file grant leaves open, and it is
 # widest in exactly the files that need granting.
+# Both sentences are as-of facts, so only the COUNT is under test here — the
+# class-A grammar check below is a separate floor and must not be what fires.
 out, status = gate lambda { |f|
   f["spec/api-gaps/entry.md"] =
-    "# An entry\n\nSDK #528 repinned to `#{SHORT}`.\n\nThe provenance pin is `#{SHORT}`.\n"
+    "# An entry\n\nSDK #528 repinned to `#{SHORT}`.\n\nSDK #530 verified against `#{SHORT}`.\n"
   grant.call(f, "count" => 1, "reason" => "as-of fact about SDK #528")
 }
 expect_fail(failures, "granted file grows an extra citation", out, status,
@@ -296,7 +327,7 @@ expect_fail(failures, "granted file grows an extra citation", out, status,
 # count still read 1 here and the new claim sailed through.
 out, status = gate lambda { |f|
   f["spec/api-gaps/entry.md"] =
-    "# An entry\n\nSDK #528 repinned to `#{SHORT}`, and the provenance pin is `#{SHORT}`.\n"
+    "# An entry\n\nSDK #528 repinned to `#{SHORT}`, and #530 verified against `#{SHORT}`.\n"
   grant.call(f, "count" => 1, "reason" => "as-of fact about SDK #528")
 }
 expect_fail(failures, "two citations on one line both count", out, status,

--- a/scripts/test-doc-constants.rb
+++ b/scripts/test-doc-constants.rb
@@ -433,6 +433,53 @@ out, status = gate lambda { |f|
 }
 expect_pass(failures, "a 3-space-indented fence still fences", out, status)
 
+# A backtick fence's info string may not contain a backtick, so "```code``` is
+# inline" is a paragraph with an inline code span, not an opening. Taking it as
+# one opened a fence the line never closes and the rest of the file went
+# unscanned — so this must FAIL.
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = <<~MD
+    # An entry
+
+    ```code``` is how you write it inline.
+
+    The provenance pin is `#{SHORT}`.
+  MD
+}
+expect_fail(failures, "a backtick in a backtick fence's info string means no fence", out, status,
+            "is the current provenance pin, restated outside a @bc3-pin span")
+
+# A normal info string still opens a fence, so its contents stay code.
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = <<~MD
+    # An entry
+
+    ```ruby
+    The provenance pin is `#{SHORT}`.
+    ```
+  MD
+}
+expect_pass(failures, "a plain info string still opens a fence", out, status)
+
+# Tilde fences carry no such restriction — backticks in their info are fine.
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = <<~MD
+    # An entry
+
+    ~~~`weird`
+    The provenance pin is `#{SHORT}`.
+    ~~~
+  MD
+}
+expect_pass(failures, "backticks in a tilde fence's info are allowed", out, status)
+
+# Uppercase hex is the same revision. A lowercase-only scan waved it through.
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = "# An entry\n\nThe provenance pin is #{SHORT.upcase}.\n"
+}
+expect_fail(failures, "an uppercase spelling of the pin still counts", out, status,
+            "is the current provenance pin, restated outside a @bc3-pin span")
+
 # An info string closes nothing — ```ruby inside a ``` block is content.
 out, status = gate lambda { |f|
   f["spec/api-gaps/entry.md"] = <<~MD

--- a/scripts/test-doc-constants.rb
+++ b/scripts/test-doc-constants.rb
@@ -251,6 +251,23 @@ out, status = gate lambda { |f|
 expect_fail(failures, "unmarked BARE current-pin restatement", out, status,
             "is the current provenance pin, restated outside a @bc3-pin span")
 
+# ...and neither must a COMPOUND code span. `A..B` is not a lone SHA, so the
+# backticked pattern skips it; blanking code spans before the bare scan used to
+# hide it from that pass too, which put the blind spot precisely on range
+# notation — the most common way these files name a revision.
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = "# An entry\n\nThe `dffa7e11b3..#{SHORT}` range is current.\n"
+}
+expect_fail(failures, "current pin inside a compound code span", out, status,
+            "is the current provenance pin, restated outside a @bc3-pin span")
+
+# The other endpoint of that range is NOT the current pin and must stay silent —
+# reading inside compound spans must not turn settled history into a finding.
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = "# An entry\n\nThe `dffa7e11b3..e83b2733` range was triaged.\n"
+}
+expect_pass(failures, "historical range is left alone", out, status)
+
 grant = lambda { |f, entry|
   cfg = JSON.parse(f["spec/doc-constants.json"])
   cfg["unmarkedPinCitations"] = { "spec/api-gaps/entry.md" => entry }

--- a/scripts/test-doc-constants.rb
+++ b/scripts/test-doc-constants.rb
@@ -1,0 +1,464 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Negative-case self-test for scripts/sync-doc-constants.rb.
+#
+# The gate's own `make check` run only ever exercises the VALID repo, which
+# proves it can say yes and nothing else. This test crafts each failure mode
+# the gate claims to catch and asserts it rejects that input (non-zero exit +
+# an expected message fragment), driving the gate through its
+# DOC_CONSTANTS_ROOT override against a tiny throwaway git repo. It also
+# confirms the real repo still passes (positive control).
+#
+# Same shape and reason as scripts/test-check-fixture-coverage.rb.
+#
+# Run directly (`ruby scripts/test-doc-constants.rb`) or via
+# `make doc-constants-check` (which runs it after the live check).
+
+require "json"
+require "tmpdir"
+require "fileutils"
+require "open3"
+
+ROOT = File.expand_path("..", __dir__)
+GATE = File.join(__dir__, "sync-doc-constants.rb")
+
+REVISION = "d0edc1283b231c58b7c88b014df5f8d231b1f7c8"
+SHORT    = REVISION[0, 8]
+PIN_DATE = "2026-07-31"
+API_VER  = "2026-08-15"
+
+failures = []
+
+def expect_pass(failures, label, out, status)
+  return if status.success?
+
+  failures << "#{label}: expected PASS, gate exited #{status.exitstatus}:\n#{out}"
+end
+
+def expect_fail(failures, label, out, status, fragment)
+  if status.success?
+    failures << "#{label}: expected FAILURE, gate exited 0:\n#{out}"
+  elsif !out.include?(fragment)
+    failures << "#{label}: failed as expected but message missing #{fragment.inspect}:\n#{out}"
+  end
+end
+
+def expect_absent(failures, label, out, fragment)
+  return unless out.include?(fragment)
+
+  failures << "#{label}: output should not mention #{fragment.inspect}:\n#{out}"
+end
+
+# --- the crafted repo ----------------------------------------------------------
+#
+# Small enough to read in one screen, and every marked value is deliberately
+# correct so that a test can make exactly one thing wrong. Files are written,
+# `git init`ed and `git add`ed, because the gate discovers Markdown through
+# `git ls-files` (so the gitignored internal docs/ tree is never scanned) and
+# would see an empty repo otherwise.
+
+# The in-repo spec carries a version NOTHING in the crafted prose matches.
+# The real spec is handed to the gate as --openapi from outside the repo, so
+# every case in this file only passes if that argument is honored — a gate that
+# quietly fell back to ./openapi.json (the bug fixed in 23d39eec2) fails the
+# whole suite rather than one case that could rot into a tautology.
+DECOY_API_VER = "2000-01-01"
+
+def default_files
+  {
+    "openapi.json" => JSON.pretty_generate("info" => { "version" => DECOY_API_VER }),
+    "conformance/schema.json" => JSON.pretty_generate(
+      "properties" => { "assertions" => { "items" => { "properties" => {
+        "type" => { "enum" => %w[status header jsonPath] },
+      } } } }
+    ),
+    "spec/api-provenance.json" => JSON.pretty_generate(
+      "bc3" => { "revision" => REVISION, "date" => PIN_DATE }
+    ),
+    "spec/doc-constants.json" => JSON.pretty_generate(
+      "markerFloors" => {
+        "api-version" => { "SPEC.md" => 1 },
+        "bc3-pin" => { "COORDINATION.md" => 1 },
+        "assertion-types" => { "SPEC.md" => 1 },
+      }
+    ),
+    "COORDINATION.md" => <<~MD,
+      # Coordination
+
+      The pin is `#{SHORT}` as of the #{PIN_DATE} sync. <!-- @bc3-pin -->
+    MD
+    "SPEC.md" => <<~MD,
+      # Spec
+
+      API_VERSION is `#{API_VER}`. <!-- @api-version -->
+
+      <!-- @assertion-types:begin -->
+      | Type | Meaning |
+      |------|---------|
+      | `status` | HTTP status |
+      | `header` | a header |
+      | `jsonPath` | a JSON path |
+      <!-- @assertion-types:end -->
+    MD
+    "spec/api-gaps/entry.md" => <<~MD,
+      # An entry
+
+      Verified against `abc1234` — the pin when this was written.
+    MD
+  }
+end
+
+# Materialise the crafted repo (after `mutate` has had a chance to break one
+# thing), run the gate in `mode`, and hand the result to `inspect_result` while
+# the tmp dir is still alive. Returns [combined_output, Process::Status].
+#
+# Layout: base/repo is the git checkout the gate scans; base/openapi-source.json
+# is the --openapi argument, deliberately OUTSIDE the checkout.
+def run_gate(mode: "--check", mutate: nil, inspect_result: nil, openapi_version: API_VER)
+  base = Dir.mktmpdir("doc-constants-test")
+  begin
+    dir = File.join(base, "repo")
+    FileUtils.mkdir_p(dir)
+
+    source = File.join(base, "openapi-source.json")
+    File.write(source, JSON.pretty_generate("info" => { "version" => openapi_version }),
+               encoding: "UTF-8")
+
+    files = default_files
+    mutate&.call(files)
+
+    files.each do |rel, body|
+      path = File.join(dir, rel)
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, body, encoding: "UTF-8")
+    end
+
+    # The gate discovers Markdown through `git ls-files`, so an un-added tree
+    # would look empty and every case would vacuously "pass".
+    Open3.capture2e("git", "-C", dir, "init", "-q")
+    Open3.capture2e("git", "-C", dir, "add", "-A")
+
+    out, status = Open3.capture2e({ "DOC_CONSTANTS_ROOT" => dir }, "ruby", GATE, mode,
+                                  "--openapi", source, chdir: dir)
+    inspect_result&.call(out, status, dir)
+    [out, status]
+  ensure
+    # git leaves the odd lock/objects file behind on macOS and mktmpdir's own
+    # cleanup raises ENOTEMPTY when it loses that race. A leaked tmp dir is a
+    # far better outcome than a gate that flakes inside `make check`.
+    begin
+      FileUtils.remove_entry(base)
+    rescue SystemCallError
+      begin
+        FileUtils.remove_entry(base)
+      rescue SystemCallError
+        nil
+      end
+    end
+  end
+end
+
+def gate(mutate = nil, openapi_version: API_VER)
+  run_gate(mutate: mutate, openapi_version: openapi_version)
+end
+
+def writer(mutate = nil, &inspect_result)
+  run_gate(mode: "--write", mutate: mutate, inspect_result: inspect_result)
+end
+
+def read_in(dir, rel)
+  File.read(File.join(dir, rel), encoding: "UTF-8")
+end
+
+# --- positive controls ---------------------------------------------------------
+
+out, status = Open3.capture2e("ruby", GATE, "--check", chdir: ROOT)
+expect_pass(failures, "real repo passes", out, status)
+
+out, status = gate
+expect_pass(failures, "crafted valid repo passes", out, status)
+
+# --- @api-version --------------------------------------------------------------
+
+out, status = gate ->(f) { f["SPEC.md"] = f["SPEC.md"].sub(API_VER, "2020-01-01") }
+expect_fail(failures, "api-version drifted", out, status,
+            "@api-version says 2020-01-01")
+
+out, status = gate ->(f) { f["SPEC.md"] = f["SPEC.md"].sub("is `#{API_VER}`", "is unknown") }
+expect_fail(failures, "api-version span has no date", out, status,
+            "states no YYYY-MM-DD version")
+
+# --openapi is the source of record, positively: move the PASSED file's version
+# and the prose that used to match must now be reported as drifted. Paired with
+# the decoy ./openapi.json every case already runs against, this pins the
+# forwarding in both directions.
+out, status = gate(nil, openapi_version: "2031-03-03")
+expect_fail(failures, "--openapi is the source of record", out, status,
+            "@api-version says #{API_VER}")
+expect_absent(failures, "--openapi is the source of record", out, DECOY_API_VER)
+
+# --- @bc3-pin ------------------------------------------------------------------
+
+out, status = gate ->(f) { f["COORDINATION.md"] = f["COORDINATION.md"].sub(SHORT, "beefbeef") }
+expect_fail(failures, "pin SHA drifted", out, status, "@bc3-pin says `beefbeef`")
+
+out, status = gate ->(f) { f["COORDINATION.md"] = f["COORDINATION.md"].sub("`#{SHORT}` ", "") }
+expect_fail(failures, "pin span has no SHA", out, status, "states no backticked bc3 SHA")
+
+out, status = gate ->(f) { f["COORDINATION.md"] = f["COORDINATION.md"].sub(" as of the #{PIN_DATE} sync", "") }
+expect_fail(failures, "pin span has no date", out, status, "states no YYYY-MM-DD sync date")
+
+out, status = gate ->(f) { f["COORDINATION.md"] = f["COORDINATION.md"].sub(PIN_DATE, "2001-01-01") }
+expect_fail(failures, "pin date drifted", out, status, "@bc3-pin says 2001-01-01")
+
+out, status = gate ->(f) { f["COORDINATION.md"] = f["COORDINATION.md"].sub("`#{SHORT}`", SHORT) }
+expect_fail(failures, "pin SHA lost its backticks", out, status, "bare SHA #{SHORT}")
+
+# The bare-SHA scan must not fire on a long decimal run — an issue or recording
+# id in a pin sentence is not a SHA. Regression test for the 7-digit false
+# positive in the first cut of this gate.
+out, status = gate lambda { |f|
+  f["COORDINATION.md"] = f["COORDINATION.md"].sub("sync.", "sync; see recording 1069479523.")
+}
+expect_pass(failures, "decimal id in a pin span is not a bare SHA", out, status)
+expect_absent(failures, "decimal id in a pin span is not a bare SHA", out, "bare SHA")
+
+# ...but an all-decimal abbreviation of the ACTUAL pin still has to be caught,
+# which is the case the letter requirement alone would miss.
+DECIMAL_REVISION = "1234567890123456789012345678901234567890"
+out, status = gate lambda { |f|
+  f["spec/api-provenance.json"] =
+    JSON.pretty_generate("bc3" => { "revision" => DECIMAL_REVISION, "date" => PIN_DATE })
+  f["COORDINATION.md"] =
+    "# Coordination\n\nThe pin is #{DECIMAL_REVISION[0, 8]} as of the #{PIN_DATE} sync. <!-- @bc3-pin -->\n"
+}
+expect_fail(failures, "all-decimal pin abbreviation is still a bare SHA", out, status,
+            "bare SHA #{DECIMAL_REVISION[0, 8]}")
+
+# --- unmarked restatement of the CURRENT pin -----------------------------------
+
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = "# An entry\n\nThe provenance pin is `#{SHORT}`.\n"
+}
+expect_fail(failures, "unmarked current-pin restatement", out, status,
+            "is the current provenance pin, restated outside a @bc3-pin span")
+
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = "# An entry\n\nSDK #528 repinned to `#{SHORT}`.\n"
+  cfg = JSON.parse(f["spec/doc-constants.json"])
+  cfg["unmarkedPinCitations"] = { "spec/api-gaps/entry.md" => "as-of fact about SDK #528" }
+  f["spec/doc-constants.json"] = JSON.pretty_generate(cfg)
+}
+expect_pass(failures, "allowlisted pin citation passes", out, status)
+
+# An allowlist entry that no longer describes anything is a standing permission
+# nobody reviewed — the file-level grant would silently cover a future unmarked
+# restatement in the same file.
+out, status = gate lambda { |f|
+  cfg = JSON.parse(f["spec/doc-constants.json"])
+  cfg["unmarkedPinCitations"] = { "spec/api-gaps/entry.md" => "stale grant" }
+  f["spec/doc-constants.json"] = JSON.pretty_generate(cfg)
+}
+expect_fail(failures, "dead pin-citation exemption", out, status,
+            "no longer names the current pin outside a marked span")
+
+# A historical SHA must NOT trip it: that is the whole point of the marker
+# convention, and a gate that flagged settled triage would be unusable.
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = "# An entry\n\nVerified at `dffa7e11b3`, the pin at the time.\n"
+}
+expect_pass(failures, "historical SHA in prose is left alone", out, status)
+
+# Fenced code is not prose. A pin sentence quoted in an example must not fire.
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = "# An entry\n\n```\nThe provenance pin is `#{SHORT}`.\n```\n"
+}
+expect_pass(failures, "fenced pin restatement is not prose", out, status)
+
+# --- @assertion-types ----------------------------------------------------------
+
+out, status = gate ->(f) { f["SPEC.md"] = f["SPEC.md"].sub("| `jsonPath` | a JSON path |\n", "") }
+expect_fail(failures, "assertion type missing from table", out, status, "missing: `jsonPath`")
+
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub("<!-- @assertion-types:end -->",
+                                  "| `invented` | nope |\n<!-- @assertion-types:end -->")
+}
+expect_fail(failures, "table documents an absent type", out, status,
+            "absent from conformance/schema.json: `invented`")
+
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub("<!-- @assertion-types:end -->",
+                                  "| `status` | again |\n<!-- @assertion-types:end -->")
+}
+expect_fail(failures, "assertion type tabulated twice", out, status, "is tabulated twice")
+
+# --- marker structure ----------------------------------------------------------
+
+out, status = gate ->(f) { f["SPEC.md"] += "\nSomething. <!-- @nope -->\n" }
+expect_fail(failures, "unknown marker kind", out, status, "unknown doc-constant marker @nope")
+
+out, status = gate ->(f) { f["SPEC.md"] += "\nSomething. <!-- @assertion-types -->\n" }
+expect_fail(failures, "block marker used as a line marker", out, status, "is a block marker")
+
+out, status = gate ->(f) { f["SPEC.md"] += "\nSomething. <!-- @bc3-pin:begin -->\n" }
+expect_fail(failures, "line marker given a :begin", out, status, "is a line marker; drop the :begin")
+
+out, status = gate ->(f) { f["SPEC.md"] = f["SPEC.md"].sub("<!-- @assertion-types:end -->", "") }
+expect_fail(failures, "unclosed block", out, status, ":begin never closed")
+
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub("<!-- @assertion-types:begin -->",
+                                  "<!-- @assertion-types:begin -->\n<!-- @assertion-types:begin -->")
+}
+expect_fail(failures, "nested block begin", out, status, "inside an unclosed")
+
+out, status = gate ->(f) { f["SPEC.md"] += "\n<!-- @assertion-types:end -->\n" }
+expect_fail(failures, ":end without :begin", out, status, ":end without a matching :begin")
+
+# --- marker-count floor --------------------------------------------------------
+
+out, status = gate ->(f) { f["COORDINATION.md"] = f["COORDINATION.md"].sub(" <!-- @bc3-pin -->", "") }
+expect_fail(failures, "marker deleted below the floor", out, status,
+            "COORDINATION.md: marker floor violated")
+
+# A marker moved to another file still leaves the original below its floor —
+# the floor is per-file precisely so this is not a silent relocation.
+out, status = gate lambda { |f|
+  f["COORDINATION.md"] = f["COORDINATION.md"].sub(" <!-- @bc3-pin -->", "")
+  f["spec/api-gaps/entry.md"] += "\nThe pin is `#{SHORT}` as of the #{PIN_DATE} sync. <!-- @bc3-pin -->\n"
+}
+expect_fail(failures, "marker relocated without moving the floor", out, status,
+            "marker floor violated")
+
+# Backticked markers are documentation OF the convention, not uses of it — they
+# must not count toward a floor.
+out, status = gate lambda { |f|
+  f["COORDINATION.md"] = "# Coordination\n\nMark the line with `<!-- @bc3-pin -->` to gate it.\n"
+}
+expect_fail(failures, "backticked marker does not satisfy the floor", out, status,
+            "marker floor violated")
+
+out, status = gate lambda { |f|
+  cfg = JSON.parse(f["spec/doc-constants.json"])
+  cfg["markerFloors"]["not-a-kind"] = { "SPEC.md" => 1 }
+  f["spec/doc-constants.json"] = JSON.pretty_generate(cfg)
+}
+expect_fail(failures, "floor declared for an unknown kind", out, status,
+            "floor declared for unknown marker @not-a-kind")
+
+# --- source-of-truth failures --------------------------------------------------
+
+out, status = gate ->(f) { f.delete("spec/api-provenance.json") }
+expect_fail(failures, "missing provenance", out, status, "missing spec/api-provenance.json")
+
+out, status = gate ->(f) { f["spec/api-provenance.json"] = "{not json" }
+expect_fail(failures, "unparseable provenance", out, status, "is not valid JSON")
+
+out, status = gate lambda { |f|
+  f["spec/api-provenance.json"] = JSON.pretty_generate("bc3" => { "revision" => "d0edc12", "date" => PIN_DATE })
+}
+expect_fail(failures, "abbreviated revision in provenance", out, status,
+            "is not a full 40-char SHA")
+
+out, status = gate lambda { |f|
+  f["conformance/schema.json"] = JSON.pretty_generate("properties" => {})
+}
+expect_fail(failures, "assertion enum moved in the schema", out, status, "schema moved?")
+
+# --- the writer ----------------------------------------------------------------
+
+repin_to = lambda { |sha, date|
+  lambda { |f|
+    f["spec/api-provenance.json"] =
+      JSON.pretty_generate("bc3" => { "revision" => sha, "date" => date })
+  }
+}
+
+writer repin_to.call("a" * 40, "2026-09-09") do |out, status, dir|
+  expect_pass(failures, "writer runs clean", out, status)
+  written = read_in(dir, "COORDINATION.md")
+  unless written.include?("`#{'a' * 8}` as of the 2026-09-09 sync.")
+    failures << "writer: expected COORDINATION.md rewritten to the new pin, got:\n#{written}"
+  end
+  # Abbreviation length is preserved, not normalised to 40.
+  if written.include?("a" * 9)
+    failures << "writer: SHA abbreviation length was not preserved:\n#{written}"
+  end
+end
+
+# The writer must never touch a .writerExcludes file, must say so, and must
+# still exit 0 so `make generate` is not held hostage — `--check` is what fails.
+writer lambda { |f|
+  repin_to.call("b" * 40, "2026-09-09").call(f)
+  cfg = JSON.parse(f["spec/doc-constants.json"])
+  cfg["writerExcludes"] = { "COORDINATION.md" => "heads a narrative" }
+  f["spec/doc-constants.json"] = JSON.pretty_generate(cfg)
+} do |out, status, dir|
+  expect_pass(failures, "writer exits 0 when it declines", out, status)
+  unless out.include?("was NOT rewritten")
+    failures << "writer: declining an excluded file must be announced, got:\n#{out}"
+  end
+  unless out.include?("heads a narrative")
+    failures << "writer: the decline must quote the committed reason, got:\n#{out}"
+  end
+  written = read_in(dir, "COORDINATION.md")
+  unless written.include?("`#{SHORT}`") && written.include?(PIN_DATE)
+    failures << "writer: excluded file must be left untouched, got:\n#{written}"
+  end
+end
+
+# ...and --check must then reject exactly that state, so declining is a
+# deferral to a human and not a hole.
+out, status = gate lambda { |f|
+  repin_to.call("b" * 40, "2026-09-09").call(f)
+  cfg = JSON.parse(f["spec/doc-constants.json"])
+  cfg["writerExcludes"] = { "COORDINATION.md" => "heads a narrative" }
+  f["spec/doc-constants.json"] = JSON.pretty_generate(cfg)
+}
+expect_fail(failures, "check rejects what the writer declined", out, status,
+            "@bc3-pin says `#{SHORT}`")
+
+# @assertion-types is out of the writer's reach by design: a new row needs a
+# description only a human can write, and failing here would break every
+# `make generate`.
+writer lambda { |f|
+  f["conformance/schema.json"] = JSON.pretty_generate(
+    "properties" => { "assertions" => { "items" => { "properties" => {
+      "type" => { "enum" => %w[status header jsonPath brandNew] },
+    } } } }
+  )
+} do |out, status, dir|
+  expect_pass(failures, "writer ignores assertion-type drift", out, status)
+  written = read_in(dir, "SPEC.md")
+  if written.include?("brandNew")
+    failures << "writer: must not invent an assertion-type row:\n#{written}"
+  end
+end
+
+# Structural marker damage IS fatal to the writer: it means a span it was
+# supposed to maintain was invisible to it.
+writer ->(f) { f["SPEC.md"] += "\nSomething. <!-- @nope -->\n" } do |out, status, _dir|
+  if status.success?
+    failures << "writer: malformed markers must be fatal, got exit 0:\n#{out}"
+  end
+end
+
+# --- locale independence -------------------------------------------------------
+#
+# Pins the LC_ALL=C fix: the tracked Markdown and openapi.json both carry
+# non-ASCII, and Ruby otherwise reads them in the locale's encoding.
+out, status = Open3.capture2e({ "LC_ALL" => "C", "LANG" => "C" }, "ruby", GATE, "--check", chdir: ROOT)
+expect_pass(failures, "real repo passes under LC_ALL=C", out, status)
+
+# --- report --------------------------------------------------------------------
+
+if failures.empty?
+  puts "sync-doc-constants self-test: all cases passed."
+  exit 0
+else
+  warn "sync-doc-constants self-test: #{failures.length} case(s) failed."
+  failures.each { |f| warn "\n#{f}" }
+  exit 1
+end

--- a/scripts/test-doc-constants.rb
+++ b/scripts/test-doc-constants.rb
@@ -251,24 +251,62 @@ out, status = gate lambda { |f|
 expect_fail(failures, "unmarked BARE current-pin restatement", out, status,
             "is the current provenance pin, restated outside a @bc3-pin span")
 
+grant = lambda { |f, entry|
+  cfg = JSON.parse(f["spec/doc-constants.json"])
+  cfg["unmarkedPinCitations"] = { "spec/api-gaps/entry.md" => entry }
+  f["spec/doc-constants.json"] = JSON.pretty_generate(cfg)
+}
+
 out, status = gate lambda { |f|
   f["spec/api-gaps/entry.md"] = "# An entry\n\nSDK #528 repinned to `#{SHORT}`.\n"
-  cfg = JSON.parse(f["spec/doc-constants.json"])
-  cfg["unmarkedPinCitations"] = { "spec/api-gaps/entry.md" => "as-of fact about SDK #528" }
-  f["spec/doc-constants.json"] = JSON.pretty_generate(cfg)
+  grant.call(f, "count" => 1, "reason" => "as-of fact about SDK #528")
 }
-expect_pass(failures, "allowlisted pin citation passes", out, status)
+expect_pass(failures, "granted pin citation passes", out, status)
 
-# An allowlist entry that no longer describes anything is a standing permission
-# nobody reviewed — the file-level grant would silently cover a future unmarked
-# restatement in the same file.
+# The grant is bounded. A SECOND unmarked citation appearing in an already-
+# granted file is the hole an unbounded file grant leaves open, and it is
+# widest in exactly the files that need granting.
 out, status = gate lambda { |f|
-  cfg = JSON.parse(f["spec/doc-constants.json"])
-  cfg["unmarkedPinCitations"] = { "spec/api-gaps/entry.md" => "stale grant" }
-  f["spec/doc-constants.json"] = JSON.pretty_generate(cfg)
+  f["spec/api-gaps/entry.md"] =
+    "# An entry\n\nSDK #528 repinned to `#{SHORT}`.\n\nThe provenance pin is `#{SHORT}`.\n"
+  grant.call(f, "count" => 1, "reason" => "as-of fact about SDK #528")
 }
-expect_fail(failures, "dead pin-citation exemption", out, status,
-            "no longer names the current pin outside a marked span")
+expect_fail(failures, "granted file grows an extra citation", out, status,
+            "grants 1 unmarked citation(s) of the current pin, found 2 (lines 3, 5)")
+
+# An entry that no longer describes anything is a standing permission nobody
+# reviewed — it would silently cover the next unmarked restatement in the file.
+out, status = gate ->(f) { grant.call(f, "count" => 1, "reason" => "stale grant") }
+expect_fail(failures, "dead pin-citation grant", out, status,
+            "found 0 — the entry no longer describes the file")
+
+# ...including when the granted file is gone entirely: a grant that outlives
+# its path springs back unreviewed the day someone recreates it.
+out, status = gate lambda { |f|
+  f.delete("spec/api-gaps/entry.md")
+  grant.call(f, "count" => 1, "reason" => "grant for a deleted file")
+}
+expect_fail(failures, "grant for a deleted file", out, status,
+            "spec/api-gaps/entry.md: spec/doc-constants.json grants 1 unmarked citation(s)")
+
+# The grant SHAPE is load-bearing. The pre-count spelling was a bare string;
+# accepting one now would read as "grant everything" in the one list whose
+# whole job is to be bounded.
+out, status = gate ->(f) { grant.call(f, "as-of fact about SDK #528") }
+expect_fail(failures, "bare-string grant rejected", out, status,
+            "must be an object with \"count\" and \"reason\"")
+
+out, status = gate ->(f) { grant.call(f, "count" => 0, "reason" => "zero") }
+expect_fail(failures, "zero count rejected", out, status,
+            ".count must be a positive integer, got 0")
+
+out, status = gate ->(f) { grant.call(f, "count" => "1", "reason" => "stringly typed") }
+expect_fail(failures, "non-integer count rejected", out, status,
+            ".count must be a positive integer, got \"1\"")
+
+out, status = gate ->(f) { grant.call(f, "count" => 1, "reason" => "   ") }
+expect_fail(failures, "blank reason rejected", out, status,
+            "needs a non-empty \"reason\"")
 
 # A historical SHA must NOT trip it: that is the whole point of the marker
 # convention, and a gate that flagged settled triage would be unusable.

--- a/scripts/test-doc-constants.rb
+++ b/scripts/test-doc-constants.rb
@@ -291,6 +291,17 @@ out, status = gate lambda { |f|
 expect_fail(failures, "granted file grows an extra citation", out, status,
             "grants 1 unmarked citation(s) of the current pin, found 2 (lines 3, 5)")
 
+# Claims are counted, not lines. A second claim appended to a line that already
+# carries one must not hide behind the first — with a first-match-only scan the
+# count still read 1 here and the new claim sailed through.
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] =
+    "# An entry\n\nSDK #528 repinned to `#{SHORT}`, and the provenance pin is `#{SHORT}`.\n"
+  grant.call(f, "count" => 1, "reason" => "as-of fact about SDK #528")
+}
+expect_fail(failures, "two citations on one line both count", out, status,
+            "grants 1 unmarked citation(s) of the current pin, found 2 (line 3 (x2))")
+
 # An entry that no longer describes anything is a standing permission nobody
 # reviewed — it would silently cover the next unmarked restatement in the file.
 out, status = gate ->(f) { grant.call(f, "count" => 1, "reason" => "stale grant") }

--- a/scripts/test-doc-constants.rb
+++ b/scripts/test-doc-constants.rb
@@ -77,7 +77,7 @@ def default_files
       "bc3" => { "revision" => REVISION, "date" => PIN_DATE }
     ),
     "spec/doc-constants.json" => JSON.pretty_generate(
-      "markerFloors" => {
+      "markerCounts" => {
         "api-version" => { "SPEC.md" => 1 },
         "bc3-pin" => { "COORDINATION.md" => 1 },
         "assertion-types" => { "SPEC.md" => 1 },
@@ -244,6 +244,13 @@ out, status = gate lambda { |f|
 expect_fail(failures, "unmarked current-pin restatement", out, status,
             "is the current provenance pin, restated outside a @bc3-pin span")
 
+# Backticks must not be the way around the rule.
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = "# An entry\n\nThe provenance pin is #{SHORT} today.\n"
+}
+expect_fail(failures, "unmarked BARE current-pin restatement", out, status,
+            "is the current provenance pin, restated outside a @bc3-pin span")
+
 out, status = gate lambda { |f|
   f["spec/api-gaps/entry.md"] = "# An entry\n\nSDK #528 repinned to `#{SHORT}`.\n"
   cfg = JSON.parse(f["spec/doc-constants.json"])
@@ -317,36 +324,62 @@ expect_fail(failures, "nested block begin", out, status, "inside an unclosed")
 out, status = gate ->(f) { f["SPEC.md"] += "\n<!-- @assertion-types:end -->\n" }
 expect_fail(failures, ":end without :begin", out, status, ":end without a matching :begin")
 
-# --- marker-count floor --------------------------------------------------------
+# --- marker inventory (exact counts) -------------------------------------------
 
 out, status = gate ->(f) { f["COORDINATION.md"] = f["COORDINATION.md"].sub(" <!-- @bc3-pin -->", "") }
-expect_fail(failures, "marker deleted below the floor", out, status,
-            "COORDINATION.md: marker floor violated")
+expect_fail(failures, "marker deleted", out, status,
+            "COORDINATION.md: spec/doc-constants.json declares 1 @bc3-pin marker(s), found 0")
 
-# A marker moved to another file still leaves the original below its floor —
-# the floor is per-file precisely so this is not a silent relocation.
+# The reason this is an exact count and not a floor: a claim ADDED to a file
+# that already satisfies its number would otherwise be unprotected forever —
+# delete it again later and the count still passes.
+out, status = gate lambda { |f|
+  f["SPEC.md"] += "\nAlso API_VERSION is `#{API_VER}`. <!-- @api-version -->\n"
+}
+expect_fail(failures, "marker added without recording it", out, status,
+            "A marked claim was added without recording it — set the count to 2")
+
+# ...and once recorded, deleting THAT marker fails too — the property a floor
+# could not give.
+out, status = gate lambda { |f|
+  cfg = JSON.parse(f["spec/doc-constants.json"])
+  cfg["markerCounts"]["api-version"]["SPEC.md"] = 2
+  f["spec/doc-constants.json"] = JSON.pretty_generate(cfg)
+}
+expect_fail(failures, "recorded marker later deleted", out, status,
+            "declares 2 @api-version marker(s), found 1")
+
+# A marker in a file the inventory never mentions is equally unprotected.
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] += "\nThe pin is `#{SHORT}` as of the #{PIN_DATE} sync. <!-- @bc3-pin -->\n"
+}
+expect_fail(failures, "marker in an undeclared file", out, status,
+            "spec/api-gaps/entry.md: carries 1 @bc3-pin marker(s) that spec/doc-constants.json does not declare")
+
+# A marker moved to another file leaves the original short — the count is
+# per-file precisely so a relocation is not silent.
 out, status = gate lambda { |f|
   f["COORDINATION.md"] = f["COORDINATION.md"].sub(" <!-- @bc3-pin -->", "")
   f["spec/api-gaps/entry.md"] += "\nThe pin is `#{SHORT}` as of the #{PIN_DATE} sync. <!-- @bc3-pin -->\n"
 }
-expect_fail(failures, "marker relocated without moving the floor", out, status,
-            "marker floor violated")
+expect_fail(failures, "marker relocated without moving the count", out, status,
+            "COORDINATION.md: spec/doc-constants.json declares 1 @bc3-pin marker(s), found 0")
 
 # Backticked markers are documentation OF the convention, not uses of it — they
-# must not count toward a floor.
+# must not count toward the inventory.
 out, status = gate lambda { |f|
   f["COORDINATION.md"] = "# Coordination\n\nMark the line with `<!-- @bc3-pin -->` to gate it.\n"
 }
-expect_fail(failures, "backticked marker does not satisfy the floor", out, status,
-            "marker floor violated")
+expect_fail(failures, "backticked marker does not satisfy the count", out, status,
+            "declares 1 @bc3-pin marker(s), found 0")
 
 out, status = gate lambda { |f|
   cfg = JSON.parse(f["spec/doc-constants.json"])
-  cfg["markerFloors"]["not-a-kind"] = { "SPEC.md" => 1 }
+  cfg["markerCounts"]["not-a-kind"] = { "SPEC.md" => 1 }
   f["spec/doc-constants.json"] = JSON.pretty_generate(cfg)
 }
-expect_fail(failures, "floor declared for an unknown kind", out, status,
-            "floor declared for unknown marker @not-a-kind")
+expect_fail(failures, "count declared for an unknown kind", out, status,
+            "count declared for unknown marker @not-a-kind")
 
 # --- source-of-truth failures --------------------------------------------------
 

--- a/spec/api-gaps/README.md
+++ b/spec/api-gaps/README.md
@@ -93,8 +93,14 @@ making the absorption journey publicly auditable.
 > tracked in #12463) and the SDK's matching removal of `GetEverythingBoosts`;
 > its `no-json-contract` is literal — the feed has no JSON API today.
 >
-> The provenance pin is `2c0dafba13` (2026-08-02). The
-> `d0edc1283b..2c0dafba13` range (11 commits) contains exactly **one**
+> The provenance pin is `2c0dafba13` (2026-08-02). <!-- @bc3-pin -->
+> That line is checked by `make doc-constants-check` and deliberately *not*
+> rewritten by `make sync-api-version`: this file is in
+> `spec/doc-constants.json` `.writerExcludes`, because the pin sentence heads
+> the range triage below and cannot advance without that triage advancing too.
+> The ranges themselves are settled history and stay unmarked.
+>
+> The `d0edc1283b..2c0dafba13` range (11 commits) contains exactly **one**
 > API-contract change: BC3 **#12384** (`dc6cd10714`, the Folders API),
 > absorbed here as `FoldersService` and recorded in
 > [`folders-api.md`](folders-api.md). BC3 **#12494** (`344581a379`) and
@@ -112,8 +118,8 @@ making the absorption journey publicly auditable.
 > Turbo-morph web-only, and one push-notification backend swap.
 >
 > Earlier pins, kept as the triage record. The provenance pin was `e83b2733`
-> (2026-07-30). The `dffa7e11..e83b2733`
-> range (96 commits) contains exactly two API-contract changes, both handled:
+> (2026-07-30); the `dffa7e11..e83b2733` range (96 commits), triaged at the
+> repin that set it, contains exactly two API-contract changes, both handled:
 > BC3 **#12464** (`b06acfac1`, boosts-feed withdrawal — absorbed by the SDK's
 > removal, recorded in `everything-boosts-withdrawn.md`) and BC3 **#12442**
 > (`b238a0743`, `assignee_ids[]`/`due` filters on the everything to-do/card

--- a/spec/api-gaps/README.md
+++ b/spec/api-gaps/README.md
@@ -117,9 +117,21 @@ making the absorption journey publicly auditable.
 > still answers `204`. The remaining seven commits are four dev-tooling, two
 > Turbo-morph web-only, and one push-notification backend swap.
 >
-> Earlier pins, kept as the triage record. The provenance pin was `e83b2733`
-> (2026-07-30); the `dffa7e11..e83b2733` range (96 commits), triaged at the
-> repin that set it, contains exactly two API-contract changes, both handled:
+> Earlier pins, kept as the triage record. Each names the pin it was written
+> against, in the past tense, because that is what it is — a range triaged
+> once, at the repin that set its end. Only the sentence above is a claim
+> about today.
+>
+> The pin was `d0edc128` (2026-07-31). The `e83b2733..d0edc128` range was
+> triaged at the Up Next priority-writes repin (SDK #528): the only `doc/api`
+> or routes change in it is `my_assignments.md`'s exact-target Deprioritize
+> contract (BC3 **#12483**), absorbed by that PR and recorded in
+> [`my-assignments-priorities.md`](my-assignments-priorities.md); everything
+> else (BC3 #12478/#12479/#12480/#12481/#12444, a completion-lock race fix and
+> relay-revocation ops tooling) is wire-neutral internals.
+>
+> The pin was `e83b2733` (2026-07-30); the `dffa7e11..e83b2733` range (96
+> commits) contains exactly two API-contract changes, both handled:
 > BC3 **#12464** (`b06acfac1`, boosts-feed withdrawal — absorbed by the SDK's
 > removal, recorded in `everything-boosts-withdrawn.md`) and BC3 **#12442**
 > (`b238a0743`, `assignee_ids[]`/`due` filters on the everything to-do/card

--- a/spec/api-gaps/calendar.md
+++ b/spec/api-gaps/calendar.md
@@ -58,14 +58,15 @@ is intentionally small.
 ## SDK absorption plan when this lands
 
 **Absorbed** (post-#504 program C8): `CalendarsService` models the show +
-update pair with the shape taken from `doc/api/sections/calendars.md` **at the
-pinned revision** (verified: no doc/controller drift since `e83b2733`): id,
-type, name, color, created_at, updated_at, url, app_url, schedule_url — all
-required non-nullable. The update body is the nested `{calendar: {color}}`
-envelope; the pinned controller's 422 contract (`{"errors": {"color": ["is not
-a valid color"]}}`, rejected up front for unknown enum values) is documented on
-the operation and pinned in per-SDK 422 tests. `UpdateCalendar` is a flagged
-idempotent PUT with an idempotency conformance case. The `GetCalendar`
+update pair with the shape taken from `doc/api/sections/calendars.md` **at
+`e83b2733`, the provenance pin when this entry was verified** (no doc or
+controller drift up to it): id, type, name, color, created_at, updated_at, url,
+app_url, schedule_url — all required non-nullable. The update body is the
+nested `{calendar: {color}}` envelope; that revision's controller returns the
+422 contract (`{"errors": {"color": ["is not a valid color"]}}`, rejected up
+front for unknown enum values), documented on the operation and pinned in
+per-SDK 422 tests. `UpdateCalendar` is a flagged idempotent PUT with an
+idempotency conformance case. The `GetCalendar`
 live-canary case ships in `live-my-surface.json` with an **env-var-only**
 fixture (`BASECAMP_BC5_CALENDAR_ID` → `BASECAMP_CALENDAR_ID` → skip): no
 modeled endpoint returns a calendar bucket id (the dock has no calendar tool;

--- a/spec/api-gaps/everything-tasks-aggregate.md
+++ b/spec/api-gaps/everything-tasks-aggregate.md
@@ -35,7 +35,8 @@ end
 ```
 
 Sitting in that block makes them *look* like siblings of the JSON aggregates.
-They are not. At the pinned `dffa7e11b3` both controllers are HTML-only:
+They are not. At `dffa7e11b3` — the provenance pin when this was verified —
+both controllers were HTML-only:
 
 ```ruby
 class Everything::AssignmentsController < ApplicationController

--- a/spec/api-gaps/my-assignments-priorities.md
+++ b/spec/api-gaps/my-assignments-priorities.md
@@ -32,8 +32,9 @@ SDK registration only — the contract shipped to `master` via BC3 **#12380**
 contract of record. The **retrieval** side (`GET /my/assignments.json` and its
 completed/due variants) is already modeled as `GetMyAssignments`; #12380 hardens
 and **documents** the **Up Next priority-management** writes, which the SDK does
-not model. This entry registers that net-new write surface so the provenance pin
-(`c3086931`) is not carrying an unrecorded API change.
+not model. This entry registers that net-new write surface so the pin it was
+filed against (`c3086931`, 2026-07-26) was not carrying an unrecorded API
+change.
 
 "Up Next" is the current user's ordered list of prioritized assignments
 (returned as `priorities` by `GetMyAssignments`). Three write operations, all

--- a/spec/api-gaps/my-bookmarks.md
+++ b/spec/api-gaps/my-bookmarks.md
@@ -34,7 +34,7 @@ SDK registration only — the contract shipped to `master` via BC3 **#12383**
 ("Add My Bookmarks JSON API", `640389c2`, 2026-07-25).
 `doc/api/sections/my_bookmarks.md` on `master` is the contract of record. The
 SDK does not yet model any of the four operations; this entry registers the
-surface so the provenance pin (`640389c2`) is not carrying an unrecorded API
+surface so the pin that absorbed `640389c2` is not carrying an unrecorded API
 change.
 
 A bookmark is a **personal** link between the current user and a single

--- a/spec/api-gaps/my-drafts.md
+++ b/spec/api-gaps/my-drafts.md
@@ -30,7 +30,8 @@ SDK registration only — the contract shipped to `master` via BC3 **#12381**
 ("Add My Drafts API and document the draft publication lifecycle", `123b2320`,
 2026-07-26). `doc/api/sections/drafts.md` on `master` is the contract of record.
 The SDK does not yet model the operation; this entry registers the surface so
-the provenance pin (`c3086931`) is not carrying an unrecorded API change.
+the pin it was filed against (`c3086931`, 2026-07-26) was not carrying an
+unrecorded API change.
 
 A draft is a message, document, upload, or client approval/correspondence that
 has been saved but not yet published. One operation:

--- a/spec/api-gaps/upload-new-version.md
+++ b/spec/api-gaps/upload-new-version.md
@@ -26,7 +26,7 @@ as `UploadsService.ListVersions` — but nothing writes a version.
 basecamp-cli#404 hypothesized that `PUT /uploads/{id}.json` with a fresh
 `attachable_sgid` would replace the file and create a version. Verified against
 `basecamp/bc3` @ `ba105ba7` (the revision `spec/api-provenance.json` pinned when
-this was verified; the pin has since advanced to `338b7a11`) — it does not:
+this was verified; the pin has advanced several times since) — it does not:
 
 - `UploadsController#update` reads `upload_params`, which permits only
   `:base_name` and `:description`. `attachable_sgid` lives in

--- a/spec/doc-constants.json
+++ b/spec/doc-constants.json
@@ -47,8 +47,8 @@
   },
   "unmarkedPinCitations": {
     "spec/api-gaps/README.md": {
-      "count": 1,
-      "reason": "the range triage names each range's endpoint, which is by definition the pin that repin set — here BC3 #12501, cited as the commit that shipped the draft-subscribers fix. The pin sentence itself is separately marked <!-- @bc3-pin --> and is the only class-A claim in the file"
+      "count": 2,
+      "reason": "the two ways a range triage names its own endpoint, which is by definition the pin that repin set: the d0edc1283b..2c0dafba13 range itself, and BC3 #12501 cited as the commit that shipped the draft-subscribers fix. Both are bound to that triage and stay true after the next repin. The pin sentence is separately marked <!-- @bc3-pin --> and is the only class-A claim in the file"
     },
     "spec/api-gaps/folders-api.md": {
       "count": 1,

--- a/spec/doc-constants.json
+++ b/spec/doc-constants.json
@@ -22,9 +22,13 @@
     "unmarkedPinCitations — files allowed to name the CURRENT bc3 revision in",
     "prose without a <!-- @bc3-pin --> marker. The default is to reject that,",
     "because an unmarked sentence stating today's pin is how every stale pin",
-    "restatement in spec/api-gaps/ was born. Listing a file asserts its SHA is an",
-    "as-of fact bound to something fixed (a PR, a verification), not a claim about",
-    "the pin."
+    "restatement in spec/api-gaps/ was born. An entry asserts those SHAs are",
+    "as-of facts bound to something fixed (a PR, a verification), not claims",
+    "about the pin — and is bounded by an exact count for the same reason",
+    "markerCounts is: an unbounded file grant would wave through whatever the",
+    "file grows next, in the files likeliest to grow a real class-A sentence.",
+    "The N+1th citation fails until someone reads it and restates the number;",
+    "fewer than N means the entry has outlived what it described."
   ],
   "markerCounts": {
     "api-version": {
@@ -42,6 +46,13 @@
     "spec/api-gaps/README.md": "the pin sentence heads a triage narrative — advancing the SHA without adding the new range's triage would make the one document whose job is recording that triage assert a range nobody triaged"
   },
   "unmarkedPinCitations": {
-    "spec/api-gaps/my-assignments-priorities.md": "names the revision SDK #528 repinned to, an as-of fact about that PR — it stays true after the next repin"
+    "spec/api-gaps/README.md": {
+      "count": 1,
+      "reason": "the range triage names each range's endpoint, which is by definition the pin that repin set — here BC3 #12501, cited as the commit that shipped the draft-subscribers fix. The pin sentence itself is separately marked <!-- @bc3-pin --> and is the only class-A claim in the file"
+    },
+    "spec/api-gaps/folders-api.md": {
+      "count": 1,
+      "reason": "names the d0edc1283b -> 2c0dafba13 repin as the event that first brought doc/api/sections/folders.md into range — an as-of fact about that repin, still true after the next one"
+    }
   }
 }

--- a/spec/doc-constants.json
+++ b/spec/doc-constants.json
@@ -2,10 +2,14 @@
   "$comment": [
     "Policy for scripts/sync-doc-constants.rb (make doc-constants-check).",
     "",
-    "markerFloors — each entry is a MINIMUM: the named file must carry at least",
-    "this many spans marked with the given HTML comment. Adding a new marked claim",
-    "never needs a bump; deleting one to make the gate go quiet fails here instead.",
-    "Moving a claim to another file is a two-line edit in the same commit.",
+    "markerCounts — the EXACT number of spans each file carries for a given HTML",
+    "comment. Any deviation fails: too few means a claim was deleted or unmarked,",
+    "too many means one was added without being recorded here (and so would not be",
+    "missed if it later went), and a marked file absent from this list is not",
+    "protected at all. Adding or moving a claim is a one-line edit in the same",
+    "commit. This was a minimum until review pointed out that a minimum protects",
+    "only the first N claims in a file — a later addition could be deleted again",
+    "with the count still satisfied.",
     "",
     "writerExcludes — files whose marked spans the WRITER (--write, reached from",
     "`make generate` via sync-api-version) must never rewrite. The gate still",
@@ -22,7 +26,7 @@
     "as-of fact bound to something fixed (a PR, a verification), not a claim about",
     "the pin."
   ],
-  "markerFloors": {
+  "markerCounts": {
     "api-version": {
       "SPEC.md": 2
     },

--- a/spec/doc-constants.json
+++ b/spec/doc-constants.json
@@ -1,0 +1,21 @@
+{
+  "$comment": [
+    "Marker-count floors for scripts/sync-doc-constants.rb (make doc-constants-check).",
+    "Each entry is a MINIMUM: the named file must carry at least this many spans",
+    "marked with the given HTML comment. Adding a new marked claim never needs a",
+    "bump; deleting one to make the gate go quiet fails here instead.",
+    "Moving a claim to another file is a two-line edit in the same commit."
+  ],
+  "markerFloors": {
+    "api-version": {
+      "SPEC.md": 2
+    },
+    "bc3-pin": {
+      "COORDINATION.md": 1,
+      "spec/api-gaps/README.md": 1
+    },
+    "assertion-types": {
+      "SPEC.md": 1
+    }
+  }
+}

--- a/spec/doc-constants.json
+++ b/spec/doc-constants.json
@@ -1,10 +1,26 @@
 {
   "$comment": [
-    "Marker-count floors for scripts/sync-doc-constants.rb (make doc-constants-check).",
-    "Each entry is a MINIMUM: the named file must carry at least this many spans",
-    "marked with the given HTML comment. Adding a new marked claim never needs a",
-    "bump; deleting one to make the gate go quiet fails here instead.",
-    "Moving a claim to another file is a two-line edit in the same commit."
+    "Policy for scripts/sync-doc-constants.rb (make doc-constants-check).",
+    "",
+    "markerFloors — each entry is a MINIMUM: the named file must carry at least",
+    "this many spans marked with the given HTML comment. Adding a new marked claim",
+    "never needs a bump; deleting one to make the gate go quiet fails here instead.",
+    "Moving a claim to another file is a two-line edit in the same commit.",
+    "",
+    "writerExcludes — files whose marked spans the WRITER (--write, reached from",
+    "`make generate` via sync-api-version) must never rewrite. The gate still",
+    "checks them; it just refuses to fix them silently, so drift surfaces as a",
+    "failed `make check` a human has to answer instead of a line that moved on its",
+    "own inside a generated commit. The value is the reason, and the reason is the",
+    "test: exclude a file only when the marked value cannot move without prose",
+    "around it moving too.",
+    "",
+    "unmarkedPinCitations — files allowed to name the CURRENT bc3 revision in",
+    "prose without a <!-- @bc3-pin --> marker. The default is to reject that,",
+    "because an unmarked sentence stating today's pin is how every stale pin",
+    "restatement in spec/api-gaps/ was born. Listing a file asserts its SHA is an",
+    "as-of fact bound to something fixed (a PR, a verification), not a claim about",
+    "the pin."
   ],
   "markerFloors": {
     "api-version": {
@@ -17,5 +33,11 @@
     "assertion-types": {
       "SPEC.md": 1
     }
+  },
+  "writerExcludes": {
+    "spec/api-gaps/README.md": "the pin sentence heads a triage narrative — advancing the SHA without adding the new range's triage would make the one document whose job is recording that triage assert a range nobody triaged"
+  },
+  "unmarkedPinCitations": {
+    "spec/api-gaps/my-assignments-priorities.md": "names the revision SDK #528 repinned to, an as-of fact about that PR — it stays true after the next repin"
   }
 }


### PR DESCRIPTION
Three constants are restated in prose. Nothing checked them, and all three had drifted — one of them for four repins.

| Claim | Prose said | Source says |
|---|---|---|
| `API_VERSION` (`SPEC.md` ×2) | `2026-03-23` | `openapi.json` `.info.version` = `2026-08-02` |
| bc3 pin (`COORDINATION.md`) | `338b7a11` (2026-07-23) | `spec/api-provenance.json` `.bc3.revision` = `2c0dafba13` (2026-08-02) |
| bc3 pin (`spec/api-gaps/README.md`) | `e83b2733` (2026-07-30) | same |
| Assertion types (SPEC §19) | 17 rows | `conformance/schema.json` defines 21 |

`headerAbsent`, `requestMethod`, `requestBody` and `requestBodyAbsent` have been in the schema and in use by the conformance fixtures the whole time, undocumented.

The pin column moved during review: this branch was rebased onto main's repin to `2c0dafba13`, which is also the best evidence in the PR — see *What the repin proved* below.

## Red proof

The first commit adds the gate and the markers but leaves the scalar values wrong, so the red is reproducible from history — `git checkout f0ae5eb1b && ruby scripts/sync-doc-constants.rb --check`:

```
ERROR: documentation constants have drifted from their sources.
  SPEC.md:1061: @api-version says 2026-03-23, openapi.json .info.version is 2026-08-02
  SPEC.md:1719-1739: conformance/schema.json defines 21 assertion types, the table documents 17; missing: `headerAbsent`, `requestMethod`, `requestBody`, `requestBodyAbsent`
  SPEC.md:1917: @api-version says 2026-03-23, openapi.json .info.version is 2026-08-02

  Scalar constants: run `make sync-api-version` to rewrite marked spans.
  Assertion types:  edit SPEC.md §19's marked table by hand — a new row needs a description only a human can write.
REAL_EXIT=1
```

(That is the bare runner, hence exit 1; `make doc-constants-check` wraps it and exits 2. The two `@bc3-pin` errors that this block showed before the rebase are gone from it because the rebase carried main's already-correct pin into that commit — the remaining three are the original drift.)

Green at the tip:

```
==> Checking documentation constants...
Doc constants match their sources (5 marked spans across 3 files).
  api-version      2026-08-02
  bc3-pin          2c0dafba (2026-08-02)
  assertion-types  21
sync-doc-constants self-test: all cases passed.
REAL_EXIT=0
```

## Why markers, not a blanket scan

`spec/api-gaps/` cites ~30 historical bc3 SHAs on purpose — "the pin has since advanced to `X`", "the `A..B` range contains exactly two contract changes". A "every SHA must equal the current pin" gate would false-positive on all of them, and worse, its *writer* would rewrite settled triage into a range claim nobody verified. That hazard was live: `spec/api-gaps/README.md` had the current-pin sentence and the `dffa7e11..e83b2733` range analysis on the same line, so a line-scoped rewrite would have produced "the `dffa7e11..2c0dafba13` range contains exactly two API-contract changes" — untrue and unverified.

So a claim about the **current** value carries an HTML comment and only marked spans are read or written:

- `<!-- @api-version -->` — trailing marker; every `YYYY-MM-DD` on that line must equal `openapi.json` `.info.version`
- `<!-- @bc3-pin -->` — trailing marker; every backticked 7–40-char hex token on that line must be a prefix of `.bc3.revision`, and every date must equal `.bc3.date`
- `<!-- @assertion-types:begin -->` / `:end` — block; the table's first-column identifiers must equal the schema enum, both directions

A marker inside an inline code span or a fenced block is a *mention* of the convention (AGENTS.md documents the syntax), not a use of it — the scanner masks both. That bit found itself: writing the AGENTS.md section turned the gate red until the masking landed. It happened a second time later, when the paragraph documenting the range trap quoted the live range and the gate failed on it.

## The writer must not touch the narrative

`make generate` → `smithy-build` → `sync-api-version` reaches this script's `--write` mode, so the gate ships a generator that edits prose. For `spec/api-gaps/README.md` that is exactly the unreviewed-rewrite hazard the marker convention exists to prevent: its pin sentence is the *heading of the range triage below it*, and advancing the SHA without adding the new range's triage would make the one document whose job is recording that triage assert a range nobody triaged.

So it is listed in `spec/doc-constants.json` `.writerExcludes`, with the reason committed next to the exclusion. The writer diffs it, refuses to write it, says so loudly, and exits 0 so `make generate` is never held hostage; `--check` then stays red until a human answers.

### What the repin proved

Main repinned to `2c0dafba13` mid-review, and the rebase became the first run of this gate against a real sync. It earned its keep three times over:

1. It caught `SPEC.md`'s two `@api-version` spans two versions stale and fixed them from `openapi.json`.
2. Main's own repin commit advanced the README pin sentence **together with ~15 lines of new range triage** — precisely the coupling the exclusion exists to protect. A writer that silently advanced only the SHA would have produced a false document.
3. It reported a now-dead `.unmarkedPinCitations` grant (`my-assignments-priorities.md`, which had described the *previous* pin) and demanded it be dropped.

Simulating a further repin shows the decline path end to end — the writer advances `COORDINATION.md`, refuses the README, and `make doc-constants-check` goes red at exit 2:

```
NOTE: spec/api-gaps/README.md has stale marked doc constants and was NOT rewritten.
      Reason it is in spec/doc-constants.json .writerExcludes:
        the pin sentence heads a triage narrative — advancing the SHA without adding the new range's triage would make the one document whose job is recording that triage assert a range nobody triaged
      Update it by hand, along with the prose that depends on it.
      `make doc-constants-check` stays red until you do.
Rewrote marked doc constants in COORDINATION.md
```

The README was byte-identical afterwards (md5 `b93ac2ec207d9c331b0eb2b21045d0fd` before and after).

## Deleting a marker doesn't work

`spec/doc-constants.json` commits the **exact** per-file marker count. Every deviation fails: too few (a claim was deleted or unmarked), too many (a claim was added without being recorded, and so would not be missed if it later went), or a marked file the inventory never mentions.

This started as a floor. Review pointed out that a minimum only protects the first N claims in a file — add a third `@api-version` to `SPEC.md` against a floor of 2, delete it a month later, and two markers remain, so the gate stays green while the value it guarded drifts. An exact count costs one line in the commit that adds the marker and buys an inventory that is true.

`.unmarkedPinCitations` is bounded the same way, for the same reason. Some files legitimately name today's pin unmarked — a range's endpoint *is* the pin that repin set, so `spec/api-gaps/README.md` does it at every sync — but an unbounded file grant would wave through whatever that file grows next, in exactly the file likeliest to grow a real "the provenance pin is X". Each grant carries an exact count and a reason, and the shape is validated so the pre-count bare-string spelling cannot read as "grant everything".

## Self-test

`make doc-constants-check` runs the live check **and** `scripts/test-doc-constants.rb`, same shape and same stated reason as `scripts/test-check-fixture-coverage.rb`: the live run only ever proves the gate can say yes.

It drives the gate against a crafted throwaway git repo via a `DOC_CONSTANTS_ROOT` override and asserts a non-zero exit plus an expected message fragment for every failure mode claimed — each constant drifting, missing SHA/date in a pin span, bare SHA, unmarked restatement (backticked, bare, inside a compound span, more than one per line), every marker-structure error, every marker-inventory case including the count, grant shape and bounds, fenced-code edge cases, the four source-of-truth failures, and the writer's own contracts. Positive controls too, including `LC_ALL=C`. 70 assertions.

It has already paid for itself twice: it caught a crash in the grant-shape validation (malformed grants reached a count comparison and died on `Integer > nil` instead of printing the message that says what to fix), and every review fix below was demonstrated to fail against the un-fixed code before being accepted.

## Review rounds

Ten findings from Codex across six rounds. Nine are fixed; one is argued and recorded. Every one of them is the same bug wearing different clothes — something the scanner could not see was something it silently vouched for:

| Finding | Hole | Outcome |
|---|---|---|
| Bare restatements | `the pin is d0edc128` unbackticked slipped past | fixed |
| Marker floor | only the first N claims in a file protected | fixed (exact counts) |
| Compound code spans | `` `A..B` `` invisible to both scan passes | fixed |
| Occurrences vs lines | two claims on one line counted once | fixed |
| Fence delimiters | odd nested fence left the rest of the file "code" | fixed |
| Fence indentation | a 4-space `` ``` `` opened a fence that never closed | fixed |
| Backtick fence info | `` ```code``` is inline `` opened a fence that never closed | fixed |
| Uppercase hex | `2C0DAFBA` not recognised as the pin | fixed |
| Grant covers a class-A claim | swap one granted citation for "the pin is X", count holds | fixed (grammar floor) + residual argued |
| Count is per file, not per claim | unmark one `@api-version`, mark another, total holds | **argued, recorded in-file** |

Each fix has a self-test case shown to fail against its own un-fixed version, and in each round only that round's cases fail — so none rides on another's fix. The fence-delimiter round failed in *both* directions against the old toggle, which also showed the toggle inventing findings inside code samples.

### The one not fixed

A marker count is per file, so unmarking one `@api-version` sentence in `SPEC.md` while marking a different one in the same change keeps the total at 2 and passes, leaving the first unprotected. True, and closing it needs per-claim identity — named markers, `<!-- @api-version#headers -->`, with the inventory listing names.

Not done here, for two reasons recorded next to the mechanism rather than only in a review thread. It changes the marker grammar that AGENTS.md and SPEC.md document and collides with the `:begin`/`:end` suffix, so it is a design change to the convention rather than a bug fix. And unlike every other finding — all of which triggered on *ordinary authoring* — this one requires a deliberate within-file relocation of a marker, which is by definition a reviewed edit to marked spans; cross-file relocation is already caught.

The symmetric fix is unavailable, which is worth knowing: `@bc3-pin` gets an unmarked-restatement scan, but `API_VERSION` cannot have one. It *is* a date, and the same date as `.bc3.date`, so the scan would fire on every legitimate mention — starting with `COORDINATION.md`'s own "as of the 2026-08-02 sync". A 40-hex SHA appears nowhere by accident; a date appears everywhere by accident.

The in-file note names the condition under which the argument stops holding, so it is falsifiable rather than a standing excuse: **a third `@api-version` claim**.

Because they kept arriving in the same shape, the file now states which way this gate should be wrong: resolve any prose-vs-code ambiguity toward **treating a line as prose**. Over-scanning costs a false alarm — loud, in front of the author, disproved in a minute. Under-scanning costs a claim nobody looked at, reported as success, carrying the gate's own green tick.

## SPEC Appendix A

Only `API_VERSION` is gated. The other 13 rows were read against their cited sources on 2026-08-03 — all 13 matched, recorded in SPEC.md with the date. They stay ungated because each is asserted of several SDKs at once in a different spelling per language, so a checker would need a per-row, per-language extraction rule rather than the one-value-one-source substitution the marker convention is built on. Also recorded: the two spellings that defeat a naive grep, since I hit both — `MAX_ERROR_MESSAGE_LENGTH` is `MaxErrorMessageBytes` in Go and `MAX_ERROR_MESSAGE_BYTES` in Ruby, and `TOKEN_REFRESH_BUFFER` is not a named constant anywhere, it is the literal `300` in `creds.ExpiresAt-300` (`go/pkg/basecamp/auth.go:287`).

## Residual pin restatements

Every present-tense restatement carrying a literal SHA is rewritten as an as-of fact bound to what makes it permanently true, across `calendar.md`, `my-bookmarks.md`, `my-drafts.md`, `my-assignments-priorities.md`, `everything-tasks-aggregate.md` and `upload-new-version.md`.

The sweep surfaced a third form that had never been written down and is usually the right answer: **name the pin by reference, not by value** — "the revision `spec/api-provenance.json` currently pins". It means today's pin, survives every repin, and restates no constant, so nothing can drift and nothing needs marking. That is now in AGENTS.md alongside the A/B rule.

## Verification

| Command | Exit |
|---|---|
| `make doc-constants-check` | 0 |
| `make sync-api-version-check` | 0 |
| `make validate-api-gaps` | 0 (31 entries) |
| `make lint-actions` | 0 (actionlint + zizmor, no findings) |
| `ruby -w -c scripts/sync-doc-constants.rb` | 0 |
| `shellcheck scripts/check-doc-constants.sh scripts/sync-api-version.sh` | 0 |

No SDK source, `openapi.json`, or `spec/basecamp.smithy` touched. SPEC §7 untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a gate and writer to keep three documentation constants in sync with their sources, with strict fence parsing, exact per‑file marker counts, and a rule that “the pin is X” sentences must be marked — grants only cover as‑of facts.

- **New Features**
  - Check: `make doc-constants-check` validates `@api-version` (vs `openapi.json` `.info.version`), `@bc3-pin` (SHA+date, vs `spec/api-provenance.json`), and `@assertion-types:begin/end` (vs `conformance/schema.json`). Runs a negative self‑test (`scripts/test-doc-constants.rb`). Supports `--openapi`; all I/O forced to UTF‑8.
  - Writer: `scripts/sync-doc-constants.rb` (`--check`/`--write`) is called from `scripts/sync-api-version.sh` and forwards `--openapi`. Preserves SHA abbreviation length; never edits files in `spec/doc-constants.json` `.writerExcludes` (e.g., `spec/api-gaps/README.md`). The assertion‑types table is check‑only.
  - Safety: scans raw prose lines (including ranges), counts every occurrence, is case‑insensitive for SHA matches, and rejects bare SHAs inside `@bc3-pin`. Fenced code is skipped with delimiter matching and ≤3‑space indentation; backtick fences with a backtick in the info string do not open; tilde fences allow any info. Ambiguities over‑scan as prose.
  - Inventory and grants: `spec/doc-constants.json` records exact per‑file marker counts (markers in undeclared files fail). `.unmarkedPinCitations` entries are shape‑validated and bounded by an exact count+reason; grants do not cover class‑A grammar (“the pin is X”, “at the pinned X”) — those lines must be marked. A per‑file count residual is documented in code comments.
  - CI/docs: wired into `check` and Actions. SPEC/AGENTS updated (A/B rule, request assertion `index`); API version, bc3 pin, and assertion‑types table corrected.

- **Migration**
  - After a repin, run `make sync-api-version` to update SDK constants and marked prose; update the triage narrative in `spec/api-gaps/README.md` by hand.
  - When adding or moving a marked claim, keep it marked and update the count in `spec/doc-constants.json`. For an as‑of reference that happens to name today’s pin, either mark it (and include the date) or add a bounded `.unmarkedPinCitations` grant with a reason.

<sup>Written for commit 57073d342fe4226e3e2ef52c2261692bdbabbda6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


