### PR TITLE
Bump the brace-expansion override floor past GHSA-rgw5-rvv9-x895

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -900,6 +900,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -917,6 +920,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -934,6 +940,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -951,6 +960,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -968,6 +980,9 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -985,6 +1000,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1002,6 +1020,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1019,6 +1040,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -900,9 +900,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -920,9 +917,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -940,9 +934,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -960,9 +951,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -980,9 +968,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1000,9 +985,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1020,9 +1002,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1040,9 +1019,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1760,9 +1736,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -67,7 +67,7 @@
   },
   "overrides": {
     "minimatch": ">=10.2.1",
-    "brace-expansion": ">=5.0.7",
+    "brace-expansion": ">=5.0.9",
     "fast-uri": ">=3.1.3",
     "js-yaml": "^4.3.0"
   }


### PR DESCRIPTION
The npm Audit job is red repo-wide as of this afternoon: [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) (high — DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation) covers `brace-expansion` 4.0.0–5.0.8. The job passed on #614's previous head at ~16:45Z and failed on a SPEC.md-only delta at ~17:51Z — the advisory published in between; `main` fails identically.

The dep rides in transitively (`openapi-typescript` → `@redocly/openapi-core` → `minimatch`) under the existing `overrides` floor `>=5.0.7` from the prior CVE's mitigation. `npm audit fix` can't move an overridden dep, so this raises the floor to `>=5.0.9` (the patched release, published today) and re-resolves the lockfile — the same leaf-bump pattern as #413, zero generated churn.

Verification: `npm audit --audit-level=high` → 0 vulnerabilities (`REAL_AUDIT_EXIT=0`); full `make ts-check` green with the re-resolved lockfile.

Every open PR inherits the audit failure until this lands, so it wants to go ahead of the queue (as #605 did this morning for the doc-constants breakage).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise the `brace-expansion` override to >=5.0.9 to patch GHSA-rgw5-rvv9-x895 and restore a green `npm audit` across the repo. This unblocks all open PRs.

- **Dependencies**
  - Update `overrides.brace-expansion` to `>=5.0.9` (transitive via `openapi-typescript` → `@redocly/openapi-core` → `minimatch`).
  - Regenerated `package-lock.json` with npm 11.17 to preserve libc fields; diff is only `brace-expansion` 5.0.8 → 5.0.9.
  - `npm audit --audit-level=high` shows 0 vulnerabilities; `make ts-check` passes.

<sup>Written for commit 517658218014048bbbd2343bfa7d5e3da1643213. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

