### PR TITLE
Register the 20 missing live operations in all four replay decoders (#553)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,6 +155,13 @@ jobs:
       - name: Runner-test reachability guard self-test
         run: ./scripts/check-runner-test-reachability --self-test
 
+      # The replay runners' own coverage gates fire only during a live canary,
+      # and that canary skips when its secrets are unset — so four decoder maps
+      # drifted 20 operations behind the live fixture with CI fully green
+      # (#553). This is the static answer to the same question.
+      - name: Replay decoders cover every live fixture operation
+        run: make check-replay-decoder-parity
+
   test-go:
     name: Go Tests
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -390,7 +390,16 @@ added to:
 - `conformance/runner/go/replay_runner.go` — Go decoder.
 - `kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/ReplayRunner.kt` — Kotlin decoder.
 
-Each runner's coverage gate refuses to start until all five are in place.
+Each runner's coverage gate refuses to start until all five are in place —
+but that gate only fires during a live canary, and the scheduled canary skips
+whenever its secrets are unconfigured, so for a long stretch four of the five
+tables sat twenty operations behind the fixture with CI fully green (#553).
+`scripts/check-replay-decoder-parity` now compares all five tables against
+`live-my-surface.json` statically on every `make check` and CI run, and runs as
+a prerequisite of `make conformance-live` so a mismatch fails in under a second
+instead of after the capture. It pins the live-operation count too: adding a
+live fixture entry means bumping `expected_live_ops` and registering the
+decoder in the same commit.
 
 > **Historical note — pairwise BC4↔BC5 comparison (retired).** An earlier
 > canary captured snapshots from two live backends (BC4 and BC5) and asserted

--- a/Makefile
+++ b/Makefile
@@ -688,8 +688,14 @@ conformance: oauth-fixtures-check oauth-token-fixtures-check conformance-fixture
 # `$$LIVE_RECORD_DIR/$$BASECAMP_BACKEND/decode/<lang>/`. Failures in any
 # stage fail the orchestrator.
 #
+# check-replay-decoder-parity runs FIRST, as a prerequisite: a fixture
+# operation missing from a replay decoder map makes the replay half of this
+# target impossible, and the runners only discover that after the ~30-minute
+# live capture has already finished. The static check answers the same question
+# in 0.3s. (#553 — the four maps were 20 operations behind and nothing said so.)
+#
 # Opt-in target: not invoked by `make check`.
-conformance-live:
+conformance-live: check-replay-decoder-parity
 	@test -n "$$LIVE_RECORD_DIR" || (echo "LIVE_RECORD_DIR is required" >&2; exit 1)
 	@test -n "$$BASECAMP_BACKEND" || (echo "BASECAMP_BACKEND is required" >&2; exit 1)
 	@test -n "$$BASECAMP_TOKEN" || (echo "BASECAMP_TOKEN is required" >&2; exit 1)
@@ -1001,7 +1007,7 @@ tools:
 # Spec-shape lints
 #------------------------------------------------------------------------------
 
-.PHONY: check-bucket-flat-parity validate-api-gaps check-deprecation-parity kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-fixture-coverage check-idempotency-parity check-retry-metadata-parity check-runner-test-reachability
+.PHONY: check-bucket-flat-parity validate-api-gaps check-deprecation-parity kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-fixture-coverage check-idempotency-parity check-retry-metadata-parity check-runner-test-reachability check-replay-decoder-parity
 
 # Verify every bucket-scoped GET list operation has a flat-path counterpart
 # (or is justified in spec/bucket-scoped-allowlist.txt). Cross-project SDK
@@ -1075,6 +1081,14 @@ check-retry-metadata-parity:
 check-runner-test-reachability:
 	@./scripts/check-runner-test-reachability
 
+# Verify every live operation in conformance/tests/live-my-surface.json has a
+# decoder in all five dispatch tables (TS LIVE_OPERATIONS plus the four replay
+# runners). The runners' own coverage gates only fire during a live canary, and
+# that canary skips whenever its secrets are unset — which is how four tables
+# sat 20 operations behind the fixture with CI green (#553). Bash+jq, 0.3s.
+check-replay-decoder-parity:
+	@./scripts/check-replay-decoder-parity
+
 #------------------------------------------------------------------------------
 # Combined targets
 #------------------------------------------------------------------------------
@@ -1097,7 +1111,7 @@ generate:
 	@echo "==> Generation complete"
 
 # Run all checks (Smithy + Go + TypeScript + Ruby + Kotlin + Swift + Python + Behavior Model + Conformance + Provenance + Actions lint)
-check: lint-actions sync-spec-version-check smithy-check behavior-model-check provenance-check sync-api-version-check doc-constants-check url-routes-check bc3-route-parity go-check-drift go-check-wrapper-drift go-check-generated-drift auth-routable-check kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity check-fixture-coverage kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-idempotency-parity check-retry-metadata-parity check-runner-test-reachability
+check: lint-actions sync-spec-version-check smithy-check behavior-model-check provenance-check sync-api-version-check doc-constants-check url-routes-check bc3-route-parity go-check-drift go-check-wrapper-drift go-check-generated-drift auth-routable-check kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity check-fixture-coverage kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-idempotency-parity check-retry-metadata-parity check-runner-test-reachability check-replay-decoder-parity
 	@echo "==> All checks passed"
 
 # Clean all build artifacts
@@ -1181,6 +1195,7 @@ help:
 	@echo "  oauth-token-fixtures-check Validate OAuth token wire-behavior fixtures against their schema"
 	@echo "  conformance-fixtures-check Validate conformance/tests fixtures against schema.json"
 	@echo "  check-runner-test-reachability  Assert every runner test file is reachable from discovery"
+	@echo "  check-replay-decoder-parity  Assert all five replay/dispatch tables cover the live fixture"
 	@echo ""
 	@echo "Ruby SDK:"
 	@echo "  rb-generate          Generate types and metadata from OpenAPI"

--- a/SPEC.md
+++ b/SPEC.md
@@ -2179,7 +2179,7 @@ account, attachments, automation, boosts, campfires, cardColumns, cardSteps, car
 | `todolists_write.json` | update-merge / update-group / edit-clear / replace-omission-clears | §5 (Todolists), §18 |
 | `cards_write.json` | Merge-safe update composite (5 cases: due-on preservation, verbatim raw path, explicit clears/empties) | §5 (Cards), §18 |
 | `schedule_entries_write.json` | update-omits-participant-ids / update-empty-participant-ids | §10 |
-| `live-my-surface.json` | Live schema validation, 30 read-surface cases (opt-in via `BASECAMP_LIVE`) | External governance (CONTRIBUTING.md, live canary) |
+| `live-my-surface.json` | Live schema validation, 31 read-surface cases (opt-in via `BASECAMP_LIVE`) | External governance (CONTRIBUTING.md, live canary) |
 
 ---
 

--- a/conformance/runner/go/replay_runner.go
+++ b/conformance/runner/go/replay_runner.go
@@ -32,8 +32,15 @@ const ReplaySchemaVersion = 1
 // bodyText into the generated response type produced by oapi-codegen
 // (the same types the SDK uses internally) and returns the unmarshal
 // error, or nil on success. Keep this table in sync with
-// LIVE_OPERATIONS in conformance/runner/typescript/live-dispatch.ts —
-// the coverage gate enforces parity.
+// LIVE_OPERATIONS in conformance/runner/typescript/live-dispatch.ts.
+//
+// Parity is enforced twice. At replay time the coverage gate refuses to run
+// with a fixture operation that has no decoder — but that only fires during a
+// live canary, which skips whenever the canary secrets are unset, so this table
+// silently lost twenty operations for the length of #553. STATICALLY,
+// scripts/check-replay-decoder-parity compares this map against
+// conformance/tests/live-my-surface.json on every `make check` and CI run, so
+// the drift now fails in 0.3s instead of never.
 var decoders = map[string]func(bodyText string) error{
 	"ListProjects": func(bt string) error {
 		var v generated.ListProjectsResponseContent
@@ -77,6 +84,87 @@ var decoders = map[string]func(bodyText string) error{
 	},
 	"GetCalendar": func(bt string) error {
 		var v generated.GetCalendarResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
+	"GetProgressReport": func(bt string) error {
+		var v generated.GetProgressReportResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
+	"GetBubbleUps": func(bt string) error {
+		var v generated.GetBubbleUpsResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
+	"ListRecordings": func(bt string) error {
+		var v generated.ListRecordingsResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
+	"Search": func(bt string) error {
+		var v generated.SearchResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
+	// The sixteen Everything aggregates.
+	"GetEverythingMessages": func(bt string) error {
+		var v generated.GetEverythingMessagesResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
+	"GetEverythingComments": func(bt string) error {
+		var v generated.GetEverythingCommentsResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
+	"GetEverythingCheckins": func(bt string) error {
+		var v generated.GetEverythingCheckinsResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
+	"GetEverythingFiles": func(bt string) error {
+		var v generated.GetEverythingFilesResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
+	"GetEverythingForwards": func(bt string) error {
+		var v generated.GetEverythingForwardsResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
+	"GetEverythingOpenTodos": func(bt string) error {
+		var v generated.GetEverythingOpenTodosResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
+	"GetEverythingCompletedTodos": func(bt string) error {
+		var v generated.GetEverythingCompletedTodosResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
+	"GetEverythingOverdueTodos": func(bt string) error {
+		var v generated.GetEverythingOverdueTodosResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
+	"GetEverythingUnassignedTodos": func(bt string) error {
+		var v generated.GetEverythingUnassignedTodosResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
+	"GetEverythingNoDueDateTodos": func(bt string) error {
+		var v generated.GetEverythingNoDueDateTodosResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
+	"GetEverythingOpenCards": func(bt string) error {
+		var v generated.GetEverythingOpenCardsResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
+	"GetEverythingCompletedCards": func(bt string) error {
+		var v generated.GetEverythingCompletedCardsResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
+	"GetEverythingOverdueCards": func(bt string) error {
+		var v generated.GetEverythingOverdueCardsResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
+	"GetEverythingUnassignedCards": func(bt string) error {
+		var v generated.GetEverythingUnassignedCardsResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
+	"GetEverythingNoDueDateCards": func(bt string) error {
+		var v generated.GetEverythingNoDueDateCardsResponseContent
+		return json.Unmarshal([]byte(bt), &v)
+	},
+	"GetEverythingNotNowCards": func(bt string) error {
+		var v generated.GetEverythingNotNowCardsResponseContent
 		return json.Unmarshal([]byte(bt), &v)
 	},
 }

--- a/conformance/runner/go/replay_runner_test.go
+++ b/conformance/runner/go/replay_runner_test.go
@@ -17,12 +17,83 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 )
 
 func strPtr(s string) *string { return &s }
+
+// liveFixtureOperations returns the distinct operations conformance's live
+// fixture declares — the same set the replay runner's coverage gate compares
+// against, read from the same file.
+func liveFixtureOperations(t *testing.T) []string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join("..", "..", "tests", "live-my-surface.json"))
+	if err != nil {
+		t.Fatalf("reading live fixture: %v", err)
+	}
+	var all []fixtureTest
+	if err := json.Unmarshal(raw, &all); err != nil {
+		t.Fatalf("parsing live fixture: %v", err)
+	}
+	seen := map[string]bool{}
+	var ops []string
+	for _, tc := range all {
+		if tc.Mode == "live" && !seen[tc.Operation] {
+			seen[tc.Operation] = true
+			ops = append(ops, tc.Operation)
+		}
+	}
+	if len(ops) == 0 {
+		t.Fatal("live fixture declared no live operations — the reader is broken")
+	}
+	sort.Strings(ops)
+	return ops
+}
+
+// The runtime coverage gate makes the same assertion, but it only runs during
+// a live canary — which skips whenever the canary secrets are unset. That is
+// how this map sat 20 operations behind the fixture (#553). Asserting it as a
+// unit test means the drift fails a normal CI run.
+func TestDecodersCoverEveryLiveFixtureOperation(t *testing.T) {
+	for _, op := range liveFixtureOperations(t) {
+		if _, ok := decoders[op]; !ok {
+			t.Errorf("no decoder registered for live operation %s", op)
+		}
+	}
+}
+
+func TestNoDecoderRegisteredForAnUnknownOperation(t *testing.T) {
+	live := map[string]bool{}
+	for _, op := range liveFixtureOperations(t) {
+		live[op] = true
+	}
+	for op := range decoders {
+		if !live[op] {
+			t.Errorf("decoder registered for %s, which is not a live fixture operation", op)
+		}
+	}
+}
+
+// Every decoder must be bound to a CONCRETE response shape: exactly one of
+// `[]` and `{}` decodes. Registering the wrong generated type (a struct where
+// the wire sends an array, say GetEverythingMessagesResponseContent vs
+// Recording) still compiles and still populates the map, so the parity check
+// alone would call it covered. A decoder that accepted both would be typed
+// `any` or `json.RawMessage` and assert nothing at all.
+func TestEveryDecoderIsBoundToOneWireShape(t *testing.T) {
+	for op, dec := range decoders {
+		arrayOK := dec(`[]`) == nil
+		objectOK := dec(`{}`) == nil
+		if arrayOK == objectOK {
+			t.Errorf("decoder %s accepts array=%v object=%v; expected exactly one — it is not bound to a concrete response type",
+				op, arrayOK, objectOK)
+		}
+	}
+}
 
 func TestResolveBodyText_EmptyPassesThrough(t *testing.T) {
 	got := resolveBodyText(wirePage{BodyText: strPtr("")})

--- a/conformance/runner/python/replay_runner.py
+++ b/conformance/runner/python/replay_runner.py
@@ -57,6 +57,13 @@ def _decode(body_text: str) -> None:
 # the dict explicit (rather than a default fallback) makes the
 # coverage_gate diagnostic accurate: a typo or missing op surfaces
 # loudly instead of being absorbed by a default decoder.
+#
+# Must cover every live operation in conformance/tests/live-my-surface.json.
+# coverage_gate() enforces that at replay time, but replay only runs during a
+# live canary — which skips whenever the canary secrets are unset, so this map
+# silently lost twenty operations for the length of #553. The static guard
+# scripts/check-replay-decoder-parity now compares it against the fixture on
+# every `make check` and CI run.
 DECODERS: dict[str, Callable[[str], None]] = {
     "ListProjects": _decode,
     "GetProject": _decode,
@@ -69,6 +76,27 @@ DECODERS: dict[str, Callable[[str], None]] = {
     "ListTodolists": _decode,
     "ListTodos": _decode,
     "GetCalendar": _decode,
+    "GetProgressReport": _decode,
+    "GetBubbleUps": _decode,
+    "ListRecordings": _decode,
+    "Search": _decode,
+    # The sixteen Everything aggregates.
+    "GetEverythingMessages": _decode,
+    "GetEverythingComments": _decode,
+    "GetEverythingCheckins": _decode,
+    "GetEverythingFiles": _decode,
+    "GetEverythingForwards": _decode,
+    "GetEverythingOpenTodos": _decode,
+    "GetEverythingCompletedTodos": _decode,
+    "GetEverythingOverdueTodos": _decode,
+    "GetEverythingUnassignedTodos": _decode,
+    "GetEverythingNoDueDateTodos": _decode,
+    "GetEverythingOpenCards": _decode,
+    "GetEverythingCompletedCards": _decode,
+    "GetEverythingOverdueCards": _decode,
+    "GetEverythingUnassignedCards": _decode,
+    "GetEverythingNoDueDateCards": _decode,
+    "GetEverythingNotNowCards": _decode,
 }
 
 

--- a/conformance/runner/python/test_replay_runner.py
+++ b/conformance/runner/python/test_replay_runner.py
@@ -27,7 +27,47 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from replay_runner import ReplayRunner, _decode, _resolve_body_text
+from replay_runner import DECODERS, ReplayRunner, _decode, _resolve_body_text
+
+LIVE_FIXTURE = Path(__file__).parent.parent.parent / "tests" / "live-my-surface.json"
+
+
+def _live_operations() -> set[str]:
+    tests = json.loads(LIVE_FIXTURE.read_text())
+    ops = {t["operation"] for t in tests if t.get("mode") == "live"}
+    # Fail closed: an empty set would make the assertions below vacuous.
+    assert ops, f"{LIVE_FIXTURE} declared no live operations — the reader is broken"
+    return ops
+
+
+class DecoderCoverageTest(unittest.TestCase):
+    """DECODERS must cover exactly the live fixture's operations.
+
+    ``ReplayRunner.coverage_gate`` asserts the same thing, but it only runs
+    during a live canary — and the scheduled canary skips whenever its secrets
+    are unconfigured. That is how DECODERS sat twenty operations behind the
+    fixture with CI fully green (#553). Asserting it here means the drift fails
+    an ordinary run. ``scripts/check-replay-decoder-parity`` makes the same
+    comparison statically across all five dispatch tables.
+    """
+
+    def test_every_live_operation_has_a_decoder(self) -> None:
+        missing = sorted(_live_operations() - DECODERS.keys())
+        self.assertEqual([], missing, "live operations with no entry in DECODERS")
+
+    def test_no_decoder_for_an_unknown_operation(self) -> None:
+        extra = sorted(DECODERS.keys() - _live_operations())
+        self.assertEqual([], extra, "DECODERS entries that are not live fixture operations")
+
+    def test_every_decoder_runs_the_sdk_normalize_boundary(self) -> None:
+        # The Python SDK has no per-op typed deserializer, so every entry must
+        # be the shared parse+normalize callable. A stub or a lambda that
+        # swallowed errors would satisfy coverage while decoding nothing.
+        for op, decoder in DECODERS.items():
+            with self.subTest(op=op):
+                self.assertIs(decoder, _decode)
+                with self.assertRaises(json.JSONDecodeError):
+                    decoder("")
 
 
 class ResolveBodyTextTest(unittest.TestCase):

--- a/conformance/runner/ruby/replay-runner.rb
+++ b/conformance/runner/ruby/replay-runner.rb
@@ -40,18 +40,45 @@ class ReplayRunner
     parsed
   end
 
+  # Must cover every live operation in conformance/tests/live-my-surface.json.
+  # coverage_gate enforces that at replay time, but replay only runs during a
+  # live canary — which skips whenever the canary secrets are unset, so this
+  # map silently lost twenty operations for the length of #553. The static
+  # guard scripts/check-replay-decoder-parity now compares it against the
+  # fixture on every `make check` and CI run.
   DECODERS = {
-    "ListProjects"              => SDK_DECODE,
-    "GetProject"                => SDK_DECODE,
-    "GetMyAssignments"          => SDK_DECODE,
-    "GetMyCompletedAssignments" => SDK_DECODE,
-    "GetMyDueAssignments"       => SDK_DECODE,
-    "GetMyNotifications"        => SDK_DECODE,
-    "GetMyProfile"              => SDK_DECODE,
-    "GetTodoset"                => SDK_DECODE,
-    "ListTodolists"             => SDK_DECODE,
-    "ListTodos"                 => SDK_DECODE,
-    "GetCalendar"               => SDK_DECODE,
+    "ListProjects"                 => SDK_DECODE,
+    "GetProject"                   => SDK_DECODE,
+    "GetMyAssignments"             => SDK_DECODE,
+    "GetMyCompletedAssignments"    => SDK_DECODE,
+    "GetMyDueAssignments"          => SDK_DECODE,
+    "GetMyNotifications"           => SDK_DECODE,
+    "GetMyProfile"                 => SDK_DECODE,
+    "GetTodoset"                   => SDK_DECODE,
+    "ListTodolists"                => SDK_DECODE,
+    "ListTodos"                    => SDK_DECODE,
+    "GetCalendar"                  => SDK_DECODE,
+    "GetProgressReport"            => SDK_DECODE,
+    "GetBubbleUps"                 => SDK_DECODE,
+    "ListRecordings"               => SDK_DECODE,
+    "Search"                       => SDK_DECODE,
+    # The sixteen Everything aggregates.
+    "GetEverythingMessages"        => SDK_DECODE,
+    "GetEverythingComments"        => SDK_DECODE,
+    "GetEverythingCheckins"        => SDK_DECODE,
+    "GetEverythingFiles"           => SDK_DECODE,
+    "GetEverythingForwards"        => SDK_DECODE,
+    "GetEverythingOpenTodos"       => SDK_DECODE,
+    "GetEverythingCompletedTodos"  => SDK_DECODE,
+    "GetEverythingOverdueTodos"    => SDK_DECODE,
+    "GetEverythingUnassignedTodos" => SDK_DECODE,
+    "GetEverythingNoDueDateTodos"  => SDK_DECODE,
+    "GetEverythingOpenCards"       => SDK_DECODE,
+    "GetEverythingCompletedCards"  => SDK_DECODE,
+    "GetEverythingOverdueCards"    => SDK_DECODE,
+    "GetEverythingUnassignedCards" => SDK_DECODE,
+    "GetEverythingNoDueDateCards"  => SDK_DECODE,
+    "GetEverythingNotNowCards"     => SDK_DECODE,
   }.freeze
 
   def initialize(replay_dir, backend, fixture_path, openapi_path)

--- a/conformance/runner/ruby/replay_runner_test.rb
+++ b/conformance/runner/ruby/replay_runner_test.rb
@@ -28,3 +28,44 @@ class SdkDecodeTest < Minitest::Test
     assert_raises(JSON::ParserError) { ReplayRunner::SDK_DECODE.call("not json") }
   end
 end
+
+# DECODERS must cover exactly the live fixture's operations.
+#
+# ReplayRunner#coverage_gate asserts the same thing, but it only runs during a
+# live canary — and the scheduled canary skips whenever its secrets are
+# unconfigured. That is how DECODERS sat twenty operations behind the fixture
+# with CI fully green (#553). Asserting it here means the drift fails an
+# ordinary run; scripts/check-replay-decoder-parity makes the same comparison
+# statically across all five dispatch tables.
+class DecoderCoverageTest < Minitest::Test
+  LIVE_FIXTURE = File.expand_path("../../tests/live-my-surface.json", __dir__)
+
+  def live_operations
+    ops = JSON.parse(File.read(LIVE_FIXTURE))
+      .select { |t| t["mode"] == "live" }
+      .map { |t| t["operation"] }
+      .uniq
+    # Fail closed: an empty set would make the assertions below vacuous.
+    refute_empty ops, "#{LIVE_FIXTURE} declared no live operations — the reader is broken"
+    ops
+  end
+
+  def test_every_live_operation_has_a_decoder
+    assert_equal [], (live_operations - ReplayRunner::DECODERS.keys).sort,
+                 "live operations with no entry in DECODERS"
+  end
+
+  def test_no_decoder_for_an_unknown_operation
+    assert_equal [], (ReplayRunner::DECODERS.keys - live_operations).sort,
+                 "DECODERS entries that are not live fixture operations"
+  end
+
+  def test_every_decoder_runs_the_sdk_decode_boundary
+    # The Ruby SDK has no typed deserializers, so every entry must be the
+    # shared SDK_DECODE lambda. A stub that swallowed errors would satisfy
+    # coverage while decoding nothing.
+    ReplayRunner::DECODERS.each do |op, decoder|
+      assert_same ReplayRunner::SDK_DECODE, decoder, "#{op} is not wired to SDK_DECODE"
+    end
+  end
+end

--- a/kotlin/conformance/build.gradle.kts
+++ b/kotlin/conformance/build.gradle.kts
@@ -41,6 +41,11 @@ dependencies {
 
 // The runner's assertion helpers are unit-tested (DelayGapsTest): a bounds
 // branch that only ever runs against passing fixtures is not a guard.
+//
+// workingDir matches `run` and `runReplay` so a test can resolve repo paths
+// the same way the runners do — ReplayDecodersTest reads the live conformance
+// fixture at ../conformance/tests/live-my-surface.json.
 tasks.withType<Test> {
     useJUnitPlatform()
+    workingDir = rootProject.projectDir
 }

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/ReplayRunner.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/ReplayRunner.kt
@@ -1,8 +1,15 @@
 package com.basecamp.sdk.conformance
 
+import com.basecamp.sdk.generated.models.BucketCardsGroup
+import com.basecamp.sdk.generated.models.BucketTodosGroup
 import com.basecamp.sdk.generated.models.Calendar
+import com.basecamp.sdk.generated.models.Card
+import com.basecamp.sdk.generated.models.EverythingFile
+import com.basecamp.sdk.generated.models.Notification
 import com.basecamp.sdk.generated.models.Person
 import com.basecamp.sdk.generated.models.Project
+import com.basecamp.sdk.generated.models.Recording
+import com.basecamp.sdk.generated.models.TimelineEvent
 import com.basecamp.sdk.generated.models.Todo
 import com.basecamp.sdk.generated.models.Todolist
 import com.basecamp.sdk.generated.models.Todoset
@@ -40,12 +47,13 @@ import kotlin.system.exitProcess
  * Decode boundary
  * ---------------
  * Where the Kotlin SDK has a typed model for the response payload (`Project`,
- * `Person`, `Todo`, `Todolist`, `Todoset`), the decoder routes through that
- * type — exactly what the generated service method does at runtime. The four
- * `My*` operations (assignments, completed assignments, due assignments,
- * notifications) currently return `JsonElement` from the SDK because
- * `MyAssignment` and `Notification` lack typed Kotlin models; for those we
- * decode as `JsonElement`, which mirrors the SDK's actual surface.
+ * `Person`, `Todo`, `Todolist`, `Todoset`, `Recording`, `Card`,
+ * `BucketTodosGroup`, `BucketCardsGroup`, `EverythingFile`, `TimelineEvent`,
+ * `Notification`), the decoder routes through that type — exactly what the
+ * generated service method does at runtime. The four `My*` operations
+ * (assignments, completed assignments, due assignments, notifications) return
+ * bare `JsonElement` from the SDK, as does each element of `Search`'s result;
+ * for those we decode as `JsonElement`, which mirrors the SDK's actual surface.
  *
  * The `Json` instance below intentionally mirrors mock-mode (`ignoreUnknownKeys
  * = true`, `coerceInputValues = false`) — additive BC5 fields must NOT decode
@@ -72,8 +80,21 @@ const val REPLAY_SCHEMA_VERSION = 1
  * For `JsonElement`-returning SDK methods, we decode as `JsonElement` —
  * that's the SDK's actual decode boundary today. When the SDK adds typed
  * models for those operations, switch the decoder to the typed model.
+ *
+ * Every list-shaped entry mirrors the generated service exactly: those
+ * methods end in `json.decodeFromString<List<T>>(body)` per page (see
+ * `generated/services/everything.kt` and friends), so the replay decoder is
+ * `ListSerializer(T.serializer())` — decoding a page as the bare element type
+ * would test something the SDK never does.
+ *
+ * Must cover every live operation in conformance/tests/live-my-surface.json.
+ * coverageGate() enforces that at replay time, but replay only runs during a
+ * live canary — which skips whenever the canary secrets are unset, so this map
+ * silently lost twenty operations for the length of #553. The static guard
+ * scripts/check-replay-decoder-parity now compares it against the fixture on
+ * every `make check` and CI run.
  */
-private val decoders: Map<String, (String) -> Unit> = mapOf(
+internal val decoders: Map<String, (String) -> Unit> = mapOf(
     "ListProjects" to { bt -> replayJson.decodeFromString(ListSerializer(Project.serializer()), bt) },
     "GetProject" to { bt -> replayJson.decodeFromString(Project.serializer(), bt) },
     "GetMyAssignments" to { bt -> replayJson.decodeFromString(JsonElement.serializer(), bt) },
@@ -85,6 +106,29 @@ private val decoders: Map<String, (String) -> Unit> = mapOf(
     "ListTodolists" to { bt -> replayJson.decodeFromString(ListSerializer(Todolist.serializer()), bt) },
     "ListTodos" to { bt -> replayJson.decodeFromString(ListSerializer(Todo.serializer()), bt) },
     "GetCalendar" to { bt -> replayJson.decodeFromString(Calendar.serializer(), bt) },
+    "GetProgressReport" to { bt -> replayJson.decodeFromString(ListSerializer(TimelineEvent.serializer()), bt) },
+    "GetBubbleUps" to { bt -> replayJson.decodeFromString(ListSerializer(Notification.serializer()), bt) },
+    "ListRecordings" to { bt -> replayJson.decodeFromString(ListSerializer(Recording.serializer()), bt) },
+    // Search returns ListResult<JsonElement> from the SDK — SearchResult has no
+    // typed Kotlin model, so JsonElement is the real boundary.
+    "Search" to { bt -> replayJson.decodeFromString(ListSerializer(JsonElement.serializer()), bt) },
+    // The sixteen Everything aggregates.
+    "GetEverythingMessages" to { bt -> replayJson.decodeFromString(ListSerializer(Recording.serializer()), bt) },
+    "GetEverythingComments" to { bt -> replayJson.decodeFromString(ListSerializer(Recording.serializer()), bt) },
+    "GetEverythingCheckins" to { bt -> replayJson.decodeFromString(ListSerializer(Recording.serializer()), bt) },
+    "GetEverythingFiles" to { bt -> replayJson.decodeFromString(ListSerializer(EverythingFile.serializer()), bt) },
+    "GetEverythingForwards" to { bt -> replayJson.decodeFromString(ListSerializer(Recording.serializer()), bt) },
+    "GetEverythingOpenTodos" to { bt -> replayJson.decodeFromString(ListSerializer(BucketTodosGroup.serializer()), bt) },
+    "GetEverythingCompletedTodos" to { bt -> replayJson.decodeFromString(ListSerializer(BucketTodosGroup.serializer()), bt) },
+    "GetEverythingOverdueTodos" to { bt -> replayJson.decodeFromString(ListSerializer(Todo.serializer()), bt) },
+    "GetEverythingUnassignedTodos" to { bt -> replayJson.decodeFromString(ListSerializer(BucketTodosGroup.serializer()), bt) },
+    "GetEverythingNoDueDateTodos" to { bt -> replayJson.decodeFromString(ListSerializer(BucketTodosGroup.serializer()), bt) },
+    "GetEverythingOpenCards" to { bt -> replayJson.decodeFromString(ListSerializer(BucketCardsGroup.serializer()), bt) },
+    "GetEverythingCompletedCards" to { bt -> replayJson.decodeFromString(ListSerializer(BucketCardsGroup.serializer()), bt) },
+    "GetEverythingOverdueCards" to { bt -> replayJson.decodeFromString(ListSerializer(Card.serializer()), bt) },
+    "GetEverythingUnassignedCards" to { bt -> replayJson.decodeFromString(ListSerializer(BucketCardsGroup.serializer()), bt) },
+    "GetEverythingNoDueDateCards" to { bt -> replayJson.decodeFromString(ListSerializer(BucketCardsGroup.serializer()), bt) },
+    "GetEverythingNotNowCards" to { bt -> replayJson.decodeFromString(ListSerializer(BucketCardsGroup.serializer()), bt) },
 )
 
 private val safeNameRegex = Regex("[^a-z0-9_-]+", RegexOption.IGNORE_CASE)

--- a/kotlin/conformance/src/test/kotlin/com/basecamp/sdk/conformance/ReplayDecodersTest.kt
+++ b/kotlin/conformance/src/test/kotlin/com/basecamp/sdk/conformance/ReplayDecodersTest.kt
@@ -1,0 +1,134 @@
+package com.basecamp.sdk.conformance
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonPrimitive
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Decoder-map coverage and shape-binding for the wire-replay runner.
+ *
+ * `ReplayRunner.coverageGate()` already asserts coverage, but it only runs
+ * during a live canary — and the scheduled canary skips whenever its secrets
+ * are unconfigured. That is how this map sat twenty operations behind the live
+ * fixture with CI fully green (#553). These run on every `:conformance:test`.
+ *
+ * `scripts/check-replay-decoder-parity` makes the same coverage assertion
+ * statically across all five dispatch tables. This file adds what a text scan
+ * cannot: that each registered decoder is bound to the response SHAPE the SDK
+ * actually decodes, so a `Recording.serializer()` where the service does
+ * `decodeFromString<List<Recording>>` is caught rather than counted as covered.
+ */
+class ReplayDecodersTest {
+    // Gradle runs tests with workingDir = rootProject.projectDir (kotlin/),
+    // matching the `run` and `runReplay` tasks — so repo paths resolve the same
+    // way Main.kt and ReplayRunner.main() resolve them.
+    private val liveFixture = File("../conformance/tests/live-my-surface.json")
+
+    private fun liveOperations(): Set<String> {
+        val all = Json.parseToJsonElement(liveFixture.readText()).jsonArray
+        val ops = all.mapNotNull { el ->
+            val obj = el as? JsonObject ?: return@mapNotNull null
+            if (obj["mode"]?.jsonPrimitive?.content != "live") null
+            else obj["operation"]?.jsonPrimitive?.content
+        }.toSet()
+        // Fail closed: an empty set would make every assertion below vacuous.
+        assertTrue(ops.isNotEmpty(), "live fixture declared no live operations — the reader is broken")
+        return ops
+    }
+
+    @Test
+    fun `every live fixture operation has a decoder`() {
+        val missing = liveOperations().filterNot { it in decoders }.sorted()
+        assertEquals(emptyList(), missing, "live operations with no decoder in ReplayRunner.kt")
+    }
+
+    @Test
+    fun `no decoder is registered for an unknown operation`() {
+        val live = liveOperations()
+        val extra = decoders.keys.filterNot { it in live }.sorted()
+        assertEquals(emptyList(), extra, "decoders registered for non-live operations")
+    }
+
+    /**
+     * The four `My*` operations decode as bare `JsonElement` — the SDK's own
+     * return type for them — so they accept any JSON value and have no shape to
+     * bind. Listed by name so the shape rules below stay strict for everyone
+     * else instead of being weakened to accommodate four exceptions.
+     */
+    private val untypedByDesign = setOf(
+        "GetMyAssignments",
+        "GetMyCompletedAssignments",
+        "GetMyDueAssignments",
+        "GetMyNotifications",
+    )
+
+    /**
+     * The single-resource GETs. Everything else on the live surface is a
+     * collection: the generated service ends in `decodeFromString<List<T>>`,
+     * so the replay decoder must be `ListSerializer(T.serializer())`.
+     */
+    private val objectShaped = setOf("GetProject", "GetMyProfile", "GetTodoset", "GetCalendar")
+
+    /**
+     * kotlinx rejects a JSON array for a class serializer unconditionally, and
+     * accepts `[]` for a list serializer (no elements to validate), so
+     * "`[]` decodes" is an exact test of list-vs-object binding.
+     *
+     * This is what neither the runtime coverage gate nor the static parity
+     * check can see: registering `Recording.serializer()` where the service
+     * does `decodeFromString<List<Recording>>` compiles, populates the map, and
+     * counts as covered — while testing a decode the SDK never performs.
+     */
+    @Test
+    fun `collection operations decode an empty array`() {
+        val wrong = decoders.keys
+            .filterNot { it in untypedByDesign || it in objectShaped }
+            .filterNot { op -> runCatching { decoders.getValue(op)("[]") }.isSuccess }
+            .sorted()
+        assertEquals(emptyList(), wrong, "collection decoders bound to the element type instead of List<T>")
+    }
+
+    @Test
+    fun `collection operations reject a JSON object`() {
+        val wrong = decoders.keys
+            .filterNot { it in untypedByDesign || it in objectShaped }
+            .filter { op -> runCatching { decoders.getValue(op)("{}") }.isSuccess }
+            .sorted()
+        assertEquals(emptyList(), wrong, "collection decoders that accept an object body are not list-bound")
+    }
+
+    @Test
+    fun `single-resource operations reject a JSON array`() {
+        for (op in objectShaped) {
+            val decode = decoders[op] ?: fail("$op is not registered")
+            assertTrue(
+                runCatching { decode("[]") }.isFailure,
+                "$op decodes an array; it should be bound to its object model",
+            )
+        }
+    }
+
+    /** The excluded four really are shape-free, not just currently passing. */
+    @Test
+    fun `the untyped My operations accept both shapes`() {
+        for (op in untypedByDesign) {
+            val decode = decoders[op] ?: fail("$op is not registered")
+            assertTrue(runCatching { decode("[]") }.isSuccess, "$op should decode an array")
+            assertTrue(runCatching { decode("{}") }.isSuccess, "$op should decode an object")
+        }
+    }
+
+    /** Both exception sets must name real registrations, or they mask drift. */
+    @Test
+    fun `the exception sets name registered operations`() {
+        for (op in untypedByDesign + objectShaped) {
+            assertTrue(op in decoders, "$op is excluded from a shape rule but is not registered")
+        }
+    }
+}

--- a/scripts/check-replay-decoder-parity
+++ b/scripts/check-replay-decoder-parity
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+#
+# check-replay-decoder-parity — assert every live conformance operation has a
+# decoder registered in all five replay/dispatch tables.
+#
+# The source of truth is conformance/tests/live-my-surface.json: the set of
+# `operation` values on its `mode: "live"` entries. Five tables must equal that
+# set EXACTLY (both directions — not subset):
+#
+#   TypeScript  conformance/runner/typescript/live-dispatch.ts  LIVE_OPERATIONS
+#   Go          conformance/runner/go/replay_runner.go          decoders
+#   Python      conformance/runner/python/replay_runner.py      DECODERS
+#   Ruby        conformance/runner/ruby/replay-runner.rb        DECODERS
+#   Kotlin      kotlin/conformance/.../ReplayRunner.kt          decoders
+#
+# Why this exists (#553): each replay runner already has a runtime coverage
+# gate ("every fixture op has a decoder"). Those gates only fire during a live
+# canary, and the scheduled canary workflow SKIPS whenever the canary secrets
+# are unconfigured — so the four non-TS tables sat 20 operations behind the
+# fixture indefinitely, with CI fully green. The `Keep this table in sync with
+# LIVE_OPERATIONS` comment in replay_runner.go was true and unenforced.
+#
+# It is also a prerequisite of `conformance-live`, so a static mismatch fails in
+# 0.3s rather than after a ~30-minute live capture whose replay half cannot run.
+#
+# Exit non-zero on any violation. Wired into `make check` and CI (spec-gates).
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT" || exit 2
+
+# Stable byte-wise collation for every sort/comm below — a non-C locale can
+# order the same op names differently than `comm` expects, yielding false diffs
+# (or masking real ones). Matches scripts/check-idempotency-parity.
+export LC_ALL=C
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "ERROR: jq is required" >&2
+    exit 2
+fi
+
+# Explicit template so this works identically under GNU and BSD/macOS mktemp.
+# Fail fast if mktemp fails (this script omits `set -e` to accumulate
+# mismatches): an empty $WORK would turn `> "$WORK/…"` into a write to /.
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/replay-decoder-parity.XXXXXX")" || exit 2
+if [[ -z "$WORK" || ! -d "$WORK" ]]; then
+    echo "ERROR: could not create a temp directory" >&2
+    exit 2
+fi
+trap 'rm -rf "$WORK"' EXIT
+
+fail=0
+pass=0
+
+# compare <label> <expected-file> <actual-file>: set equality, both directions.
+# Inputs must be sorted. Reports names missing from / extra in the table.
+compare() {
+    local label="$1" expected="$2" actual="$3"
+    local missing extra
+    # Fail closed: both sets here are non-empty by construction. An empty file
+    # means an extraction (grep/awk/jq) matched nothing — a broken adapter, not
+    # a real "empty == empty" match — so `comm` producing no diff must not be
+    # counted as a pass. This is the failure mode that would let a renamed map
+    # silently disable the whole check.
+    if [[ ! -s "$expected" || ! -s "$actual" ]]; then
+        fail=$((fail + 1))
+        echo "  FAIL: $label"
+        echo "        internal error: empty operation set (expected=$(wc -l < "$expected" | tr -d ' '), actual=$(wc -l < "$actual" | tr -d ' ')) — an extraction matched nothing"
+        return
+    fi
+    missing=$(comm -23 "$expected" "$actual")   # in the fixture, absent from the table
+    extra=$(comm -13 "$expected" "$actual")     # in the table, absent from the fixture
+    if [[ -z "$missing" && -z "$extra" ]]; then
+        pass=$((pass + 1))
+        echo "  ok: $label"
+    else
+        fail=$((fail + 1))
+        echo "  FAIL: $label"
+        if [[ -n "$missing" ]]; then
+            echo "        missing decoders (live fixture operations with no registration):"
+            echo "$missing" | sed 's/^/          /'
+        fi
+        if [[ -n "$extra" ]]; then
+            echo "        extra registrations (not a live fixture operation):"
+            echo "$extra" | sed 's/^/          /'
+        fi
+    fi
+}
+
+echo "==> Checking replay-decoder parity across five dispatch tables"
+
+# ---- Source of truth: the live fixture ---------------------------------------
+FIXTURE=conformance/tests/live-my-surface.json
+jq -r '.[] | select(.mode == "live") | .operation' "$FIXTURE" \
+    | sort -u > "$WORK/live"
+
+# Pinned count. Bump deliberately when live-my-surface.json gains or loses a
+# live operation — and register the decoder in all five tables in the same
+# commit, which is the whole point of this check.
+expected_live_ops=31
+nLive=$(wc -l < "$WORK/live" | tr -d ' ')
+echo "    source of truth: $nLive live operations in $FIXTURE"
+if [[ "$nLive" != "$expected_live_ops" ]]; then
+    echo "  FAIL: unexpected live-operation count (got $nLive, want $expected_live_ops)"
+    echo "        $FIXTURE changed shape — update expected_live_ops deliberately."
+    fail=$((fail + 1))
+fi
+
+# Extraction is deliberately regex-light. Table delimiters are matched as
+# LITERAL TEXT with awk's index() — at column 1 for four of the five tables,
+# anywhere on the line for Kotlin's, whose declaration line begins with a
+# visibility modifier that is not part of its identity — and keys with a
+# `sed -E` capture, because
+# the tool dialects differ where it matters: an earlier draft anchored Go's keys
+# with `grep -oE '^\t"..."'`, which matches under ugrep (a common macOS grep
+# replacement) and matches NOTHING under GNU grep, where ERE has no `\t` escape.
+# It went green locally and red on ubuntu. compare()'s fail-closed empty-set
+# branch is what turned that into a loud failure instead of a silent pass.
+
+# block <file> <start-line-prefix> <end-line-prefix>: the lines strictly between
+# a line starting with <start-line-prefix> and the next line starting with
+# <end-line-prefix>. Both are literal text, not patterns.
+block() {
+    awk -v start="$2" -v end="$3" '
+        !f && index($0, start) == 1 { f = 1; next }
+        f  && index($0, end)   == 1 { f = 0 }
+        f
+    ' "$1"
+}
+
+# block_anywhere <file> <start-substring> <end-line-prefix>: as block(), but the
+# start is matched ANYWHERE on the line rather than at column 1.
+#
+# For declarations whose line begins with a modifier that is not part of the
+# declaration's identity — a Kotlin visibility keyword. Anchoring the Kotlin
+# start at column 1 bound this check to the literal string `internal val
+# decoders`, so flipping that map back to `private` (its spelling before #553
+# widened it for ReplayDecodersTest) turned a parity comparison into
+# compare()'s "empty operation set" internal error. Fail-closed, so nothing
+# passed silently — but a visibility edit is not a parity failure and must not
+# be reported as one. The start substring is still literal and still carries
+# the full type signature, so it cannot collide with prose in the KDoc above.
+block_anywhere() {
+    awk -v start="$2" -v end="$3" '
+        !f && index($0, start) > 0 { f = 1; next }
+        f  && index($0, end)   == 1 { f = 0 }
+        f
+    ' "$1"
+}
+
+# keys <sed-capture>: read a block on stdin, emit one operation name per line.
+keys() { sed -nE "$1" | sort -u; }
+
+# ---- TypeScript (live-dispatch.ts, LIVE_OPERATIONS object literal) -----------
+# Keys are bare identifiers at two-space indent inside the object literal.
+block conformance/runner/typescript/live-dispatch.ts \
+    'export const LIVE_OPERATIONS: Record<string, DispatchSpec> = {' '};' \
+    | keys 's/^  ([[:alnum:]]+):.*/\1/p' > "$WORK/typescript"
+compare "TypeScript LIVE_OPERATIONS == live fixture" "$WORK/live" "$WORK/typescript"
+
+# ---- Go (replay_runner.go, decoders map) ------------------------------------
+block conformance/runner/go/replay_runner.go \
+    'var decoders = map[string]func(bodyText string) error{' '}' \
+    | keys 's/^[[:space:]]+"([[:alnum:]]+)":.*/\1/p' > "$WORK/go"
+compare "Go decoders == live fixture" "$WORK/live" "$WORK/go"
+
+# ---- Python (replay_runner.py, DECODERS dict) -------------------------------
+block conformance/runner/python/replay_runner.py \
+    'DECODERS: dict[str, Callable[[str], None]] = {' '}' \
+    | keys 's/^[[:space:]]+"([[:alnum:]]+)":.*/\1/p' > "$WORK/python"
+compare "Python DECODERS == live fixture" "$WORK/live" "$WORK/python"
+
+# ---- Ruby (replay-runner.rb, DECODERS hash) ---------------------------------
+block conformance/runner/ruby/replay-runner.rb \
+    '  DECODERS = {' '  }.freeze' \
+    | keys 's/^[[:space:]]+"([[:alnum:]]+)".*/\1/p' > "$WORK/ruby"
+compare "Ruby DECODERS == live fixture" "$WORK/live" "$WORK/ruby"
+
+# ---- Kotlin (ReplayRunner.kt, decoders mapOf) -------------------------------
+# Visibility-agnostic: `private`, `internal` and a bare `val` all match. See
+# block_anywhere — the column-1 anchor made this arm fail on a visibility edit.
+block_anywhere kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/ReplayRunner.kt \
+    'val decoders: Map<String, (String) -> Unit> = mapOf(' ')' \
+    | keys 's/^[[:space:]]+"([[:alnum:]]+)" to.*/\1/p' > "$WORK/kotlin"
+compare "Kotlin decoders == live fixture" "$WORK/live" "$WORK/kotlin"
+
+echo ""
+if [[ "$fail" -eq 0 ]]; then
+    echo "==> Replay-decoder parity clean ($pass checks passed, $nLive operations)"
+    exit 0
+else
+    echo "==> Replay-decoder parity FAILED ($fail failure(s), $pass passed)"
+    exit 1
+fi


### PR DESCRIPTION
Closes #553. Second of a three-PR stack. **Stacked on #594** (`fix/572-runner-test-discovery`) — merge that first; two of the unit tests added here live in the files #594 makes runnable. Review this PR's own commit only.

## The defect

`conformance/tests/live-my-surface.json` declares **31** live operations. The four wire-replay decoder maps registered **11** — they froze at the original surface while later programs added `GetProgressReport`, `GetBubbleUps`, `ListRecordings`, `Search` and the 16 Everything aggregates to the fixture. 20 missing per runner, 80 registrations. TypeScript's `LIVE_OPERATIONS` in `live-dispatch.ts` correctly carries all 31; this was a four-runner gap.

Consequence: every replay runner's coverage gate ("every fixture op has a decoder") fails the moment it runs, so `conformance-live` / `conformance-canary` cannot complete their replay half at all — *after* a ~30-minute live capture. Nothing surfaced because that gate only fires during a live canary and the scheduled canary workflow skips when its secrets are unconfigured. The `Keep this table in sync with LIVE_OPERATIONS — the coverage gate enforces parity` comment in `replay_runner.go` was true and unenforced.

## The fix

Each registration goes through that SDK's real decode boundary:

| Runner | Boundary |
|---|---|
| Go | `generated.<Op>ResponseContent` via `json.Unmarshal` |
| Kotlin | the typed model the generated service uses, and `List<T>` where the service does `decodeFromString<List<T>>` — `Recording`, `Card`, `Todo`, `BucketTodosGroup`, `BucketCardsGroup`, `EverythingFile`, `TimelineEvent`, `Notification`; `ListSerializer(JsonElement)` for `Search`, which the SDK returns as `ListResult<JsonElement>` |
| Python | `json.loads` + `_normalize_person_ids` (the SDK's only post-parse pass) |
| Ruby | `JSON.parse` + `Basecamp::Http.normalize_person_ids` |

**Static guard:** `scripts/check-replay-decoder-parity` compares all five dispatch tables against the fixture, both directions, with a pinned `expected_live_ops=31` and `check-idempotency-parity`'s fail-closed `compare()` — an extraction that matches nothing is a failure, not an "empty == empty" pass. Wired into `make check`, the `spec-gates` CI job, and as a **prerequisite of `conformance-live`**, so a mismatch costs 0.3s instead of a wasted capture.

## Red proof

This PR's guard against pristine `origin/main` (`5efc52f09`). Verbatim, with one marked elision:

```
$ git archive origin/main | tar -x -C $W && cp scripts/check-replay-decoder-parity $W/scripts/
$ cd $W && ./scripts/check-replay-decoder-parity
==> Checking replay-decoder parity across five dispatch tables
    source of truth: 31 live operations in conformance/tests/live-my-surface.json
  ok: TypeScript LIVE_OPERATIONS == live fixture
  FAIL: Go decoders == live fixture
        missing decoders (live fixture operations with no registration):
          GetBubbleUps
          GetEverythingCheckins
          GetEverythingComments
          GetEverythingCompletedCards
          GetEverythingCompletedTodos
          GetEverythingFiles
          GetEverythingForwards
          GetEverythingMessages
          GetEverythingNoDueDateCards
          GetEverythingNoDueDateTodos
          GetEverythingNotNowCards
          GetEverythingOpenCards
          GetEverythingOpenTodos
          GetEverythingOverdueCards
          GetEverythingOverdueTodos
          GetEverythingUnassignedCards
          GetEverythingUnassignedTodos
          GetProgressReport
          ListRecordings
          Search
  FAIL: Python DECODERS == live fixture
        missing decoders (live fixture operations with no registration):
          [...]
  FAIL: Ruby DECODERS == live fixture
        missing decoders (live fixture operations with no registration):
          [...]
  FAIL: Kotlin decoders == live fixture
        missing decoders (live fixture operations with no registration):
          [...]

==> Replay-decoder parity FAILED (4 failure(s), 1 passed)
REAL_EXIT=1
```

Each `[...]` is the same 20 operation names printed above for Go, in the same order — **60 lines cut in total, nothing else**. Verified byte-identical across all four blocks: 20 names each, sha1 `48a8515844fb…` taken over each block's name lines stripped of leading whitespace and joined with `\n`.

### The Kotlin arm was bound to a visibility keyword

**Review-driven correction.** An earlier revision anchored the Kotlin table's start delimiter at column 1 as the literal `internal val decoders: Map<String, (String) -> Unit> = mapOf(`. This PR widens that map from `private` to `internal` so `ReplayDecodersTest` can see it — which means the delimiter matched on **this branch** and matched **nothing** on main, where it is still `private val decoders` (`ReplayRunner.kt:76`).

So the fourth block above did not report a parity gap for Kotlin at all. It reported `compare()`'s fail-closed diagnostic — `internal error: empty operation set (expected=31, actual=0) — an extraction matched nothing`. Fail-closed did its job (nothing passed silently), but a visibility edit is not a parity failure, and the misreport hid the real 20-operation gap behind an internal error. **That fourth block, showing 20 missing Kotlin registrations, is what the visibility fix bought.**

The Kotlin arm now matches its start substring **anywhere on the line** (`block_anywhere`), so `private`, `internal` and a bare `val` all work. The substring still carries the full type signature, so it cannot collide with prose in the KDoc above it.

Proved both ways against the real tree, by respelling `ReplayRunner.kt`'s `internal val decoders` back to main's `private val decoders` and changing nothing else. The pre-fix check (column-1 anchor, as pushed at `784c15b52`) — verbatim, no elision:

```
==> Checking replay-decoder parity across five dispatch tables
    source of truth: 31 live operations in conformance/tests/live-my-surface.json
  ok: TypeScript LIVE_OPERATIONS == live fixture
  ok: Go decoders == live fixture
  ok: Python DECODERS == live fixture
  ok: Ruby DECODERS == live fixture
  FAIL: Kotlin decoders == live fixture
        internal error: empty operation set (expected=31, actual=0) — an extraction matched nothing

==> Replay-decoder parity FAILED (1 failure(s), 4 passed)
REAL_EXIT=1
```

This PR's check, same tree, same `private` spelling — verbatim, no elision:

```
==> Checking replay-decoder parity across five dispatch tables
    source of truth: 31 live operations in conformance/tests/live-my-surface.json
  ok: TypeScript LIVE_OPERATIONS == live fixture
  ok: Go decoders == live fixture
  ok: Python DECODERS == live fixture
  ok: Ruby DECODERS == live fixture
  ok: Kotlin decoders == live fixture

==> Replay-decoder parity clean (5 checks passed, 31 operations)
REAL_EXIT=0
```

A visibility edit is now invisible to the check. A rename is not, which is also correct.

### Both other directions

Scratch copy of this branch: one Python entry deleted, and the Kotlin map **renamed** — `decoders` to `decoderTable` — so its extraction matches nothing. Verbatim, no elision:

```
==> Checking replay-decoder parity across five dispatch tables
    source of truth: 31 live operations in conformance/tests/live-my-surface.json
  ok: TypeScript LIVE_OPERATIONS == live fixture
  ok: Go decoders == live fixture
  FAIL: Python DECODERS == live fixture
        missing decoders (live fixture operations with no registration):
          GetEverythingFiles
  ok: Ruby DECODERS == live fixture
  FAIL: Kotlin decoders == live fixture
        internal error: empty operation set (expected=31, actual=0) — an extraction matched nothing

==> Replay-decoder parity FAILED (2 failure(s), 3 passed)
REAL_EXIT=1
```

A rename still breaks the extraction and still fails closed — intended, and why the visibility coupling was worth removing rather than living with: `private`/`internal` is not a rename.

### The fail-closed branch caught a real bug in this check, on its first CI run

The Go extraction was `grep -oE '^\t"[[:alnum:]]+":'`. That matches under **ugrep** (a common macOS `grep` replacement, and what this machine runs) and under BSD grep, but matches **nothing** under GNU grep, where POSIX ERE has no `\t` escape. Green locally, red on ubuntu, with exactly that internal-error diagnostic ([thread](https://github.com/basecamp/basecamp-sdk/pull/595#discussion_r3701770230)).

Had `compare()` treated "no diff between two empty sets" as a pass, this check would have shipped permanently vacuous for Go. The extraction is now regex-light — table delimiters matched as **literal text** with awk's `index()` (at column 1 for four tables, anywhere on the line for Kotlin's), keys with a `sed -E` capture, no `grep` at all — and is verified under a `PATH` restricted to `/usr/bin:/bin` as well as this machine's default tools.

## A parity guard proves registrations exist, not that they decode

So the registrations are also unit-tested in-language — in the two files #594 just made discoverable, plus a new Kotlin suite:

- **Go** `replay_runner_test.go` — coverage both directions against the fixture, and every decoder must accept exactly one of `[]` and `{}` (a decoder typed `any` would accept both and assert nothing).
- **Kotlin** `ReplayDecodersTest.kt` — coverage both directions, plus shape binding: kotlinx rejects an array for a class serializer unconditionally and accepts `[]` for a list serializer, so "`[]` decodes" is an exact test of `List<T>`-vs-`T`. The four `My*` ops decode as bare `JsonElement` (the SDK's own return type) and are excluded by name, with a test asserting they really are shape-free and another asserting both exception sets name registered operations.
- **Python / Ruby** — coverage both directions, and every entry must be the shared parse+normalize callable rather than a stub that would satisfy coverage while decoding nothing.

Red proof for the Kotlin shape test — swapping one registration to its element serializer, which compiles and passes the parity guard:

```diff
- "GetEverythingMessages" to { bt -> ...(ListSerializer(Recording.serializer()), bt) },
+ "GetEverythingMessages" to { bt -> ...(Recording.serializer(), bt) },
```
```
$ cd kotlin && ./gradlew --quiet :conformance:test --rerun-tasks
17 tests completed, 1 failed
[...]
BUILD FAILED in 41s
REAL_EXIT=1
```

`[...]` elides Gradle's "See the report at: file://…" pointer and its "Try: Run with --scan" boilerplate. `--quiet` prints no per-test detail, so the assertion is quoted from that run's JUnit XML (`kotlin/conformance/build/test-results/test/TEST-com.basecamp.sdk.conformance.ReplayDecodersTest.xml`) rather than from the console — testcase name and failure message verbatim, XML entities unescaped:

```
collection operations decode an empty array()
org.opentest4j.AssertionFailedError: collection decoders bound to the element type instead of List<T> ==> expected: <[]> but was: <[GetEverythingMessages]>
```

`REAL_EXIT=1` there is the bare `gradlew` binary. Through `make conformance-runner-tests-kotlin` the same failure is **2**.

## Verification (real exit codes, measured on this commit)

```
./scripts/check-replay-decoder-parity     5 checks, 31 operations   REAL_EXIT=0
PATH=/usr/bin:/bin ./scripts/check-replay-decoder-parity            REAL_EXIT=0
./scripts/check-runner-test-reachability  9 checks passed           REAL_EXIT=0
./scripts/check-runner-test-reachability --self-test  6 cases       REAL_EXIT=0
make conformance-runner-tests-go          ok (cached)               REAL_EXIT=0
make conformance-runner-tests-python      20 passed, 31 subtests    REAL_EXIT=0
make conformance-runner-tests-ruby        11 + 6 runs, 0 failures   REAL_EXIT=0
make conformance-runner-tests-kotlin      (--quiet, no output)      REAL_EXIT=0
make conformance-runner-tests-swift       39 tests, 0 failures      REAL_EXIT=0
cd kotlin && ./gradlew :conformance:test --rerun-tasks
                                          DelayGapsTest 10/0/0,
                                          ReplayDecodersTest 7/0/0  REAL_EXIT=0
cd conformance/runner/go && go build ./... && go vet ./...          REAL_EXIT=0
make lint-actions                         No findings to report     REAL_EXIT=0
```

`make conformance-runner-tests-python` collects the whole `conformance/runner/python` directory, not one file: of that **20**, `test_replay_runner.py` is **8** tests and all 31 subtests (`pytest -q test_replay_runner.py` → "8 passed, 31 subtests passed", `REAL_EXIT=0`). It was **5** before this PR extended it — also `pytest -q --collect-only` on that one file, not a share of the 20.

Local figures — cite the CI job's own numbers where they differ.

## Docs

`CONTRIBUTING.md`'s "each runner's coverage gate refuses to start until all five are in place" is the claim this issue disproves — it now says why that gate is not sufficient and names the static check. `SPEC.md`'s `live-my-surface` row said 30 cases; the fixture has 31.

No spec files touched (`spec/basecamp.smithy`, `openapi.json` unchanged).
