### PR TITLE
Unbreak doc-constants-check: grant SPEC.md's two as-of pin citations

### DIFF
--- a/spec/doc-constants.json
+++ b/spec/doc-constants.json
@@ -53,6 +53,10 @@
     "spec/api-gaps/folders-api.md": {
       "count": 1,
       "reason": "names the d0edc1283b -> 2c0dafba13 repin as the event that first brought doc/api/sections/folders.md into range — an as-of fact about that repin, still true after the next one"
+    },
+    "SPEC.md": {
+      "count": 2,
+      "reason": "the documents merge-safe composite (§18, added by #601) binds its draft-subscribers safety to a fixed bc3 observation twice on one line: BC3 #12501 cited as the commit that shipped Recording::DraftSubscribers, and the resulting 'at or after 2c0dafba13' floor for this surface. Both are bound to that PR and stay true after the next repin. #601 and #590 (which added this gate) merged green independently and only conflicted composed on main"
     }
   }
 }


### PR DESCRIPTION
`make check` is red on `main` (`c441c235b`): a cross-PR semantic conflict between the last two merges.

- **#601** (`dee221c85`, merged first) added the documents merge-safe composite to SPEC.md. Its §18 prose cites BC3 #12501 (`2c0dafba13`) as the commit that shipped `Recording::DraftSubscribers`, and pins the surface to "a bc3 provenance at or after `2c0dafba13`" — one line, two backticked SHAs.
- **#590** (`c441c235b`, merged second) added `doc-constants-check`, which rejects unmarked prose naming the **current** pin — and the current pin happens to be `2c0dafba13`.

Each PR was green on its own branch; neither branch contained the other's change. Composed on `main`, the gate reads #601's citations as unmarked pin restatements:

```
ERROR: documentation constants have drifted from their sources.
  SPEC.md:415: `2c0dafba13` is the current provenance pin, restated outside a @bc3-pin span. …
make: *** [doc-constants-check] Error 1
```

**The fix is the one the gate's own error message prescribes.** Both citations are as-of facts bound to a fixed observation (BC3 #12501 / the floor it created), not claims about today's pin — they stay true when the pin advances, so marking them `<!-- @bc3-pin -->` would be wrong (the writer would rewrite a historical citation on the next repin). Record `SPEC.md` in `spec/doc-constants.json` `.unmarkedPinCitations` with count 2, matching the existing grants for `spec/api-gaps/README.md` (which already covers this same #12501 citation in its triage narrative) and `folders-api.md`.

Line 415 does not match the gate's class-A grammar floor ("the pin is X" / "at the pinned X"), so the grant is sufficient.

## Verification

- Red first (unpatched `main`): `make check` → `make: *** [doc-constants-check] Error 1` at SPEC.md:415, as quoted above.
- With this change: `make doc-constants-check` → clean (`REAL_EXIT=0`), and `ruby scripts/test-doc-constants.rb` → all cases passed.

Every open PR's `make check` inherits this breakage on rebase, so this wants to land ahead of the queue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false positives in `doc-constants-check` by granting SPEC.md two as‑of pin citations in `spec/doc-constants.json`. This prevents the gate from flagging historical references and restores a clean `make check` on `main`.

<sup>Written for commit f9bd834361afc02c1206e13e2abb21effecd3434. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

