### PR TITLE
Go: pointerize the five optional timestamps that could not represent absence

### DIFF
--- a/go/BRIEF-bc5-forward-compat-wrappers.md
+++ b/go/BRIEF-bc5-forward-compat-wrappers.md
@@ -144,17 +144,18 @@ type NotificationsResult struct {
 }
 ```
 
-For `Notification.BubbleUpAt`, use `*time.Time` rather than the bare
-`time.Time` pattern the wrapper uses for `ReadAt` / `UnreadAt`. The
-pointer is what shipped (see `my_notifications.go`): a bare `time.Time`
-with `omitempty` still marshals the zero time as
-`"0001-01-01T00:00:00Z"` (Go's `omitempty` does not suppress structs
-that are merely zero-valued), so the absence of a scheduled bubble-up
-would surface as a wrong wire value rather than an omitted key. The
-`*time.Time` convention mirrors `Card.CompletedAt` and `Todo.CompletedAt`,
-where the same omit-cleanly semantics matter. Consumers should
-`nil`-check or use the `time.Time` returned by dereferencing rather than
-calling `IsZero()`.
+For `Notification.BubbleUpAt`, use `*time.Time`. A bare `time.Time` with
+`omitempty` still marshals the zero time as `"0001-01-01T00:00:00Z"`
+(Go's `omitempty` does not suppress structs that are merely
+zero-valued), so the absence of a scheduled bubble-up would surface as a
+wrong wire value rather than an omitted key. The `*time.Time` convention
+matches `Card.CompletedAt` (`cards.go:101`) and `Todo.CompletedAt`
+(`todos.go:52`), where the same omit-cleanly semantics matter, and now
+also `Notification.ReadAt` / `UnreadAt` (`my_notifications.go:52-53`) —
+this brief previously cited those two as the bare-`time.Time`
+counter-example, which stopped being true when #562 pointerized them.
+Consumers should `nil`-check rather than calling `IsZero()`: on a
+pointer, `IsZero()` still compiles and panics on nil.
 
 ## Verification
 

--- a/go/pkg/basecamp/example_test.go
+++ b/go/pkg/basecamp/example_test.go
@@ -247,7 +247,14 @@ func ExampleSearchService_Search_sorted() {
 	}
 
 	for _, r := range results.Results {
-		fmt.Printf("%s: %s\n", r.CreatedAt.Format("2006-01-02"), r.Title)
+		// CreatedAt is optional (*time.Time) — nil means the API did not send
+		// it. Note that r.CreatedAt.Format(…) would compile here and panic on
+		// nil, so the check is load-bearing, not defensive style.
+		created := "unknown"
+		if r.CreatedAt != nil {
+			created = r.CreatedAt.Format("2006-01-02")
+		}
+		fmt.Printf("%s: %s\n", created, r.Title)
 	}
 }
 

--- a/go/pkg/basecamp/hill_charts.go
+++ b/go/pkg/basecamp/hill_charts.go
@@ -17,7 +17,7 @@ type HillChart struct {
 	// from a real value: a value-typed time.Time would read as
 	// 0001-01-01T00:00:00Z, and `,omitempty` cannot hide that because
 	// encoding/json never treats a struct as empty. Mirrors the *time.Time
-	// convention used for Card.CompletedAt and TimelineEvent.UpdatedAt.
+	// convention used for Card.CompletedAt and EverythingFile.UpdatedAt.
 	UpdatedAt      *time.Time     `json:"updated_at,omitempty"`
 	AppUpdateURL   string         `json:"app_update_url,omitempty"`
 	AppVersionsURL string         `json:"app_versions_url,omitempty"`

--- a/go/pkg/basecamp/hill_charts.go
+++ b/go/pkg/basecamp/hill_charts.go
@@ -10,9 +10,15 @@ import (
 
 // HillChart represents a hill chart for a todoset.
 type HillChart struct {
-	Enabled        bool           `json:"enabled"`
-	Stale          bool           `json:"stale"`
-	UpdatedAt      time.Time      `json:"updated_at,omitempty"`
+	Enabled bool `json:"enabled"`
+	Stale   bool `json:"stale"`
+	// UpdatedAt is when the chart last moved. Optional — a chart that has
+	// never been updated omits it. A pointer so absence stays distinguishable
+	// from a real value: a value-typed time.Time would read as
+	// 0001-01-01T00:00:00Z, and `,omitempty` cannot hide that because
+	// encoding/json never treats a struct as empty. Mirrors the *time.Time
+	// convention used for Card.CompletedAt and TimelineEvent.UpdatedAt.
+	UpdatedAt      *time.Time     `json:"updated_at,omitempty"`
 	AppUpdateURL   string         `json:"app_update_url,omitempty"`
 	AppVersionsURL string         `json:"app_versions_url,omitempty"`
 	Dots           []HillChartDot `json:"dots,omitempty"`
@@ -118,7 +124,7 @@ func hillChartFromGenerated(ghc generated.HillChart) HillChart {
 	hc := HillChart{
 		Enabled:        ghc.Enabled,
 		Stale:          ghc.Stale,
-		UpdatedAt:      deref(ghc.UpdatedAt),
+		UpdatedAt:      ghc.UpdatedAt,
 		AppUpdateURL:   deref(ghc.AppUpdateUrl),
 		AppVersionsURL: deref(ghc.AppVersionsUrl),
 	}

--- a/go/pkg/basecamp/hill_charts_test.go
+++ b/go/pkg/basecamp/hill_charts_test.go
@@ -74,6 +74,13 @@ func TestHillChart_TimestampParsing(t *testing.T) {
 		t.Fatalf("failed to unmarshal get.json: %v", err)
 	}
 
+	// UpdatedAt is optional (*time.Time): nil-check before dereferencing.
+	// `hc.UpdatedAt.IsZero()` still compiles against the pointer and would
+	// panic here if the fixture ever dropped the key — see
+	// TestNilOptionalTimestampPanicsOnValueReceiverCall.
+	if hc.UpdatedAt == nil {
+		t.Fatal("expected UpdatedAt to be present in get.json")
+	}
 	if hc.UpdatedAt.IsZero() {
 		t.Error("expected non-zero UpdatedAt")
 	}

--- a/go/pkg/basecamp/my_notifications.go
+++ b/go/pkg/basecamp/my_notifications.go
@@ -43,8 +43,14 @@ type Notification struct {
 	PreviewableAttachments []PreviewableAttachment `json:"previewable_attachments,omitempty"`
 	CreatedAt              time.Time               `json:"created_at"`
 	UpdatedAt              time.Time               `json:"updated_at"`
-	ReadAt                 time.Time               `json:"read_at,omitempty"`
-	UnreadAt               time.Time               `json:"unread_at,omitempty"`
+	// ReadAt and UnreadAt are the read/unread transition times. Both are
+	// optional and mutually exclusive in practice: an unread notification has
+	// neither or only UnreadAt, a read one carries ReadAt. Pointers so "never
+	// read" stays distinguishable from a real timestamp — a value-typed
+	// time.Time would report 0001-01-01T00:00:00Z, and `,omitempty` cannot
+	// suppress it because encoding/json never treats a struct as empty.
+	ReadAt   *time.Time `json:"read_at,omitempty"`
+	UnreadAt *time.Time `json:"unread_at,omitempty"`
 }
 
 // PreviewableAttachment represents a preview-renderable attachment surfaced on

--- a/go/pkg/basecamp/optional_timestamps_test.go
+++ b/go/pkg/basecamp/optional_timestamps_test.go
@@ -1,0 +1,324 @@
+package basecamp
+
+import (
+	"encoding/json"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/basecamp/basecamp-sdk/go/pkg/generated"
+)
+
+// Optional timestamps on the hand-written wrapper surface must be *time.Time.
+//
+// A value-typed time.Time cannot represent absence, and — unlike the string,
+// bool and numeric optionals that make up the rest of this surface — it cannot
+// even hide that fact behind `omitempty`. encoding/json's "empty" set is
+// false / 0 / nil pointer / nil interface / empty array, slice, map, string.
+// A struct is never empty, and time.Time is a struct, so `,omitempty` on a
+// value-typed time.Time is INERT: the key is emitted on every re-marshal,
+// carrying 0001-01-01T00:00:00Z as if the server had sent it.
+//
+// That is the whole distinction. `Title string \`json:"title,omitempty"\`` is
+// lossy in a benign way (absent and "" collapse, and both are then omitted, so
+// the value round-trips). `UpdatedAt time.Time \`json:"updated_at,omitempty"\``
+// is lossy in a way that fabricates data on the wire.
+
+// timestampCarrier is one (wrapper type, wire JSON) pair whose optional
+// timestamp keys must survive a decode/re-encode round trip: absent in, absent
+// out; present in, byte-identical out.
+type timestampCarrier struct {
+	name string
+	// decode unmarshals wire into a fresh value of the wrapper type and
+	// returns it for re-marshaling. Written as a closure so this table can
+	// hold heterogeneous wrapper types without reflection.
+	decode func(t *testing.T, wire []byte) any
+	// keys are the optional timestamp JSON keys under test.
+	keys []string
+	// present is a wire body carrying every key in keys.
+	present []byte
+}
+
+func unmarshalInto[T any](t *testing.T, wire []byte) any {
+	t.Helper()
+	var v T
+	if err := json.Unmarshal(wire, &v); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return v
+}
+
+func timestampCarriers() []timestampCarrier {
+	return []timestampCarrier{
+		{
+			name:    "HillChart",
+			decode:  unmarshalInto[HillChart],
+			keys:    []string{"updated_at"},
+			present: []byte(`{"enabled":true,"stale":false,"updated_at":"2026-07-31T12:34:56Z"}`),
+		},
+		{
+			name:   "Notification",
+			decode: unmarshalInto[Notification],
+			keys:   []string{"read_at", "unread_at"},
+			present: []byte(`{"id":1,"created_at":"2026-07-31T12:34:56Z","updated_at":"2026-07-31T12:34:56Z",` +
+				`"read_at":"2026-07-31T12:34:56Z","unread_at":"2026-07-30T01:02:03Z"}`),
+		},
+		{
+			name:   "SearchResult",
+			decode: unmarshalInto[SearchResult],
+			keys:   []string{"created_at", "updated_at"},
+			present: []byte(`{"id":1,"created_at":"2026-07-31T12:34:56Z","updated_at":"2026-07-30T01:02:03Z",` +
+				`"content":null,"description":null}`),
+		},
+	}
+}
+
+// marshalToKeys re-marshals v and returns its top-level object as a key map.
+// Keys are compared by exact map lookup rather than substring search: read_at
+// is a substring of unread_at, and a bytes.Contains check would silently pass
+// whenever either key survived.
+func marshalToKeys(t *testing.T, v any) map[string]json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out map[string]json.RawMessage
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("re-unmarshal %s: %v", b, err)
+	}
+	return out
+}
+
+// TestOptionalTimestampsOmitWhenAbsent is the red proof for #562: an absent
+// optional timestamp must not reappear on re-marshal.
+//
+// Against the un-fixed tree every case fails, reporting the fabricated
+// 0001-01-01T00:00:00Z that the value-typed field emitted.
+func TestOptionalTimestampsOmitWhenAbsent(t *testing.T) {
+	for _, c := range timestampCarriers() {
+		t.Run(c.name, func(t *testing.T) {
+			got := marshalToKeys(t, c.decode(t, []byte(`{}`)))
+			for _, k := range c.keys {
+				if raw, ok := got[k]; ok {
+					t.Errorf("%s.%s was absent on the wire but re-marshaled as %s; "+
+						"a value-typed time.Time cannot represent absence and `,omitempty` never fires for a struct",
+						c.name, k, raw)
+				}
+			}
+		})
+	}
+}
+
+// TestOptionalTimestampsRoundTripWhenPresent is the positive control: the fix
+// must not turn a real timestamp into an omitted one.
+func TestOptionalTimestampsRoundTripWhenPresent(t *testing.T) {
+	for _, c := range timestampCarriers() {
+		t.Run(c.name, func(t *testing.T) {
+			var in map[string]json.RawMessage
+			if err := json.Unmarshal(c.present, &in); err != nil {
+				t.Fatalf("fixture is not an object: %v", err)
+			}
+			got := marshalToKeys(t, c.decode(t, c.present))
+			for _, k := range c.keys {
+				want, ok := in[k]
+				if !ok {
+					t.Fatalf("test fixture for %s omits %s, so this case proves nothing", c.name, k)
+				}
+				raw, ok := got[k]
+				if !ok {
+					t.Errorf("%s.%s was present on the wire (%s) but did not survive re-marshal", c.name, k, want)
+					continue
+				}
+				if string(raw) != string(want) {
+					t.Errorf("%s.%s round-tripped as %s, want %s", c.name, k, raw, want)
+				}
+			}
+		})
+	}
+}
+
+// TestOptionalTimestampsSurviveGeneratedConversion covers the other ingress:
+// the *FromGenerated converters, which read the generated client's *time.Time
+// and previously flattened it through deref(). Notification has no converter —
+// it is decoded straight from the response body — so it is absent here and
+// covered by the wire-decode cases above.
+func TestOptionalTimestampsSurviveGeneratedConversion(t *testing.T) {
+	cases := []struct {
+		name string
+		from any
+		keys []string
+	}{
+		{"HillChart", hillChartFromGenerated(generated.HillChart{Enabled: true}), []string{"updated_at"}},
+		{"SearchResult", searchResultFromGenerated(generated.SearchResult{}), []string{"created_at", "updated_at"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := marshalToKeys(t, c.from)
+			for _, k := range c.keys {
+				if raw, ok := got[k]; ok {
+					t.Errorf("%s.%s: generated value carried a nil timestamp but the wrapper emitted %s", c.name, k, raw)
+				}
+			}
+		})
+	}
+}
+
+// TestNilOptionalTimestampPanicsOnValueReceiverCall pins the migration hazard
+// that made #562 worth its own PR, as executable documentation.
+//
+// `hc.UpdatedAt.IsZero()` is the idiomatic pre-fix guard, and it compiles
+// UNCHANGED after the field becomes a pointer — Go inserts the dereference for
+// a value-receiver method call. So the break is invisible to the compiler and
+// surfaces as a nil-pointer panic at runtime. Callers must nil-check first;
+// see the migration note on the PR.
+//
+// Against the un-fixed tree this test fails ("expected a nil-pointer panic"),
+// which is exactly the point: nothing panicked, and nothing complained.
+func TestNilOptionalTimestampPanicsOnValueReceiverCall(t *testing.T) {
+	hc := hillChartFromGenerated(generated.HillChart{Enabled: true})
+
+	defer func() {
+		if recover() == nil {
+			t.Error("expected a nil-pointer panic from IsZero() on an absent UpdatedAt: " +
+				"if this line is reached the field is still value-typed and absence reads as 0001-01-01T00:00:00Z")
+		}
+	}()
+
+	_ = hc.UpdatedAt.IsZero()
+}
+
+// TestNoValueTypedOptionalTimestamps is the regression guard.
+//
+// scripts/check-go-optional-pointers enforces the same invariant, but only
+// over go/pkg/generated/client.gen.go — the hand-written wrapper surface is
+// outside its scope by construction, and deliberately so: this package
+// flattens optional strings/bools/numerics to value types on purpose, and
+// ~300 fields would trip that guard's classifier for no benefit. Timestamps
+// are the carve-out, because `,omitempty` cannot save a struct.
+//
+// Scope, stated honestly rather than implied: this checks value-typed
+// time.Time fields carrying `,omitempty`. A value-typed time.Time with NO
+// omitempty whose generated counterpart is a pointer — the shape
+// SearchResult.CreatedAt had — is NOT detectable from this package's source
+// alone; catching that class needs the (wrapper, generated) pairing that
+// scripts/check-wrapper-drift already computes for tag names but not for
+// types. That gap is reported on the PR, not closed here.
+func TestNoValueTypedOptionalTimestamps(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read package dir: %v", err)
+	}
+
+	fset := token.NewFileSet()
+	var files []*ast.File
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, filepath.Join(".", name), nil, 0)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		files = append(files, f)
+	}
+	if len(files) == 0 {
+		t.Fatal("parsed zero non-test .go files — the guard is scanning the wrong directory")
+	}
+
+	var (
+		violations []string
+		scanned    int
+	)
+	for _, file := range files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			st, ok := n.(*ast.StructType)
+			if !ok {
+				return true
+			}
+			for _, f := range st.Fields.List {
+				if !isValueTime(f.Type) {
+					continue
+				}
+				scanned++
+				if f.Tag == nil {
+					continue
+				}
+				tag, err := strconv.Unquote(f.Tag.Value)
+				if err != nil {
+					t.Errorf("unparsable struct tag at %s: %s", fset.Position(f.Tag.Pos()), f.Tag.Value)
+					continue
+				}
+				if !hasOmitempty(reflect.StructTag(tag)) {
+					continue
+				}
+				violations = append(violations,
+					fmt.Sprintf("%s: %s time.Time `%s`", fset.Position(f.Pos()), fieldNames(f), tag))
+			}
+			return true
+		})
+	}
+
+	// A guard that scans nothing reports success forever. The wrapper surface
+	// carries many required value-typed timestamps (Todo.CreatedAt and the
+	// like); if none were seen, the walk broke, not the surface.
+	if scanned == 0 {
+		t.Fatal("scanned zero value-typed time.Time fields — the AST walk is broken, not the package")
+	}
+
+	sort.Strings(violations)
+	for _, v := range violations {
+		t.Errorf("optional timestamp is value-typed and cannot represent absence "+
+			"(`,omitempty` is inert for a struct, so the key is emitted as 0001-01-01T00:00:00Z): %s", v)
+	}
+}
+
+// isValueTime reports whether expr is the type `time.Time` exactly — not
+// *time.Time, not []time.Time, not a named alias.
+func isValueTime(expr ast.Expr) bool {
+	sel, ok := expr.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Time" {
+		return false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	return ok && ident.Name == "time"
+}
+
+// hasOmitempty reports whether any tag key carries the omitempty option. Every
+// key is inspected, not just json: a field tagged form:"x,omitempty" is just as
+// optional, and only checking json would exempt it.
+func hasOmitempty(tag reflect.StructTag) bool {
+	for _, key := range []string{"json", "form", "url", "query", "xml", "yaml"} {
+		v, ok := tag.Lookup(key)
+		if !ok {
+			continue
+		}
+		parts := strings.Split(v, ",")
+		for _, opt := range parts[1:] {
+			if opt == "omitempty" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func fieldNames(f *ast.Field) string {
+	if len(f.Names) == 0 {
+		return "<embedded>"
+	}
+	names := make([]string, 0, len(f.Names))
+	for _, n := range f.Names {
+		names = append(names, n.Name)
+	}
+	return strings.Join(names, ", ")
+}

--- a/go/pkg/basecamp/search.go
+++ b/go/pkg/basecamp/search.go
@@ -11,17 +11,24 @@ import (
 
 // SearchResult represents a single search result from the Basecamp API.
 type SearchResult struct {
-	ID               int64     `json:"id"`
-	Status           string    `json:"status"`
-	VisibleToClients bool      `json:"visible_to_clients"`
-	CreatedAt        time.Time `json:"created_at"`
-	UpdatedAt        time.Time `json:"updated_at"`
-	Title            string    `json:"title"`
-	InheritsStatus   bool      `json:"inherits_status"`
-	Type             string    `json:"type"`
-	URL              string    `json:"url"`
-	AppURL           string    `json:"app_url"`
-	BookmarkURL      string    `json:"bookmark_url"`
+	ID               int64  `json:"id"`
+	Status           string `json:"status"`
+	VisibleToClients bool   `json:"visible_to_clients"`
+	// CreatedAt and UpdatedAt are optional on this polymorphic projection —
+	// neither carries @required in the spec, and the generated client types
+	// both as *time.Time. Pointers here so an absent timestamp stays
+	// distinguishable rather than collapsing to 0001-01-01T00:00:00Z; the tags
+	// carry omitempty so absence round-trips as an omitted key instead of the
+	// fabricated zero time (encoding/json never treats a struct as empty, so a
+	// value-typed field would always emit).
+	CreatedAt      *time.Time `json:"created_at,omitempty"`
+	UpdatedAt      *time.Time `json:"updated_at,omitempty"`
+	Title          string     `json:"title"`
+	InheritsStatus bool       `json:"inherits_status"`
+	Type           string     `json:"type"`
+	URL            string     `json:"url"`
+	AppURL         string     `json:"app_url"`
+	BookmarkURL    string     `json:"bookmark_url"`
 	// BubbleUpURL is the URL of the Bubble Up record for this recording. Optional
 	// on this polymorphic projection: recordings/_recording.json.jbuilder emits
 	// the key only when the caller passes bubbleupable, and todolists/_todolist
@@ -346,8 +353,8 @@ func searchResultFromGenerated(gsr generated.SearchResult) SearchResult {
 	sr := SearchResult{
 		Status:               deref(gsr.Status),
 		VisibleToClients:     deref(gsr.VisibleToClients),
-		CreatedAt:            deref(gsr.CreatedAt),
-		UpdatedAt:            deref(gsr.UpdatedAt),
+		CreatedAt:            gsr.CreatedAt,
+		UpdatedAt:            gsr.UpdatedAt,
 		Title:                gsr.Title,
 		InheritsStatus:       deref(gsr.InheritsStatus),
 		Type:                 gsr.Type,

--- a/go/pkg/basecamp/search_test.go
+++ b/go/pkg/basecamp/search_test.go
@@ -186,11 +186,16 @@ func TestSearchResult_UnmarshalResults(t *testing.T) {
 		t.Errorf("expected a highlighted excerpt in PlainTextContent, got %q", r3.PlainTextContent)
 	}
 
-	// Verify timestamps are parsed
-	if r1.CreatedAt.IsZero() {
+	// Verify timestamps are parsed. Both are optional (*time.Time), so
+	// nil-check before dereferencing.
+	if r1.CreatedAt == nil {
+		t.Error("expected CreatedAt to be present")
+	} else if r1.CreatedAt.IsZero() {
 		t.Error("expected CreatedAt to be non-zero")
 	}
-	if r1.UpdatedAt.IsZero() {
+	if r1.UpdatedAt == nil {
+		t.Error("expected UpdatedAt to be present")
+	} else if r1.UpdatedAt.IsZero() {
 		t.Error("expected UpdatedAt to be non-zero")
 	}
 }


### PR DESCRIPTION
Closes #562.

## ⚠️ This is a silent breaking change. Read the migration note.

Five optional timestamps on the hand-written Go wrapper surface move from `time.Time` to `*time.Time`. **Nothing at your call sites will stop compiling.** `hc.UpdatedAt.IsZero()` compiles exactly as it did before — Go inserts the dereference for a value-receiver method call — and then panics on nil at runtime. No compiler error, just a crash in production the first time the API omits the field.

| Type | Field | Before | After |
|---|---|---|---|
| `HillChart` | `UpdatedAt` | `time.Time` `` `json:"updated_at,omitempty"` `` | `*time.Time` `` `json:"updated_at,omitempty"` `` |
| `Notification` | `ReadAt` | `time.Time` `` `json:"read_at,omitempty"` `` | `*time.Time` `` `json:"read_at,omitempty"` `` |
| `Notification` | `UnreadAt` | `time.Time` `` `json:"unread_at,omitempty"` `` | `*time.Time` `` `json:"unread_at,omitempty"` `` |
| `SearchResult` | `CreatedAt` | `time.Time` `` `json:"created_at"` `` | `*time.Time` `` `json:"created_at,omitempty"` `` |
| `SearchResult` | `UpdatedAt` | `time.Time` `` `json:"updated_at"` `` | `*time.Time` `` `json:"updated_at,omitempty"` `` |

## Migration

Nil-check before touching any of the five. Every pattern in the first block below compiles *both* before and after this change; only the second block is safe after it.

```go
// BEFORE — still compiles after this change, and panics on nil.
if hc.UpdatedAt.IsZero() { … }
fmt.Println(hc.UpdatedAt.Format(time.RFC3339))
age := time.Since(n.ReadAt)
sort.Slice(rs, func(i, j int) bool { return rs[i].CreatedAt.Before(rs[j].CreatedAt) })
```

```go
// AFTER — nil means "the API did not send this field".
if hc.UpdatedAt == nil { … }                            // absent
if hc.UpdatedAt != nil && hc.UpdatedAt.IsZero() { … }   // present and zero

if hc.UpdatedAt != nil {
    fmt.Println(hc.UpdatedAt.Format(time.RFC3339))
}

if n.ReadAt != nil {
    age := time.Since(*n.ReadAt)
}

sort.Slice(rs, func(i, j int) bool {
    if rs[i].CreatedAt == nil || rs[j].CreatedAt == nil {
        return rs[j].CreatedAt != nil                    // absent sorts last
    }
    return rs[i].CreatedAt.Before(*rs[j].CreatedAt)
})
```

Two behavioural notes beyond the type:

- **Absent no longer reads as the zero time.** Code that treated `IsZero()` as "absent" must switch to `== nil`. That reading was never sound anyway: it could not distinguish an omitted key from a server that genuinely sent `0001-01-01T00:00:00Z`.
- **The wire form changes on re-marshal.** An absent timestamp previously came back out as `"updated_at":"0001-01-01T00:00:00Z"`; it is now omitted. If you round-trip these structs through your own storage or golden files, that fabricated instant will stop appearing — which is the point, but it is a diff.

`SearchResult` additionally gains `,omitempty` on both tags. Those two were previously tagged as required while the schema marks them optional and the generated client types them `*time.Time`; the tags now match reality.

## The defect, precisely

All five schemas mark the field optional and the generated client types all five as `*time.Time`. The wrapper flattened them — through `deref()` in `hillChartFromGenerated` / `searchResultFromGenerated`, and via direct `json.Unmarshal` for `Notification`.

That did two things at once:

1. **Absence collapsed to the zero time**, indistinguishable from a real (if implausible) value.
2. **`,omitempty` was inert.** `encoding/json`'s empty set is `false` / `0` / nil pointer / nil interface / empty array, slice, map, string. A struct is never empty, and `time.Time` is a struct — so the key was re-emitted on every marshal, carrying the fabricated `0001-01-01T00:00:00Z`.

Point 2 is the boundary that separates timestamps from the rest of this surface. `` Title string `json:"title,omitempty"` `` is lossy in a benign way: absent and `""` collapse, and both are then omitted, so the value round-trips. A value-typed optional `time.Time` fabricates data on the wire.

## How the five were found — and five more that are not fixed here

The issue body names `HillChart.UpdatedAt`; its title also names the `SearchResult` timestamps. Neither grep nor any existing gate can enumerate the class, because **the wrapper source does not say the field is optional** — that evidence lives in the schema and in the generated client. So the enumeration is a type cross-reference between the two sides:

- parse every non-test `go/pkg/basecamp/*.go` for struct fields typed exactly `time.Time`, keyed `(struct name, json tag)`
- parse `go/pkg/generated/client.gen.go` the same way
- report every wrapper field whose name-matched, tag-matched generated counterpart is `*time.Time`

Against this PR's base (`a7354ae35`) that scan reads **106 value-typed `time.Time` wrapper fields, of which 10 have an optional generated counterpart, 0 unpaired**. It discriminates: `generated.Webhook.CreatedAt`, `generated.Question.CreatedAt` and `generated.ClientApproval.CreatedAt` are value `time.Time` (genuinely required) and do not appear; `EverythingFile.CreatedAt`/`UpdatedAt` are already `*time.Time` and do not appear.

**This PR fixes 5 of those 10. The other 5 are real and are reported, not fixed, in #620:**

| Struct | Field | Wrapper | Generated |
|---|---|---|---|
| `TimelineEvent` | `CreatedAt` | `timeline.go:20` — `time.Time` `` `json:"created_at"` `` | `*time.Time` |
| `WebhookDelivery` | `CreatedAt` | `webhooks.go:40` — `time.Time` `` `json:"created_at"` `` | `*time.Time` |
| `QuestionReminder` | `RemindAt` | `checkins.go:143` — `time.Time` `` `json:"remind_at"` `` | `*time.Time` |
| `ClientApprovalResponse` | `CreatedAt` | `client_approvals.go:68` — `time.Time` `` `json:"created_at"` `` | `*time.Time` |
| `ClientApprovalResponse` | `UpdatedAt` | `client_approvals.go:69` — `time.Time` `` `json:"updated_at"` `` | `*time.Time` |

None is `@required` in `spec/basecamp.smithy`. Each is a silent break with the same failure mode as the five above, so each needs the same deliberate migration note — which is why they are a separate change rather than a late amendment to this one, not because they are less real.

The five that do ship together ship together because the failure mode is invisible to the compiler: splitting them would ask consumers to hunt for nil-safety three times over, each time with no build error to guide them.

## Red proof

`go/pkg/basecamp/optional_timestamps_test.go` is written so every assertion compiles against both the fixed and un-fixed trees — it asserts on marshaled JSON keys, never on the field types, so nothing had to be edited between the two runs. Against the un-fixed tree, verbatim from `go test ./pkg/basecamp/ -run 'TestOptionalTimestamps|TestNilOptionalTimestampPanics|TestNoValueTypedOptionalTimestamps' -v`:

```
=== RUN   TestOptionalTimestampsOmitWhenAbsent
=== RUN   TestOptionalTimestampsOmitWhenAbsent/HillChart
    optional_timestamps_test.go:112: HillChart.updated_at was absent on the wire but re-marshaled as "0001-01-01T00:00:00Z"; a value-typed time.Time cannot represent absence and `,omitempty` never fires for a struct
=== RUN   TestOptionalTimestampsOmitWhenAbsent/Notification
    optional_timestamps_test.go:112: Notification.read_at was absent on the wire but re-marshaled as "0001-01-01T00:00:00Z"; a value-typed time.Time cannot represent absence and `,omitempty` never fires for a struct
    optional_timestamps_test.go:112: Notification.unread_at was absent on the wire but re-marshaled as "0001-01-01T00:00:00Z"; a value-typed time.Time cannot represent absence and `,omitempty` never fires for a struct
=== RUN   TestOptionalTimestampsOmitWhenAbsent/SearchResult
    optional_timestamps_test.go:112: SearchResult.created_at was absent on the wire but re-marshaled as "0001-01-01T00:00:00Z"; a value-typed time.Time cannot represent absence and `,omitempty` never fires for a struct
    optional_timestamps_test.go:112: SearchResult.updated_at was absent on the wire but re-marshaled as "0001-01-01T00:00:00Z"; a value-typed time.Time cannot represent absence and `,omitempty` never fires for a struct
--- FAIL: TestOptionalTimestampsOmitWhenAbsent (0.00s)
    --- FAIL: TestOptionalTimestampsOmitWhenAbsent/HillChart (0.00s)
    --- FAIL: TestOptionalTimestampsOmitWhenAbsent/Notification (0.00s)
    --- FAIL: TestOptionalTimestampsOmitWhenAbsent/SearchResult (0.00s)
=== RUN   TestOptionalTimestampsRoundTripWhenPresent
=== RUN   TestOptionalTimestampsRoundTripWhenPresent/HillChart
=== RUN   TestOptionalTimestampsRoundTripWhenPresent/Notification
=== RUN   TestOptionalTimestampsRoundTripWhenPresent/SearchResult
--- PASS: TestOptionalTimestampsRoundTripWhenPresent (0.00s)
    --- PASS: TestOptionalTimestampsRoundTripWhenPresent/HillChart (0.00s)
    --- PASS: TestOptionalTimestampsRoundTripWhenPresent/Notification (0.00s)
    --- PASS: TestOptionalTimestampsRoundTripWhenPresent/SearchResult (0.00s)
=== RUN   TestOptionalTimestampsSurviveGeneratedConversion
=== RUN   TestOptionalTimestampsSurviveGeneratedConversion/HillChart
    optional_timestamps_test.go:168: HillChart.updated_at: generated value carried a nil timestamp but the wrapper emitted "0001-01-01T00:00:00Z"
=== RUN   TestOptionalTimestampsSurviveGeneratedConversion/SearchResult
    optional_timestamps_test.go:168: SearchResult.created_at: generated value carried a nil timestamp but the wrapper emitted "0001-01-01T00:00:00Z"
    optional_timestamps_test.go:168: SearchResult.updated_at: generated value carried a nil timestamp but the wrapper emitted "0001-01-01T00:00:00Z"
--- FAIL: TestOptionalTimestampsSurviveGeneratedConversion (0.00s)
    --- FAIL: TestOptionalTimestampsSurviveGeneratedConversion/HillChart (0.00s)
    --- FAIL: TestOptionalTimestampsSurviveGeneratedConversion/SearchResult (0.00s)
=== RUN   TestNilOptionalTimestampPanicsOnValueReceiverCall
    optional_timestamps_test.go:191: expected a nil-pointer panic from IsZero() on an absent UpdatedAt: if this line is reached the field is still value-typed and absence reads as 0001-01-01T00:00:00Z
--- FAIL: TestNilOptionalTimestampPanicsOnValueReceiverCall (0.00s)
=== RUN   TestNoValueTypedOptionalTimestamps
    optional_timestamps_test.go:280: optional timestamp is value-typed and cannot represent absence (`,omitempty` is inert for a struct, so the key is emitted as 0001-01-01T00:00:00Z): hill_charts.go:15:2: UpdatedAt time.Time `json:"updated_at,omitempty"`
    optional_timestamps_test.go:280: optional timestamp is value-typed and cannot represent absence (`,omitempty` is inert for a struct, so the key is emitted as 0001-01-01T00:00:00Z): my_notifications.go:46:2: ReadAt time.Time `json:"read_at,omitempty"`
    optional_timestamps_test.go:280: optional timestamp is value-typed and cannot represent absence (`,omitempty` is inert for a struct, so the key is emitted as 0001-01-01T00:00:00Z): my_notifications.go:47:2: UnreadAt time.Time `json:"unread_at,omitempty"`
--- FAIL: TestNoValueTypedOptionalTimestamps (0.03s)
FAIL
FAIL	github.com/basecamp/basecamp-sdk/go/pkg/basecamp	0.310s
FAIL
REAL_EXIT=1
```

Note what `TestNilOptionalTimestampPanicsOnValueReceiverCall` actually proves. Pre-fix, `hc.UpdatedAt.IsZero()` on an absent timestamp does **not** panic and does **not** complain — it silently answers `true`. That silence is the disease. The panic is the *post*-fix migration hazard, and the test asserts it so the hazard lives in code rather than only in this description.

`TestOptionalTimestampsRoundTripWhenPresent` is the positive control and passes on both trees, so the fix cannot have been "omit everything".

Note also that the AST guard's red run lists only **three** of the five — that is not a defect in the run, it is the guard's coverage, and the next section is about exactly that.

Post-fix, all six subtests pass — see verification below.

## Why the existing gate did not catch this, and what is still unguarded

`scripts/check-go-optional-pointers` enforces this invariant on the generated client, so the first question was whether it should have fired. Stating the answer plainly, because an earlier version of this description and [a comment on #562](https://github.com/basecamp/basecamp-sdk/issues/562#issuecomment-5170007970) both got it wrong in the direction that hides a bug:

**Pointed at the wrapper surface, it would have caught three of the five.** `HillChart.UpdatedAt`, `Notification.ReadAt` and `Notification.UnreadAt` are value-typed and carry `,omitempty`, which is exactly its violation shape. Run against the pre-fix files it exits **1** on each:

```
$ scripts/check-go-optional-pointers <pre-fix hill_charts.go>
check-go-optional-pointers: 5 optional field(s) cannot represent absence (non-pointer value type with omitempty):
  hill_charts.go:15: UpdatedAt time.Time
  …
REAL_EXIT=1

$ scripts/check-go-optional-pointers <pre-fix my_notifications.go>
  my_notifications.go:46: ReadAt time.Time
  my_notifications.go:47: UnreadAt time.Time
REAL_EXIT=1
```

It caught none of them only because `make go-check-optional-pointers` invokes it with no argument:

```ruby
path = ARGV[0] || File.expand_path("../go/pkg/generated/client.gen.go", __dir__)
```

so its entire domain is `go/pkg/generated/client.gen.go`. That scoping should nonetheless stay: pointed at the whole pre-fix wrapper surface it reports **345** violations, because this package flattens optional `*string` / `*bool` / `*int` to value types on purpose — that is what makes it the "clean" surface.

**It could not have caught the other two at any scope.** It keys entirely on `,omitempty` (`next unless m[3].match?(OMITEMPTY)`), and `SearchResult.CreatedAt`/`UpdatedAt` were tagged `json:"created_at"` with no options — tagged as if required. Run against the pre-fix `search.go` it reports four violations and neither timestamp is among them.

So this PR adds `TestNoValueTypedOptionalTimestamps`: an AST guard over `go/pkg/basecamp/*.go` rejecting any value-typed `time.Time` carrying `,omitempty` in any tag key. It runs under `make go-test` — no new Makefile target, no new CI wiring, nothing for a sibling lane to collide with. It asserts it scanned a non-zero number of `time.Time` fields, so a broken walk fails loudly instead of reporting success forever.

**Be clear about what that guard does not do.** It inherits the same `,omitempty` blind spot (`if !hasOmitempty(tag) { continue }`), so it would not have caught the two `SearchResult` fields either, and it does not catch the five holdouts in #620 — all five are tagged without options. It prevents regression of the three-field shape, not of the class.

**Two gaps stay open, reported rather than quietly closed:**

1. **Type-level wrapper/generated drift is unguarded — this is the one that matters.** `scripts/check-wrapper-drift` already computes the `(wrapper, generated)` struct pairing from the `*FromGenerated` converters, but compares JSON tag *names* only. A wrapper field typed `time.Time` whose generated counterpart is `*time.Time` passes it cleanly. That is the only place in the tree holding both sides of the comparison, and it is where the 10-field cross-reference above belongs as a permanent gate. Two limits for whoever writes it: `Notification` has no `*FromGenerated` converter (direct `json.Unmarshal`), so converter-derived pairing misses it; and the comparison must be scoped to timestamps or it re-derives the 345-violation wall. Tracked in #620.

2. **Six non-timestamp fields are in the same inert-`omitempty` class:**

   ```
   go/pkg/basecamp/account_service.go:28: Limits       AccountLimits       `json:"limits,omitempty"`
   go/pkg/basecamp/account_service.go:29: Settings     AccountSettings     `json:"settings,omitempty"`
   go/pkg/basecamp/account_service.go:30: Subscription AccountSubscription `json:"subscription,omitempty"`
   go/pkg/basecamp/my_assignments.go:24:  Bucket       MyAssignmentBucket  `json:"bucket,omitempty"`
   go/pkg/basecamp/my_assignments.go:25:  Parent       MyAssignmentParent  `json:"parent,omitempty"`
   go/pkg/basecamp/people.go:571:         Person       OutOfOfficePerson   `json:"person,omitempty"`
   ```

   Named structs, so `omitempty` is equally inert, and each emits a fully zero-valued nested object instead of being omitted. Less harmful than a fabricated instant — a zero `{}` reads as obviously empty in a way `0001-01-01T00:00:00Z` does not — and outside this lane, so they are named in #620 rather than swept in.

## Review findings, all real, all fixed

**1. The SDK's own godoc demonstrated the hazard** (`chatgpt-codex-connector`). `ExampleSearchService_Search_sorted` called `r.CreatedAt.Format(…)` with no nil check — the exact unsafe pattern this PR warns about, shipped in the documentation. Fixed in `1fa9c13b4`. Reproduced literally first: that expression against a `SearchResult{Title: "Kickoff notes"}` panics with `runtime error: invalid memory address or nil pointer dereference`.

`make check` was green over it because godoc examples without an `// Output:` comment are compiled but never executed, and because `TestNoValueTypedOptionalTimestamps` is a *declaration* guard — it can prove no field is declared with the unsafe shape, but it cannot see an unsafe *use*.

So rather than fix the one named site and hope, I enumerated the class with the compiler. In a scratch copy all five fields became a **defined** pointer type with an empty method set:

```go
type probeTime *time.Time   // defined, not an alias: no method set, no selector auto-deref
```

Every auto-dereferencing use site then becomes a compile error, so the type checker lists them exhaustively. Three passes, neutralizing each batch to reach the next package:

```
pkg/basecamp/hill_charts_test.go:84:18: hc.UpdatedAt.IsZero undefined (type probeTime has no field or method IsZero)
pkg/basecamp/hill_charts_test.go:87:18: hc.UpdatedAt.Year undefined (type probeTime has no field or method Year)
pkg/basecamp/hill_charts_test.go:88:55: hc.UpdatedAt.Year undefined (type probeTime has no field or method Year)
pkg/basecamp/optional_timestamps_test.go:196:19: hc.UpdatedAt.IsZero undefined (type probeTime has no field or method IsZero)
pkg/basecamp/search_test.go:193:25: r1.CreatedAt.IsZero undefined (type probeTime has no field or method IsZero)
pkg/basecamp/search_test.go:198:25: r1.UpdatedAt.IsZero undefined (type probeTime has no field or method IsZero)
```
```
vet: pkg/basecamp/example_test.go:255:26: r.CreatedAt.Format undefined (type basecamp.probeTime has no field or method Format)
```
```
$ go vet ./...
REAL_EXIT=0
```

Seven sites in the whole module; the final pass is clean. Six are deliberately guarded (`hill_charts_test.go` behind `if hc.UpdatedAt == nil`, `search_test.go` behind `if … == nil { … } else if`, and `optional_timestamps_test.go:196` is the intentional nil-deref in the panic test). The seventh was the example. The probe is a one-off technique, not a committed guard — a permanent version needs a type-aware nilness pass, which belongs with the `check-wrapper-drift` gap above.

**2. A doc cross-reference that named a field that does not exist** (`copilot-pull-request-reviewer`). The `HillChart.UpdatedAt` comment cited `TimelineEvent.UpdatedAt` as precedent. `TimelineEvent` (`timeline.go:18`) has no `UpdatedAt`; the optional `*time.Time` pair at `timeline.go:85-86` belongs to `TimelineAttachment` (`timeline.go:62`). Now cites `EverythingFile.UpdatedAt` (`everything.go:64`), re-resolved to its declaring struct rather than assumed. Fixed in `1ec2c7583`.

That error came from #562's own table. My correction on the issue then overshot — it called `TimelineEvent.CreatedAt` "required and value-typed", when `structure TimelineEvent` carries no `@required` on `created_at` and the generated client types it `*time.Time`. It is value-typed, and it is a holdout, not a counter-example. [Re-corrected on the issue](https://github.com/basecamp/basecamp-sdk/issues/562#issuecomment-5170608428) and tracked in #620.

**3. A planning doc left stale by this change** (`copilot-pull-request-reviewer`, raised in the review body rather than as an inline thread). `go/BRIEF-bc5-forward-compat-wrappers.md:147` told the next author to type `Notification.BubbleUpAt` as `*time.Time` "rather than the bare `time.Time` pattern the wrapper uses for `ReadAt` / `UnreadAt`" — a counter-example this PR deletes. The advice was right and its only concrete anchor inverted. Now cites `Card.CompletedAt` (`cards.go:101`), `Todo.CompletedAt` (`todos.go:52`) and the newly-pointerized `ReadAt`/`UnreadAt` (`my_notifications.go:52-53`), each re-resolved to source.

## Scope

Go only. **No spec change:** `spec/basecamp.smithy` already marks all five optional (no `@required` on `HillChart.updated_at`, `Notification.read_at` / `unread_at`, `SearchResult.created_at` / `updated_at`), and the generated client already types them `*time.Time` — the wrapper was the only thing out of step. `spec/basecamp.smithy` and `openapi.json` are untouched, as is every generated artifact.

**No conformance fixture and no runner dispatch:** nothing under `conformance/runner/**` reads any of the five fields, so no runner gains a new case in any of the six.
