### PR TITLE
Docs: how to get a token, how to find your account ID, and three claims that were not true

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,6 +142,9 @@ jobs:
       - name: README env-var tables match what the SDKs actually read
         run: make check-readme-env-vars
 
+      - name: README env-var gate self-test (synthetic repos)
+        run: make test-check-readme-env-vars
+
       # Offline by construction — compares openapi.json against the vendored
       # spec/bc3-routes.json, so it needs no bc3 checkout and no secret and
       # therefore cannot skip. A gate that skips when its input is absent is how

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,6 +139,9 @@ jobs:
       - name: Kotlin service drift (static; jq/grep, no JVM)
         run: make kt-check-drift
 
+      - name: README env-var tables match what the SDKs actually read
+        run: make check-readme-env-vars
+
       # Offline by construction — compares openapi.json against the vendored
       # spec/bc3-routes.json, so it needs no bc3 checkout and no secret and
       # therefore cannot skip. A gate that skips when its input is absent is how

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,11 @@ python/.pytest_cache/
 python/.coverage
 python/src/*.egg-info/
 
+# Repo-level Python tooling. The README env-var gate's self-test imports the
+# gate by path, and SourceFileLoader caches its bytecode next to it.
+scripts/__pycache__/
+scripts/*.pyc
+
 # Python conformance runner artifacts
 conformance/runner/python/.venv/
 conformance/runner/python/**/__pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1007,7 +1007,7 @@ tools:
 # Spec-shape lints
 #------------------------------------------------------------------------------
 
-.PHONY: check-bucket-flat-parity validate-api-gaps check-deprecation-parity kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-fixture-coverage check-idempotency-parity check-retry-metadata-parity check-runner-test-reachability check-replay-decoder-parity
+.PHONY: check-bucket-flat-parity validate-api-gaps check-deprecation-parity kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-fixture-coverage check-idempotency-parity check-retry-metadata-parity check-runner-test-reachability check-replay-decoder-parity check-readme-env-vars
 
 # Verify every bucket-scoped GET list operation has a flat-path counterpart
 # (or is justified in spec/bucket-scoped-allowlist.txt). Cross-project SDK
@@ -1089,6 +1089,14 @@ check-runner-test-reachability:
 check-replay-decoder-parity:
 	@./scripts/check-replay-decoder-parity
 
+# Verify the README environment-variable tables against the SDK sources, both
+# directions: nothing documented that isn't read, nothing read that isn't
+# documented. Nothing here is generated, so prose drift is otherwise silent —
+# a phantom BASECAMP_ACCOUNT_ID row and an XDG_CACHE_HOME credited to Ruby both
+# shipped. Python3 — runs anywhere, enforced in CI (spec-gates job).
+check-readme-env-vars:
+	@python3 ./scripts/check-readme-env-vars.py
+
 #------------------------------------------------------------------------------
 # Combined targets
 #------------------------------------------------------------------------------
@@ -1111,7 +1119,7 @@ generate:
 	@echo "==> Generation complete"
 
 # Run all checks (Smithy + Go + TypeScript + Ruby + Kotlin + Swift + Python + Behavior Model + Conformance + Provenance + Actions lint)
-check: lint-actions sync-spec-version-check smithy-check behavior-model-check provenance-check sync-api-version-check doc-constants-check url-routes-check bc3-route-parity go-check-drift go-check-wrapper-drift go-check-generated-drift auth-routable-check kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity check-fixture-coverage kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-idempotency-parity check-retry-metadata-parity check-runner-test-reachability check-replay-decoder-parity
+check: lint-actions sync-spec-version-check smithy-check behavior-model-check provenance-check sync-api-version-check doc-constants-check url-routes-check bc3-route-parity go-check-drift go-check-wrapper-drift go-check-generated-drift auth-routable-check kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity check-fixture-coverage kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-idempotency-parity check-retry-metadata-parity check-runner-test-reachability check-replay-decoder-parity check-readme-env-vars
 	@echo "==> All checks passed"
 
 # Clean all build artifacts

--- a/Makefile
+++ b/Makefile
@@ -1007,7 +1007,7 @@ tools:
 # Spec-shape lints
 #------------------------------------------------------------------------------
 
-.PHONY: check-bucket-flat-parity validate-api-gaps check-deprecation-parity kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-fixture-coverage check-idempotency-parity check-retry-metadata-parity check-runner-test-reachability check-replay-decoder-parity check-readme-env-vars
+.PHONY: check-bucket-flat-parity validate-api-gaps check-deprecation-parity kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-fixture-coverage check-idempotency-parity check-retry-metadata-parity check-runner-test-reachability check-replay-decoder-parity check-readme-env-vars test-check-readme-env-vars
 
 # Verify every bucket-scoped GET list operation has a flat-path counterpart
 # (or is justified in spec/bucket-scoped-allowlist.txt). Cross-project SDK
@@ -1097,6 +1097,14 @@ check-replay-decoder-parity:
 check-readme-env-vars:
 	@python3 ./scripts/check-readme-env-vars.py
 
+# Drive that gate from outside with synthetic repos whose correct answer is
+# known: single- and double-quoted reads, doc-comment examples, test source
+# sets, and a checkout nested under a directory named Tests. Its failure mode is
+# silent — a read pattern that misses reports "nothing reads this", which looks
+# like a README bug rather than a gate bug — so it needs its own tests.
+test-check-readme-env-vars:
+	@python3 ./scripts/test-check-readme-env-vars.py
+
 #------------------------------------------------------------------------------
 # Combined targets
 #------------------------------------------------------------------------------
@@ -1119,7 +1127,7 @@ generate:
 	@echo "==> Generation complete"
 
 # Run all checks (Smithy + Go + TypeScript + Ruby + Kotlin + Swift + Python + Behavior Model + Conformance + Provenance + Actions lint)
-check: lint-actions sync-spec-version-check smithy-check behavior-model-check provenance-check sync-api-version-check doc-constants-check url-routes-check bc3-route-parity go-check-drift go-check-wrapper-drift go-check-generated-drift auth-routable-check kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity check-fixture-coverage kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-idempotency-parity check-retry-metadata-parity check-runner-test-reachability check-replay-decoder-parity check-readme-env-vars
+check: lint-actions sync-spec-version-check smithy-check behavior-model-check provenance-check sync-api-version-check doc-constants-check url-routes-check bc3-route-parity go-check-drift go-check-wrapper-drift go-check-generated-drift auth-routable-check kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity check-fixture-coverage kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-idempotency-parity check-retry-metadata-parity check-runner-test-reachability check-replay-decoder-parity check-readme-env-vars test-check-readme-env-vars
 	@echo "==> All checks passed"
 
 # Clean all build artifacts

--- a/README.md
+++ b/README.md
@@ -73,11 +73,15 @@ Every API path is scoped to an account — `https://3.basecampapi.com/{accountId
 
 The response lists every account the token can reach; take `accounts[].id` for an entry whose `product` is `"bc3"` (that is Basecamp — the same response also carries `"hey"` and other 37signals products). The same response carries the token's expiry — `expires_at` on the wire, `expiresAt` on the TypeScript type — which is the quickest way to confirm a static token has not lapsed.
 
-This endpoint lives on Launchpad rather than on the Basecamp API, so it is account-independent: call it on the *top-level* client, before `ForAccount`/`for_account`. TypeScript is the exception — `createBasecampClient` requires an `accountId` up front, so pass a placeholder for the bootstrap call and rebuild the client once you know the real one.
+The document is account-independent, so call it on the *top-level* client, before `ForAccount`/`for_account`. TypeScript is the exception — `createBasecampClient` requires an `accountId` up front, so pass a placeholder for the bootstrap call and rebuild the client once you know the real one.
+
+It lives on the authorization server that issued your token, not on the Basecamp API — which matters once you leave Launchpad behind. A Launchpad-issued token (authorization code, or a static token from there) reads it at Launchpad. A **device-flow** token is issued by the discovered BC5 server, and its document lives there too. Ruby follows the token: `Http#get_authorization_document` runs resource-first discovery and fetches from the *selected* issuer. The other three hardcode Launchpad, so a device-flow token needs the issuer supplied — Go takes `GetInfoOptions.Endpoint` and TypeScript an `endpoint` option, while Python's `authorization.get()` accepts no override at all, so fetch the document yourself as in the `curl` below.
 
 Swift and Kotlin ship no `authorization` service. Fetch it once with any HTTP client:
 
 ```bash
+# Launchpad-issued token. For a device-flow token, replace the host with the
+# issuer discovery selected — that is where its authorization.json lives.
 curl -s https://launchpad.37signals.com/authorization.json \
   -H "Authorization: Bearer $BASECAMP_TOKEN" \
   -H "User-Agent: my-app/1.0 (you@example.com)"

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ See the [spec README](spec/README.md) for details on the model structure.
 
 ## Environment Variables
 
-There is no environment variable every SDK honours. The Quick Start snippets above call `getenv` themselves — that is the *caller* reading its own environment, not an SDK convention. What the SDKs read on their own, and only when you ask them to (`XDG_CACHE_HOME` / `XDG_CONFIG_HOME`, which Go and Ruby use to site their cache and config directories, aside):
+There is no environment variable every SDK honours. The Quick Start snippets above call `getenv` themselves — that is the *caller* reading its own environment, not an SDK convention. What the SDKs read on their own, and only when you ask them to (the XDG directory variables aside: Go reads `XDG_CACHE_HOME` in `DefaultConfig` and `XDG_CONFIG_HOME` for its config directory, and Ruby reads `XDG_CONFIG_HOME` in `Config.global_config_dir`):
 
 | Variable | Read by | Only when |
 |----------|---------|-----------|
@@ -250,7 +250,7 @@ There is no environment variable every SDK honours. The Quick Start snippets abo
 | `BASECAMP_CACHE_ENABLED`, `BASECAMP_CACHE_DIR` | Go | `cfg.LoadConfigFromEnv()` |
 | `BASECAMP_PROJECT_ID`, `BASECAMP_TODOLIST_ID` | Go | `cfg.LoadConfigFromEnv()` |
 | `BASECAMP_TOKEN` | Go | you authenticate through `AuthManager`, which prefers it over the stored OAuth credentials |
-| `BASECAMP_NO_KEYRING` | Go | `AuthManager` chooses credential storage |
+| `BASECAMP_NO_KEYRING` | Go | you construct a `CredentialStore` via `NewCredentialStore` — which `NewAuthManager` does for you, but `NewAuthManagerWithStore` does not |
 
 TypeScript, Swift, and Kotlin read no environment variables at all — configure them entirely through their options objects.
 

--- a/README.md
+++ b/README.md
@@ -40,16 +40,23 @@ All SDKs are generated from a single [Smithy](https://smithy.io/) specification,
 
 Every Basecamp API request carries an OAuth 2.0 access token. There is no API key and no personal access token, so even a throwaway script starts here:
 
-1. Register your integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
-2. Choose the grant that matches how your code runs:
+1. Choose the grant that matches how your code runs:
 
 | Your integration | Grant | Who refreshes the token |
 |---|---|---|
 | already holds a token you obtained elsewhere | **static token** | you do |
 | can receive a browser redirect (web app, or a local callback server) | **authorization code + PKCE** | a refreshing token provider (built in for Go, Ruby, Python; wire it yourself in TypeScript and Kotlin) |
-| has no browser at all (CLI, daemon, CI job, device) | **device flow** ([RFC 8628](https://www.rfc-editor.org/rfc/rfc8628)) | a refreshing token provider (built in for Go, Ruby, Python; wire it yourself in TypeScript and Kotlin) |
+| has no browser at all (CLI, daemon, CI job, device) | **device flow** ([RFC 8628](https://www.rfc-editor.org/rfc/rfc8628)) | Go's `AuthManager`; in Ruby and Python the standalone refresh helper, **not** their built-in token providers (see below); wire it yourself in TypeScript and Kotlin |
 
 The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+
+2. Get the client credentials that grant needs:
+
+- **Authorization code + PKCE** — register your own integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
+- **Device flow** — nothing to register. It runs as the pre-registered public `basecamp-cli` client, which sends no secret, against the device endpoint that discovery returns. Launchpad advertises no device endpoint, so a client you register there is not the one this flow uses.
+- **Static token** — nothing to register; you already hold the token.
+
+A device-flow token needs a matching refresh path. BC5 device logins mint multi-account refresh tokens carrying an RFC 8707 `resource` indicator, and a refresh that does not echo it is rejected with `400 invalid_request`. Go's `AuthManager` refreshes against the stored token endpoint and echoes `resource`, so it handles this. Ruby's `OauthTokenProvider` and Python's `OAuthTokenProvider` do **not** — both are pinned to Launchpad's legacy token URL, send no `resource`, and expect a client secret the public client does not have. In those two, refresh a device token with `Basecamp::Oauth.refresh_token` / `basecamp.oauth.exchange.refresh_token`, passing the stored `resource`.
 
 A static token is the shortest path to a first successful call, and it is the one option the SDK will never refresh for you — once it expires, every request fails with `401` until you supply a new one. The Quick Start snippets below all use static tokens for brevity; move to one of the other two grants before you ship. OAuth is available in every SDK except Swift, and the device flow in Go, Ruby, TypeScript, Kotlin, and Python — see the per-language docs linked under [Documentation](#documentation).
 

--- a/README.md
+++ b/README.md
@@ -29,12 +29,54 @@ OpenAPI 3.1 spec included.
 † Ruby SDK uses Faraday - add caching via [faraday-http-cache](https://github.com/sourcelevel/faraday-http-cache)
 
 **Note:** HTTP caching is disabled by default. Enable explicitly via configuration:
-- **Go:** `cfg.CacheEnabled = true` or `BASECAMP_CACHE_ENABLED=true`
+- **Go:** `cfg.CacheEnabled = true`, or `BASECAMP_CACHE_ENABLED=true` plus a `cfg.LoadConfigFromEnv()` call
 - **TypeScript:** `enableCache: true` in client options
 - **Swift:** `BasecampConfig(enableCache: true)`
 - **Kotlin:** `enableCache = true` in builder DSL
 
 All SDKs are generated from a single [Smithy](https://smithy.io/) specification, ensuring consistent behavior and API coverage across languages.
+
+## Getting a token
+
+Every Basecamp API request carries an OAuth 2.0 access token. There is no API key and no personal access token, so even a throwaway script starts here:
+
+1. Register your integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
+2. Choose the grant that matches how your code runs:
+
+| Your integration | Grant | Who refreshes the token |
+|---|---|---|
+| already holds a token you obtained elsewhere | **static token** | you do |
+| can receive a browser redirect (web app, or a local callback server) | **authorization code + PKCE** | a refreshing token provider (built in for Go, Ruby, Python; wire it yourself in TypeScript and Kotlin) |
+| has no browser at all (CLI, daemon, CI job, device) | **device flow** ([RFC 8628](https://www.rfc-editor.org/rfc/rfc8628)) | a refreshing token provider (built in for Go, Ruby, Python; wire it yourself in TypeScript and Kotlin) |
+
+The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+
+A static token is the shortest path to a first successful call, and it is the one option the SDK will never refresh for you — once it expires, every request fails with `401` until you supply a new one. The Quick Start snippets below all use static tokens for brevity; move to one of the other two grants before you ship. OAuth is available in every SDK except Swift, and the device flow in Go, Ruby, TypeScript, Kotlin, and Python — see the per-language docs linked under [Documentation](#documentation).
+
+## Finding your account ID
+
+Every API path is scoped to an account — `https://3.basecampapi.com/{accountId}/…` — so you need that number before your first call, and the Quick Start snippets below assume you already have it. One token can reach several accounts, so ask the token which:
+
+| Language | Call |
+|---|---|
+| Go | `client.Authorization().GetInfo(ctx, nil)` |
+| Ruby | `client.authorization.get` |
+| TypeScript | `await client.authorization.getInfo()` |
+| Python | `client.authorization.get()` |
+
+The response lists every account the token can reach; take `accounts[].id` for an entry whose `product` is `"bc3"` (that is Basecamp — the same response also carries `"hey"` and other 37signals products). The same response carries the token's expiry — `expires_at` on the wire, `expiresAt` on the TypeScript type — which is the quickest way to confirm a static token has not lapsed.
+
+This endpoint lives on Launchpad rather than on the Basecamp API, so it is account-independent: call it on the *top-level* client, before `ForAccount`/`for_account`. TypeScript is the exception — `createBasecampClient` requires an `accountId` up front, so pass a placeholder for the bootstrap call and rebuild the client once you know the real one.
+
+Swift and Kotlin ship no `authorization` service. Fetch it once with any HTTP client:
+
+```bash
+curl -s https://launchpad.37signals.com/authorization.json \
+  -H "Authorization: Bearer $BASECAMP_TOKEN" \
+  -H "User-Agent: my-app/1.0 (you@example.com)"
+```
+
+A `User-Agent` identifying your app is required on every Basecamp request, including this one.
 
 ## Quick Start
 
@@ -115,15 +157,23 @@ for project in projects {
 
 ### Kotlin
 
-```kotlin
-val client = BasecampClient {
-    accessToken(System.getenv("BASECAMP_TOKEN"))
-    userAgent = "my-app/1.0 (you@example.com)"
-}
+Service accessors are extension properties, so `account.projects` needs the `com.basecamp.sdk.generated` import as well as the client's. Every service method is `suspend`, so the calls need a coroutine.
 
-val account = client.forAccount(System.getenv("BASECAMP_ACCOUNT_ID"))
-val projects = account.projects.list()
-projects.forEach { println("${it.id}: ${it.name}") }
+```kotlin
+import com.basecamp.sdk.BasecampClient
+import com.basecamp.sdk.generated.projects
+
+suspend fun main() {
+    val client = BasecampClient {
+        accessToken(System.getenv("BASECAMP_TOKEN"))
+        userAgent = "my-app/1.0 (you@example.com)"
+    }
+
+    val account = client.forAccount(System.getenv("BASECAMP_ACCOUNT_ID"))
+    account.projects.list().forEach { println("${it.id}: ${it.name}") }
+
+    client.close()
+}
 ```
 
 ### Python
@@ -148,7 +198,7 @@ All SDKs provide:
 - **OAuth 2.0 authentication** - Token refresh, PKCE support (Go, TypeScript, Ruby, Kotlin, Python), and static token options
 - **Automatic retry** - Exponential backoff with jitter, respects `Retry-After` headers
 - **Pagination** - Link header–based pagination support (high-level handling may vary by SDK; see language docs)
-- **ETag caching** - Built-in HTTP caching for efficient API usage (Go, TypeScript, Ruby†, Swift, Kotlin)
+- **ETag caching** - Opt-in HTTP caching for efficient API usage (Go, TypeScript, Ruby†, Swift, Kotlin); off by default everywhere
 - **Structured errors** - Typed errors with helpful hints, CLI-friendly exit codes, and per-field validation detail you can bind straight to a form
 - **Observability hooks** - Integration points for logging, metrics, and tracing
 
@@ -190,13 +240,21 @@ See the [spec README](spec/README.md) for details on the model structure.
 
 ## Environment Variables
 
-All SDKs support common environment variables:
+There is no environment variable every SDK honours. The Quick Start snippets above call `getenv` themselves — that is the *caller* reading its own environment, not an SDK convention. What the SDKs read on their own, and only when you ask them to (`XDG_CACHE_HOME` / `XDG_CONFIG_HOME`, which Go and Ruby use to site their cache and config directories, aside):
 
-| Variable | Description |
-|----------|-------------|
-| `BASECAMP_TOKEN` | OAuth access token |
-| `BASECAMP_ACCOUNT_ID` | Basecamp account ID |
-| `BASECAMP_BASE_URL` | API base URL (default: `https://3.basecampapi.com`) |
+| Variable | Read by | Only when |
+|----------|---------|-----------|
+| `BASECAMP_BASE_URL` | Go, Ruby, Python | `cfg.LoadConfigFromEnv()` / `Config.from_env` |
+| `BASECAMP_TIMEOUT` | Ruby, Python | `Config.from_env` |
+| `BASECAMP_MAX_RETRIES` | Ruby, Python | `Config.from_env` |
+| `BASECAMP_CACHE_ENABLED`, `BASECAMP_CACHE_DIR` | Go | `cfg.LoadConfigFromEnv()` |
+| `BASECAMP_PROJECT_ID`, `BASECAMP_TODOLIST_ID` | Go | `cfg.LoadConfigFromEnv()` |
+| `BASECAMP_TOKEN` | Go | you authenticate through `AuthManager`, which prefers it over the stored OAuth credentials |
+| `BASECAMP_NO_KEYRING` | Go | `AuthManager` chooses credential storage |
+
+TypeScript, Swift, and Kotlin read no environment variables at all — configure them entirely through their options objects.
+
+**`BASECAMP_ACCOUNT_ID` is not an SDK variable.** No SDK reads it; it is a convention shared by this repository's examples, `make conformance-*-live`, and the nightly canary. Pass the account ID explicitly to `ForAccount` / `for_account` / `forAccount` / `accountId`.
 
 See individual SDK documentation for language-specific options.
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Every Basecamp API request carries an OAuth 2.0 access token. There is no API ke
 |---|---|---|
 | already holds a token you obtained elsewhere | **static token** | you do |
 | can receive a browser redirect (web app, or a local callback server) | **authorization code + PKCE** | a refreshing token provider (built in for Go, Ruby, Python; wire it yourself in TypeScript and Kotlin) |
-| has no browser at all (CLI, daemon, CI job, device) | **device flow** ([RFC 8628](https://www.rfc-editor.org/rfc/rfc8628)) | Go's `AuthManager`; in Ruby and Python the standalone refresh helper, **not** their built-in token providers (see below); wire it yourself in TypeScript and Kotlin |
+| has no browser, but a person can approve on another device (CLI, headless server, TV) | **device flow** ([RFC 8628](https://www.rfc-editor.org/rfc/rfc8628)) | Go's `AuthManager`; in Ruby and Python the standalone refresh helper, **not** their built-in token providers (see below); wire it yourself in TypeScript and Kotlin |
 
-The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+The one-line rule: **a redirect URI you control → authorization code; no browser but someone to approve → device flow; a token already in hand → static token.** An unattended daemon or CI job fits none of the three on its own — the device flow needs a person to enter the user code at the verification URI — so provision a token out of band and hand it to the process as a static or refresh token.
 
 2. Get the client credentials that grant needs:
 

--- a/go/README.md
+++ b/go/README.md
@@ -35,9 +35,9 @@ Every Basecamp API request carries an OAuth 2.0 access token. There is no API ke
 |---|---|---|
 | already holds a token you obtained elsewhere | **static token** — [below](#using-a-static-token) | you do |
 | can receive a browser redirect (web app, or a local callback server) | **authorization code + PKCE** — [below](#using-oauth-20) | `AuthManager` |
-| has no browser at all (CLI, daemon, CI job, device) | **device flow** — [below](#oauth-device-authorization-grant-rfc-8628) | `AuthManager` |
+| has no browser, but a person can approve on another device (CLI, headless server, TV) | **device flow** — [below](#oauth-device-authorization-grant-rfc-8628) | `AuthManager` |
 
-The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+The one-line rule: **a redirect URI you control → authorization code; no browser but someone to approve → device flow; a token already in hand → static token.** An unattended daemon or CI job fits none of the three on its own — the device flow needs a person to enter the user code at the verification URI — so provision a token out of band and hand it to the process as a static or refresh token.
 
 2. Get the client credentials that grant needs:
 

--- a/go/README.md
+++ b/go/README.md
@@ -348,7 +348,7 @@ the hop-1 binding and silently soft-falls back to Launchpad.
 
 ### Environment Variables
 
-Nothing here is read automatically. The five `Config` variables apply only when you call `cfg.LoadConfigFromEnv()`, and the two auth variables only when you authenticate through `AuthManager`. (`DefaultConfig` does consult `XDG_CACHE_HOME` and `XDG_CONFIG_HOME` to site its cache and config directories.)
+Nothing here is read automatically. The five `Config` variables apply only when you call `cfg.LoadConfigFromEnv()`. `BASECAMP_TOKEN` is read by `AuthManager.AccessToken` and `AuthManager.IsAuthenticated`; `BASECAMP_NO_KEYRING` is read one level down, by `NewCredentialStore`. (Separately, `DefaultConfig` consults `XDG_CACHE_HOME` to site the cache directory, and `globalConfigDir` consults `XDG_CONFIG_HOME` to site the config directory.)
 
 | Variable | Read by | Description |
 |----------|---------|-------------|
@@ -358,7 +358,7 @@ Nothing here is read automatically. The five `Config` variables apply only when 
 | `BASECAMP_CACHE_DIR` | `cfg.LoadConfigFromEnv()` | Cache directory path (default: `~/.cache/basecamp`) |
 | `BASECAMP_CACHE_ENABLED` | `cfg.LoadConfigFromEnv()` | Enable HTTP caching (default: `false`) |
 | `BASECAMP_TOKEN` | `AuthManager` | Access token. Consulted **first**, ahead of any stored OAuth credentials, so setting it short-circuits the OAuth flow — handy for scripts and CI |
-| `BASECAMP_NO_KEYRING` | `AuthManager` | Store credentials in a file instead of the system keyring |
+| `BASECAMP_NO_KEYRING` | `NewCredentialStore` | Store credentials in a file instead of the system keyring. Read when the store is constructed, so `NewAuthManager` picks it up but `NewAuthManagerWithStore` does not — pass a store you built yourself and this variable has already been applied, or not, by that call |
 
 `StaticTokenProvider` does **not** read `BASECAMP_TOKEN`; it uses whatever string you put in its `Token` field. The Quick Start above reads the variable itself, at the call site.
 

--- a/go/README.md
+++ b/go/README.md
@@ -49,7 +49,7 @@ The one-line rule: **a redirect URI you control → authorization code; no brows
 
 ## Finding your account ID
 
-Every API path is scoped to an account — `https://3.basecampapi.com/{accountId}/…` — so `ForAccount` needs that number before your first call. One token can reach several accounts, so ask the token which. `Authorization()` hangs off the *top-level* client because the endpoint lives on Launchpad, not on the Basecamp API, and so takes no account context:
+Every API path is scoped to an account — `https://3.basecampapi.com/{accountId}/…` — so `ForAccount` needs that number before your first call. One token can reach several accounts, so ask the token which. `Authorization()` hangs off the *top-level* client because the endpoint lives on the authorization server rather than the Basecamp API, and so takes no account context. It defaults to Launchpad, which is right for a Launchpad-issued token; a **device-flow** token is issued by the discovered BC5 server and its `authorization.json` lives there, so pass that issuer as `GetInfoOptions.Endpoint`:
 
 ```go
 info, err := client.Authorization().GetInfo(context.Background(), &basecamp.GetInfoOptions{

--- a/go/README.md
+++ b/go/README.md
@@ -11,7 +11,7 @@ Official Go SDK for the [Basecamp API](https://github.com/basecamp/bc3-api).
 - Full coverage of 30+ Basecamp API services
 - OAuth 2.0 authentication with automatic token refresh
 - Static token authentication for simple integrations
-- ETag-based HTTP caching for efficient API usage
+- ETag-based HTTP caching for efficient API usage (opt-in)
 - Automatic retry with exponential backoff
 - Pagination handling with `GetAll()`
 - Structured errors with CLI-friendly exit codes
@@ -24,6 +24,43 @@ go get github.com/basecamp/basecamp-sdk/go
 ```
 
 Requires Go 1.26 or later.
+
+## Getting a token
+
+Every Basecamp API request carries an OAuth 2.0 access token. There is no API key and no personal access token, so even a throwaway script starts here:
+
+1. Register your integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
+2. Choose the grant that matches how your code runs:
+
+| Your integration | Grant | Who refreshes the token |
+|---|---|---|
+| already holds a token you obtained elsewhere | **static token** — [below](#using-a-static-token) | you do |
+| can receive a browser redirect (web app, or a local callback server) | **authorization code + PKCE** — [below](#using-oauth-20) | `AuthManager` |
+| has no browser at all (CLI, daemon, CI job, device) | **device flow** — [below](#oauth-device-authorization-grant-rfc-8628) | `AuthManager` |
+
+The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+
+`StaticTokenProvider` hands back the string you gave it and nothing more — it never refreshes, so once the token expires every call fails with `401` until you supply a new one. Use it to get a first successful call, then move to `AuthManager` before you ship.
+
+## Finding your account ID
+
+Every API path is scoped to an account — `https://3.basecampapi.com/{accountId}/…` — so `ForAccount` needs that number before your first call. One token can reach several accounts, so ask the token which. `Authorization()` hangs off the *top-level* client because the endpoint lives on Launchpad, not on the Basecamp API, and so takes no account context:
+
+```go
+info, err := client.Authorization().GetInfo(context.Background(), &basecamp.GetInfoOptions{
+    FilterProduct: "bc3", // Basecamp; the same response also carries "hey" and other products
+})
+if err != nil {
+    log.Fatal(err)
+}
+for _, a := range info.Accounts {
+    fmt.Printf("%d: %s\n", a.ID, a.Name)
+}
+
+account := client.ForAccount(fmt.Sprint(info.Accounts[0].ID))
+```
+
+`info.ExpiresAt` tells you how long the token has left, which is the quickest way to confirm a static token has not lapsed.
 
 ## Quick Start
 
@@ -311,17 +348,21 @@ the hop-1 binding and silently soft-falls back to Launchpad.
 
 ### Environment Variables
 
-| Variable | Description | Required |
-|----------|-------------|----------|
-| `BASECAMP_TOKEN` | Static API token or OAuth access token | Yes (unless using OAuth flow) |
-| `BASECAMP_PROJECT_ID` | Default project ID | No |
-| `BASECAMP_TODOLIST_ID` | Default todolist ID | No |
-| `BASECAMP_BASE_URL` | API base URL | No (default: `https://3.basecampapi.com`) |
-| `BASECAMP_CACHE_DIR` | Cache directory path | No (default: `~/.cache/basecamp`) |
-| `BASECAMP_CACHE_ENABLED` | Enable HTTP caching | No (default: `false`) |
-| `BASECAMP_NO_KEYRING` | Disable system keyring | No |
+Nothing here is read automatically. The five `Config` variables apply only when you call `cfg.LoadConfigFromEnv()`, and the two auth variables only when you authenticate through `AuthManager`. (`DefaultConfig` does consult `XDG_CACHE_HOME` and `XDG_CONFIG_HOME` to site its cache and config directories.)
 
-Note: Account ID is specified via `client.ForAccount(accountID)` rather than configuration.
+| Variable | Read by | Description |
+|----------|---------|-------------|
+| `BASECAMP_BASE_URL` | `cfg.LoadConfigFromEnv()` | API base URL (default: `https://3.basecampapi.com`) |
+| `BASECAMP_PROJECT_ID` | `cfg.LoadConfigFromEnv()` | Default project ID |
+| `BASECAMP_TODOLIST_ID` | `cfg.LoadConfigFromEnv()` | Default todolist ID |
+| `BASECAMP_CACHE_DIR` | `cfg.LoadConfigFromEnv()` | Cache directory path (default: `~/.cache/basecamp`) |
+| `BASECAMP_CACHE_ENABLED` | `cfg.LoadConfigFromEnv()` | Enable HTTP caching (default: `false`) |
+| `BASECAMP_TOKEN` | `AuthManager` | Access token. Consulted **first**, ahead of any stored OAuth credentials, so setting it short-circuits the OAuth flow — handy for scripts and CI |
+| `BASECAMP_NO_KEYRING` | `AuthManager` | Store credentials in a file instead of the system keyring |
+
+`StaticTokenProvider` does **not** read `BASECAMP_TOKEN`; it uses whatever string you put in its `Token` field. The Quick Start above reads the variable itself, at the call site.
+
+Note: account ID is specified via `client.ForAccount(accountID)` rather than configuration. `BASECAMP_ACCOUNT_ID` is a convention used by this repository's examples and tooling — no SDK reads it.
 
 ### Programmatic Configuration
 

--- a/go/README.md
+++ b/go/README.md
@@ -29,8 +29,7 @@ Requires Go 1.26 or later.
 
 Every Basecamp API request carries an OAuth 2.0 access token. There is no API key and no personal access token, so even a throwaway script starts here:
 
-1. Register your integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
-2. Choose the grant that matches how your code runs:
+1. Choose the grant that matches how your code runs:
 
 | Your integration | Grant | Who refreshes the token |
 |---|---|---|
@@ -39,6 +38,12 @@ Every Basecamp API request carries an OAuth 2.0 access token. There is no API ke
 | has no browser at all (CLI, daemon, CI job, device) | **device flow** — [below](#oauth-device-authorization-grant-rfc-8628) | `AuthManager` |
 
 The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+
+2. Get the client credentials that grant needs:
+
+- **Authorization code + PKCE** — register your own integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
+- **Device flow** — nothing to register. It runs as the pre-registered public `basecamp-cli` client, which sends no secret, against the device endpoint that discovery returns. Launchpad advertises no device endpoint, so a client you register there is not the one this flow uses.
+- **Static token** — nothing to register; you already hold the token.
 
 `StaticTokenProvider` hands back the string you gave it and nothing more — it never refreshes, so once the token expires every call fails with `401` until you supply a new one. Use it to get a first successful call, then move to `AuthManager` before you ship.
 

--- a/go/README.md
+++ b/go/README.md
@@ -54,6 +54,9 @@ Every API path is scoped to an account — `https://3.basecampapi.com/{accountId
 ```go
 info, err := client.Authorization().GetInfo(context.Background(), &basecamp.GetInfoOptions{
     FilterProduct: "bc3", // Basecamp; the same response also carries "hey" and other products
+    // Endpoint defaults to Launchpad, which is right for a Launchpad-issued
+    // token. For a device-flow token, set it to the discovered issuer:
+    //   Endpoint: issuer + "/authorization.json",
 })
 if err != nil {
     log.Fatal(err)

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -154,9 +154,9 @@ Every Basecamp API request carries an OAuth 2.0 access token. There is no API ke
 |---|---|---|
 | already holds a token you obtained elsewhere | **static token** — `accessToken("…")` | you do |
 | can receive a browser redirect (web app, or a local callback server) | **authorization code + PKCE** — [`Authorization Flow`](#authorization-flow) | you, calling the SDK's `refreshToken()` from `accessToken { … }` |
-| has no browser at all (CLI, daemon, CI job, device) | **device flow** — [`Device Authorization Flow`](#device-authorization-flow-rfc-8628) | you, calling the SDK's `refreshToken()` from `accessToken { … }` |
+| has no browser, but a person can approve on another device (CLI, headless server, TV) | **device flow** — [`Device Authorization Flow`](#device-authorization-flow-rfc-8628) | you, calling the SDK's `refreshToken()` from `accessToken { … }` |
 
-The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+The one-line rule: **a redirect URI you control → authorization code; no browser but someone to approve → device flow; a token already in hand → static token.** An unattended daemon or CI job fits none of the three on its own — the device flow needs a person to enter the user code at the verification URI — so provision a token out of band and hand it to the process as a static or refresh token.
 
 2. Get the client credentials that grant needs:
 

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -170,9 +170,11 @@ The one-line rule: **a redirect URI you control → authorization code; no brows
 
 Every API path is scoped to an account — `https://3.basecampapi.com/{accountId}/…` — so `forAccount` needs that number before your first call. One token can reach several accounts.
 
-This SDK has no `authorization` service, because that endpoint lives on Launchpad rather than on the Basecamp API. Fetch it once yourself:
+This SDK has no `authorization` service, because that endpoint lives on the authorization server rather than on the Basecamp API. Fetch it once yourself, from the server that issued your token:
 
 ```bash
+# Launchpad-issued token. For a device-flow token, replace the host with the
+# issuer discovery selected — that is where its authorization.json lives.
 curl -s https://launchpad.37signals.com/authorization.json \
   -H "Authorization: Bearer $BASECAMP_TOKEN" \
   -H "User-Agent: MyApp/1.0 (you@example.com)"

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -142,27 +142,64 @@ And put the credentials in `~/.m2/settings.xml`, where `<id>` must match the rep
 | `Username must not be null!` | Neither `gpr.user` nor `GITHUB_USER` is set. |
 | `Received status code 401 from server: Unauthorized` | The token is wrong, expired, fine-grained rather than classic, or missing the `read:packages` scope. |
 
+## Getting a token
+
+The access token in the snippets below is a **Basecamp API** token. It is unrelated to the GitHub token above, which only downloads the artifact.
+
+Every Basecamp API request carries an OAuth 2.0 access token. There is no API key and no personal access token, so even a throwaway script starts here:
+
+1. Register your integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
+2. Choose the grant that matches how your code runs:
+
+| Your integration | Grant | Who refreshes the token |
+|---|---|---|
+| already holds a token you obtained elsewhere | **static token** — `accessToken("…")` | you do |
+| can receive a browser redirect (web app, or a local callback server) | **authorization code + PKCE** — [`Authorization Flow`](#authorization-flow) | you, calling the SDK's `refreshToken()` from `accessToken { … }` |
+| has no browser at all (CLI, daemon, CI job, device) | **device flow** — [`Device Authorization Flow`](#device-authorization-flow-rfc-8628) | you, calling the SDK's `refreshToken()` from `accessToken { … }` |
+
+The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+
+`accessToken("…")` hands back that exact string forever and never refreshes, so once the token expires every call fails with `401`. The lambda form, `accessToken { fetchFreshToken() }`, is re-invoked per request — that is where a refresh belongs.
+
+## Finding your account ID
+
+Every API path is scoped to an account — `https://3.basecampapi.com/{accountId}/…` — so `forAccount` needs that number before your first call. One token can reach several accounts.
+
+This SDK has no `authorization` service, because that endpoint lives on Launchpad rather than on the Basecamp API. Fetch it once yourself:
+
+```bash
+curl -s https://launchpad.37signals.com/authorization.json \
+  -H "Authorization: Bearer $BASECAMP_TOKEN" \
+  -H "User-Agent: MyApp/1.0 (you@example.com)"
+```
+
+Take `accounts[].id` for an entry whose `product` is `"bc3"` — that is Basecamp; the same response also carries `"hey"` and other 37signals products. `expires_at` tells you how long the token has left. A `User-Agent` identifying your app is required on every Basecamp request, including this one.
+
 ## Quick Start
+
+Service accessors are extension properties, so `account.projects` needs the `com.basecamp.sdk.generated` import as well as the client's. Every service method is `suspend`, so the calls need a coroutine.
 
 ```kotlin
 import com.basecamp.sdk.BasecampClient
 import com.basecamp.sdk.generated.projects
 
-val client = BasecampClient {
-    accessToken("your-token")
-    userAgent = "MyApp/1.0 (you@example.com)"
+suspend fun main() {
+    val client = BasecampClient {
+        accessToken("your-token")
+        userAgent = "MyApp/1.0 (you@example.com)"
+    }
+
+    val account = client.forAccount("12345")
+
+    // List all projects
+    val projects = account.projects.list()
+    for (project in projects) {
+        println("${project.id}: ${project.name}")
+    }
+
+    // Clean up when done
+    client.close()
 }
-
-val account = client.forAccount("12345")
-
-// List all projects
-val projects = account.projects.list()
-for (project in projects) {
-    println("${project.id}: ${project.name}")
-}
-
-// Clean up when done
-client.close()
 ```
 
 ## Configuration

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -148,8 +148,7 @@ The access token in the snippets below is a **Basecamp API** token. It is unrela
 
 Every Basecamp API request carries an OAuth 2.0 access token. There is no API key and no personal access token, so even a throwaway script starts here:
 
-1. Register your integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
-2. Choose the grant that matches how your code runs:
+1. Choose the grant that matches how your code runs:
 
 | Your integration | Grant | Who refreshes the token |
 |---|---|---|
@@ -158,6 +157,12 @@ Every Basecamp API request carries an OAuth 2.0 access token. There is no API ke
 | has no browser at all (CLI, daemon, CI job, device) | **device flow** — [`Device Authorization Flow`](#device-authorization-flow-rfc-8628) | you, calling the SDK's `refreshToken()` from `accessToken { … }` |
 
 The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+
+2. Get the client credentials that grant needs:
+
+- **Authorization code + PKCE** — register your own integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
+- **Device flow** — nothing to register. It runs as the pre-registered public `basecamp-cli` client, which sends no secret, against the device endpoint that discovery returns. Launchpad advertises no device endpoint, so a client you register there is not the one this flow uses.
+- **Static token** — nothing to register; you already hold the token.
 
 `accessToken("…")` hands back that exact string forever and never refreshes, so once the token expires every call fails with `401`. The lambda form, `accessToken { fetchFreshToken() }`, is re-invoked per request — that is where a refresh belongs.
 

--- a/python/README.md
+++ b/python/README.md
@@ -41,16 +41,21 @@ uv add basecamp-sdk
 
 Every Basecamp API request carries an OAuth 2.0 access token. There is no API key and no personal access token, so even a throwaway script starts here:
 
-1. Register your integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
-2. Choose the grant that matches how your code runs:
+1. Choose the grant that matches how your code runs:
 
 | Your integration | Grant | Who refreshes the token |
 |---|---|---|
 | already holds a token you obtained elsewhere | **static token** — [`Static Token`](#static-token) | you do |
 | can receive a browser redirect (web app, or a local callback server) | **authorization code + PKCE** — [`PKCE and Authorization URL`](#pkce-and-authorization-url) | `OAuthTokenProvider` |
-| has no browser at all (CLI, daemon, CI job, device) | **device flow** — [`Device Authorization Grant`](#device-authorization-grant-rfc-8628) | `OAuthTokenProvider` |
+| has no browser at all (CLI, daemon, CI job, device) | **device flow** — [`Device Authorization Grant`](#device-authorization-grant-rfc-8628) | `basecamp.oauth.exchange.refresh_token`, echoing the token's `resource` — **not** `OAuthTokenProvider` |
 
 The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+
+2. Get the client credentials that grant needs:
+
+- **Authorization code + PKCE** — register your own integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
+- **Device flow** — nothing to register. It runs as the pre-registered public `basecamp-cli` client, which sends no secret, against the device endpoint that discovery returns. Launchpad advertises no device endpoint, so a client you register there is not the one this flow uses.
+- **Static token** — nothing to register; you already hold the token.
 
 `Client(access_token=...)` wraps the string in a `StaticTokenProvider`, which never refreshes — once the token expires every call fails with `401` until you supply a new one. Use it to get a first successful call, then move to `OAuthTokenProvider` before you ship.
 

--- a/python/README.md
+++ b/python/README.md
@@ -37,6 +37,44 @@ Or with [uv](https://docs.astral.sh/uv/):
 uv add basecamp-sdk
 ```
 
+## Getting a token
+
+Every Basecamp API request carries an OAuth 2.0 access token. There is no API key and no personal access token, so even a throwaway script starts here:
+
+1. Register your integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
+2. Choose the grant that matches how your code runs:
+
+| Your integration | Grant | Who refreshes the token |
+|---|---|---|
+| already holds a token you obtained elsewhere | **static token** — [`Static Token`](#static-token) | you do |
+| can receive a browser redirect (web app, or a local callback server) | **authorization code + PKCE** — [`PKCE and Authorization URL`](#pkce-and-authorization-url) | `OAuthTokenProvider` |
+| has no browser at all (CLI, daemon, CI job, device) | **device flow** — [`Device Authorization Grant`](#device-authorization-grant-rfc-8628) | `OAuthTokenProvider` |
+
+The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+
+`Client(access_token=...)` wraps the string in a `StaticTokenProvider`, which never refreshes — once the token expires every call fails with `401` until you supply a new one. Use it to get a first successful call, then move to `OAuthTokenProvider` before you ship.
+
+## Finding your account ID
+
+Every API path is scoped to an account — `https://3.basecampapi.com/{accountId}/…` — so `for_account` needs that number before your first call. One token can reach several accounts, so ask the token which. `authorization` hangs off the *top-level* `Client` because the endpoint lives on Launchpad, not on the Basecamp API, and so takes no account context:
+
+```python
+import os
+from basecamp import Client
+
+client = Client(access_token=os.environ["BASECAMP_TOKEN"])
+
+info = client.authorization.get()
+for a in info["accounts"]:
+    # "bc3" is Basecamp; the same response also carries "hey" and other products
+    if a["product"] == "bc3":
+        print(f"{a['id']}: {a['name']}")
+
+account = client.for_account(info["accounts"][0]["id"])
+```
+
+The response is a plain `dict` of parsed JSON. `info["expires_at"]` tells you how long the token has left, which is the quickest way to confirm a static token has not lapsed. On `AsyncClient`, the same call is `await client.authorization.get()`.
+
 ## Quick Start
 
 ```python

--- a/python/README.md
+++ b/python/README.md
@@ -57,7 +57,7 @@ The one-line rule: **a redirect URI you control → authorization code; no brows
 - **Device flow** — nothing to register. It runs as the pre-registered public `basecamp-cli` client, which sends no secret, against the device endpoint that discovery returns. Launchpad advertises no device endpoint, so a client you register there is not the one this flow uses.
 - **Static token** — nothing to register; you already hold the token.
 
-`Client(access_token=...)` wraps the string in a `StaticTokenProvider`, which never refreshes — once the token expires every call fails with `401` until you supply a new one. Use it to get a first successful call, then move to `OAuthTokenProvider` before you ship.
+`Client(access_token=...)` wraps the string in a `StaticTokenProvider`, which never refreshes — once the token expires every call fails with `401` until you supply a new one. Use it to get a first successful call, then move to a refreshing path before you ship — `OAuthTokenProvider` for an authorization-code token from Launchpad, or, for a device-flow token, `basecamp.oauth.exchange.refresh_token` echoing the stored `resource`. Do not hand a device-flow token to `OAuthTokenProvider`: it refreshes only against Launchpad and sends no `resource`, so it fails at the first expiry.
 
 ## Finding your account ID
 

--- a/python/README.md
+++ b/python/README.md
@@ -47,9 +47,9 @@ Every Basecamp API request carries an OAuth 2.0 access token. There is no API ke
 |---|---|---|
 | already holds a token you obtained elsewhere | **static token** — [`Static Token`](#static-token) | you do |
 | can receive a browser redirect (web app, or a local callback server) | **authorization code + PKCE** — [`PKCE and Authorization URL`](#pkce-and-authorization-url) | `OAuthTokenProvider` |
-| has no browser at all (CLI, daemon, CI job, device) | **device flow** — [`Device Authorization Grant`](#device-authorization-grant-rfc-8628) | `basecamp.oauth.exchange.refresh_token`, echoing the token's `resource` — **not** `OAuthTokenProvider` |
+| has no browser, but a person can approve on another device (CLI, headless server, TV) | **device flow** — [`Device Authorization Grant`](#device-authorization-grant-rfc-8628) | `basecamp.oauth.exchange.refresh_token`, echoing the token's `resource` — **not** `OAuthTokenProvider` |
 
-The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+The one-line rule: **a redirect URI you control → authorization code; no browser but someone to approve → device flow; a token already in hand → static token.** An unattended daemon or CI job fits none of the three on its own — the device flow needs a person to enter the user code at the verification URI — so provision a token out of band and hand it to the process as a static or refresh token.
 
 2. Get the client credentials that grant needs:
 

--- a/python/README.md
+++ b/python/README.md
@@ -65,12 +65,14 @@ from basecamp import Client
 client = Client(access_token=os.environ["BASECAMP_TOKEN"])
 
 info = client.authorization.get()
-for a in info["accounts"]:
-    # "bc3" is Basecamp; the same response also carries "hey" and other products
-    if a["product"] == "bc3":
-        print(f"{a['id']}: {a['name']}")
+# "bc3" is Basecamp; the same response also carries "hey" and other products,
+# and they are not ordered — filter before you pick, or you may scope the
+# client to a HEY account.
+basecamp_accounts = [a for a in info["accounts"] if a["product"] == "bc3"]
+for a in basecamp_accounts:
+    print(f"{a['id']}: {a['name']}")
 
-account = client.for_account(info["accounts"][0]["id"])
+account = client.for_account(basecamp_accounts[0]["id"])
 ```
 
 The response is a plain `dict` of parsed JSON. `info["expires_at"]` tells you how long the token has left, which is the quickest way to confirm a static token has not lapsed. On `AsyncClient`, the same call is `await client.authorization.get()`.
@@ -110,11 +112,15 @@ asyncio.run(main())
 
 ### Environment Variables
 
+Nothing here is read automatically. These apply only when you call `Config.from_env()`; a plain `Config()` reads no environment at all. They are also the only three environment variables the SDK reads anywhere — `from_env` does not consult `base_delay`, `max_jitter`, or `max_pages`, so those keep their defaults unless you pass them.
+
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `BASECAMP_BASE_URL` | API base URL | `https://3.basecampapi.com` |
 | `BASECAMP_TIMEOUT` | Request timeout (seconds) | `30` |
 | `BASECAMP_MAX_RETRIES` | Total attempts including the initial request | `3` |
+
+`BASECAMP_TOKEN` and `BASECAMP_ACCOUNT_ID` appear in the examples above only because the caller reads them and passes the values in; the SDK never looks them up. Pass the token to `Client(access_token=...)` and the account ID to `for_account`.
 
 ### Programmatic Configuration
 

--- a/python/README.md
+++ b/python/README.md
@@ -61,7 +61,7 @@ The one-line rule: **a redirect URI you control → authorization code; no brows
 
 ## Finding your account ID
 
-Every API path is scoped to an account — `https://3.basecampapi.com/{accountId}/…` — so `for_account` needs that number before your first call. One token can reach several accounts, so ask the token which. `authorization` hangs off the *top-level* `Client` because the endpoint lives on Launchpad, not on the Basecamp API, and so takes no account context:
+Every API path is scoped to an account — `https://3.basecampapi.com/{accountId}/…` — so `for_account` needs that number before your first call. One token can reach several accounts, so ask the token which. `authorization` hangs off the *top-level* `Client` because the endpoint lives on the authorization server rather than the Basecamp API, and so takes no account context. It is pinned to Launchpad and `authorization.get()` accepts no override, which is right for a Launchpad-issued token; a **device-flow** token is issued by the discovered BC5 server, so fetch `/authorization.json` from that issuer yourself:
 
 ```python
 import os

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -41,11 +41,11 @@ The one-line rule: **a redirect URI you control → authorization code; no brows
 - **Device flow** — nothing to register. It runs as the pre-registered public `basecamp-cli` client, which sends no secret, against the device endpoint that discovery returns. Launchpad advertises no device endpoint, so a client you register there is not the one this flow uses.
 - **Static token** — nothing to register; you already hold the token.
 
-`StaticTokenProvider` hands back the string you gave it and nothing more — it never refreshes, so once the token expires every call fails with `401` until you supply a new one. Use it to get a first successful call, then move to an OAuth provider before you ship.
+`StaticTokenProvider` hands back the string you gave it and nothing more — it never refreshes, so once the token expires every call fails with `401` until you supply a new one. Use it to get a first successful call, then move to a refreshing path before you ship — `OauthTokenProvider` for an authorization-code token from Launchpad, or, for a device-flow token, `Basecamp::Oauth.refresh_token` echoing the stored `resource`. Do not hand a device-flow token to `OauthTokenProvider`: it refreshes only against Launchpad and sends no `resource`, so it fails at the first expiry.
 
 ## Finding your account ID
 
-Every API path is scoped to an account — `https://3.basecampapi.com/{accountId}/…` — so `for_account` needs that number before your first call. One token can reach several accounts, so ask the token which. `authorization` hangs off the *top-level* client because the endpoint lives on Launchpad, not on the Basecamp API, and so takes no account context:
+Every API path is scoped to an account — `https://3.basecampapi.com/{accountId}/…` — so `for_account` needs that number before your first call. One token can reach several accounts, so ask the token which. `authorization` hangs off the *top-level* client because it takes no account context. Unlike the other SDKs, Ruby does not hardcode Launchpad here: `Http#get_authorization_document` runs resource-first discovery (SPEC.md §16) against your configured base URL and fetches `/authorization.json` from the *selected* issuer, reaching Launchpad only on a soft fallback. Point egress rules and HTTP stubs at the issuer discovery selects, not at Launchpad; a hard selection failure raises `Basecamp::Oauth::DiscoverySelectionError` before any credentialed request goes out.
 
 ```ruby
 client = Basecamp.client(access_token: ENV["BASECAMP_TOKEN"])

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -46,12 +46,15 @@ Every API path is scoped to an account — `https://3.basecampapi.com/{accountId
 client = Basecamp.client(access_token: ENV["BASECAMP_TOKEN"])
 
 info = client.authorization.get
-info["accounts"].each do |a|
-  # "bc3" is Basecamp; the same response also carries "hey" and other products
-  puts "#{a["id"]}: #{a["name"]} (#{a["product"]})" if a["product"] == "bc3"
+# "bc3" is Basecamp; the same response also carries "hey" and other products,
+# and they are not ordered — filter before you pick, or you may scope the
+# client to a HEY account.
+basecamp_accounts = info["accounts"].select { |a| a["product"] == "bc3" }
+basecamp_accounts.each do |a|
+  puts "#{a["id"]}: #{a["name"]}"
 end
 
-account = client.for_account(info["accounts"].first["id"])
+account = client.for_account(basecamp_accounts.first["id"])
 ```
 
 The response is parsed JSON with **string** keys, not symbols. `info["expires_at"]` tells you how long the token has left, which is the quickest way to confirm a static token has not lapsed.

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -31,9 +31,9 @@ Every Basecamp API request carries an OAuth 2.0 access token. There is no API ke
 |---|---|---|
 | already holds a token you obtained elsewhere | **static token** — [`Token Providers`](#token-providers) | you do |
 | can receive a browser redirect (web app, or a local callback server) | **authorization code + PKCE** — [`OAuth Flow Helpers`](#oauth-flow-helpers) | `OauthTokenProvider` |
-| has no browser at all (CLI, daemon, CI job, device) | **device flow** — [`Device Authorization Grant`](#device-authorization-grant-rfc-8628) | `Basecamp::Oauth.refresh_token`, echoing the token's `resource` — **not** `OauthTokenProvider` |
+| has no browser, but a person can approve on another device (CLI, headless server, TV) | **device flow** — [`Device Authorization Grant`](#device-authorization-grant-rfc-8628) | `Basecamp::Oauth.refresh_token`, echoing the token's `resource` — **not** `OauthTokenProvider` |
 
-The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+The one-line rule: **a redirect URI you control → authorization code; no browser but someone to approve → device flow; a token already in hand → static token.** An unattended daemon or CI job fits none of the three on its own — the device flow needs a person to enter the user code at the verification URI — so provision a token out of band and hand it to the process as a static or refresh token.
 
 2. Get the client credentials that grant needs:
 

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -21,6 +21,41 @@ Or install directly:
 gem install basecamp-sdk
 ```
 
+## Getting a token
+
+Every Basecamp API request carries an OAuth 2.0 access token. There is no API key and no personal access token, so even a throwaway script starts here:
+
+1. Register your integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
+2. Choose the grant that matches how your code runs:
+
+| Your integration | Grant | Who refreshes the token |
+|---|---|---|
+| already holds a token you obtained elsewhere | **static token** — [`Token Providers`](#token-providers) | you do |
+| can receive a browser redirect (web app, or a local callback server) | **authorization code + PKCE** — [`OAuth Flow Helpers`](#oauth-flow-helpers) | `OauthTokenProvider` |
+| has no browser at all (CLI, daemon, CI job, device) | **device flow** — [`Device Authorization Grant`](#device-authorization-grant-rfc-8628) | `OauthTokenProvider` |
+
+The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+
+`StaticTokenProvider` hands back the string you gave it and nothing more — it never refreshes, so once the token expires every call fails with `401` until you supply a new one. Use it to get a first successful call, then move to an OAuth provider before you ship.
+
+## Finding your account ID
+
+Every API path is scoped to an account — `https://3.basecampapi.com/{accountId}/…` — so `for_account` needs that number before your first call. One token can reach several accounts, so ask the token which. `authorization` hangs off the *top-level* client because the endpoint lives on Launchpad, not on the Basecamp API, and so takes no account context:
+
+```ruby
+client = Basecamp.client(access_token: ENV["BASECAMP_TOKEN"])
+
+info = client.authorization.get
+info["accounts"].each do |a|
+  # "bc3" is Basecamp; the same response also carries "hey" and other products
+  puts "#{a["id"]}: #{a["name"]} (#{a["product"]})" if a["product"] == "bc3"
+end
+
+account = client.for_account(info["accounts"].first["id"])
+```
+
+The response is parsed JSON with **string** keys, not symbols. `info["expires_at"]` tells you how long the token has left, which is the quickest way to confirm a static token has not lapsed.
+
 ## Quick Start
 
 ```ruby
@@ -491,13 +526,20 @@ client = Basecamp::Client.new(
 
 ## Environment Variables
 
+`Basecamp::Config.from_env` (and `#load_from_env` on an existing config) reads these three. They are the only `BASECAMP_*` variables the SDK reads anywhere; the sole other environment read is `XDG_CONFIG_HOME`, for `Config.global_config_dir`.
+
 | Variable | Description |
 |----------|-------------|
-| `BASECAMP_TOKEN` | OAuth access token |
-| `BASECAMP_ACCOUNT_ID` | Account ID |
 | `BASECAMP_BASE_URL` | API base URL (default: `https://3.basecampapi.com`) |
 | `BASECAMP_TIMEOUT` | Request timeout in seconds (default: `30`) |
 | `BASECAMP_MAX_RETRIES` | Total request attempts for GET requests, including the initial request (default: `3`) |
+
+```ruby
+config = Basecamp::Config.from_env
+client = Basecamp::Client.new(config: config, token_provider: token_provider)
+```
+
+Credentials are **not** among them. `BASECAMP_TOKEN` and `BASECAMP_ACCOUNT_ID` appear in the examples above only because the caller reads them and passes the values in; the SDK never looks them up. Pass the token to `Basecamp.client(access_token:)` or `StaticTokenProvider`, and the account ID to `#for_account`.
 
 ## Development
 

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -25,16 +25,21 @@ gem install basecamp-sdk
 
 Every Basecamp API request carries an OAuth 2.0 access token. There is no API key and no personal access token, so even a throwaway script starts here:
 
-1. Register your integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
-2. Choose the grant that matches how your code runs:
+1. Choose the grant that matches how your code runs:
 
 | Your integration | Grant | Who refreshes the token |
 |---|---|---|
 | already holds a token you obtained elsewhere | **static token** — [`Token Providers`](#token-providers) | you do |
 | can receive a browser redirect (web app, or a local callback server) | **authorization code + PKCE** — [`OAuth Flow Helpers`](#oauth-flow-helpers) | `OauthTokenProvider` |
-| has no browser at all (CLI, daemon, CI job, device) | **device flow** — [`Device Authorization Grant`](#device-authorization-grant-rfc-8628) | `OauthTokenProvider` |
+| has no browser at all (CLI, daemon, CI job, device) | **device flow** — [`Device Authorization Grant`](#device-authorization-grant-rfc-8628) | `Basecamp::Oauth.refresh_token`, echoing the token's `resource` — **not** `OauthTokenProvider` |
 
 The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+
+2. Get the client credentials that grant needs:
+
+- **Authorization code + PKCE** — register your own integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
+- **Device flow** — nothing to register. It runs as the pre-registered public `basecamp-cli` client, which sends no secret, against the device endpoint that discovery returns. Launchpad advertises no device endpoint, so a client you register there is not the one this flow uses.
+- **Static token** — nothing to register; you already hold the token.
 
 `StaticTokenProvider` hands back the string you gave it and nothing more — it never refreshes, so once the token expires every call fails with `401` until you supply a new one. Use it to get a first successful call, then move to an OAuth provider before you ship.
 

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -45,7 +45,7 @@ The one-line rule: **a redirect URI you control → authorization code; no brows
 
 ## Finding your account ID
 
-Every API path is scoped to an account — `https://3.basecampapi.com/{accountId}/…` — so `for_account` needs that number before your first call. One token can reach several accounts, so ask the token which. `authorization` hangs off the *top-level* client because it takes no account context. Unlike the other SDKs, Ruby does not hardcode Launchpad here: `Http#get_authorization_document` runs resource-first discovery (SPEC.md §16) against your configured base URL and fetches `/authorization.json` from the *selected* issuer, reaching Launchpad only on a soft fallback. Point egress rules and HTTP stubs at the issuer discovery selects, not at Launchpad; a hard selection failure raises `Basecamp::Oauth::DiscoverySelectionError` before any credentialed request goes out.
+Every API path is scoped to an account — `https://3.basecampapi.com/{accountId}/…` — so `for_account` needs that number before your first call. One token can reach several accounts, so ask the token which. `authorization` hangs off the *top-level* client because it takes no account context. Unlike the other SDKs that ship this service (Go, Python, TypeScript all hardcode Launchpad), Ruby does not: `Http#get_authorization_document` runs resource-first discovery (SPEC.md §16) against your configured base URL and fetches `/authorization.json` from the *selected* issuer, reaching Launchpad only on a soft fallback. Point egress rules and HTTP stubs at the issuer discovery selects, not at Launchpad; a hard selection failure raises `Basecamp::Oauth::DiscoverySelectionError` before any credentialed request goes out.
 
 ```ruby
 client = Basecamp.client(access_token: ENV["BASECAMP_TOKEN"])

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -75,6 +75,13 @@ GO_Q = r"(?P<q>[\"`])"  # Go has interpreted and raw string literals, no single 
 DQ = r"(?P<q>\")"  # Swift and Kotlin have only double-quoted strings
 ENDQ = r"(?P=q)"
 
+# `process.env` and `process["env"]` are the same object -- Node does not care
+# which spelling reaches it, so neither may this. Spelled once and shared by the
+# named-read patterns and the whole-environment detector below, because a form
+# only one of them knows about is a hole in whichever one forgot it. No named
+# group, so it can be embedded in patterns that already bind `q`.
+TS_ENV = r"process(?:\.env\b|\[\s*[\"']env[\"']\s*\])"
+
 # Where each SDK's shipping source lives, and how that language reads an env var.
 SDKS = {
     "Go": {
@@ -119,8 +126,8 @@ SDKS = {
         "patterns": [
             # `?.` is valid optional chaining, and a read the plain patterns
             # reported as nonexistent.
-            rf"process\.env\??\.{NAME}",
-            rf"process\.env(?:\?\.)?\[\s*{Q}{NAME}{ENDQ}",
+            rf"{TS_ENV}\??\.{NAME}",
+            rf"{TS_ENV}(?:\?\.)?\[\s*{Q}{NAME}{ENDQ}",
             # `const { BASECAMP_TOKEN } = process.env` is a read too. The name
             # comes *before* process.env, so this is a zero-width lookahead:
             # a consuming pattern would bind only one name per brace group,
@@ -131,11 +138,11 @@ SDKS = {
             # `const { OTHER: BASECAMP_TOKEN } = process.env`, where the key --
             # the variable actually read -- is OTHER and BASECAMP_TOKEN is just
             # what it was renamed to.
-            rf"[{{,]\s*{NAME}\b(?=[^{{}}]*\}}\s*=\s*process\.env)",
+            rf"[{{,]\s*{NAME}\b(?=[^{{}}]*\}}\s*=\s*{TS_ENV})",
             # ...and the quoted-key form, `{ "BASECAMP_TOKEN": token }`. The
             # match has to start on the brace or comma, because the name is
             # inside a literal and would be rejected as string data.
-            rf"[{{,]\s*{Q}{NAME}{ENDQ}\s*:(?=[^{{}}]*\}}\s*=\s*process\.env)",
+            rf"[{{,]\s*{Q}{NAME}{ENDQ}\s*:(?=[^{{}}]*\}}\s*=\s*{TS_ENV})",
         ],
     },
     "Swift": {
@@ -519,6 +526,23 @@ def operand_position(text: str, i: int, flags: dict) -> bool:
     # postfix one and always division.
     if text[k] in "+-" and k > 0 and text[k - 1] == text[k]:
         return False
+    # `!` is both TypeScript's postfix non-null assertion, which ends a value so
+    # `value! / x / 2` is division, and prefix negation, where `!/re/.test(s)` is
+    # a genuine regex. What precedes the `!` decides, and it has to be the whole
+    # preceding *word* rather than its last character: `return !/re/.test(s)`
+    # ends in `n`, which would otherwise read as a value and mask the regex.
+    if text[k] == "!" and k > 0:
+        j = k - 1
+        while j >= 0 and text[j] in " \t":
+            j -= 1
+        if j >= 0 and (text[j].isalnum() or text[j] == "_"):
+            word_end = j + 1
+            while j >= 0 and (text[j].isalnum() or text[j] == "_"):
+                j -= 1
+            if text[j + 1 : word_end] not in REGEX_KEYWORDS:
+                return False
+        elif j >= 0 and text[j] in ")]\"'`":
+            return False
     if text[k] in REGEX_PRECEDERS:
         return True
     if text[k] == ")":
@@ -1184,7 +1208,7 @@ def real_reads(spec: dict, scoped: bool = True) -> dict[str, list[str]]:
 # question is simpler than name resolution: touching the environment API at all
 # is the violation. That is a fixed, tiny pattern set rather than more lexer.
 ENV_API = {
-    "TypeScript": [r"process\.env\b"],
+    "TypeScript": [TS_ENV],
     "Swift": [r"ProcessInfo\.processInfo\.environment\b"],
     "Kotlin": [r"System\.getenv\b"],
 }

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -1228,7 +1228,11 @@ def real_reads(spec: dict, scoped: bool = True) -> dict[str, list[str]]:
 # question is simpler than name resolution: touching the environment API at all
 # is the violation. That is a fixed, tiny pattern set rather than more lexer.
 ENV_API = {
-    "TypeScript": [TS_ENV],
+    # ...plus `const { env } = process`, which aliases the whole environment
+    # without ever spelling `process.env`. Resolving the alias afterwards would
+    # need name binding, but for this invariant it does not have to be
+    # resolved -- destructuring `env` off `process` is itself the touch.
+    "TypeScript": [TS_ENV, r"[{,]\s*env\b(?=[^{}]*\}\s*=\s*process\b)"],
     "Swift": [r"ProcessInfo\.processInfo\.environment\b"],
     "Kotlin": [r"System\.getenv\b"],
 }
@@ -1290,12 +1294,27 @@ def prose_lines(readme: Path) -> list[tuple[int, str]]:
     and 2, and scanning them here would double-report the same defect.
     """
     out = []
-    fenced = False
+    # CommonMark fences open with ``` or ~~~ and close only on the *same*
+    # character. Toggling on backticks alone left a `~~~python` example in
+    # prose, where a `# The SDK uses BASECAMP_NEW` comment inside it counted as
+    # documentation -- so a real read could pass the reverse check with nothing
+    # written about it anywhere. Toggling on either character independently
+    # would be the mirror bug: a ``` line inside a ~~~ block would end it early
+    # and hand the rest of the example back as prose.
+    fence = None
     for lineno, line in enumerate(readme.read_text(encoding="utf-8").splitlines(), 1):
-        if line.lstrip().startswith("```"):
-            fenced = not fenced
-            continue
-        if fenced or line.strip().startswith("|"):
+        stripped = line.lstrip()
+        marker = "```" if stripped.startswith("```") else (
+            "~~~" if stripped.startswith("~~~") else None)
+        if marker:
+            if fence is None:
+                fence = marker
+                continue
+            if marker == fence:
+                fence = None
+                continue
+            # The other marker inside a fenced block is example content.
+        if fence or line.strip().startswith("|"):
             continue
         out.append((lineno, line))
     return out

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -280,7 +280,12 @@ NO_ENV_SDKS = ("TypeScript", "Swift", "Kotlin")
 # Only variables in these families are in scope; the SDKs read no others.
 VAR_RE = re.compile(r"\b((?:BASECAMP|XDG)_[A-Z0-9_]+)\b")
 
-FILENAME_TEST_MARKERS = ("_test.", "test_", ".test.", "_spec.")
+# Anchored, not merely contained. `test_` matched anywhere in the name made
+# `latest_config.py`, `contest_helper.go` and `protest_mode.rb` all test files,
+# and a read added to any shipping file so named would bypass every check here.
+# The dotted markers are already anchored by their own `.`.
+FILENAME_TEST_PREFIXES = ("test_",)
+FILENAME_TEST_MARKERS = ("_test.", ".test.", "_spec.")
 
 # Invariant 5. Only the active voice with SDK names as the subject. The passive
 # "`BASECAMP_TOKEN` is read by `AuthManager`", the symbol subject "`Config()`
@@ -987,11 +992,20 @@ def is_test(rel_path: Path) -> bool:
             return True
         if part.endswith(("Test", "Tests")):
             return True
-    return any(marker in rel_path.name for marker in FILENAME_TEST_MARKERS)
+    name = rel_path.name
+    return name.startswith(FILENAME_TEST_PREFIXES) or any(
+        marker in name for marker in FILENAME_TEST_MARKERS)
 
 
-def real_reads(spec: dict) -> dict[str, list[str]]:
-    """Env vars genuinely read by this SDK, mapped to 'file:line' call sites."""
+def real_reads(spec: dict, scoped: bool = True) -> dict[str, list[str]]:
+    """Env vars genuinely read by this SDK, mapped to 'file:line' call sites.
+
+    `scoped` keeps only the `BASECAMP_*` and `XDG_*` families, which is right for
+    the documentation invariants -- those are the only variables the READMEs
+    tabulate. It is wrong for invariant 4, which asserts an SDK reads *no*
+    environment at all: filtered, a new `process.env.HOME` disappeared and the
+    claim went on passing. That one asks for everything.
+    """
     root = REPO / spec["source"]
     found: dict[str, list[str]] = {}
     if not root.is_dir():
@@ -1024,9 +1038,10 @@ def real_reads(spec: dict) -> dict[str, list[str]]:
                 if in_string[match.start()]:
                     continue
                 name = match.group("name")
-                if VAR_RE.fullmatch(name):
-                    lineno = text.count("\n", 0, match.start()) + 1
-                    found.setdefault(name, []).append(f"{rel}:{lineno}")
+                if scoped and not VAR_RE.fullmatch(name):
+                    continue
+                lineno = text.count("\n", 0, match.start()) + 1
+                found.setdefault(name, []).append(f"{rel}:{lineno}")
     return found
 
 
@@ -1308,9 +1323,13 @@ def main() -> int:
                 )
 
     # 4. The root README's "read no environment variables at all" sentence.
+    # "At all" means at all, so this one is unscoped: `process.env.HOME` breaks
+    # the claim as surely as a BASECAMP_ variable would, and the scoped
+    # inventory could not see it.
     for sdk in NO_ENV_SDKS:
-        if reads[sdk]:
-            detail = ", ".join(f"{v} ({s[0]})" for v, s in sorted(reads[sdk].items()))
+        every = real_reads(SDKS[sdk], scoped=False)
+        if every:
+            detail = ", ".join(f"{v} ({s[0]})" for v, s in sorted(every.items()))
             failures.append(
                 f"{ROOT_README}: claims {sdk} reads no environment variables, but "
                 f"found: {detail}"

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -526,11 +526,19 @@ def operand_position(text: str, i: int, flags: dict) -> bool:
     # postfix one and always division.
     if text[k] in "+-" and k > 0 and text[k - 1] == text[k]:
         return False
-    # `!` is both TypeScript's postfix non-null assertion, which ends a value so
-    # `value! / x / 2` is division, and prefix negation, where `!/re/.test(s)` is
-    # a genuine regex. What precedes the `!` decides, and it has to be the whole
-    # preceding *word* rather than its last character: `return !/re/.test(s)`
-    # ends in `n`, which would otherwise read as a value and mask the regex.
+    # `!` runs both ways in both languages that spell a regex `/.../`. It is
+    # TypeScript's postfix non-null assertion and the tail of a Ruby bang
+    # method, both of which end a value -- so `value! / x / 2` and
+    # `save! / x / 2` are division. It is also prefix negation, where
+    # `!/re/.test(s)` and `puts !/re/.match(s)` are genuine regexes whose
+    # bodies are data.
+    #
+    # What precedes the `!` decides, and it has to be the whole preceding
+    # *word* rather than its last character: `return !/re/.test(s)` ends in
+    # `n`, which as a bare character reads as a value and would mask the regex.
+    # The two word lists this file already keeps are exactly the right ones --
+    # a keyword, or a Ruby command-form call, means the `!` negates what
+    # follows rather than terminating what came before.
     if text[k] == "!" and k > 0:
         j = k - 1
         while j >= 0 and text[j] in " \t":
@@ -539,7 +547,10 @@ def operand_position(text: str, i: int, flags: dict) -> bool:
             word_end = j + 1
             while j >= 0 and (text[j].isalnum() or text[j] == "_"):
                 j -= 1
-            if text[j + 1 : word_end] not in REGEX_KEYWORDS:
+            word = text[j + 1 : word_end]
+            negating = word in REGEX_KEYWORDS or (
+                flags.get("command_regex") and word in REGEX_COMMANDS)
+            if not negating:
                 return False
         elif j >= 0 and text[j] in ")]\"'`":
             return False

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -82,6 +82,9 @@ ENDQ = r"(?P=q)"
 # group, so it can be embedded in patterns that already bind `q`.
 TS_ENV = r"process(?:\??\.env\b|(?:\?\.)?\[\s*[\"']env[\"']\s*\])"
 
+# Same idea for Swift, whose chain is three members long and may be wrapped.
+SWIFT_ENV = r"ProcessInfo\s*\.\s*processInfo\s*\.\s*environment"
+
 # Where each SDK's shipping source lives, and how that language reads an env var.
 SDKS = {
     "Go": {
@@ -158,7 +161,9 @@ SDKS = {
         # `#*` around the quotes: a raw string is a valid dictionary key, so
         # environment[#"BASECAMP_TOKEN"#] is a real read that a bare-quote
         # pattern reports as nonexistent.
-        "patterns": [rf"ProcessInfo\.processInfo\.environment\[\s*#*{DQ}{NAME}{ENDQ}#*"],
+        # Swift formats long member chains across lines, and the dots stay
+        # dots. An exact-token pattern reported those reads as nonexistent.
+        "patterns": [rf"{SWIFT_ENV}\[\s*#*{DQ}{NAME}{ENDQ}#*"],
     },
     # kotlin/sdk/src, not just commonMain: jvmMain ships in the same artifact, so
     # scoping to commonMain would let a platform-specific read bypass this gate.
@@ -190,6 +195,11 @@ SDKS = {
 # nothing, and made every read through that import invisible.
 PY_FROM_OS_RE = re.compile(
     r"^[ \t]*from[ \t]+os[ \t]+import[ \t]*(\([^)]*\)|(?:[^\n#\\]|\\\n)+)", re.M)
+# `import os as operating_system` rebinds the module itself, so the qualified
+# patterns -- which spell the literal `os.` -- stop seeing every read through
+# it. Plain `import os` needs nothing here: those call sites are what the
+# static patterns already match, and emitting for it too would count them twice.
+PY_IMPORT_OS_RE = re.compile(r"^[ \t]*import[ \t]+os[ \t]+as[ \t]+(\w+)", re.M)
 
 
 def python_os_aliases(text: str) -> dict[str, str]:
@@ -229,6 +239,13 @@ def python_dynamic_patterns(text: str) -> list[str]:
         else:
             patterns.append(rf"(?<![.\w]){name}\.get\(\s*{Q}{NAME}{ENDQ}")
             patterns.append(rf"(?<![.\w]){name}\[\s*{Q}{NAME}{ENDQ}")
+    # ...and the module itself may be rebound, which moves every qualified
+    # spelling at once rather than one name at a time.
+    for match in PY_IMPORT_OS_RE.finditer(text):
+        module = re.escape(match.group(1))
+        patterns.append(rf"(?<![.\w]){module}\.getenv\(\s*{Q}{NAME}{ENDQ}")
+        patterns.append(rf"(?<![.\w]){module}\.environ\.get\(\s*{Q}{NAME}{ENDQ}")
+        patterns.append(rf"(?<![.\w]){module}\.environ\[\s*{Q}{NAME}{ENDQ}")
     return patterns
 
 
@@ -1299,7 +1316,7 @@ ENV_API = {
     # need name binding, but for this invariant it does not have to be
     # resolved -- destructuring `env` off `process` is itself the touch.
     "TypeScript": [TS_ENV, r"[{,]\s*env\b(?=[^{}]*\}\s*=\s*process\b)"],
-    "Swift": [r"ProcessInfo\.processInfo\.environment\b"],
+    "Swift": [SWIFT_ENV + r"\b"],
     "Kotlin": [r"System\.getenv\b"],
 }
 
@@ -1380,10 +1397,14 @@ def prose_lines(readme: Path) -> list[tuple[int, str]]:
             if fence is None:
                 fence = (char, run)
                 continue
-            if char == fence[0] and run >= fence[1]:
+            # A closing fence carries nothing but the run and trailing spaces,
+            # so ```` ```not-a-close ```` inside a block is code. Closing on the
+            # run alone ended the block there and handed the rest back as prose.
+            closes = stripped[run:].strip() == ""
+            if char == fence[0] and run >= fence[1] and closes:
                 fence = None
                 continue
-            # A shorter run, or the other marker, is example content.
+            # A shorter run, an info string, or the other marker, is content.
         if fence or line.strip().startswith("|"):
             continue
         out.append((lineno, line))

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -184,14 +184,24 @@ SDKS = {
 # Deliberately file-scoped rather than a general name resolver: an import line
 # is a local, syntactic fact, where following a name through assignments and
 # re-exports is program analysis and is where this gate stops.
-PY_FROM_OS_RE = re.compile(r"^[ \t]*from[ \t]+os[ \t]+import[ \t]+([^\n#]+)", re.M)
+# The import may be continued, and both spellings are ordinary: a
+# parenthesised list runs over as many lines as it likes, and a backslash
+# continues one. Stopping at the first newline captured `(` alone, bound
+# nothing, and made every read through that import invisible.
+PY_FROM_OS_RE = re.compile(
+    r"^[ \t]*from[ \t]+os[ \t]+import[ \t]*(\([^)]*\)|(?:[^\n#\\]|\\\n)+)", re.M)
 
 
 def python_os_aliases(text: str) -> dict[str, str]:
     """Local names this file binds to `os.getenv` / `os.environ`."""
     bound: dict[str, str] = {}
     for match in PY_FROM_OS_RE.finditer(text):
-        for part in match.group(1).strip().strip("()").split(","):
+        # The continuation marker is punctuation, not part of a name. Left in,
+        # `\` and the name after it split into two words and the clause was
+        # discarded as unparseable -- so the import bound nothing and every
+        # read through it stayed invisible.
+        clause = match.group(1).replace("\\\n", " ").strip().strip("()")
+        for part in clause.split(","):
             bits = part.split()
             if len(bits) == 3 and bits[1] == "as":
                 original, local = bits[0], bits[2]
@@ -1357,19 +1367,23 @@ def prose_lines(readme: Path) -> list[tuple[int, str]]:
     # written about it anywhere. Toggling on either character independently
     # would be the mirror bug: a ``` line inside a ~~~ block would end it early
     # and hand the rest of the example back as prose.
-    fence = None
+    # The run length is part of the fence, not just its character: a closing
+    # fence must be at least as long as the one that opened it, so a ``` line
+    # inside a ```` block is content. Storing only the character closed such a
+    # block early and handed the rest of the example back as prose.
+    fence = None  # (character, opening run length)
     for lineno, line in enumerate(readme.read_text(encoding="utf-8").splitlines(), 1):
         stripped = line.lstrip()
-        marker = "```" if stripped.startswith("```") else (
-            "~~~" if stripped.startswith("~~~") else None)
-        if marker:
+        char = stripped[0] if stripped[:1] in ("`", "~") else None
+        run = len(stripped) - len(stripped.lstrip(char)) if char else 0
+        if run >= 3:
             if fence is None:
-                fence = marker
+                fence = (char, run)
                 continue
-            if marker == fence:
+            if char == fence[0] and run >= fence[1]:
                 fence = None
                 continue
-            # The other marker inside a fenced block is example content.
+            # A shorter run, or the other marker, is example content.
         if fence or line.strip().startswith("|"):
             continue
         out.append((lineno, line))

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -80,7 +80,7 @@ ENDQ = r"(?P=q)"
 # named-read patterns and the whole-environment detector below, because a form
 # only one of them knows about is a hole in whichever one forgot it. No named
 # group, so it can be embedded in patterns that already bind `q`.
-TS_ENV = r"process(?:\.env\b|\[\s*[\"']env[\"']\s*\])"
+TS_ENV = r"process(?:\??\.env\b|(?:\?\.)?\[\s*[\"']env[\"']\s*\])"
 
 # Where each SDK's shipping source lives, and how that language reads an env var.
 SDKS = {
@@ -116,6 +116,15 @@ SDKS = {
             rf"os\.environ\.get\(\s*{Q}{NAME}{ENDQ}",
             rf"os\.environ\[\s*{Q}{NAME}{ENDQ}",
             rf"os\.getenv\(\s*{Q}{NAME}{ENDQ}",
+            # `from os import getenv` is the ordinary spelling, and requiring
+            # the `os.` qualifier made those reads invisible -- the fail-open
+            # direction, where the gate swears nothing reads the variable.
+            # The lookbehind keeps these from matching the qualified forms
+            # above a second time, which would double-count their call sites,
+            # and keeps `mygetenv(...)` out.
+            rf"(?<![.\w])getenv\(\s*{Q}{NAME}{ENDQ}",
+            rf"(?<![.\w])environ\.get\(\s*{Q}{NAME}{ENDQ}",
+            rf"(?<![.\w])environ\[\s*{Q}{NAME}{ENDQ}",
         ],
     },
     "TypeScript": {

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -186,12 +186,21 @@ SDKS = {
 #   multiline: Ruby, where an ordinary quoted literal may span physical lines.
 #            Everywhere else a newline ends it, which is what bounds the damage
 #            from an unbalanced quote.
+#   newline_operand: Ruby, where a line break ends a complete expression, so a
+#            slash at the start of the next line opens a regex. JavaScript
+#            inserts no semicolon before `/`, so there the same slash continues
+#            the expression above and is division.
+#   condition_regex: TypeScript, where `if (...)` is followed by a statement and
+#            a statement may begin with a regex. Off for Ruby, whose statement
+#            modifiers put a genuine division after the same `)`.
 LANG_FLAGS = {
     "Go": {
         "triple": False, "nested": False, "raw": False, "fstring": False,
         "multiline": False,
         "regex": False,
         "command_regex": False,
+        "newline_operand": False,
+        "condition_regex": False,
         "backtick_string": False,
         "backtick_raw": True,
         "triple_raw": False,
@@ -207,6 +216,11 @@ LANG_FLAGS = {
         "multiline": True,
         "regex": True,
         "command_regex": True,
+        # A complete Ruby expression ends at the newline, so the next line's
+        # leading slash is a regex. `if (x) / 2` after a statement modifier is
+        # not, which is why the condition rule is off here.
+        "newline_operand": True,
+        "condition_regex": False,
         "backtick_raw": False,
         # Ruby's backtick is a command literal, and it interpolates like a
         # double-quoted string. Python shares this comment style and has no such
@@ -221,6 +235,8 @@ LANG_FLAGS = {
         "multiline": False,
         "regex": False,
         "command_regex": False,
+        "newline_operand": False,
+        "condition_regex": False,
         "backtick_string": False,
         "backtick_raw": False,
         "triple_raw": False,
@@ -232,6 +248,11 @@ LANG_FLAGS = {
         "multiline": False,
         "regex": True,
         "command_regex": False,
+        # No automatic semicolon is inserted before `/`, so a line-leading slash
+        # continues the expression above it and is division. `if (...)` is
+        # followed by a statement, which may begin with a regex.
+        "newline_operand": False,
+        "condition_regex": True,
         "backtick_string": False,
         "backtick_raw": False,
         "triple_raw": False,
@@ -243,6 +264,8 @@ LANG_FLAGS = {
         "multiline": False,
         "regex": False,
         "command_regex": False,
+        "newline_operand": False,
+        "condition_regex": False,
         "backtick_string": False,
         "backtick_raw": False,
         "triple_raw": False,
@@ -254,6 +277,8 @@ LANG_FLAGS = {
         "multiline": False,
         "regex": False,
         "command_regex": False,
+        "newline_operand": False,
+        "condition_regex": False,
         "backtick_string": False,
         "backtick_raw": False,
         "triple_raw": True,
@@ -263,7 +288,7 @@ LANG_FLAGS = {
 }
 # Permissive union, used only when no language is supplied.
 DEFAULT_FLAGS = {
-    "triple": True, "nested": True, "raw": True, "fstring": True, "multiline": True, "regex": True, "command_regex": True, "backtick_string": False, "backtick_raw": False, "triple_raw": False, "percent": True,
+    "triple": True, "nested": True, "raw": True, "fstring": True, "multiline": True, "regex": True, "command_regex": True, "newline_operand": True, "condition_regex": True, "backtick_string": False, "backtick_raw": False, "triple_raw": False, "percent": True,
     "interp": {"`": [("${", "}")], '"': [("${", "}"), ("\\(", ")"), ("#{", "}")]},
 }
 
@@ -397,6 +422,54 @@ def command_argument(text: str, i: int, word: str, spaced: bool, flags: dict) ->
     return bool(after) and not after.isspace() and after != "="
 
 
+# Statement heads whose parenthesised condition is followed by a statement,
+# rather than by more of an expression.
+CONDITION_KEYWORDS = {"if", "for", "while", "switch", "catch", "with"}
+
+
+def condition_paren(text: str, close: int, flags: dict) -> bool:
+    """Whether the `)` at `close` ends an `if (...)`-style condition.
+
+    A `)` normally ends a value, so a `/` after it is division. The exception is
+    a control-flow condition: what follows that is a *statement*, and a
+    statement may begin with a regex. `if (ready) /re/.test(value)` is valid
+    TypeScript, and reading its slash as division leaves the pattern text
+    executable -- so the gate invents an environment read out of regex data.
+
+    TypeScript only, and that restriction is load-bearing rather than cautious.
+    Ruby has statement modifiers, so in `warn 'x' if (limit) / n / 2 > 1` the
+    identical `)` really is followed by division, and masking to the next slash
+    would swallow whatever sits between them. That is the fail-open direction,
+    which is the one worth erring away from.
+
+    The backward walk counts parentheses without skipping strings or comments,
+    so a `)` written inside a literal in the condition can throw the depth off.
+    That resolves to "not a condition" and falls back to division, which leaves
+    the pattern text visible: the gate over-reports rather than under-reports.
+    """
+    if not flags.get("condition_regex"):
+        return False
+    depth = 1
+    k = close - 1
+    while k >= 0:
+        if text[k] == ")":
+            depth += 1
+        elif text[k] == "(":
+            depth -= 1
+            if depth == 0:
+                break
+        k -= 1
+    if depth:
+        return False
+    k -= 1
+    while k >= 0 and text[k] in " \t\r\n":
+        k -= 1
+    word_end = k + 1
+    while k >= 0 and (text[k].isalnum() or text[k] == "_"):
+        k -= 1
+    return text[k + 1 : word_end] in CONDITION_KEYWORDS
+
+
 def operand_position(text: str, i: int, flags: dict) -> bool:
     """Whether an operand may begin at `i`, rather than a binary operator.
 
@@ -412,8 +485,26 @@ def operand_position(text: str, i: int, flags: dict) -> bool:
     spaced = k >= 0 and text[k] in " \t"
     while k >= 0 and text[k] in " \t":
         k -= 1
-    if k < 0 or text[k] in REGEX_PRECEDERS or text[k] == "\n":
+    if k < 0:
         return True
+    if text[k] in "\r\n":
+        # Whether a line break ends the statement is the whole difference
+        # between the two languages that spell a regex `/.../`, so it cannot be
+        # one rule. Ruby ends a complete expression at the newline, so a
+        # line-leading slash opens a regex. JavaScript inserts no semicolon
+        # before `/` -- the slash parses as a continuation of the line above --
+        # so `const r = 10\n/ process.env.X / 2` is division, and calling it a
+        # regex masks the read between the slashes and ships it undocumented.
+        if flags.get("newline_operand"):
+            return True
+        while k >= 0 and text[k] in " \t\r\n":
+            k -= 1
+        if k < 0:
+            return True
+    if text[k] in REGEX_PRECEDERS:
+        return True
+    if text[k] == ")":
+        return condition_paren(text, k, flags)
     if not (text[k].isalnum() or text[k] == "_"):
         return False
     word_end = k + 1
@@ -655,8 +746,18 @@ def raw_string_hashes(text: str, i: int) -> int:
 
 
 def brace_holes(text: str, start: int, stop: int, style: str, flags: dict,
-                opener: str, closer: str) -> list[tuple[int, int]]:
-    """Interpolation holes in a literal body, skipping escaped openers."""
+                opener: str, closer: str, raw: bool = False) -> list[tuple[int, int]]:
+    """Interpolation holes in a literal body, skipping escaped openers.
+
+    `raw` says the literal processes no escapes, so a backslash inside it is
+    ordinary data and protects nothing. Kotlin's triple-quoted string is the
+    case that matters: there `\\${x}` still interpolates, because the backslash
+    is literal text and the `${` after it is the template marker regardless.
+    Consuming the pair as an escape skipped the `$`, dropped the hole, and
+    masked a real `System.getenv` read -- the fail-open direction, and one the
+    root README's "Kotlin reads no environment variables" would have kept
+    looking true through.
+    """
     holes = []
     j = start
     while j < stop:
@@ -672,8 +773,9 @@ def brace_holes(text: str, start: int, stop: int, style: str, flags: dict,
         # A backslash escapes what follows, so `\#{...}` in Ruby is literal text.
         # This has to be tested *after* the opener, because Swift's opener is
         # itself `\(` -- checking the escape first would eat it and lose every
-        # Swift interpolation.
-        if text[j] == "\\":
+        # Swift interpolation. And not at all in a raw literal, where there is
+        # no escape to honour.
+        if not raw and text[j] == "\\":
             j += 2
             continue
         j += 1
@@ -704,7 +806,10 @@ def scan_literal(text: str, i: int, style: str,
             close_at = text.find(close_token, body_start)
             end = n if close_at == -1 else close_at + len(close_token)
             body_stop = close_at if close_at != -1 else n
-            holes = brace_holes(text, body_start, body_stop, style, flags, "\\" + fence + "(", ")")
+            # Raw: the escape is `\#(` with the fence, so a lone backslash here
+            # is data. `#"\\#(x)"#` is a literal backslash then an interpolation.
+            holes = brace_holes(text, body_start, body_stop, style, flags,
+                                "\\" + fence + "(", ")", raw=True)
             return end, holes
 
     triple_quote = None
@@ -725,15 +830,20 @@ def scan_literal(text: str, i: int, style: str,
         if style == "hash":
             # Only an f-string's braces are code; a plain docstring's are text.
             if has_fstring_prefix(text, i):
-                holes = brace_holes(text, i + 3, body_stop, style, flags, "{", "}")
+                holes = brace_holes(text, i + 3, body_stop, style, flags, "{", "}",
+                                    raw=triple_is_raw)
         else:
             # Swift and Kotlin multiline strings are ordinary strings, not
             # documentation, and both interpolate.
             # Whatever this language interpolates in a double-quoted string, it
             # interpolates in a multiline one: `${...}` in Kotlin, `\(...)` in
             # Swift, and nothing at all elsewhere.
+            # Whether a backslash in there escapes anything is where the two
+            # part company: Kotlin's `"""` is raw and Swift's is not, so the
+            # same `\${...}` bytes are a live read in one and text in the other.
             for opener, closer in flags["interp"].get('"', []):
-                holes += brace_holes(text, i + 3, body_stop, style, flags, opener, closer)
+                holes += brace_holes(text, i + 3, body_stop, style, flags, opener, closer,
+                                     raw=triple_is_raw)
         return end, holes
 
     quote = text[i]

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -511,6 +511,14 @@ def operand_position(text: str, i: int, flags: dict) -> bool:
             k -= 1
         if k < 0:
             return True
+    # `++` and `--` end a value, so what follows one is division -- but their
+    # single characters are both in REGEX_PRECEDERS, which read `x++ / y / 2`
+    # as a regex and masked everything between the slashes. Only the postfix
+    # form can sit here at all: prefix `++` is followed by its operand, never
+    # by an operator, so a doubled sign immediately before a `/` is always the
+    # postfix one and always division.
+    if text[k] in "+-" and k > 0 and text[k - 1] == text[k]:
+        return False
     if text[k] in REGEX_PRECEDERS:
         return True
     if text[k] == ")":
@@ -1165,6 +1173,57 @@ def real_reads(spec: dict, scoped: bool = True) -> dict[str, list[str]]:
     return found
 
 
+# Invariant 4 says "at all", and every pattern above needs a *named* variable to
+# match. A wholesale grab names none: `System.getenv()["BASECAMP_TOKEN"]`, a bare
+# `process.env` spread into a config object, `ProcessInfo.processInfo.environment`
+# handed on entire. So the one claim those break -- "reads no environment
+# variables at all" -- is exactly the one nothing here could see, and it would
+# have gone on passing while an SDK read the whole environment.
+#
+# Only the three SDKs that claim to read nothing need this, and for them the
+# question is simpler than name resolution: touching the environment API at all
+# is the violation. That is a fixed, tiny pattern set rather than more lexer.
+ENV_API = {
+    "TypeScript": [r"process\.env\b"],
+    "Swift": [r"ProcessInfo\.processInfo\.environment\b"],
+    "Kotlin": [r"System\.getenv\b"],
+}
+
+
+def env_api_sites(sdk: str, spec: dict) -> list[str]:
+    """'file:line' for every touch of the environment API in this SDK's source.
+
+    Same masking as `real_reads`, so a doc comment or a string literal spelling
+    `process.env` is not a touch -- every one of these appears in the READMEs'
+    own examples, and counting those would fail CI on a correct tree.
+    """
+    root = REPO / spec["source"]
+    sites: list[str] = []
+    if not root.is_dir():
+        return sites
+    compiled = [re.compile(p) for p in ENV_API.get(sdk, [])]
+    if not compiled:
+        return sites
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix not in spec["suffixes"]:
+            continue
+        rel = path.relative_to(REPO)
+        if is_test(rel):
+            continue
+        text, in_string = strip_noncode(
+            path.read_text(encoding="utf-8", errors="replace"),
+            spec["comments"],
+            spec.get("flags"),
+        )
+        for pattern in compiled:
+            for match in pattern.finditer(text):
+                if in_string[match.start()]:
+                    continue
+                lineno = text.count("\n", 0, match.start()) + 1
+                sites.append(f"{rel}:{lineno}")
+    return sites
+
+
 def table_rows(readme: Path) -> list[tuple[int, list[str]]]:
     """Markdown table rows, as (line number, cells)."""
     rows = []
@@ -1453,6 +1512,17 @@ def main() -> int:
             failures.append(
                 f"{ROOT_README}: claims {sdk} reads no environment variables, but "
                 f"found: {detail}"
+            )
+        # ...and a grab of the whole environment names no variable, so the
+        # inventory above cannot see it even though it breaks the same
+        # sentence. Only asked when that inventory is empty: a named read
+        # already fails this claim, and says which variable, so reporting the
+        # API touch alongside it would be the same defect twice.
+        elif env_api_sites(sdk, SDKS[sdk]):
+            sites = env_api_sites(sdk, SDKS[sdk])
+            failures.append(
+                f"{ROOT_README}: claims {sdk} reads no environment variables, but its "
+                f"source reaches the whole environment at {', '.join(sites[:3])}"
             )
 
     # 5. Prose attribution, every README: "<SDK> reads `VAR`" must be true.

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -467,7 +467,17 @@ def condition_paren(text: str, close: int, flags: dict) -> bool:
     word_end = k + 1
     while k >= 0 and (text[k].isalnum() or text[k] == "_"):
         k -= 1
-    return text[k + 1 : word_end] in CONDITION_KEYWORDS
+    if text[k + 1 : word_end] not in CONDITION_KEYWORDS:
+        return False
+    # ...but only as a statement head. `obj.if(ready) / x / 2` is a call on a
+    # property that merely spells a keyword -- legal since ES5 -- and what
+    # follows it is still an expression, so the slash there is division.
+    # Without this the mask would run to the next slash and eat the read
+    # between them, which is the fail-open direction this whole rule is
+    # supposed to be avoiding.
+    while k >= 0 and text[k] in " \t":
+        k -= 1
+    return k < 0 or text[k] != "."
 
 
 def operand_position(text: str, i: int, flags: dict) -> bool:

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -117,14 +117,10 @@ SDKS = {
             rf"os\.environ\[\s*{Q}{NAME}{ENDQ}",
             rf"os\.getenv\(\s*{Q}{NAME}{ENDQ}",
             # `from os import getenv` is the ordinary spelling, and requiring
-            # the `os.` qualifier made those reads invisible -- the fail-open
-            # direction, where the gate swears nothing reads the variable.
-            # The lookbehind keeps these from matching the qualified forms
-            # above a second time, which would double-count their call sites,
-            # and keeps `mygetenv(...)` out.
-            rf"(?<![.\w])getenv\(\s*{Q}{NAME}{ENDQ}",
-            rf"(?<![.\w])environ\.get\(\s*{Q}{NAME}{ENDQ}",
-            rf"(?<![.\w])environ\[\s*{Q}{NAME}{ENDQ}",
+            # the `os.` qualifier made those reads invisible. Those forms are
+            # not listed here, because whether `getenv(...)` is an environment
+            # read depends on where the name came from -- see
+            # `python_dynamic_patterns`, which reads the file's imports first.
         ],
     },
     "TypeScript": {
@@ -175,6 +171,56 @@ SDKS = {
         "patterns": [rf"System\.getenv\(\s*{DQ}{NAME}{ENDQ}"],
     },
 }
+
+# Python binds the unqualified spellings by import, so whether `getenv("X")` is
+# an environment read is a fact about the file's import lines, not about the
+# call. Both directions are real and both were live at some point in this PR:
+# requiring the `os.` qualifier hid every read written the ordinary way, and
+# matching the bare name regardless invented one out of
+# `from helpers import getenv`. Reading the imports settles it, and settles
+# aliases with it -- `from os import getenv as ge` binds `ge`, which no fixed
+# pattern could have known.
+#
+# Deliberately file-scoped rather than a general name resolver: an import line
+# is a local, syntactic fact, where following a name through assignments and
+# re-exports is program analysis and is where this gate stops.
+PY_FROM_OS_RE = re.compile(r"^[ \t]*from[ \t]+os[ \t]+import[ \t]+([^\n#]+)", re.M)
+
+
+def python_os_aliases(text: str) -> dict[str, str]:
+    """Local names this file binds to `os.getenv` / `os.environ`."""
+    bound: dict[str, str] = {}
+    for match in PY_FROM_OS_RE.finditer(text):
+        for part in match.group(1).strip().strip("()").split(","):
+            bits = part.split()
+            if len(bits) == 3 and bits[1] == "as":
+                original, local = bits[0], bits[2]
+            elif len(bits) == 1:
+                original = local = bits[0]
+            else:
+                continue
+            if original in ("getenv", "environ"):
+                bound[local] = original
+    return bound
+
+
+def python_dynamic_patterns(text: str) -> list[str]:
+    """Read patterns for the unqualified names this file actually imported.
+
+    The lookbehind keeps these off the `os.`-qualified spellings, which the
+    static patterns already match -- without it every qualified call site would
+    be counted a second time.
+    """
+    patterns = []
+    for local, original in sorted(python_os_aliases(text).items()):
+        name = re.escape(local)
+        if original == "getenv":
+            patterns.append(rf"(?<![.\w]){name}\(\s*{Q}{NAME}{ENDQ}")
+        else:
+            patterns.append(rf"(?<![.\w]){name}\.get\(\s*{Q}{NAME}{ENDQ}")
+            patterns.append(rf"(?<![.\w]){name}\[\s*{Q}{NAME}{ENDQ}")
+    return patterns
+
 
 # Lexical quirks that are not implied by the comment style. Getting these wrong
 # is not academic: each was a real miss found in review.
@@ -312,6 +358,11 @@ DEFAULT_FLAGS = {
 # is actually reading rather than by the comment style alone.
 for _sdk, _spec in SDKS.items():
     _spec["flags"] = LANG_FLAGS[_sdk]
+
+# Attached here rather than in the table because it is a function defined below
+# it, and only Python has one: its unqualified read spellings are bound by the
+# file's own import lines, so their patterns cannot be known until the file is.
+SDKS["Python"]["dynamic_patterns"] = python_dynamic_patterns
 
 ROOT_README = "README.md"
 
@@ -1198,7 +1249,12 @@ def real_reads(spec: dict, scoped: bool = True) -> dict[str, list[str]]:
             spec["comments"],
             spec.get("flags"),
         )
-        for pattern in compiled:
+        # Patterns that depend on this file's own imports, not just on the
+        # language. Compiled per file because that is the scope of the fact.
+        dynamic = spec.get("dynamic_patterns")
+        file_patterns = compiled + (
+            [re.compile(p) for p in dynamic(text)] if dynamic else [])
+        for pattern in file_patterns:
             # finditer + the named group, not findall: these patterns carry a
             # quote group too, and findall would hand back tuples.
             for match in pattern.finditer(text):

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -734,8 +734,13 @@ def scan_literal(text: str, i: int, style: str,
     quote = text[i]
     openers = interpolation_openers(text, i, quote, style, flags)
     swift_interp = ("\\(", ")") in openers
-    raw = (style == "hash" and has_raw_prefix(text, i)) or (
-        quote == "`" and flags.get("backtick_raw"))
+    # Two different kinds of raw, and they differ exactly where it matters. In
+    # Python's the backslash stays in the value but still keeps the next quote
+    # from closing the literal, so `r"\""` is one string. In Go's backtick
+    # literal the backslash is nothing at all, so a trailing one cannot protect
+    # the delimiter and the literal simply ends.
+    py_raw = style == "hash" and has_raw_prefix(text, i)
+    raw = py_raw or (quote == "`" and flags.get("backtick_raw"))
     j = i + 1
     holes = []
     while j < n:
@@ -748,6 +753,9 @@ def scan_literal(text: str, i: int, style: str,
                 j = end + 1
                 continue
             if raw:
+                if py_raw and text[j + 1 : j + 2] == quote:
+                    j += 2
+                    continue
                 j += 1
                 continue
             j += 2
@@ -1058,7 +1066,26 @@ def prose_lines(readme: Path) -> list[tuple[int, str]]:
 # Words that turn a mention into a denial. A bare substring test counted
 # "the SDK never looks them up" as documentation, so a variable an SDK started
 # reading could ship undocumented behind a sentence saying it does not.
-NEGATION_RE = re.compile(r"\b(never|not|no|none|nothing|cannot|n't)\b", re.I)
+# "reserved", "planned" and friends belong here rather than in some separate
+# category: saying a variable is reserved for future use is saying the SDK does
+# not read it today, which is a denial wearing optimistic clothes.
+NEGATION_RE = re.compile(
+    r"\b(never|not|no|none|nothing|cannot|n't|reserved|unused|ignored|planned)\b",
+    re.I,
+)
+
+# ...and a mention only documents a read when the sentence actually claims one.
+# Absence of a negation was never enough on its own: "`BASECAMP_FOO` appears in
+# the table." denies nothing and asserts nothing either.
+#
+# The verbs are invariant 5's, so the two checks agree about what a claim looks
+# like -- including the bare "use" that the sentence which prompted this whole
+# gate was built on ("which Go and Ruby use to site their cache directories").
+AFFIRMATIVE_RE = re.compile(
+    r"\b(reads?|uses?|consults?|honou?rs?|checks?|respects?|sets?|configures?"
+    r"|overrides?|enables?|disables?|sites?|looks? up|falls? back to)\b",
+    re.I,
+)
 
 
 def affirmative_mentions(readme: Path) -> set[str]:
@@ -1089,7 +1116,7 @@ def affirmative_mentions(readme: Path) -> set[str]:
                 # it." The pronoun is the whole trick, and taking the sentence
                 # in isolation missed it.
                 denied.update(named or previous)
-            else:
+            elif AFFIRMATIVE_RE.search(sentence):
                 mentioned.update(named)
             if named:
                 previous = named

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -538,8 +538,16 @@ def main() -> int:
         )
         return 1
 
-    total = sum(len(r) for r in reads.values())
-    print(f"README env-var check passed ({total} real read sites across {len(SDKS)} SDKs).")
+    # Count both, and name them accurately. `len(r)` is distinct variables, not
+    # call sites -- reporting it as "read sites" understated the scan by a third
+    # (16 vs 23), which is the same species of not-quite-true claim this gate
+    # exists to catch.
+    variables = sum(len(r) for r in reads.values())
+    sites = sum(len(s) for r in reads.values() for s in r.values())
+    print(
+        f"README env-var check passed ({variables} variable/SDK pairs, "
+        f"{sites} read sites, across {len(SDKS)} SDKs)."
+    )
     return 0
 
 

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -44,8 +44,7 @@ actually do with comments, string literals, and interpolation — including the
 parts that differ, which is why `LANG_FLAGS` exists: Swift and Kotlin nest block
 comments and Go and TypeScript do not; a triple-quoted literal is documentation
 in Python and an ordinary string in Kotlin; only Swift has raw strings. It does
-*not* model
-preprocessor conditionals, macros, or heredocs, and it assumes source is
+*not* model preprocessor conditionals, macros, or heredocs, and it assumes source is
 syntactically valid — a file with an unterminated literal is consumed to the
 end rather than resynchronised.
 
@@ -149,15 +148,42 @@ SDKS = {
 #   nested:  Swift and Kotlin allow `/* /* */ */`; Go and TypeScript end the
 #            comment at the first `*/`, so nesting them there would swallow code.
 #   raw:     Swift `#"..."#`, whose interpolation is `\#(...)`.
+#   interp:  which quote character interpolates, and how. Keyed by the opening
+#            quote, because it differs *within* a language: TypeScript
+#            interpolates in backticks only, so `"${x}"` is plain text, and Go
+#            interpolates nowhere at all.
+#   fstring: Python only, where the `f` prefix decides whether braces are code.
 LANG_FLAGS = {
-    "Go": {"triple": False, "nested": False, "raw": False},
-    "Ruby": {"triple": True, "nested": False, "raw": False},
-    "Python": {"triple": True, "nested": False, "raw": False},
-    "TypeScript": {"triple": False, "nested": False, "raw": False},
-    "Swift": {"triple": True, "nested": True, "raw": True},
-    "Kotlin": {"triple": True, "nested": True, "raw": False},
+    "Go": {
+        "triple": False, "nested": False, "raw": False, "fstring": False,
+        "interp": {},
+    },
+    "Ruby": {
+        "triple": True, "nested": False, "raw": False, "fstring": False,
+        "interp": {'"': [("#{", "}")]},
+    },
+    "Python": {
+        "triple": True, "nested": False, "raw": False, "fstring": True,
+        "interp": {},
+    },
+    "TypeScript": {
+        "triple": False, "nested": False, "raw": False, "fstring": False,
+        "interp": {"`": [("${", "}")]},
+    },
+    "Swift": {
+        "triple": True, "nested": True, "raw": True, "fstring": False,
+        "interp": {'"': [("\\(", ")")]},
+    },
+    "Kotlin": {
+        "triple": True, "nested": True, "raw": False, "fstring": False,
+        "interp": {'"': [("${", "}")]},
+    },
 }
-DEFAULT_FLAGS = {"triple": True, "nested": True, "raw": True}
+# Permissive union, used only when no language is supplied.
+DEFAULT_FLAGS = {
+    "triple": True, "nested": True, "raw": True, "fstring": True,
+    "interp": {"`": [("${", "}")], '"': [("${", "}"), ("\\(", ")"), ("#{", "}")]},
+}
 
 # Attach each SDK's lexical flags, so the scanner is driven by the language it
 # is actually reading rather than by the comment style alone.
@@ -203,6 +229,44 @@ STRING_QUOTES = {"hash": "\"'", "slash": "\"'`"}
 
 
 
+def comment_extent(text: str, i: int, style: str | None, flags: dict | None = None) -> int:
+    """End of the comment starting at `i`, or `i` when none starts there.
+
+    Shared by the top-level scan and the delimiter walk so the two cannot
+    disagree about where a comment ends -- they did, and a commented brace
+    truncated an interpolation as a result.
+    """
+    if not style:
+        return i
+    flags = DEFAULT_FLAGS if flags is None else flags
+    n = len(text)
+    if style == "slash" and text.startswith("//", i):
+        end = text.find("\n", i)
+        return n if end == -1 else end
+    if style == "slash" and text.startswith("/*", i):
+        # Swift and Kotlin nest block comments; Go and TypeScript end at the
+        # first `*/`, so nesting them there would swallow the code after it.
+        if flags["nested"]:
+            depth = 1
+            k = i + 2
+            while k < n and depth:
+                if text.startswith("/*", k):
+                    depth += 1
+                    k += 2
+                elif text.startswith("*/", k):
+                    depth -= 1
+                    k += 2
+                else:
+                    k += 1
+            return k
+        end = text.find("*/", i + 2)
+        return n if end == -1 else end + 2
+    if style == "hash" and text[i] == "#":
+        end = text.find("\n", i)
+        return n if end == -1 else end
+    return i
+
+
 def matching_delimiter(text: str, start: int, open_ch: str, close_ch: str,
                        style: str | None = None, flags: dict | None = None) -> int:
     """Index of the delimiter closing the one already opened, honouring nesting.
@@ -225,6 +289,12 @@ def matching_delimiter(text: str, start: int, open_ch: str, close_ch: str,
             if literal_end > k:
                 k = literal_end
                 continue
+        # A delimiter inside a comment is not a delimiter either: in
+        # `${foo(/* } */ x)}` the commented brace must not end the hole.
+        comment_end = comment_extent(text, k, style, flags)
+        if comment_end > k:
+            k = comment_end
+            continue
         if text[k] == open_ch:
             depth += 1
         elif text[k] == close_ch:
@@ -317,12 +387,15 @@ def scan_literal(text: str, i: int, style: str,
         else:
             # Swift and Kotlin multiline strings are ordinary strings, not
             # documentation, and both interpolate.
-            holes = brace_holes(text, i + 3, body_stop, style, flags, "${", "}")
-            holes += brace_holes(text, i + 3, body_stop, style, flags, "\\(", ")")
+            # Whatever this language interpolates in a double-quoted string, it
+            # interpolates in a multiline one: `${...}` in Kotlin, `\(...)` in
+            # Swift, and nothing at all elsewhere.
+            for opener, closer in flags["interp"].get('"', []):
+                holes += brace_holes(text, i + 3, body_stop, style, flags, opener, closer)
         return end, holes
 
     quote = text[i]
-    openers = interpolation_openers(text, i, quote, style)
+    openers = interpolation_openers(text, i, quote, style, flags)
     swift_interp = ("\\(", ")") in openers
     j = i + 1
     holes = []
@@ -386,27 +459,23 @@ def mask_literals(text: str, lo: int, hi: int, style: str, in_string: bytearray,
         i += 1
 
 
-def interpolation_openers(text: str, i: int, quote: str, style: str) -> list[tuple[str, str]]:
+def interpolation_openers(text: str, i: int, quote: str, style: str,
+                          flags: dict | None = None) -> list[tuple[str, str]]:
     """Interpolation delimiters valid inside the literal opening at `i`.
 
     Interpolations are the one part of a string literal that is executable, so
-    they must stay visible to the read patterns. Each language spells them
-    differently, and spelling them wrong fails *open* -- a masked read is a read
-    the gate swears does not exist.
+    they must stay visible to the read patterns. Which spelling is valid depends
+    on the language *and* the quote: TypeScript interpolates in backticks only,
+    so `"${x}"` is ordinary text there while the same bytes are code in Kotlin.
+    Applying one language's rule to another is wrong in both directions -- too
+    narrow hides a real read, too wide promotes example text to one.
     """
-    if quote == "`":
-        return [("${", "}")]  # TypeScript and Kotlin raw strings
-    if style == "slash":
-        if quote == '"':
-            return [("${", "}"), ("\\(", ")")]  # Kotlin, and Swift's \( ... )
-        return []
-    openers = []
-    if quote == '"':
-        openers.append(("#{", "}"))  # Ruby
+    flags = DEFAULT_FLAGS if flags is None else flags
+    openers = list(flags["interp"].get(quote, []))
     # Python f-strings, whose braces are code. Only with an `f` prefix: an
     # ordinary "{...}" is literal text, and treating it as code would let a
     # documentation example count as a read.
-    if has_fstring_prefix(text, i):
+    if flags["fstring"] and has_fstring_prefix(text, i):
         openers.append(("{", "}"))
     return openers
 
@@ -477,37 +546,10 @@ def strip_noncode(text: str, style: str, flags: dict | None = None) -> tuple[str
         if text[i] in quotes:
             i = take_literal(i)
             continue
-        if style == "slash" and text.startswith("//", i):
-            end = text.find("\n", i)
-            blank(i, n if end == -1 else end)
-            i = n if end == -1 else end
-            continue
-        if style == "slash" and text.startswith("/*", i):
-            # Swift and Kotlin nest block comments; Go and TypeScript end at the
-            # first `*/`, so nesting them there would swallow the code after it.
-            if flags["nested"]:
-                depth = 1
-                k = i + 2
-                while k < n and depth:
-                    if text.startswith("/*", k):
-                        depth += 1
-                        k += 2
-                    elif text.startswith("*/", k):
-                        depth -= 1
-                        k += 2
-                    else:
-                        k += 1
-                end = k
-            else:
-                end = text.find("*/", i + 2)
-                end = n if end == -1 else end + 2
-            blank(i, end)
-            i = end
-            continue
-        if style == "hash" and text[i] == "#":
-            end = text.find("\n", i)
-            blank(i, n if end == -1 else end)
-            i = n if end == -1 else end
+        comment_end = comment_extent(text, i, style, flags)
+        if comment_end > i:
+            blank(i, comment_end)
+            i = comment_end
             continue
         # Ruby block comment: =begin/=end, each at column 0.
         if style == "hash" and text.startswith("=begin", i) and (i == 0 or text[i - 1] == "\n"):

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -157,8 +157,9 @@ SDKS = {
 # Lexical quirks that are not implied by the comment style. Getting these wrong
 # is not academic: each was a real miss found in review.
 #
-#   triple:  Python/Ruby `"""`, and Swift/Kotlin multiline `"""` -- which are
-#            ordinary strings, not documentation.
+#   triple:  Python `"""`, and Swift/Kotlin multiline `"""` -- which are
+#            ordinary strings, not documentation. Not Ruby, which has no such
+#            literal: there `"""x"""` is three adjacent literals concatenated.
 #   nested:  Swift and Kotlin allow `/* /* */ */`; Go and TypeScript end the
 #            comment at the first `*/`, so nesting them there would swallow code.
 #   raw:     Swift `#"..."#`, whose interpolation is `\#(...)`.
@@ -190,8 +191,12 @@ LANG_FLAGS = {
         "percent": False,
         "interp": {},
     },
+    # Ruby has no triple-quoted literal. `"""x"""` is three adjacent literals
+    # concatenated -- `""`, `"x"`, `""` -- and the middle one interpolates, so
+    # treating the run as a docstring blanked executable code and lost the read
+    # inside it. Only Python's `"""` is documentation.
     "Ruby": {
-        "triple": True, "nested": False, "raw": False, "fstring": False,
+        "triple": False, "nested": False, "raw": False, "fstring": False,
         "multiline": True,
         "regex": True,
         "command_regex": True,
@@ -306,6 +311,23 @@ REGEX_KEYWORDS = {
 }
 
 
+# Methods that idiomatically take a bare regex as a first argument without
+# parentheses. Spacing alone cannot decide this: `total /x/ 2` and `puts /x/ 2`
+# are spelled identically, and Ruby itself tells them apart only by knowing
+# whether `total` is a local variable in scope -- which a lexer does not.
+#
+# So the rule is deliberately narrow rather than clever. A name on this list
+# with a regex-shaped argument is a regex; everything else stays division. That
+# keeps `total /ENV["X"].to_i / 2` arithmetic, where guessing "regex" would mask
+# the read between the two operators and let an undocumented variable ship --
+# the fail-open direction, and the one worth erring away from.
+REGEX_COMMANDS = {
+    "puts", "print", "p", "pp", "warn", "raise", "fail",
+    "match", "grep", "scan", "split", "sub", "gsub", "index",
+    "assert_match", "refute_match",
+}
+
+
 def command_argument(text: str, i: int, word: str, spaced: bool, flags: dict) -> bool:
     """Whether the `/` at `i` opens a regex passed to a call without parentheses.
 
@@ -316,20 +338,22 @@ def command_argument(text: str, i: int, word: str, spaced: bool, flags: dict) ->
     read, while `puts /#{ENV['X']}/` stays division, the `#` then opens a line
     comment, and a genuine interpolated read disappears.
 
-    Ruby's own parser settles the ambiguity by spacing and so does this: a space
-    before the slash and none after it is the argument form -- the spelling MRI
-    itself warns about as `ambiguous first argument`. Every other spacing stays
-    division, including `/=`, which is divide-and-assign.
+    Two things have to hold, because either alone is ambiguous. The call has to
+    be one this list knows takes a regex, and the spacing has to be the argument
+    form Ruby's own parser looks for -- a space before the slash and none after
+    it, the spelling MRI warns about as `ambiguous first argument`. Every other
+    spacing stays division, `/=` included.
 
     Ruby only. TypeScript has no parenthesis-less call, so `total /count/ 2`
     there is arithmetic and this reading would swallow it.
 
-    Being wrong here is bounded: the caller still requires a closing `/` on the
-    same line, so a lone slash falls back to division on its own.
+    Being wrong here is bounded twice over: the name must be on the list, and
+    the caller still requires a closing `/` on the same line, so a lone slash
+    falls back to division on its own.
     """
     if not flags.get("command_regex") or not spaced:
         return False
-    if not (word[:1].isalpha() or word[:1] == "_"):
+    if word not in REGEX_COMMANDS:
         return False
     after = text[i + 1 : i + 2]
     return bool(after) and not after.isspace() and after != "="
@@ -413,12 +437,22 @@ def percent_literal_extent(text: str, i: int, flags: dict) -> tuple[int, list[tu
     if opener.isalnum() or opener.isspace() or opener == "=":
         return i, []  # `a % b`, `%=`, and format strings are not literals
     closer = PERCENT_DELIMS.get(opener)
+    interpolates = letter.lower() in PERCENT_INTERPOLATING or letter.isupper()
     body_start = j + 1
     k = body_start
     depth = 1
     while k < n:
         if text[k] == "\\":
             k += 2
+            continue
+        # Inside `#{...}` the language's ordinary rules apply again, so a quoted
+        # brace there is a string and not the end of anything. The plain scan
+        # counted it and closed the literal early, which left the rest of the
+        # line -- and any real read in it -- to be eaten as a `#` comment.
+        # Quotes in the surrounding body stay data, which is why only the hole
+        # is handed to the language-aware matcher.
+        if interpolates and text.startswith("#{", k):
+            k = matching_delimiter(text, k + 2, "{", "}", "hash", flags) + 1
             continue
         if closer is None:
             if text[k] == opener:
@@ -433,7 +467,7 @@ def percent_literal_extent(text: str, i: int, flags: dict) -> tuple[int, list[tu
         k += 1
     body_stop = min(k, n)
     holes = []
-    if letter.lower() in PERCENT_INTERPOLATING or letter.isupper():
+    if interpolates:
         holes = brace_holes(text, body_start, body_stop, "hash", flags, "#{", "}")
     return min(body_stop + 1, n), holes
 
@@ -716,6 +750,19 @@ def mask_literals(text: str, lo: int, hi: int, style: str, in_string: bytearray,
                 in_string[k] = 1
             i = regex_end
             continue
+        # A percent literal is data here too. The top-level scanner knew that
+        # and this one did not, so `"#{%q{ENV['X']}}"` -- data nested one level
+        # inside an interpolation -- came back out as a read.
+        percent_end, percent_holes = percent_literal_extent(text, i, flags)
+        if percent_end > i:
+            for k in range(i, min(percent_end, hi)):
+                in_string[k] = 1
+            for hole_start, hole_end in percent_holes:
+                for k in range(hole_start, min(hole_end, hi)):
+                    in_string[k] = 0
+                mask_literals(text, hole_start, min(hole_end, hi), style, in_string, flags)
+            i = percent_end
+            continue
         if text[i] in quotes or (flags["raw"] and raw_string_hashes(text, i)):
             end, holes = scan_literal(text, i, style, flags)
             if end <= i:
@@ -972,19 +1019,41 @@ def affirmative_mentions(readme: Path) -> set[str]:
     Quick Start shows the *caller* reading BASECAMP_TOKEN from its own
     environment, which says nothing about what the SDK reads.
     """
-    found: set[str] = set()
+    tabled: set[str] = set()
     for _lineno, cells in table_rows(readme):
-        found.update(VAR_RE.findall(cells[0]))
+        tabled.update(VAR_RE.findall(cells[0]))
+    mentioned: set[str] = set()
+    denied: set[str] = set()
     for paragraph in prose_paragraphs(readme):
         text, _line_at = join_paragraph(paragraph)
         # Split on sentence enders only. A semicolon joins clauses of one
         # sentence, and splitting there detached "the SDK never looks them up"
         # from the variable it denies -- which is the exact sentence in
         # python/README.md this check exists to refuse.
+        previous: list[str] = []
         for sentence in re.split(r"(?<=[.!?])\s+", text):
-            if not NEGATION_RE.search(sentence):
-                found.update(VAR_RE.findall(sentence))
-    return found
+            named = VAR_RE.findall(sentence)
+            if NEGATION_RE.search(sentence):
+                # A denial that names nothing is denying what was just named:
+                # "`BASECAMP_TOKEN` appears in examples. The SDK never reads
+                # it." The pronoun is the whole trick, and taking the sentence
+                # in isolation missed it.
+                denied.update(named or previous)
+            else:
+                mentioned.update(named)
+            if named:
+                previous = named
+    # Absence of a denial is not an affirmation. "`BASECAMP_TOKEN` appears in
+    # examples. The SDK never reads it." passed on the strength of the first
+    # sentence, which claims nothing, while the second says the opposite of what
+    # documentation would -- so a denial anywhere in the prose withdraws a
+    # merely neutral mention.
+    #
+    # A table row survives it. The row *is* the affirmative claim, and the
+    # denial usually qualifies one code path rather than the SDK: go/README.md
+    # says `StaticTokenProvider` does not read `BASECAMP_TOKEN`, which is true,
+    # while the table documents the variable the SDK really does read.
+    return tabled | (mentioned - denied)
 
 
 def prose_paragraphs(readme: Path) -> list[list[tuple[int, str]]]:
@@ -1129,6 +1198,22 @@ def main() -> int:
                     failures.append(
                         f"{ROOT_README}:{lineno}: {sdk} reads {var} "
                         f"({reads[sdk][var][0]}) but the 'Read by' column omits it"
+                    )
+
+    # 2b. Reverse, root README: the row-by-row checks above only ever see
+    # variables that already have a row, so an SDK could start reading
+    # BASECAMP_NEW, document it in its own README, and leave the root
+    # inventory silently short. Named anywhere affirmative counts -- the XDG
+    # pair is carried in prose rather than the table on purpose, and invariant 5
+    # is what holds that sentence honest.
+    if root.is_file():
+        root_documented = affirmative_mentions(root)
+        for sdk in SDKS:
+            for var, sites in sorted(reads[sdk].items()):
+                if var not in root_documented:
+                    failures.append(
+                        f"{ROOT_README}: {sdk} reads {var} ({sites[0]}) but the root "
+                        f"README never names it"
                     )
 
     # 3. Reverse, per SDK: a real read must be documented *affirmatively*.

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -126,7 +126,10 @@ SDKS = {
         "source": "swift/Sources",
         "comments": "slash",
         "suffixes": (".swift",),
-        "patterns": [rf"ProcessInfo\.processInfo\.environment\[\s*{DQ}{NAME}{ENDQ}"],
+        # `#*` around the quotes: a raw string is a valid dictionary key, so
+        # environment[#"BASECAMP_TOKEN"#] is a real read that a bare-quote
+        # pattern reports as nonexistent.
+        "patterns": [rf"ProcessInfo\.processInfo\.environment\[\s*#*{DQ}{NAME}{ENDQ}#*"],
     },
     # kotlin/sdk/src, not just commonMain: jvmMain ships in the same artifact, so
     # scoping to commonMain would let a platform-specific read bypass this gate.
@@ -443,6 +446,15 @@ def mask_literals(text: str, lo: int, hi: int, style: str, in_string: bytearray,
     quotes = STRING_QUOTES[style]
     i = lo
     while i < hi:
+        # A comment inside the expression is not code either. The hole was
+        # un-masked wholesale, so without this `${foo(/* process.env.X */ 1)}`
+        # counts as a read. The mask means "not executable", not "in a string".
+        comment_end = comment_extent(text, i, style, flags)
+        if comment_end > i:
+            for k in range(i, min(comment_end, hi)):
+                in_string[k] = 1
+            i = comment_end
+            continue
         if text[i] in quotes or (flags["raw"] and raw_string_hashes(text, i)):
             end, holes = scan_literal(text, i, style, flags)
             if end <= i:

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -531,15 +531,17 @@ def brace_holes(text: str, start: int, stop: int, style: str, flags: dict,
         if text.startswith(opener * 2, j):
             j += 2 * len(opener)
             continue
-        # `\\(` is an escaped backslash followed by a paren, not Swift's `\(`.
-        # Skipping the pair keeps the example text masked.
-        if opener.startswith("\\") and text.startswith("\\\\", j):
-            j += 2
-            continue
         if text.startswith(opener, j):
             close = matching_delimiter(text, j + len(opener), opener[-1], closer, style, flags)
             holes.append((j + len(opener), min(close, stop)))
             j = close + 1
+            continue
+        # A backslash escapes what follows, so `\#{...}` in Ruby is literal text.
+        # This has to be tested *after* the opener, because Swift's opener is
+        # itself `\(` -- checking the escape first would eat it and lose every
+        # Swift interpolation.
+        if text[j] == "\\":
+            j += 2
             continue
         j += 1
     return holes

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -93,20 +93,24 @@ COMMENT_STARTS = ("#", "//", "*", "/*")
 FILENAME_TEST_MARKERS = ("_test.", "test_", ".test.", "_spec.")
 
 
-def is_test(path: Path) -> bool:
+def is_test(rel_path: Path) -> bool:
     """Test code, by directory or by filename.
+
+    Takes a repo-relative path: matching against an absolute one would consult
+    the checkout's parent directories, so a clone living under any directory
+    named e.g. `Tests` would silently skip every file in the repo.
 
     Directory matching has to understand Kotlin/Swift source-set naming
     (`commonTest`, `jvmTest`, `Tests`) as well as the plain `test`/`tests`/`spec`
     directories the other SDKs use.
     """
-    for part in path.parts[:-1]:
+    for part in rel_path.parts[:-1]:
         lowered = part.lower()
         if lowered in ("test", "tests", "spec", "specs"):
             return True
         if part.endswith(("Test", "Tests")):
             return True
-    return any(marker in path.name for marker in FILENAME_TEST_MARKERS)
+    return any(marker in rel_path.name for marker in FILENAME_TEST_MARKERS)
 
 
 def real_reads(spec: dict) -> dict[str, list[str]]:
@@ -117,7 +121,10 @@ def real_reads(spec: dict) -> dict[str, list[str]]:
         return found
     compiled = [re.compile(p) for p in spec["patterns"]]
     for path in sorted(root.rglob("*")):
-        if not path.is_file() or path.suffix not in spec["suffixes"] or is_test(path):
+        if not path.is_file() or path.suffix not in spec["suffixes"]:
+            continue
+        rel = path.relative_to(REPO)
+        if is_test(rel):
             continue
         for lineno, line in enumerate(path.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
             if line.lstrip().startswith(COMMENT_STARTS):
@@ -125,7 +132,7 @@ def real_reads(spec: dict) -> dict[str, list[str]]:
             for pattern in compiled:
                 for name in pattern.findall(line):
                     if VAR_RE.fullmatch(name):
-                        found.setdefault(name, []).append(f"{path.relative_to(REPO)}:{lineno}")
+                        found.setdefault(name, []).append(f"{rel}:{lineno}")
     return found
 
 

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -131,13 +131,22 @@ VAR_RE = re.compile(r"\b((?:BASECAMP|XDG)_[A-Z0-9_]+)\b")
 
 FILENAME_TEST_MARKERS = ("_test.", "test_", ".test.", "_spec.")
 
-# Invariant 5. Only the active voice with a bare SDK name as the subject --
-# "Go reads `X`". The passive "`BASECAMP_TOKEN` is read by `AuthManager`" and
-# "`Config()` reads no environment" both name a *symbol* rather than an SDK, and
-# neither matches, which is what keeps this from firing on the per-SDK READMEs.
+# Invariant 5. Only the active voice with SDK names as the subject. The passive
+# "`BASECAMP_TOKEN` is read by `AuthManager`", the symbol subject "`Config()`
+# reads no environment", and "`DefaultConfig` consults `XDG_CACHE_HOME`" all name
+# a *symbol* rather than an SDK, so none match -- which is what keeps this quiet
+# on the per-SDK READMEs, where every one of those sentences ships today.
+#
+# The subject may be compound, because the sentence this gate exists to catch
+# was: "XDG_CACHE_HOME / XDG_CONFIG_HOME, which Go and Ruby use to site their
+# cache and config directories". A single-name subject would have missed it, and
+# so would a "reads"-only verb -- both were checked against that literal string.
+SDK_ALT = "|".join(SDKS)
+SDK_SUBJECT = rf"(?:{SDK_ALT})(?:(?:,\s*|\s+and\s+|,\s*and\s+)(?:{SDK_ALT}))*"
 SDK_READS_RE = re.compile(
-    rf"\b(?P<sdk>{'|'.join(SDKS)})\b\s+reads?\b"
+    rf"\b(?P<subject>{SDK_SUBJECT})\s+(?:reads?|uses?|consults?|honou?rs?)\b"
 )
+SDK_NAME_RE = re.compile(rf"\b({SDK_ALT})\b")
 
 # A claim runs to the next such claim or the end of its sentence, whichever
 # comes first, so "Go reads `A` ... and Ruby reads `B`" splits at "Ruby".
@@ -331,19 +340,43 @@ def prose_lines(readme: Path) -> list[tuple[int, str]]:
 
 
 def prose_claims(readme: Path) -> list[tuple[int, str, list[str]]]:
-    """Every "<SDK> reads `VAR`" claim, as (line number, sdk, variables)."""
+    """Every "<SDK> reads `VAR`" claim, as (line number, sdk, variables).
+
+    A compound subject yields one claim per SDK named, so "Go and Ruby use `X`"
+    is checked against Go *and* Ruby.
+
+    Variables are taken from after the verb -- "Go reads `X`" -- and, only when
+    nothing follows, from before the subject. The backward pass is not
+    hypothetical: the sentence that motivated this gate put the variables first
+    and the subject in a trailing relative clause ("`XDG_CACHE_HOME` /
+    `XDG_CONFIG_HOME`, which Go and Ruby use to site their cache and config
+    directories"), where a forward-only scan sees no variables and reports
+    nothing. Both passes stop at a sentence boundary or a neighbouring claim, so
+    one clause cannot borrow another's variables.
+    """
     claims = []
     for lineno, line in prose_lines(readme):
         matches = list(SDK_READS_RE.finditer(line))
         for index, match in enumerate(matches):
-            start = match.end()
-            stop = matches[index + 1].start() if index + 1 < len(matches) else len(line)
-            terminator = CLAIM_END_RE.search(line, start, stop)
+            forward_start = match.end()
+            forward_stop = matches[index + 1].start() if index + 1 < len(matches) else len(line)
+            terminator = CLAIM_END_RE.search(line, forward_start, forward_stop)
             if terminator:
-                stop = terminator.start()
-            named = VAR_RE.findall(line[start:stop])
-            if named:
-                claims.append((lineno, match.group("sdk"), named))
+                forward_stop = terminator.start()
+            named = VAR_RE.findall(line[forward_start:forward_stop])
+
+            if not named:
+                # Back to the start of this sentence, but never past the previous
+                # claim -- otherwise "Go reads `X`. Ruby uses it too" would hand
+                # Go's variable to Ruby.
+                backward_start = matches[index - 1].end() if index else 0
+                for boundary in CLAIM_END_RE.finditer(line, backward_start, match.start()):
+                    backward_start = boundary.end()
+                named = VAR_RE.findall(line[backward_start:match.start()])
+
+            for sdk in SDK_NAME_RE.findall(match.group("subject")):
+                if named:
+                    claims.append((lineno, sdk, named))
     return claims
 
 

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -126,6 +126,10 @@ SDKS = {
             # a consuming pattern would bind only one name per brace group,
             # which is the "looks like coverage" failure all over again.
             rf"\b{NAME}\b(?=[^{{}}]*\}}\s*=\s*process\.env)",
+            # ...and the quoted-key form, `{ "BASECAMP_TOKEN": token }`. The
+            # match has to start on the brace or comma, because the name is
+            # inside a literal and would be rejected as string data.
+            rf"[{{,]\s*{Q}{NAME}{ENDQ}\s*:(?=[^{{}}]*\}}\s*=\s*process\.env)",
         ],
     },
     "Swift": {
@@ -163,6 +167,8 @@ SDKS = {
 #            interpolates in backticks only, so `"${x}"` is plain text, and Go
 #            interpolates nowhere at all.
 #   fstring: Python only, where the `f` prefix decides whether braces are code.
+#   triple_raw: Kotlin, whose multiline strings have no escapes at all.
+#            Swift's do, which is how `\(` interpolates there.
 #   regex:   TypeScript `/.../` literals, whose contents are data. Enabled only
 #            there: `/` is division far more often than not, and the two are
 #            told apart by the preceding token, so this stays conservative.
@@ -175,6 +181,8 @@ LANG_FLAGS = {
         "multiline": False,
         "regex": False,
         "backtick_raw": True,
+        "triple_raw": False,
+        "percent": False,
         "interp": {},
     },
     "Ruby": {
@@ -182,6 +190,8 @@ LANG_FLAGS = {
         "multiline": True,
         "regex": False,
         "backtick_raw": False,
+        "triple_raw": False,
+        "percent": True,
         "interp": {'"': [("#{", "}")]},
     },
     "Python": {
@@ -189,6 +199,8 @@ LANG_FLAGS = {
         "multiline": False,
         "regex": False,
         "backtick_raw": False,
+        "triple_raw": False,
+        "percent": False,
         "interp": {},
     },
     "TypeScript": {
@@ -196,6 +208,8 @@ LANG_FLAGS = {
         "multiline": False,
         "regex": True,
         "backtick_raw": False,
+        "triple_raw": False,
+        "percent": False,
         "interp": {"`": [("${", "}")]},
     },
     "Swift": {
@@ -203,6 +217,8 @@ LANG_FLAGS = {
         "multiline": False,
         "regex": False,
         "backtick_raw": False,
+        "triple_raw": False,
+        "percent": False,
         "interp": {'"': [("\\(", ")")]},
     },
     "Kotlin": {
@@ -210,12 +226,14 @@ LANG_FLAGS = {
         "multiline": False,
         "regex": False,
         "backtick_raw": False,
+        "triple_raw": True,
+        "percent": False,
         "interp": {'"': [("${", "}")]},
     },
 }
 # Permissive union, used only when no language is supplied.
 DEFAULT_FLAGS = {
-    "triple": True, "nested": True, "raw": True, "fstring": True, "multiline": True, "regex": True, "backtick_raw": False,
+    "triple": True, "nested": True, "raw": True, "fstring": True, "multiline": True, "regex": True, "backtick_raw": False, "triple_raw": False, "percent": True,
     "interp": {"`": [("${", "}")], '"': [("${", "}"), ("\\(", ")"), ("#{", "}")]},
 }
 
@@ -278,7 +296,7 @@ REGEX_KEYWORDS = {
 
 def regex_extent(text: str, i: int, flags: dict) -> int:
     """End of a TypeScript regex literal starting at `i`, else `i`."""
-    if not flags.get("regex") or text[i] != "/":
+    if not flags or not flags.get("regex") or text[i] != "/":
         return i
     if text.startswith("//", i) or text.startswith("/*", i):
         return i
@@ -311,6 +329,28 @@ def regex_extent(text: str, i: int, flags: dict) -> int:
             return j + 1
         j += 1
     return i
+
+
+# Ruby percent literals -- %q{...}, %w[...], %(...) -- are ordinary data, and
+# the scanner saw only quote characters, leaving their contents executable.
+PERCENT_DELIMS = {"{": "}", "[": "]", "(": ")", "<": ">"}
+
+
+def percent_literal_extent(text: str, i: int, flags: dict) -> int:
+    """End of a Ruby percent literal starting at `i`, else `i`."""
+    if not flags or not flags.get("percent") or text[i] != "%":
+        return i
+    j = i + 1
+    if j < len(text) and text[j].isalpha():
+        j += 1
+    if j >= len(text):
+        return i
+    opener = text[j]
+    closer = PERCENT_DELIMS.get(opener)
+    if closer is None:
+        return i
+    end = matching_delimiter(text, j + 1, opener, closer, "hash", flags)
+    return min(end + 1, len(text))
 
 
 def comment_extent(text: str, i: int, style: str | None, flags: dict | None = None) -> int:
@@ -500,8 +540,9 @@ def scan_literal(text: str, i: int, style: str,
             triple_quote = candidate
 
     if triple_quote:
-        close_at = find_unescaped(text, triple_quote, i + 3,
-                                  raw=style == "hash" and has_raw_prefix(text, i))
+        triple_is_raw = flags.get("triple_raw") or (
+            style == "hash" and has_raw_prefix(text, i))
+        close_at = find_unescaped(text, triple_quote, i + 3, raw=triple_is_raw)
         end = n if close_at == -1 else close_at + 3
         body_stop = close_at if close_at != -1 else n
         holes = []
@@ -695,6 +736,12 @@ def strip_noncode(text: str, style: str, flags: dict | None = None) -> tuple[str
         if comment_end > i:
             blank(i, comment_end)
             i = comment_end
+            continue
+        percent_end = percent_literal_extent(text, i, flags)
+        if percent_end > i:
+            for k in range(i, min(percent_end, n)):
+                in_string[k] = 1
+            i = percent_end
             continue
         # A regex literal is data, like a string: its contents are not calls.
         regex_end = regex_extent(text, i, flags)

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -34,41 +34,62 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parent.parent
 
+NAME = r"(?P<name>[A-Z_][A-Z0-9_]*)"
+
+# Quote styles that actually delimit a string literal in each language. Getting
+# this wrong fails *open*: a read the pattern cannot see is a read the gate will
+# swear does not exist, so it would report a phantom row as fine and an
+# undocumented variable as documented. The closing quote is a backreference, so
+# a mismatched pair cannot match.
+Q = r"(?P<q>[\"'])"  # Ruby, Python, TypeScript
+GO_Q = r"(?P<q>[\"`])"  # Go has interpreted and raw string literals, no single quotes
+DQ = r"(?P<q>\")"  # Swift and Kotlin have only double-quoted strings
+ENDQ = r"(?P=q)"
+
 # Where each SDK's shipping source lives, and how that language reads an env var.
 SDKS = {
     "Go": {
         "readme": "go/README.md",
         "source": "go/pkg",
         "suffixes": (".go",),
-        "patterns": [r'os\.Getenv\(\s*"([A-Z_][A-Z0-9_]*)"', r'os\.LookupEnv\(\s*"([A-Z_][A-Z0-9_]*)"'],
+        "patterns": [
+            rf"os\.Getenv\(\s*{GO_Q}{NAME}{ENDQ}",
+            rf"os\.LookupEnv\(\s*{GO_Q}{NAME}{ENDQ}",
+        ],
     },
     "Ruby": {
         "readme": "ruby/README.md",
         "source": "ruby/lib",
         "suffixes": (".rb",),
-        "patterns": [r'ENV\[\s*"([A-Z_][A-Z0-9_]*)"', r'ENV\.fetch\(\s*"([A-Z_][A-Z0-9_]*)"'],
+        "patterns": [
+            rf"ENV\[\s*{Q}{NAME}{ENDQ}",
+            rf"ENV\.fetch\(\s*{Q}{NAME}{ENDQ}",
+        ],
     },
     "Python": {
         "readme": "python/README.md",
         "source": "python/src",
         "suffixes": (".py",),
         "patterns": [
-            r'os\.environ\.get\(\s*"([A-Z_][A-Z0-9_]*)"',
-            r'os\.environ\[\s*"([A-Z_][A-Z0-9_]*)"',
-            r'os\.getenv\(\s*"([A-Z_][A-Z0-9_]*)"',
+            rf"os\.environ\.get\(\s*{Q}{NAME}{ENDQ}",
+            rf"os\.environ\[\s*{Q}{NAME}{ENDQ}",
+            rf"os\.getenv\(\s*{Q}{NAME}{ENDQ}",
         ],
     },
     "TypeScript": {
         "readme": "typescript/README.md",
         "source": "typescript/src",
         "suffixes": (".ts",),
-        "patterns": [r'process\.env\.([A-Z_][A-Z0-9_]*)', r'process\.env\[\s*"([A-Z_][A-Z0-9_]*)"'],
+        "patterns": [
+            rf"process\.env\.{NAME}",
+            rf"process\.env\[\s*{Q}{NAME}{ENDQ}",
+        ],
     },
     "Swift": {
         "readme": "swift/README.md",
         "source": "swift/Sources",
         "suffixes": (".swift",),
-        "patterns": [r'ProcessInfo\.processInfo\.environment\[\s*"([A-Z_][A-Z0-9_]*)"'],
+        "patterns": [rf"ProcessInfo\.processInfo\.environment\[\s*{DQ}{NAME}{ENDQ}"],
     },
     # kotlin/sdk/src, not just commonMain: jvmMain ships in the same artifact, so
     # scoping to commonMain would let a platform-specific read bypass this gate.
@@ -77,7 +98,7 @@ SDKS = {
         "readme": "kotlin/README.md",
         "source": "kotlin/sdk/src",
         "suffixes": (".kt",),
-        "patterns": [r'System\.getenv\(\s*"([A-Z_][A-Z0-9_]*)"'],
+        "patterns": [rf"System\.getenv\(\s*{DQ}{NAME}{ENDQ}"],
     },
 }
 
@@ -130,7 +151,10 @@ def real_reads(spec: dict) -> dict[str, list[str]]:
             if line.lstrip().startswith(COMMENT_STARTS):
                 continue  # a doc-comment example is not a read
             for pattern in compiled:
-                for name in pattern.findall(line):
+                # finditer + the named group, not findall: these patterns carry a
+                # quote group too, and findall would hand back tuples.
+                for match in pattern.finditer(line):
+                    name = match.group("name")
                     if VAR_RE.fullmatch(name):
                         found.setdefault(name, []).append(f"{rel}:{lineno}")
     return found

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -125,7 +125,13 @@ SDKS = {
             # comes *before* process.env, so this is a zero-width lookahead:
             # a consuming pattern would bind only one name per brace group,
             # which is the "looks like coverage" failure all over again.
-            rf"\b{NAME}\b(?=[^{{}}]*\}}\s*=\s*process\.env)",
+            #
+            # Anchored on the brace or comma so it matches destructuring *keys*
+            # only. Unanchored it also matched the local name in
+            # `const { OTHER: BASECAMP_TOKEN } = process.env`, where the key --
+            # the variable actually read -- is OTHER and BASECAMP_TOKEN is just
+            # what it was renamed to.
+            rf"[{{,]\s*{NAME}\b(?=[^{{}}]*\}}\s*=\s*process\.env)",
             # ...and the quoted-key form, `{ "BASECAMP_TOKEN": token }`. The
             # match has to start on the brace or comma, because the name is
             # inside a literal and would be rejected as string data.
@@ -186,6 +192,7 @@ LANG_FLAGS = {
         "multiline": False,
         "regex": False,
         "command_regex": False,
+        "backtick_string": False,
         "backtick_raw": True,
         "triple_raw": False,
         "percent": False,
@@ -201,15 +208,20 @@ LANG_FLAGS = {
         "regex": True,
         "command_regex": True,
         "backtick_raw": False,
+        # Ruby's backtick is a command literal, and it interpolates like a
+        # double-quoted string. Python shares this comment style and has no such
+        # literal, which is why this is a flag rather than a `hash` quote.
+        "backtick_string": True,
         "triple_raw": False,
         "percent": True,
-        "interp": {'"': [("#{", "}")]},
+        "interp": {'"': [("#{", "}")], "`": [("#{", "}")]},
     },
     "Python": {
         "triple": True, "nested": False, "raw": False, "fstring": True,
         "multiline": False,
         "regex": False,
         "command_regex": False,
+        "backtick_string": False,
         "backtick_raw": False,
         "triple_raw": False,
         "percent": False,
@@ -220,6 +232,7 @@ LANG_FLAGS = {
         "multiline": False,
         "regex": True,
         "command_regex": False,
+        "backtick_string": False,
         "backtick_raw": False,
         "triple_raw": False,
         "percent": False,
@@ -230,6 +243,7 @@ LANG_FLAGS = {
         "multiline": False,
         "regex": False,
         "command_regex": False,
+        "backtick_string": False,
         "backtick_raw": False,
         "triple_raw": False,
         "percent": False,
@@ -240,6 +254,7 @@ LANG_FLAGS = {
         "multiline": False,
         "regex": False,
         "command_regex": False,
+        "backtick_string": False,
         "backtick_raw": False,
         "triple_raw": True,
         "percent": False,
@@ -248,7 +263,7 @@ LANG_FLAGS = {
 }
 # Permissive union, used only when no language is supplied.
 DEFAULT_FLAGS = {
-    "triple": True, "nested": True, "raw": True, "fstring": True, "multiline": True, "regex": True, "command_regex": True, "backtick_raw": False, "triple_raw": False, "percent": True,
+    "triple": True, "nested": True, "raw": True, "fstring": True, "multiline": True, "regex": True, "command_regex": True, "backtick_string": False, "backtick_raw": False, "triple_raw": False, "percent": True,
     "interp": {"`": [("${", "}")], '"': [("${", "}"), ("\\(", ")"), ("#{", "}")]},
 }
 
@@ -292,6 +307,24 @@ CLAIM_END_RE = re.compile(r"\.\s|\n")
 # are kept — the variable name lives inside one — but they are skipped over so a
 # `#` or `//` inside a string is not mistaken for the start of a comment.
 STRING_QUOTES = {"hash": "\"'", "slash": "\"'`"}
+
+
+def string_quotes(style: str | None, flags: dict | None = None) -> str:
+    """Quote characters that open a literal in this language.
+
+    Keyed by comment style *and* flags, because Ruby and Python share the `hash`
+    style and only Ruby has backtick command literals. Putting the backtick in
+    the shared set would have a stray one in Python open a literal; leaving it
+    out entirely -- which is what happened -- left Ruby's ``echo `` bodies
+    executable, so `` `echo ENV["X"]` `` counted as a read while the `#` of
+    `` `echo #{ENV["X"]}` `` opened a comment and hid a real one.
+    """
+    if not style:
+        return ""
+    quotes = STRING_QUOTES[style]
+    if flags and flags.get("backtick_string"):
+        quotes += "`"
+    return quotes
 
 
 
@@ -359,6 +392,32 @@ def command_argument(text: str, i: int, word: str, spaced: bool, flags: dict) ->
     return bool(after) and not after.isspace() and after != "="
 
 
+def operand_position(text: str, i: int, flags: dict) -> bool:
+    """Whether an operand may begin at `i`, rather than a binary operator.
+
+    `/` and `%` are both overloaded the same way -- regex or division, percent
+    literal or modulo -- and both are decided by what precedes them, so both ask
+    here. Getting `%` wrong is the more violent of the two: an accepted literal
+    with a punctuation delimiter that never recurs consumes the rest of the file.
+    """
+    k = i - 1
+    # Whether anything separated the operator from the token before it. Ruby
+    # needs it to tell a command-form argument from arithmetic, and the scan
+    # below discards it.
+    spaced = k >= 0 and text[k] in " \t"
+    while k >= 0 and text[k] in " \t":
+        k -= 1
+    if k < 0 or text[k] in REGEX_PRECEDERS or text[k] == "\n":
+        return True
+    if not (text[k].isalnum() or text[k] == "_"):
+        return False
+    word_end = k + 1
+    while k >= 0 and (text[k].isalnum() or text[k] == "_"):
+        k -= 1
+    word = text[k + 1 : word_end]
+    return word in REGEX_KEYWORDS or command_argument(text, i, word, spaced, flags)
+
+
 def regex_extent(text: str, i: int, flags: dict) -> int:
     """End of a regex literal starting at `i`, else `i`.
 
@@ -371,22 +430,8 @@ def regex_extent(text: str, i: int, flags: dict) -> int:
         return i
     if text.startswith("//", i) or text.startswith("/*", i):
         return i
-    k = i - 1
-    # Whether anything separated the slash from the token before it. Ruby needs
-    # this to tell a command-form argument from division, and the scan below
-    # discards it.
-    spaced = k >= 0 and text[k] in " \t"
-    while k >= 0 and text[k] in " \t":
-        k -= 1
-    if k >= 0 and text[k] not in REGEX_PRECEDERS and text[k] != "\n":
-        if not (text[k].isalnum() or text[k] == "_"):
-            return i
-        word_end = k + 1
-        while k >= 0 and (text[k].isalnum() or text[k] == "_"):
-            k -= 1
-        word = text[k + 1 : word_end]
-        if word not in REGEX_KEYWORDS and not command_argument(text, i, word, spaced, flags):
-            return i
+    if not operand_position(text, i, flags):
+        return i
     j = i + 1
     in_class = False
     n = len(text)
@@ -424,6 +469,11 @@ def percent_literal_extent(text: str, i: int, flags: dict) -> tuple[int, list[tu
     that let a `"` inside `%q{"}` open a phantom string and run past the close.
     """
     if not flags or not flags.get("percent") or text[i] != "%":
+        return i, []
+    # `%` is modulo wherever a value just ended. Skipping this test, `10%-x`
+    # read the `-` as a bare delimiter, and with no second `-` on the way the
+    # literal ran to the end of the file and masked every read after it.
+    if not operand_position(text, i, flags):
         return i, []
     n = len(text)
     j = i + 1
@@ -525,7 +575,7 @@ def matching_delimiter(text: str, start: int, open_ch: str, close_ch: str,
     depth = 1
     k = start
     n = len(text)
-    quotes = STRING_QUOTES[style] if style else ""
+    quotes = string_quotes(style, flags)
     while k < n:
         if quotes and text[k] in quotes:
             literal_end, _ = scan_literal(text, k, style, flags)
@@ -732,7 +782,7 @@ def mask_literals(text: str, lo: int, hi: int, style: str, in_string: bytearray,
     a read, because the hole was un-masked wholesale.
     """
     flags = DEFAULT_FLAGS if flags is None else flags
-    quotes = STRING_QUOTES[style]
+    quotes = string_quotes(style, flags)
     i = lo
     while i < hi:
         # A comment inside the expression is not code either. The hole was
@@ -823,7 +873,7 @@ def strip_noncode(text: str, style: str, flags: dict | None = None) -> tuple[str
     n = len(text)
     in_string = bytearray(n)
     flags = DEFAULT_FLAGS if flags is None else flags
-    quotes = STRING_QUOTES[style]
+    quotes = string_quotes(style, flags)
     i = 0
 
     def blank(start: int, end: int) -> None:

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -37,6 +37,22 @@ ordinary code characters — and the stripped text is matched whole rather than
 line by line, so a call split across lines is still seen. Both directions of
 that matter: counting a doc example as a read lets a phantom table row pass,
 and missing a real read lets an undocumented variable pass.
+
+That scanner is a lexer, not a parser, and the distinction is worth stating
+plainly rather than discovering later. It models what these six languages
+actually do with comments, string literals, and interpolation — including the
+parts that differ, which is why `LANG_FLAGS` exists: Swift and Kotlin nest block
+comments and Go and TypeScript do not; `"""` is documentation in Python and an
+ordinary string in Kotlin; only Swift has `#"..."#`. It does *not* model
+preprocessor conditionals, macros, or heredocs, and it assumes source is
+syntactically valid — a file with an unterminated literal is consumed to the
+end rather than resynchronised.
+
+The failure directions are not symmetric, and every fix here has been argued in
+those terms. Masking too much hides a real read, so an undocumented variable
+ships silently. Masking too little promotes example text to a read, which either
+fails CI on a correct README or lets a phantom row pass behind a bogus
+no-environment break. Neither is acceptable, so both directions carry tests.
 """
 
 from __future__ import annotations

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -121,6 +121,11 @@ SDKS = {
             # reported as nonexistent.
             rf"process\.env\??\.{NAME}",
             rf"process\.env(?:\?\.)?\[\s*{Q}{NAME}{ENDQ}",
+            # `const { BASECAMP_TOKEN } = process.env` is a read too. The name
+            # comes *before* process.env, so this is a zero-width lookahead:
+            # a consuming pattern would bind only one name per brace group,
+            # which is the "looks like coverage" failure all over again.
+            rf"\b{NAME}\b(?=[^{{}}]*\}}\s*=\s*process\.env)",
         ],
     },
     "Swift": {
@@ -344,6 +349,11 @@ def brace_holes(text: str, start: int, stop: int, style: str, flags: dict,
         # A doubled opener is an escape -- literal text, not an expression.
         if text.startswith(opener * 2, j):
             j += 2 * len(opener)
+            continue
+        # `\\(` is an escaped backslash followed by a paren, not Swift's `\(`.
+        # Skipping the pair keeps the example text masked.
+        if opener.startswith("\\") and text.startswith("\\\\", j):
+            j += 2
             continue
         if text.startswith(opener, j):
             close = matching_delimiter(text, j + len(opener), opener[-1], closer, style, flags)

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -70,9 +70,12 @@ SDKS = {
         "suffixes": (".swift",),
         "patterns": [r'ProcessInfo\.processInfo\.environment\[\s*"([A-Z_][A-Z0-9_]*)"'],
     },
+    # kotlin/sdk/src, not just commonMain: jvmMain ships in the same artifact, so
+    # scoping to commonMain would let a platform-specific read bypass this gate.
+    # The source-set test directories (commonTest, jvmTest) are excluded below.
     "Kotlin": {
         "readme": "kotlin/README.md",
-        "source": "kotlin/sdk/src/commonMain",
+        "source": "kotlin/sdk/src",
         "suffixes": (".kt",),
         "patterns": [r'System\.getenv\(\s*"([A-Z_][A-Z0-9_]*)"'],
     },
@@ -87,12 +90,23 @@ NO_ENV_SDKS = ("TypeScript", "Swift", "Kotlin")
 VAR_RE = re.compile(r"\b((?:BASECAMP|XDG)_[A-Z0-9_]+)\b")
 
 COMMENT_STARTS = ("#", "//", "*", "/*")
-TEST_MARKERS = ("_test.", "test_", "/tests/", "/test/", ".test.", "Tests/", "spec/")
+FILENAME_TEST_MARKERS = ("_test.", "test_", ".test.", "_spec.")
 
 
 def is_test(path: Path) -> bool:
-    text = str(path)
-    return any(marker in text for marker in TEST_MARKERS)
+    """Test code, by directory or by filename.
+
+    Directory matching has to understand Kotlin/Swift source-set naming
+    (`commonTest`, `jvmTest`, `Tests`) as well as the plain `test`/`tests`/`spec`
+    directories the other SDKs use.
+    """
+    for part in path.parts[:-1]:
+        lowered = part.lower()
+        if lowered in ("test", "tests", "spec", "specs"):
+            return True
+        if part.endswith(("Test", "Tests")):
+            return True
+    return any(marker in path.name for marker in FILENAME_TEST_MARKERS)
 
 
 def real_reads(spec: dict) -> dict[str, list[str]]:

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -188,7 +188,7 @@ LANG_FLAGS = {
     "Ruby": {
         "triple": True, "nested": False, "raw": False, "fstring": False,
         "multiline": True,
-        "regex": False,
+        "regex": True,
         "backtick_raw": False,
         "triple_raw": False,
         "percent": True,
@@ -291,11 +291,19 @@ REGEX_PRECEDERS = set("=(,:[!&|?{};+-*%<>~^")
 REGEX_KEYWORDS = {
     "return", "typeof", "instanceof", "in", "of", "new", "delete", "void",
     "case", "do", "else", "yield", "await", "throw",
+    # Ruby positions where an operand is expected.
+    "when", "if", "unless", "elsif", "and", "or", "not", "then", "while", "until",
 }
 
 
 def regex_extent(text: str, i: int, flags: dict) -> int:
-    """End of a TypeScript regex literal starting at `i`, else `i`."""
+    """End of a regex literal starting at `i`, else `i`.
+
+    TypeScript and Ruby both spell it `/.../` and both overload `/` as division,
+    so the same preceding-token test decides. Ruby's `#{...}` interpolation
+    inside one is handled by the caller, which also has to run this before the
+    comment check -- otherwise the `#` opens a line comment and eats the rest.
+    """
     if not flags or not flags.get("regex") or text[i] != "/":
         return i
     if text.startswith("//", i) or text.startswith("/*", i):
@@ -334,35 +342,56 @@ def regex_extent(text: str, i: int, flags: dict) -> int:
 # Ruby percent literals -- %q{...}, %w[...], %(...) -- are ordinary data, and
 # the scanner saw only quote characters, leaving their contents executable.
 PERCENT_DELIMS = {"{": "}", "[": "]", "(": ")", "<": ">"}
+# %q %w %i %s are data; %Q %W %I, %r, %x and the bare form interpolate.
+PERCENT_INTERPOLATING = {"", "r", "x"}
 
 
 def percent_literal_extent(text: str, i: int, flags: dict) -> tuple[int, list[tuple[int, int]]]:
     """End of a Ruby percent literal starting at `i` (else `i`), plus its holes.
 
-    The uppercase forms interpolate and the lowercase ones do not: `%q{...}` is
-    data throughout, while `%Q{#{ENV[...]}}` contains a real call. Masking the
-    whole literal either way hid that call.
+    The delimiter may be any non-alphanumeric character, not just a bracket:
+    `%q!...!` is as valid as `%q{...}`. Paired delimiters nest, unpaired ones do
+    not. Inside the body a quote is ordinary data, so the walk here is a plain
+    scan rather than the language-aware `matching_delimiter` -- delegating to
+    that let a `"` inside `%q{"}` open a phantom string and run past the close.
     """
     if not flags or not flags.get("percent") or text[i] != "%":
         return i, []
+    n = len(text)
     j = i + 1
     letter = ""
-    if j < len(text) and text[j].isalpha():
+    if j < n and text[j].isalpha():
         letter = text[j]
         j += 1
-    if j >= len(text):
+    if j >= n:
         return i, []
     opener = text[j]
+    if opener.isalnum() or opener.isspace() or opener == "=":
+        return i, []  # `a % b`, `%=`, and format strings are not literals
     closer = PERCENT_DELIMS.get(opener)
-    if closer is None:
-        return i, []
     body_start = j + 1
-    end = matching_delimiter(text, body_start, opener, closer, "hash", flags)
-    interpolates = letter == "" or letter.isupper() or letter == "r"
+    k = body_start
+    depth = 1
+    while k < n:
+        if text[k] == "\\":
+            k += 2
+            continue
+        if closer is None:
+            if text[k] == opener:
+                break
+        else:
+            if text[k] == opener:
+                depth += 1
+            elif text[k] == closer:
+                depth -= 1
+                if depth == 0:
+                    break
+        k += 1
+    body_stop = min(k, n)
     holes = []
-    if interpolates:
-        holes = brace_holes(text, body_start, min(end, len(text)), "hash", flags, "#{", "}")
-    return min(end + 1, len(text)), holes
+    if letter.lower() in PERCENT_INTERPOLATING or letter.isupper():
+        holes = brace_holes(text, body_start, body_stop, "hash", flags, "#{", "}")
+    return min(body_stop + 1, n), holes
 
 
 def comment_extent(text: str, i: int, style: str | None, flags: dict | None = None) -> int:
@@ -744,6 +773,22 @@ def strip_noncode(text: str, style: str, flags: dict | None = None) -> tuple[str
         if text[i] in quotes:
             i = take_literal(i)
             continue
+        # Regex before comment: Ruby interpolates with `#{...}`, and the comment
+        # branch would eat the `#` and the rest of the line with it. regex_extent
+        # already refuses `//` and `/*`, so TypeScript comments are unaffected.
+        regex_end = regex_extent(text, i, flags)
+        if regex_end > i:
+            for k in range(i, min(regex_end, n)):
+                in_string[k] = 1
+            if style == "hash":
+                for hole_start, hole_end in brace_holes(
+                    text, i + 1, max(i + 1, regex_end - 1), style, flags, "#{", "}"
+                ):
+                    for k in range(hole_start, min(hole_end, n)):
+                        in_string[k] = 0
+                    mask_literals(text, hole_start, min(hole_end, n), style, in_string, flags)
+            i = regex_end
+            continue
         comment_end = comment_extent(text, i, style, flags)
         if comment_end > i:
             blank(i, comment_end)
@@ -758,13 +803,6 @@ def strip_noncode(text: str, style: str, flags: dict | None = None) -> tuple[str
                     in_string[k] = 0
                 mask_literals(text, hole_start, min(hole_end, n), style, in_string, flags)
             i = percent_end
-            continue
-        # A regex literal is data, like a string: its contents are not calls.
-        regex_end = regex_extent(text, i, flags)
-        if regex_end > i:
-            for k in range(i, min(regex_end, n)):
-                in_string[k] = 1
-            i = regex_end
             continue
         # Ruby block comment: =begin/=end, each at column 0.
         if style == "hash" and text.startswith("=begin", i) and (i == 0 or text[i - 1] == "\n"):

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -7,7 +7,7 @@ wrong SDK (`XDG_CACHE_HOME` credited to Ruby, which never reads it). Both are
 invisible to every other gate in `make check`, because nothing here is
 generated -- the prose is hand-written and drifts silently.
 
-This checks four invariants:
+This checks five invariants:
 
   1. Forward, per SDK: every variable named in an SDK README's env-var table is
      genuinely read by that SDK's source.
@@ -17,6 +17,14 @@ This checks four invariants:
      in that SDK's README, so a new read cannot ship undocumented.
   4. The root README's "TypeScript, Swift, and Kotlin read no environment
      variables at all" sentence still holds.
+  5. Prose attribution: a sentence of the form "<SDK> reads `VAR`" must be true.
+
+Invariant 5 exists because 1 and 2 only police table rows, and the attribution
+bug that prompted this gate was in prose, not a table: the root README said the
+XDG variables were the ones "Go and Ruby use to site their cache and config
+directories" when Ruby never reads `XDG_CACHE_HOME` at all. With only the table
+checks, rewording that sentence back to credit Ruby with `XDG_CACHE_HOME` passes
+silently -- verified by doing exactly that and watching the gate report success.
 
 "Genuinely reads" means an env-read call site in non-test source, not a bare
 mention. That distinction is the whole point: every `process.env.BASECAMP_*`
@@ -123,24 +131,46 @@ VAR_RE = re.compile(r"\b((?:BASECAMP|XDG)_[A-Z0-9_]+)\b")
 
 FILENAME_TEST_MARKERS = ("_test.", "test_", ".test.", "_spec.")
 
+# Invariant 5. Only the active voice with a bare SDK name as the subject --
+# "Go reads `X`". The passive "`BASECAMP_TOKEN` is read by `AuthManager`" and
+# "`Config()` reads no environment" both name a *symbol* rather than an SDK, and
+# neither matches, which is what keeps this from firing on the per-SDK READMEs.
+SDK_READS_RE = re.compile(
+    rf"\b(?P<sdk>{'|'.join(SDKS)})\b\s+reads?\b"
+)
+
+# A claim runs to the next such claim or the end of its sentence, whichever
+# comes first, so "Go reads `A` ... and Ruby reads `B`" splits at "Ruby".
+CLAIM_END_RE = re.compile(r"\.\s|\n")
+
 # Quote characters that open a string literal, per comment style. String bodies
 # are kept — the variable name lives inside one — but they are skipped over so a
 # `#` or `//` inside a string is not mistaken for the start of a comment.
 STRING_QUOTES = {"hash": "\"'", "slash": "\"'`"}
 
 
-def strip_noncode(text: str, style: str) -> str:
+def strip_noncode(text: str, style: str) -> tuple[str, bytearray]:
     """Blank comments and doc-only string blocks, preserving every offset.
+
+    Returns the cleaned text plus a mask marking offsets that sit inside a
+    string literal (opening quote included).
 
     Removed characters become spaces and newlines are kept, so match offsets
     still map to the right line of the original file.
 
-    A line-prefix test is not enough: in an unstarred block comment the interior
-    lines start with ordinary code characters, so `/*\\nprocess.env.FOO\\n*/`
-    would otherwise count as a real read.
+    Two things this has to get right, having got both wrong before:
+
+    * A line-prefix comment test is not enough — inside an unstarred block
+      comment the interior lines begin with ordinary code characters, so
+      `/*\\nprocess.env.FOO\\n*/` would count as a read.
+    * String bodies must be *kept* (the variable name lives inside one) but
+      still tracked, because an ordinary string such as
+      `"process.env.BASECAMP_FAKE"` is data, not a read. Callers reject a match
+      whose API prefix begins inside a literal; see `real_reads`.
     """
     out = list(text)
     n = len(text)
+    in_string = bytearray(n)
     quotes = STRING_QUOTES[style]
     i = 0
 
@@ -174,6 +204,8 @@ def strip_noncode(text: str, style: str) -> str:
                 if text[j] == "\n" and quote != "`":
                     break
                 j += 1
+            for k in range(i, min(j, n)):
+                in_string[k] = 1
             i = j
             continue
         if style == "slash" and text.startswith("//", i):
@@ -204,7 +236,7 @@ def strip_noncode(text: str, style: str) -> str:
             i = end
             continue
         i += 1
-    return "".join(out)
+    return "".join(out), in_string
 
 
 def is_test(rel_path: Path) -> bool:
@@ -244,11 +276,20 @@ def real_reads(spec: dict) -> dict[str, list[str]]:
         # patterns allow whitespace after the opening paren/bracket, so a call
         # split across lines — os.getenv(\n    "BASECAMP_FOO") — is still a read,
         # and a per-line scan would silently miss it.
-        text = strip_noncode(path.read_text(encoding="utf-8", errors="replace"), spec["comments"])
+        text, in_string = strip_noncode(
+            path.read_text(encoding="utf-8", errors="replace"), spec["comments"]
+        )
         for pattern in compiled:
             # finditer + the named group, not findall: these patterns carry a
             # quote group too, and findall would hand back tuples.
             for match in pattern.finditer(text):
+                # The match starts at the API prefix (`os.getenv`, `process.env`),
+                # which is code. If that prefix is itself inside a literal, this
+                # is example text in a string, not a call — `"process.env.FOO"`
+                # is data. The *name* is legitimately inside a literal, so only
+                # the start offset is tested.
+                if in_string[match.start()]:
+                    continue
                 name = match.group("name")
                 if VAR_RE.fullmatch(name):
                     lineno = text.count("\n", 0, match.start()) + 1
@@ -268,6 +309,42 @@ def table_rows(readme: Path) -> list[tuple[int, list[str]]]:
             continue  # separator row
         rows.append((lineno, cells))
     return rows
+
+
+def prose_lines(readme: Path) -> list[tuple[int, str]]:
+    """README prose, as (line number, text), minus code blocks and table rows.
+
+    Fenced blocks are shell and source examples, where "Go reads" would be a
+    comment rather than a claim; table rows are already covered by invariants 1
+    and 2, and scanning them here would double-report the same defect.
+    """
+    out = []
+    fenced = False
+    for lineno, line in enumerate(readme.read_text(encoding="utf-8").splitlines(), 1):
+        if line.lstrip().startswith("```"):
+            fenced = not fenced
+            continue
+        if fenced or line.strip().startswith("|"):
+            continue
+        out.append((lineno, line))
+    return out
+
+
+def prose_claims(readme: Path) -> list[tuple[int, str, list[str]]]:
+    """Every "<SDK> reads `VAR`" claim, as (line number, sdk, variables)."""
+    claims = []
+    for lineno, line in prose_lines(readme):
+        matches = list(SDK_READS_RE.finditer(line))
+        for index, match in enumerate(matches):
+            start = match.end()
+            stop = matches[index + 1].start() if index + 1 < len(matches) else len(line)
+            terminator = CLAIM_END_RE.search(line, start, stop)
+            if terminator:
+                stop = terminator.start()
+            named = VAR_RE.findall(line[start:stop])
+            if named:
+                claims.append((lineno, match.group("sdk"), named))
+    return claims
 
 
 def main() -> int:
@@ -330,6 +407,19 @@ def main() -> int:
                 f"{ROOT_README}: claims {sdk} reads no environment variables, but "
                 f"found: {detail}"
             )
+
+    # 5. Prose attribution, every README: "<SDK> reads `VAR`" must be true.
+    for readme_rel in [ROOT_README] + [s["readme"] for s in SDKS.values()]:
+        readme = REPO / readme_rel
+        if not readme.is_file():
+            continue
+        for lineno, sdk, named in prose_claims(readme):
+            for var in named:
+                if var not in reads[sdk]:
+                    failures.append(
+                        f"{readme_rel}:{lineno}: prose says {sdk} reads {var}, but no "
+                        f"read of it exists in {SDKS[sdk]['source']}/"
+                    )
 
     if failures:
         print("README environment-variable check FAILED:\n", file=sys.stderr)

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Keep README environment-variable tables honest against SDK source.
+
+READMEs have repeatedly claimed environment variables that no SDK reads
+(a phantom `BASECAMP_ACCOUNT_ID` row), or attributed a real variable to the
+wrong SDK (`XDG_CACHE_HOME` credited to Ruby, which never reads it). Both are
+invisible to every other gate in `make check`, because nothing here is
+generated -- the prose is hand-written and drifts silently.
+
+This checks four invariants:
+
+  1. Forward, per SDK: every variable named in an SDK README's env-var table is
+     genuinely read by that SDK's source.
+  2. Forward, root README: the "Read by" column names SDKs, and each one must
+     genuinely read that variable.
+  3. Reverse, per SDK: every variable an SDK genuinely reads is named somewhere
+     in that SDK's README, so a new read cannot ship undocumented.
+  4. The root README's "TypeScript, Swift, and Kotlin read no environment
+     variables at all" sentence still holds.
+
+"Genuinely reads" means an env-read call site in non-test source, not a bare
+mention. That distinction is the whole point: every `process.env.BASECAMP_*`
+in typescript/src and every `ENV["BASECAMP_CLIENT_ID"]` in ruby/lib sits inside
+a doc comment, so a substring search would happily bless a phantom row. Lines
+whose first non-whitespace characters open a comment (`#`, `//`, `*`, `/*`) are
+excluded for exactly that reason.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+
+# Where each SDK's shipping source lives, and how that language reads an env var.
+SDKS = {
+    "Go": {
+        "readme": "go/README.md",
+        "source": "go/pkg",
+        "suffixes": (".go",),
+        "patterns": [r'os\.Getenv\(\s*"([A-Z_][A-Z0-9_]*)"', r'os\.LookupEnv\(\s*"([A-Z_][A-Z0-9_]*)"'],
+    },
+    "Ruby": {
+        "readme": "ruby/README.md",
+        "source": "ruby/lib",
+        "suffixes": (".rb",),
+        "patterns": [r'ENV\[\s*"([A-Z_][A-Z0-9_]*)"', r'ENV\.fetch\(\s*"([A-Z_][A-Z0-9_]*)"'],
+    },
+    "Python": {
+        "readme": "python/README.md",
+        "source": "python/src",
+        "suffixes": (".py",),
+        "patterns": [
+            r'os\.environ\.get\(\s*"([A-Z_][A-Z0-9_]*)"',
+            r'os\.environ\[\s*"([A-Z_][A-Z0-9_]*)"',
+            r'os\.getenv\(\s*"([A-Z_][A-Z0-9_]*)"',
+        ],
+    },
+    "TypeScript": {
+        "readme": "typescript/README.md",
+        "source": "typescript/src",
+        "suffixes": (".ts",),
+        "patterns": [r'process\.env\.([A-Z_][A-Z0-9_]*)', r'process\.env\[\s*"([A-Z_][A-Z0-9_]*)"'],
+    },
+    "Swift": {
+        "readme": "swift/README.md",
+        "source": "swift/Sources",
+        "suffixes": (".swift",),
+        "patterns": [r'ProcessInfo\.processInfo\.environment\[\s*"([A-Z_][A-Z0-9_]*)"'],
+    },
+    "Kotlin": {
+        "readme": "kotlin/README.md",
+        "source": "kotlin/sdk/src/commonMain",
+        "suffixes": (".kt",),
+        "patterns": [r'System\.getenv\(\s*"([A-Z_][A-Z0-9_]*)"'],
+    },
+}
+
+ROOT_README = "README.md"
+
+# The root README states these three read nothing. Invariant 4 holds it true.
+NO_ENV_SDKS = ("TypeScript", "Swift", "Kotlin")
+
+# Only variables in these families are in scope; the SDKs read no others.
+VAR_RE = re.compile(r"\b((?:BASECAMP|XDG)_[A-Z0-9_]+)\b")
+
+COMMENT_STARTS = ("#", "//", "*", "/*")
+TEST_MARKERS = ("_test.", "test_", "/tests/", "/test/", ".test.", "Tests/", "spec/")
+
+
+def is_test(path: Path) -> bool:
+    text = str(path)
+    return any(marker in text for marker in TEST_MARKERS)
+
+
+def real_reads(spec: dict) -> dict[str, list[str]]:
+    """Env vars genuinely read by this SDK, mapped to 'file:line' call sites."""
+    root = REPO / spec["source"]
+    found: dict[str, list[str]] = {}
+    if not root.is_dir():
+        return found
+    compiled = [re.compile(p) for p in spec["patterns"]]
+    for path in sorted(root.rglob("*")):
+        if not path.is_file() or path.suffix not in spec["suffixes"] or is_test(path):
+            continue
+        for lineno, line in enumerate(path.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+            if line.lstrip().startswith(COMMENT_STARTS):
+                continue  # a doc-comment example is not a read
+            for pattern in compiled:
+                for name in pattern.findall(line):
+                    if VAR_RE.fullmatch(name):
+                        found.setdefault(name, []).append(f"{path.relative_to(REPO)}:{lineno}")
+    return found
+
+
+def table_rows(readme: Path) -> list[tuple[int, list[str]]]:
+    """Markdown table rows, as (line number, cells)."""
+    rows = []
+    for lineno, line in enumerate(readme.read_text(encoding="utf-8").splitlines(), 1):
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        cells = [c.strip() for c in stripped.strip("|").split("|")]
+        if all(set(c) <= set("-: ") for c in cells):
+            continue  # separator row
+        rows.append((lineno, cells))
+    return rows
+
+
+def main() -> int:
+    failures: list[str] = []
+    reads = {name: real_reads(spec) for name, spec in SDKS.items()}
+
+    # 1. Forward, per SDK.
+    for sdk, spec in SDKS.items():
+        readme = REPO / spec["readme"]
+        if not readme.is_file():
+            continue
+        for lineno, cells in table_rows(readme):
+            for var in VAR_RE.findall(cells[0]):
+                if var not in reads[sdk]:
+                    failures.append(
+                        f"{spec['readme']}:{lineno}: table names {var}, but no "
+                        f"read of it exists in {spec['source']}/"
+                    )
+
+    # 2. Forward, root README: honor the "Read by" column.
+    root = REPO / ROOT_README
+    for lineno, cells in table_rows(root):
+        if len(cells) < 2:
+            continue
+        vars_in_row = VAR_RE.findall(cells[0])
+        if not vars_in_row:
+            continue
+        claimed = [sdk for sdk in SDKS if re.search(rf"\b{sdk}\b", cells[1])]
+        if not claimed:
+            failures.append(
+                f"{ROOT_README}:{lineno}: row for {', '.join(vars_in_row)} names no "
+                f"SDK in its 'Read by' column"
+            )
+        for var in vars_in_row:
+            for sdk in claimed:
+                if var not in reads[sdk]:
+                    failures.append(
+                        f"{ROOT_README}:{lineno}: credits {var} to {sdk}, but no read "
+                        f"of it exists in {SDKS[sdk]['source']}/"
+                    )
+
+    # 3. Reverse, per SDK: a real read must be documented.
+    for sdk, spec in SDKS.items():
+        readme = REPO / spec["readme"]
+        if not readme.is_file():
+            continue
+        text = readme.read_text(encoding="utf-8")
+        for var, sites in sorted(reads[sdk].items()):
+            if var not in text:
+                failures.append(
+                    f"{spec['readme']}: {sdk} reads {var} ({sites[0]}) but the README "
+                    f"never mentions it"
+                )
+
+    # 4. The root README's "read no environment variables at all" sentence.
+    for sdk in NO_ENV_SDKS:
+        if reads[sdk]:
+            detail = ", ".join(f"{v} ({s[0]})" for v, s in sorted(reads[sdk].items()))
+            failures.append(
+                f"{ROOT_README}: claims {sdk} reads no environment variables, but "
+                f"found: {detail}"
+            )
+
+    if failures:
+        print("README environment-variable check FAILED:\n", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        print(
+            f"\n{len(failures)} problem(s). Fix the README, or the source, so the "
+            f"two agree.",
+            file=sys.stderr,
+        )
+        return 1
+
+    total = sum(len(r) for r in reads.values())
+    print(f"README env-var check passed ({total} real read sites across {len(SDKS)} SDKs).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -78,7 +78,10 @@ SDKS = {
         "suffixes": (".rb",),
         "patterns": [
             rf"ENV\[\s*{Q}{NAME}{ENDQ}",
-            rf"ENV\.fetch\(\s*{Q}{NAME}{ENDQ}",
+            # Parentheses are optional in Ruby, so `ENV.fetch "FOO", nil` is a
+            # real read. Requiring `(` made it invisible, which is the fail-open
+            # direction: the gate would report that nothing reads the variable.
+            rf"ENV\.fetch[(\s]\s*{Q}{NAME}{ENDQ}",
         ],
     },
     "Python": {
@@ -412,6 +415,60 @@ def prose_lines(readme: Path) -> list[tuple[int, str]]:
     return out
 
 
+def prose_paragraphs(readme: Path) -> list[list[tuple[int, str]]]:
+    """Prose grouped into paragraphs of consecutive lines.
+
+    Markdown reflows, so an attribution can wrap: "Go reads" at the end of one
+    line and the variable at the start of the next. Scanning line by line finds
+    no claim at all in that case and invariant 5 silently stops enforcing a
+    sentence it used to cover. A blank line ends a paragraph, and so does a gap
+    in line numbers -- prose_lines drops tables and fenced blocks, and those
+    genuinely separate one paragraph from the next.
+    """
+    groups: list[list[tuple[int, str]]] = []
+    current: list[tuple[int, str]] = []
+    for lineno, line in prose_lines(readme):
+        if not line.strip() or (current and lineno != current[-1][0] + 1):
+            if current:
+                groups.append(current)
+            current = []
+        if line.strip():
+            current.append((lineno, line))
+    if current:
+        groups.append(current)
+    return groups
+
+
+def join_paragraph(paragraph: list[tuple[int, str]]):
+    """Join a paragraph's lines, returning the text and an offset->line mapper.
+
+    Lines are joined with a single space so a wrapped "Go reads\\n`VAR`" reads as
+    one sentence, and every claim is still reported at the source line where its
+    subject appears.
+    """
+    parts: list[str] = []
+    starts: list[tuple[int, int]] = []
+    position = 0
+    for lineno, line in paragraph:
+        if parts:
+            parts.append(" ")
+            position += 1
+        starts.append((position, lineno))
+        parts.append(line)
+        position += len(line)
+
+    def line_at(offset: int) -> int:
+        found = starts[0][1]
+        for start, lineno in starts:
+            if start <= offset:
+                found = lineno
+            else:
+                break
+        return found
+
+    return "".join(parts), line_at
+
+
 def prose_claims(readme: Path) -> list[tuple[int, str, list[str]]]:
     """Every "<SDK> reads `VAR`" claim, as (line number, sdk, variables).
 
@@ -428,28 +485,29 @@ def prose_claims(readme: Path) -> list[tuple[int, str, list[str]]]:
     one clause cannot borrow another's variables.
     """
     claims = []
-    for lineno, line in prose_lines(readme):
-        matches = list(SDK_READS_RE.finditer(line))
+    for paragraph in prose_paragraphs(readme):
+        text, line_at = join_paragraph(paragraph)
+        matches = list(SDK_READS_RE.finditer(text))
         for index, match in enumerate(matches):
             forward_start = match.end()
-            forward_stop = matches[index + 1].start() if index + 1 < len(matches) else len(line)
-            terminator = CLAIM_END_RE.search(line, forward_start, forward_stop)
+            forward_stop = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+            terminator = CLAIM_END_RE.search(text, forward_start, forward_stop)
             if terminator:
                 forward_stop = terminator.start()
-            named = VAR_RE.findall(line[forward_start:forward_stop])
+            named = VAR_RE.findall(text[forward_start:forward_stop])
 
             if not named:
                 # Back to the start of this sentence, but never past the previous
                 # claim -- otherwise "Go reads `X`. Ruby uses it too" would hand
                 # Go's variable to Ruby.
                 backward_start = matches[index - 1].end() if index else 0
-                for boundary in CLAIM_END_RE.finditer(line, backward_start, match.start()):
+                for boundary in CLAIM_END_RE.finditer(text, backward_start, match.start()):
                     backward_start = boundary.end()
-                named = VAR_RE.findall(line[backward_start:match.start()])
+                named = VAR_RE.findall(text[backward_start:match.start()])
 
             for sdk in SDK_NAME_RE.findall(match.group("subject")):
                 if named:
-                    claims.append((lineno, sdk, named))
+                    claims.append((line_at(match.start()), sdk, named))
     return claims
 
 

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -117,8 +117,10 @@ SDKS = {
         "comments": "slash",
         "suffixes": (".ts",),
         "patterns": [
-            rf"process\.env\.{NAME}",
-            rf"process\.env\[\s*{Q}{NAME}{ENDQ}",
+            # `?.` is valid optional chaining, and a read the plain patterns
+            # reported as nonexistent.
+            rf"process\.env\??\.{NAME}",
+            rf"process\.env(?:\?\.)?\[\s*{Q}{NAME}{ENDQ}",
         ],
     },
     "Swift": {
@@ -156,35 +158,44 @@ SDKS = {
 #            interpolates in backticks only, so `"${x}"` is plain text, and Go
 #            interpolates nowhere at all.
 #   fstring: Python only, where the `f` prefix decides whether braces are code.
+#   multiline: Ruby, where an ordinary quoted literal may span physical lines.
+#            Everywhere else a newline ends it, which is what bounds the damage
+#            from an unbalanced quote.
 LANG_FLAGS = {
     "Go": {
         "triple": False, "nested": False, "raw": False, "fstring": False,
+        "multiline": False,
         "interp": {},
     },
     "Ruby": {
         "triple": True, "nested": False, "raw": False, "fstring": False,
+        "multiline": True,
         "interp": {'"': [("#{", "}")]},
     },
     "Python": {
         "triple": True, "nested": False, "raw": False, "fstring": True,
+        "multiline": False,
         "interp": {},
     },
     "TypeScript": {
         "triple": False, "nested": False, "raw": False, "fstring": False,
+        "multiline": False,
         "interp": {"`": [("${", "}")]},
     },
     "Swift": {
         "triple": True, "nested": True, "raw": True, "fstring": False,
+        "multiline": False,
         "interp": {'"': [("\\(", ")")]},
     },
     "Kotlin": {
         "triple": True, "nested": True, "raw": False, "fstring": False,
+        "multiline": False,
         "interp": {'"': [("${", "}")]},
     },
 }
 # Permissive union, used only when no language is supplied.
 DEFAULT_FLAGS = {
-    "triple": True, "nested": True, "raw": True, "fstring": True,
+    "triple": True, "nested": True, "raw": True, "fstring": True, "multiline": True,
     "interp": {"`": [("${", "}")], '"': [("${", "}"), ("\\(", ")"), ("#{", "}")]},
 }
 
@@ -418,7 +429,7 @@ def scan_literal(text: str, i: int, style: str,
             break
         # An unterminated single-line literal ends at the newline; Go and
         # TypeScript backtick literals legitimately span lines.
-        if text[j] == "\n" and quote != "`":
+        if text[j] == "\n" and quote != "`" and not flags["multiline"]:
             break
         opened = False
         for opener, closer in openers:

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -21,9 +21,14 @@ This checks four invariants:
 "Genuinely reads" means an env-read call site in non-test source, not a bare
 mention. That distinction is the whole point: every `process.env.BASECAMP_*`
 in typescript/src and every `ENV["BASECAMP_CLIENT_ID"]` in ruby/lib sits inside
-a doc comment, so a substring search would happily bless a phantom row. Lines
-whose first non-whitespace characters open a comment (`#`, `//`, `*`, `/*`) are
-excluded for exactly that reason.
+a doc comment, so a substring search would happily bless a phantom row.
+
+Comments are therefore removed before matching, by a scanner rather than a
+line-prefix test — inside an unstarred `/* ... */` the interior lines begin with
+ordinary code characters — and the stripped text is matched whole rather than
+line by line, so a call split across lines is still seen. Both directions of
+that matter: counting a doc example as a read lets a phantom table row pass,
+and missing a real read lets an undocumented variable pass.
 """
 
 from __future__ import annotations
@@ -51,6 +56,7 @@ SDKS = {
     "Go": {
         "readme": "go/README.md",
         "source": "go/pkg",
+        "comments": "slash",
         "suffixes": (".go",),
         "patterns": [
             rf"os\.Getenv\(\s*{GO_Q}{NAME}{ENDQ}",
@@ -60,6 +66,7 @@ SDKS = {
     "Ruby": {
         "readme": "ruby/README.md",
         "source": "ruby/lib",
+        "comments": "hash",
         "suffixes": (".rb",),
         "patterns": [
             rf"ENV\[\s*{Q}{NAME}{ENDQ}",
@@ -69,6 +76,7 @@ SDKS = {
     "Python": {
         "readme": "python/README.md",
         "source": "python/src",
+        "comments": "hash",
         "suffixes": (".py",),
         "patterns": [
             rf"os\.environ\.get\(\s*{Q}{NAME}{ENDQ}",
@@ -79,6 +87,7 @@ SDKS = {
     "TypeScript": {
         "readme": "typescript/README.md",
         "source": "typescript/src",
+        "comments": "slash",
         "suffixes": (".ts",),
         "patterns": [
             rf"process\.env\.{NAME}",
@@ -88,6 +97,7 @@ SDKS = {
     "Swift": {
         "readme": "swift/README.md",
         "source": "swift/Sources",
+        "comments": "slash",
         "suffixes": (".swift",),
         "patterns": [rf"ProcessInfo\.processInfo\.environment\[\s*{DQ}{NAME}{ENDQ}"],
     },
@@ -97,6 +107,7 @@ SDKS = {
     "Kotlin": {
         "readme": "kotlin/README.md",
         "source": "kotlin/sdk/src",
+        "comments": "slash",
         "suffixes": (".kt",),
         "patterns": [rf"System\.getenv\(\s*{DQ}{NAME}{ENDQ}"],
     },
@@ -110,8 +121,90 @@ NO_ENV_SDKS = ("TypeScript", "Swift", "Kotlin")
 # Only variables in these families are in scope; the SDKs read no others.
 VAR_RE = re.compile(r"\b((?:BASECAMP|XDG)_[A-Z0-9_]+)\b")
 
-COMMENT_STARTS = ("#", "//", "*", "/*")
 FILENAME_TEST_MARKERS = ("_test.", "test_", ".test.", "_spec.")
+
+# Quote characters that open a string literal, per comment style. String bodies
+# are kept — the variable name lives inside one — but they are skipped over so a
+# `#` or `//` inside a string is not mistaken for the start of a comment.
+STRING_QUOTES = {"hash": "\"'", "slash": "\"'`"}
+
+
+def strip_noncode(text: str, style: str) -> str:
+    """Blank comments and doc-only string blocks, preserving every offset.
+
+    Removed characters become spaces and newlines are kept, so match offsets
+    still map to the right line of the original file.
+
+    A line-prefix test is not enough: in an unstarred block comment the interior
+    lines start with ordinary code characters, so `/*\\nprocess.env.FOO\\n*/`
+    would otherwise count as a real read.
+    """
+    out = list(text)
+    n = len(text)
+    quotes = STRING_QUOTES[style]
+    i = 0
+
+    def blank(start: int, end: int) -> None:
+        for k in range(start, min(end, n)):
+            if out[k] != "\n":
+                out[k] = " "
+
+    while i < n:
+        # Python/Ruby docstrings: string literals, but used as documentation, so
+        # an example inside one is not a read.
+        if style == "hash" and text[i : i + 3] in ('"""', "'''"):
+            quote = text[i : i + 3]
+            end = text.find(quote, i + 3)
+            end = n if end == -1 else end + 3
+            blank(i, end)
+            i = end
+            continue
+        if text[i] in quotes:
+            quote = text[i]
+            j = i + 1
+            while j < n:
+                if text[j] == "\\":
+                    j += 2
+                    continue
+                if text[j] == quote:
+                    j += 1
+                    break
+                # An unterminated single-line literal ends at the newline; Go and
+                # TypeScript backtick literals legitimately span lines.
+                if text[j] == "\n" and quote != "`":
+                    break
+                j += 1
+            i = j
+            continue
+        if style == "slash" and text.startswith("//", i):
+            end = text.find("\n", i)
+            blank(i, n if end == -1 else end)
+            i = n if end == -1 else end
+            continue
+        if style == "slash" and text.startswith("/*", i):
+            end = text.find("*/", i + 2)
+            end = n if end == -1 else end + 2
+            blank(i, end)
+            i = end
+            continue
+        if style == "hash" and text[i] == "#":
+            end = text.find("\n", i)
+            blank(i, n if end == -1 else end)
+            i = n if end == -1 else end
+            continue
+        # Ruby block comment: =begin/=end, each at column 0.
+        if style == "hash" and text.startswith("=begin", i) and (i == 0 or text[i - 1] == "\n"):
+            end = text.find("\n=end", i)
+            if end == -1:
+                end = n
+            else:
+                nl = text.find("\n", end + 1)
+                end = n if nl == -1 else nl
+            blank(i, end)
+            i = end
+            continue
+        i += 1
+    return "".join(out)
 
 
 def is_test(rel_path: Path) -> bool:
@@ -147,16 +240,19 @@ def real_reads(spec: dict) -> dict[str, list[str]]:
         rel = path.relative_to(REPO)
         if is_test(rel):
             continue
-        for lineno, line in enumerate(path.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
-            if line.lstrip().startswith(COMMENT_STARTS):
-                continue  # a doc-comment example is not a read
-            for pattern in compiled:
-                # finditer + the named group, not findall: these patterns carry a
-                # quote group too, and findall would hand back tuples.
-                for match in pattern.finditer(line):
-                    name = match.group("name")
-                    if VAR_RE.fullmatch(name):
-                        found.setdefault(name, []).append(f"{rel}:{lineno}")
+        # Scan the comment-stripped file whole rather than line by line: the
+        # patterns allow whitespace after the opening paren/bracket, so a call
+        # split across lines — os.getenv(\n    "BASECAMP_FOO") — is still a read,
+        # and a per-line scan would silently miss it.
+        text = strip_noncode(path.read_text(encoding="utf-8", errors="replace"), spec["comments"])
+        for pattern in compiled:
+            # finditer + the named group, not findall: these patterns carry a
+            # quote group too, and findall would hand back tuples.
+            for match in pattern.finditer(text):
+                name = match.group("name")
+                if VAR_RE.fullmatch(name):
+                    lineno = text.count("\n", 0, match.start()) + 1
+                    found.setdefault(name, []).append(f"{rel}:{lineno}")
     return found
 
 

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -42,8 +42,9 @@ That scanner is a lexer, not a parser, and the distinction is worth stating
 plainly rather than discovering later. It models what these six languages
 actually do with comments, string literals, and interpolation — including the
 parts that differ, which is why `LANG_FLAGS` exists: Swift and Kotlin nest block
-comments and Go and TypeScript do not; `"""` is documentation in Python and an
-ordinary string in Kotlin; only Swift has `#"..."#`. It does *not* model
+comments and Go and TypeScript do not; a triple-quoted literal is documentation
+in Python and an ordinary string in Kotlin; only Swift has raw strings. It does
+*not* model
 preprocessor conditionals, macros, or heredocs, and it assumes source is
 syntactically valid — a file with an unterminated literal is consumed to the
 end rather than resynchronised.

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -158,6 +158,53 @@ CLAIM_END_RE = re.compile(r"\.\s|\n")
 STRING_QUOTES = {"hash": "\"'", "slash": "\"'`"}
 
 
+def matching_delimiter(text: str, start: int, open_ch: str, close_ch: str) -> int:
+    """Index of the delimiter closing the one already opened, honouring nesting.
+
+    Returns len(text) when unterminated, so a malformed literal consumes the
+    rest of the file rather than silently resyncing mid-expression.
+    """
+    depth = 1
+    k = start
+    while k < len(text):
+        if text[k] == open_ch:
+            depth += 1
+        elif text[k] == close_ch:
+            depth -= 1
+            if depth == 0:
+                return k
+        k += 1
+    return len(text)
+
+
+def interpolation_openers(text: str, i: int, quote: str, style: str) -> list[tuple[str, str]]:
+    """Interpolation delimiters valid inside the literal opening at `i`.
+
+    Interpolations are the one part of a string literal that is executable, so
+    they must stay visible to the read patterns. Each language spells them
+    differently, and spelling them wrong fails *open* -- a masked read is a read
+    the gate swears does not exist.
+    """
+    if quote == "`":
+        return [("${", "}")]  # TypeScript and Kotlin raw strings
+    if style == "slash":
+        if quote == '"':
+            return [("${", "}"), ("\\(", ")")]  # Kotlin, and Swift's \( ... )
+        return []
+    openers = []
+    if quote == '"':
+        openers.append(("#{", "}"))  # Ruby
+    # Python f-strings, whose braces are code. Only with an `f` prefix: an
+    # ordinary "{...}" is literal text, and treating it as code would let a
+    # documentation example count as a read.
+    prefix_start = i
+    while prefix_start > 0 and text[prefix_start - 1].isalpha():
+        prefix_start -= 1
+    if "f" in text[prefix_start:i].lower():
+        openers.append(("{", "}"))
+    return openers
+
+
 def strip_noncode(text: str, style: str) -> tuple[str, bytearray]:
     """Blank comments and doc-only string blocks, preserving every offset.
 
@@ -200,9 +247,19 @@ def strip_noncode(text: str, style: str) -> tuple[str, bytearray]:
             continue
         if text[i] in quotes:
             quote = text[i]
+            openers = interpolation_openers(text, i, quote, style)
+            swift_interp = ("\\(", ")") in openers
             j = i + 1
+            holes: list[tuple[int, int]] = []
             while j < n:
                 if text[j] == "\\":
+                    # Swift interpolation opens with a backslash, so it has to be
+                    # tested before the generic escape skip swallows the paren.
+                    if swift_interp and text.startswith("\\(", j):
+                        end = matching_delimiter(text, j + 2, "(", ")")
+                        holes.append((j + 2, end))
+                        j = end + 1
+                        continue
                     j += 2
                     continue
                 if text[j] == quote:
@@ -212,9 +269,25 @@ def strip_noncode(text: str, style: str) -> tuple[str, bytearray]:
                 # TypeScript backtick literals legitimately span lines.
                 if text[j] == "\n" and quote != "`":
                     break
+                opened = False
+                for opener, closer in openers:
+                    if opener != "\\(" and text.startswith(opener, j):
+                        end = matching_delimiter(text, j + len(opener), "{", closer)
+                        holes.append((j + len(opener), end))
+                        j = end + 1
+                        opened = True
+                        break
+                if opened:
+                    continue
                 j += 1
             for k in range(i, min(j, n)):
                 in_string[k] = 1
+            # An interpolation is executable code that merely lives inside a
+            # literal, so it is un-masked: `token=${process.env.BASECAMP_TOKEN}`
+            # is a genuine read, and masking it would hide one.
+            for hole_start, hole_end in holes:
+                for k in range(hole_start, min(hole_end, n)):
+                    in_string[k] = 0
             i = j
             continue
         if style == "slash" and text.startswith("//", i):

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -124,6 +124,29 @@ SDKS = {
     },
 }
 
+# Lexical quirks that are not implied by the comment style. Getting these wrong
+# is not academic: each was a real miss found in review.
+#
+#   triple:  Python/Ruby `"""`, and Swift/Kotlin multiline `"""` -- which are
+#            ordinary strings, not documentation.
+#   nested:  Swift and Kotlin allow `/* /* */ */`; Go and TypeScript end the
+#            comment at the first `*/`, so nesting them there would swallow code.
+#   raw:     Swift `#"..."#`, whose interpolation is `\#(...)`.
+LANG_FLAGS = {
+    "Go": {"triple": False, "nested": False, "raw": False},
+    "Ruby": {"triple": True, "nested": False, "raw": False},
+    "Python": {"triple": True, "nested": False, "raw": False},
+    "TypeScript": {"triple": False, "nested": False, "raw": False},
+    "Swift": {"triple": True, "nested": True, "raw": True},
+    "Kotlin": {"triple": True, "nested": True, "raw": False},
+}
+DEFAULT_FLAGS = {"triple": True, "nested": True, "raw": True}
+
+# Attach each SDK's lexical flags, so the scanner is driven by the language it
+# is actually reading rather than by the comment style alone.
+for _sdk, _spec in SDKS.items():
+    _spec["flags"] = LANG_FLAGS[_sdk]
+
 ROOT_README = "README.md"
 
 # The root README states these three read nothing. Invariant 4 holds it true.
@@ -161,15 +184,30 @@ CLAIM_END_RE = re.compile(r"\.\s|\n")
 STRING_QUOTES = {"hash": "\"'", "slash": "\"'`"}
 
 
-def matching_delimiter(text: str, start: int, open_ch: str, close_ch: str) -> int:
+
+
+def matching_delimiter(text: str, start: int, open_ch: str, close_ch: str,
+                       style: str | None = None, flags: dict | None = None) -> int:
     """Index of the delimiter closing the one already opened, honouring nesting.
+
+    Skips over string literals when told the language, because a delimiter
+    inside one is data: in `${foo("}", process.env.X)}` the quoted `}` is not the
+    end of the interpolation, and treating it as such truncated the hole and
+    hid the read behind it.
 
     Returns len(text) when unterminated, so a malformed literal consumes the
     rest of the file rather than silently resyncing mid-expression.
     """
     depth = 1
     k = start
-    while k < len(text):
+    n = len(text)
+    quotes = STRING_QUOTES[style] if style else ""
+    while k < n:
+        if quotes and text[k] in quotes:
+            literal_end, _ = scan_literal(text, k, style, flags)
+            if literal_end > k:
+                k = literal_end
+                continue
         if text[k] == open_ch:
             depth += 1
         elif text[k] == close_ch:
@@ -177,7 +215,7 @@ def matching_delimiter(text: str, start: int, open_ch: str, close_ch: str) -> in
             if depth == 0:
                 return k
         k += 1
-    return len(text)
+    return n
 
 
 def has_fstring_prefix(text: str, i: int) -> bool:
@@ -188,32 +226,82 @@ def has_fstring_prefix(text: str, i: int) -> bool:
     return "f" in text[prefix_start:i].lower()
 
 
-def scan_literal(text: str, i: int, style: str) -> tuple[int, list[tuple[int, int]]]:
+def raw_string_hashes(text: str, i: int) -> int:
+    """Number of `#` opening a Swift raw string at `i`, or 0 if this is not one."""
+    k = i
+    while k < len(text) and text[k] == "#":
+        k += 1
+    return k - i if k > i and k < len(text) and text[k] == '"' else 0
+
+
+def brace_holes(text: str, start: int, stop: int, style: str, flags: dict,
+                opener: str, closer: str) -> list[tuple[int, int]]:
+    """Interpolation holes in a literal body, skipping escaped openers."""
+    holes = []
+    j = start
+    while j < stop:
+        # A doubled opener is an escape -- literal text, not an expression.
+        if text.startswith(opener * 2, j):
+            j += 2 * len(opener)
+            continue
+        if text.startswith(opener, j):
+            close = matching_delimiter(text, j + len(opener), opener[-1], closer, style, flags)
+            holes.append((j + len(opener), min(close, stop)))
+            j = close + 1
+            continue
+        j += 1
+    return holes
+
+
+def scan_literal(text: str, i: int, style: str,
+                 flags: dict | None = None) -> tuple[int, list[tuple[int, int]]]:
     """Extent of the literal opening at `i`, plus its interpolation holes.
 
     Returns (end, holes) where end is one past the closing quote and each hole is
     a half-open range of executable text inside the literal.
     """
     n = len(text)
-    triple = text[i : i + 3] if style == "hash" and text[i : i + 3] in ('"""', "'''") else None
-    if triple:
-        end = text.find(triple, i + 3)
-        end = n if end == -1 else end + 3
+    flags = DEFAULT_FLAGS if flags is None else flags
+
+    # Swift raw strings: #"..."# , ##"..."## , and the #"""..."""# forms. The
+    # hash count is part of both delimiters, and interpolation becomes \#(...).
+    if flags["raw"]:
+        hashes = raw_string_hashes(text, i)
+        if hashes:
+            fence = "#" * hashes
+            body_open = i + hashes
+            triple = text[body_open : body_open + 3] == '"""'
+            open_len = 3 if triple else 1
+            close_token = ('"""' if triple else '"') + fence
+            body_start = body_open + open_len
+            close_at = text.find(close_token, body_start)
+            end = n if close_at == -1 else close_at + len(close_token)
+            body_stop = close_at if close_at != -1 else n
+            holes = brace_holes(text, body_start, body_stop, style, flags, "\\" + fence + "(", ")")
+            return end, holes
+
+    triple_quote = None
+    if flags["triple"]:
+        candidate = text[i : i + 3]
+        if style == "hash" and candidate in ('"""', "'''"):
+            triple_quote = candidate
+        elif style == "slash" and candidate == '"""':
+            triple_quote = candidate
+
+    if triple_quote:
+        close_at = text.find(triple_quote, i + 3)
+        end = n if close_at == -1 else close_at + 3
+        body_stop = close_at if close_at != -1 else n
         holes = []
-        if has_fstring_prefix(text, i):
-            j = i + 3
-            body_end = end - 3 if end < n else n
-            while j < body_end:
-                # `{{` is an escaped brace, i.e. literal text, not an expression.
-                if text.startswith("{{", j):
-                    j += 2
-                    continue
-                if text[j] == "{":
-                    close = matching_delimiter(text, j + 1, "{", "}")
-                    holes.append((j + 1, min(close, body_end)))
-                    j = close + 1
-                    continue
-                j += 1
+        if style == "hash":
+            # Only an f-string's braces are code; a plain docstring's are text.
+            if has_fstring_prefix(text, i):
+                holes = brace_holes(text, i + 3, body_stop, style, flags, "{", "}")
+        else:
+            # Swift and Kotlin multiline strings are ordinary strings, not
+            # documentation, and both interpolate.
+            holes = brace_holes(text, i + 3, body_stop, style, flags, "${", "}")
+            holes += brace_holes(text, i + 3, body_stop, style, flags, "\\(", ")")
         return end, holes
 
     quote = text[i]
@@ -226,7 +314,7 @@ def scan_literal(text: str, i: int, style: str) -> tuple[int, list[tuple[int, in
             # Swift interpolation opens with a backslash, so it has to be tested
             # before the generic escape skip swallows the paren.
             if swift_interp and text.startswith("\\(", j):
-                end = matching_delimiter(text, j + 2, "(", ")")
+                end = matching_delimiter(text, j + 2, "(", ")", style, flags)
                 holes.append((j + 2, end))
                 j = end + 1
                 continue
@@ -242,7 +330,7 @@ def scan_literal(text: str, i: int, style: str) -> tuple[int, list[tuple[int, in
         opened = False
         for opener, closer in openers:
             if opener != "\\(" and text.startswith(opener, j):
-                end = matching_delimiter(text, j + len(opener), "{", closer)
+                end = matching_delimiter(text, j + len(opener), "{", closer, style, flags)
                 holes.append((j + len(opener), end))
                 j = end + 1
                 opened = True
@@ -253,24 +341,29 @@ def scan_literal(text: str, i: int, style: str) -> tuple[int, list[tuple[int, in
     return j, holes
 
 
-def mask_literals(text: str, lo: int, hi: int, style: str, in_string: bytearray) -> None:
+def mask_literals(text: str, lo: int, hi: int, style: str, in_string: bytearray,
+                  flags: dict | None = None) -> None:
     """Mask string literals in [lo, hi), recursing through interpolation holes.
 
     Called on the inside of an interpolation, which is code: any literal *there*
     is data again. Without this, `${"process.env.BASECAMP_FAKE"}` would count as
     a read, because the hole was un-masked wholesale.
     """
+    flags = DEFAULT_FLAGS if flags is None else flags
     quotes = STRING_QUOTES[style]
     i = lo
     while i < hi:
-        if text[i] in quotes:
-            end, holes = scan_literal(text, i, style)
+        if text[i] in quotes or (flags["raw"] and raw_string_hashes(text, i)):
+            end, holes = scan_literal(text, i, style, flags)
+            if end <= i:
+                i += 1
+                continue
             for k in range(i, min(end, hi)):
                 in_string[k] = 1
             for hole_start, hole_end in holes:
                 for k in range(hole_start, min(hole_end, hi)):
                     in_string[k] = 0
-                mask_literals(text, hole_start, min(hole_end, hi), style, in_string)
+                mask_literals(text, hole_start, min(hole_end, hi), style, in_string, flags)
             i = end
             continue
         i += 1
@@ -301,7 +394,7 @@ def interpolation_openers(text: str, i: int, quote: str, style: str) -> list[tup
     return openers
 
 
-def strip_noncode(text: str, style: str) -> tuple[str, bytearray]:
+def strip_noncode(text: str, style: str, flags: dict | None = None) -> tuple[str, bytearray]:
     """Blank comments and doc-only string blocks, preserving every offset.
 
     Returns the cleaned text plus a mask marking offsets that sit inside a
@@ -323,6 +416,7 @@ def strip_noncode(text: str, style: str) -> tuple[str, bytearray]:
     out = list(text)
     n = len(text)
     in_string = bytearray(n)
+    flags = DEFAULT_FLAGS if flags is None else flags
     quotes = STRING_QUOTES[style]
     i = 0
 
@@ -331,37 +425,40 @@ def strip_noncode(text: str, style: str) -> tuple[str, bytearray]:
             if out[k] != "\n":
                 out[k] = " "
 
+    def take_literal(start: int) -> int:
+        """Mask the literal at `start`, un-masking and recursing into its holes."""
+        end, holes = scan_literal(text, start, style, flags)
+        for k in range(start, min(end, n)):
+            in_string[k] = 1
+        # An interpolation is executable code that merely lives inside a literal,
+        # so it is un-masked: `token=${process.env.BASECAMP_TOKEN}` is a genuine
+        # read, and masking it would hide one. Literals *inside* that expression
+        # are data again, hence the recursive re-mask.
+        for hole_start, hole_end in holes:
+            for k in range(hole_start, min(hole_end, n)):
+                in_string[k] = 0
+            mask_literals(text, hole_start, min(hole_end, n), style, in_string, flags)
+        return end
+
     while i < n:
         # Python/Ruby docstrings: string literals used as documentation, so an
         # example inside one is not a read -- unless it is an f-string, whose
         # braces are executable. scan_literal makes that distinction; blanking
-        # every triple-quoted literal outright hid real reads.
-        if style == "hash" and text[i : i + 3] in ('"""', "'''"):
-            end, holes = scan_literal(text, i, style)
+        # every triple-quoted literal outright hid real reads. Swift and Kotlin
+        # `"""` are ordinary strings, so they fall through to take_literal.
+        if flags["triple"] and style == "hash" and text[i : i + 3] in ('"""', "'''"):
+            end, holes = scan_literal(text, i, style, flags)
             if holes:
-                for k in range(i, min(end, n)):
-                    in_string[k] = 1
-                for hole_start, hole_end in holes:
-                    for k in range(hole_start, min(hole_end, n)):
-                        in_string[k] = 0
-                    mask_literals(text, hole_start, min(hole_end, n), style, in_string)
+                take_literal(i)
             else:
                 blank(i, end)
             i = end
             continue
+        if flags["raw"] and raw_string_hashes(text, i):
+            i = take_literal(i)
+            continue
         if text[i] in quotes:
-            end, holes = scan_literal(text, i, style)
-            for k in range(i, min(end, n)):
-                in_string[k] = 1
-            # An interpolation is executable code that merely lives inside a
-            # literal, so it is un-masked: `token=${process.env.BASECAMP_TOKEN}`
-            # is a genuine read, and masking it would hide one. Literals *inside*
-            # that expression are data again, hence the recursive re-mask.
-            for hole_start, hole_end in holes:
-                for k in range(hole_start, min(hole_end, n)):
-                    in_string[k] = 0
-                mask_literals(text, hole_start, min(hole_end, n), style, in_string)
-            i = end
+            i = take_literal(i)
             continue
         if style == "slash" and text.startswith("//", i):
             end = text.find("\n", i)
@@ -369,8 +466,24 @@ def strip_noncode(text: str, style: str) -> tuple[str, bytearray]:
             i = n if end == -1 else end
             continue
         if style == "slash" and text.startswith("/*", i):
-            end = text.find("*/", i + 2)
-            end = n if end == -1 else end + 2
+            # Swift and Kotlin nest block comments; Go and TypeScript end at the
+            # first `*/`, so nesting them there would swallow the code after it.
+            if flags["nested"]:
+                depth = 1
+                k = i + 2
+                while k < n and depth:
+                    if text.startswith("/*", k):
+                        depth += 1
+                        k += 2
+                    elif text.startswith("*/", k):
+                        depth -= 1
+                        k += 2
+                    else:
+                        k += 1
+                end = k
+            else:
+                end = text.find("*/", i + 2)
+                end = n if end == -1 else end + 2
             blank(i, end)
             i = end
             continue
@@ -432,7 +545,9 @@ def real_reads(spec: dict) -> dict[str, list[str]]:
         # split across lines — os.getenv(\n    "BASECAMP_FOO") — is still a read,
         # and a per-line scan would silently miss it.
         text, in_string = strip_noncode(
-            path.read_text(encoding="utf-8", errors="replace"), spec["comments"]
+            path.read_text(encoding="utf-8", errors="replace"),
+            spec["comments"],
+            spec.get("flags"),
         )
         for pattern in compiled:
             # finditer + the named group, not findall: these patterns carry a

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -172,6 +172,10 @@ SDKS = {
 #   regex:   TypeScript `/.../` literals, whose contents are data. Enabled only
 #            there: `/` is division far more often than not, and the two are
 #            told apart by the preceding token, so this stays conservative.
+#   command_regex: Ruby only, where a call may omit its parentheses -- so the
+#            token before the slash in `puts /re/` is an identifier and it is
+#            still a regex. TypeScript has no such form, and reading one there
+#            would swallow the arithmetic it is actually looking at.
 #   multiline: Ruby, where an ordinary quoted literal may span physical lines.
 #            Everywhere else a newline ends it, which is what bounds the damage
 #            from an unbalanced quote.
@@ -180,6 +184,7 @@ LANG_FLAGS = {
         "triple": False, "nested": False, "raw": False, "fstring": False,
         "multiline": False,
         "regex": False,
+        "command_regex": False,
         "backtick_raw": True,
         "triple_raw": False,
         "percent": False,
@@ -189,6 +194,7 @@ LANG_FLAGS = {
         "triple": True, "nested": False, "raw": False, "fstring": False,
         "multiline": True,
         "regex": True,
+        "command_regex": True,
         "backtick_raw": False,
         "triple_raw": False,
         "percent": True,
@@ -198,6 +204,7 @@ LANG_FLAGS = {
         "triple": True, "nested": False, "raw": False, "fstring": True,
         "multiline": False,
         "regex": False,
+        "command_regex": False,
         "backtick_raw": False,
         "triple_raw": False,
         "percent": False,
@@ -207,6 +214,7 @@ LANG_FLAGS = {
         "triple": False, "nested": False, "raw": False, "fstring": False,
         "multiline": False,
         "regex": True,
+        "command_regex": False,
         "backtick_raw": False,
         "triple_raw": False,
         "percent": False,
@@ -216,6 +224,7 @@ LANG_FLAGS = {
         "triple": True, "nested": True, "raw": True, "fstring": False,
         "multiline": False,
         "regex": False,
+        "command_regex": False,
         "backtick_raw": False,
         "triple_raw": False,
         "percent": False,
@@ -225,6 +234,7 @@ LANG_FLAGS = {
         "triple": True, "nested": True, "raw": False, "fstring": False,
         "multiline": False,
         "regex": False,
+        "command_regex": False,
         "backtick_raw": False,
         "triple_raw": True,
         "percent": False,
@@ -233,7 +243,7 @@ LANG_FLAGS = {
 }
 # Permissive union, used only when no language is supplied.
 DEFAULT_FLAGS = {
-    "triple": True, "nested": True, "raw": True, "fstring": True, "multiline": True, "regex": True, "backtick_raw": False, "triple_raw": False, "percent": True,
+    "triple": True, "nested": True, "raw": True, "fstring": True, "multiline": True, "regex": True, "command_regex": True, "backtick_raw": False, "triple_raw": False, "percent": True,
     "interp": {"`": [("${", "}")], '"': [("${", "}"), ("\\(", ")"), ("#{", "}")]},
 }
 
@@ -296,6 +306,35 @@ REGEX_KEYWORDS = {
 }
 
 
+def command_argument(text: str, i: int, word: str, spaced: bool, flags: dict) -> bool:
+    """Whether the `/` at `i` opens a regex passed to a call without parentheses.
+
+    Ruby lets a method drop its parentheses, so `puts /re/` passes a regex whose
+    preceding token is an ordinary identifier -- which the rule above reads as
+    division. Both directions of that are wrong, and the second is the worse:
+    `puts /ENV['X']/` hands the regex body to the read patterns and invents a
+    read, while `puts /#{ENV['X']}/` stays division, the `#` then opens a line
+    comment, and a genuine interpolated read disappears.
+
+    Ruby's own parser settles the ambiguity by spacing and so does this: a space
+    before the slash and none after it is the argument form -- the spelling MRI
+    itself warns about as `ambiguous first argument`. Every other spacing stays
+    division, including `/=`, which is divide-and-assign.
+
+    Ruby only. TypeScript has no parenthesis-less call, so `total /count/ 2`
+    there is arithmetic and this reading would swallow it.
+
+    Being wrong here is bounded: the caller still requires a closing `/` on the
+    same line, so a lone slash falls back to division on its own.
+    """
+    if not flags.get("command_regex") or not spaced:
+        return False
+    if not (word[:1].isalpha() or word[:1] == "_"):
+        return False
+    after = text[i + 1 : i + 2]
+    return bool(after) and not after.isspace() and after != "="
+
+
 def regex_extent(text: str, i: int, flags: dict) -> int:
     """End of a regex literal starting at `i`, else `i`.
 
@@ -309,15 +348,20 @@ def regex_extent(text: str, i: int, flags: dict) -> int:
     if text.startswith("//", i) or text.startswith("/*", i):
         return i
     k = i - 1
+    # Whether anything separated the slash from the token before it. Ruby needs
+    # this to tell a command-form argument from division, and the scan below
+    # discards it.
+    spaced = k >= 0 and text[k] in " \t"
     while k >= 0 and text[k] in " \t":
         k -= 1
     if k >= 0 and text[k] not in REGEX_PRECEDERS and text[k] != "\n":
-        if not (text[k].isalpha() or text[k] == "_"):
+        if not (text[k].isalnum() or text[k] == "_"):
             return i
         word_end = k + 1
         while k >= 0 and (text[k].isalnum() or text[k] == "_"):
             k -= 1
-        if text[k + 1 : word_end] not in REGEX_KEYWORDS:
+        word = text[k + 1 : word_end]
+        if word not in REGEX_KEYWORDS and not command_argument(text, i, word, spaced, flags):
             return i
     j = i + 1
     in_class = False

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -163,6 +163,9 @@ SDKS = {
 #            interpolates in backticks only, so `"${x}"` is plain text, and Go
 #            interpolates nowhere at all.
 #   fstring: Python only, where the `f` prefix decides whether braces are code.
+#   regex:   TypeScript `/.../` literals, whose contents are data. Enabled only
+#            there: `/` is division far more often than not, and the two are
+#            told apart by the preceding token, so this stays conservative.
 #   multiline: Ruby, where an ordinary quoted literal may span physical lines.
 #            Everywhere else a newline ends it, which is what bounds the damage
 #            from an unbalanced quote.
@@ -170,37 +173,43 @@ LANG_FLAGS = {
     "Go": {
         "triple": False, "nested": False, "raw": False, "fstring": False,
         "multiline": False,
+        "regex": False,
         "interp": {},
     },
     "Ruby": {
         "triple": True, "nested": False, "raw": False, "fstring": False,
         "multiline": True,
+        "regex": False,
         "interp": {'"': [("#{", "}")]},
     },
     "Python": {
         "triple": True, "nested": False, "raw": False, "fstring": True,
         "multiline": False,
+        "regex": False,
         "interp": {},
     },
     "TypeScript": {
         "triple": False, "nested": False, "raw": False, "fstring": False,
         "multiline": False,
+        "regex": True,
         "interp": {"`": [("${", "}")]},
     },
     "Swift": {
         "triple": True, "nested": True, "raw": True, "fstring": False,
         "multiline": False,
+        "regex": False,
         "interp": {'"': [("\\(", ")")]},
     },
     "Kotlin": {
         "triple": True, "nested": True, "raw": False, "fstring": False,
         "multiline": False,
+        "regex": False,
         "interp": {'"': [("${", "}")]},
     },
 }
 # Permissive union, used only when no language is supplied.
 DEFAULT_FLAGS = {
-    "triple": True, "nested": True, "raw": True, "fstring": True, "multiline": True,
+    "triple": True, "nested": True, "raw": True, "fstring": True, "multiline": True, "regex": True,
     "interp": {"`": [("${", "}")], '"': [("${", "}"), ("\\(", ")"), ("#{", "}")]},
 }
 
@@ -246,6 +255,44 @@ CLAIM_END_RE = re.compile(r"\.\s|\n")
 STRING_QUOTES = {"hash": "\"'", "slash": "\"'`"}
 
 
+
+
+# A `/` starts a regex only where an operand is expected. After a value -- an
+# identifier, literal, or closing bracket -- it is division. Testing the
+# preceding token is the standard heuristic and errs toward division, which is
+# the safe way round: mistaking division for a regex would swallow code.
+REGEX_PRECEDERS = set("=(,:[!&|?{};+-*%<>~^")
+
+
+def regex_extent(text: str, i: int, flags: dict) -> int:
+    """End of a TypeScript regex literal starting at `i`, else `i`."""
+    if not flags.get("regex") or text[i] != "/":
+        return i
+    if text.startswith("//", i) or text.startswith("/*", i):
+        return i
+    k = i - 1
+    while k >= 0 and text[k] in " \t":
+        k -= 1
+    if k >= 0 and text[k] not in REGEX_PRECEDERS and text[k] != "\n":
+        return i
+    j = i + 1
+    in_class = False
+    n = len(text)
+    while j < n:
+        c = text[j]
+        if c == "\\":
+            j += 2
+            continue
+        if c == "\n":
+            return i  # unterminated on its line: not a regex after all
+        if c == "[":
+            in_class = True
+        elif c == "]":
+            in_class = False
+        elif c == "/" and not in_class:
+            return j + 1
+        j += 1
+    return i
 
 
 def comment_extent(text: str, i: int, style: str | None, flags: dict | None = None) -> int:
@@ -314,6 +361,10 @@ def matching_delimiter(text: str, start: int, open_ch: str, close_ch: str,
         if comment_end > k:
             k = comment_end
             continue
+        regex_end = regex_extent(text, k, flags)
+        if regex_end > k:
+            k = regex_end
+            continue
         if text[k] == open_ch:
             depth += 1
         elif text[k] == close_ch:
@@ -322,6 +373,19 @@ def matching_delimiter(text: str, start: int, open_ch: str, close_ch: str,
                 return k
         k += 1
     return n
+
+
+def has_raw_prefix(text: str, i: int) -> bool:
+    """Whether the literal opening at `i` carries a Python `r` prefix.
+
+    In a raw string a backslash is an ordinary character, so `fr"\\{x}"` still
+    interpolates -- consuming the backslash as an escape swallowed the brace and
+    hid the expression.
+    """
+    start = i
+    while start > 0 and text[start - 1].isalpha():
+        start -= 1
+    return "r" in text[start:i].lower()
 
 
 def has_fstring_prefix(text: str, i: int) -> bool:
@@ -421,6 +485,7 @@ def scan_literal(text: str, i: int, style: str,
     quote = text[i]
     openers = interpolation_openers(text, i, quote, style, flags)
     swift_interp = ("\\(", ")") in openers
+    raw = style == "hash" and has_raw_prefix(text, i)
     j = i + 1
     holes = []
     while j < n:
@@ -431,6 +496,9 @@ def scan_literal(text: str, i: int, style: str,
                 end = matching_delimiter(text, j + 2, "(", ")", style, flags)
                 holes.append((j + 2, end))
                 j = end + 1
+                continue
+            if raw:
+                j += 1
                 continue
             j += 2
             continue
@@ -475,6 +543,12 @@ def mask_literals(text: str, lo: int, hi: int, style: str, in_string: bytearray,
             for k in range(i, min(comment_end, hi)):
                 in_string[k] = 1
             i = comment_end
+            continue
+        regex_end = regex_extent(text, i, flags)
+        if regex_end > i:
+            for k in range(i, min(regex_end, hi)):
+                in_string[k] = 1
+            i = regex_end
             continue
         if text[i] in quotes or (flags["raw"] and raw_string_hashes(text, i)):
             end, holes = scan_literal(text, i, style, flags)
@@ -583,6 +657,13 @@ def strip_noncode(text: str, style: str, flags: dict | None = None) -> tuple[str
         if comment_end > i:
             blank(i, comment_end)
             i = comment_end
+            continue
+        # A regex literal is data, like a string: its contents are not calls.
+        regex_end = regex_extent(text, i, flags)
+        if regex_end > i:
+            for k in range(i, min(regex_end, n)):
+                in_string[k] = 1
+            i = regex_end
             continue
         # Ruby block comment: =begin/=end, each at column 0.
         if style == "hash" and text.startswith("=begin", i) and (i == 0 or text[i - 1] == "\n"):

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -336,21 +336,33 @@ def regex_extent(text: str, i: int, flags: dict) -> int:
 PERCENT_DELIMS = {"{": "}", "[": "]", "(": ")", "<": ">"}
 
 
-def percent_literal_extent(text: str, i: int, flags: dict) -> int:
-    """End of a Ruby percent literal starting at `i`, else `i`."""
+def percent_literal_extent(text: str, i: int, flags: dict) -> tuple[int, list[tuple[int, int]]]:
+    """End of a Ruby percent literal starting at `i` (else `i`), plus its holes.
+
+    The uppercase forms interpolate and the lowercase ones do not: `%q{...}` is
+    data throughout, while `%Q{#{ENV[...]}}` contains a real call. Masking the
+    whole literal either way hid that call.
+    """
     if not flags or not flags.get("percent") or text[i] != "%":
-        return i
+        return i, []
     j = i + 1
+    letter = ""
     if j < len(text) and text[j].isalpha():
+        letter = text[j]
         j += 1
     if j >= len(text):
-        return i
+        return i, []
     opener = text[j]
     closer = PERCENT_DELIMS.get(opener)
     if closer is None:
-        return i
-    end = matching_delimiter(text, j + 1, opener, closer, "hash", flags)
-    return min(end + 1, len(text))
+        return i, []
+    body_start = j + 1
+    end = matching_delimiter(text, body_start, opener, closer, "hash", flags)
+    interpolates = letter == "" or letter.isupper() or letter == "r"
+    holes = []
+    if interpolates:
+        holes = brace_holes(text, body_start, min(end, len(text)), "hash", flags, "#{", "}")
+    return min(end + 1, len(text)), holes
 
 
 def comment_extent(text: str, i: int, style: str | None, flags: dict | None = None) -> int:
@@ -737,10 +749,14 @@ def strip_noncode(text: str, style: str, flags: dict | None = None) -> tuple[str
             blank(i, comment_end)
             i = comment_end
             continue
-        percent_end = percent_literal_extent(text, i, flags)
+        percent_end, percent_holes = percent_literal_extent(text, i, flags)
         if percent_end > i:
             for k in range(i, min(percent_end, n)):
                 in_string[k] = 1
+            for hole_start, hole_end in percent_holes:
+                for k in range(hole_start, min(hole_end, n)):
+                    in_string[k] = 0
+                mask_literals(text, hole_start, min(hole_end, n), style, in_string, flags)
             i = percent_end
             continue
         # A regex literal is data, like a string: its contents are not calls.
@@ -856,6 +872,35 @@ def prose_lines(readme: Path) -> list[tuple[int, str]]:
             continue
         out.append((lineno, line))
     return out
+
+
+# Words that turn a mention into a denial. A bare substring test counted
+# "the SDK never looks them up" as documentation, so a variable an SDK started
+# reading could ship undocumented behind a sentence saying it does not.
+NEGATION_RE = re.compile(r"\b(never|not|no|none|nothing|cannot|n't)\b", re.I)
+
+
+def affirmative_mentions(readme: Path) -> set[str]:
+    """Variables this README positively documents.
+
+    A table row counts. Prose counts only when the sentence carrying the
+    variable is not a denial. Fenced code blocks never count -- every SDK's
+    Quick Start shows the *caller* reading BASECAMP_TOKEN from its own
+    environment, which says nothing about what the SDK reads.
+    """
+    found: set[str] = set()
+    for _lineno, cells in table_rows(readme):
+        found.update(VAR_RE.findall(cells[0]))
+    for paragraph in prose_paragraphs(readme):
+        text, _line_at = join_paragraph(paragraph)
+        # Split on sentence enders only. A semicolon joins clauses of one
+        # sentence, and splitting there detached "the SDK never looks them up"
+        # from the variable it denies -- which is the exact sentence in
+        # python/README.md this check exists to refuse.
+        for sentence in re.split(r"(?<=[.!?])\s+", text):
+            if not NEGATION_RE.search(sentence):
+                found.update(VAR_RE.findall(sentence))
+    return found
 
 
 def prose_paragraphs(readme: Path) -> list[list[tuple[int, str]]]:
@@ -992,18 +1037,28 @@ def main() -> int:
                         f"{ROOT_README}:{lineno}: credits {var} to {sdk}, but no read "
                         f"of it exists in {SDKS[sdk]['source']}/"
                     )
+            # ...and the other direction: a reader the column leaves out. Without
+            # this, a second SDK could start reading a variable that already has
+            # a row and every check would still pass.
+            for sdk in SDKS:
+                if var in reads[sdk] and sdk not in claimed:
+                    failures.append(
+                        f"{ROOT_README}:{lineno}: {sdk} reads {var} "
+                        f"({reads[sdk][var][0]}) but the 'Read by' column omits it"
+                    )
 
-    # 3. Reverse, per SDK: a real read must be documented.
+    # 3. Reverse, per SDK: a real read must be documented *affirmatively*.
     for sdk, spec in SDKS.items():
         readme = REPO / spec["readme"]
         if not readme.is_file():
             continue
-        text = readme.read_text(encoding="utf-8")
+        documented = affirmative_mentions(readme)
         for var, sites in sorted(reads[sdk].items()):
-            if var not in text:
+            if var not in documented:
                 failures.append(
                     f"{spec['readme']}: {sdk} reads {var} ({sites[0]}) but the README "
-                    f"never mentions it"
+                    f"does not document it (a mention inside a code example, or in a "
+                    f"sentence saying it is *not* read, does not count)"
                 )
 
     # 4. The root README's "read no environment variables at all" sentence.

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -180,6 +180,102 @@ def matching_delimiter(text: str, start: int, open_ch: str, close_ch: str) -> in
     return len(text)
 
 
+def has_fstring_prefix(text: str, i: int) -> bool:
+    """Whether the literal opening at `i` carries a Python f prefix."""
+    prefix_start = i
+    while prefix_start > 0 and text[prefix_start - 1].isalpha():
+        prefix_start -= 1
+    return "f" in text[prefix_start:i].lower()
+
+
+def scan_literal(text: str, i: int, style: str) -> tuple[int, list[tuple[int, int]]]:
+    """Extent of the literal opening at `i`, plus its interpolation holes.
+
+    Returns (end, holes) where end is one past the closing quote and each hole is
+    a half-open range of executable text inside the literal.
+    """
+    n = len(text)
+    triple = text[i : i + 3] if style == "hash" and text[i : i + 3] in ('"""', "'''") else None
+    if triple:
+        end = text.find(triple, i + 3)
+        end = n if end == -1 else end + 3
+        holes = []
+        if has_fstring_prefix(text, i):
+            j = i + 3
+            body_end = end - 3 if end < n else n
+            while j < body_end:
+                # `{{` is an escaped brace, i.e. literal text, not an expression.
+                if text.startswith("{{", j):
+                    j += 2
+                    continue
+                if text[j] == "{":
+                    close = matching_delimiter(text, j + 1, "{", "}")
+                    holes.append((j + 1, min(close, body_end)))
+                    j = close + 1
+                    continue
+                j += 1
+        return end, holes
+
+    quote = text[i]
+    openers = interpolation_openers(text, i, quote, style)
+    swift_interp = ("\\(", ")") in openers
+    j = i + 1
+    holes = []
+    while j < n:
+        if text[j] == "\\":
+            # Swift interpolation opens with a backslash, so it has to be tested
+            # before the generic escape skip swallows the paren.
+            if swift_interp and text.startswith("\\(", j):
+                end = matching_delimiter(text, j + 2, "(", ")")
+                holes.append((j + 2, end))
+                j = end + 1
+                continue
+            j += 2
+            continue
+        if text[j] == quote:
+            j += 1
+            break
+        # An unterminated single-line literal ends at the newline; Go and
+        # TypeScript backtick literals legitimately span lines.
+        if text[j] == "\n" and quote != "`":
+            break
+        opened = False
+        for opener, closer in openers:
+            if opener != "\\(" and text.startswith(opener, j):
+                end = matching_delimiter(text, j + len(opener), "{", closer)
+                holes.append((j + len(opener), end))
+                j = end + 1
+                opened = True
+                break
+        if opened:
+            continue
+        j += 1
+    return j, holes
+
+
+def mask_literals(text: str, lo: int, hi: int, style: str, in_string: bytearray) -> None:
+    """Mask string literals in [lo, hi), recursing through interpolation holes.
+
+    Called on the inside of an interpolation, which is code: any literal *there*
+    is data again. Without this, `${"process.env.BASECAMP_FAKE"}` would count as
+    a read, because the hole was un-masked wholesale.
+    """
+    quotes = STRING_QUOTES[style]
+    i = lo
+    while i < hi:
+        if text[i] in quotes:
+            end, holes = scan_literal(text, i, style)
+            for k in range(i, min(end, hi)):
+                in_string[k] = 1
+            for hole_start, hole_end in holes:
+                for k in range(hole_start, min(hole_end, hi)):
+                    in_string[k] = 0
+                mask_literals(text, hole_start, min(hole_end, hi), style, in_string)
+            i = end
+            continue
+        i += 1
+
+
 def interpolation_openers(text: str, i: int, quote: str, style: str) -> list[tuple[str, str]]:
     """Interpolation delimiters valid inside the literal opening at `i`.
 
@@ -200,10 +296,7 @@ def interpolation_openers(text: str, i: int, quote: str, style: str) -> list[tup
     # Python f-strings, whose braces are code. Only with an `f` prefix: an
     # ordinary "{...}" is literal text, and treating it as code would let a
     # documentation example count as a read.
-    prefix_start = i
-    while prefix_start > 0 and text[prefix_start - 1].isalpha():
-        prefix_start -= 1
-    if "f" in text[prefix_start:i].lower():
+    if has_fstring_prefix(text, i):
         openers.append(("{", "}"))
     return openers
 
@@ -239,59 +332,36 @@ def strip_noncode(text: str, style: str) -> tuple[str, bytearray]:
                 out[k] = " "
 
     while i < n:
-        # Python/Ruby docstrings: string literals, but used as documentation, so
-        # an example inside one is not a read.
+        # Python/Ruby docstrings: string literals used as documentation, so an
+        # example inside one is not a read -- unless it is an f-string, whose
+        # braces are executable. scan_literal makes that distinction; blanking
+        # every triple-quoted literal outright hid real reads.
         if style == "hash" and text[i : i + 3] in ('"""', "'''"):
-            quote = text[i : i + 3]
-            end = text.find(quote, i + 3)
-            end = n if end == -1 else end + 3
-            blank(i, end)
+            end, holes = scan_literal(text, i, style)
+            if holes:
+                for k in range(i, min(end, n)):
+                    in_string[k] = 1
+                for hole_start, hole_end in holes:
+                    for k in range(hole_start, min(hole_end, n)):
+                        in_string[k] = 0
+                    mask_literals(text, hole_start, min(hole_end, n), style, in_string)
+            else:
+                blank(i, end)
             i = end
             continue
         if text[i] in quotes:
-            quote = text[i]
-            openers = interpolation_openers(text, i, quote, style)
-            swift_interp = ("\\(", ")") in openers
-            j = i + 1
-            holes: list[tuple[int, int]] = []
-            while j < n:
-                if text[j] == "\\":
-                    # Swift interpolation opens with a backslash, so it has to be
-                    # tested before the generic escape skip swallows the paren.
-                    if swift_interp and text.startswith("\\(", j):
-                        end = matching_delimiter(text, j + 2, "(", ")")
-                        holes.append((j + 2, end))
-                        j = end + 1
-                        continue
-                    j += 2
-                    continue
-                if text[j] == quote:
-                    j += 1
-                    break
-                # An unterminated single-line literal ends at the newline; Go and
-                # TypeScript backtick literals legitimately span lines.
-                if text[j] == "\n" and quote != "`":
-                    break
-                opened = False
-                for opener, closer in openers:
-                    if opener != "\\(" and text.startswith(opener, j):
-                        end = matching_delimiter(text, j + len(opener), "{", closer)
-                        holes.append((j + len(opener), end))
-                        j = end + 1
-                        opened = True
-                        break
-                if opened:
-                    continue
-                j += 1
-            for k in range(i, min(j, n)):
+            end, holes = scan_literal(text, i, style)
+            for k in range(i, min(end, n)):
                 in_string[k] = 1
             # An interpolation is executable code that merely lives inside a
             # literal, so it is un-masked: `token=${process.env.BASECAMP_TOKEN}`
-            # is a genuine read, and masking it would hide one.
+            # is a genuine read, and masking it would hide one. Literals *inside*
+            # that expression are data again, hence the recursive re-mask.
             for hole_start, hole_end in holes:
                 for k in range(hole_start, min(hole_end, n)):
                     in_string[k] = 0
-            i = j
+                mask_literals(text, hole_start, min(hole_end, n), style, in_string)
+            i = end
             continue
         if style == "slash" and text.startswith("//", i):
             end = text.find("\n", i)

--- a/scripts/check-readme-env-vars.py
+++ b/scripts/check-readme-env-vars.py
@@ -174,42 +174,48 @@ LANG_FLAGS = {
         "triple": False, "nested": False, "raw": False, "fstring": False,
         "multiline": False,
         "regex": False,
+        "backtick_raw": True,
         "interp": {},
     },
     "Ruby": {
         "triple": True, "nested": False, "raw": False, "fstring": False,
         "multiline": True,
         "regex": False,
+        "backtick_raw": False,
         "interp": {'"': [("#{", "}")]},
     },
     "Python": {
         "triple": True, "nested": False, "raw": False, "fstring": True,
         "multiline": False,
         "regex": False,
+        "backtick_raw": False,
         "interp": {},
     },
     "TypeScript": {
         "triple": False, "nested": False, "raw": False, "fstring": False,
         "multiline": False,
         "regex": True,
+        "backtick_raw": False,
         "interp": {"`": [("${", "}")]},
     },
     "Swift": {
         "triple": True, "nested": True, "raw": True, "fstring": False,
         "multiline": False,
         "regex": False,
+        "backtick_raw": False,
         "interp": {'"': [("\\(", ")")]},
     },
     "Kotlin": {
         "triple": True, "nested": True, "raw": False, "fstring": False,
         "multiline": False,
         "regex": False,
+        "backtick_raw": False,
         "interp": {'"': [("${", "}")]},
     },
 }
 # Permissive union, used only when no language is supplied.
 DEFAULT_FLAGS = {
-    "triple": True, "nested": True, "raw": True, "fstring": True, "multiline": True, "regex": True,
+    "triple": True, "nested": True, "raw": True, "fstring": True, "multiline": True, "regex": True, "backtick_raw": False,
     "interp": {"`": [("${", "}")], '"': [("${", "}"), ("\\(", ")"), ("#{", "}")]},
 }
 
@@ -262,6 +268,12 @@ STRING_QUOTES = {"hash": "\"'", "slash": "\"'`"}
 # preceding token is the standard heuristic and errs toward division, which is
 # the safe way round: mistaking division for a regex would swallow code.
 REGEX_PRECEDERS = set("=(,:[!&|?{};+-*%<>~^")
+# ...and after a keyword, whose last character is a letter and would otherwise
+# read as the end of an identifier, i.e. division.
+REGEX_KEYWORDS = {
+    "return", "typeof", "instanceof", "in", "of", "new", "delete", "void",
+    "case", "do", "else", "yield", "await", "throw",
+}
 
 
 def regex_extent(text: str, i: int, flags: dict) -> int:
@@ -274,7 +286,13 @@ def regex_extent(text: str, i: int, flags: dict) -> int:
     while k >= 0 and text[k] in " \t":
         k -= 1
     if k >= 0 and text[k] not in REGEX_PRECEDERS and text[k] != "\n":
-        return i
+        if not (text[k].isalpha() or text[k] == "_"):
+            return i
+        word_end = k + 1
+        while k >= 0 and (text[k].isalnum() or text[k] == "_"):
+            k -= 1
+        if text[k + 1 : word_end] not in REGEX_KEYWORDS:
+            return i
     j = i + 1
     in_class = False
     n = len(text)
@@ -396,6 +414,24 @@ def has_fstring_prefix(text: str, i: int) -> bool:
     return "f" in text[prefix_start:i].lower()
 
 
+def find_unescaped(text: str, token: str, start: int, raw: bool = False) -> int:
+    """Index of `token` at or after `start`, skipping backslash-escaped ones.
+
+    An escaped delimiter inside a triple-quoted literal does not close it, and
+    treating it as the terminator left the rest of the literal scanned as code.
+    """
+    j = start
+    n = len(text)
+    while j < n:
+        if not raw and text[j] == "\\":
+            j += 2
+            continue
+        if text.startswith(token, j):
+            return j
+        j += 1
+    return -1
+
+
 def raw_string_hashes(text: str, i: int) -> int:
     """Number of `#` opening a Swift raw string at `i`, or 0 if this is not one."""
     k = i
@@ -464,7 +500,8 @@ def scan_literal(text: str, i: int, style: str,
             triple_quote = candidate
 
     if triple_quote:
-        close_at = text.find(triple_quote, i + 3)
+        close_at = find_unescaped(text, triple_quote, i + 3,
+                                  raw=style == "hash" and has_raw_prefix(text, i))
         end = n if close_at == -1 else close_at + 3
         body_stop = close_at if close_at != -1 else n
         holes = []
@@ -485,7 +522,8 @@ def scan_literal(text: str, i: int, style: str,
     quote = text[i]
     openers = interpolation_openers(text, i, quote, style, flags)
     swift_interp = ("\\(", ")") in openers
-    raw = style == "hash" and has_raw_prefix(text, i)
+    raw = (style == "hash" and has_raw_prefix(text, i)) or (
+        quote == "`" and flags.get("backtick_raw"))
     j = i + 1
     holes = []
     while j < n:

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -1458,7 +1458,90 @@ def main() -> int:
         check("a documented environment API is not a touch",
               run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), [])
 
-        # 15. The shipped entrypoint, end to end. Everything above drives the
+        # 15. `!` is postfix in TypeScript's non-null assertion, so `value! / x`
+        #     is division -- and prefix in negation, so `!/re/.test(s)` is a
+        #     regex. Same character, opposite answers, decided by what is in
+        #     front of it.
+        root = tmp / "ts-nonnull-division"
+        build(root, {
+            "typescript/README.md": "The SDK reads BASECAMP_REAL.\n",
+            "typescript/src/c.ts":
+                "const n = value! / process.env.BASECAMP_REAL / 2;\n",
+        })
+        check("division after a non-null assertion keeps its read",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_REAL"])
+
+        root = tmp / "ts-negated-regex"
+        build(root, {
+            "typescript/README.md": "no tables\n",
+            "typescript/src/c.ts":
+                "const bad = !/process.env.BASECAMP_FAKE/.test(s);\n",
+        })
+        check("a negated regex is still a regex",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), [])
+
+        # ...and the word matters, not its last letter: `return` ends in `n`,
+        # which as a bare character would read as a value and mask the regex.
+        root = tmp / "ts-return-negated-regex"
+        build(root, {
+            "typescript/README.md": "no tables\n",
+            "typescript/src/c.ts":
+                "function f(s: string) { return !/process.env.BASECAMP_FAKE/.test(s); }\n",
+        })
+        check("a negated regex after a keyword is still a regex",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), [])
+
+        # 16. `process["env"]` is the same object as `process.env`. Node does not
+        #     care which spelling reaches it, so neither may the gate -- in the
+        #     named-read patterns and in the whole-environment detector both.
+        root = tmp / "ts-bracket-env-named"
+        build(root, {
+            "typescript/README.md": "The SDK reads BASECAMP_REAL.\n",
+            "typescript/src/c.ts": 'const t = process["env"].BASECAMP_REAL;\n',
+        })
+        check("a bracket-spelled env property is a read",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_REAL"])
+
+        root = tmp / "ts-bracket-env-subscript"
+        build(root, {
+            "typescript/README.md": "The SDK reads BASECAMP_REAL.\n",
+            "typescript/src/c.ts": 'const t = process["env"]["BASECAMP_REAL"];\n',
+        })
+        check("a fully bracket-spelled env read is a read",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_REAL"])
+
+        root = tmp / "ts-bracket-env-destructured"
+        build(root, {
+            "typescript/README.md": "The SDK reads BASECAMP_REAL.\n",
+            "typescript/src/c.ts": 'const { BASECAMP_REAL } = process["env"];\n',
+        })
+        check("destructuring a bracket-spelled env is a read",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_REAL"])
+
+        root = tmp / "ts-bracket-env-wholesale"
+        build(root, {
+            "typescript/README.md": "no tables\n",
+            "typescript/src/c.ts": 'const all = process["env"];\n',
+        })
+        check("a bracket-spelled whole environment breaks the claim",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), ["envapi:TypeScript"])
+
+        # ...but `process` has other properties, and none of them are the
+        # environment. Matching them would invent reads out of ordinary code.
+        root = tmp / "ts-other-process-property"
+        build(root, {
+            "typescript/README.md": "no tables\n",
+            "typescript/src/c.ts":
+                'const v = process["version"];\nconst e = process.envelope;\n',
+        })
+        check("other process properties are not the environment",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), [])
+
+        # 17. The shipped entrypoint, end to end. Everything above drives the
         #     helpers `main()` drives, so until here the exit code that `make
         #     check` and the CI step branch on had no coverage at all -- a
         #     `main()` that collected every failure and then returned 0 would

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -1607,6 +1607,36 @@ def main() -> int:
         })
         check("a lookalike helper is not an env read", run_gate(root, PY_SDK), [])
 
+        # ...and neither is a same-named function from somewhere else. Whether
+        # `getenv(...)` reads the environment is a fact about the file's
+        # imports, so matching the bare name regardless invents a read.
+        root = tmp / "py-foreign-getenv"
+        build(root, {
+            "python/README.md": "no tables\n",
+            "python/src/c.py":
+                'from helpers import getenv\n\nv = getenv("BASECAMP_FAKE")\n',
+        })
+        check("an unqualified getenv not imported from os is not a read",
+              run_gate(root, PY_SDK), [])
+
+        # Reading the imports settles aliases too, which no fixed pattern could.
+        root = tmp / "py-aliased-getenv"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_ALIAS"),
+            "python/src/c.py":
+                'from os import getenv as ge\n\nv = ge("BASECAMP_ALIAS")\n',
+        })
+        check("an aliased os import is still a read", run_gate(root, PY_SDK), [])
+
+        root = tmp / "py-aliased-environ"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_ENVA"),
+            "python/src/c.py":
+                'from os import environ as en\n\nv = en["BASECAMP_ENVA"]\n',
+        })
+        check("an aliased environ import is still a read",
+              run_gate(root, PY_SDK), [])
+
         # 18. `const { env } = process` aliases the whole environment without
         #     ever spelling `process.env`.
         root = tmp / "ts-destructured-env-alias"

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -1691,6 +1691,38 @@ def main() -> int:
         check("a short fence does not close a longer one",
               run_gate(root, PY_SDK), ["reverse:Python:BASECAMP_LONG"])
 
+        # A closing fence carries nothing but its run and trailing spaces, so a
+        # ```-prefixed word inside a block is code rather than its end.
+        root = tmp / "fence-info-string"
+        build(root, {
+            "python/README.md":
+                "intro\n\n```\n```not-a-close\n# The SDK uses BASECAMP_INFO\n```\n",
+            "python/src/c.py": 'v = os.environ.get("BASECAMP_INFO")\n',
+        })
+        check("an info-string line does not close a fence",
+              run_gate(root, PY_SDK), ["reverse:Python:BASECAMP_INFO"])
+
+        # Swift wraps long member chains across lines, and the dots stay dots.
+        root = tmp / "swift-wrapped-chain"
+        build(root, {
+            "swift/README.md": "The SDK reads BASECAMP_REAL.\n",
+            "swift/Sources/c.swift":
+                'let t = ProcessInfo\n  .processInfo\n  .environment["BASECAMP_REAL"]\n',
+        })
+        check("a wrapped swift environment chain is a read",
+              run_gate(root, SW_SDK, no_env_sdks=("Swift",)),
+              ["noenv:Swift:BASECAMP_REAL"])
+
+        # `import os as X` rebinds the module, moving every qualified spelling.
+        root = tmp / "py-module-alias"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_MODALIAS"),
+            "python/src/c.py":
+                'import os as operating_system\n\n'
+                'v = operating_system.getenv("BASECAMP_MODALIAS")\n',
+        })
+        check("an aliased os module still binds", run_gate(root, PY_SDK), [])
+
         # A parenthesised import runs over as many lines as it likes, and a
         # backslash continues one. Both are ordinary Python.
         root = tmp / "py-paren-import"

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -1560,7 +1560,54 @@ def main() -> int:
         check("other process properties are not the environment",
               run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), [])
 
-        # 17. The shipped entrypoint, end to end. Everything above drives the
+        # `process?.env` is valid optional chaining and the same object again.
+        root = tmp / "ts-optional-chained-process"
+        build(root, {
+            "typescript/README.md": "The SDK reads BASECAMP_REAL.\n",
+            "typescript/src/c.ts": "const t = process?.env.BASECAMP_REAL;\n",
+        })
+        check("optional chaining before env is a read",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_REAL"])
+
+        root = tmp / "ts-optional-chained-bracket"
+        build(root, {
+            "typescript/README.md": "The SDK reads BASECAMP_REAL.\n",
+            "typescript/src/c.ts": 'const t = process?.["env"]?.BASECAMP_REAL;\n',
+        })
+        check("optional chaining with a bracket env is a read",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_REAL"])
+
+        # 17. `from os import getenv` is the ordinary Python spelling, and the
+        #     `os.`-qualified patterns reported those reads as nonexistent.
+        root = tmp / "py-unqualified-getenv"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_UNQ"),
+            "python/src/c.py":
+                'from os import getenv\n\nv = getenv("BASECAMP_UNQ")\n',
+        })
+        check("an unqualified getenv is a read", run_gate(root, PY_SDK), [])
+
+        root = tmp / "py-unqualified-environ"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_ENVQ"),
+            "python/src/c.py":
+                'from os import environ\n\nv = environ.get("BASECAMP_ENVQ")\n'
+                'w = environ["BASECAMP_ENVQ"]\n',
+        })
+        check("an unqualified environ is a read", run_gate(root, PY_SDK), [])
+
+        # ...and a differently-named function is not one, so an unrelated
+        # helper cannot be promoted into the inventory.
+        root = tmp / "py-lookalike-getenv"
+        build(root, {
+            "python/README.md": "no tables\n",
+            "python/src/c.py": 'v = mygetenv("BASECAMP_FAKE")\n',
+        })
+        check("a lookalike helper is not an env read", run_gate(root, PY_SDK), [])
+
+        # 18. The shipped entrypoint, end to end. Everything above drives the
         #     helpers `main()` drives, so until here the exit code that `make
         #     check` and the CI step branch on had no coverage at all -- a
         #     `main()` that collected every failure and then returned 0 would

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -95,9 +95,12 @@ def run_gate(root: Path, sdks: dict, no_env_sdks: tuple = (),
                     for var in sorted(reads[s]):
                         if var not in root_documented:
                             failures.append(f"rootmissing:{s}:{var}")
+        # Invariant 4 is unscoped: "reads no environment variables at all" is
+        # broken by `process.env.HOME` too, and the scoped inventory drops it.
         for sdk in no_env_sdks:
-            if reads.get(sdk):
-                failures.append(f"noenv:{sdk}:{sorted(reads[sdk])[0]}")
+            every = gate.real_reads(sdks[sdk], scoped=False)
+            if every:
+                failures.append(f"noenv:{sdk}:{sorted(every)[0]}")
         return failures
     finally:
         gate.REPO, gate.SDKS, gate.NO_ENV_SDKS = old_repo, old_sdks, old_no_env
@@ -179,6 +182,27 @@ def main() -> int:
         check("typescript optional-chained bracket read is seen",
               run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
               ["noenv:TypeScript:BASECAMP_OPTB"])
+
+        # "Reads no environment variables at all" is broken by any read, not
+        # just a documented family. Scoping this one hid `process.env.HOME`
+        # behind a claim that the SDK reads nothing.
+        root = tmp / "noenv-unscoped"
+        build(root, {
+            "typescript/README.md": "The SDK reads nothing.\n",
+            "typescript/src/c.ts": "const h = process.env.HOME;\n",
+        })
+        check("the no-environment claim sees reads outside the documented families",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:HOME"])
+
+        # A shipping file whose name merely contains `test_` is not a test.
+        root = tmp / "filename-not-a-test"
+        build(root, {
+            "python/README.md": "The SDK reads nothing.\n",
+            "python/src/latest_config.py": 'v = os.environ.get("BASECAMP_LATEST")\n',
+        })
+        check("a shipping file named latest_* is scanned",
+              run_gate(root, PY_SDK), ["reverse:Python:BASECAMP_LATEST"])
 
         # A regex literal is data. Its braces must not close an interpolation,
         # and its contents must not read as calls.
@@ -654,9 +678,12 @@ def main() -> int:
             "typescript/README.md": TABLE.format(var="BASECAMP_TOKEN"),
             "typescript/src/c.ts": "const { OTHER: BASECAMP_TOKEN } = process.env;\n",
         })
+        # The alias is not the key, so the phantom BASECAMP_TOKEN read is gone --
+        # and OTHER, which *is* the key, correctly breaks the no-environment
+        # claim. Both halves of that are the point.
         check("a destructuring alias is not the key that was read",
               run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
-              ["forward:TypeScript:BASECAMP_TOKEN"])
+              ["forward:TypeScript:BASECAMP_TOKEN", "noenv:TypeScript:OTHER"])
 
         # ...but destructuring something else is not an environment read.
         root = tmp / "destructured-other"

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -1337,6 +1337,19 @@ def main() -> int:
               run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
               ["noenv:TypeScript:BASECAMP_REAL"])
 
+        # ...and the keyword has to be a statement head, not a property that
+        # merely spells one. `obj.if(...)` is a legal call, so what follows it
+        # is an expression and the slash is division.
+        root = tmp / "ts-property-named-if"
+        build(root, {
+            "typescript/README.md": "The SDK reads BASECAMP_REAL.\n",
+            "typescript/src/c.ts":
+                "const n = obj.if(ready) / process.env.BASECAMP_REAL / 2;\n",
+        })
+        check("a property spelled like a keyword is not a condition",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_REAL"])
+
         # Ruby has statement modifiers, so `if (x) / 2` really is division
         # inside a trailing condition. The rule above is therefore TypeScript's
         # alone -- applying it here would mask the read in that condition.

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -1492,6 +1492,25 @@ def main() -> int:
         check("a negated regex after a keyword is still a regex",
               run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), [])
 
+        # Ruby spells both meanings too, and the word lists separate them there
+        # as well: a bang method ends a value, a command-form call negates what
+        # follows it.
+        root = tmp / "ruby-bang-method-division"
+        build(root, {
+            "ruby/README.md": "no tables\n",
+            "ruby/lib/c.rb": "n = save! / ENV['BASECAMP_REAL'].to_i / 2\n",
+        })
+        check("a ruby bang method ends a value",
+              run_gate(root, RB_SDK), ["reverse:Ruby:BASECAMP_REAL"])
+
+        root = tmp / "ruby-command-negated-regex"
+        build(root, {
+            "ruby/README.md": "no tables\n",
+            "ruby/lib/c.rb": "puts !/ENV['BASECAMP_FAKE']/.match(s)\n",
+        })
+        check("a negated regex after a ruby command is still a regex",
+              run_gate(root, RB_SDK), [])
+
         # 16. `process["env"]` is the same object as `process.env`. Node does not
         #     care which spelling reaches it, so neither may the gate -- in the
         #     named-read patterns and in the whole-environment detector both.

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -1244,6 +1244,108 @@ def main() -> int:
             "python/src/c.py": 'v = os.environ.get("HTTP_PROXY")\n',
         })
         check("unrelated env vars are ignored", run_gate(root, PY_SDK), [])
+
+        # 10. Where a newline does and does not end a statement. Both of these
+        #     are the same bytes in the two languages that spell a regex `/.../`,
+        #     and they mean opposite things, so one rule cannot serve both.
+        #
+        #     JavaScript inserts no semicolon before `/`, because the slash
+        #     parses as a continuation of the expression above it. So this is
+        #     division and the read between the two slashes is real; treating
+        #     the line-leading slash as a regex opener masks it, and an
+        #     undocumented variable ships.
+        root = tmp / "ts-newline-division"
+        build(root, {
+            "typescript/README.md": "The SDK reads BASECAMP_REAL.\n",
+            "typescript/src/c.ts":
+                "const ratio = 10\n/ process.env.BASECAMP_REAL / 2;\n",
+        })
+        check("a typescript division survives the line break",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_REAL"])
+
+        # ...while a slash that continues an operator really does open a regex,
+        # so the read spelled inside it is example text and not a read.
+        root = tmp / "ts-newline-regex"
+        build(root, {
+            "typescript/README.md": "no tables\n",
+            "typescript/src/c.ts":
+                "const re =\n  /process.env.BASECAMP_FAKE/;\n",
+        })
+        check("a typescript regex after a line-broken operator is not a read",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), [])
+
+        # Ruby is the other way round: a complete expression ends at the newline,
+        # so a line-leading slash is a regex and its body is data.
+        root = tmp / "ruby-newline-regex"
+        build(root, {
+            "ruby/README.md": "no tables\n",
+            "ruby/lib/c.rb": "n = 10\n/ENV['BASECAMP_FAKE']/.match(s)\n",
+        })
+        check("a ruby line-leading slash is a regex",
+              run_gate(root, RB_SDK), [])
+
+        # 11. A `)` that closes a control-flow condition is followed by a
+        #     statement, and a statement may begin with a regex. Reading it as
+        #     division leaves the pattern text executable and invents a read.
+        root = tmp / "ts-condition-regex"
+        build(root, {
+            "typescript/README.md": "no tables\n",
+            "typescript/src/c.ts":
+                "if (ready) /process.env.BASECAMP_FAKE/.test(value);\n",
+        })
+        check("a regex after a control-flow condition is not a read",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), [])
+
+        # ...but every other `)` still ends a value, so the slash after it stays
+        # division. This is the fail-open direction of the rule above: guess
+        # "regex" here and the read between the slashes disappears.
+        root = tmp / "ts-call-division"
+        build(root, {
+            "typescript/README.md": "The SDK reads BASECAMP_REAL.\n",
+            "typescript/src/c.ts":
+                "const n = size() / process.env.BASECAMP_REAL / 2;\n",
+        })
+        check("division after a call is not a condition regex",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_REAL"])
+
+        # Ruby has statement modifiers, so `if (x) / 2` really is division
+        # inside a trailing condition. The rule above is therefore TypeScript's
+        # alone -- applying it here would mask the read in that condition.
+        root = tmp / "ruby-modifier-if-division"
+        build(root, {
+            "ruby/README.md": "no tables\n",
+            "ruby/lib/c.rb": "warn 'x' if (limit) / ENV['BASECAMP_REAL'].to_i / 2 > 1\n",
+        })
+        check("a ruby modifier-if condition keeps its division",
+              run_gate(root, RB_SDK), ["reverse:Ruby:BASECAMP_REAL"])
+
+        # 12. Kotlin's triple-quoted string is raw: a backslash is ordinary data
+        #     and does not escape the `$` after it, so `${...}` still executes.
+        #     Consuming the pair as an escape hid a real read -- and the root
+        #     README's "Kotlin reads no environment variables" stayed true-looking.
+        root = tmp / "kotlin-raw-escaped-dollar"
+        build(root, {
+            "kotlin/README.md": "The SDK reads BASECAMP_REAL.\n",
+            "kotlin/sdk/src/c.kt":
+                'val s = """\\${System.getenv("BASECAMP_REAL")}"""\n',
+        })
+        check("a backslash does not escape kotlin raw interpolation",
+              run_gate(root, KT_SDK, no_env_sdks=("Kotlin",)),
+              ["noenv:Kotlin:BASECAMP_REAL"])
+
+        # Swift's plain `"""` is not raw, so there the backslash does escape and
+        # `\\(` is literal text rather than an interpolation. Same shape, opposite
+        # answer, which is why this is a per-language flag and not a global rule.
+        root = tmp / "swift-multiline-escaped-interp"
+        build(root, {
+            "swift/README.md": "no tables\n",
+            "swift/Sources/c.swift":
+                'let s = """\n\\\\(ProcessInfo.processInfo.environment["BASECAMP_FAKE"])\n"""\n',
+        })
+        check("a backslash still escapes swift multiline interpolation",
+              run_gate(root, SW_SDK, no_env_sdks=("Swift",)), [])
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
 

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -103,6 +103,11 @@ def run_gate(root: Path, sdks: dict, no_env_sdks: tuple = (),
             every = gate.real_reads(sdks[sdk], scoped=False)
             if every:
                 failures.append(f"noenv:{sdk}:{sorted(every)[0]}")
+            # ...and a wholesale grab, which names no variable and so cannot
+            # appear in the inventory above at all. Only when that inventory is
+            # empty, matching main(): a named read already fails the claim.
+            elif gate.env_api_sites(sdk, sdks[sdk]):
+                failures.append(f"envapi:{sdk}")
         return failures
     finally:
         gate.REPO, gate.SDKS, gate.NO_ENV_SDKS = old_repo, old_sdks, old_no_env
@@ -1387,7 +1392,73 @@ def main() -> int:
         check("a backslash still escapes swift multiline interpolation",
               run_gate(root, SW_SDK, no_env_sdks=("Swift",)), [])
 
-        # 13. The shipped entrypoint, end to end. Everything above drives the
+        # 13. `++` and `--` end a value, so the slash after one is division --
+        #     but both of their characters are in REGEX_PRECEDERS, so the
+        #     single-character heuristic called it a regex and masked the read
+        #     between the slashes. Fail-open.
+        root = tmp / "ts-postfix-division"
+        build(root, {
+            "typescript/README.md": "The SDK reads BASECAMP_REAL.\n",
+            "typescript/src/c.ts":
+                "let x = 1;\nconst n = x++ / process.env.BASECAMP_REAL / 2;\n",
+        })
+        check("division after a postfix increment keeps its read",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_REAL"])
+
+        # ...while a single `+` really does expect an operand, so the regex
+        # reading must survive for it.
+        root = tmp / "ts-plus-regex"
+        build(root, {
+            "typescript/README.md": "no tables\n",
+            "typescript/src/c.ts":
+                'const s = "" + /process.env.BASECAMP_FAKE/.source;\n',
+        })
+        check("a regex after a single plus is still a regex",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), [])
+
+        # 14. "Reads no environment variables at all" is broken by a grab of the
+        #     whole environment too, and that names no variable -- so the read
+        #     patterns, which all require a quoted name, could never see it.
+        root = tmp / "kotlin-whole-env"
+        build(root, {
+            "kotlin/README.md": "no tables\n",
+            "kotlin/sdk/src/c.kt": 'val t = System.getenv()["BASECAMP_TOKEN"]\n',
+        })
+        check("a whole-environment grab breaks the no-env claim",
+              run_gate(root, KT_SDK, no_env_sdks=("Kotlin",)), ["envapi:Kotlin"])
+
+        root = tmp / "ts-whole-env"
+        build(root, {
+            "typescript/README.md": "no tables\n",
+            "typescript/src/c.ts": "const cfg = { ...process.env };\n",
+        })
+        check("a spread of process.env breaks the no-env claim",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), ["envapi:TypeScript"])
+
+        root = tmp / "swift-whole-env"
+        build(root, {
+            "swift/README.md": "no tables\n",
+            "swift/Sources/c.swift":
+                "let all = ProcessInfo.processInfo.environment\n",
+        })
+        check("passing the whole swift environment breaks the claim",
+              run_gate(root, SW_SDK, no_env_sdks=("Swift",)), ["envapi:Swift"])
+
+        # ...but the READMEs' own examples spell these APIs in prose and code
+        # blocks, and the SDK sources carry them in doc comments. Counting those
+        # would fail CI on a correct tree, which is how a gate gets deleted.
+        root = tmp / "ts-whole-env-in-comment"
+        build(root, {
+            "typescript/README.md": "no tables\n",
+            "typescript/src/c.ts":
+                '// Callers do `process.env.BASECAMP_TOKEN` themselves.\n'
+                'const s = "process.env";\n',
+        })
+        check("a documented environment API is not a touch",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), [])
+
+        # 15. The shipped entrypoint, end to end. Everything above drives the
         #     helpers `main()` drives, so until here the exit code that `make
         #     check` and the CI step branch on had no coverage at all -- a
         #     `main()` that collected every failure and then returned 0 would

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -15,7 +15,9 @@ it, and asserts on the failures returned.
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
 import shutil
 import sys
 import tempfile
@@ -104,6 +106,31 @@ def run_gate(root: Path, sdks: dict, no_env_sdks: tuple = (),
         return failures
     finally:
         gate.REPO, gate.SDKS, gate.NO_ENV_SDKS = old_repo, old_sdks, old_no_env
+
+
+def run_main(root: Path, sdks: dict, no_env_sdks: tuple = ()) -> int:
+    """Call the gate's real `main()` against a synthetic repo, returning its code.
+
+    `run_gate` above drives the same helpers `main()` drives, which is what lets
+    every case assert on a compact tag rather than on prose. What that cannot
+    cover is `main()` itself: the order it wires the five invariants in, and the
+    exit code the Makefile recipe and the CI step actually branch on. Nothing
+    else here ever runs the shipped entrypoint.
+
+    Asserting only the code, never the message text, is what keeps this cheap.
+    Sharing the whole orchestration would mean rewriting every expectation
+    against failure strings, trading a small drift risk for a large brittleness
+    one in the file whose job is to be trustworthy; a smoke test on the return
+    value buys the coverage without that.
+    """
+    old = gate.REPO, gate.SDKS, gate.NO_ENV_SDKS
+    gate.REPO, gate.SDKS, gate.NO_ENV_SDKS = root, sdks, no_env_sdks
+    try:
+        with contextlib.redirect_stdout(io.StringIO()), \
+             contextlib.redirect_stderr(io.StringIO()):
+            return gate.main()
+    finally:
+        gate.REPO, gate.SDKS, gate.NO_ENV_SDKS = old
 
 
 def check(name: str, actual, expected) -> None:
@@ -1346,6 +1373,27 @@ def main() -> int:
         })
         check("a backslash still escapes swift multiline interpolation",
               run_gate(root, SW_SDK, no_env_sdks=("Swift",)), [])
+
+        # 13. The shipped entrypoint, end to end. Everything above drives the
+        #     helpers `main()` drives, so until here the exit code that `make
+        #     check` and the CI step branch on had no coverage at all -- a
+        #     `main()` that collected every failure and then returned 0 would
+        #     have passed this whole suite.
+        root = tmp / "main-consistent"
+        build(root, {
+            "README.md": "Python reads `BASECAMP_MAIN`.\n",
+            "python/README.md": TABLE.format(var="BASECAMP_MAIN"),
+            "python/src/c.py": 'v = os.environ.get("BASECAMP_MAIN")\n',
+        })
+        check("main() exits 0 on a consistent repo", run_main(root, PY_SDK), 0)
+
+        root = tmp / "main-phantom"
+        build(root, {
+            "README.md": "Python reads `BASECAMP_PHANTOM`.\n",
+            "python/README.md": TABLE.format(var="BASECAMP_PHANTOM"),
+            "python/src/c.py": "v = 1\n",
+        })
+        check("main() exits 1 on a phantom table row", run_main(root, PY_SDK), 1)
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
 

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -164,7 +164,7 @@ def main() -> int:
         # were invisible to patterns that demanded the dot or bracket directly.
         root = tmp / "optional-chaining"
         build(root, {
-            "typescript/README.md": "mentions BASECAMP_OPT\n",
+            "typescript/README.md": "The SDK reads BASECAMP_OPT.\n",
             "typescript/src/c.ts": "const v = process.env?.BASECAMP_OPT;\n",
         })
         check("typescript optional-chained read is seen",
@@ -173,7 +173,7 @@ def main() -> int:
 
         root = tmp / "optional-chaining-bracket"
         build(root, {
-            "typescript/README.md": "mentions BASECAMP_OPTB\n",
+            "typescript/README.md": "The SDK reads BASECAMP_OPTB.\n",
             "typescript/src/c.ts": 'const v = process.env?.["BASECAMP_OPTB"];\n',
         })
         check("typescript optional-chained bracket read is seen",
@@ -184,7 +184,7 @@ def main() -> int:
         # and its contents must not read as calls.
         root = tmp / "regex-in-hole"
         build(root, {
-            "typescript/README.md": "mentions BASECAMP_SECRET\n",
+            "typescript/README.md": "The SDK reads BASECAMP_SECRET.\n",
             "typescript/src/c.ts":
                 'const x = `${(/}/, process.env.BASECAMP_SECRET)}`;\n',
         })
@@ -204,7 +204,7 @@ def main() -> int:
         # would swallow code up to the next slash and hide the read.
         root = tmp / "division-not-regex"
         build(root, {
-            "typescript/README.md": "mentions BASECAMP_DIV\n",
+            "typescript/README.md": "The SDK reads BASECAMP_DIV.\n",
             "typescript/src/c.ts": "const r = total / process.env.BASECAMP_DIV;\n",
         })
         check("a division slash is not a regex",
@@ -215,7 +215,7 @@ def main() -> int:
         # match has to start on the brace or comma to survive the string mask.
         root = tmp / "destructured-quoted-key"
         build(root, {
-            "typescript/README.md": "mentions BASECAMP_QK\n",
+            "typescript/README.md": "The SDK reads BASECAMP_QK.\n",
             "typescript/src/c.ts": 'const { "BASECAMP_QK": token } = process.env;\n',
         })
         check("a quoted destructuring key is a read",
@@ -226,7 +226,7 @@ def main() -> int:
         # escape the terminator. Swift's are not raw, which is how \( works.
         root = tmp / "kotlin-triple-raw"
         build(root, {
-            "kotlin/README.md": "mentions BASECAMP_KA\n",
+            "kotlin/README.md": "The SDK reads BASECAMP_KA.\n",
             "kotlin/sdk/src/c.kt":
                 'val s = """ends with a backslash \\"""\nval v = System.getenv("BASECAMP_KA")\n',
         })
@@ -270,6 +270,28 @@ def main() -> int:
         })
         check("a neutral mention beside a denial is not documentation",
               run_gate(root, PY_SDK), ["reverse:Python:BASECAMP_NEUTRAL"])
+
+        # ...and a sentence that denies nothing still has to claim something.
+        # "reserved for future use" documents no read at all.
+        root = tmp / "neutral-no-denial"
+        build(root, {
+            "python/README.md": "`BASECAMP_RESERVED` is reserved for future use.\n",
+            "python/src/c.py": 'v = os.environ.get("BASECAMP_RESERVED")\n',
+        })
+        check("a neutral sentence with no claim is not documentation",
+              run_gate(root, PY_SDK), ["reverse:Python:BASECAMP_RESERVED"])
+
+        # The verbs the shipping READMEs actually use have to keep working, or
+        # this fails CI on correct prose. `consults` is go/README.md's word for
+        # the XDG pair, which has no table row anywhere.
+        root = tmp / "affirmative-verbs"
+        build(root, {
+            "go/README.md":
+                "`DefaultConfig` consults `XDG_CACHE_HOME` to site the cache directory.\n",
+            "go/pkg/c.go": 'v := os.Getenv("XDG_CACHE_HOME")\n',
+        })
+        check("an affirmative verb documents a prose-only read",
+              run_gate(root, GO_SDK), [])
 
         # ...but a table row is an affirmative claim in its own right, and the
         # denial usually qualifies one code path rather than the SDK. This is
@@ -488,7 +510,7 @@ def main() -> int:
         # parenthesis-less call, so the same spelling there is arithmetic.
         root = tmp / "ts-not-command-regex"
         build(root, {
-            "typescript/README.md": "mentions BASECAMP_TSDIV\n",
+            "typescript/README.md": "The SDK reads BASECAMP_TSDIV.\n",
             "typescript/src/c.ts":
                 "const n = total /count/ 2;\nconst v = process.env.BASECAMP_TSDIV;\n",
         })
@@ -593,6 +615,18 @@ def main() -> int:
         })
         check("a go backtick literal is raw", run_gate(root, GO_SDK), [])
 
+        # A raw string keeps the backslash in its value, but the tokenizer still
+        # lets it protect a quote: `r"\""` is one literal. Advancing a single
+        # character made the escaped quote the terminator and left the rest of
+        # the literal executable.
+        root = tmp / "raw-escaped-quote"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_FAKE"),
+            "python/src/c.py": 'X = r"\\" os.getenv(\'BASECAMP_FAKE\')"\n',
+        })
+        check("an escaped quote does not end a raw string",
+              run_gate(root, PY_SDK), ["forward:Python:BASECAMP_FAKE"])
+
         # In a raw f-string the backslash is literal, so it must not eat the
         # brace that opens the expression.
         root = tmp / "raw-fstring"
@@ -605,7 +639,7 @@ def main() -> int:
         # Destructuring is a read, and every name in the pattern is one.
         root = tmp / "destructured"
         build(root, {
-            "typescript/README.md": "mentions BASECAMP_DA and BASECAMP_DB\n",
+            "typescript/README.md": "The SDK reads BASECAMP_DA and BASECAMP_DB.\n",
             "typescript/src/c.ts": "const { BASECAMP_DA, BASECAMP_DB } = process.env;\n",
         })
         check("destructured reads are seen, all of them",
@@ -768,7 +802,7 @@ def main() -> int:
         #     direction — so each language's spelling is exercised.
         root = tmp / "interp-ts"
         build(root, {
-            "typescript/README.md": "mentions BASECAMP_TMPL\n",
+            "typescript/README.md": "The SDK reads BASECAMP_TMPL.\n",
             "typescript/src/c.ts": "const label = `token=${process.env.BASECAMP_TMPL}`;\n",
         })
         check("a template-literal interpolation is a read",
@@ -820,7 +854,7 @@ def main() -> int:
 
         root = tmp / "interp-swift"
         build(root, {
-            "swift/README.md": "mentions BASECAMP_SW\n",
+            "swift/README.md": "The SDK reads BASECAMP_SW.\n",
             "swift/Sources/c.swift":
                 'let s = "tok=\\(ProcessInfo.processInfo.environment["BASECAMP_SW"])"\n',
         })
@@ -841,7 +875,7 @@ def main() -> int:
         # ...but an interpolation inside that multiline string still is.
         root = tmp / "kotlin-multiline-interp"
         build(root, {
-            "kotlin/README.md": "mentions BASECAMP_REAL\n",
+            "kotlin/README.md": "The SDK reads BASECAMP_REAL.\n",
             "kotlin/sdk/src/c.kt": 'val s = """\ntok=${System.getenv("BASECAMP_REAL")}\n"""\n',
         })
         check("kotlin multiline interpolation is a read",
@@ -859,7 +893,7 @@ def main() -> int:
 
         root = tmp / "swift-raw"
         build(root, {
-            "swift/README.md": "mentions BASECAMP_RAW\n",
+            "swift/README.md": "The SDK reads BASECAMP_RAW.\n",
             "swift/Sources/c.swift":
                 'let t = #"\\#(ProcessInfo.processInfo.environment["BASECAMP_RAW"]!)"#\n',
         })
@@ -869,7 +903,7 @@ def main() -> int:
 
         root = tmp / "brace-in-nested-literal"
         build(root, {
-            "typescript/README.md": "mentions BASECAMP_SECRET\n",
+            "typescript/README.md": "The SDK reads BASECAMP_SECRET.\n",
             "typescript/src/c.ts": 'const x = `${foo("}", process.env.BASECAMP_SECRET)}`;\n',
         })
         check("a quoted brace does not truncate the interpolation",
@@ -880,7 +914,7 @@ def main() -> int:
         # literal — otherwise the hole is truncated and the read behind it hides.
         root = tmp / "comment-in-hole"
         build(root, {
-            "typescript/README.md": "mentions BASECAMP_SECRET\n",
+            "typescript/README.md": "The SDK reads BASECAMP_SECRET.\n",
             "typescript/src/c.ts":
                 'const x = `${foo(/* } */ process.env.BASECAMP_SECRET)}`;\n',
         })
@@ -911,7 +945,7 @@ def main() -> int:
         # to accept the fences the lexer already understands.
         root = tmp / "swift-raw-key"
         build(root, {
-            "swift/README.md": "mentions BASECAMP_RAWKEY\n",
+            "swift/README.md": "The SDK reads BASECAMP_RAWKEY.\n",
             "swift/Sources/c.swift":
                 'let v = ProcessInfo.processInfo.environment[#"BASECAMP_RAWKEY"#]\n',
         })
@@ -932,7 +966,7 @@ def main() -> int:
         # ...while the identical bytes in Kotlin are code.
         root = tmp / "kotlin-dq-interp"
         build(root, {
-            "kotlin/README.md": "mentions BASECAMP_REAL\n",
+            "kotlin/README.md": "The SDK reads BASECAMP_REAL.\n",
             "kotlin/sdk/src/c.kt": 'val v = "${System.getenv("BASECAMP_REAL")}"\n',
         })
         check("kotlin double quotes do interpolate",
@@ -960,7 +994,7 @@ def main() -> int:
         # code. Nesting it everywhere would have swallowed a real read.
         root = tmp / "ts-unnested-comment"
         build(root, {
-            "typescript/README.md": "mentions BASECAMP_AFTER\n",
+            "typescript/README.md": "The SDK reads BASECAMP_AFTER.\n",
             "typescript/src/c.ts": '/* outer /* inner */ const v = process.env.BASECAMP_AFTER;\n',
         })
         check("typescript block comments do not nest",
@@ -995,7 +1029,7 @@ def main() -> int:
 
         root = tmp / "multiline-ts"
         build(root, {
-            "typescript/README.md": "mentions BASECAMP_MULTI\n",
+            "typescript/README.md": "The SDK reads BASECAMP_MULTI.\n",
             "typescript/src/c.ts": 'const v = process.env[\n  "BASECAMP_MULTI"\n];\n',
         })
         check("multiline typescript read breaks the no-env claim",
@@ -1005,7 +1039,7 @@ def main() -> int:
         # 6. The no-env claim breaks on a real read.
         root = tmp / "noenv"
         build(root, {
-            "typescript/README.md": "mentions BASECAMP_REAL\n",
+            "typescript/README.md": "The SDK reads BASECAMP_REAL.\n",
             "typescript/src/c.ts": "const v = process.env.BASECAMP_REAL;\n",
         })
         check("real read breaks the no-env claim",
@@ -1065,7 +1099,7 @@ def main() -> int:
         build(root, {
             "python/README.md": "Python reads `BASECAMP_ONE` and Ruby reads `BASECAMP_TWO` here.\n",
             "python/src/c.py": 'v = os.environ.get("BASECAMP_ONE")\n',
-            "ruby/README.md": "mentions BASECAMP_TWO\n",
+            "ruby/README.md": "The SDK reads BASECAMP_TWO.\n",
             "ruby/lib/c.rb": 'v = ENV["BASECAMP_TWO"]\n',
         })
         check("a two-SDK sentence attributes each variable to its own SDK",
@@ -1076,7 +1110,7 @@ def main() -> int:
         build(root, {
             "python/README.md": "Python reads `BASECAMP_ONE` and Ruby reads `BASECAMP_TWO` here.\n",
             "python/src/c.py": 'v = os.environ.get("BASECAMP_ONE")\n',
-            "ruby/README.md": "mentions BASECAMP_TWO\n",
+            "ruby/README.md": "The SDK reads BASECAMP_TWO.\n",
             "ruby/lib/c.rb": "v = 1\n",
         })
         check("a false second clause is caught",
@@ -1121,7 +1155,7 @@ def main() -> int:
         build(root, {
             "python/README.md": "`BASECAMP_BOTH`, which Python and Ruby use, matters.\n",
             "python/src/c.py": 'v = os.environ.get("BASECAMP_BOTH")\n',
-            "ruby/README.md": "mentions BASECAMP_BOTH\n",
+            "ruby/README.md": "The SDK reads BASECAMP_BOTH.\n",
             "ruby/lib/c.rb": "v = 1\n",
         })
         check("a compound subject is checked against each SDK named",

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -1680,6 +1680,37 @@ def main() -> int:
         check("a backtick line inside a tilde fence does not end it",
               run_gate(root, PY_SDK), ["reverse:Python:BASECAMP_MIXED"])
 
+        # A closing fence must be at least as long as the one that opened it,
+        # so a ``` line inside a ```` block is content rather than its end.
+        root = tmp / "long-fence"
+        build(root, {
+            "python/README.md":
+                "intro\n\n````\n```\n# The SDK uses BASECAMP_LONG\n```\n````\n",
+            "python/src/c.py": 'v = os.environ.get("BASECAMP_LONG")\n',
+        })
+        check("a short fence does not close a longer one",
+              run_gate(root, PY_SDK), ["reverse:Python:BASECAMP_LONG"])
+
+        # A parenthesised import runs over as many lines as it likes, and a
+        # backslash continues one. Both are ordinary Python.
+        root = tmp / "py-paren-import"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_PAREN"),
+            "python/src/c.py":
+                'from os import (\n    getenv,\n)\n\nv = getenv("BASECAMP_PAREN")\n',
+        })
+        check("a parenthesised os import still binds",
+              run_gate(root, PY_SDK), [])
+
+        root = tmp / "py-backslash-import"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_BSLASH"),
+            "python/src/c.py":
+                'from os import \\\n    getenv\n\nv = getenv("BASECAMP_BSLASH")\n',
+        })
+        check("a backslash-continued os import still binds",
+              run_gate(root, PY_SDK), [])
+
         # 20. The shipped entrypoint, end to end. Everything above drives the
         #     helpers `main()` drives, so until here the exit code that `make
         #     check` and the CI step branch on had no coverage at all -- a

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -1607,7 +1607,50 @@ def main() -> int:
         })
         check("a lookalike helper is not an env read", run_gate(root, PY_SDK), [])
 
-        # 18. The shipped entrypoint, end to end. Everything above drives the
+        # 18. `const { env } = process` aliases the whole environment without
+        #     ever spelling `process.env`.
+        root = tmp / "ts-destructured-env-alias"
+        build(root, {
+            "typescript/README.md": "no tables\n",
+            "typescript/src/c.ts":
+                "const { env } = process;\nconst t = env.BASECAMP_TOKEN;\n",
+        })
+        check("destructuring env off process breaks the claim",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), ["envapi:TypeScript"])
+
+        # ...but destructuring something else off it is not the environment.
+        root = tmp / "ts-destructured-other"
+        build(root, {
+            "typescript/README.md": "no tables\n",
+            "typescript/src/c.ts": "const { argv, pid } = process;\n",
+        })
+        check("destructuring other process fields is not the environment",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), [])
+
+        # 19. Tilde fences are code blocks too, and a comment inside one is not
+        #     documentation. Left in prose, `# The SDK uses BASECAMP_TILDE`
+        #     satisfied the reverse check for a read nothing else described.
+        root = tmp / "tilde-fence"
+        build(root, {
+            "python/README.md":
+                "intro\n\n~~~python\n# The SDK uses BASECAMP_TILDE\n~~~\n",
+            "python/src/c.py": 'v = os.environ.get("BASECAMP_TILDE")\n',
+        })
+        check("a tilde-fenced example is not documentation",
+              run_gate(root, PY_SDK), ["reverse:Python:BASECAMP_TILDE"])
+
+        # ...and the fence closes only on its own character, so a ``` line
+        # inside a ~~~ block must not end it and hand back the rest as prose.
+        root = tmp / "tilde-fence-mixed"
+        build(root, {
+            "python/README.md":
+                "intro\n\n~~~\n```\n# The SDK uses BASECAMP_MIXED\n```\n~~~\n",
+            "python/src/c.py": 'v = os.environ.get("BASECAMP_MIXED")\n',
+        })
+        check("a backtick line inside a tilde fence does not end it",
+              run_gate(root, PY_SDK), ["reverse:Python:BASECAMP_MIXED"])
+
+        # 20. The shipped entrypoint, end to end. Everything above drives the
         #     helpers `main()` drives, so until here the exit code that `make
         #     check` and the CI step branch on had no coverage at all -- a
         #     `main()` that collected every failure and then returned 0 would

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -178,6 +178,46 @@ def main() -> int:
               run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
               ["noenv:TypeScript:BASECAMP_DIV"])
 
+        # A quoted destructuring key: the name sits inside a literal, so the
+        # match has to start on the brace or comma to survive the string mask.
+        root = tmp / "destructured-quoted-key"
+        build(root, {
+            "typescript/README.md": "mentions BASECAMP_QK\n",
+            "typescript/src/c.ts": 'const { "BASECAMP_QK": token } = process.env;\n',
+        })
+        check("a quoted destructuring key is a read",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_QK"])
+
+        # Kotlin triple-quoted strings are raw, so a trailing backslash does not
+        # escape the terminator. Swift's are not raw, which is how \( works.
+        root = tmp / "kotlin-triple-raw"
+        build(root, {
+            "kotlin/README.md": "mentions BASECAMP_KA\n",
+            "kotlin/sdk/src/c.kt":
+                'val s = """ends with a backslash \\"""\nval v = System.getenv("BASECAMP_KA")\n',
+        })
+        check("a kotlin triple-quoted string is raw",
+              run_gate(root, KT_SDK, no_env_sdks=("Kotlin",)),
+              ["noenv:Kotlin:BASECAMP_KA"])
+
+        # Ruby percent literals are data.
+        root = tmp / "ruby-percent"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_FAKE"),
+            "ruby/lib/c.rb": "s = %q{ENV['BASECAMP_FAKE']}\n",
+        })
+        check("a ruby percent literal is not a read",
+              run_gate(root, RB_SDK), ["forward:Ruby:BASECAMP_FAKE"])
+
+        # ...and `%` as modulo must not start one.
+        root = tmp / "ruby-modulo"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_MOD"),
+            "ruby/lib/c.rb": 'v = ENV["BASECAMP_MOD"]\nx = a % b\n',
+        })
+        check("a ruby modulo is not a percent literal", run_gate(root, RB_SDK), [])
+
         # A keyword ends in a letter, which otherwise reads as an identifier and
         # therefore as division.
         root = tmp / "regex-after-keyword"

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -84,6 +84,7 @@ PY_SDK = {"Python": gate.SDKS["Python"]}
 RB_SDK = {"Ruby": gate.SDKS["Ruby"]}
 TS_SDK = {"TypeScript": gate.SDKS["TypeScript"]}
 PY_RB = {"Python": gate.SDKS["Python"], "Ruby": gate.SDKS["Ruby"]}
+SW_SDK = {"Swift": gate.SDKS["Swift"]}
 
 TABLE = "| Variable | Description |\n|---|---|\n| `{var}` | thing |\n"
 
@@ -214,6 +215,50 @@ def main() -> int:
         })
         check("a real read beside a string example still counts",
               run_gate(root, PY_SDK), [])
+
+        # 5b-iii. An interpolation is executable code that happens to sit inside
+        #     a literal. Masking it would hide a genuine read — the fail-open
+        #     direction — so each language's spelling is exercised.
+        root = tmp / "interp-ts"
+        build(root, {
+            "typescript/README.md": "mentions BASECAMP_TMPL\n",
+            "typescript/src/c.ts": "const label = `token=${process.env.BASECAMP_TMPL}`;\n",
+        })
+        check("a template-literal interpolation is a read",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_TMPL"])
+
+        root = tmp / "interp-rb"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_INTERP"),
+            "ruby/lib/c.rb": 'v = "#{ENV[\'BASECAMP_INTERP\']}"\n',
+        })
+        check("a ruby #{} interpolation is a read", run_gate(root, RB_SDK), [])
+
+        root = tmp / "interp-py"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_FSTR"),
+            "python/src/c.py": 'v = f"{os.environ.get(\'BASECAMP_FSTR\')}"\n',
+        })
+        check("a python f-string interpolation is a read", run_gate(root, PY_SDK), [])
+
+        # ...but the same braces without an `f` prefix are literal text.
+        root = tmp / "interp-py-plain"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_NOTF"),
+            "python/src/c.py": 'v = "{os.environ.get(\'BASECAMP_NOTF\')}"\n',
+        })
+        check("braces without an f prefix are not a read",
+              run_gate(root, PY_SDK), ["forward:Python:BASECAMP_NOTF"])
+
+        root = tmp / "interp-swift"
+        build(root, {
+            "swift/README.md": "mentions BASECAMP_SW\n",
+            "swift/Sources/c.swift":
+                'let s = "tok=\\(ProcessInfo.processInfo.environment["BASECAMP_SW"])"\n',
+        })
+        check("a swift \\() interpolation is a read",
+              run_gate(root, SW_SDK, no_env_sdks=("Swift",)), ["noenv:Swift:BASECAMP_SW"])
 
         # 5c. A `#` inside a string literal does not start a comment, so a read
         #     later on the same line must still be seen.

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -37,7 +37,8 @@ def build(root: Path, files: dict[str, str]) -> None:
         path.write_text(body, encoding="utf-8")
 
 
-def run_gate(root: Path, sdks: dict, no_env_sdks: tuple = ()) -> list[str]:
+def run_gate(root: Path, sdks: dict, no_env_sdks: tuple = (),
+             check_root_table: bool = False) -> list[str]:
     """Run the gate against a synthetic repo, returning its failure list."""
     old_repo, old_sdks, old_no_env = gate.REPO, gate.SDKS, gate.NO_ENV_SDKS
     gate.REPO, gate.SDKS, gate.NO_ENV_SDKS = root, sdks, no_env_sdks
@@ -54,14 +55,26 @@ def run_gate(root: Path, sdks: dict, no_env_sdks: tuple = ()) -> list[str]:
                 for var in gate.VAR_RE.findall(cells[0]):
                     if var not in reads[sdk]:
                         failures.append(f"forward:{sdk}:{var}")
-            text = readme.read_text(encoding="utf-8")
+            documented = gate.affirmative_mentions(readme)
             for var in sorted(reads[sdk]):
-                if var not in text:
+                if var not in documented:
                     failures.append(f"reverse:{sdk}:{var}")
             for _, claimed_sdk, named in gate.prose_claims(readme):
                 for var in named:
                     if var not in reads.get(claimed_sdk, {}):
                         failures.append(f"prose:{claimed_sdk}:{var}")
+        if check_root_table:
+            root_readme = root / gate.ROOT_README
+            if root_readme.is_file():
+                for _lineno, cells in gate.table_rows(root_readme):
+                    if len(cells) < 2:
+                        continue
+                    row_vars = gate.VAR_RE.findall(cells[0])
+                    claimed = [s for s in sdks if gate.re.search(rf"\b{s}\b", cells[1])]
+                    for var in row_vars:
+                        for s in sdks:
+                            if var in reads[s] and s not in claimed:
+                                failures.append(f"rootomits:{s}:{var}")
         for sdk in no_env_sdks:
             if reads.get(sdk):
                 failures.append(f"noenv:{sdk}:{sorted(reads[sdk])[0]}")
@@ -201,6 +214,54 @@ def main() -> int:
               run_gate(root, KT_SDK, no_env_sdks=("Kotlin",)),
               ["noenv:Kotlin:BASECAMP_KA"])
 
+        # A denial is not documentation. python/README.md really does say the
+        # SDK never reads BASECAMP_TOKEN, so a substring test would bless it the
+        # day the SDK started to.
+        root = tmp / "negative-mention"
+        build(root, {
+            "python/README.md":
+                "`BASECAMP_TOKEN` appears in the examples only because the caller "
+                "reads it; the SDK never looks it up.\n",
+            "python/src/c.py": 'v = os.environ.get("BASECAMP_TOKEN")\n',
+        })
+        check("a denial does not count as documentation",
+              run_gate(root, PY_SDK), ["reverse:Python:BASECAMP_TOKEN"])
+
+        # ...and an affirmative sentence still does, since that is how the XDG
+        # variables are documented in go/README.md and ruby/README.md.
+        root = tmp / "affirmative-mention"
+        build(root, {
+            "python/README.md":
+                "The sole other environment read is `BASECAMP_AFFIRM`, for the cache.\n",
+            "python/src/c.py": 'v = os.environ.get("BASECAMP_AFFIRM")\n',
+        })
+        check("an affirmative sentence counts as documentation",
+              run_gate(root, PY_SDK), [])
+
+        # A mention inside a fenced example is the *caller* reading its own
+        # environment, which says nothing about what the SDK reads.
+        root = tmp / "fenced-mention"
+        build(root, {
+            "python/README.md": "intro\n\n```python\nos.environ['BASECAMP_FENCED']\n```\n",
+            "python/src/c.py": 'v = os.environ.get("BASECAMP_FENCED")\n',
+        })
+        check("a fenced example does not document a read",
+              run_gate(root, PY_SDK), ["reverse:Python:BASECAMP_FENCED"])
+
+        # The root table must name every SDK that really reads the variable, not
+        # just the ones already listed.
+        root = tmp / "root-omits-reader"
+        build(root, {
+            "README.md": "| Variable | Read by |\n|---|---|\n| `BASECAMP_SHARED` | Ruby |\n",
+            "python/README.md": "The SDK reads `BASECAMP_SHARED` from the environment.\n",
+            "python/src/c.py": 'v = os.environ.get("BASECAMP_SHARED")\n',
+            "ruby/README.md": "The SDK reads `BASECAMP_SHARED` from the environment.\n",
+            "ruby/lib/c.rb": 'v = ENV["BASECAMP_SHARED"]\n',
+        })
+        check("the root table must name every reader",
+              run_gate(root, PY_RB, check_root_table=True),
+              ["rootomits:Python:BASECAMP_SHARED"])
+
         # Ruby percent literals are data.
         root = tmp / "ruby-percent"
         build(root, {
@@ -209,6 +270,14 @@ def main() -> int:
         })
         check("a ruby percent literal is not a read",
               run_gate(root, RB_SDK), ["forward:Ruby:BASECAMP_FAKE"])
+
+        # ...but the uppercase forms interpolate, so a call inside one is real.
+        root = tmp / "ruby-percent-interp"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_QINT"),
+            "ruby/lib/c.rb": 'x = %Q{#{ENV["BASECAMP_QINT"]}}\n',
+        })
+        check("a %Q interpolation is a read", run_gate(root, RB_SDK), [])
 
         # ...and `%` as modulo must not start one.
         root = tmp / "ruby-modulo"

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -87,6 +87,14 @@ def run_gate(root: Path, sdks: dict, no_env_sdks: tuple = (),
                         for s in sdks:
                             if var in reads[s] and s not in claimed:
                                 failures.append(f"rootomits:{s}:{var}")
+                # Invariant 2b: the row loop above only ever sees variables that
+                # already have a row, so a real read with no row at all slips
+                # past every check. Named anywhere affirmative counts.
+                root_documented = gate.affirmative_mentions(root_readme)
+                for s in sdks:
+                    for var in sorted(reads[s]):
+                        if var not in root_documented:
+                            failures.append(f"rootmissing:{s}:{var}")
         for sdk in no_env_sdks:
             if reads.get(sdk):
                 failures.append(f"noenv:{sdk}:{sorted(reads[sdk])[0]}")
@@ -250,6 +258,31 @@ def main() -> int:
         check("an affirmative sentence counts as documentation",
               run_gate(root, PY_SDK), [])
 
+        # Absence of a denial is not an affirmation. A neutral sentence claims
+        # nothing, and the denial that follows it refers back by pronoun -- so
+        # taking each sentence in isolation counted the README as documenting
+        # the very read it goes on to disclaim.
+        root = tmp / "neutral-then-denial"
+        build(root, {
+            "python/README.md":
+                "`BASECAMP_NEUTRAL` appears in examples. The SDK never reads it.\n",
+            "python/src/c.py": 'v = os.environ.get("BASECAMP_NEUTRAL")\n',
+        })
+        check("a neutral mention beside a denial is not documentation",
+              run_gate(root, PY_SDK), ["reverse:Python:BASECAMP_NEUTRAL"])
+
+        # ...but a table row is an affirmative claim in its own right, and the
+        # denial usually qualifies one code path rather than the SDK. This is
+        # go/README.md's real sentence about `StaticTokenProvider`.
+        root = tmp / "denial-beside-table"
+        build(root, {
+            "go/README.md": TABLE.format(var="BASECAMP_TOKEN")
+                + "\n`StaticTokenProvider` does not read `BASECAMP_TOKEN`.\n",
+            "go/pkg/c.go": 'v := os.Getenv("BASECAMP_TOKEN")\n',
+        })
+        check("a table row survives a denial elsewhere",
+              run_gate(root, GO_SDK), [])
+
         # A mention inside a fenced example is the *caller* reading its own
         # environment, which says nothing about what the SDK reads.
         root = tmp / "fenced-mention"
@@ -303,6 +336,20 @@ def main() -> int:
         check("a root row must name at least one SDK",
               run_gate(root, PY_SDK, check_root_table=True),
               ["rootnosdk:BASECAMP_ORPHAN", "rootomits:Python:BASECAMP_ORPHAN"])
+
+        # A real read with no root row at all is invisible to the row loop --
+        # it never gets a row to iterate. The root README is an inventory, so a
+        # variable documented only in its own SDK's README still fails.
+        root = tmp / "root-missing-row"
+        build(root, {
+            "README.md": "| Variable | Read by |\n|---|---|\n| `BASECAMP_OLD` | Python |\n",
+            "python/README.md": "The SDK reads `BASECAMP_OLD` and `BASECAMP_NEW`.\n",
+            "python/src/c.py":
+                'a = os.environ.get("BASECAMP_OLD")\nb = os.environ.get("BASECAMP_NEW")\n',
+        })
+        check("a real read absent from the root README is caught",
+              run_gate(root, PY_SDK, check_root_table=True),
+              ["rootmissing:Python:BASECAMP_NEW"])
 
         # Ruby percent literals are data.
         root = tmp / "ruby-percent"
@@ -425,6 +472,18 @@ def main() -> int:
         check("ruby divide-and-assign is not a command-form regex",
               run_gate(root, RB_SDK), [])
 
+        # Spacing alone cannot decide this, so the call has to be one that takes
+        # a regex. `total /x/ 2` is arithmetic after a local variable, and
+        # guessing "regex" masks everything between the two operators -- the
+        # fail-open direction, where a real read vanishes.
+        root = tmp / "ruby-lvar-division"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_LVAR"),
+            "ruby/lib/c.rb": 'total /ENV["BASECAMP_LVAR"].to_i / 2\n',
+        })
+        check("division after a local variable keeps its read visible",
+              run_gate(root, RB_SDK), [])
+
         # The rule is Ruby's, not a general one: TypeScript has no
         # parenthesis-less call, so the same spelling there is arithmetic.
         root = tmp / "ts-not-command-regex"
@@ -436,6 +495,38 @@ def main() -> int:
         check("typescript keeps the division reading",
               run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
               ["noenv:TypeScript:BASECAMP_TSDIV"])
+
+        # Ruby has no triple-quoted literal: `"""x"""` is three adjacent
+        # literals concatenated, and the middle one interpolates. Blanking the
+        # run as a docstring lost the read inside it.
+        root = tmp / "ruby-adjacent-quotes"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_RADJ"),
+            "ruby/lib/c.rb": 'x = """#{ENV[\'BASECAMP_RADJ\']}"""\n',
+        })
+        check("ruby adjacent quotes are not a docstring",
+              run_gate(root, RB_SDK), [])
+
+        # A percent literal nested inside an interpolation is data too. Only the
+        # top-level scanner knew that, so this came back out as a read.
+        root = tmp / "ruby-percent-in-hole"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_FAKE"),
+            "ruby/lib/c.rb": 's = "#{%q{ENV[\'BASECAMP_FAKE\']}}"\n',
+        })
+        check("a percent literal inside an interpolation is not a read",
+              run_gate(root, RB_SDK), ["forward:Ruby:BASECAMP_FAKE"])
+
+        # Inside `#{...}` the ordinary rules apply again, so a quoted brace there
+        # is a string. Counting it closed the literal early and let the rest of
+        # the line -- and the read in it -- be eaten as a `#` comment.
+        root = tmp / "ruby-percent-hole-quote"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_RQB"),
+            "ruby/lib/c.rb": 's = %Q{#{"}"}, #{ENV["BASECAMP_RQB"]}}\n',
+        })
+        check("a quoted brace inside a percent hole does not close it",
+              run_gate(root, RB_SDK), [])
 
         # ...and `%` as modulo must not start one.
         root = tmp / "ruby-modulo"

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -314,6 +314,17 @@ def main() -> int:
         })
         check("a ruby regex interpolation is a read", run_gate(root, RB_SDK), [])
 
+        # An escaped interpolation marker is literal text. The escape test has to
+        # run after the opener test, because Swift's opener is itself a backslash
+        # sequence and checking the escape first eats it.
+        root = tmp / "ruby-escaped-interp"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_ESC"),
+            "ruby/lib/c.rb": 'x = %Q{\\#{ENV["BASECAMP_ESC"]}}\n',
+        })
+        check("an escaped ruby interpolation marker is not a read",
+              run_gate(root, RB_SDK), ["forward:Ruby:BASECAMP_ESC"])
+
         root = tmp / "ruby-regex-data"
         build(root, {
             "ruby/README.md": TABLE.format(var="BASECAMP_RXD"),

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -86,6 +86,7 @@ TS_SDK = {"TypeScript": gate.SDKS["TypeScript"]}
 PY_RB = {"Python": gate.SDKS["Python"], "Ruby": gate.SDKS["Ruby"]}
 SW_SDK = {"Swift": gate.SDKS["Swift"]}
 KT_SDK = {"Kotlin": gate.SDKS["Kotlin"]}
+GO_SDK = {"Go": gate.SDKS["Go"]}
 
 TABLE = "| Variable | Description |\n|---|---|\n| `{var}` | thing |\n"
 
@@ -339,6 +340,46 @@ def main() -> int:
         check("a quoted brace does not truncate the interpolation",
               run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
               ["noenv:TypeScript:BASECAMP_SECRET"])
+
+        # A delimiter inside a comment is not a delimiter, same as inside a
+        # literal — otherwise the hole is truncated and the read behind it hides.
+        root = tmp / "comment-in-hole"
+        build(root, {
+            "typescript/README.md": "mentions BASECAMP_SECRET\n",
+            "typescript/src/c.ts":
+                'const x = `${foo(/* } */ process.env.BASECAMP_SECRET)}`;\n',
+        })
+        check("a commented brace does not truncate the interpolation",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_SECRET"])
+
+        # Interpolation is per language *and* per quote: TypeScript interpolates
+        # in backticks only, so this is ordinary text and not a read.
+        root = tmp / "ts-dq-not-interp"
+        build(root, {
+            "typescript/README.md": "no tables\n",
+            "typescript/src/c.ts": 'const example = "${process.env.BASECAMP_FAKE}";\n',
+        })
+        check("typescript double quotes do not interpolate",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), [])
+
+        # ...while the identical bytes in Kotlin are code.
+        root = tmp / "kotlin-dq-interp"
+        build(root, {
+            "kotlin/README.md": "mentions BASECAMP_REAL\n",
+            "kotlin/sdk/src/c.kt": 'val v = "${System.getenv("BASECAMP_REAL")}"\n',
+        })
+        check("kotlin double quotes do interpolate",
+              run_gate(root, KT_SDK, no_env_sdks=("Kotlin",)),
+              ["noenv:Kotlin:BASECAMP_REAL"])
+
+        # Go interpolates nowhere, so neither spelling is a read.
+        root = tmp / "go-no-interp"
+        build(root, {
+            "go/README.md": "no tables\n",
+            "go/pkg/c.go": 'v := "${os.Getenv(\\"BASECAMP_FAKE\\")}"\n',
+        })
+        check("go strings never interpolate", run_gate(root, GO_SDK), [])
 
         root = tmp / "swift-nested-comment"
         build(root, {

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -528,6 +528,34 @@ def main() -> int:
         check("a quoted brace inside a percent hole does not close it",
               run_gate(root, RB_SDK), [])
 
+        # A backtick command literal is data, like any other string...
+        root = tmp / "ruby-backtick-data"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_FAKE"),
+            "ruby/lib/c.rb": 's = `echo ENV["BASECAMP_FAKE"]`\n',
+        })
+        check("a ruby backtick literal is not a read",
+              run_gate(root, RB_SDK), ["forward:Ruby:BASECAMP_FAKE"])
+
+        # ...and it interpolates, so the `#` must not open a comment.
+        root = tmp / "ruby-backtick-interp"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_BTI"),
+            "ruby/lib/c.rb": 's = `echo #{ENV["BASECAMP_BTI"]}`\n',
+        })
+        check("a ruby backtick interpolation is a read",
+              run_gate(root, RB_SDK), [])
+
+        # `%` after a value is modulo. Accepting `-` as a delimiter here ran the
+        # literal to the end of the file, masking every read after it.
+        root = tmp / "ruby-modulo-unary"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_MODU"),
+            "ruby/lib/c.rb": '10%-ENV["BASECAMP_MODU"].to_i\n',
+        })
+        check("modulo before a unary operand is not a percent literal",
+              run_gate(root, RB_SDK), [])
+
         # ...and `%` as modulo must not start one.
         root = tmp / "ruby-modulo"
         build(root, {
@@ -583,6 +611,18 @@ def main() -> int:
         check("destructured reads are seen, all of them",
               run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
               ["noenv:TypeScript:BASECAMP_DA"])
+
+        # Renaming reads the *key*, not the local name it is bound to. The
+        # unanchored lookahead matched identifiers on the value side of `:` too,
+        # so this invented a BASECAMP_TOKEN read the code never makes.
+        root = tmp / "destructured-alias"
+        build(root, {
+            "typescript/README.md": TABLE.format(var="BASECAMP_TOKEN"),
+            "typescript/src/c.ts": "const { OTHER: BASECAMP_TOKEN } = process.env;\n",
+        })
+        check("a destructuring alias is not the key that was read",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["forward:TypeScript:BASECAMP_TOKEN"])
 
         # ...but destructuring something else is not an environment read.
         root = tmp / "destructured-other"

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -74,30 +74,11 @@ def check(name: str, actual, expected) -> None:
         FAILURES.append(name)
 
 
-PY_SDK = {
-    "Python": {
-        "readme": "python/README.md",
-        "source": "python/src",
-        "suffixes": (".py",),
-        "patterns": gate.SDKS["Python"]["patterns"],
-    }
-}
-RB_SDK = {
-    "Ruby": {
-        "readme": "ruby/README.md",
-        "source": "ruby/lib",
-        "suffixes": (".rb",),
-        "patterns": gate.SDKS["Ruby"]["patterns"],
-    }
-}
-TS_SDK = {
-    "TypeScript": {
-        "readme": "typescript/README.md",
-        "source": "typescript/src",
-        "suffixes": (".ts",),
-        "patterns": gate.SDKS["TypeScript"]["patterns"],
-    }
-}
+# Reuse the real per-SDK specs verbatim, so the fixtures exercise the patterns
+# and comment style that actually ship rather than a copy that can drift.
+PY_SDK = {"Python": gate.SDKS["Python"]}
+RB_SDK = {"Ruby": gate.SDKS["Ruby"]}
+TS_SDK = {"TypeScript": gate.SDKS["TypeScript"]}
 
 TABLE = "| Variable | Description |\n|---|---|\n| `{var}` | thing |\n"
 
@@ -165,13 +146,74 @@ def main() -> int:
         check("commented-out read does not satisfy the table",
               run_gate(root, PY_SDK), ["forward:Python:BASECAMP_COMMENTED"])
 
+        # A whole JSDoc block, delimiters included — this is the shape that
+        # actually ships in typescript/src, and every BASECAMP_* there is inside
+        # one. A bare " * ..." fragment with no opening /* is not valid source
+        # and must not be what the fixture asserts on.
         root = tmp / "comments-ts"
         build(root, {
             "typescript/README.md": "no tables\n",
-            "typescript/src/c.ts": " *   accessToken: process.env.BASECAMP_TOKEN!,\n",
+            "typescript/src/c.ts": (
+                "/**\n * const client = createBasecampClient({\n"
+                " *   accessToken: process.env.BASECAMP_TOKEN!,\n * });\n */\n"
+                "export const x = 1;\n"
+            ),
         })
         check("jsdoc example is not a read (no-env claim survives)",
               run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), [])
+
+        # 5b. Interior lines of an unstarred block comment begin with ordinary
+        #     code characters, so a line-prefix test would count them.
+        root = tmp / "blockcomment"
+        build(root, {
+            "typescript/README.md": "no tables\n",
+            "typescript/src/c.ts": "/*\nprocess.env.BASECAMP_DOC\n*/\n",
+        })
+        check("unstarred block comment is not a read",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), [])
+
+        root = tmp / "docstring"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_DOCSTR"),
+            "python/src/c.py": 'def f():\n    """Example: os.environ.get("BASECAMP_DOCSTR")"""\n    return 1\n',
+        })
+        check("python docstring example is not a read",
+              run_gate(root, PY_SDK), ["forward:Python:BASECAMP_DOCSTR"])
+
+        # 5c. A `#` inside a string literal does not start a comment, so a read
+        #     later on the same line must still be seen.
+        root = tmp / "hashinstring"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_AFTERHASH"),
+            "python/src/c.py": 'u = "http://h/#frag"\nv = os.environ.get("BASECAMP_AFTERHASH")\n',
+        })
+        check("hash inside a string does not hide a later read",
+              run_gate(root, PY_SDK), [])
+
+        # 5d. Reads split across lines. A per-line scan misses these entirely,
+        #     which fails open on the reverse and no-env checks.
+        root = tmp / "multiline-py"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_MULTI"),
+            "python/src/c.py": 'v = os.getenv(\n    "BASECAMP_MULTI"\n)\n',
+        })
+        check("multiline python read is seen", run_gate(root, PY_SDK), [])
+
+        root = tmp / "multiline-rb"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_MULTI"),
+            "ruby/lib/c.rb": 'v = ENV.fetch(\n  "BASECAMP_MULTI", nil\n)\n',
+        })
+        check("multiline ruby read is seen", run_gate(root, RB_SDK), [])
+
+        root = tmp / "multiline-ts"
+        build(root, {
+            "typescript/README.md": "mentions BASECAMP_MULTI\n",
+            "typescript/src/c.ts": 'const v = process.env[\n  "BASECAMP_MULTI"\n];\n',
+        })
+        check("multiline typescript read breaks the no-env claim",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_MULTI"])
 
         # 6. The no-env claim breaks on a real read.
         root = tmp / "noenv"

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Self-test for check-readme-env-vars.py, driven by synthetic repos.
+
+The gate answers "does this SDK really read this variable?", and its failure
+mode is silent: if a read pattern misses, the gate does not error — it reports
+that nothing reads the variable, which reads as a README bug rather than a gate
+bug. Two such defects already shipped in this script (a commonMain-only Kotlin
+root that could not see jvmMain, and an absolute-path test filter that skipped
+the entire repo when the checkout sat under a directory named `Tests`), so the
+gate needs its own tests against inputs whose correct answer is known.
+
+Each case builds a throwaway tree, points the gate's module-level constants at
+it, and asserts on the failures returned.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+spec = importlib.util.spec_from_file_location("gate", HERE / "check-readme-env-vars.py")
+gate = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gate)
+
+FAILURES: list[str] = []
+
+
+def build(root: Path, files: dict[str, str]) -> None:
+    for rel, body in files.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+
+
+def run_gate(root: Path, sdks: dict, no_env_sdks: tuple = ()) -> list[str]:
+    """Run the gate against a synthetic repo, returning its failure list."""
+    old_repo, old_sdks, old_no_env = gate.REPO, gate.SDKS, gate.NO_ENV_SDKS
+    gate.REPO, gate.SDKS, gate.NO_ENV_SDKS = root, sdks, no_env_sdks
+    try:
+        failures: list[str] = []
+        # Re-implement main()'s collection by calling it and capturing stderr is
+        # brittle; instead drive the same helpers main() uses.
+        reads = {name: gate.real_reads(s) for name, s in sdks.items()}
+        for sdk, s in sdks.items():
+            readme = root / s["readme"]
+            if not readme.is_file():
+                continue
+            for lineno, cells in gate.table_rows(readme):
+                for var in gate.VAR_RE.findall(cells[0]):
+                    if var not in reads[sdk]:
+                        failures.append(f"forward:{sdk}:{var}")
+            text = readme.read_text(encoding="utf-8")
+            for var in sorted(reads[sdk]):
+                if var not in text:
+                    failures.append(f"reverse:{sdk}:{var}")
+        for sdk in no_env_sdks:
+            if reads.get(sdk):
+                failures.append(f"noenv:{sdk}:{sorted(reads[sdk])[0]}")
+        return failures
+    finally:
+        gate.REPO, gate.SDKS, gate.NO_ENV_SDKS = old_repo, old_sdks, old_no_env
+
+
+def check(name: str, actual, expected) -> None:
+    if actual == expected:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name}\n         expected: {expected}\n         actual:   {actual}")
+        FAILURES.append(name)
+
+
+PY_SDK = {
+    "Python": {
+        "readme": "python/README.md",
+        "source": "python/src",
+        "suffixes": (".py",),
+        "patterns": gate.SDKS["Python"]["patterns"],
+    }
+}
+RB_SDK = {
+    "Ruby": {
+        "readme": "ruby/README.md",
+        "source": "ruby/lib",
+        "suffixes": (".rb",),
+        "patterns": gate.SDKS["Ruby"]["patterns"],
+    }
+}
+TS_SDK = {
+    "TypeScript": {
+        "readme": "typescript/README.md",
+        "source": "typescript/src",
+        "suffixes": (".ts",),
+        "patterns": gate.SDKS["TypeScript"]["patterns"],
+    }
+}
+
+TABLE = "| Variable | Description |\n|---|---|\n| `{var}` | thing |\n"
+
+
+def main() -> int:
+    tmp = Path(tempfile.mkdtemp(prefix="check-readme-env-vars-test-"))
+    try:
+        # 1. Single-quoted reads count. A double-quote-only pattern would report
+        #    "no read exists" and the reverse check would pass in silence.
+        root = tmp / "quotes-py"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_SINGLE"),
+            "python/src/c.py": "v = os.environ.get('BASECAMP_SINGLE')\n",
+        })
+        check("python single-quoted read is seen", run_gate(root, PY_SDK), [])
+
+        root = tmp / "quotes-rb"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_SINGLE"),
+            "ruby/lib/c.rb": "v = ENV['BASECAMP_SINGLE']\n",
+        })
+        check("ruby single-quoted read is seen", run_gate(root, RB_SDK), [])
+
+        root = tmp / "quotes-ts"
+        build(root, {
+            "typescript/README.md": TABLE.format(var="BASECAMP_SINGLE"),
+            "typescript/src/c.ts": "const v = process.env['BASECAMP_SINGLE'];\n",
+        })
+        check("typescript single-quoted read is seen", run_gate(root, TS_SDK), [])
+
+        # 2. A mismatched quote pair is not a string literal and must not match.
+        root = tmp / "mismatched"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_BAD"),
+            "python/src/c.py": "v = os.environ.get(\"BASECAMP_BAD')\n",
+        })
+        check("mismatched quotes do not count as a read",
+              run_gate(root, PY_SDK), ["forward:Python:BASECAMP_BAD"])
+
+        # 3. A documented variable nothing reads — the phantom-row defect.
+        root = tmp / "phantom"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_PHANTOM"),
+            "python/src/c.py": "v = 1\n",
+        })
+        check("phantom table row is caught",
+              run_gate(root, PY_SDK), ["forward:Python:BASECAMP_PHANTOM"])
+
+        # 4. A read nobody documented — the reverse direction.
+        root = tmp / "undocumented"
+        build(root, {
+            "python/README.md": "no tables here\n",
+            "python/src/c.py": 'v = os.environ.get("BASECAMP_SECRET")\n',
+        })
+        check("undocumented read is caught",
+              run_gate(root, PY_SDK), ["reverse:Python:BASECAMP_SECRET"])
+
+        # 5. Doc-comment examples are not reads. This is what makes a plain
+        #    substring search useless for this job.
+        root = tmp / "comments"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_COMMENTED"),
+            "python/src/c.py": '# v = os.environ.get("BASECAMP_COMMENTED")\n',
+        })
+        check("commented-out read does not satisfy the table",
+              run_gate(root, PY_SDK), ["forward:Python:BASECAMP_COMMENTED"])
+
+        root = tmp / "comments-ts"
+        build(root, {
+            "typescript/README.md": "no tables\n",
+            "typescript/src/c.ts": " *   accessToken: process.env.BASECAMP_TOKEN!,\n",
+        })
+        check("jsdoc example is not a read (no-env claim survives)",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), [])
+
+        # 6. The no-env claim breaks on a real read.
+        root = tmp / "noenv"
+        build(root, {
+            "typescript/README.md": "mentions BASECAMP_REAL\n",
+            "typescript/src/c.ts": "const v = process.env.BASECAMP_REAL;\n",
+        })
+        check("real read breaks the no-env claim",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_REAL"])
+
+        # 7. Test code is excluded, including Kotlin/Swift source-set naming...
+        root = tmp / "testdirs"
+        build(root, {
+            "python/README.md": "no tables\n",
+            "python/src/tests/c.py": 'v = os.environ.get("BASECAMP_INTEST")\n',
+            "python/src/commonTest/c.py": 'v = os.environ.get("BASECAMP_INSET")\n',
+            "python/src/c_test.py": 'v = os.environ.get("BASECAMP_INFILE")\n',
+        })
+        check("test dirs and files are excluded", run_gate(root, PY_SDK), [])
+
+        # ...but a nested non-test directory under the source root is not.
+        root = tmp / "nested"
+        build(root, {
+            "python/README.md": "no tables\n",
+            "python/src/basecamp/deep/c.py": 'v = os.environ.get("BASECAMP_DEEP")\n',
+        })
+        check("nested real source is scanned",
+              run_gate(root, PY_SDK), ["reverse:Python:BASECAMP_DEEP"])
+
+        # 8. The repo living under a directory named `Tests` must not disable
+        #    the whole gate (the absolute-path bug).
+        root = tmp / "Tests" / "checkout"
+        build(root, {
+            "python/README.md": "no tables\n",
+            "python/src/c.py": 'v = os.environ.get("BASECAMP_UNDER_TESTS")\n',
+        })
+        check("checkout under a Tests/ parent still scans",
+              run_gate(root, PY_SDK), ["reverse:Python:BASECAMP_UNDER_TESTS"])
+
+        # 9. Out-of-family variables are ignored; the gate only polices
+        #    BASECAMP_*/XDG_*, not every env var an SDK might touch.
+        root = tmp / "outoffamily"
+        build(root, {
+            "python/README.md": "no tables\n",
+            "python/src/c.py": 'v = os.environ.get("HTTP_PROXY")\n',
+        })
+        check("unrelated env vars are ignored", run_gate(root, PY_SDK), [])
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    if FAILURES:
+        print(f"\n{len(FAILURES)} self-test failure(s): {', '.join(FAILURES)}", file=sys.stderr)
+        return 1
+    print("\ncheck-readme-env-vars self-test passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -348,6 +348,45 @@ def main() -> int:
         })
         check("a symbol subject is not an SDK attribution", run_gate(root, PY_SDK), [])
 
+        # The literal sentence this gate was built to catch: compound subject,
+        # verb "use" rather than "reads", and the variables *before* the subject
+        # in a trailing relative clause. Ruby has never read XDG_CACHE_HOME.
+        root = tmp / "prose-original-defect"
+        build(root, {
+            "ruby/README.md": (
+                "What the SDKs read on their own (the XDG directory variables aside: "
+                "`XDG_CACHE_HOME` / `XDG_CONFIG_HOME`, which Ruby uses to site its "
+                "cache and config directories):\n"
+            ),
+            "ruby/lib/c.rb": 'd = ENV["XDG_CONFIG_HOME"]\n',
+        })
+        check("the original 'uses' + variables-first sentence is caught",
+              run_gate(root, RB_SDK), ["prose:Ruby:XDG_CACHE_HOME"])
+
+        # A compound subject is checked against every SDK it names, not just the
+        # first — Ruby is the false half here.
+        root = tmp / "prose-compound"
+        build(root, {
+            "python/README.md": "`BASECAMP_BOTH`, which Python and Ruby use, matters.\n",
+            "python/src/c.py": 'v = os.environ.get("BASECAMP_BOTH")\n',
+            "ruby/README.md": "mentions BASECAMP_BOTH\n",
+            "ruby/lib/c.rb": "v = 1\n",
+        })
+        check("a compound subject is checked against each SDK named",
+              run_gate(root, PY_RB), ["prose:Ruby:BASECAMP_BOTH"])
+
+        # The backward pass must not reach across a sentence boundary into the
+        # previous claim's variables.
+        root = tmp / "prose-backward-bounded"
+        build(root, {
+            "python/README.md": "Python reads `BASECAMP_MINE`. Ruby uses a config file.\n",
+            "python/src/c.py": 'v = os.environ.get("BASECAMP_MINE")\n',
+            "ruby/README.md": "no tables\n",
+            "ruby/lib/c.rb": "v = 1\n",
+        })
+        check("the backward pass stops at the sentence boundary",
+              run_gate(root, PY_RB), [])
+
         # Fenced examples are not claims.
         root = tmp / "prose-fenced"
         build(root, {

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -147,6 +147,35 @@ def main() -> int:
               run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
               ["noenv:TypeScript:BASECAMP_OPTB"])
 
+        # Destructuring is a read, and every name in the pattern is one.
+        root = tmp / "destructured"
+        build(root, {
+            "typescript/README.md": "mentions BASECAMP_DA and BASECAMP_DB\n",
+            "typescript/src/c.ts": "const { BASECAMP_DA, BASECAMP_DB } = process.env;\n",
+        })
+        check("destructured reads are seen, all of them",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_DA"])
+
+        # ...but destructuring something else is not an environment read.
+        root = tmp / "destructured-other"
+        build(root, {
+            "typescript/README.md": TABLE.format(var="BASECAMP_NOTENV"),
+            "typescript/src/c.ts": "const { BASECAMP_NOTENV } = someOtherObject;\n",
+        })
+        check("destructuring a non-env object is not a read",
+              run_gate(root, TS_SDK), ["forward:TypeScript:BASECAMP_NOTENV"])
+
+        # An escaped backslash is not Swift's interpolation marker.
+        root = tmp / "swift-escaped-interp"
+        build(root, {
+            "swift/README.md": "no tables\n",
+            "swift/Sources/c.swift":
+                'let s = """\n\\\\(ProcessInfo.processInfo.environment["BASECAMP_FAKE"])\n"""\n',
+        })
+        check("an escaped backslash is not a swift interpolation",
+              run_gate(root, SW_SDK, no_env_sdks=("Swift",)), [])
+
         # A Ruby quoted literal may span physical lines. Ending it at the newline
         # left the rest of the string executable.
         root = tmp / "ruby-multiline-literal"

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -63,6 +63,11 @@ def run_gate(root: Path, sdks: dict, no_env_sdks: tuple = (),
                 for var in named:
                     if var not in reads.get(claimed_sdk, {}):
                         failures.append(f"prose:{claimed_sdk}:{var}")
+        # Invariant 2, in the order main() reports it: a row must name an SDK,
+        # every SDK it names must really read the variable, and every SDK that
+        # really reads it must be named. Reproducing only the last of the three
+        # left the first two with no coverage at all -- and the root table is
+        # what the READMEs get wrong most often.
         if check_root_table:
             root_readme = root / gate.ROOT_README
             if root_readme.is_file():
@@ -70,8 +75,15 @@ def run_gate(root: Path, sdks: dict, no_env_sdks: tuple = (),
                     if len(cells) < 2:
                         continue
                     row_vars = gate.VAR_RE.findall(cells[0])
+                    if not row_vars:
+                        continue
                     claimed = [s for s in sdks if gate.re.search(rf"\b{s}\b", cells[1])]
+                    if not claimed:
+                        failures.append(f"rootnosdk:{','.join(row_vars)}")
                     for var in row_vars:
+                        for s in claimed:
+                            if var not in reads[s]:
+                                failures.append(f"rootcredits:{s}:{var}")
                         for s in sdks:
                             if var in reads[s] and s not in claimed:
                                 failures.append(f"rootomits:{s}:{var}")
@@ -262,6 +274,36 @@ def main() -> int:
               run_gate(root, PY_RB, check_root_table=True),
               ["rootomits:Python:BASECAMP_SHARED"])
 
+        # ...and the forward direction of the same invariant: a 'Read by' column
+        # may not credit an SDK that does not read the variable. This is the
+        # half the root table gets wrong in practice -- it is how Ruby came to be
+        # credited with XDG_CACHE_HOME -- so it needs its own case.
+        root = tmp / "root-credits-nonreader"
+        build(root, {
+            "README.md":
+                "| Variable | Read by |\n|---|---|\n| `BASECAMP_PHANTOM` | Python, Ruby |\n",
+            "python/README.md": "The SDK reads `BASECAMP_PHANTOM` from the environment.\n",
+            "python/src/c.py": 'v = os.environ.get("BASECAMP_PHANTOM")\n',
+            "ruby/README.md": "no table here\n",
+            "ruby/lib/c.rb": "v = 1\n",
+        })
+        check("the root table may not credit a non-reader",
+              run_gate(root, PY_RB, check_root_table=True),
+              ["rootcredits:Ruby:BASECAMP_PHANTOM"])
+
+        # A row that names no SDK at all is the same defect wearing a disguise:
+        # nothing to check against, so every other invariant passes it.
+        root = tmp / "root-names-no-sdk"
+        build(root, {
+            "README.md":
+                "| Variable | Read by |\n|---|---|\n| `BASECAMP_ORPHAN` | the CLI |\n",
+            "python/README.md": "The SDK reads `BASECAMP_ORPHAN` from the environment.\n",
+            "python/src/c.py": 'v = os.environ.get("BASECAMP_ORPHAN")\n',
+        })
+        check("a root row must name at least one SDK",
+              run_gate(root, PY_SDK, check_root_table=True),
+              ["rootnosdk:BASECAMP_ORPHAN", "rootomits:Python:BASECAMP_ORPHAN"])
+
         # Ruby percent literals are data.
         root = tmp / "ruby-percent"
         build(root, {
@@ -325,6 +367,16 @@ def main() -> int:
         check("an escaped ruby interpolation marker is not a read",
               run_gate(root, RB_SDK), ["forward:Ruby:BASECAMP_ESC"])
 
+        # ...and the same escape inside a regex literal, which reaches
+        # brace_holes by a different path in strip_noncode.
+        root = tmp / "ruby-regex-escaped-interp"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_RESC"),
+            "ruby/lib/c.rb": "r = /\\#{ENV['BASECAMP_RESC']}/\n",
+        })
+        check("an escaped marker in a ruby regex is not a read",
+              run_gate(root, RB_SDK), ["forward:Ruby:BASECAMP_RESC"])
+
         root = tmp / "ruby-regex-data"
         build(root, {
             "ruby/README.md": TABLE.format(var="BASECAMP_RXD"),
@@ -332,6 +384,58 @@ def main() -> int:
         })
         check("ruby regex contents are not a read",
               run_gate(root, RB_SDK), ["forward:Ruby:BASECAMP_RXD"])
+
+        # Ruby calls may omit their parentheses, so the argument to `puts` is a
+        # regex even though the preceding token is an identifier. Reading it as
+        # division hands the regex body to the read patterns as code.
+        root = tmp / "ruby-command-regex"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_FAKE"),
+            "ruby/lib/c.rb": "puts /ENV['BASECAMP_FAKE']/\n",
+        })
+        check("a regex argument to a parenthesis-less call is not a read",
+              run_gate(root, RB_SDK), ["forward:Ruby:BASECAMP_FAKE"])
+
+        # The inverse costs more than a phantom row: misread as division, the
+        # `#` opens a line comment and a genuine interpolated read vanishes.
+        root = tmp / "ruby-command-regex-interp"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_CMDI"),
+            "ruby/lib/c.rb": "puts /#{ENV['BASECAMP_CMDI']}/\n",
+        })
+        check("an interpolated read in a command-form regex is still a read",
+              run_gate(root, RB_SDK), [])
+
+        # Spacing is what tells the two apart, so symmetric spacing stays
+        # division: `a / b / c` must not swallow the read that follows it.
+        root = tmp / "ruby-spaced-division"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_DIV"),
+            "ruby/lib/c.rb": "n = total / count / 2\nv = ENV['BASECAMP_DIV']\n",
+        })
+        check("a spaced ruby division is not a command-form regex",
+              run_gate(root, RB_SDK), [])
+
+        # ...and so does divide-and-assign, whose `=` follows the slash.
+        root = tmp / "ruby-divide-assign"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_DIVA"),
+            "ruby/lib/c.rb": "n /= 2\nv = ENV['BASECAMP_DIVA']\n",
+        })
+        check("ruby divide-and-assign is not a command-form regex",
+              run_gate(root, RB_SDK), [])
+
+        # The rule is Ruby's, not a general one: TypeScript has no
+        # parenthesis-less call, so the same spelling there is arithmetic.
+        root = tmp / "ts-not-command-regex"
+        build(root, {
+            "typescript/README.md": "mentions BASECAMP_TSDIV\n",
+            "typescript/src/c.ts":
+                "const n = total /count/ 2;\nconst v = process.env.BASECAMP_TSDIV;\n",
+        })
+        check("typescript keeps the division reading",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_TSDIV"])
 
         # ...and `%` as modulo must not start one.
         root = tmp / "ruby-modulo"

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -85,6 +85,7 @@ RB_SDK = {"Ruby": gate.SDKS["Ruby"]}
 TS_SDK = {"TypeScript": gate.SDKS["TypeScript"]}
 PY_RB = {"Python": gate.SDKS["Python"], "Ruby": gate.SDKS["Ruby"]}
 SW_SDK = {"Swift": gate.SDKS["Swift"]}
+KT_SDK = {"Kotlin": gate.SDKS["Kotlin"]}
 
 TABLE = "| Variable | Description |\n|---|---|\n| `{var}` | thing |\n"
 
@@ -289,6 +290,75 @@ def main() -> int:
         })
         check("a swift \\() interpolation is a read",
               run_gate(root, SW_SDK, no_env_sdks=("Swift",)), ["noenv:Swift:BASECAMP_SW"])
+
+        # 5b-iv. Language-specific lexical forms. Each of these was a real miss:
+        #     the scanner is driven by per-SDK flags, not by comment style alone.
+        root = tmp / "kotlin-multiline"
+        build(root, {
+            "kotlin/README.md": "no tables\n",
+            "kotlin/sdk/src/c.kt":
+                'val s = """\n    System.getenv("BASECAMP_FAKE")\n    """.trimIndent()\n',
+        })
+        check("kotlin multiline string body is not a read",
+              run_gate(root, KT_SDK, no_env_sdks=("Kotlin",)), [])
+
+        # ...but an interpolation inside that multiline string still is.
+        root = tmp / "kotlin-multiline-interp"
+        build(root, {
+            "kotlin/README.md": "mentions BASECAMP_REAL\n",
+            "kotlin/sdk/src/c.kt": 'val s = """\ntok=${System.getenv("BASECAMP_REAL")}\n"""\n',
+        })
+        check("kotlin multiline interpolation is a read",
+              run_gate(root, KT_SDK, no_env_sdks=("Kotlin",)),
+              ["noenv:Kotlin:BASECAMP_REAL"])
+
+        root = tmp / "swift-multiline"
+        build(root, {
+            "swift/README.md": "no tables\n",
+            "swift/Sources/c.swift":
+                'let s = """\nProcessInfo.processInfo.environment["BASECAMP_FAKE"]\n"""\n',
+        })
+        check("swift multiline string body is not a read",
+              run_gate(root, SW_SDK, no_env_sdks=("Swift",)), [])
+
+        root = tmp / "swift-raw"
+        build(root, {
+            "swift/README.md": "mentions BASECAMP_RAW\n",
+            "swift/Sources/c.swift":
+                'let t = #"\\#(ProcessInfo.processInfo.environment["BASECAMP_RAW"]!)"#\n',
+        })
+        check("swift raw-string interpolation is a read",
+              run_gate(root, SW_SDK, no_env_sdks=("Swift",)),
+              ["noenv:Swift:BASECAMP_RAW"])
+
+        root = tmp / "brace-in-nested-literal"
+        build(root, {
+            "typescript/README.md": "mentions BASECAMP_SECRET\n",
+            "typescript/src/c.ts": 'const x = `${foo("}", process.env.BASECAMP_SECRET)}`;\n',
+        })
+        check("a quoted brace does not truncate the interpolation",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_SECRET"])
+
+        root = tmp / "swift-nested-comment"
+        build(root, {
+            "swift/README.md": "no tables\n",
+            "swift/Sources/c.swift":
+                '/* outer /* inner */ ProcessInfo.processInfo.environment["BASECAMP_DOC"] */\n',
+        })
+        check("swift nested block comment stays a comment",
+              run_gate(root, SW_SDK, no_env_sdks=("Swift",)), [])
+
+        # ...while TypeScript does *not* nest, so code after the inner `*/` is
+        # code. Nesting it everywhere would have swallowed a real read.
+        root = tmp / "ts-unnested-comment"
+        build(root, {
+            "typescript/README.md": "mentions BASECAMP_AFTER\n",
+            "typescript/src/c.ts": '/* outer /* inner */ const v = process.env.BASECAMP_AFTER;\n',
+        })
+        check("typescript block comments do not nest",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_AFTER"])
 
         # 5c. A `#` inside a string literal does not start a comment, so a read
         #     later on the same line must still be seen.

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -353,6 +353,37 @@ def main() -> int:
               run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
               ["noenv:TypeScript:BASECAMP_SECRET"])
 
+        # A comment inside an interpolation is not code. The hole is un-masked
+        # wholesale, so without blanking it the example text counts as a read.
+        root = tmp / "comment-inside-hole"
+        build(root, {
+            "typescript/README.md": "no tables\n",
+            "typescript/src/c.ts":
+                'const x = `${foo(/* process.env.BASECAMP_FAKE */ 1)}`;\n',
+        })
+        check("a comment inside an interpolation is not a read",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), [])
+
+        root = tmp / "comment-inside-hole-rb"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_FAKE"),
+            "ruby/lib/c.rb": 'v = "#{foo( # ENV[\'BASECAMP_FAKE\']\n 1)}"\n',
+        })
+        check("a ruby comment inside an interpolation is not a read",
+              run_gate(root, RB_SDK), ["forward:Ruby:BASECAMP_FAKE"])
+
+        # A Swift raw string is a valid dictionary key, so the read pattern has
+        # to accept the fences the lexer already understands.
+        root = tmp / "swift-raw-key"
+        build(root, {
+            "swift/README.md": "mentions BASECAMP_RAWKEY\n",
+            "swift/Sources/c.swift":
+                'let v = ProcessInfo.processInfo.environment[#"BASECAMP_RAWKEY"#]\n',
+        })
+        check("a swift raw-string environment key is a read",
+              run_gate(root, SW_SDK, no_env_sdks=("Swift",)),
+              ["noenv:Swift:BASECAMP_RAWKEY"])
+
         # Interpolation is per language *and* per quote: TypeScript interpolates
         # in backticks only, so this is ordinary text and not a read.
         root = tmp / "ts-dq-not-interp"

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -261,6 +261,26 @@ def main() -> int:
         check("braces without an f prefix are not a read",
               run_gate(root, PY_SDK), ["forward:Python:BASECAMP_NOTF"])
 
+        # A triple-quoted f-string is not documentation — its braces execute.
+        # Blanking every triple-quoted literal outright hid the read entirely.
+        root = tmp / "interp-py-triple"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_TRIPLE"),
+            "python/src/c.py": 'X = f"""token={os.getenv(\'BASECAMP_TRIPLE\')}"""\n',
+        })
+        check("a triple-quoted f-string interpolation is a read",
+              run_gate(root, PY_SDK), [])
+
+        # A literal *inside* an interpolation is data again, so un-masking the
+        # hole wholesale wrongly promoted example text to a read.
+        root = tmp / "interp-nested-literal"
+        build(root, {
+            "typescript/README.md": "no tables\n",
+            "typescript/src/c.ts": 'const x = `${"process.env.BASECAMP_FAKE"}`;\n',
+        })
+        check("a literal nested in an interpolation is not a read",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), [])
+
         root = tmp / "interp-swift"
         build(root, {
             "swift/README.md": "mentions BASECAMP_SW\n",

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -178,6 +178,35 @@ def main() -> int:
               run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
               ["noenv:TypeScript:BASECAMP_DIV"])
 
+        # A keyword ends in a letter, which otherwise reads as an identifier and
+        # therefore as division.
+        root = tmp / "regex-after-keyword"
+        build(root, {
+            "typescript/README.md": TABLE.format(var="BASECAMP_FAKE"),
+            "typescript/src/c.ts":
+                "function f() { return /process.env.BASECAMP_FAKE/; }\n",
+        })
+        check("a regex after a keyword is still a regex",
+              run_gate(root, TS_SDK), ["forward:TypeScript:BASECAMP_FAKE"])
+
+        # An escaped delimiter does not close a triple-quoted literal.
+        root = tmp / "escaped-triple"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_FAKE"),
+            "python/src/c.py": 'X = """a \\""" os.getenv(\'BASECAMP_FAKE\') b"""\n',
+        })
+        check("an escaped triple quote does not end the literal",
+              run_gate(root, PY_SDK), ["forward:Python:BASECAMP_FAKE"])
+
+        # Go backticks are raw: a trailing backslash does not escape the closing
+        # delimiter, so the literal ends and the code after it is scanned.
+        root = tmp / "go-backtick-raw"
+        build(root, {
+            "go/README.md": TABLE.format(var="BASECAMP_GO"),
+            "go/pkg/c.go": 's := `raw\\`\nv := os.Getenv("BASECAMP_GO")\n',
+        })
+        check("a go backtick literal is raw", run_gate(root, GO_SDK), [])
+
         # In a raw f-string the backslash is literal, so it must not eat the
         # brace that opens the expression.
         root = tmp / "raw-fstring"

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -147,6 +147,46 @@ def main() -> int:
               run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
               ["noenv:TypeScript:BASECAMP_OPTB"])
 
+        # A regex literal is data. Its braces must not close an interpolation,
+        # and its contents must not read as calls.
+        root = tmp / "regex-in-hole"
+        build(root, {
+            "typescript/README.md": "mentions BASECAMP_SECRET\n",
+            "typescript/src/c.ts":
+                'const x = `${(/}/, process.env.BASECAMP_SECRET)}`;\n',
+        })
+        check("a regex brace does not truncate the interpolation",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_SECRET"])
+
+        root = tmp / "regex-content"
+        build(root, {
+            "typescript/README.md": TABLE.format(var="BASECAMP_FAKE"),
+            "typescript/src/c.ts": "const re = /process.env.BASECAMP_FAKE/;\n",
+        })
+        check("regex contents are not a read",
+              run_gate(root, TS_SDK), ["forward:TypeScript:BASECAMP_FAKE"])
+
+        # ...but `/` after a value is division, not a regex. Getting this wrong
+        # would swallow code up to the next slash and hide the read.
+        root = tmp / "division-not-regex"
+        build(root, {
+            "typescript/README.md": "mentions BASECAMP_DIV\n",
+            "typescript/src/c.ts": "const r = total / process.env.BASECAMP_DIV;\n",
+        })
+        check("a division slash is not a regex",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_DIV"])
+
+        # In a raw f-string the backslash is literal, so it must not eat the
+        # brace that opens the expression.
+        root = tmp / "raw-fstring"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_RAWF"),
+            "python/src/c.py": 'v = fr"\\{os.getenv(\'BASECAMP_RAWF\')}"\n',
+        })
+        check("a raw f-string interpolation is a read", run_gate(root, PY_SDK), [])
+
         # Destructuring is a read, and every name in the pattern is one.
         root = tmp / "destructured"
         build(root, {

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -279,6 +279,49 @@ def main() -> int:
         })
         check("a %Q interpolation is a read", run_gate(root, RB_SDK), [])
 
+        # A quote inside a percent literal is data. Delegating the delimiter walk
+        # to the language-aware matcher let it open a phantom string and run past
+        # the close, masking the read after it.
+        root = tmp / "ruby-percent-quote"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_AFTERQ"),
+            "ruby/lib/c.rb": 's = %q{"}\nv = ENV["BASECAMP_AFTERQ"]\n',
+        })
+        check("a quote inside a percent literal is data", run_gate(root, RB_SDK), [])
+
+        # The delimiter can be any non-alphanumeric character, not just a bracket.
+        root = tmp / "ruby-percent-bang"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_FAKE"),
+            "ruby/lib/c.rb": "s = %q!ENV['BASECAMP_FAKE']!\n",
+        })
+        check("an unpaired percent delimiter still delimits",
+              run_gate(root, RB_SDK), ["forward:Ruby:BASECAMP_FAKE"])
+
+        # %x is a command literal: lowercase, but it interpolates.
+        root = tmp / "ruby-percent-x"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_XCMD"),
+            "ruby/lib/c.rb": 's = %x{echo #{ENV["BASECAMP_XCMD"]}}\n',
+        })
+        check("a %x command literal interpolates", run_gate(root, RB_SDK), [])
+
+        # Ruby regexes interpolate, and the `#` must not open a comment.
+        root = tmp / "ruby-regex-interp"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_RXI"),
+            "ruby/lib/c.rb": 'r = /#{ENV["BASECAMP_RXI"]}/\n',
+        })
+        check("a ruby regex interpolation is a read", run_gate(root, RB_SDK), [])
+
+        root = tmp / "ruby-regex-data"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_RXD"),
+            "ruby/lib/c.rb": "r = /ENV['BASECAMP_RXD']/\n",
+        })
+        check("ruby regex contents are not a read",
+              run_gate(root, RB_SDK), ["forward:Ruby:BASECAMP_RXD"])
+
         # ...and `%` as modulo must not start one.
         root = tmp / "ruby-modulo"
         build(root, {

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -127,6 +127,45 @@ def main() -> int:
         })
         check("typescript single-quoted read is seen", run_gate(root, TS_SDK), [])
 
+        # Optional chaining is valid TypeScript and a real read; both spellings
+        # were invisible to patterns that demanded the dot or bracket directly.
+        root = tmp / "optional-chaining"
+        build(root, {
+            "typescript/README.md": "mentions BASECAMP_OPT\n",
+            "typescript/src/c.ts": "const v = process.env?.BASECAMP_OPT;\n",
+        })
+        check("typescript optional-chained read is seen",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_OPT"])
+
+        root = tmp / "optional-chaining-bracket"
+        build(root, {
+            "typescript/README.md": "mentions BASECAMP_OPTB\n",
+            "typescript/src/c.ts": 'const v = process.env?.["BASECAMP_OPTB"];\n',
+        })
+        check("typescript optional-chained bracket read is seen",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)),
+              ["noenv:TypeScript:BASECAMP_OPTB"])
+
+        # A Ruby quoted literal may span physical lines. Ending it at the newline
+        # left the rest of the string executable.
+        root = tmp / "ruby-multiline-literal"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_FAKE"),
+            "ruby/lib/c.rb": 's = "line one\nENV[\'BASECAMP_FAKE\']\nline three"\n',
+        })
+        check("a ruby literal spanning lines is not a read",
+              run_gate(root, RB_SDK), ["forward:Ruby:BASECAMP_FAKE"])
+
+        # ...and code after it is still code.
+        root = tmp / "ruby-multiline-then-read"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_REAL"),
+            "ruby/lib/c.rb": 's = "a\nb"\nv = ENV[\'BASECAMP_REAL\']\n',
+        })
+        check("a read after a multiline literal still counts",
+              run_gate(root, RB_SDK), [])
+
         # 2. A mismatched quote pair is not a string literal and must not match.
         root = tmp / "mismatched"
         build(root, {

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -108,6 +108,16 @@ def main() -> int:
         })
         check("ruby single-quoted read is seen", run_gate(root, RB_SDK), [])
 
+        # Ruby parentheses are optional, so `ENV.fetch "FOO", nil` is a real read
+        # that a `(`-only pattern reports as nonexistent.
+        root = tmp / "ruby-no-parens"
+        build(root, {
+            "ruby/README.md": TABLE.format(var="BASECAMP_NOPAREN"),
+            "ruby/lib/c.rb": 'v = ENV.fetch "BASECAMP_NOPAREN", nil\n',
+        })
+        check("ruby ENV.fetch without parentheses is seen",
+              run_gate(root, RB_SDK), [])
+
         root = tmp / "quotes-ts"
         build(root, {
             "typescript/README.md": TABLE.format(var="BASECAMP_SINGLE"),
@@ -431,6 +441,34 @@ def main() -> int:
         })
         check("the backward pass stops at the sentence boundary",
               run_gate(root, PY_RB), [])
+
+        # Markdown reflows, so an attribution can wrap mid-sentence. A per-line
+        # scan finds no claim at all and invariant 5 silently stops enforcing it.
+        root = tmp / "prose-wrapped"
+        build(root, {
+            "python/README.md": "Python reads\n`BASECAMP_WRAPPED` on request.\n",
+            "python/src/c.py": "v = 1\n",
+        })
+        check("a claim wrapped across lines is still checked",
+              run_gate(root, PY_SDK), ["prose:Python:BASECAMP_WRAPPED"])
+
+        # The variables-first form has to survive wrapping too.
+        root = tmp / "prose-wrapped-backward"
+        build(root, {
+            "ruby/README.md": "`XDG_CACHE_HOME`, which\nRuby uses to site its cache.\n",
+            "ruby/lib/c.rb": "v = 1\n",
+        })
+        check("a wrapped variables-first claim is still checked",
+              run_gate(root, RB_SDK), ["prose:Ruby:XDG_CACHE_HOME"])
+
+        # A blank line still separates paragraphs, so an unrelated later
+        # paragraph cannot lend its variables to an earlier claim.
+        root = tmp / "prose-paragraph-break"
+        build(root, {
+            "python/README.md": "Python reads nothing here.\n\n`BASECAMP_ELSEWHERE` is unrelated.\n",
+            "python/src/c.py": "v = 1\n",
+        })
+        check("a blank line ends the paragraph", run_gate(root, PY_SDK), [])
 
         # Fenced examples are not claims.
         root = tmp / "prose-fenced"

--- a/scripts/test-check-readme-env-vars.py
+++ b/scripts/test-check-readme-env-vars.py
@@ -58,6 +58,10 @@ def run_gate(root: Path, sdks: dict, no_env_sdks: tuple = ()) -> list[str]:
             for var in sorted(reads[sdk]):
                 if var not in text:
                     failures.append(f"reverse:{sdk}:{var}")
+            for _, claimed_sdk, named in gate.prose_claims(readme):
+                for var in named:
+                    if var not in reads.get(claimed_sdk, {}):
+                        failures.append(f"prose:{claimed_sdk}:{var}")
         for sdk in no_env_sdks:
             if reads.get(sdk):
                 failures.append(f"noenv:{sdk}:{sorted(reads[sdk])[0]}")
@@ -79,6 +83,7 @@ def check(name: str, actual, expected) -> None:
 PY_SDK = {"Python": gate.SDKS["Python"]}
 RB_SDK = {"Ruby": gate.SDKS["Ruby"]}
 TS_SDK = {"TypeScript": gate.SDKS["TypeScript"]}
+PY_RB = {"Python": gate.SDKS["Python"], "Ruby": gate.SDKS["Ruby"]}
 
 TABLE = "| Variable | Description |\n|---|---|\n| `{var}` | thing |\n"
 
@@ -180,6 +185,36 @@ def main() -> int:
         check("python docstring example is not a read",
               run_gate(root, PY_SDK), ["forward:Python:BASECAMP_DOCSTR"])
 
+        # 5b-ii. Example text inside an ordinary string is data, not a call.
+        root = tmp / "stringliteral-ts"
+        build(root, {
+            "typescript/README.md": "no tables\n",
+            "typescript/src/c.ts": 'const hint = "process.env.BASECAMP_FAKE";\n',
+        })
+        check("env syntax inside a string is not a read",
+              run_gate(root, TS_SDK, no_env_sdks=("TypeScript",)), [])
+
+        root = tmp / "stringliteral-py"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_FAKE"),
+            "python/src/c.py": 'HINT = \'os.environ.get("BASECAMP_FAKE")\'\n',
+        })
+        check("env call quoted inside a string is not a read",
+              run_gate(root, PY_SDK), ["forward:Python:BASECAMP_FAKE"])
+
+        # ...while the real call on the very next line still registers, so the
+        # mask rejects only the literal and not the file.
+        root = tmp / "stringliteral-mixed"
+        build(root, {
+            "python/README.md": TABLE.format(var="BASECAMP_REALONE"),
+            "python/src/c.py": (
+                'HINT = "process.env.BASECAMP_FAKE"\n'
+                'v = os.environ.get("BASECAMP_REALONE")\n'
+            ),
+        })
+        check("a real read beside a string example still counts",
+              run_gate(root, PY_SDK), [])
+
         # 5c. A `#` inside a string literal does not start a comment, so a read
         #     later on the same line must still be seen.
         root = tmp / "hashinstring"
@@ -253,6 +288,73 @@ def main() -> int:
         })
         check("checkout under a Tests/ parent still scans",
               run_gate(root, PY_SDK), ["reverse:Python:BASECAMP_UNDER_TESTS"])
+
+        # 8b. Prose attribution (invariant 5). The tables were never where the
+        #     original XDG bug lived — it was a sentence — so a true sentence
+        #     must pass and a false one must fail.
+        root = tmp / "prose-true"
+        build(root, {
+            "python/README.md": "Python reads `BASECAMP_REALPROSE` on request.\n",
+            "python/src/c.py": 'v = os.environ.get("BASECAMP_REALPROSE")\n',
+        })
+        check("true prose attribution passes", run_gate(root, PY_SDK), [])
+
+        root = tmp / "prose-false"
+        build(root, {
+            "python/README.md": "Python reads `BASECAMP_PROSEPHANTOM` on request.\n",
+            "python/src/c.py": "v = 1\n",
+        })
+        check("false prose attribution is caught",
+              run_gate(root, PY_SDK), ["prose:Python:BASECAMP_PROSEPHANTOM"])
+
+        # Two claims on one line must split at the second SDK, not pool their
+        # variables — this is the shape the root README actually ships.
+        root = tmp / "prose-split-ok"
+        build(root, {
+            "python/README.md": "Python reads `BASECAMP_ONE` and Ruby reads `BASECAMP_TWO` here.\n",
+            "python/src/c.py": 'v = os.environ.get("BASECAMP_ONE")\n',
+            "ruby/README.md": "mentions BASECAMP_TWO\n",
+            "ruby/lib/c.rb": 'v = ENV["BASECAMP_TWO"]\n',
+        })
+        check("a two-SDK sentence attributes each variable to its own SDK",
+              run_gate(root, PY_RB), [])
+
+        # ...and the second clause is really checked, not merely parsed.
+        root = tmp / "prose-split-bad"
+        build(root, {
+            "python/README.md": "Python reads `BASECAMP_ONE` and Ruby reads `BASECAMP_TWO` here.\n",
+            "python/src/c.py": 'v = os.environ.get("BASECAMP_ONE")\n',
+            "ruby/README.md": "mentions BASECAMP_TWO\n",
+            "ruby/lib/c.rb": "v = 1\n",
+        })
+        check("a false second clause is caught",
+              run_gate(root, PY_RB), ["prose:Ruby:BASECAMP_TWO"])
+
+        # The passive voice names a symbol, not an SDK, and must not fire —
+        # go/README.md ships exactly this sentence.
+        root = tmp / "prose-passive"
+        build(root, {
+            "python/README.md": "`BASECAMP_PASSIVE` is read by `AuthManager.AccessToken`.\n",
+            "python/src/c.py": "v = 1\n",
+        })
+        check("passive voice is not an SDK attribution", run_gate(root, PY_SDK), [])
+
+        # Likewise a symbol subject: python/README.md says "a plain `Config()`
+        # reads no environment at all".
+        root = tmp / "prose-symbol-subject"
+        build(root, {
+            "python/README.md": "A plain `Config()` reads no environment; `BASECAMP_NOPE` is inert.\n",
+            "python/src/c.py": "v = 1\n",
+        })
+        check("a symbol subject is not an SDK attribution", run_gate(root, PY_SDK), [])
+
+        # Fenced examples are not claims.
+        root = tmp / "prose-fenced"
+        build(root, {
+            "python/README.md": "intro\n\n```\nPython reads `BASECAMP_INFENCE`\n```\n",
+            "python/src/c.py": "v = 1\n",
+        })
+        check("a fenced example is not a prose claim", run_gate(root, PY_SDK), [])
 
         # 9. Out-of-family variables are ignored; the gate only polices
         #    BASECAMP_*/XDG_*, not every env var an SDK might touch.

--- a/swift/README.md
+++ b/swift/README.md
@@ -55,9 +55,9 @@ Every Basecamp API request carries an OAuth 2.0 access token. There is no API ke
 |---|---|---|
 | already holds a token you obtained elsewhere | **static token** — `BasecampClient(accessToken:)` | you do |
 | can receive a browser redirect (app with `ASWebAuthenticationSession`, or a local callback server) | **authorization code + PKCE** | your code |
-| has no browser at all (daemon, CI job) | **device flow** ([RFC 8628](https://www.rfc-editor.org/rfc/rfc8628)) | your code |
+| has no browser, but a person can approve on another device (CLI, headless server, TV) | **device flow** ([RFC 8628](https://www.rfc-editor.org/rfc/rfc8628)) | your code |
 
-The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+The one-line rule: **a redirect URI you control → authorization code; no browser but someone to approve → device flow; a token already in hand → static token.** An unattended daemon or CI job fits none of the three on its own — the device flow needs a person to enter the user code at the verification URI — so provision a token out of band and hand it to the process as a static or refresh token.
 
 2. Get the client credentials that grant needs:
 

--- a/swift/README.md
+++ b/swift/README.md
@@ -49,8 +49,7 @@ targets: [
 
 Every Basecamp API request carries an OAuth 2.0 access token. There is no API key and no personal access token, so even a throwaway script starts here:
 
-1. Register your integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
-2. Choose the grant that matches how your code runs:
+1. Choose the grant that matches how your code runs:
 
 | Your integration | Grant | Who refreshes the token |
 |---|---|---|
@@ -59,6 +58,12 @@ Every Basecamp API request carries an OAuth 2.0 access token. There is no API ke
 | has no browser at all (daemon, CI job) | **device flow** ([RFC 8628](https://www.rfc-editor.org/rfc/rfc8628)) | your code |
 
 The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+
+2. Get the client credentials that grant needs:
+
+- **Authorization code + PKCE** — register your own integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
+- **Device flow** — nothing to register. It runs as the pre-registered public `basecamp-cli` client, which sends no secret, against the device endpoint that discovery returns. Launchpad advertises no device endpoint, so a client you register there is not the one this flow uses.
+- **Static token** — nothing to register; you already hold the token.
 
 **This SDK ships no OAuth client.** It consumes tokens; it does not obtain them. `accessToken:` is never refreshed, so once it expires every call fails with `401`. For anything longer-lived, run the flow yourself (or in a companion service) and supply a [`TokenProvider`](#token-providers) that hands back a fresh token on each call — that is the extension point the SDK gives you in place of a built-in flow.
 

--- a/swift/README.md
+++ b/swift/README.md
@@ -71,9 +71,11 @@ The one-line rule: **a redirect URI you control → authorization code; no brows
 
 Every API path is scoped to an account — `https://3.basecampapi.com/{accountId}/…` — so `forAccount` needs that number before your first call. One token can reach several accounts.
 
-This SDK has no `authorization` service, because that endpoint lives on Launchpad rather than on the Basecamp API. Fetch it once yourself:
+This SDK has no `authorization` service, because that endpoint lives on the authorization server rather than on the Basecamp API. Fetch it once yourself, from the server that issued your token:
 
 ```bash
+# Launchpad-issued token. For a device-flow token, replace the host with the
+# issuer discovery selected — that is where its authorization.json lives.
 curl -s https://launchpad.37signals.com/authorization.json \
   -H "Authorization: Bearer $BASECAMP_TOKEN" \
   -H "User-Agent: MyApp/1.0 (you@example.com)"

--- a/swift/README.md
+++ b/swift/README.md
@@ -45,6 +45,37 @@ targets: [
 ]
 ```
 
+## Getting a token
+
+Every Basecamp API request carries an OAuth 2.0 access token. There is no API key and no personal access token, so even a throwaway script starts here:
+
+1. Register your integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
+2. Choose the grant that matches how your code runs:
+
+| Your integration | Grant | Who refreshes the token |
+|---|---|---|
+| already holds a token you obtained elsewhere | **static token** — `BasecampClient(accessToken:)` | you do |
+| can receive a browser redirect (app with `ASWebAuthenticationSession`, or a local callback server) | **authorization code + PKCE** | your code |
+| has no browser at all (daemon, CI job) | **device flow** ([RFC 8628](https://www.rfc-editor.org/rfc/rfc8628)) | your code |
+
+The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+
+**This SDK ships no OAuth client.** It consumes tokens; it does not obtain them. `accessToken:` is never refreshed, so once it expires every call fails with `401`. For anything longer-lived, run the flow yourself (or in a companion service) and supply a [`TokenProvider`](#token-providers) that hands back a fresh token on each call — that is the extension point the SDK gives you in place of a built-in flow.
+
+## Finding your account ID
+
+Every API path is scoped to an account — `https://3.basecampapi.com/{accountId}/…` — so `forAccount` needs that number before your first call. One token can reach several accounts.
+
+This SDK has no `authorization` service, because that endpoint lives on Launchpad rather than on the Basecamp API. Fetch it once yourself:
+
+```bash
+curl -s https://launchpad.37signals.com/authorization.json \
+  -H "Authorization: Bearer $BASECAMP_TOKEN" \
+  -H "User-Agent: MyApp/1.0 (you@example.com)"
+```
+
+Take `accounts[].id` for an entry whose `product` is `"bc3"` — that is Basecamp; the same response also carries `"hey"` and other 37signals products. `expires_at` tells you how long the token has left. A `User-Agent` identifying your app is required on every Basecamp request, including this one.
+
 ## Quick Start
 
 ```swift

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -61,7 +61,10 @@ const token = process.env.BASECAMP_TOKEN!;
 // for the bootstrap call.
 const bootstrap = createBasecampClient({ accountId: "0", accessToken: token });
 
-// "bc3" is Basecamp; the unfiltered response also carries "hey" and other products
+// "bc3" is Basecamp; the unfiltered response also carries "hey" and other products.
+// endpoint defaults to Launchpad, which is right for a Launchpad-issued token.
+// For a device-flow token, pass the discovered issuer:
+//   { filterProduct: "bc3", endpoint: `${issuer}/authorization.json` }
 const info = await bootstrap.authorization.getInfo({ filterProduct: "bc3" });
 for (const account of info.accounts) {
   console.log(`${account.id}: ${account.name}`);

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -11,7 +11,7 @@ Official TypeScript SDK for the [Basecamp API](https://github.com/basecamp/bc3-a
 - Full type safety with TypeScript generics
 - 30+ services covering the complete Basecamp API
 - OAuth 2.0 with PKCE support
-- ETag-based HTTP caching
+- ETag-based HTTP caching (opt-in)
 - Automatic retry with exponential backoff
 - Pagination helpers for large result sets
 - Observability hooks for logging, metrics, and tracing
@@ -24,6 +24,52 @@ npm install @37signals/basecamp
 ```
 
 Requires Node.js 22.12+ and TypeScript 5.0+.
+
+## Getting a token
+
+Every Basecamp API request carries an OAuth 2.0 access token. There is no API key and no personal access token, so even a throwaway script starts here:
+
+1. Register your integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
+2. Choose the grant that matches how your code runs:
+
+| Your integration | Grant | Who refreshes the token |
+|---|---|---|
+| already holds a token you obtained elsewhere | **static token** — [`Token Providers`](#token-providers) | you do |
+| can receive a browser redirect (web app, or a local callback server) | **authorization code + PKCE** — [`Manual Authorization Flow`](#manual-authorization-flow), or [`Interactive Login`](#interactive-login-cli--desktop) for a CLI | your `accessToken` function, which the SDK re-invokes per request |
+| has no browser at all (daemon, CI job, device) | **device flow** — [`Device flow`](#device-flow-rfc-8628) | your `accessToken` function, which the SDK re-invokes per request |
+
+The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+
+A bare `accessToken` string is never refreshed — once it expires every call fails with `401` until you supply a new one. Use it to get a first successful call, then pass an async token provider or an `AuthStrategy` before you ship.
+
+## Finding your account ID
+
+Every API path is scoped to an account — `https://3.basecampapi.com/{accountId}/…` — so `createBasecampClient` needs that number before your first call. One token can reach several accounts, so ask the token which:
+
+```ts
+import { createBasecampClient } from "@37signals/basecamp";
+
+const token = process.env.BASECAMP_TOKEN!;
+
+// createBasecampClient always requires an accountId, but authorization.getInfo()
+// talks to Launchpad rather than the account-scoped API, so a placeholder is fine
+// for the bootstrap call.
+const bootstrap = createBasecampClient({ accountId: "0", accessToken: token });
+
+// "bc3" is Basecamp; the unfiltered response also carries "hey" and other products
+const info = await bootstrap.authorization.getInfo({ filterProduct: "bc3" });
+for (const account of info.accounts) {
+  console.log(`${account.id}: ${account.name}`);
+}
+
+// Rebuild with the real account ID — that is the client you keep.
+const client = createBasecampClient({
+  accountId: String(info.accounts[0].id),
+  accessToken: token,
+});
+```
+
+`info.expiresAt` is a `Date` telling you how long the token has left, which is the quickest way to confirm a static token has not lapsed.
 
 ## Quick Start
 
@@ -626,25 +672,23 @@ const client = createBasecampClient({
 
 ## Caching
 
-The SDK uses ETag-based HTTP caching to reduce API calls and respect Basecamp's rate limits:
-
-```ts
-// First request fetches from API
-const projects = await client.projects.list();
-
-// Second request returns cached data if unchanged (304 Not Modified)
-const projects2 = await client.projects.list();
-```
-
-Disable caching if needed:
+The SDK can do ETag-based HTTP caching to reduce API calls and respect Basecamp's rate limits, but it is **off by default** — `enableCache` defaults to `false`, and a client built without it sends no `If-None-Match` and stores no responses. Opt in:
 
 ```ts
 const client = createBasecampClient({
   accountId: "12345",
   accessToken: "token",
-  enableCache: false,
+  enableCache: true,
 });
+
+// First request fetches from the API and stores the ETag
+const projects = await client.projects.list();
+
+// Second request revalidates with If-None-Match; a 304 is served from the store
+const projects2 = await client.projects.list();
 ```
+
+The store is in-memory and per-client — it lives and dies with the client instance — holds at most 1,000 entries, and is keyed by URL plus a hash of the `Authorization` header, so a refreshed or swapped token never reads another token's entries.
 
 ## Observability
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -49,7 +49,7 @@ A bare `accessToken` string is never refreshed — once it expires every call fa
 
 ## Finding your account ID
 
-Every API path is scoped to an account — `https://3.basecampapi.com/{accountId}/…` — so `createBasecampClient` needs that number before your first call. One token can reach several accounts, so ask the token which:
+Every API path is scoped to an account — `https://3.basecampapi.com/{accountId}/…` — so `createBasecampClient` needs that number before your first call. One token can reach several accounts, so ask the token which. `getInfo()` addresses Launchpad by default, which is right for a Launchpad-issued token; a **device-flow** token is issued by the discovered BC5 server, so pass that issuer as the `endpoint` option:
 
 ```ts
 import { createBasecampClient } from "@37signals/basecamp";

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -35,9 +35,9 @@ Every Basecamp API request carries an OAuth 2.0 access token. There is no API ke
 |---|---|---|
 | already holds a token you obtained elsewhere | **static token** — [`Token Providers`](#token-providers) | you do |
 | can receive a browser redirect (web app, or a local callback server) | **authorization code + PKCE** — [`Manual Authorization Flow`](#manual-authorization-flow), or [`Interactive Login`](#interactive-login-cli--desktop) for a CLI | your `accessToken` function, which the SDK re-invokes per request |
-| has no browser at all (daemon, CI job, device) | **device flow** — [`Device flow`](#device-flow-rfc-8628) | your `accessToken` function, which the SDK re-invokes per request |
+| has no browser, but a person can approve on another device (CLI, headless server, TV) | **device flow** — [`Device flow`](#device-flow-rfc-8628) | your `accessToken` function, which the SDK re-invokes per request |
 
-The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+The one-line rule: **a redirect URI you control → authorization code; no browser but someone to approve → device flow; a token already in hand → static token.** An unattended daemon or CI job fits none of the three on its own — the device flow needs a person to enter the user code at the verification URI — so provision a token out of band and hand it to the process as a static or refresh token.
 
 2. Get the client credentials that grant needs:
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -29,8 +29,7 @@ Requires Node.js 22.12+ and TypeScript 5.0+.
 
 Every Basecamp API request carries an OAuth 2.0 access token. There is no API key and no personal access token, so even a throwaway script starts here:
 
-1. Register your integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
-2. Choose the grant that matches how your code runs:
+1. Choose the grant that matches how your code runs:
 
 | Your integration | Grant | Who refreshes the token |
 |---|---|---|
@@ -39,6 +38,12 @@ Every Basecamp API request carries an OAuth 2.0 access token. There is no API ke
 | has no browser at all (daemon, CI job, device) | **device flow** — [`Device flow`](#device-flow-rfc-8628) | your `accessToken` function, which the SDK re-invokes per request |
 
 The one-line rule: **a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.**
+
+2. Get the client credentials that grant needs:
+
+- **Authorization code + PKCE** — register your own integration at **<https://launchpad.37signals.com/integrations>**. You get a client ID, a client secret, and whatever redirect URI you nominated.
+- **Device flow** — nothing to register. It runs as the pre-registered public `basecamp-cli` client, which sends no secret, against the device endpoint that discovery returns. Launchpad advertises no device endpoint, so a client you register there is not the one this flow uses.
+- **Static token** — nothing to register; you already hold the token.
 
 A bare `accessToken` string is never refreshed — once it expires every call fails with `401` until you supply a new one. Use it to get a first successful call, then pass an async token provider or an `AuthStrategy` before you ship.
 

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -268,7 +268,7 @@ const DEFAULT_USER_AGENT = `basecamp-sdk-ts/${VERSION} (api:${API_VERSION})`;
  * Creates a type-safe Basecamp API client with built-in middleware for:
  * - Authentication (Bearer token)
  * - Retry with exponential backoff (respects Retry-After header)
- * - ETag-based HTTP caching
+ * - ETag-based HTTP caching, opt-in via `enableCache` (defaults to false)
  *
  * @example
  * ```ts


### PR DESCRIPTION
## Why

No README in this repository told a developer **how to obtain a token** — the first thing an external consumer needs, and the one step no amount of API reference substitutes for. `https://launchpad.37signals.com/integrations` appears nowhere in any README today; the only occurrence in the whole tree is a `registration_endpoint` value inside a Python discovery test fixture — a hand-written mock, which is *not* evidence for the URL. Grounded live instead: Launchpad's discovery document advertises no `registration_endpoint` at all, so the URL does not come from discovery; and `/integrations` redirects to sign-in while a bogus sibling path 404s, so it is a real auth-gated route. Details and commands in [this comment](https://github.com/basecamp/basecamp-sdk/pull/591#issuecomment-5164087737).

`authorization.getInfo()` — the way to discover the account ID that every API path requires — was documented in exactly one place, `go/README.md:96`, and even there only as an incidental step inside the OAuth sample.

## What

All seven READMEs (root + six SDKs) gain two sections ahead of their Quick Start:

**`## Getting a token`** — register at <https://launchpad.37signals.com/integrations>, then a table plus a one-line rule:

> a redirect URI you control → authorization code; no browser → device flow; a token already in hand → static token.

Each row names who refreshes, because that genuinely differs: Go/Ruby/Python ship refreshing providers, TypeScript re-invokes your `accessToken` function, Kotlin hands you `refreshToken()` to wire into `accessToken { … }`, and Swift ships no OAuth client at all.

**`## Finding your account ID`** — `authorization.getInfo()` in each language's own spelling, with the two real caveats: TypeScript's `createBasecampClient` demands an `accountId` up front so the bootstrap call needs a placeholder, and Swift/Kotlin ship no `authorization` service so they get a `curl` against Launchpad.

## Defects fixed

### 1. `BASECAMP_ACCOUNT_ID` documented but read by nothing (`README.md:191-200`)

Grep across all six SDKs' library source:

```
$ rg -n 'BASECAMP_ACCOUNT_ID' go/pkg ruby/lib typescript/src python/src swift/Sources kotlin/sdk/src
REAL_EXIT=1        # ripgrep exit 1 = no matches
```

Every other occurrence in the repo is a caller-side `getenv` in an example, the Makefile's live-canary targets, or CI. **Deleted rather than made real** — an SDK that silently picks an account out of the environment is worse than one that makes you pass it. The root table is replaced with what each SDK actually reads and the call that makes it read it:

| Variable | Read by | Only when |
|---|---|---|
| `BASECAMP_BASE_URL` | Go, Ruby, Python | `cfg.LoadConfigFromEnv()` / `Config.from_env` |
| `BASECAMP_TIMEOUT`, `BASECAMP_MAX_RETRIES` | Ruby, Python | `Config.from_env` |
| `BASECAMP_CACHE_ENABLED`, `BASECAMP_CACHE_DIR`, `BASECAMP_PROJECT_ID`, `BASECAMP_TODOLIST_ID` | Go | `cfg.LoadConfigFromEnv()` |
| `BASECAMP_TOKEN`, `BASECAMP_NO_KEYRING` | Go | `AuthManager` |

TypeScript, Swift and Kotlin read no environment variables at all — every `process.env` / `System.getenv` hit in their sources is inside a doc comment.

**Two more of the same class, found by the same grep:**

- `go/README.md` marked `BASECAMP_TOKEN` *"Required: Yes (unless using OAuth flow)"* — exactly inverted. Only `AuthManager` consults it (`go/pkg/basecamp/auth.go:268`); `StaticTokenProvider` returns its `Token` field and never looks at the environment. It was also listed beside five variables that require an explicit `LoadConfigFromEnv()` call, which `DefaultConfig()` does not make.
- `ruby/README.md:496-497` listed `BASECAMP_TOKEN` and `BASECAMP_ACCOUNT_ID`; `ruby/lib` reads neither. Its only `BASECAMP_*` reads are the three in `Config.from_env`.

### 2. Root README Kotlin quickstart did not compile (`README.md:118`)

Service accessors are extension properties on `AccountClient` declared in `com.basecamp.sdk.generated` (`ServiceAccessors.kt:35`), and the snippet carried **no imports at all**. Compiled verbatim by the embedded Kotlin compiler against the built SDK (`K2JVMCompiler`, same technique as `DeprecationDiagnosticsTest`), with the one import a reader would infer from the class name supplied:

```kotlin
import com.basecamp.sdk.BasecampClient

suspend fun main() {
    val client = BasecampClient { accessToken(System.getenv("BASECAMP_TOKEN")); userAgent = "…" }
    val account = client.forAccount(System.getenv("BASECAMP_ACCOUNT_ID"))
    val projects = account.projects.list()
    projects.forEach { println("${it.id}: ${it.name}") }
}
```

**RED:**
```
ReadmeKotlinSnippetProofTest[jvm] > rootReadmeQuickstartCompilesWithTheObviousImport()[jvm] FAILED
    ERROR: Unresolved reference 'projects'.
    ERROR: Unresolved reference 'it'.
    ERROR: Unresolved reference 'it'.
```

With no imports at all (the snippet exactly as shipped) it fails harder — `Unresolved reference 'BasecampClient'`.

The same fixture also caught **`kotlin/README.md`'s quickstart**, which *does* carry both imports but calls the `suspend fun list()` from a top-level property initializer:

```
ReadmeKotlinSnippetProofTest[jvm] > kotlinReadmeQuickstartCompilesAtTopLevel()[jvm] FAILED
    ERROR: Suspend function 'suspend fun list(options: ListProjectsOptions? = ...): ListResult<Project>'
           can only be called from a coroutine or another suspend function.
    ERROR: Syntax error: Expecting a top level declaration.   (×6)
    ERROR: Function declaration must have a name.
    ERROR: Unresolved reference 'project'.
```

**GREEN** — fixture re-pointed to read the ` ```kotlin ` fence following `## Quick Start` straight off disk in both files, so it verifies the shipped bytes rather than a transcription:

```
BUILD SUCCESSFUL in 1m 27s
tests="2" failures="0"
```

Both quickstarts are now inside `suspend fun main()` with both imports, and each gains a one-line note explaining *why* (extension properties; every service method is `suspend`).

### 3. `enableCache` default false vs README presenting caching as on

`typescript/src/client.ts:288` destructures `enableCache = false`. The README's `## Caching` section described caching as already working and only ever showed `enableCache` in order to switch it **off**.

**The code is right** — every other SDK is opt-in, the root README's feature table already says "(opt-in)", Swift/Kotlin/Go all say "**Caching is disabled by default** to avoid storing private data unexpectedly", and `typescript/README.md:106` itself says `default: false` twenty lines earlier. So the docs were wrong.

**RED** — asserting the claim the section made, with a client constructed the way that section implied (no `enableCache`), against a handler that returns an `ETag` and honours `If-None-Match`:

```
FAIL tests/readme-caching-proof.test.ts > README '## Caching' claim
     > a default client revalidates the second identical GET with If-None-Match
AssertionError: expected [ null, null ] to deeply equal [ null, '"v1"' ]

- Expected
+ Received
  [
    null,
-   "\"v1\"",
+   null,
  ]
```

The second identical GET sends no `If-None-Match`, because `createCacheMiddleware()` is never added to the chain. **GREEN** after the rewrite: 3 tests — default sends `[null, null]`, `enableCache: true` sends `[null, '"v1"']` and serves the 304 body, and the new bootstrap snippet runs verbatim.

The section now leads with "off by default", shows the opt-in, and describes the store's real shape (per client, in-memory, ≤1,000 entries, keyed by URL + a hash of the `Authorization` header). The unqualified "ETag-based HTTP caching" feature bullets in the TypeScript and Go READMEs and "Built-in HTTP caching" in the root are qualified to match. The `createBasecampClient` JSDoc, which listed caching among the middleware unqualified, gets the same one-line correction — the only non-Markdown change in the PR.

## Verification

Every snippet added here was executed or compiled, not eyeballed.

| Check | Result |
|---|---|
| Kotlin README fences compile (embedded `K2JVMCompiler`, read off disk) | `BUILD SUCCESSFUL`, `REAL_EXIT=0`, `tests="2" failures="0"` |
| Go "Finding your account ID" snippet — `go mod tidy && go vet ./...` against the local module | `REAL_EXIT=0` |
| Ruby snippet verbatim, WebMock-stubbed Launchpad | `REAL_EXIT=0` — prints `999333: Honest Ann's (bc3)`, `Basecamp::AccountClient` |
| Python snippet verbatim, respx-stubbed Launchpad | `REAL_EXIT=0` — prints `999333: Honest Ann's`, `AccountClient` |
| TypeScript caching + bootstrap snippets (vitest + MSW) | `REAL_EXIT=0`, 3/3 |
| `npm run typecheck` | `TYPECHECK_REAL_EXIT=0` |
| `npm run lint` | `LINT_REAL_EXIT=0` |
| `npm test` (full suite) | `REAL_EXIT=0` — 77 files, 1127 tests |
| In-document anchor links, GitHub slug rules | `missing=0`, `REAL_EXIT=0` |
| `git diff --check` | `REAL_EXIT=0` |

Anchor checking needed GitHub's exact slug rule — it replaces each space individually rather than collapsing runs, so `Interactive Login (CLI / Desktop)` is `#interactive-login-cli--desktop` with a double hyphen. A collapsing checker reports a false positive there.

## Not done

The proof fixtures are deliberately **not** committed — this lane is prose-only. Two of them would make good permanent gates and I can land them separately if wanted:

- **README snippet compile gate** — the `K2JVMCompiler` fixture reading the `## Quick Start` fence off disk is ~90 lines, runs in the existing `jvmTest` source set, and would have caught both Kotlin defects at authoring time. This is the cheap enforcement for "our quickstarts compile".
- **Documented-env-var gate** — assert every `BASECAMP_*` variable named in a README is actually read by that SDK's library source. Mechanical, and exactly the check that would have caught all three env-var defects here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds clear “Getting a token” and “Finding your account ID” sections to all READMEs, fixes OAuth/device‑flow/caching/env‑var docs, and adds a CI gate that checks README env‑var tables and prose against what the SDKs actually read with a language‑aware scanner. The gate now also handles Swift’s wrapped environment chains, Python `import os as ...` aliases, and stricter Markdown fence closing.

- **New Features**
  - Per‑SDK token/account‑ID sections: how to choose a grant; who refreshes; device‑flow notes; issuer/endpoint guidance; TypeScript’s placeholder `accountId`; Swift/Kotlin use a `curl`.
  - README env‑var gate (CI): validates tables and affirmative prose; forward + reverse checks; language‑aware scanner with self‑tests; ignores examples/fences; flags whole‑environment API touches that violate “no env vars”.

- **Bug Fixes**
  - Gate robustness: binds Python `getenv`/`environ` only when imported from `os` (supports `as` aliases, parenthesized/`\`‑continued imports, and `import os as …`); detects Swift reads in wrapped `ProcessInfo.processInfo.environment[...]` chains; respects code‑fence length and requires bare closers (info‑string lines don’t close); handles TypeScript optional chaining, `process["env"]`, destructuring (including quoted/aliased keys) and env aliasing; recognizes Ruby percent/regex/backtick literals and Swift/Kotlin interpolation/raw‑string cases; correctly ignores fenced examples and doc comments.
  - Docs: remove phantom env‑var claims; fix Kotlin quickstarts to compile; clarify TypeScript caching is opt‑in (`enableCache: true`); correct issuer/endpoint guidance for `authorization.json`; device‑flow refresh guidance per SDK.

<sup>Written for commit c0bfc482fe2daf47002949f4d263db14efaab5a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

