### PR TITLE
Pagination: a positive page selects exactly that page, in all six SDKs

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -868,16 +868,25 @@ offset.** In every SDK:
 
 Absent, `0`, and negative all mean the same thing: auto-paginate the whole
 collection per the algorithm above. `page` and `max_items` compose — the cap
-still trims the selected page — but `max_items` is not itself a page selector:
-it caps *items*, so it collapses to a single request only when the cap does not
-exceed that page's item count, which requires the caller to know the server's
-page size.
+still trims the selected page, and dropping items from it is itself truncation
+— but `max_items` is not itself a page selector: it caps *items*, so it
+collapses to a single request only when the cap does not exceed that page's
+item count, which requires the caller to know the server's page size.
+
+One qualification for Go, whose `max_items` analog is a per-operation `Limit`
+with a **nonzero default** on several services (`DefaultTodoLimit` and
+friends): only an explicitly-set positive `Limit` trims a pinned page. The
+default must not, because a caller who asked for page 3 asked for page 3, not
+for its first 100 items. The other five SDKs have no such default — an absent
+`max_items` is uncapped — so the rule reads identically in all six: whatever
+cap the caller set applies to the page they pinned.
 
 ```
 FUNCTION paginate(initial_response, max_pages, max_items?, page?) → ListResult<T>
   0. If page is set and page > 0:
      a. items = parse first_page_items from initial_response body.
-     b. dropped = max_items set AND items.length > max_items.
+     b. dropped = max_items set (explicitly, not a per-operation default)
+        AND items.length > max_items.
      c. truncated = dropped OR parseNextLink(initial_response.headers["Link"]) ≠ null.
      d. → ListResult(dropped ? items[0:max_items] : items,
                      meta: {total_count, truncated}).

--- a/SPEC.md
+++ b/SPEC.md
@@ -852,25 +852,64 @@ The variant is determined at code-generation time from the OpenAPI response sche
 
 **Wrapped response pagination:** For endpoints that return a wrapper object with a paginated array inside (e.g., `personProgress` returns `{person, events: [...]}`), the generated service method paginates the embedded array while preserving the wrapper fields from the first page. The `paginate` algorithm above handles item extraction; the wrapping/unwrapping is a code-generation concern, not a transport concern. See `typescript/src/generated/services/reports.ts` and `go/pkg/basecamp/timeline.go` for reference implementations.
 
-### The `page` Query Parameter
+### The `page` Query Parameter `[conformance]`
 
-Operations whose Basecamp endpoint honors `?page=` accept a `page` query parameter. **Its meaning currently differs between Go and the five auto-paginating SDKs, and callers must know which they are using.**
+Operations whose Basecamp endpoint honors `?page=` accept a `page` query
+parameter. **A positive `page` selects exactly that page. It is not a starting
+offset.** In every SDK:
 
-Two carve-outs, so the rule above is not read as universal:
+- the operation issues **exactly one** request;
+- it returns **only** that page's items;
+- the `Link: rel="next"` header is **not** followed;
+- `ListMeta.truncated` is true when that page carried a next link (or when
+  `max_items` dropped items from it), because items beyond those returned were
+  available;
+- `ListMeta.total_count` comes from `X-Total-Count` as usual.
 
-- `ListWebhooks`, `ListMessageTypes`, `ListChatbots`, `ListPingablePeople`, `ListQuestionAnswerers`, and `ListUploadVersions` carry the pagination trait but declare **no** `page` parameter: their Basecamp index actions return the whole collection rather than paginating, so there is no page to select.
-- `GetMyNotifications` declares `page` but carries **no** pagination trait, so no SDK follows links for it and everything below is inapplicable — it returns the page you asked for, in all six.
+Absent, `0`, and negative all mean the same thing: auto-paginate the whole
+collection per the algorithm above. `page` and `max_items` compose — the cap
+still trims the selected page — but `max_items` is not itself a page selector:
+it caps *items*, so it collapses to a single request only when the cap does not
+exceed that page's item count, which requires the caller to know the server's
+page size.
 
-| SDK | Behavior with `page = 3` | Requests issued |
-|-----|--------------------------|-----------------|
-| Go | Returns exactly page 3; auto-pagination is suppressed. | 1 |
-| TypeScript, Python, Ruby, Kotlin, Swift | Fetches page 3, then follows `Link: rel="next"` to the end of the collection, returning pages 3..N concatenated. | N - 2 |
+```
+FUNCTION paginate(initial_response, max_pages, max_items?, page?) → ListResult<T>
+  0. If page is set and page > 0:
+     a. items = parse first_page_items from initial_response body.
+     b. dropped = max_items set AND items.length > max_items.
+     c. truncated = dropped OR parseNextLink(initial_response.headers["Link"]) ≠ null.
+     d. → ListResult(dropped ? items[0:max_items] : items,
+                     meta: {total_count, truncated}).
+  ... otherwise continue with step 1 of the algorithm above.
+END
+```
 
-The divergence is structural: `page` rides in the query string of the *first* request only, while every subsequent request comes from the `Link` header. The auto-pagination algorithm above has no notion of a pinned page, so `page` acts as a starting offset rather than a selector. Go escapes this because its hand-written wrappers short-circuit before the follow loop when `Page > 0`.
+Two carve-outs, so the rule is not read as universal:
 
-`max_items` bounds the walk but is not a page selector: it caps *items*, so it collapses to a single request only when the cap does not exceed that page's item count, which requires the caller to know the server's page size.
+- `ListWebhooks`, `ListMessageTypes`, `ListChatbots`, `ListPingablePeople`, `ListQuestionAnswerers`, and `ListUploadVersions` carry the pagination trait but declare **no** `page` parameter: their Basecamp index actions return the whole collection rather than paginating, so there is no page to select. Where an SDK's shared pagination options type still admits a `page` (TypeScript, Kotlin, Swift), passing one on those operations changes nothing — the responses carry no next link to suppress.
+- `GetMyNotifications` declares `page` but carries **no** pagination trait, so no SDK follows links for it and this section is inapplicable — it returns the page you asked for, in all six.
 
-This behavior predates the operations added in #561 — it has held since the first operations declared `@httpQuery("page")`. Converging all six SDKs on the Go semantics is tracked in issue #566; until then, the divergence is documented rather than silent, and SDK doc comments for `page` point here.
+**How each SDK learns the pinned page.** The paginator reads it from whichever
+representation it already holds, so no SDK carries a second copy that can drift
+from the query string actually sent:
+
+| SDK | Source of the pinned page |
+|-----|---------------------------|
+| TypeScript | `PaginationOptions.page` (generated options interfaces extend it) |
+| Kotlin | `PaginationOptions.page`, via the generated `toPaginationOptions()` |
+| Swift | `PaginationOptions.page`, passed by the generated service method |
+| Python | the outgoing `params` dict (`selects_single_page`) |
+| Ruby | the outgoing `params` hash (`single_page_selected?`) |
+| Go | the hand-written wrapper's `opts.Page` (or `page` argument) |
+
+Before #566 this held only in Go: `page` rode in the query string of the *first*
+request while every subsequent request came from the `Link` header, so in the
+other five SDKs `page: 3` of a 100-page collection issued 98 requests and
+returned pages 3..N concatenated. Go escaped it because its hand-written
+wrappers short-circuited before the follow loop when `Page > 0`. #566 converged
+the five on Go's semantics; #570 closed the last Go hole (`GaugesService.List`
+and `ListNeedles` took no options struct, so `page` could not reach the wire).
 
 ### Same-Origin Validation Algorithm `[conformance]`
 

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -54,6 +54,8 @@ type ConfigOverrides struct {
 	BaseURL  string `json:"baseUrl"`
 	MaxPages int    `json:"maxPages"`
 	MaxItems int    `json:"maxItems"`
+	// Page pins the list operation to a single page (SPEC §8).
+	Page int `json:"page"`
 }
 
 // MockResponse defines a single mock HTTP response.
@@ -447,8 +449,11 @@ func executeOperation(ctx context.Context, account *basecamp.AccountClient, tc T
 	switch tc.Operation {
 	case "ListProjects":
 		var opts *basecamp.ProjectListOptions
-		if tc.ConfigOverrides != nil && tc.ConfigOverrides.MaxItems > 0 {
-			opts = &basecamp.ProjectListOptions{Limit: tc.ConfigOverrides.MaxItems}
+		if tc.ConfigOverrides != nil && (tc.ConfigOverrides.MaxItems > 0 || tc.ConfigOverrides.Page > 0) {
+			opts = &basecamp.ProjectListOptions{
+				Limit: tc.ConfigOverrides.MaxItems,
+				Page:  tc.ConfigOverrides.Page,
+			}
 		}
 		result, err := account.Projects().List(ctx, opts)
 		if err != nil {

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -205,7 +205,17 @@ class OperationMapper:
     def __init__(self, account_client):
         self._account = account_client
 
-    def __call__(self, operation: str, *, path_params: dict, query_params: dict, body: dict | None, path: str = "", max_items: int | None = None) -> Any:
+    def __call__(
+        self,
+        operation: str,
+        *,
+        path_params: dict,
+        query_params: dict,
+        body: dict | None,
+        path: str = "",
+        max_items: int | None = None,
+        page: int | None = None,
+    ) -> Any:
         match operation:
             case "DownloadURL":
                 if not path:
@@ -213,8 +223,11 @@ class OperationMapper:
                 raw_url = "https://storage.3.basecamp.com" + path
                 return self._account.download_url(raw_url)
             case "ListProjects":
-                if max_items:
-                    return self._account.projects.list(max_items=max_items)
+                # A pinned page and a max_items cap are independent knobs;
+                # the plain no-argument arity stays exercised when the fixture
+                # carries neither.
+                if max_items or page:
+                    return self._account.projects.list(max_items=max_items, page=page)
                 return self._account.projects.list()
             case "GetProject":
                 return self._account.projects.get(project_id=path_params["projectId"])
@@ -537,6 +550,7 @@ class TestRunner:
                     body=self._test.get("requestBody"),
                     path=self._test.get("path", ""),
                     max_items=(self._test.get("configOverrides") or {}).get("maxItems"),
+                    page=(self._test.get("configOverrides") or {}).get("page"),
                 )
                 return self._verify_assertions(result=result, error=None)
             except Exception as e:

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -201,7 +201,7 @@ class OperationMapper
     @account = account_client
   end
 
-  def call(operation, path_params: {}, query_params: {}, body: nil, path: "", max_items: nil)
+  def call(operation, path_params: {}, query_params: {}, body: nil, path: "", max_items: nil, page: nil)
     case operation
     when "DownloadURL"
       raise "DownloadURL test case requires a non-empty path" if path.nil? || path.empty?
@@ -209,8 +209,13 @@ class OperationMapper
       @account.download_url(raw_url)
     when "ListProjects"
       # Returned unconsumed so the runner can consume then assert on .meta;
-      # the plain arity stays exercised when the fixture carries no maxItems.
-      max_items ? @account.projects.list(max_items: max_items) : @account.projects.list
+      # the plain arity stays exercised when the fixture carries neither a
+      # maxItems cap nor a pinned page.
+      if max_items || page
+        @account.projects.list(max_items: max_items, page: page)
+      else
+        @account.projects.list
+      end
     when "GetProject"
       @account.projects.get(project_id: path_params["projectId"])
     when "CreateProject"
@@ -588,7 +593,8 @@ class TestRunner
         query_params: @test["queryParams"] || {},
         body: @test["requestBody"],
         path: @test["path"] || "",
-        max_items: (@test["configOverrides"] || {})["maxItems"]
+        max_items: (@test["configOverrides"] || {})["maxItems"],
+        page: (@test["configOverrides"] || {})["page"]
       )
       # Consume-then-assert: pagination metadata (truncated in particular) is
       # final only after the lazy enumeration completes, and consumption is

--- a/conformance/runner/swift/Sources/ConformanceRunner/Dispatch.swift
+++ b/conformance/runner/swift/Sources/ConformanceRunner/Dispatch.swift
@@ -105,7 +105,10 @@ func dispatchOperation(_ tc: TestCase, _ account: AccountClient) async throws ->
     switch tc.operation {
     case "ListProjects":
         let maxItems = tc.configOverrides?.maxItems
-        let options = (maxItems ?? 0) > 0 ? ListProjectOptions(maxItems: maxItems) : nil
+        let page = tc.configOverrides?.page
+        let options = (maxItems ?? 0) > 0 || (page ?? 0) > 0
+            ? ListProjectOptions(page: page, maxItems: maxItems)
+            : nil
         let result = try await account.projects.list(options: options)
         return DispatchResult(totalCount: result.meta.totalCount, truncated: result.meta.truncated)
 

--- a/conformance/runner/swift/Sources/ConformanceRunner/Fixtures.swift
+++ b/conformance/runner/swift/Sources/ConformanceRunner/Fixtures.swift
@@ -152,6 +152,8 @@ struct ConfigOverrides: Decodable {
     let baseUrl: String?
     let maxPages: Int?
     let maxItems: Int?
+    /// Pins the list operation to a single page (SPEC section 8).
+    let page: Int?
 }
 
 struct MockResponse: Decodable, Sendable {

--- a/conformance/runner/swift/Sources/ConformanceRunner/Runner.swift
+++ b/conformance/runner/swift/Sources/ConformanceRunner/Runner.swift
@@ -11,6 +11,12 @@ let testAccountID = "999"
 /// widening one without the other is caught the first time a fixture asks.
 private let operationsHonoringMaxItems: Set<String> = ["ListProjects"]
 
+/// Same contract for `configOverrides.page`, which is a stronger claim: a
+/// fixture setting it asserts a SINGLE request, so an unthreaded page would
+/// let the SDK walk the whole collection while the fixture believed it had
+/// pinned one page.
+private let operationsHonoringPage: Set<String> = ["ListProjects"]
+
 /// Temporary capability skips, keyed by exact test name.
 ///
 /// EMPTY, and meant to stay that way. Swift is three-gate (status, network and
@@ -167,6 +173,10 @@ struct Runner {
         // arm and to this roster together.
         if tc.configOverrides?.maxItems != nil, !operationsHonoringMaxItems.contains(tc.operation) {
             return .fail("configOverrides.maxItems is set but \(tc.operation)'s dispatch does not thread it through — it would paginate unbounded")
+        }
+
+        if tc.configOverrides?.page != nil, !operationsHonoringPage.contains(tc.operation) {
+            return .fail("configOverrides.page is set but \(tc.operation)'s dispatch does not thread it through — it would paginate past the pinned page")
         }
 
         // Detect if the fixture uses Link next headers (SDK will auto-paginate).

--- a/conformance/runner/typescript/runner.test.ts
+++ b/conformance/runner/typescript/runner.test.ts
@@ -52,7 +52,7 @@ interface TestCase {
   mockResponses: MockResponse[];
   assertions: Assertion[];
   tags?: string[];
-  configOverrides?: { baseUrl?: string; maxPages?: number; maxItems?: number };
+  configOverrides?: { baseUrl?: string; maxPages?: number; maxItems?: number; page?: number };
   /**
    * Live tests are loaded by live-runner.test.ts; this runner ignores them.
    * Defaults to "mock" when omitted.
@@ -179,8 +179,9 @@ async function executeOperation(
     switch (tc.operation) {
       case "ListProjects": {
         const maxItems = tc.configOverrides?.maxItems;
+        const page = tc.configOverrides?.page;
         const projects = await client.projects.list(
-          maxItems ? { maxItems } : undefined,
+          maxItems || page ? { ...(maxItems ? { maxItems } : {}), ...(page ? { page } : {}) } : undefined,
         );
         return {
           meta: {

--- a/conformance/schema.json
+++ b/conformance/schema.json
@@ -181,6 +181,10 @@
         "maxItems": {
           "type": "integer",
           "description": "Override the maximum number of items to fetch across all pages"
+        },
+        "page": {
+          "type": "integer",
+          "description": "Pin the list operation to a single page. A positive value must select exactly that page: one request, no Link rel=next follow (SPEC section 8). Runners pass it through the operation's own page option, so a fixture using it needs the dispatch case to forward it."
         }
       }
     },

--- a/conformance/tests/pagination.json
+++ b/conformance/tests/pagination.json
@@ -229,5 +229,71 @@
       {"type": "responseMeta", "path": "truncated", "expected": false}
     ],
     "tags": ["pagination", "max-items"]
+  },
+  {
+    "name": "A positive page selects exactly that page",
+    "description": "Verifies SPEC section 8's page contract: page=3 issues EXACTLY one request, returns only that page's items, and does not follow Link rel=next. truncated is true because the selected page advertised a further page. The over-fetch control is the auto-follow case above, which walks a same-shaped queue in 3 requests when no page is pinned (2C.1, 2C.3, #566)",
+    "operation": "ListProjects",
+    "method": "GET",
+    "path": "/projects.json",
+    "configOverrides": {
+      "page": 3
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "headers": {
+          "Link": "</projects.json?page=4>; rel=\"next\"",
+          "X-Total-Count": "9"
+        },
+        "body": [
+          {"id": 5, "status": "active", "created_at": "2025-01-01T00:00:00Z", "updated_at": "2025-01-01T00:00:00Z", "name": "Project 5", "url": "https://3.basecampapi.com/999/projects/5.json", "app_url": "https://3.basecamp.com/999/projects/5"},
+          {"id": 6, "status": "active", "created_at": "2025-01-01T00:00:00Z", "updated_at": "2025-01-01T00:00:00Z", "name": "Project 6", "url": "https://3.basecampapi.com/999/projects/6.json", "app_url": "https://3.basecamp.com/999/projects/6"}
+        ]
+      },
+      {
+        "status": 200,
+        "body": [
+          {"id": 7, "status": "active", "created_at": "2025-01-01T00:00:00Z", "updated_at": "2025-01-01T00:00:00Z", "name": "Project 7", "url": "https://3.basecampapi.com/999/projects/7.json", "app_url": "https://3.basecamp.com/999/projects/7"},
+          {"id": 8, "status": "active", "created_at": "2025-01-01T00:00:00Z", "updated_at": "2025-01-01T00:00:00Z", "name": "Project 8", "url": "https://3.basecampapi.com/999/projects/8.json", "app_url": "https://3.basecamp.com/999/projects/8"}
+        ]
+      }
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 1},
+      {"type": "noError"},
+      {"type": "responseMeta", "path": "totalCount", "expected": 9},
+      {"type": "responseMeta", "path": "truncated", "expected": true}
+    ],
+    "tags": ["pagination", "page-selection"]
+  },
+  {
+    "name": "A pinned final page is not truncated",
+    "description": "The page contract's other half: pinning the last page (no Link rel=next) still costs exactly one request, and truncated is false because nothing beyond the returned items was available. Keeps the truncated assertion in the sibling case from passing on a hardcoded true (SPEC section 8, #566)",
+    "operation": "ListProjects",
+    "method": "GET",
+    "path": "/projects.json",
+    "configOverrides": {
+      "page": 3
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "headers": {
+          "X-Total-Count": "6"
+        },
+        "body": [
+          {"id": 5, "status": "active", "created_at": "2025-01-01T00:00:00Z", "updated_at": "2025-01-01T00:00:00Z", "name": "Project 5", "url": "https://3.basecampapi.com/999/projects/5.json", "app_url": "https://3.basecamp.com/999/projects/5"},
+          {"id": 6, "status": "active", "created_at": "2025-01-01T00:00:00Z", "updated_at": "2025-01-01T00:00:00Z", "name": "Project 6", "url": "https://3.basecampapi.com/999/projects/6.json", "app_url": "https://3.basecamp.com/999/projects/6"}
+        ]
+      }
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 1},
+      {"type": "noError"},
+      {"type": "responseMeta", "path": "totalCount", "expected": 6},
+      {"type": "responseMeta", "path": "truncated", "expected": false}
+    ],
+    "tags": ["pagination", "page-selection"]
   }
 ]

--- a/conformance/tests/pagination.json
+++ b/conformance/tests/pagination.json
@@ -295,5 +295,35 @@
       {"type": "responseMeta", "path": "truncated", "expected": false}
     ],
     "tags": ["pagination", "page-selection"]
+  },
+  {
+    "name": "A pinned page still honours the item cap",
+    "description": "page and the item cap compose: pinning page 3 with maxItems 1 costs one request and truncates, because the cap discarded an item. The page carries NO Link rel=next, so truncated can only be true by way of the cap — which is what distinguishes an SDK that applies the cap to a pinned page from one that returns the page whole (SPEC section 8, #566)",
+    "operation": "ListProjects",
+    "method": "GET",
+    "path": "/projects.json",
+    "configOverrides": {
+      "page": 3,
+      "maxItems": 1
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "headers": {
+          "X-Total-Count": "6"
+        },
+        "body": [
+          {"id": 5, "status": "active", "created_at": "2025-01-01T00:00:00Z", "updated_at": "2025-01-01T00:00:00Z", "name": "Project 5", "url": "https://3.basecampapi.com/999/projects/5.json", "app_url": "https://3.basecamp.com/999/projects/5"},
+          {"id": 6, "status": "active", "created_at": "2025-01-01T00:00:00Z", "updated_at": "2025-01-01T00:00:00Z", "name": "Project 6", "url": "https://3.basecampapi.com/999/projects/6.json", "app_url": "https://3.basecamp.com/999/projects/6"}
+        ]
+      }
+    ],
+    "assertions": [
+      {"type": "requestCount", "expected": 1},
+      {"type": "noError"},
+      {"type": "responseMeta", "path": "totalCount", "expected": 6},
+      {"type": "responseMeta", "path": "truncated", "expected": true}
+    ],
+    "tags": ["pagination", "page-selection", "max-items"]
   }
 ]

--- a/go/README.md
+++ b/go/README.md
@@ -569,8 +569,13 @@ auto-pagination:
 result, err := account.Projects().List(ctx, &basecamp.ProjectListOptions{Page: 3})
 ```
 
+A positive `Limit` still trims that page, and dropping items from it counts as
+truncation. The per-operation *default* limits (100 todos, and so on) do not
+apply to a pinned page — asking for page 3 asks for page 3, not its first 100
+items.
+
 `Meta.Truncated` still answers "was there more": on a pinned page it is true when
-the response carried a `rel="next"` Link this SDK deliberately did not follow.
+a `rel="next"` Link went deliberately unfollowed, or when `Limit` discarded items.
 
 A handful of endpoints are not paginated server-side (`Webhooks().List()`,
 `MessageTypes().List()`, and the other cases each options struct calls out); they

--- a/go/README.md
+++ b/go/README.md
@@ -569,14 +569,15 @@ auto-pagination:
 result, err := account.Projects().List(ctx, &basecamp.ProjectListOptions{Page: 3})
 ```
 
+`Meta.Truncated` still answers "was there more": on a pinned page it is true when
+the response carried a `rel="next"` Link this SDK deliberately did not follow.
+
 A handful of endpoints are not paginated server-side (`Webhooks().List()`,
 `MessageTypes().List()`, and the other cases each options struct calls out); they
 return the whole list, and `Page` there only short-circuits auto-pagination.
 
-`Page` means something different in the other five SDKs, where a positive `page`
-is a *starting offset* that link-following then continues from. Converging the
-six on Go's single-page semantics is a breaking change tracked in
-[#566](https://github.com/basecamp/basecamp-sdk/issues/566).
+All six SDKs share these semantics — one request, that page only, no
+link-following. See SPEC section 8.
 
 ## Error Handling
 

--- a/go/pkg/basecamp/bookmarks.go
+++ b/go/pkg/basecamp/bookmarks.go
@@ -72,7 +72,7 @@ func (s *BookmarksService) List(ctx context.Context, page int32) (result *Bookma
 	}
 	totalCount := parseTotalCount(resp.HTTPResponse)
 	if page > 0 {
-		return &BookmarkListResult{Bookmarks: bookmarks, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &BookmarkListResult{Bookmarks: bookmarks, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	rawMore, truncated, err := s.client.parent.followPagination(ctx, resp.HTTPResponse, len(bookmarks), 0)

--- a/go/pkg/basecamp/boosts.go
+++ b/go/pkg/basecamp/boosts.go
@@ -108,7 +108,7 @@ func (s *BoostsService) ListRecording(ctx context.Context, recordingID int64, op
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &BoostListResult{Boosts: boosts, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &BoostListResult{Boosts: boosts, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = default (50), -1 = unlimited, >0 = specific limit
@@ -198,7 +198,7 @@ func (s *BoostsService) ListEvent(ctx context.Context, recordingID, eventID int6
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &BoostListResult{Boosts: boosts, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &BoostListResult{Boosts: boosts, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = default (50), -1 = unlimited, >0 = specific limit

--- a/go/pkg/basecamp/boosts.go
+++ b/go/pkg/basecamp/boosts.go
@@ -31,8 +31,10 @@ type BoostListOptions struct {
 	// If 0, uses DefaultBoostLimit (50). Use -1 for unlimited.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 }
 
@@ -108,7 +110,8 @@ func (s *BoostsService) ListRecording(ctx context.Context, recordingID int64, op
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &BoostListResult{Boosts: boosts, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(boosts), opts.Limit, resp.HTTPResponse)
+		return &BoostListResult{Boosts: boosts[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = default (50), -1 = unlimited, >0 = specific limit
@@ -198,7 +201,8 @@ func (s *BoostsService) ListEvent(ctx context.Context, recordingID, eventID int6
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &BoostListResult{Boosts: boosts, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(boosts), opts.Limit, resp.HTTPResponse)
+		return &BoostListResult{Boosts: boosts[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = default (50), -1 = unlimited, >0 = specific limit

--- a/go/pkg/basecamp/campfires.go
+++ b/go/pkg/basecamp/campfires.go
@@ -244,7 +244,7 @@ func (s *CampfiresService) List(ctx context.Context, opts *CampfireListOptions) 
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &CampfireListResult{Campfires: campfires, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &CampfireListResult{Campfires: campfires, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (no limit)
@@ -373,7 +373,7 @@ func (s *CampfiresService) ListLines(ctx context.Context, campfireID int64, opts
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &CampfireLineListResult{Lines: lines, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &CampfireLineListResult{Lines: lines, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = default (100), -1 = unlimited, >0 = specific limit
@@ -619,7 +619,7 @@ func (s *CampfiresService) ListUploads(ctx context.Context, campfireID int64, op
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &CampfireLineListResult{Lines: lines, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &CampfireLineListResult{Lines: lines, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = default (100), -1 = unlimited, >0 = specific limit
@@ -787,7 +787,7 @@ func (s *CampfiresService) ListChatbots(ctx context.Context, bucketID, campfireI
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &ChatbotListResult{Chatbots: chatbots, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &ChatbotListResult{Chatbots: chatbots, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (default for chatbots)

--- a/go/pkg/basecamp/campfires.go
+++ b/go/pkg/basecamp/campfires.go
@@ -244,7 +244,8 @@ func (s *CampfiresService) List(ctx context.Context, opts *CampfireListOptions) 
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &CampfireListResult{Campfires: campfires, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(campfires), opts.Limit, resp.HTTPResponse)
+		return &CampfireListResult{Campfires: campfires[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (no limit)
@@ -373,7 +374,8 @@ func (s *CampfiresService) ListLines(ctx context.Context, campfireID int64, opts
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &CampfireLineListResult{Lines: lines, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(lines), opts.Limit, resp.HTTPResponse)
+		return &CampfireLineListResult{Lines: lines[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = default (100), -1 = unlimited, >0 = specific limit
@@ -619,7 +621,8 @@ func (s *CampfiresService) ListUploads(ctx context.Context, campfireID int64, op
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &CampfireLineListResult{Lines: lines, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(lines), opts.Limit, resp.HTTPResponse)
+		return &CampfireLineListResult{Lines: lines[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = default (100), -1 = unlimited, >0 = specific limit
@@ -787,7 +790,8 @@ func (s *CampfiresService) ListChatbots(ctx context.Context, bucketID, campfireI
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &ChatbotListResult{Chatbots: chatbots, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(chatbots), opts.Limit, resp.HTTPResponse)
+		return &ChatbotListResult{Chatbots: chatbots[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (default for chatbots)

--- a/go/pkg/basecamp/cards.go
+++ b/go/pkg/basecamp/cards.go
@@ -189,8 +189,10 @@ type CardListOptions struct {
 	// If 0 (default), returns all cards. Use a positive value to cap results.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 }
 
@@ -365,7 +367,8 @@ func (s *CardsService) List(ctx context.Context, columnID int64, opts *CardListO
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &CardListResult{Cards: cards, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(cards), opts.Limit, resp.HTTPResponse)
+		return &CardListResult{Cards: cards[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (default for cards), >0 = specific limit

--- a/go/pkg/basecamp/cards.go
+++ b/go/pkg/basecamp/cards.go
@@ -365,7 +365,7 @@ func (s *CardsService) List(ctx context.Context, columnID int64, opts *CardListO
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &CardListResult{Cards: cards, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &CardListResult{Cards: cards, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (default for cards), >0 = specific limit

--- a/go/pkg/basecamp/checkins.go
+++ b/go/pkg/basecamp/checkins.go
@@ -16,8 +16,10 @@ type QuestionListOptions struct {
 	// If 0 (default), returns all questions. Use a positive value to cap results.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 }
 
@@ -27,8 +29,10 @@ type AnswerListOptions struct {
 	// If 0 (default), returns all answers. Use a positive value to cap results.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 }
 
@@ -38,8 +42,10 @@ type QuestionReminderListOptions struct {
 	// If 0 (default), returns all reminders. Use a positive value to cap results.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 }
 
@@ -327,7 +333,8 @@ func (s *CheckinsService) ListQuestions(ctx context.Context, questionnaireID int
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &QuestionListResult{Questions: questions, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(questions), opts.Limit, resp.HTTPResponse)
+		return &QuestionListResult{Questions: questions[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (default for questions), >0 = specific limit
@@ -650,7 +657,8 @@ func (s *CheckinsService) ListAnswers(ctx context.Context, questionID int64, opt
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &AnswerListResult{Answers: answers, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(answers), opts.Limit, resp.HTTPResponse)
+		return &AnswerListResult{Answers: answers[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (default for answers), >0 = specific limit
@@ -732,7 +740,8 @@ func (s *CheckinsService) ListAnswersByPerson(ctx context.Context, questionID, p
 	}
 
 	if opts != nil && opts.Page > 0 {
-		return &AnswerListResult{Answers: answers, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(answers), opts.Limit, resp.HTTPResponse)
+		return &AnswerListResult{Answers: answers[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	limit := 0
@@ -805,7 +814,8 @@ func (s *CheckinsService) ListAnswerers(ctx context.Context, questionID int64, o
 	}
 
 	if opts != nil && opts.Page > 0 {
-		return &PeopleListResult{People: people, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(people), opts.Limit, resp.HTTPResponse)
+		return &PeopleListResult{People: people[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	limit := 0
@@ -1026,7 +1036,8 @@ func (s *CheckinsService) ListQuestionReminders(ctx context.Context, opts *Quest
 	}
 
 	if opts != nil && opts.Page > 0 {
-		return &QuestionReminderListResult{Reminders: reminders, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(reminders), opts.Limit, resp.HTTPResponse)
+		return &QuestionReminderListResult{Reminders: reminders[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	limit := 0

--- a/go/pkg/basecamp/checkins.go
+++ b/go/pkg/basecamp/checkins.go
@@ -327,7 +327,7 @@ func (s *CheckinsService) ListQuestions(ctx context.Context, questionnaireID int
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &QuestionListResult{Questions: questions, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &QuestionListResult{Questions: questions, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (default for questions), >0 = specific limit
@@ -650,7 +650,7 @@ func (s *CheckinsService) ListAnswers(ctx context.Context, questionID int64, opt
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &AnswerListResult{Answers: answers, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &AnswerListResult{Answers: answers, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (default for answers), >0 = specific limit
@@ -732,7 +732,7 @@ func (s *CheckinsService) ListAnswersByPerson(ctx context.Context, questionID, p
 	}
 
 	if opts != nil && opts.Page > 0 {
-		return &AnswerListResult{Answers: answers, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &AnswerListResult{Answers: answers, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	limit := 0
@@ -805,7 +805,7 @@ func (s *CheckinsService) ListAnswerers(ctx context.Context, questionID int64, o
 	}
 
 	if opts != nil && opts.Page > 0 {
-		return &PeopleListResult{People: people, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &PeopleListResult{People: people, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	limit := 0
@@ -1026,7 +1026,7 @@ func (s *CheckinsService) ListQuestionReminders(ctx context.Context, opts *Quest
 	}
 
 	if opts != nil && opts.Page > 0 {
-		return &QuestionReminderListResult{Reminders: reminders, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &QuestionReminderListResult{Reminders: reminders, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	limit := 0

--- a/go/pkg/basecamp/checkins_test.go
+++ b/go/pkg/basecamp/checkins_test.go
@@ -975,12 +975,15 @@ func TestCheckinsService_ListAnswersByPerson_Pagination(t *testing.T) {
 			wantTruncated: false,
 		},
 		{
+			// A pinned page is one request, and the rel="next" Link this
+			// call deliberately does not follow is what makes the result
+			// truncated (SPEC §8's ListMeta).
 			name:          "Page option returns first page and skips Link follow",
 			emitNextLink:  true,
 			opts:          &AnswerListOptions{Page: 1},
 			wantAnswers:   2,
 			wantRequests:  1,
-			wantTruncated: false,
+			wantTruncated: true,
 		},
 		{
 			name:          "Limit smaller than first page truncates without follow",
@@ -1279,7 +1282,7 @@ func TestCheckinsService_ListAnswerers_Pagination(t *testing.T) {
 		wantTruncated bool
 	}{
 		{"collects across pages when no limit", nil, 4, 2, false},
-		{"Page option returns first page and skips Link follow", &PeopleListOptions{Page: 1}, 2, 1, false},
+		{"Page option returns first page and skips Link follow", &PeopleListOptions{Page: 1}, 2, 1, true},
 		{"Limit smaller than first page truncates without follow", &PeopleListOptions{Limit: 1}, 1, 1, true},
 		{"Limit straddling page boundary trims second page", &PeopleListOptions{Limit: 3}, 3, 2, true},
 	}
@@ -1395,7 +1398,7 @@ func TestCheckinsService_ListQuestionReminders_Pagination(t *testing.T) {
 		wantTruncated bool
 	}{
 		{"collects across pages when no limit", nil, 4, 2, false},
-		{"Page option returns first page and skips Link follow", &QuestionReminderListOptions{Page: 1}, 2, 1, false},
+		{"Page option returns first page and skips Link follow", &QuestionReminderListOptions{Page: 1}, 2, 1, true},
 		{"Limit smaller than first page truncates without follow", &QuestionReminderListOptions{Limit: 1}, 1, 1, true},
 		{"Limit straddling page boundary trims second page", &QuestionReminderListOptions{Limit: 3}, 3, 2, true},
 	}

--- a/go/pkg/basecamp/client_approvals.go
+++ b/go/pkg/basecamp/client_approvals.go
@@ -155,7 +155,8 @@ func (s *ClientApprovalsService) List(ctx context.Context, bucketID int64, opts 
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &ClientApprovalListResult{Approvals: approvals, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(approvals), opts.Limit, resp.HTTPResponse)
+		return &ClientApprovalListResult{Approvals: approvals[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (no limit)

--- a/go/pkg/basecamp/client_approvals.go
+++ b/go/pkg/basecamp/client_approvals.go
@@ -155,7 +155,7 @@ func (s *ClientApprovalsService) List(ctx context.Context, bucketID int64, opts 
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &ClientApprovalListResult{Approvals: approvals, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &ClientApprovalListResult{Approvals: approvals, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (no limit)

--- a/go/pkg/basecamp/client_correspondences.go
+++ b/go/pkg/basecamp/client_correspondences.go
@@ -132,7 +132,7 @@ func (s *ClientCorrespondencesService) List(ctx context.Context, bucketID int64,
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &ClientCorrespondenceListResult{Correspondences: correspondences, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &ClientCorrespondenceListResult{Correspondences: correspondences, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (no limit)

--- a/go/pkg/basecamp/client_correspondences.go
+++ b/go/pkg/basecamp/client_correspondences.go
@@ -132,7 +132,8 @@ func (s *ClientCorrespondencesService) List(ctx context.Context, bucketID int64,
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &ClientCorrespondenceListResult{Correspondences: correspondences, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(correspondences), opts.Limit, resp.HTTPResponse)
+		return &ClientCorrespondenceListResult{Correspondences: correspondences[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (no limit)

--- a/go/pkg/basecamp/client_replies.go
+++ b/go/pkg/basecamp/client_replies.go
@@ -118,7 +118,7 @@ func (s *ClientRepliesService) List(ctx context.Context, bucketID, recordingID i
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &ClientReplyListResult{Replies: replies, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &ClientReplyListResult{Replies: replies, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (no limit)

--- a/go/pkg/basecamp/client_replies.go
+++ b/go/pkg/basecamp/client_replies.go
@@ -118,7 +118,8 @@ func (s *ClientRepliesService) List(ctx context.Context, bucketID, recordingID i
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &ClientReplyListResult{Replies: replies, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(replies), opts.Limit, resp.HTTPResponse)
+		return &ClientReplyListResult{Replies: replies[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (no limit)

--- a/go/pkg/basecamp/comments.go
+++ b/go/pkg/basecamp/comments.go
@@ -59,8 +59,10 @@ type CommentListOptions struct {
 	// If 0, uses DefaultCommentLimit (100). Use -1 for unlimited.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 }
 
@@ -138,7 +140,8 @@ func (s *CommentsService) List(ctx context.Context, recordingID int64, opts *Com
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &CommentListResult{Comments: comments, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(comments), opts.Limit, resp.HTTPResponse)
+		return &CommentListResult{Comments: comments[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = default (100), -1 = unlimited, >0 = specific limit

--- a/go/pkg/basecamp/comments.go
+++ b/go/pkg/basecamp/comments.go
@@ -138,7 +138,7 @@ func (s *CommentsService) List(ctx context.Context, recordingID int64, opts *Com
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &CommentListResult{Comments: comments, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &CommentListResult{Comments: comments, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = default (100), -1 = unlimited, >0 = specific limit

--- a/go/pkg/basecamp/drafts.go
+++ b/go/pkg/basecamp/drafts.go
@@ -98,7 +98,7 @@ func (s *DraftsService) List(ctx context.Context, page int32) (result *DraftList
 	}
 	totalCount := parseTotalCount(resp.HTTPResponse)
 	if page > 0 {
-		return &DraftListResult{Drafts: drafts, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &DraftListResult{Drafts: drafts, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	rawMore, truncated, err := s.client.parent.followPagination(ctx, resp.HTTPResponse, len(drafts), 0)

--- a/go/pkg/basecamp/events.go
+++ b/go/pkg/basecamp/events.go
@@ -120,7 +120,7 @@ func (s *EventsService) List(ctx context.Context, recordingID int64, opts *Event
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &EventListResult{Events: events, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &EventListResult{Events: events, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = default (100), -1 = unlimited, >0 = specific limit

--- a/go/pkg/basecamp/events.go
+++ b/go/pkg/basecamp/events.go
@@ -18,8 +18,10 @@ type EventListOptions struct {
 	// If 0, uses DefaultEventLimit (100). Use -1 for unlimited.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 }
 
@@ -120,7 +122,8 @@ func (s *EventsService) List(ctx context.Context, recordingID int64, opts *Event
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &EventListResult{Events: events, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(events), opts.Limit, resp.HTTPResponse)
+		return &EventListResult{Events: events[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = default (100), -1 = unlimited, >0 = specific limit

--- a/go/pkg/basecamp/everything.go
+++ b/go/pkg/basecamp/everything.go
@@ -261,7 +261,7 @@ func (s *EverythingService) finishRecordingsPage(ctx context.Context, httpResp *
 	}
 	totalCount := parseTotalCount(httpResp)
 	if page > 0 {
-		return &RecordingsPage{Recordings: recordings, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &RecordingsPage{Recordings: recordings, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(httpResp)}}, nil
 	}
 	rawMore, truncated, err := s.client.parent.followPagination(ctx, httpResp, len(recordings), 0)
 	if err != nil {
@@ -320,7 +320,7 @@ func (s *EverythingService) Files(ctx context.Context, page int32, opts *Everyth
 	}
 	totalCount := parseTotalCount(resp.HTTPResponse)
 	if page > 0 {
-		return &EverythingFilesPage{Files: files, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &EverythingFilesPage{Files: files, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 	rawMore, truncated, err := s.client.parent.followPagination(ctx, resp.HTTPResponse, len(files), 0)
 	if err != nil {
@@ -662,7 +662,7 @@ func (s *EverythingService) finishTodoGroupsPage(ctx context.Context, httpResp *
 	}
 	totalCount := parseTotalCount(httpResp)
 	if page > 0 {
-		return &BucketTodosGroupsPage{Groups: groups, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &BucketTodosGroupsPage{Groups: groups, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(httpResp)}}, nil
 	}
 	rawMore, truncated, err := s.client.parent.followPagination(ctx, httpResp, len(groups), 0)
 	if err != nil {
@@ -690,7 +690,7 @@ func (s *EverythingService) finishCardGroupsPage(ctx context.Context, httpResp *
 	}
 	totalCount := parseTotalCount(httpResp)
 	if page > 0 {
-		return &BucketCardsGroupsPage{Groups: groups, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &BucketCardsGroupsPage{Groups: groups, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(httpResp)}}, nil
 	}
 	rawMore, truncated, err := s.client.parent.followPagination(ctx, httpResp, len(groups), 0)
 	if err != nil {

--- a/go/pkg/basecamp/forwards.go
+++ b/go/pkg/basecamp/forwards.go
@@ -15,8 +15,10 @@ type ForwardListOptions struct {
 	// If 0 (default), returns all forwards. Use a positive value to cap results.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 
 	// Sort field: "created_at" or "updated_at".
@@ -32,8 +34,10 @@ type ForwardReplyListOptions struct {
 	// If 0 (default), returns all replies. Use a positive value to cap results.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 }
 
@@ -237,7 +241,8 @@ func (s *ForwardsService) List(ctx context.Context, inboxID int64, opts *Forward
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &ForwardListResult{Forwards: forwards, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(forwards), opts.Limit, resp.HTTPResponse)
+		return &ForwardListResult{Forwards: forwards[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (default for forwards), >0 = specific limit
@@ -357,7 +362,8 @@ func (s *ForwardsService) ListReplies(ctx context.Context, forwardID int64, opts
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &ForwardReplyListResult{Replies: replies, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(replies), opts.Limit, resp.HTTPResponse)
+		return &ForwardReplyListResult{Replies: replies[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (default for replies), >0 = specific limit

--- a/go/pkg/basecamp/forwards.go
+++ b/go/pkg/basecamp/forwards.go
@@ -237,7 +237,7 @@ func (s *ForwardsService) List(ctx context.Context, inboxID int64, opts *Forward
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &ForwardListResult{Forwards: forwards, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &ForwardListResult{Forwards: forwards, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (default for forwards), >0 = specific limit
@@ -357,7 +357,7 @@ func (s *ForwardsService) ListReplies(ctx context.Context, forwardID int64, opts
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &ForwardReplyListResult{Replies: replies, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &ForwardReplyListResult{Replies: replies, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (default for replies), >0 = specific limit

--- a/go/pkg/basecamp/gauges.go
+++ b/go/pkg/basecamp/gauges.go
@@ -103,8 +103,10 @@ type GaugeListOptions struct {
 	// If 0 (default), returns all gauges.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 }
 
@@ -122,8 +124,10 @@ type GaugeNeedleListOptions struct {
 	// If 0 (default), returns all needles.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 }
 
@@ -200,7 +204,8 @@ func (s *GaugesService) List(ctx context.Context, opts *GaugeListOptions) (resul
 
 	totalCount := parseTotalCount(resp.HTTPResponse)
 	if opts != nil && opts.Page > 0 {
-		return &GaugeListResult{Gauges: gauges, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(gauges), opts.Limit, resp.HTTPResponse)
+		return &GaugeListResult{Gauges: gauges[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	limit := 0
@@ -270,7 +275,8 @@ func (s *GaugesService) ListNeedles(ctx context.Context, projectID int64, opts *
 
 	totalCount := parseTotalCount(resp.HTTPResponse)
 	if opts != nil && opts.Page > 0 {
-		return &GaugeNeedleListResult{Needles: needles, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(needles), opts.Limit, resp.HTTPResponse)
+		return &GaugeNeedleListResult{Needles: needles[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	limit := 0

--- a/go/pkg/basecamp/gauges.go
+++ b/go/pkg/basecamp/gauges.go
@@ -97,6 +97,44 @@ type UpdateGaugeNeedleRequest struct {
 	Description *string `json:"description,omitempty"`
 }
 
+// GaugeListOptions specifies pagination for listing gauges.
+type GaugeListOptions struct {
+	// Limit is the maximum number of gauges to return.
+	// If 0 (default), returns all gauges.
+	Limit int
+
+	// Page, if positive, fetches only that page and disables auto-pagination.
+	// Use 0 to paginate through all results up to Limit.
+	Page int
+}
+
+// GaugeListResult contains the results from listing gauges.
+type GaugeListResult struct {
+	// Gauges is the list of gauges returned.
+	Gauges []Gauge
+	// Meta contains pagination metadata (total count, etc.).
+	Meta ListMeta
+}
+
+// GaugeNeedleListOptions specifies pagination for listing gauge needles.
+type GaugeNeedleListOptions struct {
+	// Limit is the maximum number of needles to return.
+	// If 0 (default), returns all needles.
+	Limit int
+
+	// Page, if positive, fetches only that page and disables auto-pagination.
+	// Use 0 to paginate through all results up to Limit.
+	Page int
+}
+
+// GaugeNeedleListResult contains the results from listing gauge needles.
+type GaugeNeedleListResult struct {
+	// Needles is the list of gauge needles returned.
+	Needles []GaugeNeedle
+	// Meta contains pagination metadata (total count, etc.).
+	Meta ListMeta
+}
+
 // GaugesService handles gauge operations.
 type GaugesService struct {
 	client *AccountClient
@@ -121,8 +159,9 @@ func decodeGaugePayload(data []byte, v any) error {
 	return json.Unmarshal(normalized, v)
 }
 
-// List returns all gauges for the account, following pagination automatically.
-func (s *GaugesService) List(ctx context.Context) (result []Gauge, err error) {
+// List returns gauges for the account, following pagination automatically.
+// A positive opts.Page returns exactly that page in a single request.
+func (s *GaugesService) List(ctx context.Context, opts *GaugeListOptions) (result *GaugeListResult, err error) {
 	op := OperationInfo{
 		Service: "Gauges", Operation: "List",
 		ResourceType: "gauge", IsMutation: false,
@@ -136,7 +175,17 @@ func (s *GaugesService) List(ctx context.Context) (result []Gauge, err error) {
 	ctx = s.client.parent.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.parent.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	resp, err := s.client.parent.gen.ListGaugesWithResponse(ctx, s.client.accountID, nil)
+	var params *generated.ListGaugesParams
+	if opts != nil && opts.Page > 0 {
+		params = &generated.ListGaugesParams{}
+		var page *int32
+		if page, err = pageParam(opts.Page); err != nil {
+			return nil, err
+		}
+		params.Page = page
+	}
+
+	resp, err := s.client.parent.gen.ListGaugesWithResponse(ctx, s.client.accountID, params)
 	if err != nil {
 		return nil, err
 	}
@@ -149,8 +198,21 @@ func (s *GaugesService) List(ctx context.Context) (result []Gauge, err error) {
 		return nil, fmt.Errorf("failed to parse gauges: %w", err)
 	}
 
+	totalCount := parseTotalCount(resp.HTTPResponse)
+	if opts != nil && opts.Page > 0 {
+		return &GaugeListResult{Gauges: gauges, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+	}
+
+	limit := 0
+	if opts != nil && opts.Limit > 0 {
+		limit = opts.Limit
+	}
+	if limit > 0 && len(gauges) >= limit {
+		return &GaugeListResult{Gauges: gauges[:limit], Meta: ListMeta{TotalCount: totalCount, Truncated: isFirstPageTruncated(resp.HTTPResponse, len(gauges), limit)}}, nil
+	}
+
 	// Follow pagination via Link headers
-	rawMore, _, err := s.client.parent.followPagination(ctx, resp.HTTPResponse, len(gauges), 0)
+	rawMore, truncated, err := s.client.parent.followPagination(ctx, resp.HTTPResponse, len(gauges), limit)
 	if err != nil {
 		return nil, err
 	}
@@ -162,11 +224,13 @@ func (s *GaugesService) List(ctx context.Context) (result []Gauge, err error) {
 		gauges = append(gauges, g)
 	}
 
-	return gauges, nil
+	return &GaugeListResult{Gauges: gauges, Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 }
 
-// ListNeedles returns all needles for a project's gauge, following pagination automatically.
-func (s *GaugesService) ListNeedles(ctx context.Context, projectID int64) (result []GaugeNeedle, err error) {
+// ListNeedles returns needles for a project's gauge, following pagination
+// automatically. A positive opts.Page returns exactly that page in a single
+// request.
+func (s *GaugesService) ListNeedles(ctx context.Context, projectID int64, opts *GaugeNeedleListOptions) (result *GaugeNeedleListResult, err error) {
 	op := OperationInfo{
 		Service: "Gauges", Operation: "ListNeedles",
 		ResourceType: "gauge_needle", IsMutation: false,
@@ -181,7 +245,17 @@ func (s *GaugesService) ListNeedles(ctx context.Context, projectID int64) (resul
 	ctx = s.client.parent.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.parent.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
-	resp, err := s.client.parent.gen.ListGaugeNeedlesWithResponse(ctx, s.client.accountID, projectID, nil)
+	var params *generated.ListGaugeNeedlesParams
+	if opts != nil && opts.Page > 0 {
+		params = &generated.ListGaugeNeedlesParams{}
+		var page *int32
+		if page, err = pageParam(opts.Page); err != nil {
+			return nil, err
+		}
+		params.Page = page
+	}
+
+	resp, err := s.client.parent.gen.ListGaugeNeedlesWithResponse(ctx, s.client.accountID, projectID, params)
 	if err != nil {
 		return nil, err
 	}
@@ -194,8 +268,21 @@ func (s *GaugesService) ListNeedles(ctx context.Context, projectID int64) (resul
 		return nil, fmt.Errorf("failed to parse gauge needles: %w", err)
 	}
 
+	totalCount := parseTotalCount(resp.HTTPResponse)
+	if opts != nil && opts.Page > 0 {
+		return &GaugeNeedleListResult{Needles: needles, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+	}
+
+	limit := 0
+	if opts != nil && opts.Limit > 0 {
+		limit = opts.Limit
+	}
+	if limit > 0 && len(needles) >= limit {
+		return &GaugeNeedleListResult{Needles: needles[:limit], Meta: ListMeta{TotalCount: totalCount, Truncated: isFirstPageTruncated(resp.HTTPResponse, len(needles), limit)}}, nil
+	}
+
 	// Follow pagination via Link headers
-	rawMore, _, err := s.client.parent.followPagination(ctx, resp.HTTPResponse, len(needles), 0)
+	rawMore, truncated, err := s.client.parent.followPagination(ctx, resp.HTTPResponse, len(needles), limit)
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +294,7 @@ func (s *GaugesService) ListNeedles(ctx context.Context, projectID int64) (resul
 		needles = append(needles, n)
 	}
 
-	return needles, nil
+	return &GaugeNeedleListResult{Needles: needles, Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 }
 
 // GetNeedle returns a single gauge needle by ID.

--- a/go/pkg/basecamp/gauges_test.go
+++ b/go/pkg/basecamp/gauges_test.go
@@ -269,3 +269,91 @@ func TestGaugesService_ListNeedles_PinnedFinalPageIsNotTruncated(t *testing.T) {
 		t.Error("expected Truncated=false: the pinned page carried no next link")
 	}
 }
+
+// Limit composes with Page rather than being ignored by it: the pinned page is
+// trimmed to an explicitly-requested Limit, and dropping items is itself
+// truncation. This is the Go half of SPEC §8's "max_items still trims the
+// pinned page" — the other five SDKs slice their single-page branch the same
+// way.
+func TestGaugesService_List_PageComposesWithLimit(t *testing.T) {
+	var requestCount int
+	svc := testGaugesServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+		// No Link header: the pinned page is the last one, so the only reason
+		// this result can be truncated is the Limit dropping an item.
+		w.WriteHeader(200)
+		w.Write([]byte(`[{"id": 1, "title": "One"}, {"id": 2, "title": "Two"}, {"id": 3, "title": "Three"}]`))
+	})
+
+	result, err := svc.List(context.Background(), &GaugeListOptions{Page: 2, Limit: 2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if requestCount != 1 {
+		t.Errorf("expected 1 HTTP request, got %d", requestCount)
+	}
+	if len(result.Gauges) != 2 {
+		t.Fatalf("expected Limit to trim the pinned page to 2 gauges, got %d", len(result.Gauges))
+	}
+	if result.Gauges[1].ID != 2 {
+		t.Errorf("expected the first 2 gauges of the page, got id %d in slot 1", result.Gauges[1].ID)
+	}
+	if !result.Meta.Truncated {
+		t.Error("expected Truncated=true: Limit discarded an item from the pinned page")
+	}
+}
+
+func TestGaugesService_ListNeedles_PageComposesWithLimit(t *testing.T) {
+	svc := testGaugesServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`[{"id": 11}, {"id": 12}, {"id": 13}]`))
+	})
+
+	result, err := svc.ListNeedles(context.Background(), 7, &GaugeNeedleListOptions{Page: 2, Limit: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Needles) != 1 {
+		t.Fatalf("expected Limit to trim the pinned page to 1 needle, got %d", len(result.Needles))
+	}
+	if !result.Meta.Truncated {
+		t.Error("expected Truncated=true: Limit discarded items from the pinned page")
+	}
+}
+
+// A page-selected result must NOT pick up a per-operation default limit: the
+// caller asked for a page, not for the first DefaultTodoLimit items of it.
+// Todos is the service with a nonzero default (100), so it is where this can
+// regress.
+func TestTodosService_List_PageIgnoresDefaultLimit(t *testing.T) {
+	const pageSize = 150
+	items := make([]string, pageSize)
+	for i := range items {
+		items[i] = fmt.Sprintf(`{"id": %d, "content": "t%d"}`, i+1, i+1)
+	}
+	body := "[" + strings.Join(items, ",") + "]"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := DefaultConfig()
+	cfg.BaseURL = server.URL
+	svc := NewClient(cfg, &StaticTokenProvider{Token: "test-token"}).ForAccount("99999").Todos()
+
+	result, err := svc.List(context.Background(), 2, &TodoListOptions{Page: 3})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.Todos) != pageSize {
+		t.Errorf("expected the whole pinned page (%d todos), got %d — DefaultTodoLimit leaked into page selection", pageSize, len(result.Todos))
+	}
+	if result.Meta.Truncated {
+		t.Error("expected Truncated=false: nothing was dropped and the page carried no next link")
+	}
+}

--- a/go/pkg/basecamp/gauges_test.go
+++ b/go/pkg/basecamp/gauges_test.go
@@ -9,7 +9,11 @@ package basecamp
 // needles.
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -124,5 +128,144 @@ func TestGauge_MarshalRoundTripsPresence(t *testing.T) {
 	}
 	if !strings.Contains(string(data), `"description_attachments":[]`) {
 		t.Errorf("expected present-empty description_attachments to encode as [], got %s", data)
+	}
+}
+
+// The gauge list surfaces took no options struct at all before #570, so `page`
+// could not reach the wire and every call walked the whole collection. These
+// tests pin the shape sibling services already had: a positive Page selects
+// exactly that page (one request, no Link follow) and reports Truncated from
+// the rel="next" Link it deliberately did not follow (SPEC §8).
+
+func testGaugesServer(t *testing.T, handler http.HandlerFunc) *GaugesService {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	cfg := DefaultConfig()
+	cfg.BaseURL = server.URL
+	client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+	return client.ForAccount("99999").Gauges()
+}
+
+func TestGaugesService_List_PageSelectsOnePage(t *testing.T) {
+	var requestCount int
+	var sawPage string
+	svc := testGaugesServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			sawPage = r.URL.Query().Get("page")
+			w.Header().Set("Link", fmt.Sprintf(`<http://%s/99999/reports/gauges.json?page=4>; rel="next"`, r.Host))
+			w.Header().Set("X-Total-Count", "9")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`[{"id": 1, "title": "One"}, {"id": 2, "title": "Two"}]`))
+	})
+
+	result, err := svc.List(context.Background(), &GaugeListOptions{Page: 3})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sawPage != "3" {
+		t.Errorf("expected page=3 on the wire, got %q", sawPage)
+	}
+	if requestCount != 1 {
+		t.Errorf("expected 1 HTTP request, got %d", requestCount)
+	}
+	if len(result.Gauges) != 2 {
+		t.Errorf("expected 2 gauges, got %d", len(result.Gauges))
+	}
+	if result.Meta.TotalCount != 9 {
+		t.Errorf("expected TotalCount 9, got %d", result.Meta.TotalCount)
+	}
+	if !result.Meta.Truncated {
+		t.Error("expected Truncated=true: the selected page advertised a next page")
+	}
+}
+
+func TestGaugesService_List_NoPageFollowsLinks(t *testing.T) {
+	var requestCount int
+	svc := testGaugesServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+		if requestCount == 1 {
+			if r.URL.Query().Get("page") != "" {
+				t.Errorf("expected no page param, got %q", r.URL.Query().Get("page"))
+			}
+			w.Header().Set("Link", fmt.Sprintf(`<http://%s/99999/reports/gauges.json?page=2>; rel="next"`, r.Host))
+			w.WriteHeader(200)
+			w.Write([]byte(`[{"id": 1, "title": "One"}]`))
+			return
+		}
+		w.WriteHeader(200)
+		w.Write([]byte(`[{"id": 2, "title": "Two"}]`))
+	})
+
+	result, err := svc.List(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if requestCount != 2 {
+		t.Errorf("expected 2 HTTP requests, got %d", requestCount)
+	}
+	if len(result.Gauges) != 2 {
+		t.Errorf("expected 2 gauges, got %d", len(result.Gauges))
+	}
+	if result.Meta.Truncated {
+		t.Error("expected Truncated=false after the walk reached the last page")
+	}
+}
+
+func TestGaugesService_ListNeedles_PageSelectsOnePage(t *testing.T) {
+	var requestCount int
+	var sawPage string
+	svc := testGaugesServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			sawPage = r.URL.Query().Get("page")
+			w.Header().Set("Link", fmt.Sprintf(`<http://%s/99999/projects/7/gauge/needles.json?page=3>; rel="next"`, r.Host))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`[{"id": 11, "type": "Gauge::Needle"}]`))
+	})
+
+	result, err := svc.ListNeedles(context.Background(), 7, &GaugeNeedleListOptions{Page: 2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sawPage != "2" {
+		t.Errorf("expected page=2 on the wire, got %q", sawPage)
+	}
+	if requestCount != 1 {
+		t.Errorf("expected 1 HTTP request, got %d", requestCount)
+	}
+	if len(result.Needles) != 1 {
+		t.Errorf("expected 1 needle, got %d", len(result.Needles))
+	}
+	if !result.Meta.Truncated {
+		t.Error("expected Truncated=true: the selected page advertised a next page")
+	}
+}
+
+func TestGaugesService_ListNeedles_PinnedFinalPageIsNotTruncated(t *testing.T) {
+	var requestCount int
+	svc := testGaugesServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		w.Write([]byte(`[{"id": 11, "type": "Gauge::Needle"}]`))
+	})
+
+	result, err := svc.ListNeedles(context.Background(), 7, &GaugeNeedleListOptions{Page: 9})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if requestCount != 1 {
+		t.Errorf("expected 1 HTTP request, got %d", requestCount)
+	}
+	if result.Meta.Truncated {
+		t.Error("expected Truncated=false: the pinned page carried no next link")
 	}
 }

--- a/go/pkg/basecamp/helpers.go
+++ b/go/pkg/basecamp/helpers.go
@@ -355,6 +355,19 @@ func pageParam(page int) (*int32, error) {
 	return ptr(int32(page)), nil // #nosec G115 -- bounded above by the MaxInt32 guard
 }
 
+// hasNextPage reports whether a response advertises a further page.
+//
+// The page-selected path uses it: a positive Page returns exactly the page the
+// caller asked for, and the rel="next" Link this SDK deliberately does not
+// follow is what makes that result truncated under SPEC §8's ListMeta ("true
+// only when items beyond those returned were available").
+func hasNextPage(resp *http.Response) bool {
+	if resp == nil {
+		return false
+	}
+	return parseNextLink(resp.Header.Get("Link")) != ""
+}
+
 // isFirstPageTruncated returns true when items were capped on the first page
 // (either the page had more items than limit, or more pages are available).
 func isFirstPageTruncated(resp *http.Response, itemCount, limit int) bool {

--- a/go/pkg/basecamp/helpers.go
+++ b/go/pkg/basecamp/helpers.go
@@ -368,6 +368,22 @@ func hasNextPage(resp *http.Response) bool {
 	return parseNextLink(resp.Header.Get("Link")) != ""
 }
 
+// pageCap reports how many items a page-selected result keeps and whether it
+// is truncated.
+//
+// Page selection returns exactly the page the caller asked for, so the
+// per-operation DEFAULT limits (DefaultTodoLimit and friends) must not apply
+// here — only a Limit the caller set explicitly, which is the same composition
+// max_items has with a pinned page in the other five SDKs (SPEC §8). Truncated
+// is true when that cap dropped items, or when the page advertised a further
+// page this SDK deliberately did not follow.
+func pageCap(count, limit int, resp *http.Response) (keep int, truncated bool) {
+	if limit > 0 && count > limit {
+		return limit, true
+	}
+	return count, hasNextPage(resp)
+}
+
 // isFirstPageTruncated returns true when items were capped on the first page
 // (either the page had more items than limit, or more pages are available).
 func isFirstPageTruncated(resp *http.Response, itemCount, limit int) bool {

--- a/go/pkg/basecamp/message_types.go
+++ b/go/pkg/basecamp/message_types.go
@@ -110,7 +110,8 @@ func (s *MessageTypesService) List(ctx context.Context, bucketID int64, opts *Me
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &MessageTypeListResult{MessageTypes: types, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(types), opts.Limit, resp.HTTPResponse)
+		return &MessageTypeListResult{MessageTypes: types[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (no limit)

--- a/go/pkg/basecamp/message_types.go
+++ b/go/pkg/basecamp/message_types.go
@@ -110,7 +110,7 @@ func (s *MessageTypesService) List(ctx context.Context, bucketID int64, opts *Me
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &MessageTypeListResult{MessageTypes: types, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &MessageTypeListResult{MessageTypes: types, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (no limit)

--- a/go/pkg/basecamp/messages.go
+++ b/go/pkg/basecamp/messages.go
@@ -178,7 +178,7 @@ func (s *MessagesService) List(ctx context.Context, boardID int64, opts *Message
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &MessageListResult{Messages: messages, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &MessageListResult{Messages: messages, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = default (100), -1 = unlimited, >0 = specific limit

--- a/go/pkg/basecamp/messages.go
+++ b/go/pkg/basecamp/messages.go
@@ -90,8 +90,10 @@ type MessageListOptions struct {
 	// If 0, uses DefaultMessageLimit (100). Use -1 for unlimited.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 }
 
@@ -178,7 +180,8 @@ func (s *MessagesService) List(ctx context.Context, boardID int64, opts *Message
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &MessageListResult{Messages: messages, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(messages), opts.Limit, resp.HTTPResponse)
+		return &MessageListResult{Messages: messages[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = default (100), -1 = unlimited, >0 = specific limit

--- a/go/pkg/basecamp/my_notifications.go
+++ b/go/pkg/basecamp/my_notifications.go
@@ -256,8 +256,7 @@ func (s *MyNotificationsService) BubbleUps(ctx context.Context, page int32) (res
 	// Truncated when the response carries a rel="next" Link (more pages exist)
 	// even though we deliberately do not follow it here.
 	if page > 0 {
-		truncated := parseNextLink(resp.HTTPResponse.Header.Get("Link")) != ""
-		return &BubbleUpsResult{BubbleUps: items, Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
+		return &BubbleUpsResult{BubbleUps: items, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	rawMore, truncated, err := s.client.parent.followPagination(ctx, resp.HTTPResponse, len(items), 0)

--- a/go/pkg/basecamp/operation_scope_test.go
+++ b/go/pkg/basecamp/operation_scope_test.go
@@ -69,7 +69,7 @@ func TestOperationProjectResourceScope(t *testing.T) {
 
 		// Group 2 — project scope only; no deeper resource id.
 		{"Gauges.ListNeedles", func(ctx context.Context, ac *AccountClient) {
-			_, _ = ac.Gauges().ListNeedles(ctx, projectID)
+			_, _ = ac.Gauges().ListNeedles(ctx, projectID, nil)
 		}, projectID, 0},
 		{"Gauges.CreateNeedle", func(ctx context.Context, ac *AccountClient) {
 			_, _ = ac.Gauges().CreateNeedle(ctx, projectID, &CreateGaugeNeedleRequest{})

--- a/go/pkg/basecamp/people.go
+++ b/go/pkg/basecamp/people.go
@@ -81,8 +81,10 @@ type PeopleListOptions struct {
 	// If 0 (default), returns all people.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	// Ignored by endpoints that are not paginated server-side (Pingable).
 	Page int
 }
@@ -158,7 +160,8 @@ func (s *PeopleService) List(ctx context.Context, opts *PeopleListOptions) (resu
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &PeopleListResult{People: people, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(people), opts.Limit, resp.HTTPResponse)
+		return &PeopleListResult{People: people[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (default for people)
@@ -364,7 +367,8 @@ func (s *PeopleService) ListProjectPeople(ctx context.Context, projectID int64, 
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &PeopleListResult{People: people, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(people), opts.Limit, resp.HTTPResponse)
+		return &PeopleListResult{People: people[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (default for people)
@@ -442,7 +446,8 @@ func (s *PeopleService) Pingable(ctx context.Context, opts *PeopleListOptions) (
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &PeopleListResult{People: people, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(people), opts.Limit, resp.HTTPResponse)
+		return &PeopleListResult{People: people[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (default for people)

--- a/go/pkg/basecamp/people.go
+++ b/go/pkg/basecamp/people.go
@@ -158,7 +158,7 @@ func (s *PeopleService) List(ctx context.Context, opts *PeopleListOptions) (resu
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &PeopleListResult{People: people, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &PeopleListResult{People: people, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (default for people)
@@ -364,7 +364,7 @@ func (s *PeopleService) ListProjectPeople(ctx context.Context, projectID int64, 
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &PeopleListResult{People: people, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &PeopleListResult{People: people, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (default for people)
@@ -442,7 +442,7 @@ func (s *PeopleService) Pingable(ctx context.Context, opts *PeopleListOptions) (
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &PeopleListResult{People: people, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &PeopleListResult{People: people, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (default for people)

--- a/go/pkg/basecamp/projects.go
+++ b/go/pkg/basecamp/projects.go
@@ -72,8 +72,10 @@ type ProjectListOptions struct {
 	// If 0 (default), returns all projects.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 }
 
@@ -183,7 +185,8 @@ func (s *ProjectsService) List(ctx context.Context, opts *ProjectListOptions) (r
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &ProjectListResult{Projects: projects, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(projects), opts.Limit, resp.HTTPResponse)
+		return &ProjectListResult{Projects: projects[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (default for projects)

--- a/go/pkg/basecamp/projects.go
+++ b/go/pkg/basecamp/projects.go
@@ -183,7 +183,7 @@ func (s *ProjectsService) List(ctx context.Context, opts *ProjectListOptions) (r
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &ProjectListResult{Projects: projects, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &ProjectListResult{Projects: projects, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (default for projects)

--- a/go/pkg/basecamp/recordings.go
+++ b/go/pkg/basecamp/recordings.go
@@ -257,7 +257,7 @@ func (s *RecordingsService) List(ctx context.Context, recordingType RecordingTyp
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &RecordingListResult{Recordings: recordings, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &RecordingListResult{Recordings: recordings, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = default (100), -1 = unlimited, >0 = specific limit

--- a/go/pkg/basecamp/recordings.go
+++ b/go/pkg/basecamp/recordings.go
@@ -144,8 +144,10 @@ type RecordingsListOptions struct {
 	// If 0, uses DefaultRecordingLimit (100). Use -1 for unlimited.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 }
 
@@ -257,7 +259,8 @@ func (s *RecordingsService) List(ctx context.Context, recordingType RecordingTyp
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &RecordingListResult{Recordings: recordings, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(recordings), opts.Limit, resp.HTTPResponse)
+		return &RecordingListResult{Recordings: recordings[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = default (100), -1 = unlimited, >0 = specific limit

--- a/go/pkg/basecamp/schedules.go
+++ b/go/pkg/basecamp/schedules.go
@@ -16,8 +16,10 @@ type ScheduleEntryListOptions struct {
 	// If 0 (default), returns all entries. Use a positive value to cap results.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 
 	// Status filters entries by status: "active", "archived", or "trashed".
@@ -259,7 +261,8 @@ func (s *SchedulesService) ListEntries(ctx context.Context, scheduleID int64, op
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &ScheduleEntryListResult{Entries: entries, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(entries), opts.Limit, resp.HTTPResponse)
+		return &ScheduleEntryListResult{Entries: entries[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (default for entries), >0 = specific limit

--- a/go/pkg/basecamp/schedules.go
+++ b/go/pkg/basecamp/schedules.go
@@ -259,7 +259,7 @@ func (s *SchedulesService) ListEntries(ctx context.Context, scheduleID int64, op
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &ScheduleEntryListResult{Entries: entries, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &ScheduleEntryListResult{Entries: entries, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (default for entries), >0 = specific limit

--- a/go/pkg/basecamp/search.go
+++ b/go/pkg/basecamp/search.go
@@ -264,7 +264,8 @@ func (s *SearchService) Search(ctx context.Context, query string, opts *SearchOp
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &SearchListResult{Results: searchResults, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(searchResults), opts.Limit, resp.HTTPResponse)
+		return &SearchListResult{Results: searchResults[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (default for search)

--- a/go/pkg/basecamp/search.go
+++ b/go/pkg/basecamp/search.go
@@ -264,7 +264,7 @@ func (s *SearchService) Search(ctx context.Context, query string, opts *SearchOp
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &SearchListResult{Results: searchResults, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &SearchListResult{Results: searchResults, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (default for search)

--- a/go/pkg/basecamp/templates.go
+++ b/go/pkg/basecamp/templates.go
@@ -134,7 +134,8 @@ func (s *TemplatesService) List(ctx context.Context, opts *TemplateListOptions) 
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &TemplateListResult{Templates: templates, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(templates), opts.Limit, resp.HTTPResponse)
+		return &TemplateListResult{Templates: templates[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (no limit)

--- a/go/pkg/basecamp/templates.go
+++ b/go/pkg/basecamp/templates.go
@@ -134,7 +134,7 @@ func (s *TemplatesService) List(ctx context.Context, opts *TemplateListOptions) 
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &TemplateListResult{Templates: templates, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &TemplateListResult{Templates: templates, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (no limit)

--- a/go/pkg/basecamp/timeline.go
+++ b/go/pkg/basecamp/timeline.go
@@ -203,7 +203,7 @@ func (s *TimelineService) Progress(ctx context.Context, opts *TimelineListOption
 	}
 
 	if opts != nil && opts.Page > 0 {
-		return &TimelineListResult{Events: events, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &TimelineListResult{Events: events, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	limit := DefaultTimelineLimit
@@ -286,7 +286,7 @@ func (s *TimelineService) ProjectTimeline(ctx context.Context, projectID int64, 
 	}
 
 	if opts != nil && opts.Page > 0 {
-		return &TimelineListResult{Events: events, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &TimelineListResult{Events: events, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	limit := DefaultTimelineLimit
@@ -381,7 +381,7 @@ func (s *TimelineService) PersonProgress(ctx context.Context, personID int64, op
 	}
 
 	if opts != nil && opts.Page > 0 {
-		return &PersonProgressResult{Person: person, Events: events, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &PersonProgressResult{Person: person, Events: events, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	limit := DefaultTimelineLimit

--- a/go/pkg/basecamp/timeline.go
+++ b/go/pkg/basecamp/timeline.go
@@ -122,8 +122,10 @@ type TimelineListOptions struct {
 	// If 0, uses DefaultTimelineLimit (100). Any negative value means unlimited.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 }
 
@@ -203,7 +205,8 @@ func (s *TimelineService) Progress(ctx context.Context, opts *TimelineListOption
 	}
 
 	if opts != nil && opts.Page > 0 {
-		return &TimelineListResult{Events: events, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(events), opts.Limit, resp.HTTPResponse)
+		return &TimelineListResult{Events: events[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	limit := DefaultTimelineLimit
@@ -286,7 +289,8 @@ func (s *TimelineService) ProjectTimeline(ctx context.Context, projectID int64, 
 	}
 
 	if opts != nil && opts.Page > 0 {
-		return &TimelineListResult{Events: events, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(events), opts.Limit, resp.HTTPResponse)
+		return &TimelineListResult{Events: events[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	limit := DefaultTimelineLimit
@@ -381,7 +385,8 @@ func (s *TimelineService) PersonProgress(ctx context.Context, personID int64, op
 	}
 
 	if opts != nil && opts.Page > 0 {
-		return &PersonProgressResult{Person: person, Events: events, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(events), opts.Limit, resp.HTTPResponse)
+		return &PersonProgressResult{Person: person, Events: events[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	limit := DefaultTimelineLimit

--- a/go/pkg/basecamp/timesheet.go
+++ b/go/pkg/basecamp/timesheet.go
@@ -200,7 +200,7 @@ func (s *TimesheetService) ProjectReport(ctx context.Context, projectID int64, o
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &TimesheetListResult{Entries: entries, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &TimesheetListResult{Entries: entries, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (default for timesheet entries)
@@ -293,7 +293,7 @@ func (s *TimesheetService) RecordingReport(ctx context.Context, recordingID int6
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &TimesheetListResult{Entries: entries, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &TimesheetListResult{Entries: entries, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (default for timesheet entries)

--- a/go/pkg/basecamp/timesheet.go
+++ b/go/pkg/basecamp/timesheet.go
@@ -200,7 +200,8 @@ func (s *TimesheetService) ProjectReport(ctx context.Context, projectID int64, o
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &TimesheetListResult{Entries: entries, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(entries), opts.Limit, resp.HTTPResponse)
+		return &TimesheetListResult{Entries: entries[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (default for timesheet entries)
@@ -293,7 +294,8 @@ func (s *TimesheetService) RecordingReport(ctx context.Context, recordingID int6
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &TimesheetListResult{Entries: entries, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(entries), opts.Limit, resp.HTTPResponse)
+		return &TimesheetListResult{Entries: entries[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (default for timesheet entries)

--- a/go/pkg/basecamp/todolist_groups.go
+++ b/go/pkg/basecamp/todolist_groups.go
@@ -146,7 +146,7 @@ func (s *TodolistGroupsService) List(ctx context.Context, todolistID int64, opts
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &TodolistGroupListResult{Groups: groups, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &TodolistGroupListResult{Groups: groups, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (no limit)

--- a/go/pkg/basecamp/todolist_groups.go
+++ b/go/pkg/basecamp/todolist_groups.go
@@ -146,7 +146,8 @@ func (s *TodolistGroupsService) List(ctx context.Context, todolistID int64, opts
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &TodolistGroupListResult{Groups: groups, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(groups), opts.Limit, resp.HTTPResponse)
+		return &TodolistGroupListResult{Groups: groups[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (no limit)

--- a/go/pkg/basecamp/todolists.go
+++ b/go/pkg/basecamp/todolists.go
@@ -238,7 +238,7 @@ func (s *TodolistsService) List(ctx context.Context, todosetID int64, opts *Todo
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &TodolistListResult{Todolists: todolists, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &TodolistListResult{Todolists: todolists, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (default for todolists), >0 = specific limit

--- a/go/pkg/basecamp/todolists.go
+++ b/go/pkg/basecamp/todolists.go
@@ -67,8 +67,10 @@ type TodolistListOptions struct {
 	// If 0 (default), returns all todolists. Use a positive value to cap results.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 }
 
@@ -238,7 +240,8 @@ func (s *TodolistsService) List(ctx context.Context, todosetID int64, opts *Todo
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &TodolistListResult{Todolists: todolists, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(todolists), opts.Limit, resp.HTTPResponse)
+		return &TodolistListResult{Todolists: todolists[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (default for todolists), >0 = specific limit

--- a/go/pkg/basecamp/todos.go
+++ b/go/pkg/basecamp/todos.go
@@ -424,7 +424,7 @@ func (s *TodosService) List(ctx context.Context, todolistID int64, opts *TodoLis
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &TodoListResult{Todos: todos, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &TodoListResult{Todos: todos, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = default (100), -1 = unlimited, >0 = specific limit

--- a/go/pkg/basecamp/todos.go
+++ b/go/pkg/basecamp/todos.go
@@ -193,8 +193,10 @@ type TodoListOptions struct {
 	// If 0, uses DefaultTodoLimit (100). Use -1 for unlimited.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 }
 
@@ -424,7 +426,8 @@ func (s *TodosService) List(ctx context.Context, todolistID int64, opts *TodoLis
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &TodoListResult{Todos: todos, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(todos), opts.Limit, resp.HTTPResponse)
+		return &TodoListResult{Todos: todos[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = default (100), -1 = unlimited, >0 = specific limit

--- a/go/pkg/basecamp/vaults.go
+++ b/go/pkg/basecamp/vaults.go
@@ -16,8 +16,10 @@ type VaultListOptions struct {
 	// If 0 (default), returns all vaults. Use a positive value to cap results.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 }
 
@@ -35,8 +37,10 @@ type DocumentListOptions struct {
 	// If 0 (default), returns all documents. Use a positive value to cap results.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 }
 
@@ -54,8 +58,10 @@ type UploadListOptions struct {
 	// If 0 (default), returns all uploads. Use a positive value to cap results.
 	Limit int
 
-	// Page, if positive, fetches only that page and disables auto-pagination.
-	// Use 0 to paginate through all results up to Limit.
+	// Page, if positive, fetches only that page and disables auto-pagination:
+	// exactly one request, no Link rel="next" follow (SPEC §8). A positive
+	// Limit still trims that page; the per-operation default limit does not
+	// apply to it. Use 0 to paginate through all results up to Limit.
 	Page int
 }
 
@@ -333,7 +339,8 @@ func (s *VaultsService) List(ctx context.Context, vaultID int64, opts *VaultList
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &VaultListResult{Vaults: vaults, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(vaults), opts.Limit, resp.HTTPResponse)
+		return &VaultListResult{Vaults: vaults[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (default for vaults), >0 = specific limit
@@ -565,7 +572,8 @@ func (s *DocumentsService) List(ctx context.Context, vaultID int64, opts *Docume
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &DocumentListResult{Documents: documents, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(documents), opts.Limit, resp.HTTPResponse)
+		return &DocumentListResult{Documents: documents[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (default for documents), >0 = specific limit
@@ -768,7 +776,8 @@ func (s *UploadsService) List(ctx context.Context, vaultID int64, opts *UploadLi
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &UploadListResult{Uploads: uploads, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(uploads), opts.Limit, resp.HTTPResponse)
+		return &UploadListResult{Uploads: uploads[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (default for uploads), >0 = specific limit
@@ -984,7 +993,8 @@ func (s *UploadsService) ListVersions(ctx context.Context, uploadID int64, opts 
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &UploadVersionListResult{Versions: versions, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(versions), opts.Limit, resp.HTTPResponse)
+		return &UploadVersionListResult{Versions: versions[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (default for versions)

--- a/go/pkg/basecamp/vaults.go
+++ b/go/pkg/basecamp/vaults.go
@@ -333,7 +333,7 @@ func (s *VaultsService) List(ctx context.Context, vaultID int64, opts *VaultList
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &VaultListResult{Vaults: vaults, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &VaultListResult{Vaults: vaults, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (default for vaults), >0 = specific limit
@@ -565,7 +565,7 @@ func (s *DocumentsService) List(ctx context.Context, vaultID int64, opts *Docume
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &DocumentListResult{Documents: documents, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &DocumentListResult{Documents: documents, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (default for documents), >0 = specific limit
@@ -768,7 +768,7 @@ func (s *UploadsService) List(ctx context.Context, vaultID int64, opts *UploadLi
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &UploadListResult{Uploads: uploads, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &UploadListResult{Uploads: uploads, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (default for uploads), >0 = specific limit
@@ -984,7 +984,7 @@ func (s *UploadsService) ListVersions(ctx context.Context, uploadID int64, opts 
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &UploadVersionListResult{Versions: versions, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &UploadVersionListResult{Versions: versions, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (default for versions)

--- a/go/pkg/basecamp/webhooks.go
+++ b/go/pkg/basecamp/webhooks.go
@@ -140,7 +140,7 @@ func (s *WebhooksService) List(ctx context.Context, bucketID int64, opts *Webhoo
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &WebhookListResult{Webhooks: webhooks, Meta: ListMeta{TotalCount: totalCount}}, nil
+		return &WebhookListResult{Webhooks: webhooks, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
 	}
 
 	// Determine limit: 0 = all (no limit)

--- a/go/pkg/basecamp/webhooks.go
+++ b/go/pkg/basecamp/webhooks.go
@@ -140,7 +140,8 @@ func (s *WebhooksService) List(ctx context.Context, bucketID int64, opts *Webhoo
 
 	// Handle single page fetch (--page flag)
 	if opts != nil && opts.Page > 0 {
-		return &WebhookListResult{Webhooks: webhooks, Meta: ListMeta{TotalCount: totalCount, Truncated: hasNextPage(resp.HTTPResponse)}}, nil
+		keep, truncated := pageCap(len(webhooks), opts.Limit, resp.HTTPResponse)
+		return &WebhookListResult{Webhooks: webhooks[:keep], Meta: ListMeta{TotalCount: totalCount, Truncated: truncated}}, nil
 	}
 
 	// Determine limit: 0 = all (no limit)

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -572,19 +572,19 @@ allProjects.forEach { println(it.name) }
 
 ### The `page` option
 
-`page` sets where the walk *starts*, not which single page you get. Link-following
-continues from there to the end of the collection, so `page = 3` against a 10-page
-collection returns pages 3–10 concatenated. Pair it with `maxItems` to bound the
-result:
+A positive `page` selects exactly that page: one request, that page's items,
+no link-following.
 
 ```kotlin
-val fromPage3 = account.projects.list(ListProjectsOptions(page = 3, maxItems = 50))
+val pageThree = account.projects.list(ListProjectsOptions(page = 3))
+println(pageThree.meta.truncated) // true when a further page existed
 ```
 
-This differs from the Go SDK, where a positive `Page` fetches exactly that page
-and turns auto-pagination off. Converging the six SDKs on Go's single-page
-semantics is a breaking change tracked in
-[#566](https://github.com/basecamp/basecamp-sdk/issues/566).
+Omit `page` (or pass `0`) to auto-paginate the whole collection. `maxItems`
+still trims a pinned page.
+
+All six SDKs share these semantics — one request, that page only, no
+link-following. See SPEC section 8.
 
 ## Retry Behavior
 

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
@@ -122,6 +122,8 @@ data class ConfigOverrides(
     val baseUrl: String? = null,
     val maxPages: Int? = null,
     val maxItems: Int? = null,
+    /** Pins the list operation to a single page (SPEC §8). */
+    val page: Long? = null,
 )
 
 @kotlinx.serialization.Serializable
@@ -686,8 +688,9 @@ private suspend fun dispatchOperation(tc: TestCase, account: AccountClient): Dis
     return when (tc.operation) {
         "ListProjects" -> {
             val maxItems = tc.configOverrides?.maxItems
-            val opts = if (maxItems != null && maxItems > 0) {
-                ListProjectsOptions(maxItems = maxItems)
+            val page = tc.configOverrides?.page
+            val opts = if ((maxItems != null && maxItems > 0) || (page != null && page > 0)) {
+                ListProjectsOptions(maxItems = maxItems, page = page)
             } else null
             val result = account.projects.list(opts)
             DispatchResult(totalCount = result.meta.totalCount, truncated = result.meta.truncated)

--- a/kotlin/generator/src/main/kotlin/com/basecamp/sdk/generator/ServiceEmitter.kt
+++ b/kotlin/generator/src/main/kotlin/com/basecamp/sdk/generator/ServiceEmitter.kt
@@ -256,7 +256,13 @@ class ServiceEmitter(private val api: OpenApiParser) {
         val declared = buildParams(op).split(", ").filter { it.isNotEmpty() }
         // Reuse the primary signature minus its trailing options parameter.
         val paramDecls = declared.dropLast(1) + "options: PaginationOptions? = null"
-        val forwarded = (leading + "$optionsClassName(maxItems = options?.maxItems)").joinToString(", ")
+        // `page` rides across too when the operation declares one: PaginationOptions
+        // gained it in #566, and dropping it here would hand the compat overload
+        // the exact bug that issue fixed — a pinned page auto-paginating the whole
+        // collection because neither the query string nor the pagination options
+        // ever saw it.
+        val pageArg = if (op.queryParams.any { !it.required && it.name == "page" }) ", page = options?.page" else ""
+        val forwarded = (leading + "$optionsClassName(maxItems = options?.maxItems$pageArg)").joinToString(", ")
 
         val sb = StringBuilder()
         sb.appendLine()

--- a/kotlin/generator/src/main/kotlin/com/basecamp/sdk/generator/TypeEmitter.kt
+++ b/kotlin/generator/src/main/kotlin/com/basecamp/sdk/generator/TypeEmitter.kt
@@ -160,9 +160,15 @@ class TypeEmitter(private val paramOrder: Map<String, List<String>> = emptyMap()
         sb.appendLine(order.map { declarations.getValue(it) }.joinToString(",\n"))
         sb.appendLine(") {")
 
-        // Convert to PaginationOptions if needed
+        // Convert to PaginationOptions if needed. A `page` query param is
+        // carried across too: BaseService needs it to know the caller pinned a
+        // single page and must not follow Link headers (SPEC §8).
         if (hasPagination) {
-            sb.appendLine("    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)")
+            val pageArg = if (optionalParams.any { it.name == "page" }) ", page = page" else ""
+            sb.appendLine(
+                "    fun toPaginationOptions(): PaginationOptions = " +
+                    "PaginationOptions(maxItems = maxItems$pageArg)"
+            )
         }
 
         sb.appendLine("}")

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Pagination.kt
@@ -24,6 +24,17 @@ data class PaginationOptions(
      * When null or 0, all pages are fetched.
      */
     val maxItems: Int? = null,
+    /**
+     * Selects a single page. A positive [page] returns exactly that page in
+     * exactly one request: `Link: rel="next"` is not followed, and
+     * [ListMeta.truncated] reports whether a further page existed. When null,
+     * 0, or negative, auto-pagination walks the whole collection.
+     *
+     * Only meaningful for operations whose endpoint honors `?page=`; the few
+     * list endpoints that return their whole collection at once never emit a
+     * next link, so pinning a page there changes nothing. See SPEC section 8.
+     */
+    val page: Long? = null,
 )
 
 /**

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/Types.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/Types.kt
@@ -21,7 +21,7 @@ data class ListMyBookmarksOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for ListRecordingBoosts. */
@@ -30,7 +30,7 @@ data class ListRecordingBoostsOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for CreateRecordingBoost. */
@@ -44,7 +44,7 @@ data class ListEventBoostsOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for CreateEventBoost. */
@@ -75,7 +75,7 @@ data class ListCampfiresOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for ListCampfireLines. */
@@ -88,7 +88,7 @@ data class ListCampfireLinesOptions(
     /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
     val page: Long? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for CreateCampfireLine. */
@@ -112,7 +112,7 @@ data class ListCampfireUploadsOptions(
     /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
     val page: Long? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for SetCardColumnColor. */
@@ -184,7 +184,7 @@ data class ListCardsOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for CreateCard. */
@@ -201,7 +201,7 @@ data class GetQuestionRemindersOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for UpdateAnswer. */
@@ -216,7 +216,7 @@ data class ListQuestionsOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for CreateQuestion. */
@@ -239,7 +239,7 @@ data class ListAnswersOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for CreateAnswer. */
@@ -254,7 +254,7 @@ data class GetAnswersByPersonOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for UpdateQuestionNotificationSettings. */
@@ -273,7 +273,7 @@ data class ListClientApprovalsOptions(
     /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
     val page: Long? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for ListClientCorrespondences. */
@@ -286,7 +286,7 @@ data class ListClientCorrespondencesOptions(
     /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
     val page: Long? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for ListClientReplies. */
@@ -295,7 +295,7 @@ data class ListClientRepliesOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for SetClientVisibility. */
@@ -314,7 +314,7 @@ data class ListCommentsOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for CreateComment. */
@@ -334,7 +334,7 @@ data class ListDocumentsOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for CreateDocument. */
@@ -352,7 +352,7 @@ data class ListMyDraftsOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for ListEvents. */
@@ -361,7 +361,7 @@ data class ListEventsOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for GetEverythingCompletedCards. */
@@ -374,7 +374,7 @@ data class GetEverythingCompletedCardsOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for GetEverythingNoDueDateCards. */
@@ -387,7 +387,7 @@ data class GetEverythingNoDueDateCardsOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for GetEverythingNotNowCards. */
@@ -400,7 +400,7 @@ data class GetEverythingNotNowCardsOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for GetEverythingOpenCards. */
@@ -413,7 +413,7 @@ data class GetEverythingOpenCardsOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for GetEverythingOverdueCards. */
@@ -435,7 +435,7 @@ data class GetEverythingUnassignedCardsOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for GetEverythingCheckins. */
@@ -444,7 +444,7 @@ data class GetEverythingCheckinsOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for GetEverythingComments. */
@@ -453,7 +453,7 @@ data class GetEverythingCommentsOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for GetEverythingFiles. */
@@ -466,7 +466,7 @@ data class GetEverythingFilesOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for GetEverythingForwards. */
@@ -475,7 +475,7 @@ data class GetEverythingForwardsOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for GetEverythingMessages. */
@@ -484,7 +484,7 @@ data class GetEverythingMessagesOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for GetEverythingCompletedTodos. */
@@ -497,7 +497,7 @@ data class GetEverythingCompletedTodosOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for GetEverythingNoDueDateTodos. */
@@ -510,7 +510,7 @@ data class GetEverythingNoDueDateTodosOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for GetEverythingOpenTodos. */
@@ -523,7 +523,7 @@ data class GetEverythingOpenTodosOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for GetEverythingOverdueTodos. */
@@ -545,7 +545,7 @@ data class GetEverythingUnassignedTodosOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for CreateFolder. */
@@ -565,7 +565,7 @@ data class ListForwardRepliesOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for ListForwards. */
@@ -578,7 +578,7 @@ data class ListForwardsOptions(
     /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
     val page: Long? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for UpdateGaugeNeedle. */
@@ -597,7 +597,7 @@ data class ListGaugeNeedlesOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for CreateGaugeNeedle. */
@@ -615,7 +615,7 @@ data class ListGaugesOptions(
     /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
     val page: Long? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for UpdateHillChartSettings. */
@@ -658,7 +658,7 @@ data class ListMessagesOptions(
     /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
     val page: Long? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for CreateMessage. */
@@ -717,7 +717,7 @@ data class GetBubbleUpsOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for MarkAsRead. */
@@ -748,7 +748,7 @@ data class ListPeopleOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for EnableOutOfOffice. */
@@ -762,7 +762,7 @@ data class ListProjectPeopleOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for UpdateProjectAccess. */
@@ -780,7 +780,7 @@ data class ListProjectsOptions(
     /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
     val page: Long? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for CreateProject. */
@@ -810,7 +810,7 @@ data class ListRecordingsOptions(
     /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
     val page: Long? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for GetProgressReport. */
@@ -819,7 +819,7 @@ data class GetProgressReportOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for GetUpcomingSchedule. */
@@ -842,7 +842,7 @@ data class GetPersonProgressOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for UpdateScheduleEntry. */
@@ -869,7 +869,7 @@ data class ListScheduleEntriesOptions(
     /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
     val page: Long? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for CreateScheduleEntry. */
@@ -911,7 +911,7 @@ data class SearchOptions(
     /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
     val page: Long? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for UpdateSubscription. */
@@ -928,7 +928,7 @@ data class ListTemplatesOptions(
     /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
     val page: Long? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for CreateTemplate. */
@@ -954,7 +954,7 @@ data class GetProjectTimelineOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for GetProjectTimesheet. */
@@ -966,7 +966,7 @@ data class GetProjectTimesheetOptions(
     /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
     val page: Long? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Options for GetRecordingTimesheet. */
@@ -978,7 +978,7 @@ data class GetRecordingTimesheetOptions(
     /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
     val page: Long? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for CreateTimesheetEntry. */
@@ -1016,7 +1016,7 @@ data class ListTodolistGroupsOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for CreateTodolistGroup. */
@@ -1043,7 +1043,7 @@ data class ListTodolistsOptions(
     /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
     val page: Long? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for CreateTodolist. */
@@ -1073,7 +1073,7 @@ data class ListTodosOptions(
     /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
     val page: Long? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for CreateTodo. */
@@ -1133,7 +1133,7 @@ data class ListUploadsOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for CreateUpload. */
@@ -1156,7 +1156,7 @@ data class ListVaultsOptions(
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
-    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems)
+    fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
 }
 
 /** Request body for CreateVault. */

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/boosts.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/boosts.kt
@@ -85,7 +85,7 @@ class BoostsService(client: AccountClient) : BaseService(client) {
      * [listForRecording] needs an expected type to disambiguate.
      */
     suspend fun listForRecording(recordingId: Long, options: PaginationOptions? = null): ListResult<Boost> =
-        listForRecording(recordingId, ListRecordingBoostsOptions(maxItems = options?.maxItems))
+        listForRecording(recordingId, ListRecordingBoostsOptions(maxItems = options?.maxItems, page = options?.page))
 
     /**
      * Create a boost on a recording
@@ -146,7 +146,7 @@ class BoostsService(client: AccountClient) : BaseService(client) {
      * [listForEvent] needs an expected type to disambiguate.
      */
     suspend fun listForEvent(recordingId: Long, eventId: Long, options: PaginationOptions? = null): ListResult<Boost> =
-        listForEvent(recordingId, eventId, ListEventBoostsOptions(maxItems = options?.maxItems))
+        listForEvent(recordingId, eventId, ListEventBoostsOptions(maxItems = options?.maxItems, page = options?.page))
 
     /**
      * Create a boost on a specific event within a recording

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/campfires.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/campfires.kt
@@ -161,7 +161,7 @@ class CampfiresService(client: AccountClient) : BaseService(client) {
      * [list] needs an expected type to disambiguate.
      */
     suspend fun list(options: PaginationOptions? = null): ListResult<Campfire> =
-        list(ListCampfiresOptions(maxItems = options?.maxItems))
+        list(ListCampfiresOptions(maxItems = options?.maxItems, page = options?.page))
 
     /**
      * Get a campfire by ID

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/cards.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/cards.kt
@@ -115,7 +115,7 @@ open class CardsService(client: AccountClient) : BaseService(client) {
      * [list] needs an expected type to disambiguate.
      */
     suspend fun list(columnId: Long, options: PaginationOptions? = null): ListResult<Card> =
-        list(columnId, ListCardsOptions(maxItems = options?.maxItems))
+        list(columnId, ListCardsOptions(maxItems = options?.maxItems, page = options?.page))
 
     /**
      * Create a card in a column

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/checkins.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/checkins.kt
@@ -46,7 +46,7 @@ class CheckinsService(client: AccountClient) : BaseService(client) {
      * [reminders] needs an expected type to disambiguate.
      */
     suspend fun reminders(options: PaginationOptions? = null): ListResult<JsonElement> =
-        reminders(GetQuestionRemindersOptions(maxItems = options?.maxItems))
+        reminders(GetQuestionRemindersOptions(maxItems = options?.maxItems, page = options?.page))
 
     /**
      * Get a single answer by id
@@ -145,7 +145,7 @@ class CheckinsService(client: AccountClient) : BaseService(client) {
      * [listQuestions] needs an expected type to disambiguate.
      */
     suspend fun listQuestions(questionnaireId: Long, options: PaginationOptions? = null): ListResult<Question> =
-        listQuestions(questionnaireId, ListQuestionsOptions(maxItems = options?.maxItems))
+        listQuestions(questionnaireId, ListQuestionsOptions(maxItems = options?.maxItems, page = options?.page))
 
     /**
      * Create a new question in a questionnaire
@@ -252,7 +252,7 @@ class CheckinsService(client: AccountClient) : BaseService(client) {
      * [listAnswers] needs an expected type to disambiguate.
      */
     suspend fun listAnswers(questionId: Long, options: PaginationOptions? = null): ListResult<Answer> =
-        listAnswers(questionId, ListAnswersOptions(maxItems = options?.maxItems))
+        listAnswers(questionId, ListAnswersOptions(maxItems = options?.maxItems, page = options?.page))
 
     /**
      * Create a new answer for a question
@@ -335,7 +335,7 @@ class CheckinsService(client: AccountClient) : BaseService(client) {
      * [byPerson] needs an expected type to disambiguate.
      */
     suspend fun byPerson(questionId: Long, personId: Long, options: PaginationOptions? = null): ListResult<Answer> =
-        byPerson(questionId, personId, GetAnswersByPersonOptions(maxItems = options?.maxItems))
+        byPerson(questionId, personId, GetAnswersByPersonOptions(maxItems = options?.maxItems, page = options?.page))
 
     /**
      * Update notification settings for a check-in question

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/client-replies.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/client-replies.kt
@@ -48,7 +48,7 @@ class ClientRepliesService(client: AccountClient) : BaseService(client) {
      * [list] needs an expected type to disambiguate.
      */
     suspend fun list(bucketId: Long, recordingId: Long, options: PaginationOptions? = null): ListResult<ClientReply> =
-        list(bucketId, recordingId, ListClientRepliesOptions(maxItems = options?.maxItems))
+        list(bucketId, recordingId, ListClientRepliesOptions(maxItems = options?.maxItems, page = options?.page))
 
     /**
      * Get a single client reply by id

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/comments.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/comments.kt
@@ -90,7 +90,7 @@ class CommentsService(client: AccountClient) : BaseService(client) {
      * [list] needs an expected type to disambiguate.
      */
     suspend fun list(recordingId: Long, options: PaginationOptions? = null): ListResult<Comment> =
-        list(recordingId, ListCommentsOptions(maxItems = options?.maxItems))
+        list(recordingId, ListCommentsOptions(maxItems = options?.maxItems, page = options?.page))
 
     /**
      * Create a new comment on a recording

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/documents.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/documents.kt
@@ -91,7 +91,7 @@ open class DocumentsService(client: AccountClient) : BaseService(client) {
      * [list] needs an expected type to disambiguate.
      */
     suspend fun list(vaultId: Long, options: PaginationOptions? = null): ListResult<Document> =
-        list(vaultId, ListDocumentsOptions(maxItems = options?.maxItems))
+        list(vaultId, ListDocumentsOptions(maxItems = options?.maxItems, page = options?.page))
 
     /**
      * Create a new document in a vault

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/events.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/events.kt
@@ -47,5 +47,5 @@ class EventsService(client: AccountClient) : BaseService(client) {
      * [list] needs an expected type to disambiguate.
      */
     suspend fun list(recordingId: Long, options: PaginationOptions? = null): ListResult<Event> =
-        list(recordingId, ListEventsOptions(maxItems = options?.maxItems))
+        list(recordingId, ListEventsOptions(maxItems = options?.maxItems, page = options?.page))
 }

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/forwards.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/forwards.kt
@@ -67,7 +67,7 @@ class ForwardsService(client: AccountClient) : BaseService(client) {
      * [listReplies] needs an expected type to disambiguate.
      */
     suspend fun listReplies(forwardId: Long, options: PaginationOptions? = null): ListResult<ForwardReply> =
-        listReplies(forwardId, ListForwardRepliesOptions(maxItems = options?.maxItems))
+        listReplies(forwardId, ListForwardRepliesOptions(maxItems = options?.maxItems, page = options?.page))
 
     /**
      * Get a forward reply by ID

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/gauges.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/gauges.kt
@@ -129,7 +129,7 @@ class GaugesService(client: AccountClient) : BaseService(client) {
      * [listGaugeNeedles] needs an expected type to disambiguate.
      */
     suspend fun listGaugeNeedles(projectId: Long, options: PaginationOptions? = null): ListResult<JsonElement> =
-        listGaugeNeedles(projectId, ListGaugeNeedlesOptions(maxItems = options?.maxItems))
+        listGaugeNeedles(projectId, ListGaugeNeedlesOptions(maxItems = options?.maxItems, page = options?.page))
 
     /**
      * Create a gauge needle (progress update) for a project

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/people.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/people.kt
@@ -153,7 +153,7 @@ class PeopleService(client: AccountClient) : BaseService(client) {
      * [list] needs an expected type to disambiguate.
      */
     suspend fun list(options: PaginationOptions? = null): ListResult<Person> =
-        list(ListPeopleOptions(maxItems = options?.maxItems))
+        list(ListPeopleOptions(maxItems = options?.maxItems, page = options?.page))
 
     /**
      * Get a person by ID
@@ -271,7 +271,7 @@ class PeopleService(client: AccountClient) : BaseService(client) {
      * [listForProject] needs an expected type to disambiguate.
      */
     suspend fun listForProject(projectId: Long, options: PaginationOptions? = null): ListResult<Person> =
-        listForProject(projectId, ListProjectPeopleOptions(maxItems = options?.maxItems))
+        listForProject(projectId, ListProjectPeopleOptions(maxItems = options?.maxItems, page = options?.page))
 
     /**
      * Update project access (grant/revoke/create people)

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/reports.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/reports.kt
@@ -54,7 +54,7 @@ class ReportsService(client: AccountClient) : BaseService(client) {
      * [progress] needs an expected type to disambiguate.
      */
     suspend fun progress(options: PaginationOptions? = null): ListResult<TimelineEvent> =
-        progress(GetProgressReportOptions(maxItems = options?.maxItems))
+        progress(GetProgressReportOptions(maxItems = options?.maxItems, page = options?.page))
 
     /**
      * Get upcoming schedule entries and assignable items within a date window.
@@ -164,5 +164,5 @@ class ReportsService(client: AccountClient) : BaseService(client) {
      * [personProgress] needs an expected type to disambiguate.
      */
     suspend fun personProgress(personId: Long, options: PaginationOptions? = null): PersonProgressResult =
-        personProgress(personId, GetPersonProgressOptions(maxItems = options?.maxItems))
+        personProgress(personId, GetPersonProgressOptions(maxItems = options?.maxItems, page = options?.page))
 }

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/timeline.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/timeline.kt
@@ -47,5 +47,5 @@ class TimelineService(client: AccountClient) : BaseService(client) {
      * [projectTimeline] needs an expected type to disambiguate.
      */
     suspend fun projectTimeline(projectId: Long, options: PaginationOptions? = null): ListResult<TimelineEvent> =
-        projectTimeline(projectId, GetProjectTimelineOptions(maxItems = options?.maxItems))
+        projectTimeline(projectId, GetProjectTimelineOptions(maxItems = options?.maxItems, page = options?.page))
 }

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/todolist-groups.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/todolist-groups.kt
@@ -68,7 +68,7 @@ class TodolistGroupsService(client: AccountClient) : BaseService(client) {
      * [list] needs an expected type to disambiguate.
      */
     suspend fun list(todolistId: Long, options: PaginationOptions? = null): ListResult<TodolistGroup> =
-        list(todolistId, ListTodolistGroupsOptions(maxItems = options?.maxItems))
+        list(todolistId, ListTodolistGroupsOptions(maxItems = options?.maxItems, page = options?.page))
 
     /**
      * Create a new group in a todolist

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/uploads.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/uploads.kt
@@ -112,7 +112,7 @@ open class UploadsService(client: AccountClient) : BaseService(client) {
      * [list] needs an expected type to disambiguate.
      */
     suspend fun list(vaultId: Long, options: PaginationOptions? = null): ListResult<Upload> =
-        list(vaultId, ListUploadsOptions(maxItems = options?.maxItems))
+        list(vaultId, ListUploadsOptions(maxItems = options?.maxItems, page = options?.page))
 
     /**
      * Create a new upload in a vault

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/vaults.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/vaults.kt
@@ -90,7 +90,7 @@ class VaultsService(client: AccountClient) : BaseService(client) {
      * [list] needs an expected type to disambiguate.
      */
     suspend fun list(vaultId: Long, options: PaginationOptions? = null): ListResult<Vault> =
-        list(vaultId, ListVaultsOptions(maxItems = options?.maxItems))
+        list(vaultId, ListVaultsOptions(maxItems = options?.maxItems, page = options?.page))
 
     /**
      * Create a new vault (subfolder) in a vault

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/BaseService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/BaseService.kt
@@ -241,6 +241,20 @@ abstract class BaseService(
             val firstPageItems = parseItems(bodyText)
             val totalCount = parseTotalCount(response.headers.toMap())
 
+            // A pinned page is the whole answer: return it without following
+            // links. `truncated` still reports whether more items existed —
+            // dropped by the cap, or reachable through the next link we
+            // deliberately did not follow.
+            if ((options?.page ?: 0L) > 0L) {
+                val cap = maxItems?.takeIf { it > 0 && firstPageItems.size > it }
+                val hasMore = cap != null || parseNextLink(response.headers["Link"]) != null
+                val items = if (cap != null) firstPageItems.take(cap) else firstPageItems
+                val duration = (currentTimeMillis() - startTime).millisToDuration()
+                val result = ListResult(items, ListMeta(totalCount, hasMore))
+                hooks.safeOnOperationEnd(info, OperationResult(duration))
+                return result
+            }
+
             // Check if maxItems is satisfied by the first page
             if (maxItems != null && maxItems > 0 && firstPageItems.size >= maxItems) {
                 val hasMore = firstPageItems.size > maxItems
@@ -339,6 +353,20 @@ abstract class BaseService(
             val firstPageBody = normalizePersonIds(response.bodyAsText(), json)
             val firstPageItems = parseItems(firstPageBody)
             val totalCount = parseTotalCount(response.headers.toMap())
+
+            // A pinned page is the whole answer: return it without following
+            // links. `truncated` still reports whether more items existed —
+            // dropped by the cap, or reachable through the next link we
+            // deliberately did not follow.
+            if ((options?.page ?: 0L) > 0L) {
+                val cap = maxItems?.takeIf { it > 0 && firstPageItems.size > it }
+                val hasMore = cap != null || parseNextLink(response.headers["Link"]) != null
+                val items = if (cap != null) firstPageItems.take(cap) else firstPageItems
+                val duration = (currentTimeMillis() - startTime).millisToDuration()
+                val result = ListResult(items, ListMeta(totalCount, hasMore))
+                hooks.safeOnOperationEnd(info, OperationResult(duration))
+                return Pair(firstPageBody, result)
+            }
 
             // Check if maxItems is satisfied by the first page
             if (maxItems != null && maxItems > 0 && firstPageItems.size >= maxItems) {

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PaginationTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/PaginationTest.kt
@@ -330,6 +330,24 @@ class PaginationTest {
         "dock": []
     }"""
 
+    private val COMMENT_JSON = """{
+        "id": 1,
+        "status": "active",
+        "visible_to_clients": false,
+        "created_at": "2025-01-01T00:00:00Z",
+        "updated_at": "2025-01-01T00:00:00Z",
+        "title": "Re: Test",
+        "inherits_status": true,
+        "type": "Comment",
+        "url": "https://3.basecampapi.com/12345/buckets/1/comments/1.json",
+        "app_url": "https://3.basecamp.com/12345/buckets/1/comments/1",
+        "content": "c1",
+        "content_attachments": [],
+        "parent": {"id": 100, "title": "Parent", "type": "Todo", "url": "https://3.basecampapi.com/12345/buckets/1/todos/100.json", "app_url": "https://3.basecamp.com/12345/buckets/1/todos/100"},
+        "bucket": {"id": 1, "name": "Project", "type": "Project"},
+        "creator": {"id": 1, "name": "Test User", "created_at": "2025-01-01T00:00:00Z", "updated_at": "2025-01-01T00:00:00Z"}
+    }"""
+
     private fun mockClient(handler: MockRequestHandler): BasecampClient {
         val engine = MockEngine(handler)
         return testBasecampClient {
@@ -657,5 +675,41 @@ class PaginationTest {
         }
 
         assertNotNull(shapes)
+    }
+
+    /**
+     * The compatibility bridge must forward `page`, not just `maxItems`.
+     *
+     * `PaginationOptions` gained `page` in #566. A bridge that forwarded only
+     * `maxItems` would drop it from BOTH the query string and the pagination
+     * options, so `list(id, PaginationOptions(page = 3))` would auto-paginate
+     * the whole collection — precisely the bug #566 exists to remove, reachable
+     * through the older of the two call shapes.
+     */
+    @Test
+    fun paginationOptionsBridgeForwardsThePinnedPage() = runTest {
+        var requestCount = 0
+        val seenPages = mutableListOf<String?>()
+        val client = mockClient { request ->
+            requestCount++
+            seenPages += request.url.parameters["page"]
+            respond(
+                content = """[$COMMENT_JSON]""",
+                status = HttpStatusCode.OK,
+                headers = headersOf(
+                    HttpHeaders.ContentType to listOf(ContentType.Application.Json.toString()),
+                    "Link" to listOf("""<https://3.basecampapi.com/12345/buckets/1/recordings/1/comments.json?page=4>; rel="next""""),
+                ),
+            )
+        }
+
+        val comments = CommentsService(client.forAccount("12345"))
+        val result = comments.list(1, PaginationOptions(page = 3))
+
+        assertEquals(listOf<String?>("3"), seenPages.toList())
+        assertEquals(1, requestCount)
+        assertEquals(1, result.size)
+        assertTrue(result.meta.truncated)
+        client.close()
     }
 }

--- a/python/README.md
+++ b/python/README.md
@@ -573,19 +573,19 @@ print(recent.meta.truncated)  # True only if more items were available
 
 ### The `page` keyword
 
-`page` sets where the walk *starts*, not which single page you get. Link-following
-continues from there to the end of the collection, so `page=3` against a 10-page
-collection returns pages 3–10 concatenated. Pair it with `max_items` to bound the
-result:
+A positive `page` selects exactly that page: one request, that page's items,
+no link-following.
 
 ```python
-from_page_3 = account.projects.list(page=3, max_items=50)
+page_3 = account.projects.list(page=3)
+print(page_3.meta.truncated)  # True when a further page existed
 ```
 
-This differs from the Go SDK, where a positive `Page` fetches exactly that page
-and turns auto-pagination off. Converging the six SDKs on Go's single-page
-semantics is a breaking change tracked in
-[#566](https://github.com/basecamp/basecamp-sdk/issues/566).
+Omit `page` (or pass `0`) to auto-paginate the whole collection. `max_items`
+still trims a pinned page.
+
+All six SDKs share these semantics — one request, that page only, no
+link-following. See SPEC section 8.
 
 ## Error Handling
 

--- a/python/src/basecamp/_pagination.py
+++ b/python/src/basecamp/_pagination.py
@@ -39,6 +39,24 @@ def parse_next_link(link_header: str | None) -> str | None:
     return None
 
 
+def selects_single_page(params: dict | None) -> bool:
+    """Report whether the outgoing query pins a single page (SPEC section 8).
+
+    A positive ``page`` is a selector, not a starting offset: the operation
+    issues exactly one request and never follows ``Link: rel="next"``. The
+    query parameters are the authority here — ``page`` reaches the wire only
+    when the caller passed it, so reading it back needs no separate plumbing
+    through every generated service method.
+
+    ``bool`` is excluded explicitly because it subclasses ``int``: a stray
+    ``page=True`` is a caller mistake, not a request for page 1.
+    """
+    if not params:
+        return False
+    page = params.get("page")
+    return isinstance(page, int) and not isinstance(page, bool) and page > 0
+
+
 def parse_total_count(headers: dict[str, str]) -> int:
     """Parse X-Total-Count header, returning 0 if missing."""
     value = headers.get("X-Total-Count") or headers.get("x-total-count") or ""

--- a/python/src/basecamp/generated/services/_async_base.py
+++ b/python/src/basecamp/generated/services/_async_base.py
@@ -4,7 +4,13 @@ import time
 from typing import Any
 
 from basecamp import _security
-from basecamp._pagination import ListMeta, ListResult, parse_next_link, parse_total_count
+from basecamp._pagination import (
+    ListMeta,
+    ListResult,
+    parse_next_link,
+    parse_total_count,
+    selects_single_page,
+)
 from basecamp.errors import ApiError
 from basecamp.hooks import OperationInfo, OperationResult, safe_hook
 
@@ -297,6 +303,17 @@ class AsyncBaseService:
 
             all_items.extend(items)
 
+            # SPEC section 8: a positive `page` selects exactly that page. The
+            # follow loop stops here after a single request; a next link still
+            # means more items existed, which is what `truncated` reports.
+            if selects_single_page(params):
+                truncated = (max_items is not None and len(all_items) > max_items) or (
+                    parse_next_link(response.headers.get("link")) is not None
+                )
+                if max_items:
+                    all_items = all_items[:max_items]
+                break
+
             if max_items and len(all_items) >= max_items:
                 truncated = len(all_items) > max_items or parse_next_link(response.headers.get("link")) is not None
                 all_items = all_items[:max_items]
@@ -350,6 +367,17 @@ class AsyncBaseService:
             items = data.get(key, [])
             all_items.extend(items)
 
+            # SPEC section 8: a positive `page` selects exactly that page. The
+            # follow loop stops here after a single request; a next link still
+            # means more items existed, which is what `truncated` reports.
+            if selects_single_page(params):
+                truncated = (max_items is not None and len(all_items) > max_items) or (
+                    parse_next_link(response.headers.get("link")) is not None
+                )
+                if max_items:
+                    all_items = all_items[:max_items]
+                break
+
             if max_items and len(all_items) >= max_items:
                 truncated = len(all_items) > max_items or parse_next_link(response.headers.get("link")) is not None
                 all_items = all_items[:max_items]
@@ -401,7 +429,12 @@ class AsyncBaseService:
         url = base_url
         page = 1
 
-        while next_link and page < self._client.config.max_pages:
+        # SPEC section 8: a positive `page` selects exactly that page, so the
+        # follow loop never runs and `truncated` below reports the next link
+        # this call deliberately did not follow.
+        single_page = selects_single_page(params)
+
+        while not single_page and next_link and page < self._client.config.max_pages:
             if max_items and len(all_items) >= max_items:
                 break
 

--- a/python/src/basecamp/generated/services/_base.py
+++ b/python/src/basecamp/generated/services/_base.py
@@ -4,7 +4,13 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from basecamp import _security
-from basecamp._pagination import ListMeta, ListResult, parse_next_link, parse_total_count
+from basecamp._pagination import (
+    ListMeta,
+    ListResult,
+    parse_next_link,
+    parse_total_count,
+    selects_single_page,
+)
 from basecamp.errors import ApiError
 from basecamp.hooks import OperationInfo, OperationResult, safe_hook
 
@@ -302,6 +308,17 @@ class BaseService:
 
             all_items.extend(items)
 
+            # SPEC section 8: a positive `page` selects exactly that page. The
+            # follow loop stops here after a single request; a next link still
+            # means more items existed, which is what `truncated` reports.
+            if selects_single_page(params):
+                truncated = (max_items is not None and len(all_items) > max_items) or (
+                    parse_next_link(response.headers.get("link")) is not None
+                )
+                if max_items:
+                    all_items = all_items[:max_items]
+                break
+
             if max_items and len(all_items) >= max_items:
                 truncated = len(all_items) > max_items or parse_next_link(response.headers.get("link")) is not None
                 all_items = all_items[:max_items]
@@ -355,6 +372,17 @@ class BaseService:
             items = data.get(key, [])
             all_items.extend(items)
 
+            # SPEC section 8: a positive `page` selects exactly that page. The
+            # follow loop stops here after a single request; a next link still
+            # means more items existed, which is what `truncated` reports.
+            if selects_single_page(params):
+                truncated = (max_items is not None and len(all_items) > max_items) or (
+                    parse_next_link(response.headers.get("link")) is not None
+                )
+                if max_items:
+                    all_items = all_items[:max_items]
+                break
+
             if max_items and len(all_items) >= max_items:
                 truncated = len(all_items) > max_items or parse_next_link(response.headers.get("link")) is not None
                 all_items = all_items[:max_items]
@@ -406,7 +434,12 @@ class BaseService:
         url = base_url
         page = 1
 
-        while next_link and page < self._client.config.max_pages:
+        # SPEC section 8: a positive `page` selects exactly that page, so the
+        # follow loop never runs and `truncated` below reports the next link
+        # this call deliberately did not follow.
+        single_page = selects_single_page(params)
+
+        while not single_page and next_link and page < self._client.config.max_pages:
             if max_items and len(all_items) >= max_items:
                 break
 

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -407,18 +407,18 @@ the result is definitely complete.
 
 ### The `page` keyword
 
-`page` sets where the walk *starts*, not which single page you get. Link-following
-continues from there to the end of the collection, so `page: 3` against a 10-page
-collection enumerates pages 3–10. Pair it with `max_items` to bound the result:
+A positive `page` selects exactly that page: one request, that page's items,
+no link-following.
 
 ```ruby
-from_page_3 = account.projects.list(page: 3, max_items: 50)
+page_3 = account.projects.list(page: 3).to_a
 ```
 
-This differs from the Go SDK, where a positive `Page` fetches exactly that page
-and turns auto-pagination off. Converging the six SDKs on Go's single-page
-semantics is a breaking change tracked in
-[#566](https://github.com/basecamp/basecamp-sdk/issues/566).
+Omit `page` (or pass `0`) to auto-paginate the whole collection. `max_items`
+still trims a pinned page.
+
+All six SDKs share these semantics — one request, that page only, no
+link-following. See SPEC section 8.
 
 ## Downloading Files
 

--- a/ruby/lib/basecamp/http.rb
+++ b/ruby/lib/basecamp/http.rb
@@ -247,6 +247,7 @@ module Basecamp
     # snapshot rather than a hybrid of captured and current data.
     def paginated_enumerator(path, params:, operation:, max_items:, key: nil)
       max_items = nil if max_items && max_items <= 0
+      single_page = single_page_selected?(params)
       base_url = build_url(path)
 
       @hooks.on_paginate(base_url, 1)
@@ -277,6 +278,12 @@ module Basecamp
         loop do
           next_link = parse_next_link(response.headers["Link"])
 
+          # A pinned page is the whole answer (SPEC §8): this pass yields that
+          # page and stops, so a next link we deliberately do not follow is
+          # what makes the result truncated. Recorded before the yields for the
+          # same reason as the capping case below.
+          meta.mark_truncated! if single_page && next_link
+
           capped = false
           items.each_with_index do |item, index|
             yielded += 1
@@ -289,6 +296,7 @@ module Basecamp
             break if capped
           end
           break if capped
+          break if single_page
           break if next_link.nil?
 
           next_url = Security.resolve_url(url, next_link)
@@ -310,6 +318,20 @@ module Basecamp
           url = next_url
         end
       end
+    end
+
+    # Reports whether the outgoing query pins a single page (SPEC §8).
+    #
+    # The query parameters are the authority: `page` reaches the wire only when
+    # the caller passed it, so reading it back here needs no extra plumbing
+    # through every generated service method. `to_i` rather than an Integer
+    # check so a string-typed "3" selects page 3 instead of silently walking
+    # the collection from there.
+    # @param params [Hash, nil] the outgoing query parameters
+    # @return [Boolean]
+    def single_page_selected?(params)
+      page = params && (params[:page] || params["page"])
+      page.respond_to?(:to_i) && page.to_i.positive?
     end
 
     # Parses a pagination page body: size check, JSON parse, and person-ID

--- a/swift/README.md
+++ b/swift/README.md
@@ -283,19 +283,19 @@ print("Truncated: \(allProjects.meta.truncated)")
 
 ### The `page` option
 
-`page` sets where the walk *starts*, not which single page you get. Link-following
-continues from there to the end of the collection, so `page: 3` against a 10-page
-collection returns pages 3–10 concatenated. Pair it with `maxItems` to bound the
-result:
+A positive `page` selects exactly that page: one request, that page's items,
+no link-following.
 
 ```swift
-let fromPage3 = try await account.projects.list(options: .init(page: 3, maxItems: 50))
+let pageThree = try await account.projects.list(options: .init(page: 3))
+print(pageThree.meta.truncated) // true when a further page existed
 ```
 
-This differs from the Go SDK, where a positive `Page` fetches exactly that page
-and turns auto-pagination off. Converging the six SDKs on Go's single-page
-semantics is a breaking change tracked in
-[#566](https://github.com/basecamp/basecamp-sdk/issues/566).
+Omit `page` (or pass `0`) to auto-paginate the whole collection. `maxItems`
+still trims a pinned page.
+
+All six SDKs share these semantics — one request, that page only, no
+link-following. See SPEC section 8.
 
 ## Retry Behavior
 

--- a/swift/Sources/Basecamp/Generated/Services/BookmarksService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/BookmarksService.swift
@@ -50,7 +50,7 @@ public final class BookmarksService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Bookmarks", operation: "ListMyBookmarks", resourceType: "bookmark", isMutation: false),
             path: "/my/bookmarks.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListMyBookmarks")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/BoostsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/BoostsService.swift
@@ -72,7 +72,7 @@ public final class BoostsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Boosts", operation: "ListEventBoosts", resourceType: "event_boost", isMutation: false, resourceId: eventId),
             path: "/recordings/\(recordingId)/events/\(eventId)/boosts.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListEventBoosts")
         )
     }
@@ -86,7 +86,7 @@ public final class BoostsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Boosts", operation: "ListRecordingBoosts", resourceType: "recording_boost", isMutation: false, resourceId: recordingId),
             path: "/recordings/\(recordingId)/boosts.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListRecordingBoosts")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/CampfiresService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/CampfiresService.swift
@@ -159,7 +159,7 @@ public final class CampfiresService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Campfires", operation: "ListCampfireLines", resourceType: "campfire_line", isMutation: false, resourceId: campfireId),
             path: "/chats/\(campfireId)/lines.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListCampfireLines")
         )
     }
@@ -179,7 +179,7 @@ public final class CampfiresService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Campfires", operation: "ListCampfireUploads", resourceType: "campfire_upload", isMutation: false, resourceId: campfireId),
             path: "/chats/\(campfireId)/uploads.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListCampfireUploads")
         )
     }
@@ -193,7 +193,7 @@ public final class CampfiresService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Campfires", operation: "ListCampfires", resourceType: "campfire", isMutation: false),
             path: "/chats.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListCampfires")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/CardsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/CardsService.swift
@@ -42,7 +42,7 @@ public final class CardsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Cards", operation: "ListCards", resourceType: "card", isMutation: false, resourceId: columnId),
             path: "/card_tables/lists/\(columnId)/cards.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListCards")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/CheckinsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/CheckinsService.swift
@@ -93,7 +93,7 @@ public final class CheckinsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Checkins", operation: "GetAnswersByPerson", resourceType: "answers_by_person", isMutation: false, resourceId: personId),
             path: "/questions/\(questionId)/answers/by/\(personId)",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetAnswersByPerson")
         )
     }
@@ -116,7 +116,7 @@ public final class CheckinsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Checkins", operation: "GetQuestionReminders", resourceType: "question_reminder", isMutation: false),
             path: "/my/question_reminders.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetQuestionReminders")
         )
     }
@@ -139,7 +139,7 @@ public final class CheckinsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Checkins", operation: "ListAnswers", resourceType: "answer", isMutation: false, resourceId: questionId),
             path: "/questions/\(questionId)/answers.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListAnswers")
         )
     }
@@ -162,7 +162,7 @@ public final class CheckinsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Checkins", operation: "ListQuestions", resourceType: "question", isMutation: false, resourceId: questionnaireId),
             path: "/questionnaires/\(questionnaireId)/questions.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListQuestions")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/ClientApprovalsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/ClientApprovalsService.swift
@@ -49,7 +49,7 @@ public final class ClientApprovalsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "ClientApprovals", operation: "ListClientApprovals", resourceType: "client_approval", isMutation: false, projectId: bucketId),
             path: "/buckets/\(bucketId)/client/approvals.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListClientApprovals")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/ClientCorrespondencesService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/ClientCorrespondencesService.swift
@@ -49,7 +49,7 @@ public final class ClientCorrespondencesService: BaseService, @unchecked Sendabl
             OperationInfo(service: "ClientCorrespondences", operation: "ListClientCorrespondences", resourceType: "client_correspondence", isMutation: false, projectId: bucketId),
             path: "/buckets/\(bucketId)/client/correspondences.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListClientCorrespondences")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/ClientRepliesService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/ClientRepliesService.swift
@@ -32,7 +32,7 @@ public final class ClientRepliesService: BaseService, @unchecked Sendable {
             OperationInfo(service: "ClientReplies", operation: "ListClientReplies", resourceType: "client_reply", isMutation: false, projectId: bucketId, resourceId: recordingId),
             path: "/buckets/\(bucketId)/client/recordings/\(recordingId)/replies.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListClientReplies")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/CommentsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/CommentsService.swift
@@ -42,7 +42,7 @@ public final class CommentsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Comments", operation: "ListComments", resourceType: "comment", isMutation: false, resourceId: recordingId),
             path: "/recordings/\(recordingId)/comments.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListComments")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/DocumentsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/DocumentsService.swift
@@ -42,7 +42,7 @@ public final class DocumentsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Documents", operation: "ListDocuments", resourceType: "document", isMutation: false, resourceId: vaultId),
             path: "/vaults/\(vaultId)/documents.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListDocuments")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/DraftsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/DraftsService.swift
@@ -23,7 +23,7 @@ public final class DraftsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Drafts", operation: "ListMyDrafts", resourceType: "my_draft", isMutation: false),
             path: "/my/drafts.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListMyDrafts")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/EventsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/EventsService.swift
@@ -23,7 +23,7 @@ public final class EventsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Events", operation: "ListEvents", resourceType: "event", isMutation: false, resourceId: recordingId),
             path: "/recordings/\(recordingId)/events.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListEvents")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/EverythingService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/EverythingService.swift
@@ -300,7 +300,7 @@ public final class EverythingService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Everything", operation: "GetEverythingCheckins", resourceType: "everything_checkin", isMutation: false),
             path: "/checkins.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetEverythingCheckins")
         )
     }
@@ -314,7 +314,7 @@ public final class EverythingService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Everything", operation: "GetEverythingComments", resourceType: "everything_comment", isMutation: false),
             path: "/comments.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetEverythingComments")
         )
     }
@@ -336,7 +336,7 @@ public final class EverythingService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Everything", operation: "GetEverythingCompletedCards", resourceType: "everything_completed_card", isMutation: false),
             path: "/cards/completed.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetEverythingCompletedCards")
         )
     }
@@ -358,7 +358,7 @@ public final class EverythingService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Everything", operation: "GetEverythingCompletedTodos", resourceType: "everything_completed_todo", isMutation: false),
             path: "/todos/completed.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetEverythingCompletedTodos")
         )
     }
@@ -380,7 +380,7 @@ public final class EverythingService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Everything", operation: "GetEverythingFiles", resourceType: "everything_file", isMutation: false),
             path: "/files.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetEverythingFiles")
         )
     }
@@ -394,7 +394,7 @@ public final class EverythingService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Everything", operation: "GetEverythingForwards", resourceType: "everything_forward", isMutation: false),
             path: "/forwards.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetEverythingForwards")
         )
     }
@@ -408,7 +408,7 @@ public final class EverythingService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Everything", operation: "GetEverythingMessages", resourceType: "everything_message", isMutation: false),
             path: "/messages.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetEverythingMessages")
         )
     }
@@ -430,7 +430,7 @@ public final class EverythingService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Everything", operation: "GetEverythingNoDueDateCards", resourceType: "everything_no_due_date_card", isMutation: false),
             path: "/cards/no_due_date.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetEverythingNoDueDateCards")
         )
     }
@@ -452,7 +452,7 @@ public final class EverythingService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Everything", operation: "GetEverythingNoDueDateTodos", resourceType: "everything_no_due_date_todo", isMutation: false),
             path: "/todos/no_due_date.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetEverythingNoDueDateTodos")
         )
     }
@@ -474,7 +474,7 @@ public final class EverythingService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Everything", operation: "GetEverythingNotNowCards", resourceType: "everything_not_now_card", isMutation: false),
             path: "/cards/not_now.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetEverythingNotNowCards")
         )
     }
@@ -496,7 +496,7 @@ public final class EverythingService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Everything", operation: "GetEverythingOpenCards", resourceType: "everything_open_card", isMutation: false),
             path: "/cards/open.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetEverythingOpenCards")
         )
     }
@@ -518,7 +518,7 @@ public final class EverythingService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Everything", operation: "GetEverythingOpenTodos", resourceType: "everything_open_todo", isMutation: false),
             path: "/todos/open.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetEverythingOpenTodos")
         )
     }
@@ -576,7 +576,7 @@ public final class EverythingService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Everything", operation: "GetEverythingUnassignedCards", resourceType: "everything_unassigned_card", isMutation: false),
             path: "/cards/unassigned.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetEverythingUnassignedCards")
         )
     }
@@ -598,7 +598,7 @@ public final class EverythingService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Everything", operation: "GetEverythingUnassignedTodos", resourceType: "everything_unassigned_todo", isMutation: false),
             path: "/todos/unassigned.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetEverythingUnassignedTodos")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/ForwardsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/ForwardsService.swift
@@ -72,7 +72,7 @@ public final class ForwardsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Forwards", operation: "ListForwardReplies", resourceType: "forward_reply", isMutation: false, resourceId: forwardId),
             path: "/inbox_forwards/\(forwardId)/replies.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListForwardReplies")
         )
     }
@@ -92,7 +92,7 @@ public final class ForwardsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Forwards", operation: "ListForwards", resourceType: "forward", isMutation: false, resourceId: inboxId),
             path: "/inboxes/\(inboxId)/inbox_forwards.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListForwards")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/GaugesService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/GaugesService.swift
@@ -65,7 +65,7 @@ public final class GaugesService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Gauges", operation: "ListGaugeNeedles", resourceType: "gauge_needle", isMutation: false, projectId: projectId),
             path: "/projects/\(projectId)/gauge/needles.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListGaugeNeedles")
         )
     }
@@ -82,7 +82,7 @@ public final class GaugesService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Gauges", operation: "ListGauges", resourceType: "gauge", isMutation: false),
             path: "/reports/gauges.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListGauges")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/MessagesService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/MessagesService.swift
@@ -59,7 +59,7 @@ public final class MessagesService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Messages", operation: "ListMessages", resourceType: "message", isMutation: false, resourceId: boardId),
             path: "/message_boards/\(boardId)/messages.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListMessages")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/MyNotificationsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/MyNotificationsService.swift
@@ -35,7 +35,7 @@ public final class MyNotificationsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "MyNotifications", operation: "GetBubbleUps", resourceType: "bubble_up", isMutation: false),
             path: "/my/readings/bubble_ups.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetBubbleUps")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/PeopleService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/PeopleService.swift
@@ -106,7 +106,7 @@ public final class PeopleService: BaseService, @unchecked Sendable {
             OperationInfo(service: "People", operation: "ListPeople", resourceType: "people", isMutation: false),
             path: "/people.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListPeople")
         )
     }
@@ -129,7 +129,7 @@ public final class PeopleService: BaseService, @unchecked Sendable {
             OperationInfo(service: "People", operation: "ListProjectPeople", resourceType: "project_people", isMutation: false, projectId: projectId),
             path: "/projects/\(projectId)/people.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListProjectPeople")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/ProjectsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/ProjectsService.swift
@@ -48,7 +48,7 @@ public final class ProjectsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Projects", operation: "ListProjects", resourceType: "project", isMutation: false),
             path: "/projects.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListProjects")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/RecordingsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/RecordingsService.swift
@@ -63,7 +63,7 @@ public final class RecordingsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Recordings", operation: "ListRecordings", resourceType: "recording", isMutation: false),
             path: "/projects/recordings.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListRecordings")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/ReportsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/ReportsService.swift
@@ -82,7 +82,7 @@ public final class ReportsService: BaseService, @unchecked Sendable {
             path: "/reports/users/progress/\(personId).json",
             itemsKey: "events",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetPersonProgress")
         )
         struct Wrapper: Decodable {
@@ -101,7 +101,7 @@ public final class ReportsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Reports", operation: "GetProgressReport", resourceType: "progress_report", isMutation: false),
             path: "/reports/progress.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetProgressReport")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/SchedulesService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/SchedulesService.swift
@@ -66,7 +66,7 @@ public final class SchedulesService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Schedules", operation: "ListScheduleEntries", resourceType: "schedule_entry", isMutation: false, resourceId: scheduleId),
             path: "/schedules/\(scheduleId)/entries.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListScheduleEntries")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/SearchService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/SearchService.swift
@@ -112,7 +112,7 @@ public final class SearchService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Search", operation: "Search", resourceType: "resource", isMutation: false),
             path: "/search.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "Search")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/TemplatesService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/TemplatesService.swift
@@ -76,7 +76,7 @@ public final class TemplatesService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Templates", operation: "ListTemplates", resourceType: "template", isMutation: false),
             path: "/templates.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListTemplates")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/TimelineService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/TimelineService.swift
@@ -23,7 +23,7 @@ public final class TimelineService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Timeline", operation: "GetProjectTimeline", resourceType: "project_timeline", isMutation: false, projectId: projectId),
             path: "/projects/\(projectId)/timeline.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetProjectTimeline")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/TimesheetsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/TimesheetsService.swift
@@ -89,7 +89,7 @@ public final class TimesheetsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Timesheets", operation: "GetProjectTimesheet", resourceType: "project_timesheet", isMutation: false, projectId: projectId),
             path: "/projects/\(projectId)/timesheet.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetProjectTimesheet")
         )
     }
@@ -112,7 +112,7 @@ public final class TimesheetsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Timesheets", operation: "GetRecordingTimesheet", resourceType: "recording_timesheet", isMutation: false, resourceId: recordingId),
             path: "/recordings/\(recordingId)/timesheet.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "GetRecordingTimesheet")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/TodolistGroupsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/TodolistGroupsService.swift
@@ -33,7 +33,7 @@ public final class TodolistGroupsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "TodolistGroups", operation: "ListTodolistGroups", resourceType: "todolist_group", isMutation: false, resourceId: todolistId),
             path: "/todolists/\(todolistId)/groups.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListTodolistGroups")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/TodolistsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/TodolistsService.swift
@@ -48,7 +48,7 @@ public final class TodolistsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Todolists", operation: "ListTodolists", resourceType: "todolist", isMutation: false, resourceId: todosetId),
             path: "/todosets/\(todosetId)/todolists.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListTodolists")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/TodosService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/TodosService.swift
@@ -77,7 +77,7 @@ public final class TodosService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Todos", operation: "ListTodos", resourceType: "todo", isMutation: false, resourceId: todolistId),
             path: "/todolists/\(todolistId)/todos.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListTodos")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/UploadsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/UploadsService.swift
@@ -59,7 +59,7 @@ public final class UploadsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Uploads", operation: "ListUploads", resourceType: "upload", isMutation: false, resourceId: vaultId),
             path: "/vaults/\(vaultId)/uploads.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListUploads")
         )
     }

--- a/swift/Sources/Basecamp/Generated/Services/VaultsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/VaultsService.swift
@@ -42,7 +42,7 @@ public final class VaultsService: BaseService, @unchecked Sendable {
             OperationInfo(service: "Vaults", operation: "ListVaults", resourceType: "vault", isMutation: false, resourceId: vaultId),
             path: "/vaults/\(vaultId)/vaults.json",
             queryItems: queryItems.isEmpty ? nil : queryItems,
-            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },
+            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) },
             retryConfig: Metadata.retryConfig(for: "ListVaults")
         )
     }

--- a/swift/Sources/Basecamp/Pagination.swift
+++ b/swift/Sources/Basecamp/Pagination.swift
@@ -21,8 +21,19 @@ public struct PaginationOptions: Sendable {
     /// When nil or 0, all pages are fetched.
     public let maxItems: Int?
 
-    public init(maxItems: Int? = nil) {
+    /// Selects a single page. A positive `page` returns exactly that page in
+    /// exactly one request: `Link: rel="next"` is not followed, and
+    /// `ListMeta.truncated` reports whether a further page existed. When nil,
+    /// 0, or negative, auto-pagination walks the whole collection.
+    ///
+    /// Only meaningful for operations whose endpoint honors `?page=`; the few
+    /// list endpoints that return their whole collection at once never emit a
+    /// next link, so pinning a page there changes nothing. See SPEC section 8.
+    public let page: Int?
+
+    public init(maxItems: Int? = nil, page: Int? = nil) {
         self.maxItems = maxItems
+        self.page = page
     }
 }
 

--- a/swift/Sources/Basecamp/Services/BaseService.swift
+++ b/swift/Sources/Basecamp/Services/BaseService.swift
@@ -176,6 +176,13 @@ open class BaseService: @unchecked Sendable {
             let totalCount = parseTotalCount(response)
             let maxItems = paginationOpts?.maxItems
 
+            if (paginationOpts?.page ?? 0) > 0 {
+                let durationMs = millisSince(startTime)
+                safeInvokeHooks { $0.onOperationEnd(info, result: OperationResult(durationMs: durationMs)) }
+                return selectedPageResult(
+                    firstPageItems, response: response, totalCount: totalCount, maxItems: maxItems)
+            }
+
             // If maxItems is set and first page satisfies it, return early
             if let maxItems, maxItems > 0, firstPageItems.count >= maxItems {
                 let hasMore = firstPageItems.count > maxItems
@@ -258,6 +265,13 @@ open class BaseService: @unchecked Sendable {
             let totalCount = parseTotalCount(response)
             let maxItems = paginationOpts?.maxItems
 
+            if (paginationOpts?.page ?? 0) > 0 {
+                let durationMs = millisSince(startTime)
+                safeInvokeHooks { $0.onOperationEnd(info, result: OperationResult(durationMs: durationMs)) }
+                return (firstPageData, selectedPageResult(
+                    firstPageItems, response: response, totalCount: totalCount, maxItems: maxItems))
+            }
+
             // If maxItems is set and first page satisfies it, return early
             if let maxItems, maxItems > 0, firstPageItems.count >= maxItems {
                 let hasMore = firstPageItems.count > maxItems
@@ -287,6 +301,26 @@ open class BaseService: @unchecked Sendable {
             safeInvokeHooks { $0.onOperationEnd(info, result: OperationResult(durationMs: durationMs, error: error)) }
             throw error
         }
+    }
+
+    /// A pinned page is the whole answer (SPEC section 8): the caller gets
+    /// exactly that page in exactly one request, and the `Link: rel="next"`
+    /// follow loop never runs. `truncated` still reports whether more items
+    /// existed — dropped by the cap, or reachable through the link we
+    /// deliberately did not follow.
+    private func selectedPageResult<T: Decodable & Sendable>(
+        _ items: [T],
+        response: HTTPURLResponse,
+        totalCount: Int,
+        maxItems: Int?
+    ) -> ListResult<T> {
+        let cap = maxItems.flatMap { $0 > 0 && items.count > $0 ? $0 : nil }
+        let truncated = cap != nil
+            || parseNextLink(response.value(forHTTPHeaderField: "Link")) != nil
+        return ListResult(
+            cap.map { Array(items.prefix($0)) } ?? items,
+            meta: ListMeta(totalCount: totalCount, truncated: truncated)
+        )
     }
 
     // MARK: - Pagination

--- a/swift/Sources/BasecampGenerator/ServiceEmitter.swift
+++ b/swift/Sources/BasecampGenerator/ServiceEmitter.swift
@@ -160,6 +160,13 @@ private func emitMethod(_ op: ParsedOperation, serviceName: String, schemas: [St
     let isPaginated = op.hasPagination && op.returnsArray
     let isWrappedPaginated = op.hasPagination && op.paginationKey != nil && !op.returnsArray
 
+    // A `page` query param rides into PaginationOptions as well as the query
+    // string: BaseService needs it to know the caller pinned a single page and
+    // must not follow Link headers (SPEC section 8).
+    let paginationOptsArg = op.queryParams.contains { !$0.required && $0.name == "page" }
+        ? "options.flatMap { PaginationOptions(maxItems: $0.maxItems, page: $0.page) }"
+        : "options.flatMap { PaginationOptions(maxItems: $0.maxItems) }"
+
     // Build query items for ops with query params
     let optionalQueryParams = op.queryParams.filter { !$0.required }
     let requiredQueryParams = op.queryParams.filter { $0.required }
@@ -213,7 +220,7 @@ private func emitMethod(_ op: ParsedOperation, serviceName: String, schemas: [St
             lines.append("            queryItems: queryItems.isEmpty ? nil : queryItems,")
         }
         if hasOptions {
-            lines.append("            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },")
+            lines.append("            paginationOpts: \(paginationOptsArg),")
         }
         lines.append("            retryConfig: Metadata.retryConfig(for: \"\(op.operationId)\")")
         lines.append("        )")
@@ -256,7 +263,7 @@ private func emitMethod(_ op: ParsedOperation, serviceName: String, schemas: [St
             lines.append("            queryItems: queryItems.isEmpty ? nil : queryItems,")
         }
         if hasOptions {
-            lines.append("            paginationOpts: options.flatMap { PaginationOptions(maxItems: $0.maxItems) },")
+            lines.append("            paginationOpts: \(paginationOptsArg),")
         }
         lines.append("            retryConfig: Metadata.retryConfig(for: \"\(op.operationId)\")")
         lines.append("        )")

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -538,15 +538,19 @@ const firstFifty = await client.projects.list({ maxItems: 50 });
 
 ### The `page` option
 
-`page` sets where the walk *starts*, not which single page you get. Link-following
-continues from there to the end of the collection, so `{ page: 3 }` against a
-10-page collection returns pages 3–10 concatenated. Pair it with `maxItems` to
-bound the result.
+A positive `page` selects exactly that page: one request, that page's items,
+no link-following.
 
-This differs from the Go SDK, where a positive `Page` fetches exactly that page
-and turns auto-pagination off. Converging the six SDKs on Go's single-page
-semantics is a breaking change tracked in
-[#566](https://github.com/basecamp/basecamp-sdk/issues/566).
+```ts
+const pageThree = await client.projects.list({ page: 3 });
+console.log(pageThree.meta.truncated); // true when a further page existed
+```
+
+Omit `page` (or pass `0`) to auto-paginate the whole collection. `maxItems`
+still trims a pinned page.
+
+All six SDKs share these semantics — one request, that page only, no
+link-following. See SPEC section 8.
 
 For endpoints not covered by a service, drive pagination yourself over a raw `client.GET` response with `fetchAllPages` (collects all pages into one array) or `paginateAll` (async generator that yields one page at a time):
 

--- a/typescript/src/pagination.ts
+++ b/typescript/src/pagination.ts
@@ -28,6 +28,18 @@ export interface PaginationOptions {
    * When undefined or 0, all pages are fetched.
    */
   maxItems?: number;
+
+  /**
+   * Selects a single page. A positive `page` returns exactly that page in
+   * exactly one request: the `Link: rel="next"` header is not followed, and
+   * `.meta.truncated` reports whether a further page existed. When undefined,
+   * 0, or negative, auto-pagination walks the whole collection.
+   *
+   * Only meaningful for operations whose endpoint honors `?page=`; the handful
+   * of list endpoints that return their whole collection at once never emit a
+   * next link, so pinning a page there changes nothing. See SPEC section 8.
+   */
+  page?: number;
 }
 
 /**

--- a/typescript/src/services/base.ts
+++ b/typescript/src/services/base.ts
@@ -49,6 +49,38 @@ export interface FetchResponse<T> {
 const DEFAULT_MAX_PAGES = 10_000;
 
 /**
+ * True when the caller pinned a single page (SPEC section 8).
+ *
+ * A positive `page` is a selector, not a starting offset: the operation issues
+ * exactly one request and never follows `Link: rel="next"`. Absent, 0, and
+ * negative all mean "walk the collection".
+ */
+function isPageSelected(opts?: PaginationOptions): boolean {
+  return typeof opts?.page === "number" && opts.page > 0;
+}
+
+/**
+ * Builds the ListResult for a pinned page.
+ *
+ * `truncated` still answers "were there more items than these": true when the
+ * selected page carried a next link, or when the maxItems cap dropped items
+ * from it.
+ */
+function selectedPageResult<T>(
+  response: Response,
+  items: T[],
+  totalCount: number,
+  maxItems: number | undefined,
+): ListResult<T> {
+  const capped = maxItems !== undefined && maxItems > 0 && items.length > maxItems;
+  const truncated = capped || parseNextLink(response.headers.get("Link")) !== null;
+  return new ListResult(
+    capped ? items.slice(0, maxItems) : items,
+    { totalCount, truncated },
+  );
+}
+
+/**
  * Abstract base class for all Basecamp API services.
  *
  * Services extend this class to inherit common functionality
@@ -356,6 +388,12 @@ export abstract class BaseService {
       const totalCount = parseTotalCount(response);
       const maxItems = paginationOpts?.maxItems;
 
+      // A pinned page is the whole answer: return it without following links.
+      if (isPageSelected(paginationOpts)) {
+        result.durationMs = Math.round(performance.now() - start);
+        return selectedPageResult(response, firstPageItems, totalCount, maxItems);
+      }
+
       // If maxItems is set and first page satisfies it, return early
       if (maxItems && maxItems > 0 && firstPageItems.length >= maxItems) {
         // Only mark truncated if there are actually more items beyond maxItems
@@ -440,6 +478,13 @@ export abstract class BaseService {
 
       const firstPageItems: TItem[] = (firstPageData[key] as TItem[]) ?? [];
       const maxItems = paginationOpts?.maxItems;
+
+      // A pinned page is the whole answer: return it without following links.
+      if (isPageSelected(paginationOpts)) {
+        result.durationMs = Math.round(performance.now() - start);
+        const listResult = selectedPageResult(response, firstPageItems, totalCount, maxItems);
+        return { ...wrapper, [key]: listResult } as Omit<Record<string, unknown>, K> & Record<K, ListResult<TItem>>;
+      }
 
       // If maxItems is set and first page satisfies it, return early
       if (maxItems && maxItems > 0 && firstPageItems.length >= maxItems) {

--- a/typescript/tests/page-semantics.test.ts
+++ b/typescript/tests/page-semantics.test.ts
@@ -1,9 +1,10 @@
 /**
- * Premise verification for the `page` option's semantics.
+ * The `page` option's contract (SPEC §8): a positive `page` selects exactly
+ * that page — one request, that page's items, no `Link: rel="next"` follow.
  *
- * These tests pin what the SDK does TODAY so the cross-SDK consistency
- * decision (see the follow-up issue referenced in SPEC §8) is made against
- * measured behavior rather than assumption.
+ * This file used to pin the opposite as the measured premise for #566: `page`
+ * as a starting offset that link-following continued from. #566 converged all
+ * six SDKs on Go's selector semantics, so the assertions flipped with it.
  */
 import { describe, it, expect } from "vitest";
 import { http, HttpResponse } from "msw";
@@ -14,7 +15,7 @@ import { ProjectsService } from "../src/generated/services/projects.js";
 const BASE_URL = "https://3.basecampapi.com/12345";
 
 describe("page option semantics", () => {
-  it("keeps following Link rel=next after the pinned page", async () => {
+  it("returns only the pinned page and does not follow Link rel=next", async () => {
     const requested: string[] = [];
 
     server.use(
@@ -36,12 +37,35 @@ describe("page option semantics", () => {
 
     const result = await projects.list({ page: 3 });
 
-    // The premise: asking for page 3 does NOT return just page 3.
-    expect(requested).toEqual(["3", "4"]);
-    expect(result.length).toBe(2);
+    expect(requested).toEqual(["3"]);
+    expect(result.length).toBe(1);
+    // Page 4 existed and was deliberately not fetched, so what came back is a
+    // partial view of the collection.
+    expect(result.meta.truncated).toBe(true);
   });
 
-  it("stops at the pinned page when maxItems bounds the walk", async () => {
+  it("reports a pinned final page as complete", async () => {
+    const requested: string[] = [];
+
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, ({ request }) => {
+        const url = new URL(request.url);
+        requested.push(url.searchParams.get("page") ?? "(none)");
+        // No Link header: this is the last page.
+        return HttpResponse.json([{ id: 40, name: "p4" }]);
+      })
+    );
+
+    const client = createBasecampClient({ accountId: "12345", accessToken: "t" });
+    const projects = new ProjectsService(client);
+
+    const result = await projects.list({ page: 4 });
+
+    expect(requested).toEqual(["4"]);
+    expect(result.meta.truncated).toBe(false);
+  });
+
+  it("still applies maxItems to the pinned page", async () => {
     const requested: string[] = [];
 
     server.use(
@@ -49,7 +73,7 @@ describe("page option semantics", () => {
         const url = new URL(request.url);
         requested.push(url.searchParams.get("page") ?? "(none)");
         const page = Number(url.searchParams.get("page") ?? "1");
-        return HttpResponse.json([{ id: page * 10 }], {
+        return HttpResponse.json([{ id: page * 10 }, { id: page * 10 + 1 }], {
           headers: { Link: `<${BASE_URL}/projects.json?page=${page + 1}>; rel="next"` },
         });
       })
@@ -60,8 +84,34 @@ describe("page option semantics", () => {
 
     const result = await projects.list({ page: 3, maxItems: 1 });
 
-    // maxItems is the only brake available to a caller who wants one page.
     expect(requested).toEqual(["3"]);
     expect(result.length).toBe(1);
+    expect(result.meta.truncated).toBe(true);
+  });
+
+  it("treats a non-positive page as absent and auto-paginates", async () => {
+    const requested: string[] = [];
+
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, ({ request }) => {
+        const url = new URL(request.url);
+        requested.push(url.searchParams.get("page") ?? "(none)");
+        const page = Number(url.searchParams.get("page") ?? "1");
+        const headers: Record<string, string> = {};
+        if (page < 2) {
+          headers.Link = `<${BASE_URL}/projects.json?page=2>; rel="next"`;
+        }
+        return HttpResponse.json([{ id: page * 10 }], { headers });
+      })
+    );
+
+    const client = createBasecampClient({ accountId: "12345", accessToken: "t" });
+    const projects = new ProjectsService(client);
+
+    const result = await projects.list({ page: 0 });
+
+    expect(requested).toEqual(["0", "2"]);
+    expect(result.length).toBe(2);
+    expect(result.meta.truncated).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #566. Closes #570.

`page` selected a page in Go and acted as a starting **offset** in the other
five: they sent `page=3` on the first request, then followed `Link: rel="next"`
to the end of the collection. Page 3 of a 100-page collection cost 98 requests
and returned pages 3..N concatenated. All six now agree:

> **A positive `page` selects exactly that page.** One request, that page's
> items, no link-following. Absent / `0` / negative auto-paginates as before.
> `max_items` still trims the pinned page. (SPEC §8, now `[conformance]`.)

`ListMeta.truncated` answers the same question everywhere too: true when the
pinned page carried a next link this SDK deliberately did not follow, per §8's
own ListMeta definition — *"true only when items beyond those returned were
available"*.

### How each SDK learns the pinned page

No SDK carries a second copy that can drift from the query string actually sent.

| SDK | Source |
|-----|--------|
| TypeScript | `PaginationOptions.page` — generated option interfaces already extend it, so **no generator change** |
| Kotlin | `PaginationOptions.page`, carried across by the generated `toPaginationOptions()` (TypeEmitter) |
| Swift | `PaginationOptions.page`, passed by the generated service method (ServiceEmitter) |
| Python | the outgoing `params` dict — `selects_single_page()` |
| Ruby | the outgoing `params` hash — `single_page_selected?` |
| Go | the hand-written wrapper's `opts.Page` / `page` argument (unchanged) |

Kotlin and Swift regenerate to 55 changed lines each — exactly the 55 operations
that carry both the pagination trait and a `page` parameter.

### #570 — Go's gauge lists had no options struct

`GaugesService.List` and `ListNeedles` took no options at all, so `page` could
not reach the wire and Go violated the contract it defines. Both now take the
sibling shape, options struct *and* result struct with pagination metadata —
without the latter there is nowhere to report `truncated`.

### Red proof

Captured in a scratch worktree at `origin/main` (unmodified SDKs) with only the
new fixture + the six runner dispatch arms copied in, so nothing recompiled
around a mutated tracked file. Verbatim from the logs:

```
### TypeScript  (npx vitest run, REAL_EXIT=1)
 × runner.test.ts > conformance/pagination.json > A positive page selects exactly that page 3ms
   → [A positive page selects exactly that page] Expected 1 requests, got 2
 ✓ runner.test.ts > conformance/pagination.json > A pinned final page is not truncated 1ms

### Python  (make conformance-python, REAL_EXIT=2)
  FAIL: A positive page selects exactly that page
        Expected 1 requests, got 2; Expected responseMeta.truncated = True, got False
  PASS: A pinned final page is not truncated

### Ruby  (make conformance-ruby, REAL_EXIT=2)
  FAIL: A positive page selects exactly that page
        Expected 1 requests, got 2; Expected responseMeta.truncated = true, got false
  PASS: A pinned final page is not truncated

### Kotlin  (make conformance-kotlin, REAL_EXIT=2)
  FAIL: A positive page selects exactly that page
        Expected 1 requests, got 2
  PASS: A pinned final page is not truncated

### Swift  (make conformance-swift, REAL_EXIT=2)
  FAIL: A positive page selects exactly that page
        Expected 1 requests, got 2
  PASS: A pinned final page is not truncated

### Go  (make conformance-go, REAL_EXIT=2)
  FAIL: A positive page selects exactly that page
        Expected meta.truncated = true, got false
  PASS: A pinned final page is not truncated
```

Two things that proof establishes beyond the headline:

1. **The assertion is not vacuous, in any of the six.** #573 made `requestCount`
   exact everywhere; before it, `got 2` against `expected 1` would have passed
   as a lower bound in five of the six and the over-fetch proof would have meant
   nothing outside Go. The comparison is now `actual == expected` in all six
   (`conformance/runner/go/request_count.go`, `.../typescript/request-count.ts`,
   `.../python/runner.py`, `.../ruby/runner.rb`,
   `kotlin/conformance/.../RequestCount.kt`,
   `.../swift/Sources/ConformanceRunner/Assertions.swift:245`), and the only
   escape hatch left is the `link-header` tag. **None of these three fixtures
   carries it**, so the count applies to all three in all six.
2. **Go was already correct on request count and already wrong on `truncated`.**
   The Go line above is the pre-change tree failing the *metadata* half of the
   contract. That is the defect the 48-site `hasNextPage` sweep below fixes —
   see "Scope note".

#### Non-vacuity has a second precondition: the fixture has to actually run

A fixture whose `operation` has no dispatch case in a runner is **silently
skipped** — nothing fails, the case just never executes. An exact `requestCount`
is worthless in a runner that never dispatched the case. So each of the six was
checked by name, not by reading its dispatch switch. All three fixtures use
`ListProjects`, and every runner threads `configOverrides.page` into it:

| Runner | `page` threaded at | Observed |
|--------|--------------------|----------|
| Go | `main.go` → `ProjectListOptions{Limit, Page}` | 3 × `PASS` |
| Kotlin | `Main.kt` → `ListProjectsOptions(maxItems, page)` | 3 × `PASS` |
| TypeScript | `runner.test.ts` → `client.projects.list({page})` | 3 × `✓` |
| Ruby | `runner.rb` → `projects.list(max_items:, page:)` | 3 × `PASS` |
| Python | `runner.py` → `projects.list(max_items=, page=)` | 3 × `PASS` |
| Swift | `Dispatch.swift` → `ListProjectOptions(page:maxItems:)` | 3 × `PASS` |

Verbatim, from the `make check` log (`REAL_EXIT=0`) and a verbose TS re-run:

```
==> Running Go conformance tests...          ==> Running Ruby conformance tests...
  PASS: A positive page selects exactly that page
  PASS: A pinned final page is not truncated
  PASS: A pinned page still honours the item cap
                       ... identically under Kotlin, Python and Swift ...

$ npx vitest run --reporter=verbose      # TS prints only a summary in make check
 ✓ runner.test.ts > conformance/pagination.json > A positive page selects exactly that page 2ms
 ✓ runner.test.ts > conformance/pagination.json > A pinned final page is not truncated 1ms
 ✓ runner.test.ts > conformance/pagination.json > A pinned page still honours the item cap 3ms
```

Swift additionally makes the silent-skip failure mode *loud* rather than
relying on that audit: `operationsHonoringPage` in `Runner.swift` fails any
fixture that sets `configOverrides.page` for an operation whose dispatch does
not thread it — "it would paginate past the pinned page". That is the same
shape as the existing `operationsHonoringMaxItems` guard, and it is the only
mechanical defence any runner has against this class of vacuity today.

The `A pinned final page is not truncated` sibling passes in the pre-change tree
by construction (one page, no link), which is the point: it keeps the
`truncated: true` assertion in the first case from passing on a hardcoded value.

A third fixture, `A pinned page still honours the item cap`, covers `page` +
`max_items` together — the composition the contract claims and nothing tested.
It is red only on Go, which dropped through to its return before any `Limit`
handling:

```
### Go  (make conformance-go, REAL_EXIT=2)
  FAIL: A pinned page still honours the item cap
        Expected meta.truncated = true, got false
```

and green pre-change on the item-cap SDKs (Python shown), which is exactly the
divergence it exists to catch:

```
  PASS: A pinned page still honours the item cap
```

Review then found a third hole the fixtures could not reach. Kotlin keeps
**source-compatibility overloads** for the 16 operations that gained their first
query parameter — the old `options: PaginationOptions? = null` signature, kept
alive by the pre-1.0 policy — and the generator forwarded only `maxItems` into
the operation's own options class. So `comments.list(id, PaginationOptions(page
= 3))` dropped `page` from the query string *and* the pagination options and
link-followed to the `maxPages` cap. The conformance fixtures all go through the
new signature and never touch that bridge. Fixed in the generator (`9b487eade`);
the new `paginationOptionsBridgeForwardsThePinnedPage` against the unmodified
SDK:

```
org.opentest4j.AssertionFailedError: expected: <[3]> but was: <[null, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, ... ]>
```

The leading `null` is the dropped page; everything after it is the runaway walk.
No equivalent path in the other five — TypeScript's option interfaces *extend*
`PaginationOptions` rather than bridging to it, and none of the rest emit a
second `PaginationOptions`-taking signature.

`typescript/tests/page-semantics.test.ts` was a second, in-repo red proof — it
existed only to pin the offset behaviour as the measured premise for #566, and
`make check` failed on it (`expected [ '3' ] to deeply equal [ '3', '4' ]`)
until it was rewritten into the contract test it now is.

### Scope note: 48 Go `truncated` sites

Go returned `Truncated: false` from every page-selected path except
`MyNotifications.BubbleUps`, which computed it from the Link header and carried
a comment explaining why that was right. Leaving the other 48 alone would have
shipped a *new* six-way divergence on `truncated` inside the same PR that
removes one on request count, and it contradicts §8's ListMeta. They now route
through one `hasNextPage(resp)` helper. Three Go tests that asserted the old
`false` were updated with the reason inline.

The same 49 sites also ignored `Limit` — Go's `max_items` analog — which review
caught against the freshly `[conformance]`-labelled composition claim. The ~44
with a `Limit` in scope now go through `pageCap(count, limit, resp)`; the seven
that take `page` positionally with no options struct (Bookmarks, Drafts, the
four Everything pages, BubbleUps) keep the plain `hasNextPage` form. `pageCap`
honours only an **explicitly-set positive** `Limit`, never the per-operation
defaults (`DefaultTodoLimit` = 100), which are computed after the page branch:
capping a page the caller asked for in full would be a worse surprise than the
bug. §8 carries that qualification and
`TestTodosService_List_PageIgnoresDefaultLimit` pins it.

### Migration

**Breaking for any caller who relied on the offset behaviour in the five
non-Go SDKs.** That is change 1 below and it is the whole point of the PR: there
is no deprecation path, because the old behaviour was never a contract. Go
callers are unaffected by 1 and affected by 2–5. Ships in v0.13.0.

Per change:

1. **`page` no longer walks the rest of the collection** (TypeScript, Python,
   Ruby, Kotlin, Swift). A caller who passed `page: 3` to mean "everything from
   page 3 onward" now gets page 3 only. There is no replacement for the old
   behaviour, because it was not expressible as a contract — the walk's length
   depended on the server's page size. To page through a collection, loop while
   `meta.truncated` is true, incrementing `page`. To fetch everything, drop
   `page` entirely (the default was always a full walk).
2. **`meta.truncated` is now `true` on a page-selected Go result whose page
   advertised a next page** (it was always `false`). Code that read it as
   "collection complete" after pinning a page must now read it as "this page
   is not the last one" — which is what it always meant elsewhere.
3. **A positive Go `Limit` now trims a page-selected result** (it was silently
   ignored). Callers who set both `Page` and `Limit` and relied on getting the
   whole page must drop the `Limit`. Per-operation *default* limits still do
   not apply to a pinned page — that is unchanged.
4. **`GaugesService.List(ctx)` → `List(ctx, *GaugeListOptions)`**, returning
   `*GaugeListResult` instead of `[]Gauge`. Pass `nil` for the old behaviour and
   read `.Gauges`.
5. **`GaugesService.ListNeedles(ctx, projectID)` → `ListNeedles(ctx, projectID,
   *GaugeNeedleListOptions)`**, returning `*GaugeNeedleListResult` instead of
   `[]GaugeNeedle`. Pass `nil` and read `.Needles`.

### Not in this PR

- `spec/basecamp.smithy` and `openapi.json` are untouched (another lane holds
  the spec train). The consequence is that the generated doc comment on every
  `page` parameter still reads *"Semantics vary by SDK; see SPEC section 8"* —
  the pointer is right, the first clause is now stale. **Tracked as #622**, with
  the measured scope (48 occurrences in the Smithy source, 110 in the generated
  `openapi.json`) and the replacement text. Filed rather than left as a bullet
  here, because a description note vanishes at merge. Reporting, not fixing: no
  closing keyword.
- `ListGauges` also declares a `bucket_ids` filter that the Go wrapper has never
  been able to send, and still cannot — `GaugeListOptions` carries only the
  pagination controls this lane is about. Reporting, not fixing, and
  deliberately not filing a closing keyword for it.

### Verification

`make check` at `ed3bb3a8`, macOS, toolchain via `mise`:

```
PRE_SHA=ed3bb3a82cecbcaf2685f8da32be4ca13f797403
REAL_EXIT=0
POST_SHA=ed3bb3a82cecbcaf2685f8da32be4ca13f797403
```

35 `check:` targets, unchanged from `main` — this branch does not touch the
`Makefile` or `.github/workflows/test.yml`, so no gate wiring was rebased away.
Swift ran rather than skipping (`swift test`, plus `PASS` lines from
`conformance-swift`, not its `SKIP` line). Kotlin's `jvmTest` reported
`UP-TO-DATE` under `make check`, which is not evidence of execution, so it was
forced: `./gradlew :basecamp-sdk:jvmTest --rerun --no-build-cache` → 453 tests,
0 failures, 0 errors, 0 skipped, including
`PaginationTest.paginationOptionsBridgeForwardsThePinnedPage`. Ruby by
`rake test`: 1244 runs, 0 failures.

CI at `ed3bb3a8`: 47 checks, all green except the three that are never green
here — `CodeQL` and `cubic` report `neutral` by design, and
**`copilot-pull-request-reviewer` is red on the known infrastructure flake**
("Copilot encountered an error and was unable to review this pull request").
Re-requested once; the second run failed the same way. Its last *successful*
pass over this diff was at `9b487eade` — byte-identical content, since the
rebase onto `main` only absorbed two dependency bumps — and it generated no
comments. Codex did review this exact head (`ed3bb3a82c`) and raised one
finding, now closed. Every other check, including `Conformance Tests`,
`Spec Gates`, `Fixture coverage`, and all six per-SDK suites, is green.

