### PR TITLE
Refuse a malformed GET field instead of writing it back (#576)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -348,7 +348,9 @@ jobs:
         # vacuous assertion (#563) survives a fully green conformance run.
         if: matrix.ruby == '3.3'
         working-directory: conformance/runner/ruby
-        run: bundle exec ruby delay_gaps_test.rb
+        run: |
+          bundle exec ruby delay_gaps_test.rb
+          bundle exec ruby error_raised_test.rb
 
   test-python:
     name: Python ${{ matrix.python }}
@@ -427,7 +429,7 @@ jobs:
         # vacuous assertion (#563) survives a fully green conformance run.
         if: matrix.python == '3.13'
         working-directory: conformance/runner/python
-        run: uv run --python ${{ matrix.python }} python -m pytest -q test_delay_gaps.py
+        run: uv run --python ${{ matrix.python }} python -m pytest -q test_delay_gaps.py test_error_raised.py
 
   test-swift:
     name: Swift Tests

--- a/Makefile
+++ b/Makefile
@@ -507,6 +507,12 @@ oauth-token-fixtures-check:
 # like `$comment` placed there declares a property of that name with a string
 # for a schema — accepted silently by the fixture pass, rejected by any
 # validator that meta-validates first.
+#
+# The self-test runs after the live check for the same reason the gate exists:
+# pointed only at the valid fixture set, the gate proves it can say yes and
+# nothing else. Several of its rejections — a kill case answering 204 above all
+# — are invisible to both the schema pass and every runner, so a regression that
+# removed them would show up as a clean `make conformance` and nowhere else.
 conformance-fixtures-check:
 	@echo "==> Validating conformance schemas against the JSON Schema metaschema..."
 	uvx --from 'check-jsonschema==$(CHECK_JSONSCHEMA_VERSION)' check-jsonschema \
@@ -516,6 +522,8 @@ conformance-fixtures-check:
 		--schemafile conformance/tests.schema.json conformance/tests/*.json
 	@echo "==> Checking errorRaised fixtures have body-pinning control siblings..."
 	python3 conformance/check_kill_case_controls.py
+	@echo "==> Self-testing the control-sibling gate's rejections..."
+	@python3 conformance/test_check_kill_case_controls.py
 
 # Unit-test the runners' own assertion helpers.
 #

--- a/Makefile
+++ b/Makefile
@@ -500,7 +500,17 @@ oauth-token-fixtures-check:
 # fail loudly on a body that no longer matches) — except where a fixture
 # declares errorRaised, which deliberately switches that policy off. The
 # control-sibling gate below is what keeps those fixtures honest.
+#
+# The metaschema pass runs FIRST because validating fixtures against a schema
+# that is not itself a valid schema proves nothing. Draft 2020-12 requires every
+# value under `properties` to be a schema object or boolean, so an annotation
+# like `$comment` placed there declares a property of that name with a string
+# for a schema — accepted silently by the fixture pass, rejected by any
+# validator that meta-validates first.
 conformance-fixtures-check:
+	@echo "==> Validating conformance schemas against the JSON Schema metaschema..."
+	uvx --from 'check-jsonschema==$(CHECK_JSONSCHEMA_VERSION)' check-jsonschema \
+		--check-metaschema conformance/schema.json conformance/tests.schema.json
 	@echo "==> Validating conformance fixtures against schema.json..."
 	uvx --from 'check-jsonschema==$(CHECK_JSONSCHEMA_VERSION)' check-jsonschema \
 		--schemafile conformance/tests.schema.json conformance/tests/*.json

--- a/Makefile
+++ b/Makefile
@@ -494,10 +494,18 @@ oauth-token-fixtures-check:
 # {status:204, networkError:false}) would only be caught, if at all, by each
 # runner's looser runtime backstop. tests.schema.json wraps schema.json as an
 # array so check-jsonschema validates each element of the array-shaped files.
+#
+# Schema validation checks the fixture FORMAT, not that a mock body still
+# decodes into the generated models. The runners enforce that (Kotlin/Swift
+# fail loudly on a body that no longer matches) — except where a fixture
+# declares errorRaised, which deliberately switches that policy off. The
+# control-sibling gate below is what keeps those fixtures honest.
 conformance-fixtures-check:
 	@echo "==> Validating conformance fixtures against schema.json..."
 	uvx --from 'check-jsonschema==$(CHECK_JSONSCHEMA_VERSION)' check-jsonschema \
 		--schemafile conformance/tests.schema.json conformance/tests/*.json
+	@echo "==> Checking errorRaised fixtures have body-pinning control siblings..."
+	python3 conformance/check_kill_case_controls.py
 
 # Unit-test the runners' own assertion helpers.
 #

--- a/Makefile
+++ b/Makefile
@@ -506,11 +506,16 @@ conformance-fixtures-check:
 # #563 shipped a delayBetweenRequests check that vacuously passed when the gap
 # it named did not exist; nothing caught it because every committed fixture
 # supplied the gap. These pin the branches the fixtures cannot reach.
+#
+# errorRaised (#576) is the same shape: every fixture declaring it is one the
+# SDK does refuse, so its failing branch is unreachable from conformance/tests/
+# and a handler that accepted everything would look green in all six runners.
 conformance-runner-tests:
 	@echo "==> Running conformance runner unit tests..."
 	cd conformance/runner/go && go test ./...
-	cd conformance/runner/python && uv run python -m pytest -q test_delay_gaps.py
+	cd conformance/runner/python && uv run python -m pytest -q test_delay_gaps.py test_error_raised.py
 	cd conformance/runner/ruby && bundle install --quiet && bundle exec ruby delay_gaps_test.rb
+	cd conformance/runner/ruby && bundle exec ruby error_raised_test.rb
 	cd kotlin && ./gradlew --quiet :conformance:test
 	@$(MAKE) --no-print-directory conformance-swift-runner-tests
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1846,6 +1846,7 @@ undocumented:
 | `headerValue` | Named header has specific value |
 | `errorType` | Error type classification |
 | `noError` | Operation completed without error |
+| `errorRaised` | Operation failed, without naming how — the code-agnostic inverse of `noError`. For cases the SDKs refuse by *different* mechanisms (a hand-written guard raises `api_error`; a model decoder raises its own language's decode failure), so no single `errorType` is assertable and what all six agree on is that the call fails at all. Declaring it also tells the decoder-backed runners that a decode failure is the behaviour under test rather than a stale fixture body, which switches the stop-on-mismatch policy off for that case — so every fixture declaring it must have a non-`errorRaised` control sibling whose decoded body differs in exactly one field, enforced by `conformance/check_kill_case_controls.py`. |
 | `requestPath` | URL path of the outgoing request |
 | `requestMethod` | HTTP method of the outgoing request |
 | `requestBody` | Value at `path` (dot-notation key) inside the captured JSON request body. A request that sent no JSON body fails, as does a body that omits the key. |

--- a/conformance/check_kill_case_controls.py
+++ b/conformance/check_kill_case_controls.py
@@ -22,13 +22,29 @@ does NOT declare `errorRaised`, so it keeps the full #555 policy. Model drift
 therefore still fails loudly — in the sibling. This gate is what keeps that
 true, because nothing else stops the two bodies from drifting apart:
 
-    for every case declaring errorRaised, some case in the same file that does
-    NOT declare it must have a mock response body with the identical key set,
-    differing in exactly one field.
+    for every case declaring errorRaised, a case in the same file that does NOT
+    declare it, exercising the SAME operation, must have a first mock response
+    body with the identical key set, differing in exactly one field.
 
-That one differing field is the field under test. Enforcing the claim rather
-than asserting it in a comment, per the lesson from #576 itself: a guarantee
-nobody checks is a guarantee that quietly stops holding.
+That one differing field is the field under test.
+
+Two deliberate restrictions, both load-bearing — a looser version of this gate
+can be satisfied by a body that is never decoded:
+
+* **The first response only, on both sides.** These cases assert
+  `requestCount: 1`, so response 0 is the GET whose decoder rejection is under
+  test; the second queued response is a decoy, there so a runner cannot pass by
+  exhausting the queue instead of refusing the field. It is never consumed.
+  Matching a kill body against *any* queued response of *any* control would let
+  an unconsumed decoy satisfy the gate while the body that actually gets
+  decoded drifts away from its control — which is the exact hole this gate
+  exists to close, one level up.
+* **The same operation.** A body that decodes into a different model says
+  nothing about whether this one still decodes.
+
+Enforcing the claim rather than asserting it in a comment, per the lesson from
+#576 itself: a guarantee nobody checks is a guarantee that quietly stops
+holding.
 
 Run: `python3 conformance/check_kill_case_controls.py` (wired into
 `make conformance-fixtures-check`).
@@ -43,13 +59,13 @@ import sys
 ASSERTION = "errorRaised"
 
 
-def bodies(case: dict) -> list[dict]:
-    """Every object-shaped mock response body in a case."""
-    return [
-        r["body"]
-        for r in case.get("mockResponses", [])
-        if isinstance(r.get("body"), dict)
-    ]
+def consumed_body(case: dict) -> dict | None:
+    """The first mock response body — the one the case under test decodes."""
+    responses = case.get("mockResponses", [])
+    if not responses:
+        return None
+    body = responses[0].get("body")
+    return body if isinstance(body, dict) else None
 
 
 def declares_error_raised(case: dict) -> bool:
@@ -61,30 +77,29 @@ def check_file(path: str) -> list[str]:
         cases = json.load(f)
 
     failures: list[str] = []
+    name = os.path.basename(path)
     controls = [c for c in cases if not declares_error_raised(c)]
 
     for kill in (c for c in cases if declares_error_raised(c)):
-        kill_bodies = bodies(kill)
-        if not kill_bodies:
+        kill_body = consumed_body(kill)
+        if kill_body is None:
             failures.append(
-                f"{os.path.basename(path)}: {kill['name']!r} declares {ASSERTION} "
-                f"but has no object-shaped mock response body to control against"
+                f"{name}: {kill['name']!r} declares {ASSERTION} but its first mock "
+                f"response has no object-shaped body to control against"
             )
             continue
 
+        operation = kill.get("operation")
         matched = None
-        for kb in kill_bodies:
-            for control in controls:
-                for cb in bodies(control):
-                    if set(cb) != set(kb):
-                        continue
-                    differing = sorted(k for k in kb if kb[k] != cb[k])
-                    if len(differing) == 1:
-                        matched = (control["name"], differing[0])
-                        break
-                if matched:
-                    break
-            if matched:
+        for control in controls:
+            if control.get("operation") != operation:
+                continue
+            control_body = consumed_body(control)
+            if control_body is None or set(control_body) != set(kill_body):
+                continue
+            differing = sorted(k for k in kill_body if kill_body[k] != control_body[k])
+            if len(differing) == 1:
+                matched = (control["name"], differing[0])
                 break
 
         if matched:
@@ -94,13 +109,13 @@ def check_file(path: str) -> list[str]:
             )
         else:
             failures.append(
-                f"{os.path.basename(path)}: {kill['name']!r} declares {ASSERTION} but no "
-                f"non-{ASSERTION} case in this file has a mock body with the same key set "
-                f"differing in exactly one field.\n"
+                f"{name}: {kill['name']!r} declares {ASSERTION} but no non-{ASSERTION} "
+                f"case for operation {operation!r} in this file has a FIRST mock response "
+                f"body with the same key set differing in exactly one field.\n"
                 f"      Without one, a decode failure caused by unrelated model drift would "
                 f"satisfy this case and it would stop testing the field it names.\n"
-                f"      Add (or repair) the control case so the two bodies differ only in "
-                f"the field under test."
+                f"      Add (or repair) the control case so the two decoded bodies differ "
+                f"only in the field under test."
             )
 
     return failures
@@ -115,8 +130,7 @@ def main() -> int:
 
     failures: list[str] = []
     for path in paths:
-        found = check_file(path)
-        failures.extend(found)
+        failures.extend(check_file(path))
 
     if failures:
         print("\nFAIL: errorRaised fixtures without a control sibling:\n", file=sys.stderr)

--- a/conformance/check_kill_case_controls.py
+++ b/conformance/check_kill_case_controls.py
@@ -59,13 +59,43 @@ import sys
 ASSERTION = "errorRaised"
 
 
+def consumed_response(case: dict) -> dict | None:
+    """The first mock response — the one the case under test decodes."""
+    responses = case.get("mockResponses", [])
+    return responses[0] if responses else None
+
+
 def consumed_body(case: dict) -> dict | None:
     """The first mock response body — the one the case under test decodes."""
-    responses = case.get("mockResponses", [])
-    if not responses:
+    response = consumed_response(case)
+    if response is None:
         return None
-    body = responses[0].get("body")
+    body = response.get("body")
     return body if isinstance(body, dict) else None
+
+
+def not_a_success(response: dict) -> str | None:
+    """Why this response would fail the call before the body is ever decoded.
+
+    A kill case's premise is that the malformed value arrived in a SUCCESSFUL
+    API response — that is what makes it the SDK's problem rather than the
+    server's, and it is why #576 classifies the refusal as `api_error` with no
+    status rather than as a transport or HTTP failure.
+
+    If the response were quietly changed to a 500, or to `networkError`, the
+    SDK would fail on that instead and `errorRaised` would still hold — along
+    with `requestCount`, `requestMethod` and `requestPath` — while the
+    malformed field was never decoded at all. The case would go green having
+    tested nothing. Body equality cannot see that, so it is checked here.
+    """
+    if response.get("networkError"):
+        return "declares networkError, so the call fails in transport and the body is never decoded"
+    status = response.get("status")
+    if not isinstance(status, int):
+        return f"has a non-integer status {status!r}"
+    if not 200 <= status < 300:
+        return f"has status {status}, so the call fails on the HTTP error before the body is decoded"
+    return None
 
 
 def declares_error_raised(case: dict) -> bool:
@@ -81,11 +111,26 @@ def check_file(path: str) -> list[str]:
     controls = [c for c in cases if not declares_error_raised(c)]
 
     for kill in (c for c in cases if declares_error_raised(c)):
+        kill_response = consumed_response(kill)
         kill_body = consumed_body(kill)
-        if kill_body is None:
+        if kill_response is None or kill_body is None:
             failures.append(
                 f"{name}: {kill['name']!r} declares {ASSERTION} but its first mock "
                 f"response has no object-shaped body to control against"
+            )
+            continue
+
+        # The body must actually reach a decoder for its shape to matter.
+        reason = not_a_success(kill_response)
+        if reason is not None:
+            failures.append(
+                f"{name}: {kill['name']!r} declares {ASSERTION}, but its first mock response "
+                f"{reason}.\n"
+                f"      {ASSERTION} would then be satisfied by that failure — with requestCount, "
+                f"requestMethod and requestPath still green — and the malformed field would "
+                f"never be decoded, so the case would test nothing.\n"
+                f"      A kill case must deliver its malformed value in a SUCCESSFUL (2xx) "
+                f"response."
             )
             continue
 

--- a/conformance/check_kill_case_controls.py
+++ b/conformance/check_kill_case_controls.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Every `errorRaised` fixture must have a control sibling that pins its body.
+
+Declaring `errorRaised` switches OFF the #555 stop-on-mismatch policy in the
+decoder-backed runners: Swift's `DecodingError` branch and Kotlin's
+`MissingFieldException`/`SerializationException` branches normally fail loudly
+on a mock body that no longer decodes into the generated model, but when the
+fixture declares `errorRaised` they treat the refusal as the behaviour under
+test and pass.
+
+That is correct — a decoder rejecting a deliberately malformed field is exactly
+how Go, Kotlin and Swift satisfy the #576 kill cases — but on its own it is
+also a way for a kill case to keep passing for the wrong reason. If the model
+later gains a required field, or any unrelated field in one of these large mock
+bodies drifts, the decode fails for a reason that has nothing to do with the
+field under test. `errorRaised`, `requestCount: 1`, `requestMethod` and
+`requestPath` all still hold, and the case silently stops proving anything.
+
+The protection is structural rather than declared: each kill body is some
+passing case's body with exactly one field perturbed, and that passing sibling
+does NOT declare `errorRaised`, so it keeps the full #555 policy. Model drift
+therefore still fails loudly — in the sibling. This gate is what keeps that
+true, because nothing else stops the two bodies from drifting apart:
+
+    for every case declaring errorRaised, some case in the same file that does
+    NOT declare it must have a mock response body with the identical key set,
+    differing in exactly one field.
+
+That one differing field is the field under test. Enforcing the claim rather
+than asserting it in a comment, per the lesson from #576 itself: a guarantee
+nobody checks is a guarantee that quietly stops holding.
+
+Run: `python3 conformance/check_kill_case_controls.py` (wired into
+`make conformance-fixtures-check`).
+"""
+from __future__ import annotations
+
+import glob
+import json
+import os
+import sys
+
+ASSERTION = "errorRaised"
+
+
+def bodies(case: dict) -> list[dict]:
+    """Every object-shaped mock response body in a case."""
+    return [
+        r["body"]
+        for r in case.get("mockResponses", [])
+        if isinstance(r.get("body"), dict)
+    ]
+
+
+def declares_error_raised(case: dict) -> bool:
+    return any(a.get("type") == ASSERTION for a in case.get("assertions", []))
+
+
+def check_file(path: str) -> list[str]:
+    with open(path) as f:
+        cases = json.load(f)
+
+    failures: list[str] = []
+    controls = [c for c in cases if not declares_error_raised(c)]
+
+    for kill in (c for c in cases if declares_error_raised(c)):
+        kill_bodies = bodies(kill)
+        if not kill_bodies:
+            failures.append(
+                f"{os.path.basename(path)}: {kill['name']!r} declares {ASSERTION} "
+                f"but has no object-shaped mock response body to control against"
+            )
+            continue
+
+        matched = None
+        for kb in kill_bodies:
+            for control in controls:
+                for cb in bodies(control):
+                    if set(cb) != set(kb):
+                        continue
+                    differing = sorted(k for k in kb if kb[k] != cb[k])
+                    if len(differing) == 1:
+                        matched = (control["name"], differing[0])
+                        break
+                if matched:
+                    break
+            if matched:
+                break
+
+        if matched:
+            print(
+                f"  ok  {kill['name'][:64]!r}\n"
+                f"      field {matched[1]!r} controlled by {matched[0][:56]!r}"
+            )
+        else:
+            failures.append(
+                f"{os.path.basename(path)}: {kill['name']!r} declares {ASSERTION} but no "
+                f"non-{ASSERTION} case in this file has a mock body with the same key set "
+                f"differing in exactly one field.\n"
+                f"      Without one, a decode failure caused by unrelated model drift would "
+                f"satisfy this case and it would stop testing the field it names.\n"
+                f"      Add (or repair) the control case so the two bodies differ only in "
+                f"the field under test."
+            )
+
+    return failures
+
+
+def main() -> int:
+    root = os.path.dirname(os.path.abspath(__file__))
+    paths = sorted(glob.glob(os.path.join(root, "tests", "*.json")))
+    if not paths:
+        print("no fixtures found", file=sys.stderr)
+        return 1
+
+    failures: list[str] = []
+    for path in paths:
+        found = check_file(path)
+        failures.extend(found)
+
+    if failures:
+        print("\nFAIL: errorRaised fixtures without a control sibling:\n", file=sys.stderr)
+        for f in failures:
+            print(f"  - {f}", file=sys.stderr)
+        return 1
+
+    print("\nAll errorRaised fixtures have a body-pinning control sibling.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conformance/check_kill_case_controls.py
+++ b/conformance/check_kill_case_controls.py
@@ -139,6 +139,16 @@ def check_file(path: str) -> list[str]:
         for control in controls:
             if control.get("operation") != operation:
                 continue
+            control_response = consumed_response(control)
+            # The control earns its keep only by being DECODED: that is what
+            # makes it fail loudly (#555) when the model drifts, which is the
+            # entire protection the kill case borrows from it. A control that
+            # answers 500 or networkError never reaches its decoder, so it can
+            # sit green on its own HTTP/transport assertions while the drift it
+            # was supposed to catch goes unnoticed in both bodies. Same check as
+            # the kill side, for the same reason.
+            if control_response is None or not_a_success(control_response) is not None:
+                continue
             control_body = consumed_body(control)
             if control_body is None or set(control_body) != set(kill_body):
                 continue
@@ -155,8 +165,9 @@ def check_file(path: str) -> list[str]:
         else:
             failures.append(
                 f"{name}: {kill['name']!r} declares {ASSERTION} but no non-{ASSERTION} "
-                f"case for operation {operation!r} in this file has a FIRST mock response "
-                f"body with the same key set differing in exactly one field.\n"
+                f"case for operation {operation!r} in this file has a SUCCESSFUL (2xx) FIRST "
+                f"mock response whose body has the same key set differing in exactly one "
+                f"field.\n"
                 f"      Without one, a decode failure caused by unrelated model drift would "
                 f"satisfy this case and it would stop testing the field it names.\n"
                 f"      Add (or repair) the control case so the two decoded bodies differ "

--- a/conformance/check_kill_case_controls.py
+++ b/conformance/check_kill_case_controls.py
@@ -28,7 +28,7 @@ true, because nothing else stops the two bodies from drifting apart:
 
 That one differing field is the field under test.
 
-Two deliberate restrictions, both load-bearing — a looser version of this gate
+Three deliberate restrictions, all load-bearing — a looser version of this gate
 can be satisfied by a body that is never decoded:
 
 * **The first response only, on both sides.** These cases assert
@@ -41,13 +41,19 @@ can be satisfied by a body that is never decoded:
   exists to close, one level up.
 * **The same operation.** A body that decodes into a different model says
   nothing about whether this one still decodes.
+* **A status whose body is actually decoded, on both sides.** Body equality is
+  blind to the response *outcome*, and several outcomes hand the body to
+  nobody: a transport failure, an HTTP error, and — less obviously — a 204,
+  which the SDKs short-circuit before any parse. See `DECODED_STATUSES`.
 
 Enforcing the claim rather than asserting it in a comment, per the lesson from
 #576 itself: a guarantee nobody checks is a guarantee that quietly stops
 holding.
 
-Run: `python3 conformance/check_kill_case_controls.py` (wired into
-`make conformance-fixtures-check`).
+Run: `python3 conformance/check_kill_case_controls.py [FIXTURE_DIR]` — defaulting
+to `conformance/tests` — wired into `make conformance-fixtures-check`, which then
+runs `conformance/test_check_kill_case_controls.py` to prove the gate can still
+say no.
 """
 from __future__ import annotations
 
@@ -57,6 +63,36 @@ import os
 import sys
 
 ASSERTION = "errorRaised"
+
+# The statuses whose response body actually reaches a generated model's decoder
+# in every SDK the conformance runners drive. Two independent constraints meet
+# here, and the intersection is {200, 201}:
+#
+# * **Go's success arm is exactly {200, 201, 204}** (`go/pkg/basecamp/client.go`,
+#   `case http.StatusOK, http.StatusCreated, http.StatusNoContent`). 202, 203,
+#   205 and 206 fall through to the error default, so a body sent under them is
+#   never decoded there at all.
+# * **204 is short-circuited before any parse**, everywhere it is recognised:
+#   TypeScript returns `undefined` (`typescript/src/services/base.ts`), Kotlin
+#   returns `Unit` without calling `parse` (`kotlin/.../BaseService.kt`), and Go
+#   rewrites the body to JSON `null` (`client.go`). A 204 carries no body by
+#   definition, and 205 makes the same promise in HTTP terms.
+#
+# So a kill case whose first response is a 204 is silently vacuous: the malformed
+# field is never decoded, the composite fails because the record came back absent,
+# and `errorRaised` + `requestCount: 1` + `requestMethod` + `requestPath` are all
+# still satisfied. Meanwhile its control, still a 200, stays green — so body
+# equality alone certifies the pair as valid while the kill case tests nothing.
+#
+# Written as an allowlist rather than a 204 exclusion, deliberately. This gate's
+# entire job is to prove a body is decoded, and it cannot prove that for a status
+# nobody has reasoned about; closed-by-default means the next such status is
+# rejected with a message pointing here instead of quietly joining 204.
+DECODED_STATUSES = frozenset({200, 201})
+
+# Statuses that forbid a response body outright, called out separately only so
+# the failure explains itself rather than reading as an arbitrary allowlist miss.
+NO_BODY_STATUSES = frozenset({204, 205})
 
 
 def consumed_response(case: dict) -> dict | None:
@@ -74,19 +110,26 @@ def consumed_body(case: dict) -> dict | None:
     return body if isinstance(body, dict) else None
 
 
-def not_a_success(response: dict) -> str | None:
-    """Why this response would fail the call before the body is ever decoded.
+def not_decoded(response: dict) -> str | None:
+    """Why this response's body never reaches a decoder — or None if it does.
 
-    A kill case's premise is that the malformed value arrived in a SUCCESSFUL
-    API response — that is what makes it the SDK's problem rather than the
-    server's, and it is why #576 classifies the refusal as `api_error` with no
-    status rather than as a transport or HTTP failure.
+    A kill case's premise is that the malformed value arrived in a response the
+    SDK ACCEPTED AND DECODED. That is what makes it the SDK's problem rather
+    than the server's, and it is why #576 classifies the refusal as `api_error`
+    with no status rather than as a transport or HTTP failure.
 
-    If the response were quietly changed to a 500, or to `networkError`, the
-    SDK would fail on that instead and `errorRaised` would still hold — along
-    with `requestCount`, `requestMethod` and `requestPath` — while the
-    malformed field was never decoded at all. The case would go green having
-    tested nothing. Body equality cannot see that, so it is checked here.
+    Three ways a body goes undecoded, and all three leave the case green:
+
+    * `networkError` — the call dies in transport.
+    * a non-2xx status — the call fails on the HTTP error first.
+    * a 2xx the SDKs do not decode a body from, of which 204 is the live one:
+      it is short-circuited before any parse, so the composite fails merely
+      because the record came back absent.
+
+    In every case `errorRaised` still holds — along with `requestCount`,
+    `requestMethod` and `requestPath` — while the malformed field was never
+    decoded at all, and the case goes green having tested nothing. Body
+    equality cannot see any of it, so it is checked here.
     """
     if response.get("networkError"):
         return "declares networkError, so the call fails in transport and the body is never decoded"
@@ -95,6 +138,19 @@ def not_a_success(response: dict) -> str | None:
         return f"has a non-integer status {status!r}"
     if not 200 <= status < 300:
         return f"has status {status}, so the call fails on the HTTP error before the body is decoded"
+    if status in NO_BODY_STATUSES:
+        return (
+            f"has status {status}, which carries no body by definition and is "
+            f"short-circuited before any parse — TypeScript returns undefined, Kotlin "
+            f"returns Unit without parsing, Go rewrites the body to JSON null — so the "
+            f"body is never decoded"
+        )
+    if status not in DECODED_STATUSES:
+        return (
+            f"has status {status}, which is not one of the statuses whose body every SDK "
+            f"decodes ({', '.join(str(s) for s in sorted(DECODED_STATUSES))}); Go's "
+            f"success arm alone excludes it, so the body is never decoded there"
+        )
     return None
 
 
@@ -121,7 +177,7 @@ def check_file(path: str) -> list[str]:
             continue
 
         # The body must actually reach a decoder for its shape to matter.
-        reason = not_a_success(kill_response)
+        reason = not_decoded(kill_response)
         if reason is not None:
             failures.append(
                 f"{name}: {kill['name']!r} declares {ASSERTION}, but its first mock response "
@@ -129,8 +185,9 @@ def check_file(path: str) -> list[str]:
                 f"      {ASSERTION} would then be satisfied by that failure — with requestCount, "
                 f"requestMethod and requestPath still green — and the malformed field would "
                 f"never be decoded, so the case would test nothing.\n"
-                f"      A kill case must deliver its malformed value in a SUCCESSFUL (2xx) "
-                f"response."
+                f"      A kill case must deliver its malformed value in a response the SDKs "
+                f"DECODE: status "
+                f"{' or '.join(str(s) for s in sorted(DECODED_STATUSES))}."
             )
             continue
 
@@ -143,11 +200,11 @@ def check_file(path: str) -> list[str]:
             # The control earns its keep only by being DECODED: that is what
             # makes it fail loudly (#555) when the model drifts, which is the
             # entire protection the kill case borrows from it. A control that
-            # answers 500 or networkError never reaches its decoder, so it can
-            # sit green on its own HTTP/transport assertions while the drift it
-            # was supposed to catch goes unnoticed in both bodies. Same check as
-            # the kill side, for the same reason.
-            if control_response is None or not_a_success(control_response) is not None:
+            # answers 500, a 204, or networkError never reaches its decoder, so
+            # it can sit green on its own HTTP/transport assertions while the
+            # drift it was supposed to catch goes unnoticed in both bodies. Same
+            # check as the kill side, for the same reason.
+            if control_response is None or not_decoded(control_response) is not None:
                 continue
             control_body = consumed_body(control)
             if control_body is None or set(control_body) != set(kill_body):
@@ -165,9 +222,9 @@ def check_file(path: str) -> list[str]:
         else:
             failures.append(
                 f"{name}: {kill['name']!r} declares {ASSERTION} but no non-{ASSERTION} "
-                f"case for operation {operation!r} in this file has a SUCCESSFUL (2xx) FIRST "
-                f"mock response whose body has the same key set differing in exactly one "
-                f"field.\n"
+                f"case for operation {operation!r} in this file has a DECODED (status "
+                f"{' or '.join(str(s) for s in sorted(DECODED_STATUSES))}) FIRST mock "
+                f"response whose body has the same key set differing in exactly one field.\n"
                 f"      Without one, a decode failure caused by unrelated model drift would "
                 f"satisfy this case and it would stop testing the field it names.\n"
                 f"      Add (or repair) the control case so the two decoded bodies differ "
@@ -177,11 +234,18 @@ def check_file(path: str) -> list[str]:
     return failures
 
 
-def main() -> int:
-    root = os.path.dirname(os.path.abspath(__file__))
-    paths = sorted(glob.glob(os.path.join(root, "tests", "*.json")))
+def main(argv: list[str] | None = None) -> int:
+    # The optional argument exists for the self-test, which has to be able to
+    # make this gate FAIL — a gate only ever pointed at the valid repo proves
+    # it can say yes and nothing else (the #576 lesson, applied to the gate).
+    args = sys.argv[1:] if argv is None else argv
+    if len(args) > 1:
+        print(f"usage: {os.path.basename(__file__)} [FIXTURE_DIR]", file=sys.stderr)
+        return 2
+    root = args[0] if args else os.path.join(os.path.dirname(os.path.abspath(__file__)), "tests")
+    paths = sorted(glob.glob(os.path.join(root, "*.json")))
     if not paths:
-        print("no fixtures found", file=sys.stderr)
+        print(f"no fixtures found in {root}", file=sys.stderr)
         return 1
 
     failures: list[str] = []

--- a/conformance/runner/go/error_raised.go
+++ b/conformance/runner/go/error_raised.go
@@ -1,0 +1,28 @@
+package main
+
+// errorRaisedFailure validates one `errorRaised` assertion, returning "" when
+// it holds and a failure message otherwise.
+//
+// The inverse of noError, and deliberately code-agnostic. The
+// malformed-response family (#576) is refused by a hand-written guard in
+// TypeScript, Python and Ruby and by the model decoder in Go, Kotlin and
+// Swift; those two mechanisms share no canonical error code, so pinning
+// errorType would make the fixture unwritable. What all six agree on is that
+// the call fails at all — which, paired with requestCount, is the whole
+// contract: the composite refused the field instead of writing it.
+//
+// Split out of checkAssertion so the failing branch is unit-testable. NO
+// COMMITTED FIXTURE CAN REACH IT: every case declaring errorRaised is one the
+// SDK does refuse, so a handler that accepted everything would report green in
+// all six runners at once. That is the #563 shape — a delayBetweenRequests
+// check that passed vacuously because no fixture supplied a gap it could fail
+// on — and the reason `make conformance-runner-tests` exists.
+//
+// The message is pinned verbatim by the unit tests in all six runners: a
+// fixture debugged in one language should not read differently in another.
+func errorRaisedFailure(dispatchFailed bool) string {
+	if dispatchFailed {
+		return ""
+	}
+	return "Expected the call to fail, but it succeeded"
+}

--- a/conformance/runner/go/error_raised_test.go
+++ b/conformance/runner/go/error_raised_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+// The wording is asserted verbatim, here and in the five sibling runners. A
+// fixture debugged in one language should not read differently in another.
+const errorRaisedMessage = "Expected the call to fail, but it succeeded"
+
+// Both directions of the errorRaised contract.
+//
+// Only the passing direction ever runs against a committed fixture: every case
+// declaring errorRaised is one the SDK does refuse. A handler that accepted
+// everything would therefore look green in all six runners, which is exactly
+// how #563 shipped a vacuous delayBetweenRequests check.
+func TestErrorRaisedFailure(t *testing.T) {
+	if msg := errorRaisedFailure(true); msg != "" {
+		t.Fatalf("a failed dispatch satisfies errorRaised, got %q", msg)
+	}
+	if msg := errorRaisedFailure(false); msg != errorRaisedMessage {
+		t.Fatalf("expected %q for a successful dispatch, got %q", errorRaisedMessage, msg)
+	}
+}
+
+// The wiring, not just the predicate: checkAssertion must route the assertion
+// type to that branch and surface its message. A typo'd case label would leave
+// errorRaised falling through to the default and asserting nothing.
+func TestCheckAssertionRoutesErrorRaised(t *testing.T) {
+	tc := TestCase{Name: "update-kill"}
+	assertion := Assertion{Type: "errorRaised"}
+
+	if res := checkAssertion(tc, assertion, operationResult{err: errors.New("malformed response")}, 1, nil, nil, nil, nil, nil); res != nil {
+		t.Fatalf("expected a refused dispatch to pass, got %q", res.Message)
+	}
+
+	res := checkAssertion(tc, assertion, operationResult{}, 2, nil, nil, nil, nil, nil)
+	if res == nil {
+		t.Fatal("expected checkAssertion to fail when the dispatch succeeded, got a pass")
+	}
+	if res.Message != errorRaisedMessage {
+		t.Fatalf("expected %q, got %q", errorRaisedMessage, res.Message)
+	}
+}

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -1092,6 +1092,18 @@ func checkAssertion(
 			return fail(tc, fmt.Sprintf("Expected no error, got: %v", sdkErr))
 		}
 
+	// The inverse of noError, and deliberately code-agnostic. The
+	// malformed-response family (#576) is refused by a hand-written guard in
+	// TypeScript, Python and Ruby and by the model decoder in Go, Kotlin and
+	// Swift; those two mechanisms do not share a canonical code, so pinning
+	// errorType would make the fixture unwritable. What every SDK must agree on
+	// is that the call fails at all — which, paired with requestCount, is the
+	// whole contract: the composite refused the field instead of writing it.
+	case "errorRaised":
+		if sdkErr == nil {
+			return fail(tc, "Expected the call to fail, but it succeeded")
+		}
+
 	case "errorType":
 		if sdkErr == nil {
 			return fail(tc, fmt.Sprintf("Expected error type %v, but got no error", assertion.Expected))

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -1092,16 +1092,13 @@ func checkAssertion(
 			return fail(tc, fmt.Sprintf("Expected no error, got: %v", sdkErr))
 		}
 
-	// The inverse of noError, and deliberately code-agnostic. The
-	// malformed-response family (#576) is refused by a hand-written guard in
-	// TypeScript, Python and Ruby and by the model decoder in Go, Kotlin and
-	// Swift; those two mechanisms do not share a canonical code, so pinning
-	// errorType would make the fixture unwritable. What every SDK must agree on
-	// is that the call fails at all — which, paired with requestCount, is the
-	// whole contract: the composite refused the field instead of writing it.
+	// The inverse of noError, and deliberately code-agnostic. See
+	// errorRaisedFailure (error_raised.go) for the contract and for why the
+	// branch lives there rather than inline: no committed fixture can reach
+	// its failing side, so it is unit-tested instead.
 	case "errorRaised":
-		if sdkErr == nil {
-			return fail(tc, "Expected the call to fail, but it succeeded")
+		if msg := errorRaisedFailure(sdkErr != nil); msg != "" {
+			return fail(tc, msg)
 		}
 
 	case "errorType":

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -571,6 +571,19 @@ class TestRunner:
                     if error:
                         failures.append(f"Expected no error, got: {type(error).__name__}: {error}")
 
+                # The inverse of noError, and deliberately code-agnostic. The
+                # malformed-response family (#576) is refused by a hand-written
+                # guard in TypeScript, Python and Ruby and by the model decoder
+                # in Go, Kotlin and Swift; those two mechanisms do not share a
+                # canonical code, so pinning errorType would make the fixture
+                # unwritable. What every SDK must agree on is that the call
+                # fails at all — which, paired with requestCount, is the whole
+                # contract: the composite refused the field instead of writing
+                # it.
+                case "errorRaised":
+                    if not error:
+                        failures.append("Expected the call to fail, but it succeeded")
+
                 case "statusCode":
                     expected = assertion["expected"]
                     actual_status = getattr(error, "http_status", None) if error else None

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -38,6 +38,30 @@ _CARD_WRITE_FIELDS = ("title", "content", "due_on", "assignee_ids")
 _MISSING = object()
 
 
+def error_raised_failure(dispatch_failed: bool) -> str | None:
+    """Validate one ``errorRaised`` assertion; None when it holds.
+
+    The inverse of noError, and deliberately code-agnostic. The
+    malformed-response family (#576) is refused by a hand-written guard in
+    TypeScript, Python and Ruby and by the model decoder in Go, Kotlin and
+    Swift; those two mechanisms share no canonical error code, so pinning
+    errorType would make the fixture unwritable. What all six agree on is that
+    the call fails at all — which, paired with requestCount, is the whole
+    contract: the composite refused the field instead of writing it.
+
+    Split out of the assertion loop so the failing branch is unit-testable. NO
+    COMMITTED FIXTURE CAN REACH IT: every case declaring errorRaised is one the
+    SDK does refuse, so a handler that accepted everything would report green in
+    all six runners at once. That is the #563 shape — a delayBetweenRequests
+    check that passed vacuously because no fixture supplied a gap it could fail
+    on — and the reason ``make conformance-runner-tests`` exists.
+
+    The message is pinned verbatim by the unit tests in all six runners: a
+    fixture debugged in one language should not read differently in another.
+    """
+    return None if dispatch_failed else "Expected the call to fail, but it succeeded"
+
+
 def check_delay_gaps(
     delays: list[float], min_delay: float | None, index: int | None, request_count: int
 ) -> str | None:
@@ -571,18 +595,14 @@ class TestRunner:
                     if error:
                         failures.append(f"Expected no error, got: {type(error).__name__}: {error}")
 
-                # The inverse of noError, and deliberately code-agnostic. The
-                # malformed-response family (#576) is refused by a hand-written
-                # guard in TypeScript, Python and Ruby and by the model decoder
-                # in Go, Kotlin and Swift; those two mechanisms do not share a
-                # canonical code, so pinning errorType would make the fixture
-                # unwritable. What every SDK must agree on is that the call
-                # fails at all — which, paired with requestCount, is the whole
-                # contract: the composite refused the field instead of writing
-                # it.
+                # The inverse of noError, and deliberately code-agnostic. See
+                # error_raised_failure for the contract and for why the branch
+                # lives there rather than inline: no committed fixture can reach
+                # its failing side, so it is unit-tested instead.
                 case "errorRaised":
-                    if not error:
-                        failures.append("Expected the call to fail, but it succeeded")
+                    failure = error_raised_failure(error is not None)
+                    if failure:
+                        failures.append(failure)
 
                 case "statusCode":
                     expected = assertion["expected"]

--- a/conformance/runner/python/test_error_raised.py
+++ b/conformance/runner/python/test_error_raised.py
@@ -1,0 +1,26 @@
+"""Both directions of the ``errorRaised`` assertion contract.
+
+Run: `uv run pytest test_error_raised.py`
+
+Only the passing direction ever runs against a committed fixture: every case
+declaring errorRaised is one the SDK does refuse. A handler that accepted
+everything would therefore look green in all six runners at once, which is
+exactly how #563 shipped a vacuous delayBetweenRequests check.
+"""
+from __future__ import annotations
+
+from runner import error_raised_failure
+
+# Asserted verbatim here and in the five sibling runners. A fixture debugged in
+# one language should not read differently in another.
+MESSAGE = "Expected the call to fail, but it succeeded"
+
+
+def test_a_failed_dispatch_satisfies_the_assertion():
+    assert error_raised_failure(True) is None
+
+
+def test_a_successful_dispatch_fails_the_assertion():
+    # The branch under test. It is unreachable from conformance/tests/, so
+    # without this case the handler could accept everything undetected.
+    assert error_raised_failure(False) == MESSAGE

--- a/conformance/runner/ruby/error_raised_test.rb
+++ b/conformance/runner/ruby/error_raised_test.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Both directions of the errorRaised assertion contract.
+#
+# Only the passing direction ever runs against a committed fixture: every case
+# declaring errorRaised is one the SDK does refuse. A handler that accepted
+# everything would therefore look green in all six runners at once, which is
+# exactly how #563 shipped a vacuous delayBetweenRequests check.
+#
+# Run: `bundle exec ruby error_raised_test.rb`
+
+require "minitest/autorun"
+require_relative "runner"
+
+class ErrorRaisedTest < Minitest::Test
+  # Asserted verbatim here and in the five sibling runners. A fixture debugged
+  # in one language should not read differently in another.
+  MESSAGE = "Expected the call to fail, but it succeeded"
+
+  def test_a_failed_dispatch_satisfies_the_assertion
+    assert_nil ErrorRaised.check(true)
+  end
+
+  def test_a_successful_dispatch_fails_the_assertion
+    # The branch under test. It is unreachable from conformance/tests/, so
+    # without this case the handler could accept everything undetected.
+    assert_equal MESSAGE, ErrorRaised.check(false)
+  end
+end

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -658,6 +658,17 @@ class TestRunner
           failures << "Expected no error, got: #{error.class}: #{error.message}"
         end
 
+      # The inverse of noError, and deliberately code-agnostic. The
+      # malformed-response family (#576) is refused by a hand-written guard in
+      # TypeScript, Python and Ruby and by the model decoder in Go, Kotlin and
+      # Swift; those two mechanisms do not share a canonical code, so pinning
+      # errorType would make the fixture unwritable. What every SDK must agree
+      # on is that the call fails at all — which, paired with requestCount, is
+      # the whole contract: the composite refused the field instead of writing
+      # it.
+      when "errorRaised"
+        failures << "Expected the call to fail, but it succeeded" unless error
+
       when "statusCode"
         expected = assertion["expected"]
         actual_status = extract_http_status(error)

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -15,6 +15,34 @@ require "set"
 WebMock.enable!
 WebMock.disable_net_connect!
 
+# The errorRaised assertion contract, kept apart from the runner so its failing
+# branch is unit-testable (error_raised_test.rb).
+module ErrorRaised
+  # Validates one assertion, returning nil when it holds and a failure message
+  # otherwise.
+  #
+  # The inverse of noError, and deliberately code-agnostic. The
+  # malformed-response family (#576) is refused by a hand-written guard in
+  # TypeScript, Python and Ruby and by the model decoder in Go, Kotlin and
+  # Swift; those two mechanisms share no canonical error code, so pinning
+  # errorType would make the fixture unwritable. What all six agree on is that
+  # the call fails at all — which, paired with requestCount, is the whole
+  # contract: the composite refused the field instead of writing it.
+  #
+  # NO COMMITTED FIXTURE CAN REACH THE FAILING BRANCH: every case declaring
+  # errorRaised is one the SDK does refuse, so a handler that accepted
+  # everything would report green in all six runners at once. That is the #563
+  # shape — a delayBetweenRequests check that passed vacuously because no
+  # fixture supplied a gap it could fail on — and the reason
+  # `make conformance-runner-tests` exists.
+  #
+  # The message is pinned verbatim by the unit tests in all six runners: a
+  # fixture debugged in one language should not read differently in another.
+  def self.check(dispatch_failed)
+    dispatch_failed ? nil : "Expected the call to fail, but it succeeded"
+  end
+end
+
 # The delayBetweenRequests assertion contract, kept apart from the runner so
 # its bounds branches are unit-testable (delay_gaps_test.rb).
 module DelayGaps
@@ -658,16 +686,13 @@ class TestRunner
           failures << "Expected no error, got: #{error.class}: #{error.message}"
         end
 
-      # The inverse of noError, and deliberately code-agnostic. The
-      # malformed-response family (#576) is refused by a hand-written guard in
-      # TypeScript, Python and Ruby and by the model decoder in Go, Kotlin and
-      # Swift; those two mechanisms do not share a canonical code, so pinning
-      # errorType would make the fixture unwritable. What every SDK must agree
-      # on is that the call fails at all — which, paired with requestCount, is
-      # the whole contract: the composite refused the field instead of writing
-      # it.
+      # The inverse of noError, and deliberately code-agnostic. See
+      # ErrorRaised.check for the contract and for why the branch lives there
+      # rather than inline: no committed fixture can reach its failing side, so
+      # it is unit-tested instead.
       when "errorRaised"
-        failures << "Expected the call to fail, but it succeeded" unless error
+        failure = ErrorRaised.check(!error.nil?)
+        failures << failure if failure
 
       when "statusCode"
         expected = assertion["expected"]

--- a/conformance/runner/swift/Sources/ConformanceRunner/Assertions.swift
+++ b/conformance/runner/swift/Sources/ConformanceRunner/Assertions.swift
@@ -92,7 +92,11 @@ func evaluateAssertions(
     _ tc: TestCase,
     transport: ScriptedTransport,
     caughtError: BasecampError?,
-    dispatchFailed: Bool = false,
+    // No default. The one call site is required to say whether the dispatch
+    // failed, because a defaulted `false` fails CLOSED: a future call site that
+    // omitted it would report "the call succeeded" on a call that did not, and
+    // every errorRaised fixture would go red for a reason nowhere near the bug.
+    dispatchFailed: Bool,
     httpStatus: Int?,
     dispatch: DispatchResult
 ) -> TestResult {
@@ -260,17 +264,18 @@ func evaluateAssertions(
                 return .fail("Expected no error, got: \(caughtError.message)")
             }
 
-        // The inverse of noError, and deliberately code-agnostic. The
-        // malformed-response family (#576) is refused by a hand-written guard
-        // in TypeScript, Python and Ruby and by the model decoder in Go, Kotlin
-        // and Swift; those two mechanisms do not share a canonical code, so
-        // pinning errorType would make the fixture unwritable. What every SDK
-        // must agree on is that the call fails at all — which, paired with
-        // requestCount, is the whole contract: the composite refused the field
-        // instead of writing it.
+        // The inverse of noError, and deliberately code-agnostic. See
+        // errorRaisedFailure (ConformanceSupport/ErrorRaised.swift) for the
+        // contract and for why the branch lives there rather than inline: no
+        // committed fixture can reach its failing side, so it is unit-tested
+        // instead.
+        //
+        // Read from BOTH signals: every path that records caughtError also sets
+        // dispatchFailed, and the union keeps that true by construction rather
+        // than by call-site discipline.
         case "errorRaised":
-            if !dispatchFailed {
-                return .fail("Expected the call to fail, but it succeeded")
+            if let message = errorRaisedFailure(dispatchFailed: dispatchFailed || caughtError != nil) {
+                return .fail(message)
             }
 
         case "requestPath":

--- a/conformance/runner/swift/Sources/ConformanceRunner/Assertions.swift
+++ b/conformance/runner/swift/Sources/ConformanceRunner/Assertions.swift
@@ -92,6 +92,7 @@ func evaluateAssertions(
     _ tc: TestCase,
     transport: ScriptedTransport,
     caughtError: BasecampError?,
+    dispatchFailed: Bool = false,
     httpStatus: Int?,
     dispatch: DispatchResult
 ) -> TestResult {
@@ -257,6 +258,19 @@ func evaluateAssertions(
         case "noError":
             if let caughtError {
                 return .fail("Expected no error, got: \(caughtError.message)")
+            }
+
+        // The inverse of noError, and deliberately code-agnostic. The
+        // malformed-response family (#576) is refused by a hand-written guard
+        // in TypeScript, Python and Ruby and by the model decoder in Go, Kotlin
+        // and Swift; those two mechanisms do not share a canonical code, so
+        // pinning errorType would make the fixture unwritable. What every SDK
+        // must agree on is that the call fails at all — which, paired with
+        // requestCount, is the whole contract: the composite refused the field
+        // instead of writing it.
+        case "errorRaised":
+            if !dispatchFailed {
+                return .fail("Expected the call to fail, but it succeeded")
             }
 
         case "requestPath":

--- a/conformance/runner/swift/Sources/ConformanceRunner/Runner.swift
+++ b/conformance/runner/swift/Sources/ConformanceRunner/Runner.swift
@@ -187,6 +187,19 @@ struct Runner {
         var httpStatus: Int?
         var dispatch = DispatchResult()
 
+        // Set when the dispatch failed by ANY mechanism, including a decoder
+        // rejection that never becomes a BasecampError. Only `errorRaised`
+        // reads it; errorType, errorCode and errorMessage still read
+        // caughtError, so a fixture pinning a canonical code cannot be
+        // satisfied by a raw DecodingError.
+        var dispatchFailed = false
+        // A fixture declaring errorRaised is asserting that the body is
+        // DELIBERATELY malformed and that refusing it is the behaviour under
+        // test (#576). That flips the usual reading of a decoder rejection
+        // below: it is the point of the case, not an under-specified mock body
+        // to repair.
+        let expectsFailure = tc.allAssertions.contains { $0.type == "errorRaised" }
+
         if requiresHTTPSCrashProbe(baseURL) {
             // The SDK enforces HTTPS with preconditionFailure — a trap, not a
             // thrown error — so it can only be observed from outside the
@@ -218,6 +231,7 @@ struct Runner {
                 httpStatus = transport.lastConsumedIndex.flatMap { tc.responses[$0].status }
             } catch let error as BasecampError {
                 caughtError = error
+                dispatchFailed = true
                 httpStatus = error.httpStatusCode
             } catch let error as RunnerError {
                 // A fixture the dispatch table cannot honor as written: an
@@ -231,7 +245,16 @@ struct Runner {
                 // gets fixed (canonical bodies live in spec/fixtures/) instead
                 // of silently degrading coverage. Kotlin's #555 policy, adopted
                 // from day one.
-                return .fail("Mock body lacks required Swift model fields: \(describeDecodingError(error))")
+                //
+                // Unless the fixture declares errorRaised: then the body is
+                // deliberately malformed and Codable refusing it IS the
+                // behaviour under test. That is how Swift satisfies the #576
+                // kill cases — the decoder is its guard, where TypeScript,
+                // Python and Ruby need a hand-written one.
+                guard expectsFailure else {
+                    return .fail("Mock body lacks required Swift model fields: \(describeDecodingError(error))")
+                }
+                dispatchFailed = true
             } catch {
                 return .fail("Unexpected exception: \(type(of: error)): \(error)")
             }
@@ -241,6 +264,7 @@ struct Runner {
             tc,
             transport: transport,
             caughtError: caughtError,
+            dispatchFailed: dispatchFailed,
             httpStatus: httpStatus,
             dispatch: dispatch
         )

--- a/conformance/runner/swift/Sources/ConformanceRunner/Runner.swift
+++ b/conformance/runner/swift/Sources/ConformanceRunner/Runner.swift
@@ -209,6 +209,12 @@ struct Runner {
             switch runHTTPSProbe(baseURL) {
             case .enforced:
                 caughtError = .usage(message: "Base URL must use HTTPS: \(baseURL)", hint: nil)
+                // The child died as required, so the dispatch DID fail — by a
+                // trap rather than a throw. Recording only caughtError left
+                // this the one failure path that did not flag itself, and an
+                // errorRaised fixture with an http:// configOverrides.baseUrl
+                // would have read it as a call that succeeded.
+                dispatchFailed = true
             case .constructionSucceeded:
                 return .fail("client construction with non-HTTPS base URL unexpectedly succeeded")
             case .probeFailure(let message):

--- a/conformance/runner/swift/Sources/ConformanceSupport/ErrorRaised.swift
+++ b/conformance/runner/swift/Sources/ConformanceSupport/ErrorRaised.swift
@@ -1,0 +1,28 @@
+/// Validates one `errorRaised` assertion, returning `nil` when it holds and a
+/// failure message otherwise.
+///
+/// The inverse of `noError`, and deliberately code-agnostic. The
+/// malformed-response family (#576) is refused by a hand-written guard in
+/// TypeScript, Python and Ruby and by the model decoder in Go, Kotlin and
+/// Swift; those two mechanisms share no canonical error code, so pinning
+/// `errorType` would make the fixture unwritable. What all six agree on is that
+/// the call fails at all — which, paired with `requestCount`, is the whole
+/// contract: the composite refused the field instead of writing it.
+///
+/// It lives here rather than in Assertions.swift for the reason the whole
+/// ConformanceSupport target exists: a target carrying `@main` cannot host
+/// XCTest cleanly, and this branch never executes against a fixture that
+/// passes. NO COMMITTED FIXTURE CAN REACH IT — every case declaring
+/// `errorRaised` is one the SDK does refuse, so a handler that accepted
+/// everything would report green in all six runners at once. That is the #563
+/// shape, and the reason `make conformance-runner-tests` exists.
+///
+/// `dispatchFailed` is the union of every failure mechanism, not just the ones
+/// that produce a `BasecampError`: a `DecodingError` never becomes one, and the
+/// HTTPS-enforcement probe observes a trapped child process rather than a throw.
+///
+/// The message is pinned verbatim by the unit tests in all six runners: a
+/// fixture debugged in one language should not read differently in another.
+public func errorRaisedFailure(dispatchFailed: Bool) -> String? {
+    dispatchFailed ? nil : "Expected the call to fail, but it succeeded"
+}

--- a/conformance/runner/swift/Tests/ConformanceSupportTests/ErrorRaisedTests.swift
+++ b/conformance/runner/swift/Tests/ConformanceSupportTests/ErrorRaisedTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+@testable import ConformanceSupport
+
+/// Both directions of the errorRaised assertion contract.
+///
+/// Only the passing direction ever runs against a committed fixture: every case
+/// declaring errorRaised is one the SDK does refuse. A handler that accepted
+/// everything would therefore look green in all six runners at once, which is
+/// exactly how #563 shipped a vacuous delayBetweenRequests check.
+final class ErrorRaisedTests: XCTestCase {
+    /// Asserted verbatim here and in the five sibling runners. A fixture
+    /// debugged in one language should not read differently in another.
+    private let message = "Expected the call to fail, but it succeeded"
+
+    func testFailedDispatchSatisfiesTheAssertion() {
+        XCTAssertNil(errorRaisedFailure(dispatchFailed: true))
+    }
+
+    func testSuccessfulDispatchFailsTheAssertion() {
+        // The branch under test. It is unreachable from conformance/tests/, so
+        // without this case the handler could accept everything undetected.
+        XCTAssertEqual(message, errorRaisedFailure(dispatchFailed: false))
+    }
+}

--- a/conformance/runner/typescript/error-raised.test.ts
+++ b/conformance/runner/typescript/error-raised.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Both directions of the errorRaised assertion contract.
+ *
+ * Only the passing direction ever runs against a committed fixture: every case
+ * declaring errorRaised is one the SDK does refuse. A handler that accepted
+ * everything would therefore look green in all six runners at once, which is
+ * exactly how #563 shipped a vacuous delayBetweenRequests check.
+ */
+import { describe, it, expect } from "vitest";
+import { errorRaisedFailure } from "./error-raised.js";
+
+// Asserted verbatim here and in the five sibling runners. A fixture debugged in
+// one language should not read differently in another.
+const MESSAGE = "Expected the call to fail, but it succeeded";
+
+describe("errorRaisedFailure", () => {
+  it("is satisfied by a dispatch that failed", () => {
+    expect(errorRaisedFailure(true)).toBeUndefined();
+  });
+
+  it("fails a dispatch that succeeded", () => {
+    // The branch under test. It is unreachable from conformance/tests/, so
+    // without this case the handler could accept everything undetected.
+    expect(errorRaisedFailure(false)).toBe(MESSAGE);
+  });
+});

--- a/conformance/runner/typescript/error-raised.ts
+++ b/conformance/runner/typescript/error-raised.ts
@@ -1,0 +1,30 @@
+/**
+ * The `errorRaised` assertion contract, kept apart from the runner so its
+ * failing branch is unit-testable (error-raised.test.ts).
+ */
+
+/**
+ * Validates one assertion, returning `undefined` when it holds and a failure
+ * message otherwise.
+ *
+ * The inverse of `noError`, and deliberately code-agnostic. The
+ * malformed-response family (#576) is refused by a hand-written guard in
+ * TypeScript, Python and Ruby and by the model decoder in Go, Kotlin and
+ * Swift; those two mechanisms share no canonical error code, so pinning
+ * `errorType` would make the fixture unwritable. What all six agree on is that
+ * the call fails at all — which, paired with `requestCount`, is the whole
+ * contract: the composite refused the field instead of writing it.
+ *
+ * NO COMMITTED FIXTURE CAN REACH THE FAILING BRANCH: every case declaring
+ * `errorRaised` is one the SDK does refuse, so a handler that accepted
+ * everything would report green in all six runners at once. That is the #563
+ * shape — a `delayBetweenRequests` check that passed vacuously because no
+ * fixture supplied a gap it could fail on — and the reason
+ * `make conformance-runner-tests` exists.
+ *
+ * The message is pinned verbatim by the unit tests in all six runners: a
+ * fixture debugged in one language should not read differently in another.
+ */
+export function errorRaisedFailure(dispatchFailed: boolean): string | undefined {
+  return dispatchFailed ? undefined : "Expected the call to fail, but it succeeded";
+}

--- a/conformance/runner/typescript/runner.test.ts
+++ b/conformance/runner/typescript/runner.test.ts
@@ -16,6 +16,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { checkDelayGaps } from "./delay-gaps.js";
+import { errorRaisedFailure } from "./error-raised.js";
 
 // =============================================================================
 // Types mirroring conformance/schema.json
@@ -933,19 +934,13 @@ function checkAssertions(
         break;
       }
 
-      // The inverse of noError, and deliberately code-agnostic. The
-      // malformed-response family (#576) is refused by a hand-written guard in
-      // TypeScript, Python and Ruby and by the model decoder in Go, Kotlin and
-      // Swift; those two mechanisms do not share a canonical code, so pinning
-      // errorType would make the fixture unwritable. What every SDK must agree
-      // on is that the call fails at all — which, paired with requestCount, is
-      // the whole contract: the composite refused the field instead of writing
-      // it.
+      // The inverse of noError, and deliberately code-agnostic. See
+      // errorRaisedFailure for the contract and for why the branch lives there
+      // rather than inline: no committed fixture can reach its failing side, so
+      // it is unit-tested instead.
       case "errorRaised": {
-        expect(
-          result.error,
-          `[${tc.name}] expected the call to fail, but it succeeded`,
-        ).toBeDefined();
+        const failure = errorRaisedFailure(result.error !== undefined);
+        expect(failure, `[${tc.name}] ${failure}`).toBeUndefined();
         break;
       }
 

--- a/conformance/runner/typescript/runner.test.ts
+++ b/conformance/runner/typescript/runner.test.ts
@@ -933,6 +933,22 @@ function checkAssertions(
         break;
       }
 
+      // The inverse of noError, and deliberately code-agnostic. The
+      // malformed-response family (#576) is refused by a hand-written guard in
+      // TypeScript, Python and Ruby and by the model decoder in Go, Kotlin and
+      // Swift; those two mechanisms do not share a canonical code, so pinning
+      // errorType would make the fixture unwritable. What every SDK must agree
+      // on is that the call fails at all — which, paired with requestCount, is
+      // the whole contract: the composite refused the field instead of writing
+      // it.
+      case "errorRaised": {
+        expect(
+          result.error,
+          `[${tc.name}] expected the call to fail, but it succeeded`,
+        ).toBeDefined();
+        break;
+      }
+
       case "statusCode": {
         const expected = Number(assertion.expected);
         if (result.error instanceof BasecampError) {

--- a/conformance/schema.json
+++ b/conformance/schema.json
@@ -115,6 +115,7 @@
       "items": {
         "type": "object",
         "required": ["type"],
+        "$comment": "errorRaised is the inverse of noError and takes no `expected`: the dispatch must fail SOMEHOW, without pinning which canonical code. It exists for the malformed-response family (#576), where the six SDKs refuse the same body by six different mechanisms — a hand-written guard in TypeScript/Python/Ruby, and the model decoder in Go/Kotlin/Swift — so no single errorType is assertable. A fixture declaring it also tells the Kotlin and Swift runners that a decoder rejection is the POINT of the case rather than a malformed-fixture bug.",
         "properties": {
           "type": {
             "type": "string",
@@ -146,7 +147,6 @@
           "expected": {
             "description": "Expected value for the assertion"
           },
-          "$comment": "errorRaised is the inverse of noError and takes no `expected`: the dispatch must fail SOMEHOW, without pinning which canonical code. It exists for the malformed-response family (#576), where the six SDKs refuse the same body by six different mechanisms — a hand-written guard in TypeScript/Python/Ruby, and the model decoder in Go/Kotlin/Swift — so no single errorType is assertable. A fixture declaring it also tells the Kotlin and Swift runners that a decoder rejection is the POINT of the case rather than a malformed-fixture bug.",
           "min": {
             "type": "number",
             "description": "Minimum value (for range assertions)"

--- a/conformance/schema.json
+++ b/conformance/schema.json
@@ -129,6 +129,7 @@
               "headerValue",
               "errorType",
               "noError",
+              "errorRaised",
               "requestPath",
               "requestMethod",
               "requestBody",
@@ -145,6 +146,7 @@
           "expected": {
             "description": "Expected value for the assertion"
           },
+          "$comment": "errorRaised is the inverse of noError and takes no `expected`: the dispatch must fail SOMEHOW, without pinning which canonical code. It exists for the malformed-response family (#576), where the six SDKs refuse the same body by six different mechanisms — a hand-written guard in TypeScript/Python/Ruby, and the model decoder in Go/Kotlin/Swift — so no single errorType is assertable. A fixture declaring it also tells the Kotlin and Swift runners that a decoder rejection is the POINT of the case rather than a malformed-fixture bug.",
           "min": {
             "type": "number",
             "description": "Minimum value (for range assertions)"

--- a/conformance/test_check_kill_case_controls.py
+++ b/conformance/test_check_kill_case_controls.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Negative-case self-test for conformance/check_kill_case_controls.py.
+
+The gate's own `make conformance-fixtures-check` run only ever exercises the
+VALID fixture set, which proves it can say yes and nothing else. Every rejection
+this gate claims to make was, until this file existed, correct by inspection
+alone — and the gate exists precisely because "correct by inspection" is what
+let #576 through five review passes.
+
+So each case here crafts one input the gate claims to reject and asserts that it
+does: non-zero exit plus the expected message fragment, driven through the REAL
+entry point via its FIXTURE_DIR argument. The real fixture set is run too, as a
+positive control, so a gate that had regressed into rejecting everything would
+fail here rather than look thorough.
+
+The pairs are handcrafted rather than lifted from conformance/tests, so this file
+stays readable and does not rot the day a fixture body gains a field.
+
+Run directly (`python3 conformance/test_check_kill_case_controls.py`) or via
+`make conformance-fixtures-check`, which runs it after the live check.
+Stdlib only: the Makefile invokes it with a bare `python3`.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+GATE = os.path.join(HERE, "check_kill_case_controls.py")
+REAL_FIXTURES = os.path.join(HERE, "tests")
+
+failures: list[str] = []
+
+
+# --- the crafted pair ----------------------------------------------------------
+#
+# One control and one kill, differing in exactly `description` — the smallest
+# input the gate accepts. Every case below breaks exactly one thing about it, so
+# a failure names the property under test rather than an incidental defect.
+
+GOOD_DESCRIPTION = "<p>From the store</p>"
+MALFORMED_DESCRIPTION = ["x"]
+
+
+def body(description: object = GOOD_DESCRIPTION, **overrides: object) -> dict:
+    b: dict = {
+        "id": 456,
+        "title": "Buy milk",
+        "description": description,
+        "due_on": "2024-03-01",
+    }
+    b.update(overrides)
+    return b
+
+
+def ok_response(b: dict, status: int = 200) -> dict:
+    return {"status": status, "headers": {"Content-Type": "application/json"}, "body": b}
+
+
+def control_case(**overrides: object) -> dict:
+    case: dict = {
+        "name": "update-merge: content-only update preserves every unset field",
+        "operation": "UpdateTodo",
+        "method": "PUT",
+        "path": "/todos/{todoId}",
+        # Two queued responses on both sides, matching the real fixtures: the
+        # GET under test and a decoy the case must never reach.
+        "mockResponses": [ok_response(body()), ok_response(body())],
+        "assertions": [{"type": "requestCount", "expected": 2}],
+    }
+    case.update(overrides)
+    return case
+
+
+def kill_case(**overrides: object) -> dict:
+    case: dict = {
+        "name": "update-kill: an array description is refused before the full-replace PUT",
+        "operation": "UpdateTodo",
+        "method": "PUT",
+        "path": "/todos/{todoId}",
+        "mockResponses": [
+            ok_response(body(description=MALFORMED_DESCRIPTION)),
+            ok_response(body(description=MALFORMED_DESCRIPTION)),
+        ],
+        "assertions": [{"type": "errorRaised"}, {"type": "requestCount", "expected": 1}],
+    }
+    case.update(overrides)
+    return case
+
+
+def pair(kill: dict | None = None, control: dict | None = None) -> list[dict]:
+    return [control if control is not None else control_case(),
+            kill if kill is not None else kill_case()]
+
+
+# --- harness -------------------------------------------------------------------
+
+
+def run(cases: list[dict] | None, *, args: list[str] | None = None,
+        empty_dir: bool = False) -> tuple[str, int]:
+    """Run the gate over a throwaway fixture directory. Returns (output, exit)."""
+    with tempfile.TemporaryDirectory(prefix="kill-case-controls-test") as tmp:
+        if not empty_dir:
+            with open(os.path.join(tmp, "todos_write.json"), "w") as f:
+                json.dump(cases, f, indent=2)
+        argv = args if args is not None else [tmp]
+        proc = subprocess.run(
+            [sys.executable, GATE, *argv],
+            capture_output=True, text=True,
+        )
+        return proc.stdout + proc.stderr, proc.returncode
+
+
+def expect_pass(label: str, out: str, code: int) -> None:
+    if code != 0:
+        failures.append(f"{label}: expected PASS, gate exited {code}:\n{out}")
+
+
+def expect_fail(label: str, out: str, code: int, fragment: str) -> None:
+    if code == 0:
+        failures.append(f"{label}: expected FAILURE, gate exited 0:\n{out}")
+    elif fragment not in out:
+        failures.append(f"{label}: failed as expected but message missing {fragment!r}:\n{out}")
+
+
+# --- positive controls ---------------------------------------------------------
+
+out, code = run(None, args=[REAL_FIXTURES])
+expect_pass("the real fixture set passes", out, code)
+
+out, code = run(pair())
+expect_pass("a crafted valid pair passes", out, code)
+
+# The gate must also work with no argument at all, since that is how the Makefile
+# calls it — an argv change that broke the default would otherwise go unnoticed.
+out, code = run(None, args=[])
+expect_pass("the default fixture directory is conformance/tests", out, code)
+
+# ...and the control really is what carries the pair: delete it and the same kill
+# case must be rejected. Without this, every "valid pair" case above could be
+# passing for a reason unrelated to the control.
+out, code = run([kill_case()])
+expect_fail("a kill case with no control at all", out, code,
+            "no non-errorRaised case for operation 'UpdateTodo'")
+
+
+# --- the kill response must reach a decoder ------------------------------------
+
+# THE #204 CASE. Only the kill's first response changes, 200 -> 204; the control
+# stays 200 and the one-field body comparison still holds. Before this was
+# checked, the gate printed "ok" and exited 0 for exactly this input, certifying
+# a case that cannot kill anything: TypeScript returns undefined for a 204,
+# Kotlin returns Unit without parsing, Go rewrites the body to JSON null — so the
+# malformed description is never decoded, the composite fails because the record
+# came back absent, and errorRaised + requestCount: 1 are satisfied by that.
+out, code = run(pair(kill=kill_case(mockResponses=[
+    ok_response(body(description=MALFORMED_DESCRIPTION), status=204),
+    ok_response(body(description=MALFORMED_DESCRIPTION)),
+])))
+expect_fail("kill case answers 204", out, code,
+            "has status 204, which carries no body by definition")
+
+# 205 forbids a body for the same reason and must not need its own discovery.
+out, code = run(pair(kill=kill_case(mockResponses=[
+    ok_response(body(description=MALFORMED_DESCRIPTION), status=205),
+    ok_response(body(description=MALFORMED_DESCRIPTION)),
+])))
+expect_fail("kill case answers 205", out, code,
+            "has status 205, which carries no body by definition")
+
+# The allowlist is what makes this closed-by-default: 202 is a 2xx nobody
+# excluded by name, and Go's success arm does not cover it, so its body is never
+# decoded there. A 204-only exclusion would wave this through.
+out, code = run(pair(kill=kill_case(mockResponses=[
+    ok_response(body(description=MALFORMED_DESCRIPTION), status=202),
+    ok_response(body(description=MALFORMED_DESCRIPTION)),
+])))
+expect_fail("kill case answers an undecoded 2xx", out, code,
+            "has status 202, which is not one of the statuses whose body every SDK decodes")
+
+# 201 IS decoded, so the allowlist must not be a 200-only rule wearing a larger
+# name — otherwise the next fixture to use a create response fails spuriously.
+out, code = run(pair(
+    control=control_case(mockResponses=[ok_response(body(), status=201), ok_response(body())]),
+    kill=kill_case(mockResponses=[
+        ok_response(body(description=MALFORMED_DESCRIPTION), status=201),
+        ok_response(body(description=MALFORMED_DESCRIPTION)),
+    ]),
+))
+expect_pass("201 is a decoded status", out, code)
+
+out, code = run(pair(kill=kill_case(mockResponses=[
+    ok_response(body(description=MALFORMED_DESCRIPTION), status=500),
+    ok_response(body(description=MALFORMED_DESCRIPTION)),
+])))
+expect_fail("kill case answers an HTTP error", out, code,
+            "has status 500, so the call fails on the HTTP error before the body is decoded")
+
+# `body` alongside `networkError` is schema-VALID (conformance/schema.json only
+# makes status and networkError mutually exclusive), so flipping a status to
+# networkError while retaining the body sails through the schema pass. This gate
+# is the only thing that catches it, which is why the case keeps its body.
+out, code = run(pair(kill=kill_case(mockResponses=[
+    {"networkError": True, "body": body(description=MALFORMED_DESCRIPTION)},
+    ok_response(body(description=MALFORMED_DESCRIPTION)),
+])))
+expect_fail("kill case dies in transport", out, code,
+            "declares networkError, so the call fails in transport")
+
+# Dropping the body too is caught earlier, by the object-shape branch.
+out, code = run(pair(kill=kill_case(mockResponses=[
+    {"networkError": True},
+    ok_response(body(description=MALFORMED_DESCRIPTION)),
+])))
+expect_fail("kill case dies in transport with no body", out, code,
+            "has no object-shaped body to control against")
+
+out, code = run(pair(kill=kill_case(mockResponses=[
+    {"status": "200", "body": body(description=MALFORMED_DESCRIPTION)},
+    ok_response(body(description=MALFORMED_DESCRIPTION)),
+])))
+expect_fail("kill case has a stringly-typed status", out, code,
+            "has a non-integer status '200'")
+
+out, code = run(pair(kill=kill_case(mockResponses=[])))
+expect_fail("kill case queues no response", out, code,
+            "has no object-shaped body to control against")
+
+out, code = run(pair(kill=kill_case(mockResponses=[{"status": 200, "body": "not an object"}])))
+expect_fail("kill case body is not an object", out, code,
+            "has no object-shaped body to control against")
+
+
+# --- the control response must reach a decoder too -----------------------------
+#
+# The symmetric half. A control that is never decoded cannot fail loudly (#555)
+# when the model drifts, which is the entire protection the kill case borrows
+# from it.
+
+out, code = run(pair(control=control_case(mockResponses=[
+    ok_response(body(), status=204),
+    ok_response(body()),
+])))
+expect_fail("control answers 204", out, code,
+            "no non-errorRaised case for operation 'UpdateTodo'")
+
+out, code = run(pair(control=control_case(mockResponses=[
+    ok_response(body(), status=500),
+    ok_response(body()),
+])))
+expect_fail("control answers an HTTP error", out, code,
+            "no non-errorRaised case for operation 'UpdateTodo'")
+
+out, code = run(pair(control=control_case(mockResponses=[
+    {"networkError": True, "body": body()},
+    ok_response(body()),
+])))
+expect_fail("control dies in transport", out, code,
+            "no non-errorRaised case for operation 'UpdateTodo'")
+
+
+# --- the control must be the right control -------------------------------------
+
+out, code = run(pair(control=control_case(operation="UpdateCard")))
+expect_fail("control exercises a different operation", out, code,
+            "no non-errorRaised case for operation 'UpdateTodo'")
+
+out, code = run(pair(control=control_case(mockResponses=[
+    ok_response(body(title="Buy oat milk")),
+    ok_response(body()),
+])))
+expect_fail("control differs in two fields", out, code,
+            "no non-errorRaised case for operation 'UpdateTodo'")
+
+out, code = run(pair(control=control_case(mockResponses=[
+    ok_response({"id": 456, "title": "Buy milk", "description": GOOD_DESCRIPTION}),
+    ok_response(body()),
+])))
+expect_fail("control body has a different key set", out, code,
+            "no non-errorRaised case for operation 'UpdateTodo'")
+
+# A control whose bodies are IDENTICAL to the kill's pins nothing: there is no
+# field under test, so the gate cannot name what the kill case kills.
+out, code = run(pair(control=control_case(mockResponses=[
+    ok_response(body(description=MALFORMED_DESCRIPTION)),
+    ok_response(body()),
+])))
+expect_fail("control body is identical to the kill body", out, code,
+            "no non-errorRaised case for operation 'UpdateTodo'")
+
+
+# --- only the FIRST response counts, on both sides -----------------------------
+#
+# The second queued response is a decoy that is never consumed. Matching against
+# it would let the body that actually gets decoded drift away from its control —
+# the hole this gate exists to close, one level up.
+
+out, code = run(pair(control=control_case(mockResponses=[
+    ok_response(body(title="Buy oat milk")),   # first: differs in TWO fields
+    ok_response(body()),                       # second: would match, but is a decoy
+])))
+expect_fail("a control's decoy response cannot satisfy the gate", out, code,
+            "no non-errorRaised case for operation 'UpdateTodo'")
+
+out, code = run(pair(kill=kill_case(mockResponses=[
+    ok_response(body(description=MALFORMED_DESCRIPTION, title="Buy oat milk")),  # decoded: 2 fields off
+    ok_response(body(description=MALFORMED_DESCRIPTION)),                        # decoy: would match
+])))
+expect_fail("a kill's decoy response cannot satisfy the gate", out, code,
+            "no non-errorRaised case for operation 'UpdateTodo'")
+
+
+# --- entry point ---------------------------------------------------------------
+
+out, code = run(None, empty_dir=True)
+expect_fail("an empty fixture directory is not a pass", out, code, "no fixtures found")
+
+out, code = run(None, args=["a", "b"])
+expect_fail("more than one argument is a usage error", out, code, "usage:")
+if code != 2:
+    failures.append(f"usage error must exit 2, got {code}:\n{out}")
+
+
+# --- report --------------------------------------------------------------------
+
+if failures:
+    print(f"check_kill_case_controls self-test: {len(failures)} case(s) failed.", file=sys.stderr)
+    for f in failures:
+        print(f"\n{f}", file=sys.stderr)
+    sys.exit(1)
+
+print("check_kill_case_controls self-test: all cases passed.")

--- a/conformance/tests/cards_write.json
+++ b/conformance/tests/cards_write.json
@@ -1129,7 +1129,7 @@
   },
   {
     "name": "update-kill: an array due_on is refused before the replacement PUT",
-    "description": "This composite exists solely to stop an omitted due_on from erasing the card's date (`{ due_on: nil }.merge(card_params)`), so resending a value it never validated defeats its whole purpose. requestCount: 1 is the assertion that matters: a second request means the unvalidated value has already been written.\n\nOn main Ruby forwarded the array verbatim \u2014 compact_params is kwargs.compact, which removes only nil \u2014 and Python forwarded it too, since `or None` leaves a truthy value alone.\n\nThe kill case for #576, and the reason it lives here rather than in six per-language test files: the defect survived five consecutive review passes because each pass fixed one instance. A shared fixture catches every instance at once, in every runner, permanently \u2014 and it did: writing it surfaced the Kotlin scalar-coercion hole above, which five language-specific passes had missed.\n\nAll six SDKs must refuse it, by two different mechanisms, which is why the value under test is a JSON array/object rather than a scalar. Go, Kotlin and Swift decode into a typed model: json.Unmarshal, kotlinx.serialization and Codable all reject a structural mismatch. TypeScript, Python and Ruby have no decoder at all \u2014 schema.d.ts is erased at build time, and the generated Python and Ruby services return an untyped dict/Hash \u2014 so they carry an explicit guard. A scalar (42, false) would NOT discriminate in Kotlin: its client-wide Json { isLenient = true } coerces one into a String field, so the composite decodes \"42\" and writes it back. That is the same defect one layer down and is tracked separately; it cannot be fixed by a per-composite guard, because by the time the composite runs the coercion has already happened.\n\nerrorRaised rather than errorType: a hand-written guard raises api_error while a decoder raises its own language's decode failure, so no single canonical code is assertable. What all six agree on is that the call fails at all \u2014 which, paired with requestCount: 1, is the whole contract.\n\nCoverage note, so this case is not read as proving more than it does: in TypeScript the generated updateVerbatim's YYYY-MM-DD check already rejects a truthy non-string, so this fixture passes there with or without the guard. TypeScript's discriminating shape is a FALSEY non-string (false, 0), which `if (current.due_on)` dropped \u2014 and an omitted due_on is precisely how BC3 erases a card's due date, so on main it issued a real erasing PUT. A scalar cannot be used here because Kotlin coerces one (see above), so that path is pinned in typescript/tests/services/cards.test.ts instead.",
+    "description": "This composite exists solely to stop an omitted due_on from erasing the card's date (`{ due_on: nil }.merge(card_params)`), so resending a value it never validated defeats its whole purpose. requestCount: 1 is the assertion that matters: a second request means the unvalidated value has already been written.\n\nOn main Ruby forwarded the array verbatim \u2014 compact_params is kwargs.compact, which removes only nil \u2014 and Python forwarded it too, since `or None` leaves a truthy value alone.\n\nThe kill case for #576, and the reason it lives here rather than in six per-language test files: the defect survived five consecutive review passes because each pass fixed one instance. A shared fixture catches every instance at once, in every runner, permanently \u2014 and it did: writing it surfaced the Kotlin scalar-coercion hole above, which five language-specific passes had missed.\n\nAll six SDKs must refuse it, by two different mechanisms, which is why the value under test is a JSON array/object rather than a scalar. Go, Kotlin and Swift decode into a typed model: json.Unmarshal, kotlinx.serialization and Codable all reject a structural mismatch. TypeScript, Python and Ruby have no decoder at all \u2014 schema.d.ts is erased at build time, and the generated Python and Ruby services return an untyped dict/Hash \u2014 so they carry an explicit guard. A scalar (42, false) would NOT discriminate in Kotlin: its client-wide Json { isLenient = true } coerces one into a String field, so the composite decodes \"42\" and writes it back. That is the same defect one layer down and is tracked separately; it cannot be fixed by a per-composite guard, because by the time the composite runs the coercion has already happened.\n\nerrorRaised rather than errorType: a hand-written guard raises api_error while a decoder raises its own language's decode failure, so no single canonical code is assertable. What all six agree on is that the call fails at all \u2014 which, paired with requestCount: 1, is the whole contract.\n\nCoverage note, so this case is not read as proving more than it does: in TypeScript the generated updateVerbatim's YYYY-MM-DD check already rejects a truthy non-string, so this fixture passes there with or without the guard. TypeScript's discriminating shape is a FALSEY non-string (false, 0), which `if (current.due_on)` dropped \u2014 and an omitted due_on is precisely how BC3 erases a card's due date, so on main it issued a real erasing PUT. A scalar cannot be used here because Kotlin coerces one (see above), so that path is pinned in typescript/tests/services/cards.test.ts instead. The case AFTER this pair is the Cards kill case that does discriminate in TypeScript: [\"2024-02-01\"] stringifies to a valid date, so the format check waves it through and only the guard stops it.",
     "operation": "UpdateCard",
     "method": "PUT",
     "path": "/card_tables/cards/{cardId}",
@@ -1471,7 +1471,7 @@
   },
   {
     "name": "update-kill: an empty-object due_on is refused, not coerced or dropped",
-    "description": "The falsey-shaped twin of the array case. Python's `... or None` collapses an empty object to None, which the generated _compact then strips \u2014 so the PUT went out with due_on ABSENT and BC3 erased the date, on a call that only renamed the card. Ruby forwarded `{}` verbatim instead. Same defect, opposite failure mode.\n\nThe kill case for #576, and the reason it lives here rather than in six per-language test files: the defect survived five consecutive review passes because each pass fixed one instance. A shared fixture catches every instance at once, in every runner, permanently \u2014 and it did: writing it surfaced the Kotlin scalar-coercion hole above, which five language-specific passes had missed.\n\nAll six SDKs must refuse it, by two different mechanisms, which is why the value under test is a JSON array/object rather than a scalar. Go, Kotlin and Swift decode into a typed model: json.Unmarshal, kotlinx.serialization and Codable all reject a structural mismatch. TypeScript, Python and Ruby have no decoder at all \u2014 schema.d.ts is erased at build time, and the generated Python and Ruby services return an untyped dict/Hash \u2014 so they carry an explicit guard. A scalar (42, false) would NOT discriminate in Kotlin: its client-wide Json { isLenient = true } coerces one into a String field, so the composite decodes \"42\" and writes it back. That is the same defect one layer down and is tracked separately; it cannot be fixed by a per-composite guard, because by the time the composite runs the coercion has already happened.\n\nerrorRaised rather than errorType: a hand-written guard raises api_error while a decoder raises its own language's decode failure, so no single canonical code is assertable. What all six agree on is that the call fails at all \u2014 which, paired with requestCount: 1, is the whole contract.\n\nCoverage note, so this case is not read as proving more than it does: in TypeScript the generated updateVerbatim's YYYY-MM-DD check already rejects a truthy non-string, so this fixture passes there with or without the guard. TypeScript's discriminating shape is a FALSEY non-string (false, 0), which `if (current.due_on)` dropped \u2014 and an omitted due_on is precisely how BC3 erases a card's due date, so on main it issued a real erasing PUT. A scalar cannot be used here because Kotlin coerces one (see above), so that path is pinned in typescript/tests/services/cards.test.ts instead.",
+    "description": "The falsey-shaped twin of the array case. Python's `... or None` collapses an empty object to None, which the generated _compact then strips \u2014 so the PUT went out with due_on ABSENT and BC3 erased the date, on a call that only renamed the card. Ruby forwarded `{}` verbatim instead. Same defect, opposite failure mode.\n\nThe kill case for #576, and the reason it lives here rather than in six per-language test files: the defect survived five consecutive review passes because each pass fixed one instance. A shared fixture catches every instance at once, in every runner, permanently \u2014 and it did: writing it surfaced the Kotlin scalar-coercion hole above, which five language-specific passes had missed.\n\nAll six SDKs must refuse it, by two different mechanisms, which is why the value under test is a JSON array/object rather than a scalar. Go, Kotlin and Swift decode into a typed model: json.Unmarshal, kotlinx.serialization and Codable all reject a structural mismatch. TypeScript, Python and Ruby have no decoder at all \u2014 schema.d.ts is erased at build time, and the generated Python and Ruby services return an untyped dict/Hash \u2014 so they carry an explicit guard. A scalar (42, false) would NOT discriminate in Kotlin: its client-wide Json { isLenient = true } coerces one into a String field, so the composite decodes \"42\" and writes it back. That is the same defect one layer down and is tracked separately; it cannot be fixed by a per-composite guard, because by the time the composite runs the coercion has already happened.\n\nerrorRaised rather than errorType: a hand-written guard raises api_error while a decoder raises its own language's decode failure, so no single canonical code is assertable. What all six agree on is that the call fails at all \u2014 which, paired with requestCount: 1, is the whole contract.\n\nCoverage note, so this case is not read as proving more than it does: in TypeScript the generated updateVerbatim's YYYY-MM-DD check already rejects a truthy non-string, so this fixture passes there with or without the guard. TypeScript's discriminating shape is a FALSEY non-string (false, 0), which `if (current.due_on)` dropped \u2014 and an omitted due_on is precisely how BC3 erases a card's due date, so on main it issued a real erasing PUT. A scalar cannot be used here because Kotlin coerces one (see above), so that path is pinned in typescript/tests/services/cards.test.ts instead. The case AFTER this pair is the Cards kill case that does discriminate in TypeScript: [\"2024-02-01\"] stringifies to a valid date, so the format check waves it through and only the guard stops it.",
     "operation": "UpdateCard",
     "method": "PUT",
     "path": "/card_tables/cards/{cardId}",
@@ -1504,6 +1504,348 @@
           "content": "<div>Add OAuth2 login flow with Google and GitHub providers</div>",
           "description": "Add OAuth2 login flow with Google and GitHub providers",
           "due_on": {},
+          "completed": false,
+          "comments_count": 2,
+          "comments_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479350/comments.json",
+          "completion_url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350/completion.json",
+          "parent": {
+            "id": 1069479347,
+            "title": "In Progress",
+            "type": "Kanban::Column",
+            "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/columns/1069479347.json",
+            "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/columns/1069479347"
+          },
+          "bucket": {
+            "id": 2085958499,
+            "name": "The Leto Laptop",
+            "type": "Project"
+          },
+          "creator": {
+            "id": 1049715914,
+            "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--xyz456",
+            "name": "Victor Cooper",
+            "email_address": "victor@honchodesign.com",
+            "personable_type": "User",
+            "title": "Chief Strategist",
+            "bio": "Leading product strategy",
+            "location": "Chicago, IL",
+            "created_at": "2024-01-01T08:00:00.000-06:00",
+            "updated_at": "2024-01-15T10:00:00.000-06:00",
+            "admin": true,
+            "owner": true,
+            "client": false,
+            "employee": true,
+            "time_zone": "America/Chicago",
+            "avatar_url": "https://3.basecamp-static.com/avatar/123.jpg",
+            "can_ping": true,
+            "can_manage_projects": true,
+            "can_manage_people": true
+          },
+          "assignees": [
+            {
+              "id": 1049715915,
+              "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--abc789",
+              "name": "Annie Bryan",
+              "email_address": "annie@honchodesign.com",
+              "personable_type": "User",
+              "title": "Designer",
+              "admin": false,
+              "owner": false,
+              "client": false,
+              "employee": true,
+              "time_zone": "America/Chicago",
+              "avatar_url": "https://3.basecamp-static.com/avatar/456.jpg"
+            }
+          ],
+          "completion_subscribers": [],
+          "steps": [
+            {
+              "id": 1069479360,
+              "status": "active",
+              "visible_to_clients": false,
+              "created_at": "2024-01-16T10:05:00.000-06:00",
+              "updated_at": "2024-01-18T11:00:00.000-06:00",
+              "title": "Set up OAuth providers",
+              "inherits_status": true,
+              "type": "Kanban::Step",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/steps/1069479360.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/steps/1069479360",
+              "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/step1.json",
+              "position": 1,
+              "completed": true,
+              "completed_at": "2024-01-18T11:00:00.000-06:00",
+              "parent": {
+                "id": 1069479350,
+                "title": "Implement user authentication",
+                "type": "Kanban::Card",
+                "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+                "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350"
+              },
+              "bucket": {
+                "id": 2085958499,
+                "name": "The Leto Laptop",
+                "type": "Project"
+              },
+              "creator": {
+                "id": 1049715914,
+                "name": "Victor Cooper"
+              },
+              "completer": {
+                "id": 1049715915,
+                "name": "Annie Bryan"
+              },
+              "assignees": []
+            },
+            {
+              "id": 1069479361,
+              "status": "active",
+              "visible_to_clients": false,
+              "created_at": "2024-01-16T10:06:00.000-06:00",
+              "updated_at": "2024-01-16T10:06:00.000-06:00",
+              "title": "Implement callback handlers",
+              "inherits_status": true,
+              "type": "Kanban::Step",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/steps/1069479361.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/steps/1069479361",
+              "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/step2.json",
+              "position": 2,
+              "completed": false,
+              "parent": {
+                "id": 1069479350,
+                "title": "Implement user authentication",
+                "type": "Kanban::Card",
+                "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+                "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350"
+              },
+              "bucket": {
+                "id": 2085958499,
+                "name": "The Leto Laptop",
+                "type": "Project"
+              },
+              "creator": {
+                "id": 1049715914,
+                "name": "Victor Cooper"
+              },
+              "assignees": []
+            }
+          ],
+          "description_attachments": []
+        }
+      },
+      {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "id": 1069479350,
+          "status": "active",
+          "visible_to_clients": false,
+          "created_at": "2024-01-16T10:00:00.000-06:00",
+          "updated_at": "2024-01-20T15:30:00.000-06:00",
+          "title": "Implement user authentication",
+          "inherits_status": true,
+          "type": "Kanban::Card",
+          "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+          "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350",
+          "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/card1.json",
+          "subscription_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479350/subscription.json",
+          "position": 1,
+          "content": "<div>Add OAuth2 login flow with Google and GitHub providers</div>",
+          "description": "Add OAuth2 login flow with Google and GitHub providers",
+          "due_on": "2024-02-01",
+          "completed": false,
+          "comments_count": 2,
+          "comments_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479350/comments.json",
+          "completion_url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350/completion.json",
+          "parent": {
+            "id": 1069479347,
+            "title": "In Progress",
+            "type": "Kanban::Column",
+            "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/columns/1069479347.json",
+            "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/columns/1069479347"
+          },
+          "bucket": {
+            "id": 2085958499,
+            "name": "The Leto Laptop",
+            "type": "Project"
+          },
+          "creator": {
+            "id": 1049715914,
+            "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--xyz456",
+            "name": "Victor Cooper",
+            "email_address": "victor@honchodesign.com",
+            "personable_type": "User",
+            "title": "Chief Strategist",
+            "bio": "Leading product strategy",
+            "location": "Chicago, IL",
+            "created_at": "2024-01-01T08:00:00.000-06:00",
+            "updated_at": "2024-01-15T10:00:00.000-06:00",
+            "admin": true,
+            "owner": true,
+            "client": false,
+            "employee": true,
+            "time_zone": "America/Chicago",
+            "avatar_url": "https://3.basecamp-static.com/avatar/123.jpg",
+            "can_ping": true,
+            "can_manage_projects": true,
+            "can_manage_people": true
+          },
+          "assignees": [
+            {
+              "id": 1049715915,
+              "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--abc789",
+              "name": "Annie Bryan",
+              "email_address": "annie@honchodesign.com",
+              "personable_type": "User",
+              "title": "Designer",
+              "admin": false,
+              "owner": false,
+              "client": false,
+              "employee": true,
+              "time_zone": "America/Chicago",
+              "avatar_url": "https://3.basecamp-static.com/avatar/456.jpg"
+            }
+          ],
+          "completion_subscribers": [],
+          "steps": [
+            {
+              "id": 1069479360,
+              "status": "active",
+              "visible_to_clients": false,
+              "created_at": "2024-01-16T10:05:00.000-06:00",
+              "updated_at": "2024-01-18T11:00:00.000-06:00",
+              "title": "Set up OAuth providers",
+              "inherits_status": true,
+              "type": "Kanban::Step",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/steps/1069479360.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/steps/1069479360",
+              "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/step1.json",
+              "position": 1,
+              "completed": true,
+              "completed_at": "2024-01-18T11:00:00.000-06:00",
+              "parent": {
+                "id": 1069479350,
+                "title": "Implement user authentication",
+                "type": "Kanban::Card",
+                "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+                "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350"
+              },
+              "bucket": {
+                "id": 2085958499,
+                "name": "The Leto Laptop",
+                "type": "Project"
+              },
+              "creator": {
+                "id": 1049715914,
+                "name": "Victor Cooper"
+              },
+              "completer": {
+                "id": 1049715915,
+                "name": "Annie Bryan"
+              },
+              "assignees": []
+            },
+            {
+              "id": 1069479361,
+              "status": "active",
+              "visible_to_clients": false,
+              "created_at": "2024-01-16T10:06:00.000-06:00",
+              "updated_at": "2024-01-16T10:06:00.000-06:00",
+              "title": "Implement callback handlers",
+              "inherits_status": true,
+              "type": "Kanban::Step",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/steps/1069479361.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/steps/1069479361",
+              "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/step2.json",
+              "position": 2,
+              "completed": false,
+              "parent": {
+                "id": 1069479350,
+                "title": "Implement user authentication",
+                "type": "Kanban::Card",
+                "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+                "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350"
+              },
+              "bucket": {
+                "id": 2085958499,
+                "name": "The Leto Laptop",
+                "type": "Project"
+              },
+              "creator": {
+                "id": 1049715914,
+                "name": "Victor Cooper"
+              },
+              "assignees": []
+            }
+          ],
+          "description_attachments": []
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "errorRaised"
+      },
+      {
+        "type": "requestCount",
+        "expected": 1
+      },
+      {
+        "type": "requestMethod",
+        "expected": "GET",
+        "index": 0
+      },
+      {
+        "type": "requestPath",
+        "expected": "/999/card_tables/cards/1069479350",
+        "index": 0
+      }
+    ],
+    "tags": [
+      "cards",
+      "merge-safe",
+      "due-on",
+      "malformed"
+    ]
+  },
+  {
+    "name": "update-kill: a date-shaped array due_on is refused where the format check is blind",
+    "description": "The Cards kill case that discriminates in TypeScript. The two above do not: the generated updateVerbatim guards due_on with /^\\d{4}-\\d{2}-\\d{2}$/.test(req.dueOn), and RegExp.test COERCES its argument to a string, so [\"x\"] (\"x\") and {} (\"[object Object]\") both fail that check and are rejected before the PUT. Those two therefore pass in TypeScript with or without this PR's guard, and leave the TypeScript Cards composite with no regression protection.\n\n[\"2024-02-01\"] is the shape the format check is blind to: String([\"2024-02-01\"]) is exactly \"2024-02-01\", so the regex matches, the array rides through untouched, and on main the composite issues a real second request with \"due_on\": [\"2024-02-01\"] in the body -- a JSON array written onto a field the API stores as a date. requestCount: 1 is what fails there: two requests mean the unvalidated value has already been written.\n\nIt discriminates in Python and Ruby for the same reason the plain array case does -- `or None` leaves a truthy value alone, and compact_params is kwargs.compact, which removes only nil -- so all three hand-written guards are exercised by this one case.\n\nAnd it keeps the property that makes a SHARED fixture worth writing at all: Go, Kotlin and Swift decode due_on into a String field, and json.Unmarshal, kotlinx.serialization and Codable all reject a JSON array there, structurally, exactly as they reject [\"x\"]. The date-shaped element is invisible to a decoder -- it is a string INSIDE an array, and the array is the mismatch. A scalar would not discriminate in Kotlin; see the array case above for why.",
+    "operation": "UpdateCard",
+    "method": "PUT",
+    "path": "/card_tables/cards/{cardId}",
+    "pathParams": {
+      "cardId": 1069479350
+    },
+    "requestBody": {
+      "title": "Renamed card"
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "id": 1069479350,
+          "status": "active",
+          "visible_to_clients": false,
+          "created_at": "2024-01-16T10:00:00.000-06:00",
+          "updated_at": "2024-01-20T15:30:00.000-06:00",
+          "title": "Implement user authentication",
+          "inherits_status": true,
+          "type": "Kanban::Card",
+          "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+          "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350",
+          "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/card1.json",
+          "subscription_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479350/subscription.json",
+          "position": 1,
+          "content": "<div>Add OAuth2 login flow with Google and GitHub providers</div>",
+          "description": "Add OAuth2 login flow with Google and GitHub providers",
+          "due_on": [
+            "2024-02-01"
+          ],
           "completed": false,
           "comments_count": 2,
           "comments_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479350/comments.json",

--- a/conformance/tests/cards_write.json
+++ b/conformance/tests/cards_write.json
@@ -1126,5 +1126,687 @@
       "merge-safe",
       "presence"
     ]
+  },
+  {
+    "name": "update-kill: an array due_on is refused before the replacement PUT",
+    "description": "This composite exists solely to stop an omitted due_on from erasing the card's date (`{ due_on: nil }.merge(card_params)`), so resending a value it never validated defeats its whole purpose. requestCount: 1 is the assertion that matters: a second request means the unvalidated value has already been written.\n\nOn main Ruby forwarded the array verbatim \u2014 compact_params is kwargs.compact, which removes only nil \u2014 and Python forwarded it too, since `or None` leaves a truthy value alone.\n\nThe kill case for #576, and the reason it lives here rather than in six per-language test files: the defect survived five consecutive review passes because each pass fixed one instance. A shared fixture catches every instance at once, in every runner, permanently \u2014 and it did: writing it surfaced the Kotlin scalar-coercion hole above, which five language-specific passes had missed.\n\nAll six SDKs must refuse it, by two different mechanisms, which is why the value under test is a JSON array/object rather than a scalar. Go, Kotlin and Swift decode into a typed model: json.Unmarshal, kotlinx.serialization and Codable all reject a structural mismatch. TypeScript, Python and Ruby have no decoder at all \u2014 schema.d.ts is erased at build time, and the generated Python and Ruby services return an untyped dict/Hash \u2014 so they carry an explicit guard. A scalar (42, false) would NOT discriminate in Kotlin: its client-wide Json { isLenient = true } coerces one into a String field, so the composite decodes \"42\" and writes it back. That is the same defect one layer down and is tracked separately; it cannot be fixed by a per-composite guard, because by the time the composite runs the coercion has already happened.\n\nerrorRaised rather than errorType: a hand-written guard raises api_error while a decoder raises its own language's decode failure, so no single canonical code is assertable. What all six agree on is that the call fails at all \u2014 which, paired with requestCount: 1, is the whole contract.\n\nCoverage note, so this case is not read as proving more than it does: in TypeScript the generated updateVerbatim's YYYY-MM-DD check already rejects a truthy non-string, so this fixture passes there with or without the guard. TypeScript's discriminating shape is a FALSEY non-string (false, 0), which `if (current.due_on)` dropped \u2014 and an omitted due_on is precisely how BC3 erases a card's due date, so on main it issued a real erasing PUT. A scalar cannot be used here because Kotlin coerces one (see above), so that path is pinned in typescript/tests/services/cards.test.ts instead.",
+    "operation": "UpdateCard",
+    "method": "PUT",
+    "path": "/card_tables/cards/{cardId}",
+    "pathParams": {
+      "cardId": 1069479350
+    },
+    "requestBody": {
+      "title": "Renamed card"
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "id": 1069479350,
+          "status": "active",
+          "visible_to_clients": false,
+          "created_at": "2024-01-16T10:00:00.000-06:00",
+          "updated_at": "2024-01-20T15:30:00.000-06:00",
+          "title": "Implement user authentication",
+          "inherits_status": true,
+          "type": "Kanban::Card",
+          "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+          "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350",
+          "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/card1.json",
+          "subscription_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479350/subscription.json",
+          "position": 1,
+          "content": "<div>Add OAuth2 login flow with Google and GitHub providers</div>",
+          "description": "Add OAuth2 login flow with Google and GitHub providers",
+          "due_on": [
+            "x"
+          ],
+          "completed": false,
+          "comments_count": 2,
+          "comments_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479350/comments.json",
+          "completion_url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350/completion.json",
+          "parent": {
+            "id": 1069479347,
+            "title": "In Progress",
+            "type": "Kanban::Column",
+            "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/columns/1069479347.json",
+            "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/columns/1069479347"
+          },
+          "bucket": {
+            "id": 2085958499,
+            "name": "The Leto Laptop",
+            "type": "Project"
+          },
+          "creator": {
+            "id": 1049715914,
+            "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--xyz456",
+            "name": "Victor Cooper",
+            "email_address": "victor@honchodesign.com",
+            "personable_type": "User",
+            "title": "Chief Strategist",
+            "bio": "Leading product strategy",
+            "location": "Chicago, IL",
+            "created_at": "2024-01-01T08:00:00.000-06:00",
+            "updated_at": "2024-01-15T10:00:00.000-06:00",
+            "admin": true,
+            "owner": true,
+            "client": false,
+            "employee": true,
+            "time_zone": "America/Chicago",
+            "avatar_url": "https://3.basecamp-static.com/avatar/123.jpg",
+            "can_ping": true,
+            "can_manage_projects": true,
+            "can_manage_people": true
+          },
+          "assignees": [
+            {
+              "id": 1049715915,
+              "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--abc789",
+              "name": "Annie Bryan",
+              "email_address": "annie@honchodesign.com",
+              "personable_type": "User",
+              "title": "Designer",
+              "admin": false,
+              "owner": false,
+              "client": false,
+              "employee": true,
+              "time_zone": "America/Chicago",
+              "avatar_url": "https://3.basecamp-static.com/avatar/456.jpg"
+            }
+          ],
+          "completion_subscribers": [],
+          "steps": [
+            {
+              "id": 1069479360,
+              "status": "active",
+              "visible_to_clients": false,
+              "created_at": "2024-01-16T10:05:00.000-06:00",
+              "updated_at": "2024-01-18T11:00:00.000-06:00",
+              "title": "Set up OAuth providers",
+              "inherits_status": true,
+              "type": "Kanban::Step",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/steps/1069479360.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/steps/1069479360",
+              "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/step1.json",
+              "position": 1,
+              "completed": true,
+              "completed_at": "2024-01-18T11:00:00.000-06:00",
+              "parent": {
+                "id": 1069479350,
+                "title": "Implement user authentication",
+                "type": "Kanban::Card",
+                "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+                "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350"
+              },
+              "bucket": {
+                "id": 2085958499,
+                "name": "The Leto Laptop",
+                "type": "Project"
+              },
+              "creator": {
+                "id": 1049715914,
+                "name": "Victor Cooper"
+              },
+              "completer": {
+                "id": 1049715915,
+                "name": "Annie Bryan"
+              },
+              "assignees": []
+            },
+            {
+              "id": 1069479361,
+              "status": "active",
+              "visible_to_clients": false,
+              "created_at": "2024-01-16T10:06:00.000-06:00",
+              "updated_at": "2024-01-16T10:06:00.000-06:00",
+              "title": "Implement callback handlers",
+              "inherits_status": true,
+              "type": "Kanban::Step",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/steps/1069479361.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/steps/1069479361",
+              "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/step2.json",
+              "position": 2,
+              "completed": false,
+              "parent": {
+                "id": 1069479350,
+                "title": "Implement user authentication",
+                "type": "Kanban::Card",
+                "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+                "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350"
+              },
+              "bucket": {
+                "id": 2085958499,
+                "name": "The Leto Laptop",
+                "type": "Project"
+              },
+              "creator": {
+                "id": 1049715914,
+                "name": "Victor Cooper"
+              },
+              "assignees": []
+            }
+          ],
+          "description_attachments": []
+        }
+      },
+      {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "id": 1069479350,
+          "status": "active",
+          "visible_to_clients": false,
+          "created_at": "2024-01-16T10:00:00.000-06:00",
+          "updated_at": "2024-01-20T15:30:00.000-06:00",
+          "title": "Implement user authentication",
+          "inherits_status": true,
+          "type": "Kanban::Card",
+          "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+          "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350",
+          "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/card1.json",
+          "subscription_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479350/subscription.json",
+          "position": 1,
+          "content": "<div>Add OAuth2 login flow with Google and GitHub providers</div>",
+          "description": "Add OAuth2 login flow with Google and GitHub providers",
+          "due_on": "2024-02-01",
+          "completed": false,
+          "comments_count": 2,
+          "comments_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479350/comments.json",
+          "completion_url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350/completion.json",
+          "parent": {
+            "id": 1069479347,
+            "title": "In Progress",
+            "type": "Kanban::Column",
+            "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/columns/1069479347.json",
+            "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/columns/1069479347"
+          },
+          "bucket": {
+            "id": 2085958499,
+            "name": "The Leto Laptop",
+            "type": "Project"
+          },
+          "creator": {
+            "id": 1049715914,
+            "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--xyz456",
+            "name": "Victor Cooper",
+            "email_address": "victor@honchodesign.com",
+            "personable_type": "User",
+            "title": "Chief Strategist",
+            "bio": "Leading product strategy",
+            "location": "Chicago, IL",
+            "created_at": "2024-01-01T08:00:00.000-06:00",
+            "updated_at": "2024-01-15T10:00:00.000-06:00",
+            "admin": true,
+            "owner": true,
+            "client": false,
+            "employee": true,
+            "time_zone": "America/Chicago",
+            "avatar_url": "https://3.basecamp-static.com/avatar/123.jpg",
+            "can_ping": true,
+            "can_manage_projects": true,
+            "can_manage_people": true
+          },
+          "assignees": [
+            {
+              "id": 1049715915,
+              "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--abc789",
+              "name": "Annie Bryan",
+              "email_address": "annie@honchodesign.com",
+              "personable_type": "User",
+              "title": "Designer",
+              "admin": false,
+              "owner": false,
+              "client": false,
+              "employee": true,
+              "time_zone": "America/Chicago",
+              "avatar_url": "https://3.basecamp-static.com/avatar/456.jpg"
+            }
+          ],
+          "completion_subscribers": [],
+          "steps": [
+            {
+              "id": 1069479360,
+              "status": "active",
+              "visible_to_clients": false,
+              "created_at": "2024-01-16T10:05:00.000-06:00",
+              "updated_at": "2024-01-18T11:00:00.000-06:00",
+              "title": "Set up OAuth providers",
+              "inherits_status": true,
+              "type": "Kanban::Step",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/steps/1069479360.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/steps/1069479360",
+              "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/step1.json",
+              "position": 1,
+              "completed": true,
+              "completed_at": "2024-01-18T11:00:00.000-06:00",
+              "parent": {
+                "id": 1069479350,
+                "title": "Implement user authentication",
+                "type": "Kanban::Card",
+                "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+                "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350"
+              },
+              "bucket": {
+                "id": 2085958499,
+                "name": "The Leto Laptop",
+                "type": "Project"
+              },
+              "creator": {
+                "id": 1049715914,
+                "name": "Victor Cooper"
+              },
+              "completer": {
+                "id": 1049715915,
+                "name": "Annie Bryan"
+              },
+              "assignees": []
+            },
+            {
+              "id": 1069479361,
+              "status": "active",
+              "visible_to_clients": false,
+              "created_at": "2024-01-16T10:06:00.000-06:00",
+              "updated_at": "2024-01-16T10:06:00.000-06:00",
+              "title": "Implement callback handlers",
+              "inherits_status": true,
+              "type": "Kanban::Step",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/steps/1069479361.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/steps/1069479361",
+              "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/step2.json",
+              "position": 2,
+              "completed": false,
+              "parent": {
+                "id": 1069479350,
+                "title": "Implement user authentication",
+                "type": "Kanban::Card",
+                "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+                "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350"
+              },
+              "bucket": {
+                "id": 2085958499,
+                "name": "The Leto Laptop",
+                "type": "Project"
+              },
+              "creator": {
+                "id": 1049715914,
+                "name": "Victor Cooper"
+              },
+              "assignees": []
+            }
+          ],
+          "description_attachments": []
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "errorRaised"
+      },
+      {
+        "type": "requestCount",
+        "expected": 1
+      },
+      {
+        "type": "requestMethod",
+        "expected": "GET",
+        "index": 0
+      },
+      {
+        "type": "requestPath",
+        "expected": "/999/card_tables/cards/1069479350",
+        "index": 0
+      }
+    ],
+    "tags": [
+      "cards",
+      "merge-safe",
+      "due-on",
+      "malformed"
+    ]
+  },
+  {
+    "name": "update-kill: an empty-object due_on is refused, not coerced or dropped",
+    "description": "The falsey-shaped twin of the array case. Python's `... or None` collapses an empty object to None, which the generated _compact then strips \u2014 so the PUT went out with due_on ABSENT and BC3 erased the date, on a call that only renamed the card. Ruby forwarded `{}` verbatim instead. Same defect, opposite failure mode.\n\nThe kill case for #576, and the reason it lives here rather than in six per-language test files: the defect survived five consecutive review passes because each pass fixed one instance. A shared fixture catches every instance at once, in every runner, permanently \u2014 and it did: writing it surfaced the Kotlin scalar-coercion hole above, which five language-specific passes had missed.\n\nAll six SDKs must refuse it, by two different mechanisms, which is why the value under test is a JSON array/object rather than a scalar. Go, Kotlin and Swift decode into a typed model: json.Unmarshal, kotlinx.serialization and Codable all reject a structural mismatch. TypeScript, Python and Ruby have no decoder at all \u2014 schema.d.ts is erased at build time, and the generated Python and Ruby services return an untyped dict/Hash \u2014 so they carry an explicit guard. A scalar (42, false) would NOT discriminate in Kotlin: its client-wide Json { isLenient = true } coerces one into a String field, so the composite decodes \"42\" and writes it back. That is the same defect one layer down and is tracked separately; it cannot be fixed by a per-composite guard, because by the time the composite runs the coercion has already happened.\n\nerrorRaised rather than errorType: a hand-written guard raises api_error while a decoder raises its own language's decode failure, so no single canonical code is assertable. What all six agree on is that the call fails at all \u2014 which, paired with requestCount: 1, is the whole contract.\n\nCoverage note, so this case is not read as proving more than it does: in TypeScript the generated updateVerbatim's YYYY-MM-DD check already rejects a truthy non-string, so this fixture passes there with or without the guard. TypeScript's discriminating shape is a FALSEY non-string (false, 0), which `if (current.due_on)` dropped \u2014 and an omitted due_on is precisely how BC3 erases a card's due date, so on main it issued a real erasing PUT. A scalar cannot be used here because Kotlin coerces one (see above), so that path is pinned in typescript/tests/services/cards.test.ts instead.",
+    "operation": "UpdateCard",
+    "method": "PUT",
+    "path": "/card_tables/cards/{cardId}",
+    "pathParams": {
+      "cardId": 1069479350
+    },
+    "requestBody": {
+      "title": "Renamed card"
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "id": 1069479350,
+          "status": "active",
+          "visible_to_clients": false,
+          "created_at": "2024-01-16T10:00:00.000-06:00",
+          "updated_at": "2024-01-20T15:30:00.000-06:00",
+          "title": "Implement user authentication",
+          "inherits_status": true,
+          "type": "Kanban::Card",
+          "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+          "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350",
+          "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/card1.json",
+          "subscription_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479350/subscription.json",
+          "position": 1,
+          "content": "<div>Add OAuth2 login flow with Google and GitHub providers</div>",
+          "description": "Add OAuth2 login flow with Google and GitHub providers",
+          "due_on": {},
+          "completed": false,
+          "comments_count": 2,
+          "comments_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479350/comments.json",
+          "completion_url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350/completion.json",
+          "parent": {
+            "id": 1069479347,
+            "title": "In Progress",
+            "type": "Kanban::Column",
+            "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/columns/1069479347.json",
+            "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/columns/1069479347"
+          },
+          "bucket": {
+            "id": 2085958499,
+            "name": "The Leto Laptop",
+            "type": "Project"
+          },
+          "creator": {
+            "id": 1049715914,
+            "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--xyz456",
+            "name": "Victor Cooper",
+            "email_address": "victor@honchodesign.com",
+            "personable_type": "User",
+            "title": "Chief Strategist",
+            "bio": "Leading product strategy",
+            "location": "Chicago, IL",
+            "created_at": "2024-01-01T08:00:00.000-06:00",
+            "updated_at": "2024-01-15T10:00:00.000-06:00",
+            "admin": true,
+            "owner": true,
+            "client": false,
+            "employee": true,
+            "time_zone": "America/Chicago",
+            "avatar_url": "https://3.basecamp-static.com/avatar/123.jpg",
+            "can_ping": true,
+            "can_manage_projects": true,
+            "can_manage_people": true
+          },
+          "assignees": [
+            {
+              "id": 1049715915,
+              "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--abc789",
+              "name": "Annie Bryan",
+              "email_address": "annie@honchodesign.com",
+              "personable_type": "User",
+              "title": "Designer",
+              "admin": false,
+              "owner": false,
+              "client": false,
+              "employee": true,
+              "time_zone": "America/Chicago",
+              "avatar_url": "https://3.basecamp-static.com/avatar/456.jpg"
+            }
+          ],
+          "completion_subscribers": [],
+          "steps": [
+            {
+              "id": 1069479360,
+              "status": "active",
+              "visible_to_clients": false,
+              "created_at": "2024-01-16T10:05:00.000-06:00",
+              "updated_at": "2024-01-18T11:00:00.000-06:00",
+              "title": "Set up OAuth providers",
+              "inherits_status": true,
+              "type": "Kanban::Step",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/steps/1069479360.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/steps/1069479360",
+              "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/step1.json",
+              "position": 1,
+              "completed": true,
+              "completed_at": "2024-01-18T11:00:00.000-06:00",
+              "parent": {
+                "id": 1069479350,
+                "title": "Implement user authentication",
+                "type": "Kanban::Card",
+                "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+                "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350"
+              },
+              "bucket": {
+                "id": 2085958499,
+                "name": "The Leto Laptop",
+                "type": "Project"
+              },
+              "creator": {
+                "id": 1049715914,
+                "name": "Victor Cooper"
+              },
+              "completer": {
+                "id": 1049715915,
+                "name": "Annie Bryan"
+              },
+              "assignees": []
+            },
+            {
+              "id": 1069479361,
+              "status": "active",
+              "visible_to_clients": false,
+              "created_at": "2024-01-16T10:06:00.000-06:00",
+              "updated_at": "2024-01-16T10:06:00.000-06:00",
+              "title": "Implement callback handlers",
+              "inherits_status": true,
+              "type": "Kanban::Step",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/steps/1069479361.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/steps/1069479361",
+              "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/step2.json",
+              "position": 2,
+              "completed": false,
+              "parent": {
+                "id": 1069479350,
+                "title": "Implement user authentication",
+                "type": "Kanban::Card",
+                "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+                "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350"
+              },
+              "bucket": {
+                "id": 2085958499,
+                "name": "The Leto Laptop",
+                "type": "Project"
+              },
+              "creator": {
+                "id": 1049715914,
+                "name": "Victor Cooper"
+              },
+              "assignees": []
+            }
+          ],
+          "description_attachments": []
+        }
+      },
+      {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "id": 1069479350,
+          "status": "active",
+          "visible_to_clients": false,
+          "created_at": "2024-01-16T10:00:00.000-06:00",
+          "updated_at": "2024-01-20T15:30:00.000-06:00",
+          "title": "Implement user authentication",
+          "inherits_status": true,
+          "type": "Kanban::Card",
+          "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+          "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350",
+          "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/card1.json",
+          "subscription_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479350/subscription.json",
+          "position": 1,
+          "content": "<div>Add OAuth2 login flow with Google and GitHub providers</div>",
+          "description": "Add OAuth2 login flow with Google and GitHub providers",
+          "due_on": "2024-02-01",
+          "completed": false,
+          "comments_count": 2,
+          "comments_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479350/comments.json",
+          "completion_url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350/completion.json",
+          "parent": {
+            "id": 1069479347,
+            "title": "In Progress",
+            "type": "Kanban::Column",
+            "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/columns/1069479347.json",
+            "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/columns/1069479347"
+          },
+          "bucket": {
+            "id": 2085958499,
+            "name": "The Leto Laptop",
+            "type": "Project"
+          },
+          "creator": {
+            "id": 1049715914,
+            "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--xyz456",
+            "name": "Victor Cooper",
+            "email_address": "victor@honchodesign.com",
+            "personable_type": "User",
+            "title": "Chief Strategist",
+            "bio": "Leading product strategy",
+            "location": "Chicago, IL",
+            "created_at": "2024-01-01T08:00:00.000-06:00",
+            "updated_at": "2024-01-15T10:00:00.000-06:00",
+            "admin": true,
+            "owner": true,
+            "client": false,
+            "employee": true,
+            "time_zone": "America/Chicago",
+            "avatar_url": "https://3.basecamp-static.com/avatar/123.jpg",
+            "can_ping": true,
+            "can_manage_projects": true,
+            "can_manage_people": true
+          },
+          "assignees": [
+            {
+              "id": 1049715915,
+              "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--abc789",
+              "name": "Annie Bryan",
+              "email_address": "annie@honchodesign.com",
+              "personable_type": "User",
+              "title": "Designer",
+              "admin": false,
+              "owner": false,
+              "client": false,
+              "employee": true,
+              "time_zone": "America/Chicago",
+              "avatar_url": "https://3.basecamp-static.com/avatar/456.jpg"
+            }
+          ],
+          "completion_subscribers": [],
+          "steps": [
+            {
+              "id": 1069479360,
+              "status": "active",
+              "visible_to_clients": false,
+              "created_at": "2024-01-16T10:05:00.000-06:00",
+              "updated_at": "2024-01-18T11:00:00.000-06:00",
+              "title": "Set up OAuth providers",
+              "inherits_status": true,
+              "type": "Kanban::Step",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/steps/1069479360.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/steps/1069479360",
+              "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/step1.json",
+              "position": 1,
+              "completed": true,
+              "completed_at": "2024-01-18T11:00:00.000-06:00",
+              "parent": {
+                "id": 1069479350,
+                "title": "Implement user authentication",
+                "type": "Kanban::Card",
+                "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+                "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350"
+              },
+              "bucket": {
+                "id": 2085958499,
+                "name": "The Leto Laptop",
+                "type": "Project"
+              },
+              "creator": {
+                "id": 1049715914,
+                "name": "Victor Cooper"
+              },
+              "completer": {
+                "id": 1049715915,
+                "name": "Annie Bryan"
+              },
+              "assignees": []
+            },
+            {
+              "id": 1069479361,
+              "status": "active",
+              "visible_to_clients": false,
+              "created_at": "2024-01-16T10:06:00.000-06:00",
+              "updated_at": "2024-01-16T10:06:00.000-06:00",
+              "title": "Implement callback handlers",
+              "inherits_status": true,
+              "type": "Kanban::Step",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/steps/1069479361.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/steps/1069479361",
+              "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/step2.json",
+              "position": 2,
+              "completed": false,
+              "parent": {
+                "id": 1069479350,
+                "title": "Implement user authentication",
+                "type": "Kanban::Card",
+                "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/cards/1069479350.json",
+                "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/cards/1069479350"
+              },
+              "bucket": {
+                "id": 2085958499,
+                "name": "The Leto Laptop",
+                "type": "Project"
+              },
+              "creator": {
+                "id": 1049715914,
+                "name": "Victor Cooper"
+              },
+              "assignees": []
+            }
+          ],
+          "description_attachments": []
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "errorRaised"
+      },
+      {
+        "type": "requestCount",
+        "expected": 1
+      },
+      {
+        "type": "requestMethod",
+        "expected": "GET",
+        "index": 0
+      },
+      {
+        "type": "requestPath",
+        "expected": "/999/card_tables/cards/1069479350",
+        "index": 0
+      }
+    ],
+    "tags": [
+      "cards",
+      "merge-safe",
+      "due-on",
+      "malformed"
+    ]
   }
 ]

--- a/conformance/tests/todos_write.json
+++ b/conformance/tests/todos_write.json
@@ -547,5 +547,331 @@
       "write",
       "replace"
     ]
+  },
+  {
+    "name": "update-kill: an array description is refused before the full-replace PUT",
+    "description": "The merge-safe update GETs the todo, reads every writable field, and PUTs the FULL representation back — so a value read is a value written, on a call that only set the content. A malformed one must be refused BEFORE the PUT, which is exactly what requestCount: 1 pins: the moment a second request appears, the malformed value has already landed on a full-replace endpoint.\n\nThis is the CORRUPTION half of #576. Neither `or \"\"` (Python) nor `|| \"\"` (Ruby) nor `?? \"\"` (TypeScript) coalesces a non-empty array, so on main all three PUT `\"description\": [\"x\"]` to the todo — an array where the rich-text body belongs.\n\nThe kill case for #576, and the reason it lives here rather than in six per-language test files: the defect survived five consecutive review passes because each pass fixed one instance. A shared fixture catches every instance at once, in every runner, permanently — and it did: writing it surfaced the Kotlin scalar-coercion hole above, which five language-specific passes had missed.\n\nAll six SDKs must refuse it, by two different mechanisms, which is why the value under test is a JSON array/object rather than a scalar. Go, Kotlin and Swift decode into a typed model: json.Unmarshal, kotlinx.serialization and Codable all reject a structural mismatch. TypeScript, Python and Ruby have no decoder at all — schema.d.ts is erased at build time, and the generated Python and Ruby services return an untyped dict/Hash — so they carry an explicit guard. A scalar (42, false) would NOT discriminate in Kotlin: its client-wide Json { isLenient = true } coerces one into a String field, so the composite decodes \"42\" and writes it back. That is the same defect one layer down and is tracked separately; it cannot be fixed by a per-composite guard, because by the time the composite runs the coercion has already happened.\n\nerrorRaised rather than errorType: a hand-written guard raises api_error while a decoder raises its own language's decode failure, so no single canonical code is assertable. What all six agree on is that the call fails at all — which, paired with requestCount: 1, is the whole contract.",
+    "operation": "UpdateTodo",
+    "method": "PUT",
+    "path": "/todos/{todoId}",
+    "pathParams": {
+      "todoId": 456
+    },
+    "requestBody": {
+      "content": "New title"
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "id": 456,
+          "status": "active",
+          "visible_to_clients": false,
+          "created_at": "2024-01-15T10:00:00Z",
+          "updated_at": "2024-01-15T10:00:00Z",
+          "title": "Buy milk",
+          "inherits_status": true,
+          "type": "Todo",
+          "url": "https://3.basecampapi.com/999/buckets/1/todos/456.json",
+          "app_url": "https://3.basecamp.com/999/buckets/1/todos/456",
+          "bookmark_url": "https://3.basecampapi.com/999/my/bookmarks/abc123.json",
+          "content": "Buy milk",
+          "description": [
+            "x"
+          ],
+          "due_on": "2024-03-01",
+          "starts_on": "2024-02-01",
+          "completed": false,
+          "comments_count": 0,
+          "position": 1,
+          "parent": {
+            "id": 2,
+            "title": "Todolist",
+            "type": "Todolist",
+            "url": "https://3.basecampapi.com/999/buckets/1/todolists/2.json",
+            "app_url": "https://3.basecamp.com/999/buckets/1/todolists/2"
+          },
+          "bucket": {
+            "id": 1,
+            "name": "Project",
+            "type": "Project"
+          },
+          "creator": {
+            "id": 1,
+            "name": "Test User",
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z"
+          },
+          "assignees": [
+            {
+              "id": 100,
+              "name": "Jane Doe",
+              "created_at": "2024-01-01T00:00:00Z",
+              "updated_at": "2024-01-01T00:00:00Z"
+            }
+          ],
+          "completion_subscribers": [
+            {
+              "id": 555,
+              "name": "Sub Scriber",
+              "created_at": "2024-01-01T00:00:00Z",
+              "updated_at": "2024-01-01T00:00:00Z"
+            }
+          ],
+          "description_attachments": []
+        }
+      },
+      {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "id": 456,
+          "status": "active",
+          "visible_to_clients": false,
+          "created_at": "2024-01-15T10:00:00Z",
+          "updated_at": "2024-01-15T10:00:00Z",
+          "title": "Buy milk",
+          "inherits_status": true,
+          "type": "Todo",
+          "url": "https://3.basecampapi.com/999/buckets/1/todos/456.json",
+          "app_url": "https://3.basecamp.com/999/buckets/1/todos/456",
+          "bookmark_url": "https://3.basecampapi.com/999/my/bookmarks/abc123.json",
+          "content": "Buy milk",
+          "description": "<p>From the store</p>",
+          "due_on": "2024-03-01",
+          "starts_on": "2024-02-01",
+          "completed": false,
+          "comments_count": 0,
+          "position": 1,
+          "parent": {
+            "id": 2,
+            "title": "Todolist",
+            "type": "Todolist",
+            "url": "https://3.basecampapi.com/999/buckets/1/todolists/2.json",
+            "app_url": "https://3.basecamp.com/999/buckets/1/todolists/2"
+          },
+          "bucket": {
+            "id": 1,
+            "name": "Project",
+            "type": "Project"
+          },
+          "creator": {
+            "id": 1,
+            "name": "Test User",
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z"
+          },
+          "assignees": [
+            {
+              "id": 100,
+              "name": "Jane Doe",
+              "created_at": "2024-01-01T00:00:00Z",
+              "updated_at": "2024-01-01T00:00:00Z"
+            }
+          ],
+          "completion_subscribers": [
+            {
+              "id": 555,
+              "name": "Sub Scriber",
+              "created_at": "2024-01-01T00:00:00Z",
+              "updated_at": "2024-01-01T00:00:00Z"
+            }
+          ],
+          "description_attachments": []
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "errorRaised"
+      },
+      {
+        "type": "requestCount",
+        "expected": 1
+      },
+      {
+        "type": "requestMethod",
+        "expected": "GET",
+        "index": 0
+      },
+      {
+        "type": "requestPath",
+        "expected": "/999/todos/456",
+        "index": 0
+      }
+    ],
+    "tags": [
+      "todos",
+      "write",
+      "merge",
+      "malformed"
+    ]
+  },
+  {
+    "name": "update-kill: an empty-object description is refused, not coalesced to empty",
+    "description": "The ERASURE half of #576, and the half whose absence produced this issue's original wrong verdict. Python's `or \"\"` turns every falsey non-string — {} included — into \"\", and on a full-replace endpoint that empty value is written back over the real description: the field the composite exists to preserve, wiped by a call that only set the content. Ruby and TypeScript reach the same endpoint by the other road and forward `{}` verbatim. Testing for corruption alone would miss the erasure; testing for erasure alone is what let TypeScript be called structurally safe.\n\nThe kill case for #576, and the reason it lives here rather than in six per-language test files: the defect survived five consecutive review passes because each pass fixed one instance. A shared fixture catches every instance at once, in every runner, permanently — and it did: writing it surfaced the Kotlin scalar-coercion hole above, which five language-specific passes had missed.\n\nAll six SDKs must refuse it, by two different mechanisms, which is why the value under test is a JSON array/object rather than a scalar. Go, Kotlin and Swift decode into a typed model: json.Unmarshal, kotlinx.serialization and Codable all reject a structural mismatch. TypeScript, Python and Ruby have no decoder at all — schema.d.ts is erased at build time, and the generated Python and Ruby services return an untyped dict/Hash — so they carry an explicit guard. A scalar (42, false) would NOT discriminate in Kotlin: its client-wide Json { isLenient = true } coerces one into a String field, so the composite decodes \"42\" and writes it back. That is the same defect one layer down and is tracked separately; it cannot be fixed by a per-composite guard, because by the time the composite runs the coercion has already happened.\n\nerrorRaised rather than errorType: a hand-written guard raises api_error while a decoder raises its own language's decode failure, so no single canonical code is assertable. What all six agree on is that the call fails at all — which, paired with requestCount: 1, is the whole contract.",
+    "operation": "UpdateTodo",
+    "method": "PUT",
+    "path": "/todos/{todoId}",
+    "pathParams": {
+      "todoId": 456
+    },
+    "requestBody": {
+      "content": "New title"
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "id": 456,
+          "status": "active",
+          "visible_to_clients": false,
+          "created_at": "2024-01-15T10:00:00Z",
+          "updated_at": "2024-01-15T10:00:00Z",
+          "title": "Buy milk",
+          "inherits_status": true,
+          "type": "Todo",
+          "url": "https://3.basecampapi.com/999/buckets/1/todos/456.json",
+          "app_url": "https://3.basecamp.com/999/buckets/1/todos/456",
+          "bookmark_url": "https://3.basecampapi.com/999/my/bookmarks/abc123.json",
+          "content": "Buy milk",
+          "description": {},
+          "due_on": "2024-03-01",
+          "starts_on": "2024-02-01",
+          "completed": false,
+          "comments_count": 0,
+          "position": 1,
+          "parent": {
+            "id": 2,
+            "title": "Todolist",
+            "type": "Todolist",
+            "url": "https://3.basecampapi.com/999/buckets/1/todolists/2.json",
+            "app_url": "https://3.basecamp.com/999/buckets/1/todolists/2"
+          },
+          "bucket": {
+            "id": 1,
+            "name": "Project",
+            "type": "Project"
+          },
+          "creator": {
+            "id": 1,
+            "name": "Test User",
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z"
+          },
+          "assignees": [
+            {
+              "id": 100,
+              "name": "Jane Doe",
+              "created_at": "2024-01-01T00:00:00Z",
+              "updated_at": "2024-01-01T00:00:00Z"
+            }
+          ],
+          "completion_subscribers": [
+            {
+              "id": 555,
+              "name": "Sub Scriber",
+              "created_at": "2024-01-01T00:00:00Z",
+              "updated_at": "2024-01-01T00:00:00Z"
+            }
+          ],
+          "description_attachments": []
+        }
+      },
+      {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "id": 456,
+          "status": "active",
+          "visible_to_clients": false,
+          "created_at": "2024-01-15T10:00:00Z",
+          "updated_at": "2024-01-15T10:00:00Z",
+          "title": "Buy milk",
+          "inherits_status": true,
+          "type": "Todo",
+          "url": "https://3.basecampapi.com/999/buckets/1/todos/456.json",
+          "app_url": "https://3.basecamp.com/999/buckets/1/todos/456",
+          "bookmark_url": "https://3.basecampapi.com/999/my/bookmarks/abc123.json",
+          "content": "Buy milk",
+          "description": "<p>From the store</p>",
+          "due_on": "2024-03-01",
+          "starts_on": "2024-02-01",
+          "completed": false,
+          "comments_count": 0,
+          "position": 1,
+          "parent": {
+            "id": 2,
+            "title": "Todolist",
+            "type": "Todolist",
+            "url": "https://3.basecampapi.com/999/buckets/1/todolists/2.json",
+            "app_url": "https://3.basecamp.com/999/buckets/1/todolists/2"
+          },
+          "bucket": {
+            "id": 1,
+            "name": "Project",
+            "type": "Project"
+          },
+          "creator": {
+            "id": 1,
+            "name": "Test User",
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z"
+          },
+          "assignees": [
+            {
+              "id": 100,
+              "name": "Jane Doe",
+              "created_at": "2024-01-01T00:00:00Z",
+              "updated_at": "2024-01-01T00:00:00Z"
+            }
+          ],
+          "completion_subscribers": [
+            {
+              "id": 555,
+              "name": "Sub Scriber",
+              "created_at": "2024-01-01T00:00:00Z",
+              "updated_at": "2024-01-01T00:00:00Z"
+            }
+          ],
+          "description_attachments": []
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "errorRaised"
+      },
+      {
+        "type": "requestCount",
+        "expected": 1
+      },
+      {
+        "type": "requestMethod",
+        "expected": "GET",
+        "index": 0
+      },
+      {
+        "type": "requestPath",
+        "expected": "/999/todos/456",
+        "index": 0
+      }
+    ],
+    "tags": [
+      "todos",
+      "write",
+      "merge",
+      "malformed"
+    ]
   }
 ]

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/ErrorRaised.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/ErrorRaised.kt
@@ -1,0 +1,31 @@
+package com.basecamp.sdk.conformance
+
+/**
+ * Validates one `errorRaised` assertion, returning `null` when it holds and a
+ * failure message otherwise.
+ *
+ * The inverse of `noError`, and deliberately code-agnostic. The
+ * malformed-response family (#576) is refused by a hand-written guard in
+ * TypeScript, Python and Ruby and by the model decoder in Go, Kotlin and
+ * Swift; those two mechanisms share no canonical error code, so pinning
+ * `errorType` would make the fixture unwritable. What all six agree on is that
+ * the call fails at all — which, paired with `requestCount`, is the whole
+ * contract: the composite refused the field instead of writing it.
+ *
+ * Split out of the runner so the failing branch is unit-testable
+ * (ErrorRaisedTest). NO COMMITTED FIXTURE CAN REACH IT: every case declaring
+ * `errorRaised` is one the SDK does refuse, so a handler that accepted
+ * everything would report green in all six runners at once. That is the #563
+ * shape — a `delayBetweenRequests` check that passed vacuously because no
+ * fixture supplied a gap it could fail on — and the reason
+ * `make conformance-runner-tests` exists.
+ *
+ * `dispatchFailed` is the union of every failure mechanism, not just the ones
+ * that produce a BasecampException: a decoder rejection never becomes one, and
+ * refusing a malformed body IS the behaviour under test here.
+ *
+ * The message is pinned verbatim by the unit tests in all six runners: a
+ * fixture debugged in one language should not read differently in another.
+ */
+fun errorRaisedFailure(dispatchFailed: Boolean): String? =
+    if (dispatchFailed) null else "Expected the call to fail, but it succeeded"

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
@@ -396,17 +396,17 @@ private fun runTest(tc: TestCase): TestResult {
                 }
             }
 
-            // The inverse of noError, and deliberately code-agnostic. The
-            // malformed-response family (#576) is refused by a hand-written
-            // guard in TypeScript, Python and Ruby and by the model decoder in
-            // Go, Kotlin and Swift; those two mechanisms do not share a
-            // canonical code, so pinning errorType would make the fixture
-            // unwritable. What every SDK must agree on is that the call fails
-            // at all — which, paired with requestCount, is the whole contract:
-            // the composite refused the field instead of writing it.
+            // The inverse of noError, and deliberately code-agnostic. See
+            // errorRaisedFailure (ErrorRaised.kt) for the contract and for why
+            // the branch lives there rather than inline: no committed fixture
+            // can reach its failing side, so it is unit-tested instead.
+            //
+            // Read from BOTH signals: every path that records caughtException
+            // also sets dispatchFailed today, and the union keeps that true by
+            // construction rather than by call-site discipline.
             "errorRaised" -> {
-                if (!dispatchFailed) {
-                    return TestResult(false, "Expected the call to fail, but it succeeded")
+                errorRaisedFailure(dispatchFailed || caughtException != null)?.let {
+                    return TestResult(false, it)
                 }
             }
 

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
@@ -9,6 +9,7 @@ import io.ktor.http.*
 import io.ktor.http.content.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.MissingFieldException
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.*
 import java.io.File
 import java.io.IOException
@@ -256,6 +257,18 @@ private fun runTest(tc: TestCase): TestResult {
     var httpStatusCode: Int? = null
     var dispatchResult = DispatchResult()
 
+    // Set when the dispatch failed by ANY mechanism, including a decoder
+    // rejection that never becomes a BasecampException. Only `errorRaised`
+    // reads it; errorType, errorCode and errorMessage still read
+    // caughtException, so a fixture pinning a canonical code cannot be
+    // satisfied by a raw kotlinx.serialization throw.
+    var dispatchFailed = false
+    // A fixture declaring errorRaised is asserting that the body is
+    // DELIBERATELY malformed and that refusing it is the behaviour under test
+    // (#576). That flips the usual reading of a decoder rejection here: it is
+    // the point of the case, not an under-specified mock body to repair.
+    val expectsFailure = tc.assertions.any { it.type == "errorRaised" }
+
     val overrideBaseUrl = tc.configOverrides?.baseUrl
 
     try {
@@ -278,14 +291,29 @@ private fun runTest(tc: TestCase): TestResult {
             }
         } catch (e: BasecampException) {
             caughtException = e
+            dispatchFailed = true
             httpStatusCode = e.httpStatus
         } catch (e: MissingFieldException) {
             // A mock body that fails the model's required-field validation is a
             // fixture bug, not a runner limitation: fail loudly so it gets fixed
             // (canonical bodies live in spec/fixtures/) instead of silently
             // degrading coverage. Was SKIP until every rider was repaired.
-            client.close()
-            return TestResult(passed = false, message = "Mock body lacks required Kotlin model fields: ${e.message}")
+            if (!expectsFailure) {
+                client.close()
+                return TestResult(passed = false, message = "Mock body lacks required Kotlin model fields: ${e.message}")
+            }
+            dispatchFailed = true
+        } catch (e: SerializationException) {
+            // A wrong-TYPED field, as opposed to a missing one. Same policy:
+            // normally a fixture bug, but the refusal itself when the fixture
+            // declares errorRaised. This is how Kotlin satisfies the #576 kill
+            // cases — kotlinx.serialization is its guard, where TypeScript,
+            // Python and Ruby need a hand-written one.
+            if (!expectsFailure) {
+                client.close()
+                return TestResult(passed = false, message = "Mock body does not decode into the Kotlin model: ${e.message}")
+            }
+            dispatchFailed = true
         } catch (e: Exception) {
             client.close()
             return TestResult(false, "Unexpected exception: ${e::class.simpleName}: ${e.message}")
@@ -296,6 +324,7 @@ private fun runTest(tc: TestCase): TestResult {
         // SDK's require() throws IllegalArgumentException for HTTPS enforcement.
         // Map to BasecampException.Usage for assertion compatibility.
         caughtException = BasecampException.Usage(e.message ?: "HTTPS required")
+        dispatchFailed = true
     }
 
     // Run assertions
@@ -364,6 +393,20 @@ private fun runTest(tc: TestCase): TestResult {
             "noError" -> {
                 if (caughtException != null) {
                     return TestResult(false, "Expected no error, got: ${caughtException.message}")
+                }
+            }
+
+            // The inverse of noError, and deliberately code-agnostic. The
+            // malformed-response family (#576) is refused by a hand-written
+            // guard in TypeScript, Python and Ruby and by the model decoder in
+            // Go, Kotlin and Swift; those two mechanisms do not share a
+            // canonical code, so pinning errorType would make the fixture
+            // unwritable. What every SDK must agree on is that the call fails
+            // at all — which, paired with requestCount, is the whole contract:
+            // the composite refused the field instead of writing it.
+            "errorRaised" -> {
+                if (!dispatchFailed) {
+                    return TestResult(false, "Expected the call to fail, but it succeeded")
                 }
             }
 

--- a/kotlin/conformance/src/test/kotlin/com/basecamp/sdk/conformance/ErrorRaisedTest.kt
+++ b/kotlin/conformance/src/test/kotlin/com/basecamp/sdk/conformance/ErrorRaisedTest.kt
@@ -1,0 +1,35 @@
+package com.basecamp.sdk.conformance
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Both directions of the errorRaised assertion contract.
+ *
+ * Only the passing direction ever runs against a committed fixture: every case
+ * declaring errorRaised is one the SDK does refuse. A handler that accepted
+ * everything would therefore look green in all six runners at once, which is
+ * exactly how #563 shipped a vacuous delayBetweenRequests check.
+ */
+class ErrorRaisedTest {
+    companion object {
+        /**
+         * Asserted verbatim here and in the five sibling runners. A fixture
+         * debugged in one language should not read differently in another.
+         */
+        const val MESSAGE = "Expected the call to fail, but it succeeded"
+    }
+
+    @Test
+    fun `a failed dispatch satisfies the assertion`() {
+        assertNull(errorRaisedFailure(true))
+    }
+
+    @Test
+    fun `a successful dispatch fails the assertion`() {
+        // The branch under test. It is unreachable from conformance/tests/, so
+        // without this case the handler could accept everything undetected.
+        assertEquals(MESSAGE, errorRaisedFailure(false))
+    }
+}

--- a/python/src/basecamp/services/cards.py
+++ b/python/src/basecamp/services/cards.py
@@ -19,6 +19,9 @@ from typing import Any
 
 from basecamp.generated.services.cards import AsyncCardsService as _GeneratedAsyncCardsService
 from basecamp.generated.services.cards import CardsService as _GeneratedCardsService
+from basecamp.services._merge_safe import require_mapping, writable_string
+
+_ESCAPE = "update_verbatim()"
 
 _UPDATE_DOC = """Update a card without disturbing fields you did not mention.
 
@@ -44,9 +47,20 @@ def _resolve_due_on(due_on: str | None, current: dict[str, Any] | None) -> str |
     ``_compact`` strips ``None``, and BC3 nils an omitted due date. Sending an
     explicit null would violate body compaction (SPEC §18), and sending ``""``
     risks a date-format error.
+
+    The fetched value is validated before it is resent, because this composite
+    exists precisely to stop an omitted ``due_on`` from erasing the date and
+    resending an unvalidated one defeats that. The bare ``or None`` this
+    replaced failed in both directions: a falsey non-string (``False``, ``0``,
+    ``[]``, ``{}``) collapsed to ``None``, which ``_compact`` then stripped —
+    so the PUT went out with ``due_on`` absent and BC3 erased the date — while
+    a truthy one (``42``, ``True``, ``["x"]``) rode through verbatim and was
+    written to the card. ``get`` returns ``dict[str, Any]``, so nothing below
+    this validates it (#576).
     """
     if due_on is None:
-        return (current or {}).get("due_on") or None
+        body = require_mapping(current, record="Card", operation="GetCard", escape=_ESCAPE)
+        return writable_string(body, "due_on", record="Card", escape=_ESCAPE) or None
     if due_on == "":
         return None
     return due_on

--- a/python/src/basecamp/services/todos.py
+++ b/python/src/basecamp/services/todos.py
@@ -17,17 +17,31 @@ from typing import Any
 from basecamp.errors import UsageError
 from basecamp.generated.services.todos import AsyncTodosService as _GeneratedAsyncTodosService
 from basecamp.generated.services.todos import TodosService as _GeneratedTodosService
+from basecamp.services._merge_safe import require_mapping, writable_id_list, writable_string
+
+_ESCAPE = "replace()"
 
 
 def _fields_from_todo(todo: dict[str, Any]) -> dict[str, Any]:
-    """Derive a todo's full writable state from a GET response."""
+    """Derive a todo's full writable state from a GET response.
+
+    Every value here is resent in the full-replace PUT, so every value is
+    validated before it is read. The plain ``or ""`` this replaced coerced each
+    falsey non-string (``False``, ``0``, ``[]``, ``{}``) to ``""`` — erasing the
+    field on a call that never mentioned it — and passed ``42``/``True``
+    straight through to be written verbatim. Python has no typed decoder
+    between the GET and this read (``get`` returns ``dict[str, Any]``), so the
+    check is explicit work here rather than something the layer below already
+    did. See :mod:`basecamp.services._merge_safe` and #576.
+    """
+    body = require_mapping(todo, record="Todo", operation="GetTodo", escape=_ESCAPE)
     return {
-        "content": todo.get("content") or "",
-        "description": todo.get("description") or "",
-        "assignee_ids": [p["id"] for p in todo.get("assignees") or []],
-        "completion_subscriber_ids": [p["id"] for p in todo.get("completion_subscribers") or []],
-        "due_on": todo.get("due_on") or "",
-        "starts_on": todo.get("starts_on") or "",
+        "content": writable_string(body, "content", record="Todo", escape=_ESCAPE),
+        "description": writable_string(body, "description", record="Todo", escape=_ESCAPE),
+        "assignee_ids": writable_id_list(body, "assignees", record="Todo", escape=_ESCAPE),
+        "completion_subscriber_ids": writable_id_list(body, "completion_subscribers", record="Todo", escape=_ESCAPE),
+        "due_on": writable_string(body, "due_on", record="Todo", escape=_ESCAPE),
+        "starts_on": writable_string(body, "starts_on", record="Todo", escape=_ESCAPE),
         # Send directive, not todo state: never populated from the current
         # todo; sent only when True.
         "notify": False,

--- a/python/tests/services/test_cards.py
+++ b/python/tests/services/test_cards.py
@@ -15,6 +15,7 @@ import pytest
 import respx
 
 from basecamp import AsyncClient, Client
+from basecamp.errors import ApiError
 
 BASE = "https://3.basecampapi.com/12345"
 
@@ -146,3 +147,90 @@ class TestAsyncUpdate:
 
         assert not get_route.called
         assert put_route.call_count == 1
+
+
+# --- #576: a malformed GET due_on must never reach the replacement PUT -------
+#
+# `update` reads the card only to resend its due date, so that one value is the
+# whole reason the composite exists. Before the guard it was forwarded
+# unvalidated: `_compact` strips only `None`, so `False`, `0`, `[]`, `{}`, `42`,
+# `True` and `["x"]` all reached the wire and were written to the card. Python
+# has no typed decoder between the GET and the read — the generated `get`
+# returns `dict[str, Any]`.
+#
+# The assertion that matters is the ORDERING: `put_route.called` must be False.
+
+_MALFORMED_DUE_ON = [
+    pytest.param(False, id="false"),
+    pytest.param(0, id="zero"),
+    pytest.param([], id="empty-list"),
+    pytest.param({}, id="empty-dict"),
+    pytest.param(42, id="number"),
+    pytest.param(True, id="true"),
+    pytest.param(["x"], id="list"),
+    pytest.param({"a": 1}, id="dict"),
+]
+
+
+class TestMalformedDueOn:
+    @respx.mock
+    @pytest.mark.parametrize("value", _MALFORMED_DUE_ON)
+    def test_update_refuses_a_non_string_due_on_before_writing(self, value):
+        get_route = respx.get(f"{BASE}/card_tables/cards/42").mock(
+            return_value=httpx.Response(200, json=_card(due_on=value))
+        )
+        put_route = respx.put(f"{BASE}/card_tables/cards/42").mock(return_value=httpx.Response(200, json=_card()))
+
+        with pytest.raises(ApiError) as excinfo:
+            _sync_cards().update(card_id=42, title="Renamed")
+
+        assert "Card field 'due_on' is not a string" in str(excinfo.value)
+        # api_error, not usage: the value arrived in a successful response.
+        assert excinfo.value.code == "api_error"
+        assert get_route.called
+        assert not put_route.called, "the guard must fire BEFORE the replacement PUT"
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_async_update_refuses_a_non_string_due_on_before_writing(self):
+        get_route = respx.get(f"{BASE}/card_tables/cards/42").mock(
+            return_value=httpx.Response(200, json=_card(due_on=42))
+        )
+        put_route = respx.put(f"{BASE}/card_tables/cards/42").mock(return_value=httpx.Response(200, json=_card()))
+
+        with pytest.raises(ApiError):
+            await _async_cards().update(card_id=42, title="Renamed")
+
+        assert get_route.called
+        assert not put_route.called
+
+    @respx.mock
+    @pytest.mark.parametrize("value", [None, "absent"])
+    def test_absent_and_null_stay_genuinely_empty(self, value):
+        # The other half of the rule: a card with no due date is not malformed.
+        card = _card()
+        if value is None:
+            card["due_on"] = None
+        else:
+            card.pop("due_on")
+        respx.get(f"{BASE}/card_tables/cards/42").mock(return_value=httpx.Response(200, json=card))
+        put_route = respx.put(f"{BASE}/card_tables/cards/42").mock(return_value=httpx.Response(200, json=_card()))
+
+        _sync_cards().update(card_id=42, title="Renamed")
+
+        assert "due_on" not in _put_body(put_route)
+
+    @respx.mock
+    @pytest.mark.parametrize("raw", [b"[]", b'"card"', b"42", b"null", b"true"])
+    def test_update_refuses_a_non_object_response_before_writing(self, raw):
+        get_route = respx.get(f"{BASE}/card_tables/cards/42").mock(
+            return_value=httpx.Response(200, content=raw, headers={"Content-Type": "application/json"})
+        )
+        put_route = respx.put(f"{BASE}/card_tables/cards/42").mock(return_value=httpx.Response(200, json=_card()))
+
+        with pytest.raises(ApiError) as excinfo:
+            _sync_cards().update(card_id=42, title="Renamed")
+
+        assert "GetCard returned" in str(excinfo.value)
+        assert get_route.called
+        assert not put_route.called

--- a/python/tests/services/test_todos.py
+++ b/python/tests/services/test_todos.py
@@ -10,7 +10,7 @@ import pytest
 import respx
 
 from basecamp import AsyncClient, Client, Config
-from basecamp.errors import UsageError, ValidationError
+from basecamp.errors import ApiError, UsageError, ValidationError
 from basecamp.hooks import BasecampHooks, OperationInfo
 
 BASE = "https://3.basecampapi.com/12345"
@@ -412,3 +412,164 @@ class TestCompleteRetriesIdempotentPost:
         await client.for_account("12345").todos.complete(todo_id=42)
 
         assert route.call_count == 2  # initial 503 + 1 retry that succeeds
+
+
+# --- #576: a malformed GET field must never reach the full-replace PUT -------
+#
+# `update`/`edit` GET the todo, read each writable field, and PUT the FULL
+# representation back. Every value read is therefore written, including one the
+# caller never mentioned. The old `todo.get(key) or ""` coerced each falsey
+# non-string to `""` (erasure) and passed `42`/`True` through verbatim
+# (corruption). Python has no typed decoder between the GET and the read — the
+# generated `get` returns `dict[str, Any]` — so the refusal is explicit.
+#
+# The assertion that matters is the ORDERING: `put_route.called` must be False.
+# A guard that fires after the PUT has already lost the field.
+
+_MALFORMED = [
+    pytest.param(False, id="false"),
+    pytest.param(0, id="zero"),
+    pytest.param([], id="empty-list"),
+    pytest.param({}, id="empty-dict"),
+    pytest.param(42, id="number"),
+    pytest.param(True, id="true"),
+    pytest.param(["x"], id="list"),
+    pytest.param({"a": 1}, id="dict"),
+]
+
+_WRITABLE_STRINGS = ["content", "description", "due_on", "starts_on"]
+
+_ID_LISTS = ["assignees", "completion_subscribers"]
+
+
+def _malformed_routes(todo: dict):
+    get_route = respx.get(f"{BASE}/todos/42").mock(return_value=httpx.Response(200, json=todo))
+    put_route = respx.put(f"{BASE}/todos/42").mock(return_value=httpx.Response(200, json=_todo()))
+    return get_route, put_route
+
+
+class TestMalformedResponseFields:
+    @respx.mock
+    @pytest.mark.parametrize("field", _WRITABLE_STRINGS)
+    @pytest.mark.parametrize("value", _MALFORMED)
+    def test_update_refuses_a_non_string_before_writing(self, field, value):
+        get_route, put_route = _malformed_routes(_todo(**{field: value}))
+
+        with pytest.raises(ApiError) as excinfo:
+            _sync_todos().update(todo_id=42, content="New title")
+
+        assert f"Todo field {field!r} is not a string" in str(excinfo.value)
+        # api_error, not usage: the value arrived in a successful response.
+        assert excinfo.value.code == "api_error"
+        assert get_route.called
+        assert not put_route.called, "the guard must fire BEFORE the full-replace PUT"
+
+    @respx.mock
+    @pytest.mark.parametrize("field", _WRITABLE_STRINGS)
+    def test_edit_refuses_a_non_string_before_writing(self, field):
+        get_route, put_route = _malformed_routes(_todo(**{field: 42}))
+
+        with pytest.raises(ApiError), _sync_todos().edit(todo_id=42) as t:
+            t.content = "New title"
+
+        assert get_route.called
+        assert not put_route.called
+
+    @respx.mock
+    @pytest.mark.parametrize("field", _WRITABLE_STRINGS)
+    @pytest.mark.asyncio
+    async def test_async_update_refuses_a_non_string_before_writing(self, field):
+        get_route, put_route = _malformed_routes(_todo(**{field: ["x"]}))
+
+        with pytest.raises(ApiError):
+            await _async_todos().update(todo_id=42, content="New title")
+
+        assert get_route.called
+        assert not put_route.called
+
+    @respx.mock
+    @pytest.mark.parametrize("absent", [True, False], ids=["absent", "null"])
+    @pytest.mark.parametrize("field", _WRITABLE_STRINGS)
+    def test_absent_and_null_stay_genuinely_empty(self, field, absent):
+        # The other half of the rule: absent and null are not malformed, they
+        # are empty. Guarding types must not turn a legitimately blank field
+        # into an error. The call overlays an ID list rather than a string so
+        # that no writable string under test is overwritten by the caller.
+        todo = _todo()
+        if absent:
+            todo.pop(field, None)
+        else:
+            todo[field] = None
+        _, put_route = _malformed_routes(todo)
+
+        _sync_todos().update(todo_id=42, assignee_ids=[100])
+
+        body = _put_body(put_route)
+        if field in ("due_on", "starts_on"):
+            # Dates ride only when non-empty: "" is a format error and an
+            # omitted date is how the server clears one.
+            assert field not in body
+        else:
+            assert body[field] == ""
+
+    @respx.mock
+    @pytest.mark.parametrize("value", _MALFORMED)
+    @pytest.mark.parametrize("field", _ID_LISTS)
+    def test_update_refuses_a_non_array_id_list_before_writing(self, field, value):
+        if isinstance(value, list):
+            pytest.skip("a list is checked element-wise, not by the array guard")
+        get_route, put_route = _malformed_routes(_todo(**{field: value}))
+
+        with pytest.raises(ApiError) as excinfo:
+            _sync_todos().update(todo_id=42, content="New title")
+
+        assert f"Todo field {field!r} is not an array" in str(excinfo.value)
+        assert get_route.called
+        assert not put_route.called
+
+    @respx.mock
+    @pytest.mark.parametrize("field", _ID_LISTS)
+    def test_update_refuses_a_non_object_element_before_writing(self, field):
+        get_route, put_route = _malformed_routes(_todo(**{field: ["nope"]}))
+
+        with pytest.raises(ApiError) as excinfo:
+            _sync_todos().update(todo_id=42, content="New title")
+
+        assert f"Todo field {field!r}[0] is not an object" in str(excinfo.value)
+        assert get_route.called
+        assert not put_route.called
+
+    @respx.mock
+    @pytest.mark.parametrize("bad_id", ["100", 10.5, None, True, [], {}])
+    @pytest.mark.parametrize("field", _ID_LISTS)
+    def test_update_refuses_a_non_integer_person_id_before_writing(self, field, bad_id):
+        # The ID lists are resent in full, so a string, float, bool or null id
+        # would be written as the complete assignee set. `True` matters
+        # specifically: bool subclasses int in Python, so a naive isinstance
+        # check passes it.
+        get_route, put_route = _malformed_routes(_todo(**{field: [{"id": bad_id, "name": "Jane"}]}))
+
+        with pytest.raises(ApiError) as excinfo:
+            _sync_todos().update(todo_id=42, content="New title")
+
+        assert f"Todo field {field!r}[0]" in str(excinfo.value)
+        assert get_route.called
+        assert not put_route.called
+
+    @respx.mock
+    @pytest.mark.parametrize("raw", [b"[]", b'"todo"', b"42", b"null", b"true"])
+    def test_update_refuses_a_non_object_response_before_writing(self, raw):
+        # One level up from the field guards: a successful GET can return a
+        # scalar, a list or null, and `body.get(key)` would raise a raw
+        # AttributeError instead of the documented statusless api_error.
+        get_route = respx.get(f"{BASE}/todos/42").mock(
+            return_value=httpx.Response(200, content=raw, headers={"Content-Type": "application/json"})
+        )
+        put_route = respx.put(f"{BASE}/todos/42").mock(return_value=httpx.Response(200, json=_todo()))
+
+        with pytest.raises(ApiError) as excinfo:
+            _sync_todos().update(todo_id=42, content="New title")
+
+        assert "GetTodo returned" in str(excinfo.value)
+        assert get_route.called
+        assert not put_route.called

--- a/ruby/lib/basecamp/services/cards_extensions.rb
+++ b/ruby/lib/basecamp/services/cards_extensions.rb
@@ -19,6 +19,10 @@ module Basecamp
     # PUT is overwritten with the value this call read. The window is one
     # round-trip.
     module CardsExtensions
+      # The deliberate-overwrite escape hatch named in every malformed-response
+      # hint raised out of this composite.
+      ESCAPE_HATCH = "update_verbatim"
+
       # Updates a card without disturbing fields the caller did not mention.
       #
       # +due_on+ is tri-state, which is what makes this safe:
@@ -43,7 +47,7 @@ module Basecamp
       def update(card_id:, title: nil, content: nil, due_on: nil, assignee_ids: nil)
         resolved_due_on =
           if due_on.nil?
-            get(card_id: card_id)["due_on"]
+            current_due_on(get(card_id: card_id))
           elsif due_on.to_s.empty?
             # Clearing is encoded by OMITTING due_on — compact_params strips the
             # nil below, and BC3 nils an omitted due date. Sending an explicit
@@ -61,6 +65,27 @@ module Basecamp
           due_on: resolved_due_on,
           assignee_ids: assignee_ids
         )
+      end
+
+      private
+
+      # Reads the fetched card's due date, refusing to resend a malformed one.
+      #
+      # +compact_params+ is +kwargs.compact+, which removes only +nil+, so
+      # before this guard +false+, +0+, +[]+, <tt>{}</tt>, +42+, +true+ and
+      # <tt>["x"]</tt> all reached the replacement request and were written to
+      # the card. This composite exists precisely to stop an omitted +due_on+
+      # from erasing the date, so resending an unvalidated one defeats it.
+      # Ruby has no typed decoder between the GET and this read (+get+ returns
+      # a raw Hash), so the check is explicit work here. See {MergeSafe}
+      # and #576.
+      #
+      # An empty date is normalised to +nil+ rather than sent: <tt>""</tt> is
+      # not a date BC3 accepts, and omission is how the clear is encoded.
+      def current_due_on(card)
+        body = MergeSafe.require_hash(card, record: "Card", operation: "GetCard", escape: ESCAPE_HATCH)
+        value = MergeSafe.writable_string(body, "due_on", record: "Card", escape: ESCAPE_HATCH)
+        value.empty? ? nil : value
       end
     end
   end

--- a/ruby/lib/basecamp/services/todos_extensions.rb
+++ b/ruby/lib/basecamp/services/todos_extensions.rb
@@ -26,6 +26,10 @@ module Basecamp
         keyword_init: true
       )
 
+      # The deliberate-overwrite escape hatch named in every malformed-response
+      # hint raised out of this composite.
+      ESCAPE_HATCH = "replace"
+
       # Sets the given fields on a todo and preserves everything else:
       # GETs the current todo, overlays the explicitly-passed keyword
       # arguments, and PUTs the full representation back. An omitted
@@ -85,14 +89,26 @@ module Basecamp
       private
 
       # Derives the full writable state from a GET response.
+      #
+      # Every value here is resent in the full-replace PUT, so every value is
+      # validated before it is read. The plain <tt>|| ""</tt> this replaced
+      # turned +false+ into <tt>""</tt> — erasing the field on a call that never
+      # mentioned it — and passed arrays, hashes, numbers and +true+ straight
+      # through to be written verbatim. Ruby has no typed decoder between the
+      # GET and this read (+get+ returns a raw Hash), so the check is explicit
+      # work here rather than something the layer below already did. See
+      # {MergeSafe} and #576.
       def fields_from_todo(todo)
+        body = MergeSafe.require_hash(todo, record: "Todo", operation: "GetTodo", escape: ESCAPE_HATCH)
         TodoFields.new(
-          content: todo["content"] || "",
-          description: todo["description"] || "",
-          assignee_ids: (todo["assignees"] || []).map { |p| p["id"] },
-          completion_subscriber_ids: (todo["completion_subscribers"] || []).map { |p| p["id"] },
-          due_on: todo["due_on"] || "",
-          starts_on: todo["starts_on"] || "",
+          content: MergeSafe.writable_string(body, "content", record: "Todo", escape: ESCAPE_HATCH),
+          description: MergeSafe.writable_string(body, "description", record: "Todo", escape: ESCAPE_HATCH),
+          assignee_ids: MergeSafe.writable_id_list(body, "assignees", record: "Todo", escape: ESCAPE_HATCH),
+          completion_subscriber_ids: MergeSafe.writable_id_list(
+            body, "completion_subscribers", record: "Todo", escape: ESCAPE_HATCH
+          ),
+          due_on: MergeSafe.writable_string(body, "due_on", record: "Todo", escape: ESCAPE_HATCH),
+          starts_on: MergeSafe.writable_string(body, "starts_on", record: "Todo", escape: ESCAPE_HATCH),
           notify: false
         )
       end

--- a/ruby/test/basecamp/services/cards_service_test.rb
+++ b/ruby/test/basecamp/services/cards_service_test.rb
@@ -109,4 +109,64 @@ class CardsServiceTest < Minitest::Test
 
     assert_nil result
   end
+
+  # --- #576: a malformed GET due_on must never reach the replacement PUT -----
+  #
+  # `update` reads the card only to resend its due date, so that one value is
+  # the whole reason the composite exists. `compact_params` is `kwargs.compact`,
+  # which removes only nil, so before the guard `false`, `0`, `[]`, `{}`, `42`,
+  # `true` and `["x"]` all reached the wire and were written to the card. Ruby
+  # has no typed decoder between the GET and the read: the generated `get`
+  # returns a raw Hash.
+  #
+  # The assertion that matters is the ORDERING -- assert_not_requested :put.
+  [ false, 0, [], {}, 42, true, [ "x" ], { "a" => 1 } ].each do |malformed|
+    define_method("test_update_refuses_a_malformed_due_on_#{malformed.inspect}") do
+      stub_get("/12345/card_tables/cards/200", response_body: sample_card(id: 200).merge("due_on" => malformed))
+      stub_put("/12345/card_tables/cards/200", response_body: sample_card(id: 200))
+
+      error = assert_raises(Basecamp::ApiError) do
+        @account.cards.update(card_id: 200, title: "Updated Title")
+      end
+
+      assert_includes error.message, 'Card field "due_on" is not a string'
+      # api_error, not usage: the value arrived in a successful response.
+      assert_equal Basecamp::ErrorCode::API, error.code
+      assert_requested :get, "#{BASE_URL}/12345/card_tables/cards/200", times: 1
+      assert_not_requested :put, "#{BASE_URL}/12345/card_tables/cards/200"
+    end
+  end
+
+  # The other half of the rule: a card with no due date is not malformed.
+  [ [ "missing", :delete ], [ "nil", nil ] ].each do |label, mode|
+    define_method("test_#{label}_due_on_stays_genuinely_empty") do
+      current = sample_card(id: 200)
+      mode == :delete ? current.delete("due_on") : current["due_on"] = nil
+      stub_get("/12345/card_tables/cards/200", response_body: current)
+      stub_put("/12345/card_tables/cards/200", response_body: sample_card(id: 200))
+
+      @account.cards.update(card_id: 200, title: "Updated Title")
+
+      assert_requested(:put, "#{BASE_URL}/12345/card_tables/cards/200") do |req|
+        !JSON.parse(req.body).key?("due_on")
+      end
+    end
+  end
+
+  # One level up from the field guard: a successful GET can return a scalar, an
+  # Array or nil, and `card["due_on"]` would raise a raw TypeError instead of
+  # the documented statusless api_error.
+  [ 42, "nope", nil, [ "a" ], true ].each do |body|
+    define_method("test_update_refuses_a_non_object_response_body_#{body.inspect}") do
+      stub_get("/12345/card_tables/cards/200", response_body: body.to_json)
+      stub_put("/12345/card_tables/cards/200", response_body: sample_card(id: 200))
+
+      error = assert_raises(Basecamp::ApiError) do
+        @account.cards.update(card_id: 200, title: "Updated Title")
+      end
+
+      assert_includes error.message, "GetCard returned"
+      assert_not_requested :put, "#{BASE_URL}/12345/card_tables/cards/200"
+    end
+  end
 end

--- a/ruby/test/basecamp/services/todos_service_test.rb
+++ b/ruby/test/basecamp/services/todos_service_test.rb
@@ -333,6 +333,151 @@ class TodosServiceTest < Minitest::Test
     assert_nil pdf.height
   end
 
+  # --- #576: a malformed GET field must never reach the full-replace PUT ------
+  #
+  # `update`/`edit` GET the todo, read each writable field, and PUT the FULL
+  # representation back, so every value read is written -- including one the
+  # caller never mentioned. Ruby's `||` treats only nil and false as falsy, so
+  # the old `todo["content"] || ""` ERASED the field on `false` and passed
+  # arrays, hashes, numbers and `true` straight through to be written verbatim.
+  # There is no typed decoder between the GET and the read: the generated `get`
+  # returns a raw Hash.
+  #
+  # The assertion that matters is the ORDERING -- assert_not_requested :put. A
+  # guard that fires after the PUT has already lost the field.
+  MALFORMED_VALUES = [ false, 0, [], {}, 42, true, [ "x" ], { "a" => 1 } ].freeze
+  WRITABLE_STRINGS = %w[content description due_on starts_on].freeze
+  ID_LIST_FIELDS = %w[assignees completion_subscribers].freeze
+
+  WRITABLE_STRINGS.each do |field|
+    MALFORMED_VALUES.each do |malformed|
+      define_method("test_update_refuses_a_malformed_#{field}_#{malformed.inspect}") do
+        stub_todo_get_and_put(todo: full_todo(field => malformed))
+
+        error = assert_raises(Basecamp::ApiError) do
+          @account.todos.update(todo_id: 456, content: "New title")
+        end
+
+        assert_includes error.message, "Todo field \"#{field}\" is not a string"
+        # api_error, not usage: the value arrived in a successful response.
+        assert_equal Basecamp::ErrorCode::API, error.code
+        assert_requested :get, "#{BASE_URL}/12345/todos/456", times: 1
+        assert_not_requested :put, "#{BASE_URL}/12345/todos/456"
+      end
+    end
+
+    define_method("test_edit_refuses_a_malformed_#{field}_before_writing") do
+      stub_todo_get_and_put(todo: full_todo(field => 42))
+
+      assert_raises(Basecamp::ApiError) do
+        @account.todos.edit(todo_id: 456) { |t| t.content = "New title" }
+      end
+
+      assert_not_requested :put, "#{BASE_URL}/12345/todos/456"
+    end
+
+    # The other half of the rule: missing and nil are not malformed, they are
+    # empty. The call overlays an id list rather than a string so that no
+    # writable string under test is overwritten by the caller.
+    define_method("test_missing_#{field}_stays_genuinely_empty") do
+      captured = stub_todo_get_and_put(todo: full_todo.except(field))
+
+      @account.todos.update(todo_id: 456, assignee_ids: [ 100 ])
+
+      if %w[due_on starts_on].include?(field)
+        # Dates ride only when non-empty: "" is a format error and an omitted
+        # date is how the server clears one.
+        assert_not_includes captured[:body].keys, field
+      else
+        assert_equal "", captured[:body][field]
+      end
+    end
+
+    define_method("test_nil_#{field}_stays_genuinely_empty") do
+      captured = stub_todo_get_and_put(todo: full_todo(field => nil))
+
+      @account.todos.update(todo_id: 456, assignee_ids: [ 100 ])
+
+      if %w[due_on starts_on].include?(field)
+        assert_not_includes captured[:body].keys, field
+      else
+        assert_equal "", captured[:body][field]
+      end
+    end
+  end
+
+  ID_LIST_FIELDS.each do |field|
+    (MALFORMED_VALUES - [ [], [ "x" ] ]).each do |malformed|
+      define_method("test_update_refuses_a_non_array_#{field}_#{malformed.inspect}") do
+        stub_todo_get_and_put(todo: full_todo(field => malformed))
+
+        error = assert_raises(Basecamp::ApiError) do
+          @account.todos.update(todo_id: 456, content: "New title")
+        end
+
+        assert_includes error.message, "Todo field \"#{field}\" is not an array"
+        assert_not_requested :put, "#{BASE_URL}/12345/todos/456"
+      end
+    end
+
+    define_method("test_update_refuses_a_non_object_#{field}_element") do
+      stub_todo_get_and_put(todo: full_todo(field => [ "nope" ]))
+
+      error = assert_raises(Basecamp::ApiError) do
+        @account.todos.update(todo_id: 456, content: "New title")
+      end
+
+      assert_includes error.message, "Todo field \"#{field}\"[0] is not an object"
+      assert_not_requested :put, "#{BASE_URL}/12345/todos/456"
+    end
+
+    # The id lists are resent in full, so a string, float or null id would be
+    # written as the complete assignee set.
+    [ "100", 10.5, nil, true, [], {} ].each do |bad_id|
+      define_method("test_update_refuses_a_non_integer_#{field}_id_#{bad_id.inspect}") do
+        stub_todo_get_and_put(todo: full_todo(field => [ { "id" => bad_id, "name" => "Jane" } ]))
+
+        error = assert_raises(Basecamp::ApiError) do
+          @account.todos.update(todo_id: 456, content: "New title")
+        end
+
+        assert_includes error.message, "Todo field \"#{field}\"[0]"
+        assert_not_requested :put, "#{BASE_URL}/12345/todos/456"
+      end
+    end
+  end
+
+  # One level up from the field guards: a successful GET can return a scalar,
+  # an Array or nil, and `body["content"]` would raise a raw TypeError instead
+  # of the documented statusless api_error.
+  [ 42, "nope", nil, [ "a" ], true ].each do |body|
+    define_method("test_update_refuses_a_non_object_response_body_#{body.inspect}") do
+      # stub_get passes Strings through verbatim, so encode first.
+      stub_get("/12345/todos/456", response_body: body.to_json)
+      stub_request(:put, "#{BASE_URL}/12345/todos/456")
+        .to_return(status: 200, body: full_todo.to_json, headers: { "Content-Type" => "application/json" })
+
+      error = assert_raises(Basecamp::ApiError) do
+        @account.todos.update(todo_id: 456, content: "New title")
+      end
+
+      assert_includes error.message, "GetTodo returned"
+      assert_not_requested :put, "#{BASE_URL}/12345/todos/456"
+    end
+  end
+
+  # SPEC section 9 caps error messages at 500 bytes; the malformed value is
+  # interpolated into one, so the cap has to survive a huge body.
+  def test_malformed_message_is_capped
+    stub_todo_get_and_put(todo: full_todo("description" => [ "x" ] * 50_000))
+
+    error = assert_raises(Basecamp::ApiError) do
+      @account.todos.update(todo_id: 456, content: "New title")
+    end
+
+    assert_operator error.message.bytesize, :<=, 500
+  end
+
   class TrackingHooks
     include Basecamp::Hooks
 

--- a/typescript/src/services/cards-extensions.ts
+++ b/typescript/src/services/cards-extensions.ts
@@ -1,5 +1,9 @@
 import { CardsService as GeneratedCardsService } from "../generated/services/cards.js";
 import type { Card } from "../generated/services/cards.js";
+import { requireRecord, writableString } from "./merge-safe.js";
+
+/** The deliberate-overwrite escape hatch named in this composite's error hints. */
+const ESCAPE = "updateVerbatim()";
 
 /**
  * Request parameters for `update`.
@@ -87,10 +91,25 @@ export class CardsService extends GeneratedCardsService {
 
     if (req.dueOn === undefined) {
       // Unaddressed: preserve whatever is there now.
-      const current = await this.get(cardId);
+      //
+      // The fetched date is validated before it is resent. `if (current.due_on)`
+      // was the worst instance of #576 and failed in both directions at once:
+      // a falsey non-string was DROPPED, and an omitted `due_on` is exactly how
+      // BC3 erases a card's due date — the behaviour this composite exists to
+      // prevent — while a truthy non-string (`42`, `true`, `["x"]`, `{a:1}`)
+      // was forwarded verbatim and written to the card. Nothing below this
+      // rejects either: `schema.d.ts` is erased at build time, so `Card` is a
+      // compile-time claim about runtime data. See `merge-safe.ts`.
+      const current = requireRecord(await this.get(cardId), {
+        record: "Card",
+        operation: "GetCard",
+        escape: ESCAPE,
+      });
       // The Card response carries wire-shaped keys; the request builder takes
-      // camelCase.
-      if (current.due_on) body.dueOn = current.due_on;
+      // camelCase. An absent or null date stays absent — omission is how the
+      // API expresses "no due date", and `""` is not a date it accepts.
+      const dueOn = writableString(current, "due_on", { record: "Card", escape: ESCAPE });
+      if (dueOn !== "") body.dueOn = dueOn;
     } else if (req.dueOn !== null) {
       body.dueOn = req.dueOn;
     }

--- a/typescript/src/services/todos-extensions.ts
+++ b/typescript/src/services/todos-extensions.ts
@@ -1,5 +1,9 @@
 import { TodosService as GeneratedTodosService } from "../generated/services/todos.js";
 import type { Todo } from "../generated/services/todos.js";
+import { requireRecord, writableIdList, writableString } from "./merge-safe.js";
+
+/** The deliberate-overwrite escape hatch named in this composite's error hints. */
+const ESCAPE = "replace()";
 
 /**
  * Request parameters for update. Every field is optional: an omitted field
@@ -126,16 +130,32 @@ export class TodosService extends GeneratedTodosService {
     return this.putFields(todoId, fields);
   }
 
-  /** Fetches the todo and derives its full writable state. */
+  /**
+   * Fetches the todo and derives its full writable state.
+   *
+   * Every value here is resent in the full-replace PUT, so every value is
+   * validated before it is read. `?? ""` coalesces only `null` and `undefined`,
+   * so it left corruption wide open: `false`, `0`, `[]`, `{}`, `42`, `true`,
+   * `["x"]` and `{a:1}` were all forwarded **verbatim** and written to the
+   * todo on a call that never mentioned the field — a broader surface than
+   * Python's, which at least collapsed the falsey four to `""`. Nothing below
+   * this rejects them: `schema.d.ts` is erased at build time, so `Todo` is a
+   * compile-time claim about runtime data. See `merge-safe.ts` and #576.
+   */
   private async currentFields(todoId: number): Promise<TodoFields> {
-    const current = await this.get(todoId);
+    const current = requireRecord(await this.get(todoId), {
+      record: "Todo",
+      operation: "GetTodo",
+      escape: ESCAPE,
+    });
+    const opts = { record: "Todo", escape: ESCAPE };
     return {
-      content: current.content ?? "",
-      description: current.description ?? "",
-      assigneeIds: (current.assignees ?? []).map((p) => p.id),
-      completionSubscriberIds: (current.completion_subscribers ?? []).map((p) => p.id),
-      dueOn: current.due_on ?? "",
-      startsOn: current.starts_on ?? "",
+      content: writableString(current, "content", opts),
+      description: writableString(current, "description", opts),
+      assigneeIds: writableIdList(current, "assignees", opts),
+      completionSubscriberIds: writableIdList(current, "completion_subscribers", opts),
+      dueOn: writableString(current, "due_on", opts),
+      startsOn: writableString(current, "starts_on", opts),
       notify: false,
     };
   }

--- a/typescript/tests/services/cards.test.ts
+++ b/typescript/tests/services/cards.test.ts
@@ -189,4 +189,107 @@ describe("CardsService", () => {
       ).resolves.toBeUndefined();
     });
   });
+
+  // --- #576: a malformed GET due_on must never reach the replacement PUT ----
+  //
+  // `update` reads the card only to resend its due date, so that one value is
+  // the whole reason the composite exists -- and `if (current.due_on)` failed
+  // in both directions at once. A falsey non-string was DROPPED, and an
+  // omitted `due_on` is exactly how BC3 erases a card's due date
+  // (`{ due_on: nil }.merge(card_params)`), the behaviour this composite
+  // exists to prevent. A truthy non-string was forwarded VERBATIM and written
+  // to the card.
+  //
+  // TypeScript has no runtime decoder to catch either -- `schema.d.ts` is
+  // erased at build time, so `Card` is a compile-time claim nothing validates.
+  //
+  // The assertion that matters is the ORDERING: `requests` must be ["GET"].
+  describe("malformed due_on (#576)", () => {
+    const malformed: [string, unknown][] = [
+      ["false", false],
+      ["zero", 0],
+      ["empty array", []],
+      ["empty object", {}],
+      ["number", 42],
+      ["true", true],
+      ["array", ["x"]],
+      ["object", { a: 1 }],
+    ];
+
+    const serve = (body: unknown, requests: string[]) => {
+      server.use(
+        http.get(`${BASE_URL}/card_tables/cards/42`, () => {
+          requests.push("GET");
+          return HttpResponse.json(body);
+        }),
+        http.put(`${BASE_URL}/card_tables/cards/42`, () => {
+          requests.push("PUT");
+          return HttpResponse.json(sampleCard(42));
+        })
+      );
+    };
+
+    const rejection = async (promise: Promise<unknown>): Promise<unknown> =>
+      promise.then(
+        () => {
+          throw new Error("expected the call to reject, but it resolved");
+        },
+        (error: unknown) => error
+      );
+
+    it.each(malformed)("update refuses a %s due_on before writing", async (_label, value) => {
+      const requests: string[] = [];
+      serve({ ...sampleCard(42), due_on: value }, requests);
+
+      const error = await rejection(client.cards.update(42, { title: "Renamed" }));
+
+      expect(error).toBeInstanceOf(BasecampError);
+      // api_error, not usage: the value arrived in a successful response.
+      expect((error as BasecampError).code).toBe("api_error");
+      expect((error as BasecampError).message).toMatch(/Card field "due_on" is not a string/);
+      expect(requests).toEqual(["GET"]);
+    });
+
+    // The other half of the rule: a card with no due date is not malformed.
+    it.each([
+      ["absent", undefined],
+      ["null", null],
+    ])("treats a %s due_on as genuinely empty", async (_label, value) => {
+      let putBody: Record<string, unknown> = {};
+      const body: Record<string, unknown> = { ...sampleCard(42), due_on: value };
+      if (value === undefined) delete body.due_on;
+      server.use(
+        http.get(`${BASE_URL}/card_tables/cards/42`, () => HttpResponse.json(body)),
+        http.put(`${BASE_URL}/card_tables/cards/42`, async ({ request }) => {
+          putBody = (await request.json()) as Record<string, unknown>;
+          return HttpResponse.json(sampleCard(42));
+        })
+      );
+
+      await client.cards.update(42, { title: "Renamed" });
+
+      expect(putBody).not.toHaveProperty("due_on");
+    });
+
+    // One level up from the field guard: a successful GET can return a scalar,
+    // an array or null, and reading `current.due_on` off null throws a raw
+    // TypeError instead of the documented statusless api_error.
+    it.each([
+      ["array", []],
+      ["string", "card"],
+      ["number", 42],
+      ["null", null],
+      ["boolean", true],
+    ])("update refuses a %s response body before writing", async (_label, body) => {
+      const requests: string[] = [];
+      serve(body, requests);
+
+      const error = await rejection(client.cards.update(42, { title: "Renamed" }));
+
+      expect(error).toBeInstanceOf(BasecampError);
+      expect((error as BasecampError).code).toBe("api_error");
+      expect((error as BasecampError).message).toMatch(/GetCard returned/);
+      expect(requests).toEqual(["GET"]);
+    });
+  });
 });

--- a/typescript/tests/services/todos.test.ts
+++ b/typescript/tests/services/todos.test.ts
@@ -517,4 +517,194 @@ describe("TodosService", () => {
       ).resolves.toBeUndefined();
     });
   });
+
+  // --- #576: a malformed GET field must never reach the full-replace PUT ----
+  //
+  // `update`/`edit` GET the todo, read each writable field, and PUT the FULL
+  // representation back, so every value read is written -- including one the
+  // caller never mentioned. `?? ""` coalesces only null and undefined, so it
+  // ruled out *erasure* while leaving *corruption* wide open: all eight
+  // malformed shapes rode through VERBATIM into the PUT, a broader surface
+  // than Python's, which at least collapsed the falsey four to "".
+  //
+  // TypeScript has no runtime decoder to catch this -- `schema.d.ts` is erased
+  // at build time, so `Todo` is a compile-time claim nothing validates. That
+  // places this composite with Python and Ruby, not with Go and Swift.
+  //
+  // The assertion that matters is the ORDERING: `requests` must be ["GET"]. A
+  // guard that fires after the PUT has already lost the field.
+  describe("malformed writable fields (#576)", () => {
+    const fullTodo = (id = 42, overrides: Record<string, unknown> = {}) => ({
+      ...sampleTodo(id),
+      starts_on: "2024-02-01",
+      completion_subscribers: [{ id: 555, name: "Sub Scriber" }],
+      ...overrides,
+    });
+
+    const malformed: [string, unknown][] = [
+      ["false", false],
+      ["zero", 0],
+      ["empty array", []],
+      ["empty object", {}],
+      ["number", 42],
+      ["true", true],
+      ["array", ["x"]],
+      ["object", { a: 1 }],
+    ];
+
+    const writableStrings = ["content", "description", "due_on", "starts_on"] as const;
+    const idLists = ["assignees", "completion_subscribers"] as const;
+
+    // Serve a GET carrying `body` and a PUT that records that it happened.
+    const serve = (body: unknown, requests: string[]) => {
+      server.use(
+        http.get(`${BASE_URL}/todos/42`, () => {
+          requests.push("GET");
+          return HttpResponse.json(body);
+        }),
+        http.put(`${BASE_URL}/todos/42`, () => {
+          requests.push("PUT");
+          return HttpResponse.json(fullTodo());
+        })
+      );
+    };
+
+    const rejection = async (promise: Promise<unknown>): Promise<unknown> =>
+      promise.then(
+        () => {
+          throw new Error("expected the call to reject, but it resolved");
+        },
+        (error: unknown) => error
+      );
+
+    // Asserting only the message is vacuous about the taxonomy: a wrong `code`
+    // satisfies it. The value arrived in a successful API response, so this is
+    // `api_error` -- the caller passed nothing wrong.
+    const expectResponseError = (error: unknown, pattern: RegExp, requests: string[]) => {
+      expect(error).toBeInstanceOf(BasecampError);
+      expect((error as BasecampError).code).toBe("api_error");
+      expect((error as BasecampError).message).toMatch(pattern);
+      expect(requests).toEqual(["GET"]);
+    };
+
+    for (const field of writableStrings) {
+      it.each(malformed)(`update refuses a %s ${field} before writing`, async (_label, value) => {
+        const requests: string[] = [];
+        serve(fullTodo(42, { [field]: value }), requests);
+
+        const error = await rejection(client.todos.update(42, { content: "New title" }));
+        expectResponseError(error, new RegExp(`Todo field "${field}" is not a string`), requests);
+      });
+
+      it(`edit refuses a malformed ${field} before writing`, async () => {
+        const requests: string[] = [];
+        serve(fullTodo(42, { [field]: 42 }), requests);
+
+        const error = await rejection(
+          client.todos.edit(42, (t) => {
+            t.content = "New title";
+          })
+        );
+        expectResponseError(error, new RegExp(`Todo field "${field}" is not a string`), requests);
+      });
+
+      // The other half of the rule: absent and null are not malformed, they
+      // are empty. The call overlays an ID list rather than a string so that
+      // no writable string under test is overwritten by the caller.
+      it.each([
+        ["absent", undefined],
+        ["null", null],
+      ])(`treats a %s ${field} as genuinely empty`, async (_label, value) => {
+        let putBody: Record<string, unknown> = {};
+        const body = fullTodo(42, { [field]: value });
+        if (value === undefined) delete (body as Record<string, unknown>)[field];
+        server.use(
+          http.get(`${BASE_URL}/todos/42`, () => HttpResponse.json(body)),
+          http.put(`${BASE_URL}/todos/42`, async ({ request }) => {
+            putBody = (await request.json()) as Record<string, unknown>;
+            return HttpResponse.json(fullTodo());
+          })
+        );
+
+        if (field === "content") {
+          // Pre-existing, unchanged by these guards: the generated `replace`
+          // presence-validates content, so an empty one is refused client-side
+          // as a caller `validation` error before any PUT. Recorded here so the
+          // divergence from Python and Ruby (which send `content: ""`) is
+          // visible rather than folded into a skipped case.
+          const error = await rejection(client.todos.update(42, { assigneeIds: [100] }));
+          expect((error as BasecampError).code).toBe("validation");
+          return;
+        }
+
+        await client.todos.update(42, { assigneeIds: [100] });
+
+        if (field === "due_on" || field === "starts_on") {
+          // Dates ride only when non-empty: "" is a format error and an
+          // omitted date is how the server clears one.
+          expect(putBody).not.toHaveProperty(field);
+        } else {
+          expect(putBody[field]).toBe("");
+        }
+      });
+    }
+
+    for (const field of idLists) {
+      it.each(malformed.filter(([, v]) => !Array.isArray(v)))(
+        `update refuses a %s ${field} before writing`,
+        async (_label, value) => {
+          const requests: string[] = [];
+          serve(fullTodo(42, { [field]: value }), requests);
+
+          const error = await rejection(client.todos.update(42, { content: "New title" }));
+          expectResponseError(error, new RegExp(`Todo field "${field}" is not an array`), requests);
+        }
+      );
+
+      it(`update refuses a non-object ${field} element before writing`, async () => {
+        const requests: string[] = [];
+        serve(fullTodo(42, { [field]: ["nope"] }), requests);
+
+        const error = await rejection(client.todos.update(42, { content: "New title" }));
+        expectResponseError(
+          error,
+          new RegExp(`Todo field "${field}"\\[0\\] is not an object`),
+          requests
+        );
+      });
+
+      // The ID lists are resent in full, so a string, float, boolean or null
+      // id would be written as the complete assignee set.
+      it.each([
+        ["string", "100"],
+        ["float", 10.5],
+        ["NaN", Number.NaN],
+        ["null", null],
+        ["boolean", true],
+      ])(`update refuses a %s ${field} id before writing`, async (_label, badId) => {
+        const requests: string[] = [];
+        serve(fullTodo(42, { [field]: [{ id: badId, name: "Jane" }] }), requests);
+
+        const error = await rejection(client.todos.update(42, { content: "New title" }));
+        expectResponseError(error, new RegExp(`Todo field "${field}"\\[0\\]`), requests);
+      });
+    }
+
+    // One level up from the field guards: a successful GET can return a
+    // scalar, an array or null, and reading a property off null throws a raw
+    // TypeError instead of the documented statusless api_error.
+    it.each([
+      ["array", []],
+      ["string", "todo"],
+      ["number", 42],
+      ["null", null],
+      ["boolean", true],
+    ])("update refuses a %s response body before writing", async (_label, body) => {
+      const requests: string[] = [];
+      serve(body, requests);
+
+      const error = await rejection(client.todos.update(42, { content: "New title" }));
+      expectResponseError(error, /GetTodo returned/, requests);
+    });
+  });
 });


### PR DESCRIPTION
Closes #576.

The shipped Todos and Cards merge-safe composites in **Python, Ruby and TypeScript** GET a record, read each writable field, and PUT the **full** representation back. Every value read is therefore a value written — on a call that never mentioned the field — and none of the three validated what they read.

Two failure modes, the same defect wearing different clothes. **Erasure**: a falsey non-string coalesced away, wiping the field. **Corruption**: a non-string forwarded verbatim, writing a number, boolean, array or object where a string belongs. Testing only for the first is what produced #576's original wrong verdict on TypeScript.

## Red proof — what `main` actually puts on the wire

Probed against the unfixed composites, one call each: `update(content: "New title")` and `update(title: "Renamed")`. Nothing in these calls mentions the corrupted field.

**Python Todos** (`update(content=…)` with a malformed GET `description`)
```
  GET description=False        -> PUT description=''
  GET description=0            -> PUT description=''
  GET description=[]           -> PUT description=''
  GET description={}           -> PUT description=''
  GET description=42           -> PUT description=42
  GET description=True         -> PUT description=True
  GET description=['x']        -> PUT description=['x']
  GET description={'a': 1}     -> PUT description={'a': 1}
```
**Python Todos** — the ID lists, resent in full as the complete assignee set:
```
  GET assignees[0].id='100'    -> PUT assignee_ids=['100']
  GET assignees[0].id=10.5     -> PUT assignee_ids=[10.5]
  GET assignees[0].id=True     -> PUT assignee_ids=[True]
  GET assignees[0].id=None     -> PUT assignee_ids=[None]
```
**Python Cards** (`update(title=…)` with a malformed GET `due_on`)
```
  GET due_on=False        -> PUT due_on='<omitted -> BC3 ERASES the due date>'
  GET due_on=0            -> PUT due_on='<omitted -> BC3 ERASES the due date>'
  GET due_on=[]           -> PUT due_on='<omitted -> BC3 ERASES the due date>'
  GET due_on={}           -> PUT due_on='<omitted -> BC3 ERASES the due date>'
  GET due_on=42           -> PUT due_on=42
  GET due_on=True         -> PUT due_on=True
  GET due_on=['x']        -> PUT due_on=['x']
  GET due_on={'a': 1}     -> PUT due_on={'a': 1}
```
**Ruby Todos / Ruby Cards**
```
  GET description=false        -> PUT description=""
  GET description=0            -> PUT description=0
  GET description=[]           -> PUT description=[]
  GET description={}           -> PUT description={}
  GET description=42           -> PUT description=42
  GET description=true         -> PUT description=true
  GET description=["x"]        -> PUT description=["x"]
  GET description={"a" => 1}   -> PUT description={"a" => 1}

  GET due_on=false        -> PUT due_on=false
  GET due_on=0            -> PUT due_on=0
  GET due_on=[]           -> PUT due_on=[]
  GET due_on={}           -> PUT due_on={}
  GET due_on=42           -> PUT due_on=42
  GET due_on=true         -> PUT due_on=true
  GET due_on=["x"]        -> PUT due_on=["x"]
  GET due_on={"a" => 1}   -> PUT due_on={"a" => 1}
```
**TypeScript Todos / TypeScript Cards**
```
  GET description=false     -> PUT description=false
  GET description=0         -> PUT description=0
  GET description=[]        -> PUT description=[]
  GET description={}        -> PUT description={}
  GET description=42        -> PUT description=42
  GET description=true      -> PUT description=true
  GET description=["x"]     -> PUT description=["x"]
  GET description={"a":1}   -> PUT description={"a":1}

  GET due_on=false     -> PUT sent with due_on OMITTED -> BC3 ERASES the due date
  GET due_on=0         -> PUT sent with due_on OMITTED -> BC3 ERASES the due date
  GET due_on=[]        -> BasecampError: Due on must be in YYYY-MM-DD format
  GET due_on={}        -> BasecampError: Due on must be in YYYY-MM-DD format
  GET due_on=42        -> BasecampError: Due on must be in YYYY-MM-DD format
  ...
```
One **correction to the issue's TypeScript Cards table**: the truthy shapes do not reach the wire on `main` — the generated `updateVerbatim`'s YYYY-MM-DD check intercepts them first (misclassified as a caller `validation` error, but no PUT). The *falsey* shapes are the ones that do real damage, and they are the worst case in the issue: `if (current.due_on)` drops them, and an omitted `due_on` is precisely how BC3 erases a card's due date.

### Red proof — the tests

Every new test was run against the unfixed composites (`git show HEAD:<path>` swap, no stash) before the fix landed:

| suite | failures against unfixed code | after |
|---|---|---|
| `python/tests/services/{test_todos,test_cards}.py` | **85 failed**, 41 passed, 4 skipped | 126 passed, 4 skipped |
| `ruby` full suite (`make rb-test`) | 1171 runs, 2643 assertions, **81 failures** — **exit 2** | 1171 runs, 0 failures |
| `typescript/tests/services/{todos,cards}.test.ts` | **78 failed**, 43 passed | 121 passed |
| conformance kill cases (python / ruby / typescript) | **5 / 5 / 3 failed** | all pass |

Exit codes are the ones those exact commands produce: a failing `make <target>` exits **2** (make's own code for a failed recipe) while the bare runner underneath exits 1 — `make: *** [rb-test] Error 1` on the line above `REAL_EXIT=2`. An earlier revision of this write-up reported 1 for the Ruby row; the counts were right, the number was not.

Representative messages, all from the unfixed code:
```
Failed: DID NOT RAISE <class 'basecamp.errors.ApiError'>            (x69, Python)
TodosServiceTest#test_update_refuses_a_non_object_response_body_42:
  [Basecamp::ApiError] exception expected, not
  Class: <TypeError>  Message: <"no implicit conversion of String into Integer">
TodosServiceTest#test_update_refuses_a_non_array_completion_subscribers_0:
  Class: <NoMethodError>  Message: <"undefined method 'map' for an instance of Integer">
AssertionError: expected TypeError: Cannot read properties of null… to be an instance of BasecampError
FAIL: update-kill: an array description is refused before the full-replace PUT
      Expected the call to fail, but it succeeded; Expected 1 requests, got 2
```

## The fix

Absent or explicit null is genuinely empty; an actual string passes verbatim; anything else raises **before** the PUT, naming the field. The ID-list fields get the analogous check — an array, of objects, each carrying an integer `id`. One level up, the response body itself must be an object: on `main` a scalar or null body produced a raw `TypeError`/`AttributeError` rather than the documented statusless `api_error`.

Classification is `api_error`, not `usage`: the value arrived in a successful API response, so nothing the caller passed is at fault. Non-retryable — re-requesting cannot repair a malformed body.

The rule underneath, from #576: **a composite is safe exactly when a decoder *rejects* a wrong-typed field at runtime — not when a type merely claims one.** Go (`json.Unmarshal`) and Swift (`Codable`) genuinely refuse. TypeScript's `schema.d.ts` is erased at build time and the generated Python and Ruby services return an untyped `dict`/`Hash`, so those three do it by hand — once per language in a shared helper (`_merge_safe.py`, `merge_safe.rb`, `merge-safe.ts`) rather than six copies.

**Those three helper files are no longer part of this diff.** #601 (the Documents triad) landed byte-identical copies of all three while this PR was in review, so rebasing onto `main` collapsed them to a zero diff — confirmed by matching SHA-256 on each before the rebase, and by their absence from `git diff --name-only origin/main...HEAD` after it. They are `main`'s files now, unchanged. What remains here is the Todos and Cards consumers plus the conformance work.

Todolists keeps its own copy from #574. It is deliberately untouched here: #544 owns those files, and #578's generated validating layer is the intended end state for all of them.

## Shared kill fixtures, and the fourth language they found

Per #576, kill coverage belongs in the **shared conformance fixtures, not per language** — the defect survived five consecutive review passes precisely because each pass fixed one instance. Five cases across `todos_write.json` and `cards_write.json` assert `errorRaised` + `requestCount: 1`: the guard must fire *before* the PUT, because a guard that fires after has already lost the field. A second mock response is queued in each so a runner cannot pass by exhausting the queue instead of refusing the field.

`errorRaised` is a new assertion type, the code-agnostic inverse of `noError`. The six SDKs refuse the same body by two different mechanisms — a hand-written guard versus a model decoder — and those share no canonical error code, so `errorType` would make the fixture unwritable. Declaring it also tells the Kotlin and Swift runners that a decoder rejection is the *point* of the case rather than an under-specified fixture body (their #555 policy otherwise fails it).

**Writing the fixture immediately earned its keep: it found a fourth affected language.** #576 lists Kotlin Todos and Cards as structurally safe on the grounds that "kotlinx.serialization rejects a wrong-typed field at decode". That is only true for structural mismatches. Kotlin's client-wide `Json { isLenient = true; coerceInputValues = true }` (`BasecampClient.kt:156`) **coerces a JSON scalar into a `String` field**, so the composite decodes it and writes it back. Proven on the wire by temporarily flipping the kill fixtures to `requestCount: 2` with a `requestBody` pin, all four PASSING:

```
PASS: update-kill … (assertions: requestCount 2, requestBody description == "42")
PASS: update-kill … (assertions: requestCount 2, requestBody description == "false")
PASS: update-kill … (assertions: requestCount 2, requestBody due_on == "false")
PASS: update-kill … (assertions: requestCount 2, requestBody due_on == "42")
```
i.e. `GET "description": 42` → `PUT "description": "42"`, and `GET "due_on": false` → `PUT "due_on": "false"`.

This **cannot** be fixed by this PR's pattern: the coercion happens at decode, so by the time the composite runs it only ever sees a `String`. The shipped fixtures therefore use array/object shapes, which kotlinx.serialization *does* reject, and the scalar hole is filed separately as a follow-up. The fixture descriptions say so, in the fixtures, so the limit of what they prove travels with them.

### The fifth case, and the TypeScript Cards hole it closes

The first two Cards kill cases (`["x"]`, `{}`) do **not** discriminate in TypeScript. The generated `updateVerbatim` guards the date with ``/^\d{4}-\d{2}-\d{2}$/.test(req.dueOn)``, and `RegExp.test` coerces its argument to a string first: `String(["x"])` is `"x"` and `String({})` is `"[object Object]"`, so both are rejected before the PUT **with or without this PR's guard**. Measured, not reasoned — against the unfixed composites TypeScript conformance failed **2** cases, not 4, and both were Todos. TypeScript Cards had no regression protection from the shared fixture at all.

A fifth case fixes that. `["2024-02-01"]` is the shape the format check is blind to: `String(["2024-02-01"])` is exactly `"2024-02-01"`, so the regex matches and the array rides through untouched. With the case temporarily flipped to `requestCount: 2` + `requestMethod PUT` + a `requestBody` pin — the same probe used for Kotlin above — against the unfixed TypeScript composite:

```
 ✓ runner.test.ts > conformance/cards_write.json > update-kill: a date-shaped array due_on is refused where the format check is blind 25ms
 Test Files  1 passed | 6 skipped (7)
      Tests  1 passed | 182 skipped (183)
REAL_EXIT=0
```

That is `main` issuing a real second request whose body carries `"due_on": ["2024-02-01"]` — a JSON array written onto a field the API stores as a date, on a call that only renamed the card.

Restored to its shipped `errorRaised` + `requestCount: 1` form, it is red against the unfixed composites in all three hand-written-guard languages. TypeScript (`make conformance-typescript`, `REAL_EXIT=2`):

```
 FAIL  runner.test.ts > conformance/cards_write.json > update-kill: a date-shaped array due_on is refused where the format check is blind
AssertionError: [update-kill: a date-shaped array due_on is refused where the format check is blind] Expected the call to fail, but it succeeded: expected 'Expected the call to fail, but it suc…' to be undefined
```

Python and Ruby (`make conformance-python` / `make conformance-ruby`, both `REAL_EXIT=2`) print the same two lines, and name the PUT that the TypeScript runner stops short of reporting because `expect` throws on the first failing assertion:

```
  FAIL: update-kill: a date-shaped array due_on is refused where the format check is blind
        Expected the call to fail, but it succeeded; Expected 1 requests, got 2
```

So the shared fixture is now non-vacuous in every language it can be: TypeScript fails **3** cases against the unfixed composites rather than 2, Python and Ruby **5** rather than 4.

It also keeps the property that makes a *shared* fixture worth writing. Go, Kotlin and Swift decode `due_on` into a `String`, and `json.Unmarshal`, kotlinx.serialization and `Codable` reject a JSON array there structurally, exactly as they reject `["x"]`. The date-shaped element is invisible to a decoder — it is a string *inside* an array, and the array is the mismatch. A scalar still cannot be used, for the Kotlin coercion reason above.

### The `errorRaised` handler is unit-tested in all six runners

`errorRaised`'s failing branch is unreachable from `conformance/tests/`: every case declaring it is one the SDK does refuse, so a handler that accepted everything would report green in all six runners **at once**. That is precisely the #563 shape — a `delayBetweenRequests` check that passed vacuously because no fixture supplied a gap it could fail on.

So the predicate is split out per runner — `error_raised.go`, `error_raised_failure` in `runner.py`, `ErrorRaised.check` in `runner.rb`, `error-raised.ts`, `ErrorRaised.kt`, `ErrorRaised.swift` — and unit-tested on **both** directions, next to the existing `delayGaps` tests. Go additionally asserts the *wiring*, that `checkAssertion` routes the type to that branch: a typo'd case label would fall through to the default and assert nothing.

Non-vacuity proved by mutation rather than by inspection. Each handler was temporarily changed to return the pass value unconditionally, and every runner's unit test went red:

| runner | command | under mutation |
|---|---|---|
| Go | `go test ./...` | `--- FAIL: TestErrorRaisedFailure`, `--- FAIL: TestCheckAssertionRoutesErrorRaised` — **exit 1** |
| Python | `uv run python -m pytest -q test_error_raised.py` | `1 failed, 1 passed` — **exit 1** |
| Ruby | `bundle exec ruby error_raised_test.rb` | `2 runs, 2 assertions, 1 failures` — **exit 1** |
| Kotlin | `./gradlew --quiet :conformance:test` | `12 tests completed, 1 failed` — **exit 1** |
| Swift | `swift test` | `ErrorRaisedTests` failed — **exit 1** |
| TypeScript | `npx vitest run error-raised.test.ts` | `Tests  1 failed \| 1 passed (2)` — **exit 1** |

Verbatim, for the three that had previously only been checked by inspection:

```
--- FAIL: TestErrorRaisedFailure (0.00s)
    error_raised_test.go:23: expected "Expected the call to fail, but it succeeded" for a successful dispatch, got ""
--- FAIL: TestCheckAssertionRoutesErrorRaised (0.00s)
    error_raised_test.go:40: expected checkAssertion to fail when the dispatch succeeded, got a pass
```
```
FAILED: com.basecamp.sdk.conformance.ErrorRaisedTest.a successful dispatch fails the assertion()
   org.opentest4j.AssertionFailedError: expected: <Expected the call to fail, but it succeeded> but was: <null>
```
```
ErrorRaisedTests.swift:23: error: -[ConformanceSupportTests.ErrorRaisedTests testSuccessfulDispatchFailsTheAssertion] : XCTAssertEqual failed: ("Optional("Expected the call to fail, but it succeeded")") is not equal to ("nil")
```

The message is pinned verbatim in all six, so a fixture debugged in one language does not read differently in another. Go, Python, Ruby, Kotlin and Swift run under `make conformance-runner-tests` (and in CI, which this PR extends to cover the two new Ruby and Python files); the TypeScript case runs under `make conformance-typescript`, where `delay-gaps.test.ts` already lives.

## One behaviour change beyond pure containment

Ruby `Cards.update`, in the case where the server returns `due_on: ""`.

- **Before:** `get(card_id:)["due_on"]` handed `""` straight to `update_verbatim`, and `compact_params` is `kwargs.compact`, which strips only `nil` — so the PUT went out carrying `due_on: ""`.
- **After:** `writable_string` passes the `""` through (it *is* a String, so the guard does not fire), `current_due_on` then normalises `""` to `nil`, and `compact_params` strips it — so the PUT **omits** `due_on`.

An omitted `due_on` is exactly how BC3 clears the date (`{ due_on: nil }.merge(card_params)`), so this changes what goes on the wire, not merely what gets validated. It is called out here rather than left inside the containment story. Three reasons it is nonetheless the right change:

1. **It restores parity with Python**, which has always omitted in this case: `... or None` collapses `""` to `None` and the generated `_compact` strips it. Ruby was the outlier, before and after.
2. **`due_on: ""` is not a value BC3 accepts.** The composite's own comment on the sibling branch already says sending `""` "risks a date-format error", which is why an explicit caller-requested clear is encoded as an *omission*. The `nil` branch now agrees with the `""` branch instead of contradicting it.
3. **The record ends up in the same state.** The server told us the card has no due date; omitting `due_on` leaves it with no due date. The bytes change; the card does not.

The trigger is narrow — BC3 returns `null`, not `""`, for a card with no due date — so this is an edge-shaped-response path, which is the path this PR is about.

## Verification

Re-run in full after the rebase onto `main` at `dc5f17ee6` — #592, #601, #590, #605 and three dependency bumps all landed under this branch, so every number below is measured at the current head, not carried forward. Every conformance total is unchanged by the dependency bumps. Every command was run with `REAL_EXIT=$?` written into a log and grepped back; a failing `make <target>` exits **2**, the bare runner underneath exits 1.

| command | result |
|---|---|
| `make py-check` | 1046 passed, 4 skipped; mypy `no issues found in 38 source files`; ruff clean — **exit 0** |
| `make rb-check` | 1244 runs, 29713 assertions, 0 failures; rubocop 150 files, no offenses — **exit 0** |
| `make ts-check` | 79 files, 1282 tests passed; tsc clean — **exit 0** |
| `make kt-check` | `BUILD SUCCESSFUL` — **exit 0**. Locally this was a Gradle `allTests UP-TO-DATE` hit, so the load-bearing evidence is CI's **Kotlin Tests** job at this head, which builds cold. `make conformance-kotlin` did execute (155/0/1). |
| `make swift-check` | `Executed 333 tests, with 0 failures` (genuinely ran, not the macOS SKIP line) — **exit 0** |
| `make conformance-go` | 154 passed, 0 failed, 2 skipped — **exit 0** |
| `make conformance-python` | 156 passed, 0 failed, 0 skipped — **exit 0** |
| `make conformance-ruby` | 145 passed, 0 failed, 11 skipped — **exit 0** |
| `make conformance-typescript` | 189 passed, 2 skipped (7 files) — **exit 0** |
| `make conformance-kotlin` | 155 passed, 0 failed, 1 skipped — **exit 0** |
| `make conformance-swift` | 155 passed, 0 failed, 1 skipped — **exit 0** |
| `make conformance-runner-tests` | Go/Python/Ruby/Kotlin/Swift runner units, 0 failures; Swift's 41 XCTest cases include both `ErrorRaisedTests` — **exit 0** |
| `make conformance-fixtures-check` | metaschema ok; fixture validation ok; all 5 `errorRaised` fixtures have a body-pinning control sibling; gate self-test 25/25 — **exit 0** |

The conformance totals are higher than the previous revision because the rebase brought in #601's Documents fixtures, not because of anything here.

All five kill cases were confirmed to actually *run* in every runner — a fixture whose operation has no dispatch case silently *skips*, which would look identical to a pass in the totals. Verbatim `PASS:` lines in Go, Python, Ruby, Kotlin and Swift, and a `--reporter=verbose` re-run for TypeScript, which does not name passing cases by default:

```
 ✓ runner.test.ts > conformance/cards_write.json > update-kill: an array due_on is refused before the replacement PUT 18ms
 ✓ runner.test.ts > conformance/cards_write.json > update-kill: an empty-object due_on is refused, not coerced or dropped 3ms
 ✓ runner.test.ts > conformance/cards_write.json > update-kill: a date-shaped array due_on is refused where the format check is blind 2ms
 ✓ runner.test.ts > conformance/todos_write.json > update-kill: an array description is refused before the full-replace PUT 1ms
 ✓ runner.test.ts > conformance/todos_write.json > update-kill: an empty-object description is refused, not coalesced to empty 1ms
      Tests  5 passed | 178 skipped (183)
REAL_EXIT=0
```

The Go runner-unit result above is from a `-count=1` re-run, because `go test` had reported a cached `ok` after the mutation probe restored the file.

## Review follow-ups

**Codex P2, `Assertions.swift` — "mark an enforced HTTPS crash as a dispatch failure".** Real, and fixed. The `.enforced` branch recorded `caughtError` but never set `dispatchFailed`, so an `errorRaised` fixture with an `http://` `configOverrides.baseUrl` would have read a trapped child process as a call that *succeeded*. Fixed at both ends rather than one: `Runner.swift` now sets `dispatchFailed = true` in that branch (the child died as required, so the dispatch did fail — by a trap rather than a throw), and the assertion reads `dispatchFailed || caughtError != nil`, so the union holds by construction instead of by call-site discipline. Kotlin's `Main.kt` takes the same union for the same reason.

**Codex P2, `Runner.swift` — "require the intended decoding error".** Also real, also fixed, by a different route than proposed. Declaring `errorRaised` switches the #555 stop-on-mismatch policy **off wholesale** in the decoder-backed runners: Swift's `DecodingError` branch and Kotlin's `MissingFieldException`/`SerializationException` branches accept *any* decode failure. So if a model gains a required field, or an unrelated field in one of these 27-key bodies drifts, the decode fails for an unrelated reason while `errorRaised` + `requestCount: 1` + `requestMethod` + `requestPath` all still hold — the case passes and has stopped testing the field it names. Nothing else covered it: `conformance-fixtures-check` validates fixture *format*, not that mock bodies still decode into the generated models.

The proposed fix (pin the expected field per decode path) is structured and cheap in Swift, but in Kotlin it means matching `SerializationException`'s message prose for `at path: $.due_on` — the type-mismatch case has no structured field accessor — and a cross-language invariant encoded as a string match against one serializer's error text is a worse thing to own than the hole.

What the investigation turned up instead: the protection **already exists structurally** and only needed enforcing. Every kill body is a *passing* case's body with exactly one field perturbed, and that sibling does not declare `errorRaised`, so it keeps the full #555 policy and fails loudly on precisely that drift — Cards kill cases pair with `update-preserves-due-on` (differing only in `due_on`), Todos with `update-merge` (differing only in `description`). But nothing enforced the coupling: edit one body and not the other and it silently breaks, which is the real failure mode. So `conformance/check_kill_case_controls.py` now asserts the invariant — *for every case declaring `errorRaised`, some case in the same file that does not declare it must have a mock body with the identical key set, differing in exactly one field* — and that one differing field is the field under test. It runs inside `make conformance-fixtures-check`, which CI already invokes, so no new job. Enforcing the claim rather than asserting it in a comment is #576's own lesson applied to #576's fixtures.

Non-vacuous, not assumed. Perturbing a kill body in a **second** field fails it:

```
FAIL: errorRaised fixtures without a control sibling:

  - cards_write.json: 'update-kill: a date-shaped array due_on is refused where the format check is blind' declares errorRaised but no non-errorRaised case in this file has a mock body with the same key set differing in exactly one field.
      Without one, a decode failure caused by unrelated model drift would satisfy this case and it would stop testing the field it names.
      Add (or repair) the control case so the two bodies differ only in the field under test.
REAL_EXIT=1
```

A follow-up Codex P2 then found the gate had the same vacuity one level up: it matched a kill body against *any* queued response of *any* control. Each kill case queues two object-shaped responses — response 0 is the GET whose decoder rejection is under test, response 1 is a decoy queued so a runner cannot pass by exhausting the queue — and the decoy is never consumed. Reachable, not theoretical; the case that separates the two versions drifts the **consumed** body by a second field while making the **decoy** differ from its control by exactly one:

```
consumed[0]: 2 fields differ from control (due_on + title)
decoy[1]   : 1 field differs from control (due_on)
```
```
########## OLD gate (matches ANY queued response) ##########
  ok  'update-kill: a date-shaped array due_on is refused where the for'
REAL_EXIT=0

########## NEW gate (consumed response only) ##########
FAIL: errorRaised fixtures without a control sibling:
  - cards_write.json: 'update-kill: a date-shaped array due_on is refused where the format check is blind' declares errorRaised but no non-errorRaised case for operation 'UpdateCard' in this file has a FIRST mock response body with the same key set differing in exactly one field.
REAL_EXIT=1
```

The gate is now restricted on both sides — the **first response only**, and a control exercising the **same operation** — and on the shipped fixtures it names each pairing, at `REAL_EXIT=0`:

```
  ok  'update-kill: a date-shaped array due_on is refused where the for'
      field 'due_on' controlled by 'update-preserves-due-on: composite refetches and resends'
  ok  'update-kill: an array description is refused before the full-rep'
      field 'description' controlled by 'update-merge: content-only update preserves every unset '

All errorRaised fixtures have a body-pinning control sibling.
```

**Codex P2, `conformance/schema.json` — "move `$comment` out of the properties map".** Correct, and the interesting half is why it shipped. The `errorRaised` annotation sat inside `properties.assertions.items.properties`, declaring a property literally named `$comment` whose schema was a **string**; Draft 2020-12 requires every value under `properties` to be a schema object or boolean, so `schema.json` was not itself a valid schema — and `tests.schema.json` `$ref`s it, so a validator that meta-validates would reject the conformance schema before reading a single fixture.

The gap underneath is that `conformance-fixtures-check` validated fixtures *against* the schema and never validated the schema *itself*, so an invalid schema sailed through a green gate. Same shape as everything else here, so it got the same treatment: the target now runs `--check-metaschema` over `schema.json` and `tests.schema.json` **first**. Red proof through the make target rather than the bare validator — putting the annotation back inside `properties` gives `REAL_EXIT=2` and `'...' is not of type 'object', 'boolean'`.

**`evaluateAssertions(dispatchFailed:)` lost its default.** It was `dispatchFailed: Bool = false`. There is exactly one call site and it does pass the argument, so nothing was broken — but a defaulted parameter on a *new* assertion path is an invitation, and this default fails **closed**: a future call site that omitted it would report "the call succeeded" on a call that did not, turning every `errorRaised` fixture red for a reason nowhere near the actual bug. The parameter is now required, so omitting it is a compile error.

**Codex P2, `check_kill_case_controls.py` — "reject 204 responses before accepting kill cases".** Correct, and it is this PR's own false-green shape one layer further down. Both sides of the gate accepted any 2xx, so a kill case answering **204** passed: TypeScript returns `undefined` for a 204 (`base.ts`), Kotlin returns `Unit` without calling `parse` (`BaseService.kt`), Go rewrites the body to JSON `null` (`client.go`). The malformed field is never decoded; the composite fails because the record came back *absent*; and `errorRaised` + `requestCount: 1` + `requestMethod` + `requestPath` are all satisfied by that unrelated failure while the control, still a 200, stays green. Strictly worse than the 500 case above it — a 500 at least *fails* the call, so `errorRaised` is satisfied by something about the response.

Reachable, not merely structural. The shipped Todos kill case and its shipped control, with **only** the kill's first response changed 200 -> 204, against the gate at `c348acf7b`:

```
  ok  'update-kill (204): the malformed description never reaches a dec'
      field 'description' controlled by 'update-merge: content-only update preserves every unset '

All errorRaised fixtures have a body-pinning control sibling.
REAL_EXIT=0
```

Fixed as an **allowlist**, `{200, 201}`, rather than a 204 exclusion — the review offered both, and excluding 204 by name only closes the status somebody happened to think of. Two constraints meet there: Go's success arm is exactly `{200, 201, 204}` (`case http.StatusOK, http.StatusCreated, http.StatusNoContent`), so 202, 203, 205 and 206 are never decoded there at all; and 204/205 forbid a body outright. A 202 is now rejected too, with a message that names why. `not_a_success` becomes `not_decoded`, because a 204 does not fail the call — it bypasses the decode, and the old name asserted the wrong property.

### The gate itself is now self-tested

This was the fifth defect found in a gate every one of whose rejections was correct **by inspection alone** — the standard that let #576 through five review passes. So it gets #576's own treatment. `conformance/test_check_kill_case_controls.py` crafts 25 inputs — 21 claimed rejections (both sides' 204 / 205 / undecoded-2xx / HTTP-error / `networkError`, the same-operation, key-set and exactly-one-field rules, the first-response-only restriction on *both* sides, and the entry point's own failure modes) plus 4 positive controls, the real fixture set among them — and drives each through the real entry point, via a new optional `FIXTURE_DIR` argument added for exactly that purpose.

Non-vacuous by measurement rather than by claim. Reverting **only** the two new status branches, leaving the renames, the argument and every other rejection intact, turns exactly four cases red and nothing else:

```
check_kill_case_controls self-test: 4 case(s) failed.

kill case answers 204: expected FAILURE, gate exited 0:
  ok  'update-kill: an array description is refused before the full-rep'
      field 'description' controlled by 'update-merge: content-only update preserves every unset '

All errorRaised fixtures have a body-pinning control sibling.
[...three further cases: 205, an undecoded 2xx, and the control-side 204...]
```

It runs inside `make conformance-fixtures-check`, which CI already invokes, so no new job.

## The doc-constants gate the rebase brought into range

#590 landed `make doc-constants-check` on `main` after this branch was cut, and it holds SPEC.md §19's marked table against the `conformance/schema.json` assertion enum: *"defines 22 assertion types, the table documents 21; missing: `errorRaised`"*. This branch is what added the 22nd, so §19 now carries a row for it — what the type is for, and what declaring it costs (declaring it switches the stop-on-mismatch policy off for that case, which is why every fixture declaring it needs a control sibling).

That one row is the **entire** SPEC.md diff of this PR, and `spec/doc-constants.json` is untouched (byte-identical to `main`).

The same red run also flagged SPEC.md §Documents for restating the current pin, which was #601's line, not this branch's. An earlier revision of this branch carried a fix for it — at the time `main` was red on it and nothing was open against it. **#605 has since fixed it on `main`**, with a count-2 grant that keeps the prose as written, so that commit is dropped rather than rebased: it would have contradicted a merged decision inside an unrelated PR. If the by-reference rewrite AGENTS.md prefers is still worth making, it belongs in its own PR.


## Deliberately out of scope

- **The caller-side mirror.** `edit` hands the caller a mutable view and a closure assigning `42` walks into the same PUT. That is caller misuse of a value the caller chose, not a value silently substituted for one they asked to preserve, and #576 is scoped to the GET-field path.
- **Kotlin's lenient decoder.** Same defect class, different layer; the only fixes are strict client-wide decoding (large blast radius) or per-field serializers. Filed separately.
- **#578.** No guard here is written in anticipation of it, and none is deleted for it. When the generated validating layer lands, these guards go and **the shared kill fixtures stay** — they are what proves the replacement actually replaced something.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refuse malformed GET fields in merge‑safe `Todos` and `Cards` (Python, Ruby, TypeScript) and fail before any PUT; strengthen cross‑SDK checks with `errorRaised` fixtures, gates, and runner unit tests.

- **Bug Fixes**
  - Require the GET response body to be an object; raise `api_error` if not.
  - Writable strings (`content`, `description`, `due_on`, etc.): allow absent/null or a string; otherwise raise before PUT.
  - ID lists: require an array of objects with integer `id`; otherwise raise before PUT.
  - `Cards.update`: validate `due_on`; reject non‑strings and, in Ruby, omit `""` instead of sending it.

- **Refactors**
  - Implement `errorRaised` in Go, Python, Ruby, TypeScript, Kotlin, and Swift with unit tests; add CI hooks.
  - Add `conformance/check_kill_case_controls.py` gate: same operation, first response only, identical key set with exactly one differing field; require decoded 2xx on both kill/control; forbid 204/205 and `networkError`; add a self‑test suite.
  - Run metaschema checks first and move `$comment` out of assertion `properties`; validate fixtures after.
  - Add a TypeScript‑discriminating Cards kill case (`["2024‑02‑01"]`).
  - Kotlin/Swift runners: treat decoder rejections and HTTPS traps as dispatch failures; require explicit `dispatchFailed` (no default).
  - Document `errorRaised` in SPEC §19 and update Makefile/workflows to run the new checks.

<sup>Written for commit f3377f81bfb7b3e6dd7fdc2d47eb09563a8fc598. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


