### PR TITLE
Page docs: state the contract #617 established, not the divergence it removed

### DIFF
--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -3568,7 +3568,7 @@ type ListClientApprovalsParams struct {
 	// Direction asc|desc
 	Direction *string `form:"direction,omitempty" json:"direction,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3580,19 +3580,19 @@ type ListClientCorrespondencesParams struct {
 	// Direction asc|desc
 	Direction *string `form:"direction,omitempty" json:"direction,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListClientRepliesParams defines parameters for ListClientReplies.
 type ListClientRepliesParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListCardsParams defines parameters for ListCards.
 type ListCardsParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3605,7 +3605,7 @@ type GetEverythingCompletedCardsParams struct {
 	// Due Filter by due date: with, without, or overdue. Unrecognized values are ignored.
 	Due *string `form:"due,omitempty" json:"due,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3618,7 +3618,7 @@ type GetEverythingNoDueDateCardsParams struct {
 	// Due Filter by due date: with, without, or overdue. Unrecognized values are ignored.
 	Due *string `form:"due,omitempty" json:"due,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3631,7 +3631,7 @@ type GetEverythingNotNowCardsParams struct {
 	// Due Filter by due date: with, without, or overdue. Unrecognized values are ignored.
 	Due *string `form:"due,omitempty" json:"due,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3644,7 +3644,7 @@ type GetEverythingOpenCardsParams struct {
 	// Due Filter by due date: with, without, or overdue. Unrecognized values are ignored.
 	Due *string `form:"due,omitempty" json:"due,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3667,13 +3667,13 @@ type GetEverythingUnassignedCardsParams struct {
 	// Due Filter by due date: with, without, or overdue. Unrecognized values are ignored.
 	Due *string `form:"due,omitempty" json:"due,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListCampfiresParams defines parameters for ListCampfires.
 type ListCampfiresParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3685,7 +3685,7 @@ type ListCampfireLinesParams struct {
 	// Direction asc|desc
 	Direction *string `form:"direction,omitempty" json:"direction,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3697,7 +3697,7 @@ type ListCampfireUploadsParams struct {
 	// Direction asc|desc
 	Direction *string `form:"direction,omitempty" json:"direction,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3709,13 +3709,13 @@ type CreateCampfireUploadParams struct {
 
 // GetEverythingCheckinsParams defines parameters for GetEverythingCheckins.
 type GetEverythingCheckinsParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetEverythingCommentsParams defines parameters for GetEverythingComments.
 type GetEverythingCommentsParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3727,19 +3727,19 @@ type GetEverythingFilesParams struct {
 	// PeopleIds Restrict to files created by the given people (repeatable).
 	PeopleIds *[]int64 `form:"people_ids[],omitempty" json:"people_ids[],omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetEverythingForwardsParams defines parameters for GetEverythingForwards.
 type GetEverythingForwardsParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListForwardRepliesParams defines parameters for ListForwardReplies.
 type ListForwardRepliesParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3751,7 +3751,7 @@ type ListForwardsParams struct {
 	// Direction asc|desc
 	Direction *string `form:"direction,omitempty" json:"direction,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3763,13 +3763,13 @@ type ListMessagesParams struct {
 	// Direction asc|desc
 	Direction *string `form:"direction,omitempty" json:"direction,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetEverythingMessagesParams defines parameters for GetEverythingMessages.
 type GetEverythingMessagesParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3782,19 +3782,19 @@ type GetMyDueAssignmentsParams struct {
 
 // ListMyBookmarksParams defines parameters for ListMyBookmarks.
 type ListMyBookmarksParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListMyDraftsParams defines parameters for ListMyDrafts.
 type ListMyDraftsParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetQuestionRemindersParams defines parameters for GetQuestionReminders.
 type GetQuestionRemindersParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3814,13 +3814,13 @@ type GetMyNotificationsParams struct {
 
 // GetBubbleUpsParams defines parameters for GetBubbleUps.
 type GetBubbleUpsParams struct {
-	// Page Page number. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListPeopleParams defines parameters for ListPeople.
 type ListPeopleParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3829,7 +3829,7 @@ type ListProjectsParams struct {
 	// Status active|archived|trashed
 	Status *string `form:"status,omitempty" json:"status,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3848,25 +3848,25 @@ type ListRecordingsParams struct {
 	// Direction asc|desc
 	Direction *string `form:"direction,omitempty" json:"direction,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListGaugeNeedlesParams defines parameters for ListGaugeNeedles.
 type ListGaugeNeedlesParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListProjectPeopleParams defines parameters for ListProjectPeople.
 type ListProjectPeopleParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetProjectTimelineParams defines parameters for GetProjectTimeline.
 type GetProjectTimelineParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3876,49 +3876,49 @@ type GetProjectTimesheetParams struct {
 	To       *string `form:"to,omitempty" json:"to,omitempty"`
 	PersonId *int64  `form:"person_id,omitempty" json:"person_id,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListQuestionsParams defines parameters for ListQuestions.
 type ListQuestionsParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListAnswersParams defines parameters for ListAnswers.
 type ListAnswersParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetAnswersByPersonParams defines parameters for GetAnswersByPerson.
 type GetAnswersByPersonParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListRecordingBoostsParams defines parameters for ListRecordingBoosts.
 type ListRecordingBoostsParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListCommentsParams defines parameters for ListComments.
 type ListCommentsParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListEventsParams defines parameters for ListEvents.
 type ListEventsParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListEventBoostsParams defines parameters for ListEventBoosts.
 type ListEventBoostsParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3928,7 +3928,7 @@ type GetRecordingTimesheetParams struct {
 	To       *string `form:"to,omitempty" json:"to,omitempty"`
 	PersonId *int64  `form:"person_id,omitempty" json:"person_id,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3938,13 +3938,13 @@ type ListGaugesParams struct {
 	// in the order specified instead of by risk level.
 	BucketIds *string `form:"bucket_ids,omitempty" json:"bucket_ids,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // GetProgressReportParams defines parameters for GetProgressReport.
 type GetProgressReportParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3969,7 +3969,7 @@ type GetAssignedTodosParams struct {
 
 // GetPersonProgressParams defines parameters for GetPersonProgress.
 type GetPersonProgressParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -3978,7 +3978,7 @@ type ListScheduleEntriesParams struct {
 	// Status active|archived|trashed
 	Status *string `form:"status,omitempty" json:"status,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -4024,7 +4024,7 @@ type SearchParams struct {
 	// Deprecated: prefer creator_ids[].
 	CreatorId *int64 `form:"creator_id,omitempty" json:"creator_id,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -4033,13 +4033,13 @@ type ListTemplatesParams struct {
 	// Status active|archived|trashed
 	Status *string `form:"status,omitempty" json:"status,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListTodolistGroupsParams defines parameters for ListTodolistGroups.
 type ListTodolistGroupsParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -4049,7 +4049,7 @@ type ListTodosParams struct {
 	Status    *string `form:"status,omitempty" json:"status,omitempty"`
 	Completed *bool   `form:"completed,omitempty" json:"completed,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -4062,7 +4062,7 @@ type GetEverythingCompletedTodosParams struct {
 	// Due Filter by due date: with, without, or overdue. Unrecognized values are ignored.
 	Due *string `form:"due,omitempty" json:"due,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -4075,7 +4075,7 @@ type GetEverythingNoDueDateTodosParams struct {
 	// Due Filter by due date: with, without, or overdue. Unrecognized values are ignored.
 	Due *string `form:"due,omitempty" json:"due,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -4088,7 +4088,7 @@ type GetEverythingOpenTodosParams struct {
 	// Due Filter by due date: with, without, or overdue. Unrecognized values are ignored.
 	Due *string `form:"due,omitempty" json:"due,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -4111,7 +4111,7 @@ type GetEverythingUnassignedTodosParams struct {
 	// Due Filter by due date: with, without, or overdue. Unrecognized values are ignored.
 	Due *string `form:"due,omitempty" json:"due,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
@@ -4120,25 +4120,25 @@ type ListTodolistsParams struct {
 	// Status active|archived|trashed
 	Status *string `form:"status,omitempty" json:"status,omitempty"`
 
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListDocumentsParams defines parameters for ListDocuments.
 type ListDocumentsParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListUploadsParams defines parameters for ListUploads.
 type ListUploadsParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 
 // ListVaultsParams defines parameters for ListVaults.
 type ListVaultsParams struct {
-	// Page Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+	// Page Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
 	Page *int32 `form:"page,omitempty" json:"page,omitempty"`
 }
 

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/Types.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/Types.kt
@@ -17,7 +17,7 @@ data class UpdateAccountNameBody(
 
 /** Options for ListMyBookmarks. */
 data class ListMyBookmarksOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -26,7 +26,7 @@ data class ListMyBookmarksOptions(
 
 /** Options for ListRecordingBoosts. */
 data class ListRecordingBoostsOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -40,7 +40,7 @@ data class CreateRecordingBoostBody(
 
 /** Options for ListEventBoosts. */
 data class ListEventBoostsOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -71,7 +71,7 @@ data class UpdateChatbotBody(
 
 /** Options for ListCampfires. */
 data class ListCampfiresOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -85,7 +85,7 @@ data class ListCampfireLinesOptions(
     /** asc|desc */
     val direction: String? = null,
     val maxItems: Int? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null
 ) {
     fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
@@ -109,7 +109,7 @@ data class ListCampfireUploadsOptions(
     /** asc|desc */
     val direction: String? = null,
     val maxItems: Int? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null
 ) {
     fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
@@ -180,7 +180,7 @@ data class MoveCardBody(
 
 /** Options for ListCards. */
 data class ListCardsOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -197,7 +197,7 @@ data class CreateCardBody(
 
 /** Options for GetQuestionReminders. */
 data class GetQuestionRemindersOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -212,7 +212,7 @@ data class UpdateAnswerBody(
 
 /** Options for ListQuestions. */
 data class ListQuestionsOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -235,7 +235,7 @@ data class UpdateQuestionBody(
 
 /** Options for ListAnswers. */
 data class ListAnswersOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -250,7 +250,7 @@ data class CreateAnswerBody(
 
 /** Options for GetAnswersByPerson. */
 data class GetAnswersByPersonOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -270,7 +270,7 @@ data class ListClientApprovalsOptions(
     /** asc|desc */
     val direction: String? = null,
     val maxItems: Int? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null
 ) {
     fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
@@ -283,7 +283,7 @@ data class ListClientCorrespondencesOptions(
     /** asc|desc */
     val direction: String? = null,
     val maxItems: Int? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null
 ) {
     fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
@@ -291,7 +291,7 @@ data class ListClientCorrespondencesOptions(
 
 /** Options for ListClientReplies. */
 data class ListClientRepliesOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -310,7 +310,7 @@ data class UpdateCommentBody(
 
 /** Options for ListComments. */
 data class ListCommentsOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -330,7 +330,7 @@ data class ReplaceDocumentBody(
 
 /** Options for ListDocuments. */
 data class ListDocumentsOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -348,7 +348,7 @@ data class CreateDocumentBody(
 
 /** Options for ListMyDrafts. */
 data class ListMyDraftsOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -357,7 +357,7 @@ data class ListMyDraftsOptions(
 
 /** Options for ListEvents. */
 data class ListEventsOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -370,7 +370,7 @@ data class GetEverythingCompletedCardsOptions(
     val assigneeIds: List<Long>? = null,
     /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
     val due: String? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -383,7 +383,7 @@ data class GetEverythingNoDueDateCardsOptions(
     val assigneeIds: List<Long>? = null,
     /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
     val due: String? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -396,7 +396,7 @@ data class GetEverythingNotNowCardsOptions(
     val assigneeIds: List<Long>? = null,
     /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
     val due: String? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -409,7 +409,7 @@ data class GetEverythingOpenCardsOptions(
     val assigneeIds: List<Long>? = null,
     /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
     val due: String? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -431,7 +431,7 @@ data class GetEverythingUnassignedCardsOptions(
     val assigneeIds: List<Long>? = null,
     /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
     val due: String? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -440,7 +440,7 @@ data class GetEverythingUnassignedCardsOptions(
 
 /** Options for GetEverythingCheckins. */
 data class GetEverythingCheckinsOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -449,7 +449,7 @@ data class GetEverythingCheckinsOptions(
 
 /** Options for GetEverythingComments. */
 data class GetEverythingCommentsOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -462,7 +462,7 @@ data class GetEverythingFilesOptions(
     val kind: String? = null,
     /** Restrict to files created by the given people (repeatable). */
     val peopleIds: List<Long>? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -471,7 +471,7 @@ data class GetEverythingFilesOptions(
 
 /** Options for GetEverythingForwards. */
 data class GetEverythingForwardsOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -480,7 +480,7 @@ data class GetEverythingForwardsOptions(
 
 /** Options for GetEverythingMessages. */
 data class GetEverythingMessagesOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -493,7 +493,7 @@ data class GetEverythingCompletedTodosOptions(
     val assigneeIds: List<Long>? = null,
     /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
     val due: String? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -506,7 +506,7 @@ data class GetEverythingNoDueDateTodosOptions(
     val assigneeIds: List<Long>? = null,
     /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
     val due: String? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -519,7 +519,7 @@ data class GetEverythingOpenTodosOptions(
     val assigneeIds: List<Long>? = null,
     /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
     val due: String? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -541,7 +541,7 @@ data class GetEverythingUnassignedTodosOptions(
     val assigneeIds: List<Long>? = null,
     /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
     val due: String? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -561,7 +561,7 @@ data class UpdateFolderBody(
 
 /** Options for ListForwardReplies. */
 data class ListForwardRepliesOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -575,7 +575,7 @@ data class ListForwardsOptions(
     /** asc|desc */
     val direction: String? = null,
     val maxItems: Int? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null
 ) {
     fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
@@ -593,7 +593,7 @@ data class ToggleGaugeBody(
 
 /** Options for ListGaugeNeedles. */
 data class ListGaugeNeedlesOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -612,7 +612,7 @@ data class ListGaugesOptions(
     /** Comma-separated list of project IDs. When provided, results are returned in the order specified instead of by risk level. */
     val bucketIds: String? = null,
     val maxItems: Int? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null
 ) {
     fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
@@ -655,7 +655,7 @@ data class ListMessagesOptions(
     /** asc|desc */
     val direction: String? = null,
     val maxItems: Int? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null
 ) {
     fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
@@ -713,7 +713,7 @@ data class GetMyNotificationsOptions(
 
 /** Options for GetBubbleUps. */
 data class GetBubbleUpsOptions(
-    /** Page number. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -744,7 +744,7 @@ data class UpdateMyProfileBody(
 
 /** Options for ListPeople. */
 data class ListPeopleOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -758,7 +758,7 @@ data class EnableOutOfOfficeBody(
 
 /** Options for ListProjectPeople. */
 data class ListProjectPeopleOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -777,7 +777,7 @@ data class ListProjectsOptions(
     /** active|archived|trashed */
     val status: String? = null,
     val maxItems: Int? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null
 ) {
     fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
@@ -807,7 +807,7 @@ data class ListRecordingsOptions(
     /** asc|desc */
     val direction: String? = null,
     val maxItems: Int? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null
 ) {
     fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
@@ -815,7 +815,7 @@ data class ListRecordingsOptions(
 
 /** Options for GetProgressReport. */
 data class GetProgressReportOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -838,7 +838,7 @@ data class GetAssignedTodosOptions(
 
 /** Options for GetPersonProgress. */
 data class GetPersonProgressOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -866,7 +866,7 @@ data class ListScheduleEntriesOptions(
     /** active|archived|trashed */
     val status: String? = null,
     val maxItems: Int? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null
 ) {
     fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
@@ -908,7 +908,7 @@ data class SearchOptions(
     @Deprecated("prefer creator_ids[].")
     val creatorId: Long? = null,
     val maxItems: Int? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null
 ) {
     fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
@@ -925,7 +925,7 @@ data class ListTemplatesOptions(
     /** active|archived|trashed */
     val status: String? = null,
     val maxItems: Int? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null
 ) {
     fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
@@ -950,7 +950,7 @@ data class CreateProjectFromTemplateBody(
 
 /** Options for GetProjectTimeline. */
 data class GetProjectTimelineOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -963,7 +963,7 @@ data class GetProjectTimesheetOptions(
     val to: String? = null,
     val personId: Long? = null,
     val maxItems: Int? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null
 ) {
     fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
@@ -975,7 +975,7 @@ data class GetRecordingTimesheetOptions(
     val to: String? = null,
     val personId: Long? = null,
     val maxItems: Int? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null
 ) {
     fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
@@ -1012,7 +1012,7 @@ data class RepositionTodolistGroupBody(
 
 /** Options for ListTodolistGroups. */
 data class ListTodolistGroupsOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -1040,7 +1040,7 @@ data class ListTodolistsOptions(
     /** active|archived|trashed */
     val status: String? = null,
     val maxItems: Int? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null
 ) {
     fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
@@ -1070,7 +1070,7 @@ data class ListTodosOptions(
     val status: String? = null,
     val completed: Boolean? = null,
     val maxItems: Int? = null,
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null
 ) {
     fun toPaginationOptions(): PaginationOptions = PaginationOptions(maxItems = maxItems, page = page)
@@ -1129,7 +1129,7 @@ data class UpdateUploadBody(
 
 /** Options for ListUploads. */
 data class ListUploadsOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {
@@ -1152,7 +1152,7 @@ data class UpdateVaultBody(
 
 /** Options for ListVaults. */
 data class ListVaultsOptions(
-    /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+    /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
     val page: Long? = null,
     val maxItems: Int? = null
 ) {

--- a/openapi.json
+++ b/openapi.json
@@ -2520,10 +2520,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -2645,10 +2645,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -2761,10 +2761,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -4383,10 +4383,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -5421,10 +5421,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -5543,10 +5543,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -5665,10 +5665,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -5787,10 +5787,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -6016,10 +6016,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -6114,10 +6114,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -6331,10 +6331,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -6887,10 +6887,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -7105,10 +7105,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -7475,10 +7475,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -8301,10 +8301,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -8399,10 +8399,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -8908,10 +8908,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -9226,10 +9226,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -9813,10 +9813,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -10021,10 +10021,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -10561,10 +10561,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -10659,10 +10659,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -11596,10 +11596,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -11782,10 +11782,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -11969,10 +11969,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -12456,10 +12456,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -12733,10 +12733,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -13246,10 +13246,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -13473,10 +13473,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -13788,10 +13788,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -13924,10 +13924,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -14321,10 +14321,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -14742,10 +14742,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -15071,10 +15071,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -15969,10 +15969,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -16301,10 +16301,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -16518,10 +16518,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -16634,10 +16634,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -17640,10 +17640,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -18146,10 +18146,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -18244,10 +18244,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -18815,10 +18815,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -19448,10 +19448,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -19782,10 +19782,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -20466,10 +20466,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -21805,10 +21805,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -22038,10 +22038,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -22270,10 +22270,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -22392,10 +22392,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -22514,10 +22514,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -22743,10 +22743,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -23763,10 +23763,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -24485,10 +24485,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -24702,10 +24702,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -24919,10 +24919,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }

--- a/ruby/lib/basecamp/generated/services/bookmarks_service.rb
+++ b/ruby/lib/basecamp/generated/services/bookmarks_service.rb
@@ -8,7 +8,7 @@ module Basecamp
     class BookmarksService < BaseService
 
       # List the current user's bookmarks, most recently bookmarked first (paginated).
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list_my_bookmarks(page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/boosts_service.rb
+++ b/ruby/lib/basecamp/generated/services/boosts_service.rb
@@ -28,7 +28,7 @@ module Basecamp
 
       # List boosts on a recording
       # @param recording_id [Integer] recording id ID
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list_recording_boosts(recording_id:, page: nil, max_items: nil)
@@ -51,7 +51,7 @@ module Basecamp
       # List boosts on a specific event within a recording
       # @param recording_id [Integer] recording id ID
       # @param event_id [Integer] event id ID
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list_event_boosts(recording_id:, event_id:, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/campfires_service.rb
+++ b/ruby/lib/basecamp/generated/services/campfires_service.rb
@@ -69,7 +69,7 @@ module Basecamp
       end
 
       # List all campfires across the account
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list(page: nil, max_items: nil)
@@ -92,7 +92,7 @@ module Basecamp
       # @param campfire_id [Integer] campfire id ID
       # @param sort [String, nil] created_at|updated_at
       # @param direction [String, nil] asc|desc
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list_lines(campfire_id:, sort: nil, direction: nil, page: nil, max_items: nil)
@@ -150,7 +150,7 @@ module Basecamp
       # @param campfire_id [Integer] campfire id ID
       # @param sort [String, nil] created_at|updated_at
       # @param direction [String, nil] asc|desc
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list_uploads(campfire_id:, sort: nil, direction: nil, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/cards_service.rb
+++ b/ruby/lib/basecamp/generated/services/cards_service.rb
@@ -43,7 +43,7 @@ module Basecamp
 
       # List cards in a column
       # @param column_id [Integer] column id ID
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list(column_id:, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/checkins_service.rb
+++ b/ruby/lib/basecamp/generated/services/checkins_service.rb
@@ -8,7 +8,7 @@ module Basecamp
     class CheckinsService < BaseService
 
       # Get pending check-in reminders for the current user
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def reminders(page: nil, max_items: nil)
@@ -50,7 +50,7 @@ module Basecamp
 
       # List all questions in a questionnaire
       # @param questionnaire_id [Integer] questionnaire id ID
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list_questions(questionnaire_id:, page: nil, max_items: nil)
@@ -95,7 +95,7 @@ module Basecamp
 
       # List all answers for a question
       # @param question_id [Integer] question id ID
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list_answers(question_id:, page: nil, max_items: nil)
@@ -129,7 +129,7 @@ module Basecamp
       # Get all answers from a specific person for a question
       # @param question_id [Integer] question id ID
       # @param person_id [Integer] person id ID
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def by_person(question_id:, person_id:, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/client_approvals_service.rb
+++ b/ruby/lib/basecamp/generated/services/client_approvals_service.rb
@@ -11,7 +11,7 @@ module Basecamp
       # @param bucket_id [Integer] bucket id ID
       # @param sort [String, nil] created_at|updated_at
       # @param direction [String, nil] asc|desc
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list(bucket_id:, sort: nil, direction: nil, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/client_correspondences_service.rb
+++ b/ruby/lib/basecamp/generated/services/client_correspondences_service.rb
@@ -11,7 +11,7 @@ module Basecamp
       # @param bucket_id [Integer] bucket id ID
       # @param sort [String, nil] created_at|updated_at
       # @param direction [String, nil] asc|desc
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list(bucket_id:, sort: nil, direction: nil, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/client_replies_service.rb
+++ b/ruby/lib/basecamp/generated/services/client_replies_service.rb
@@ -10,7 +10,7 @@ module Basecamp
       # List all client replies for a recording (correspondence or approval)
       # @param bucket_id [Integer] bucket id ID
       # @param recording_id [Integer] recording id ID
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list(bucket_id:, recording_id:, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/comments_service.rb
+++ b/ruby/lib/basecamp/generated/services/comments_service.rb
@@ -28,7 +28,7 @@ module Basecamp
 
       # List comments on a recording
       # @param recording_id [Integer] recording id ID
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list(recording_id:, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/documents_service.rb
+++ b/ruby/lib/basecamp/generated/services/documents_service.rb
@@ -29,7 +29,7 @@ module Basecamp
 
       # List documents in a vault
       # @param vault_id [Integer] vault id ID
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list(vault_id:, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/drafts_service.rb
+++ b/ruby/lib/basecamp/generated/services/drafts_service.rb
@@ -8,7 +8,7 @@ module Basecamp
     class DraftsService < BaseService
 
       # List the current user's drafts across their active projects, most recently
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list_my_drafts(page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/events_service.rb
+++ b/ruby/lib/basecamp/generated/services/events_service.rb
@@ -9,7 +9,7 @@ module Basecamp
 
       # List all events for a recording
       # @param recording_id [Integer] recording id ID
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list(recording_id:, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/everything_service.rb
+++ b/ruby/lib/basecamp/generated/services/everything_service.rb
@@ -11,7 +11,7 @@ module Basecamp
       # @param assignee_ids [Array, nil] Restrict to tasks assigned to at least one of the given people (repeatable).
       #   Assignees on nested steps are not considered.
       # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def get_everything_completed_cards(assignee_ids: nil, due: nil, page: nil, max_items: nil)
@@ -25,7 +25,7 @@ module Basecamp
       # @param assignee_ids [Array, nil] Restrict to tasks assigned to at least one of the given people (repeatable).
       #   Assignees on nested steps are not considered.
       # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def get_everything_no_due_date_cards(assignee_ids: nil, due: nil, page: nil, max_items: nil)
@@ -39,7 +39,7 @@ module Basecamp
       # @param assignee_ids [Array, nil] Restrict to tasks assigned to at least one of the given people (repeatable).
       #   Assignees on nested steps are not considered.
       # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def get_everything_not_now_cards(assignee_ids: nil, due: nil, page: nil, max_items: nil)
@@ -53,7 +53,7 @@ module Basecamp
       # @param assignee_ids [Array, nil] Restrict to tasks assigned to at least one of the given people (repeatable).
       #   Assignees on nested steps are not considered.
       # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def get_everything_open_cards(assignee_ids: nil, due: nil, page: nil, max_items: nil)
@@ -78,7 +78,7 @@ module Basecamp
       # @param assignee_ids [Array, nil] Restrict to tasks assigned to at least one of the given people (repeatable).
       #   Assignees on nested steps are not considered.
       # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def get_everything_unassigned_cards(assignee_ids: nil, due: nil, page: nil, max_items: nil)
@@ -89,7 +89,7 @@ module Basecamp
       end
 
       # Get every automatic check-in answer across all accessible projects, newest-first.
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def get_everything_checkins(page: nil, max_items: nil)
@@ -100,7 +100,7 @@ module Basecamp
       end
 
       # Get every comment across all accessible projects, newest-first (paginated).
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def get_everything_comments(page: nil, max_items: nil)
@@ -113,7 +113,7 @@ module Basecamp
       # Get every file recording across all accessible projects, newest-first (paginated).
       # @param kind [String, nil] Filter by file kind: all (default), images, pdfs, documents, or videos.
       # @param people_ids [Array, nil] Restrict to files created by the given people (repeatable).
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def get_everything_files(kind: nil, people_ids: nil, page: nil, max_items: nil)
@@ -124,7 +124,7 @@ module Basecamp
       end
 
       # Get every inbox forward across all accessible projects, newest-first (paginated).
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def get_everything_forwards(page: nil, max_items: nil)
@@ -135,7 +135,7 @@ module Basecamp
       end
 
       # Get every message across all accessible projects, newest-first (paginated).
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def get_everything_messages(page: nil, max_items: nil)
@@ -149,7 +149,7 @@ module Basecamp
       # @param assignee_ids [Array, nil] Restrict to tasks assigned to at least one of the given people (repeatable).
       #   Assignees on nested steps are not considered.
       # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def get_everything_completed_todos(assignee_ids: nil, due: nil, page: nil, max_items: nil)
@@ -163,7 +163,7 @@ module Basecamp
       # @param assignee_ids [Array, nil] Restrict to tasks assigned to at least one of the given people (repeatable).
       #   Assignees on nested steps are not considered.
       # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def get_everything_no_due_date_todos(assignee_ids: nil, due: nil, page: nil, max_items: nil)
@@ -177,7 +177,7 @@ module Basecamp
       # @param assignee_ids [Array, nil] Restrict to tasks assigned to at least one of the given people (repeatable).
       #   Assignees on nested steps are not considered.
       # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def get_everything_open_todos(assignee_ids: nil, due: nil, page: nil, max_items: nil)
@@ -202,7 +202,7 @@ module Basecamp
       # @param assignee_ids [Array, nil] Restrict to tasks assigned to at least one of the given people (repeatable).
       #   Assignees on nested steps are not considered.
       # @param due [String, nil] Filter by due date: with, without, or overdue. Unrecognized values are ignored.
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def get_everything_unassigned_todos(assignee_ids: nil, due: nil, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/forwards_service.rb
+++ b/ruby/lib/basecamp/generated/services/forwards_service.rb
@@ -18,7 +18,7 @@ module Basecamp
 
       # List all replies to a forward
       # @param forward_id [Integer] forward id ID
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list_replies(forward_id:, page: nil, max_items: nil)
@@ -51,7 +51,7 @@ module Basecamp
       # @param inbox_id [Integer] inbox id ID
       # @param sort [String, nil] created_at|updated_at
       # @param direction [String, nil] asc|desc
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list(inbox_id:, sort: nil, direction: nil, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/gauges_service.rb
+++ b/ruby/lib/basecamp/generated/services/gauges_service.rb
@@ -49,7 +49,7 @@ module Basecamp
 
       # List gauge needles for a project, ordered newest first.
       # @param project_id [Integer] project id ID
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list_gauge_needles(project_id:, page: nil, max_items: nil)
@@ -74,7 +74,7 @@ module Basecamp
       # List gauges across all projects the authenticated user has access to.
       # @param bucket_ids [String, nil] Comma-separated list of project IDs. When provided, results are returned
       #   in the order specified instead of by risk level.
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list_gauges(bucket_ids: nil, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/messages_service.rb
+++ b/ruby/lib/basecamp/generated/services/messages_service.rb
@@ -11,7 +11,7 @@ module Basecamp
       # @param board_id [Integer] board id ID
       # @param sort [String, nil] created_at|updated_at
       # @param direction [String, nil] asc|desc
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list(board_id:, sort: nil, direction: nil, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/my_notifications_service.rb
+++ b/ruby/lib/basecamp/generated/services/my_notifications_service.rb
@@ -23,7 +23,7 @@ module Basecamp
       end
 
       # Get the current user's current and scheduled bubble-ups (paginated, 50 per page).
-      # @param page [Integer, nil] Page number. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def get_bubble_ups(page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/people_service.rb
+++ b/ruby/lib/basecamp/generated/services/people_service.rb
@@ -59,7 +59,7 @@ module Basecamp
       end
 
       # List all people visible to the current user
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list(page: nil, max_items: nil)
@@ -109,7 +109,7 @@ module Basecamp
 
       # List all active people on a project
       # @param project_id [Integer] project id ID
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list_for_project(project_id:, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/projects_service.rb
+++ b/ruby/lib/basecamp/generated/services/projects_service.rb
@@ -9,7 +9,7 @@ module Basecamp
 
       # List projects (active by default; optionally archived/trashed)
       # @param status [String, nil] active|archived|trashed
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list(status: nil, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/recordings_service.rb
+++ b/ruby/lib/basecamp/generated/services/recordings_service.rb
@@ -13,7 +13,7 @@ module Basecamp
       # @param status [String, nil] active|archived|trashed
       # @param sort [String, nil] created_at|updated_at
       # @param direction [String, nil] asc|desc
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list(type:, bucket: nil, status: nil, sort: nil, direction: nil, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/reports_service.rb
+++ b/ruby/lib/basecamp/generated/services/reports_service.rb
@@ -8,7 +8,7 @@ module Basecamp
     class ReportsService < BaseService
 
       # Get account-wide activity feed (progress report)
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def progress(page: nil, max_items: nil)
@@ -48,7 +48,7 @@ module Basecamp
 
       # Get a person's activity timeline
       # @param person_id [Integer] person id ID
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [Hash] wrapper fields merged with a ListEnumerator of the paginated items
       def person_progress(person_id:, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/schedules_service.rb
+++ b/ruby/lib/basecamp/generated/services/schedules_service.rb
@@ -72,7 +72,7 @@ module Basecamp
       # List entries on a schedule
       # @param schedule_id [Integer] schedule id ID
       # @param status [String, nil] active|archived|trashed
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list_entries(schedule_id:, status: nil, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/search_service.rb
+++ b/ruby/lib/basecamp/generated/services/search_service.rb
@@ -21,7 +21,7 @@ module Basecamp
       # @param type [String, nil] Deprecated: prefer type_names[].
       # @param bucket_id [Integer, nil] Deprecated: prefer bucket_ids[].
       # @param creator_id [Integer, nil] Deprecated: prefer creator_ids[].
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def search(q:, type_names: nil, bucket_ids: nil, creator_ids: nil, file_type: nil, exclude_chat: nil, since: nil, sort: nil, type: nil, bucket_id: nil, creator_id: nil, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/templates_service.rb
+++ b/ruby/lib/basecamp/generated/services/templates_service.rb
@@ -9,7 +9,7 @@ module Basecamp
 
       # List all templates visible to the current user
       # @param status [String, nil] active|archived|trashed
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list(status: nil, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/timeline_service.rb
+++ b/ruby/lib/basecamp/generated/services/timeline_service.rb
@@ -9,7 +9,7 @@ module Basecamp
 
       # Get project timeline
       # @param project_id [Integer] project id ID
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def get_project_timeline(project_id:, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/timesheets_service.rb
+++ b/ruby/lib/basecamp/generated/services/timesheets_service.rb
@@ -12,7 +12,7 @@ module Basecamp
       # @param from [String, nil] from
       # @param to [String, nil] to
       # @param person_id [Integer, nil] person id
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def for_project(project_id:, from: nil, to: nil, person_id: nil, page: nil, max_items: nil)
@@ -27,7 +27,7 @@ module Basecamp
       # @param from [String, nil] from
       # @param to [String, nil] to
       # @param person_id [Integer, nil] person id
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def for_recording(recording_id:, from: nil, to: nil, person_id: nil, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/todolist_groups_service.rb
+++ b/ruby/lib/basecamp/generated/services/todolist_groups_service.rb
@@ -20,7 +20,7 @@ module Basecamp
 
       # List groups in a todolist
       # @param todolist_id [Integer] todolist id ID
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list(todolist_id:, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/todolists_service.rb
+++ b/ruby/lib/basecamp/generated/services/todolists_service.rb
@@ -41,7 +41,7 @@ module Basecamp
       # List todolists in a todoset
       # @param todoset_id [Integer] todoset id ID
       # @param status [String, nil] active|archived|trashed
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list(todoset_id:, status: nil, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/todos_service.rb
+++ b/ruby/lib/basecamp/generated/services/todos_service.rb
@@ -28,7 +28,7 @@ module Basecamp
       # @param todolist_id [Integer] todolist id ID
       # @param status [String, nil] active|archived|trashed
       # @param completed [Boolean, nil] completed
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list(todolist_id:, status: nil, completed: nil, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/uploads_service.rb
+++ b/ruby/lib/basecamp/generated/services/uploads_service.rb
@@ -39,7 +39,7 @@ module Basecamp
 
       # List uploads in a vault
       # @param vault_id [Integer] vault id ID
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list(vault_id:, page: nil, max_items: nil)

--- a/ruby/lib/basecamp/generated/services/vaults_service.rb
+++ b/ruby/lib/basecamp/generated/services/vaults_service.rb
@@ -28,7 +28,7 @@ module Basecamp
 
       # List vaults (subfolders) in a vault
       # @param vault_id [Integer] vault id ID
-      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+      # @param page [Integer, nil] Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
       # @param max_items [Integer, nil] cap on items yielded across pages; nil or non-positive means no cap
       # @return [ListEnumerator<Hash>] lazily paginated results (#meta carries pagination metadata)
       def list(vault_id:, page: nil, max_items: nil)

--- a/spec/basecamp.smithy
+++ b/spec/basecamp.smithy
@@ -473,7 +473,7 @@ structure ListProjectsInput {
   @httpQuery("status")
   status: ProjectStatus
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -727,7 +727,7 @@ structure ListTodosInput {
   @httpQuery("completed")
   completed: Boolean
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -1107,7 +1107,7 @@ structure ListTodolistsInput {
   @httpQuery("status")
   status: TodolistStatus
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -1281,7 +1281,7 @@ structure ListTodolistGroupsInput {
   @httpLabel
   todolistId: TodolistId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -1741,7 +1741,7 @@ structure ListCommentsInput {
   @httpLabel
   recordingId: RecordingId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -1865,7 +1865,7 @@ structure ListMessagesInput {
   @httpQuery("direction")
   direction: SortDirection
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -2220,7 +2220,7 @@ structure ListVaultsInput {
   @httpLabel
   vaultId: VaultId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -2335,7 +2335,7 @@ structure ListDocumentsInput {
   @httpLabel
   vaultId: VaultId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -2484,7 +2484,7 @@ structure ListUploadsInput {
   @httpLabel
   vaultId: VaultId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -2724,7 +2724,7 @@ structure ListScheduleEntriesInput {
   @httpQuery("status")
   status: ScheduleEntryStatus
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -2938,7 +2938,7 @@ structure GetProjectTimesheetInput {
   @httpQuery("person_id")
   person_id: PersonId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -2977,7 +2977,7 @@ structure GetRecordingTimesheetInput {
   @httpQuery("person_id")
   person_id: PersonId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -3558,7 +3558,7 @@ structure ListCampfiresInput {
   @httpLabel
   accountId: AccountId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -3622,7 +3622,7 @@ structure ListCampfireLinesInput {
   @httpQuery("direction")
   direction: SortDirection
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -3783,7 +3783,7 @@ structure ListCampfireUploadsInput {
   @httpQuery("direction")
   direction: SortDirection
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -4057,7 +4057,7 @@ structure ListForwardsInput {
   @httpQuery("direction")
   direction: SortDirection
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -4115,7 +4115,7 @@ structure ListForwardRepliesInput {
   @httpLabel
   forwardId: ForwardId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -4444,7 +4444,7 @@ structure ListCardsInput {
   @httpLabel
   columnId: CardColumnId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -5344,7 +5344,7 @@ structure ListPeopleInput {
   @httpLabel
   accountId: AccountId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -5461,7 +5461,7 @@ structure ListProjectPeopleInput {
   @httpLabel
   projectId: ProjectId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -5697,7 +5697,7 @@ structure ListClientApprovalsInput {
   @httpQuery("direction")
   direction: SortDirection
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -5763,7 +5763,7 @@ structure ListClientCorrespondencesInput {
   @httpQuery("direction")
   direction: SortDirection
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -5827,7 +5827,7 @@ structure ListClientRepliesInput {
   @httpLabel
   recordingId: RecordingId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -6202,7 +6202,7 @@ structure ListEventsInput {
   @httpLabel
   recordingId: RecordingId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -6249,7 +6249,7 @@ structure ListRecordingsInput {
   @httpQuery("direction")
   direction: SortDirection
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -6673,7 +6673,7 @@ structure ListQuestionsInput {
   @httpLabel
   questionnaireId: QuestionnaireId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -6876,7 +6876,7 @@ structure ListAnswersInput {
   @httpLabel
   questionId: QuestionId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -7036,7 +7036,7 @@ structure GetAnswersByPersonInput {
   @httpLabel
   personId: PersonId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -7067,7 +7067,7 @@ structure GetQuestionRemindersInput {
   @httpLabel
   accountId: AccountId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -7302,7 +7302,7 @@ structure SearchInput {
   @httpQuery("creator_id")
   creatorId: PersonId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -7357,7 +7357,7 @@ structure ListTemplatesInput {
   @httpQuery("status")
   status: TemplateStatus
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -7832,7 +7832,7 @@ structure GetProgressReportInput {
   @httpLabel
   accountId: AccountId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -7861,7 +7861,7 @@ structure GetProjectTimelineInput {
   @httpLabel
   projectId: ProjectId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -7890,7 +7890,7 @@ structure GetPersonProgressInput {
   @httpLabel
   personId: PersonId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -8426,7 +8426,7 @@ structure ListRecordingBoostsInput {
   @httpLabel
   recordingId: RecordingId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -8459,7 +8459,7 @@ structure ListEventBoostsInput {
   @httpLabel
   eventId: EventId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -8770,7 +8770,7 @@ structure ListGaugesInput {
   @httpQuery("bucket_ids")
   bucket_ids: String
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -8800,7 +8800,7 @@ structure ListGaugeNeedlesInput {
   @httpLabel
   projectId: ProjectId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -9230,7 +9230,7 @@ structure GetEverythingMessagesInput {
   @httpLabel
   accountId: AccountId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -9256,7 +9256,7 @@ structure GetEverythingCommentsInput {
   @httpLabel
   accountId: AccountId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -9282,7 +9282,7 @@ structure GetEverythingCheckinsInput {
   @httpLabel
   accountId: AccountId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -9308,7 +9308,7 @@ structure GetEverythingForwardsInput {
   @httpLabel
   accountId: AccountId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -9346,7 +9346,7 @@ structure GetEverythingFilesInput {
   @httpQuery("people_ids[]")
   people_ids: PersonIdList
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -9601,7 +9601,7 @@ structure EverythingTodosFilterInput {
   @httpQuery("due")
   due: String
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -9624,7 +9624,7 @@ structure EverythingCardsFilterInput {
   @httpQuery("due")
   due: String
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -9825,7 +9825,7 @@ structure GetBubbleUpsInput {
   @httpLabel
   accountId: AccountId
 
-  /// Page number. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -10026,7 +10026,7 @@ structure ListMyDraftsInput {
   @httpLabel
   accountId: AccountId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }
@@ -10114,7 +10114,7 @@ structure ListMyBookmarksInput {
   @httpLabel
   accountId: AccountId
 
-  /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+  /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
   @httpQuery("page")
   page: Integer
 }

--- a/swift/Sources/Basecamp/Generated/Services/BookmarksService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/BookmarksService.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 public struct ListMyBookmarksBookmarkOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/BoostsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/BoostsService.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 public struct ListForEventBoostOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -13,7 +13,7 @@ public struct ListForEventBoostOptions: Sendable {
 }
 
 public struct ListForRecordingBoostOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/CampfiresService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/CampfiresService.swift
@@ -6,7 +6,7 @@ public struct ListLinesCampfireOptions: Sendable {
     public var sort: String?
     /// asc|desc
     public var direction: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -28,7 +28,7 @@ public struct ListUploadsCampfireOptions: Sendable {
     public var sort: String?
     /// asc|desc
     public var direction: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -46,7 +46,7 @@ public struct ListUploadsCampfireOptions: Sendable {
 }
 
 public struct ListCampfireOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/CardsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/CardsService.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 public struct ListCardOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/CheckinsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/CheckinsService.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 public struct ByPersonCheckinOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -13,7 +13,7 @@ public struct ByPersonCheckinOptions: Sendable {
 }
 
 public struct RemindersCheckinOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -24,7 +24,7 @@ public struct RemindersCheckinOptions: Sendable {
 }
 
 public struct ListAnswersCheckinOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -43,7 +43,7 @@ public struct AnswerersCheckinOptions: Sendable {
 }
 
 public struct ListQuestionsCheckinOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/ClientApprovalsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/ClientApprovalsService.swift
@@ -6,7 +6,7 @@ public struct ListClientApprovalOptions: Sendable {
     public var sort: String?
     /// asc|desc
     public var direction: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/ClientCorrespondencesService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/ClientCorrespondencesService.swift
@@ -6,7 +6,7 @@ public struct ListClientCorrespondenceOptions: Sendable {
     public var sort: String?
     /// asc|desc
     public var direction: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/ClientRepliesService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/ClientRepliesService.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 public struct ListClientReplyOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/CommentsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/CommentsService.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 public struct ListCommentOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/DocumentsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/DocumentsService.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 public struct ListDocumentOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/DraftsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/DraftsService.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 public struct ListMyDraftsDraftOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/EventsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/EventsService.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 public struct ListEventOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/EverythingService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/EverythingService.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 public struct EverythingCheckinsEverythingOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -13,7 +13,7 @@ public struct EverythingCheckinsEverythingOptions: Sendable {
 }
 
 public struct EverythingCommentsEverythingOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -28,7 +28,7 @@ public struct EverythingCompletedCardsEverythingOptions: Sendable {
     public var assigneeIds: [Int]?
     /// Filter by due date: with, without, or overdue. Unrecognized values are ignored.
     public var due: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -50,7 +50,7 @@ public struct EverythingCompletedTodosEverythingOptions: Sendable {
     public var assigneeIds: [Int]?
     /// Filter by due date: with, without, or overdue. Unrecognized values are ignored.
     public var due: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -72,7 +72,7 @@ public struct EverythingFilesEverythingOptions: Sendable {
     public var kind: String?
     /// Restrict to files created by the given people (repeatable).
     public var peopleIds: [Int]?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -90,7 +90,7 @@ public struct EverythingFilesEverythingOptions: Sendable {
 }
 
 public struct EverythingForwardsEverythingOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -101,7 +101,7 @@ public struct EverythingForwardsEverythingOptions: Sendable {
 }
 
 public struct EverythingMessagesEverythingOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -116,7 +116,7 @@ public struct EverythingNoDueDateCardsEverythingOptions: Sendable {
     public var assigneeIds: [Int]?
     /// Filter by due date: with, without, or overdue. Unrecognized values are ignored.
     public var due: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -138,7 +138,7 @@ public struct EverythingNoDueDateTodosEverythingOptions: Sendable {
     public var assigneeIds: [Int]?
     /// Filter by due date: with, without, or overdue. Unrecognized values are ignored.
     public var due: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -160,7 +160,7 @@ public struct EverythingNotNowCardsEverythingOptions: Sendable {
     public var assigneeIds: [Int]?
     /// Filter by due date: with, without, or overdue. Unrecognized values are ignored.
     public var due: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -182,7 +182,7 @@ public struct EverythingOpenCardsEverythingOptions: Sendable {
     public var assigneeIds: [Int]?
     /// Filter by due date: with, without, or overdue. Unrecognized values are ignored.
     public var due: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -204,7 +204,7 @@ public struct EverythingOpenTodosEverythingOptions: Sendable {
     public var assigneeIds: [Int]?
     /// Filter by due date: with, without, or overdue. Unrecognized values are ignored.
     public var due: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -250,7 +250,7 @@ public struct EverythingUnassignedCardsEverythingOptions: Sendable {
     public var assigneeIds: [Int]?
     /// Filter by due date: with, without, or overdue. Unrecognized values are ignored.
     public var due: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -272,7 +272,7 @@ public struct EverythingUnassignedTodosEverythingOptions: Sendable {
     public var assigneeIds: [Int]?
     /// Filter by due date: with, without, or overdue. Unrecognized values are ignored.
     public var due: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/ForwardsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/ForwardsService.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 public struct ListRepliesForwardOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -17,7 +17,7 @@ public struct ListForwardOptions: Sendable {
     public var sort: String?
     /// asc|desc
     public var direction: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/GaugesService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/GaugesService.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 public struct ListGaugeNeedlesGaugeOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -15,7 +15,7 @@ public struct ListGaugeNeedlesGaugeOptions: Sendable {
 public struct ListGaugesGaugeOptions: Sendable {
     /// Comma-separated list of project IDs. When provided, results are returned in the order specified instead of by risk level.
     public var bucketIds: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/MessagesService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/MessagesService.swift
@@ -6,7 +6,7 @@ public struct ListMessageOptions: Sendable {
     public var sort: String?
     /// asc|desc
     public var direction: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/MyNotificationsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/MyNotificationsService.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 public struct BubbleUpsMyNotificationOptions: Sendable {
-    /// Page number. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/PeopleService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/PeopleService.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 public struct ListPeopleOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -21,7 +21,7 @@ public struct ListPingablePeopleOptions: Sendable {
 }
 
 public struct ListForProjectPeopleOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/ProjectsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/ProjectsService.swift
@@ -4,7 +4,7 @@ import Foundation
 public struct ListProjectOptions: Sendable {
     /// active|archived|trashed
     public var status: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/RecordingsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/RecordingsService.swift
@@ -9,7 +9,7 @@ public struct ListRecordingOptions: Sendable {
     public var sort: String?
     /// asc|desc
     public var direction: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/ReportsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/ReportsService.swift
@@ -11,7 +11,7 @@ public struct AssignedReportOptions: Sendable {
 }
 
 public struct PersonProgressReportOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -22,7 +22,7 @@ public struct PersonProgressReportOptions: Sendable {
 }
 
 public struct ProgressReportOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/SchedulesService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/SchedulesService.swift
@@ -4,7 +4,7 @@ import Foundation
 public struct ListEntriesScheduleOptions: Sendable {
     /// active|archived|trashed
     public var status: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/SearchService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/SearchService.swift
@@ -22,7 +22,7 @@ public struct SearchSearchOptions: Sendable {
     public var bucketId: Int?
     /// Deprecated: prefer creator_ids[].
     public var creatorId: Int?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/TemplatesService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/TemplatesService.swift
@@ -4,7 +4,7 @@ import Foundation
 public struct ListTemplateOptions: Sendable {
     /// active|archived|trashed
     public var status: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/TimelineService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/TimelineService.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 public struct ProjectTimelineTimelineOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/TimesheetsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/TimesheetsService.swift
@@ -5,7 +5,7 @@ public struct ForProjectTimesheetOptions: Sendable {
     public var from: String?
     public var to: String?
     public var personId: Int?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 
@@ -28,7 +28,7 @@ public struct ForRecordingTimesheetOptions: Sendable {
     public var from: String?
     public var to: String?
     public var personId: Int?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/TodolistGroupsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/TodolistGroupsService.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 public struct ListTodolistGroupOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/TodolistsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/TodolistsService.swift
@@ -4,7 +4,7 @@ import Foundation
 public struct ListTodolistOptions: Sendable {
     /// active|archived|trashed
     public var status: String?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/TodosService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/TodosService.swift
@@ -5,7 +5,7 @@ public struct ListTodoOptions: Sendable {
     /// active|archived|trashed
     public var status: String?
     public var completed: Bool?
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/UploadsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/UploadsService.swift
@@ -10,7 +10,7 @@ public struct ListVersionsUploadOptions: Sendable {
 }
 
 public struct ListUploadOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/swift/Sources/Basecamp/Generated/Services/VaultsService.swift
+++ b/swift/Sources/Basecamp/Generated/Services/VaultsService.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 public struct ListVaultOptions: Sendable {
-    /// Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+    /// Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
     public var page: Int?
     public var maxItems: Int?
 

--- a/typescript/src/generated/openapi-stripped.json
+++ b/typescript/src/generated/openapi-stripped.json
@@ -2252,10 +2252,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -2366,10 +2366,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -2471,10 +2471,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -3928,10 +3928,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -4856,10 +4856,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -4967,10 +4967,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -5078,10 +5078,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -5189,10 +5189,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -5396,10 +5396,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -5483,10 +5483,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -5678,10 +5678,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -6179,10 +6179,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -6375,10 +6375,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -6700,10 +6700,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -7438,10 +7438,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -7525,10 +7525,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -7979,10 +7979,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -8264,10 +8264,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -8783,10 +8783,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -8969,10 +8969,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -9441,10 +9441,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -9528,10 +9528,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -10347,10 +10347,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -10511,10 +10511,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -10675,10 +10675,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -11107,10 +11107,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -11344,10 +11344,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -11802,10 +11802,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -12007,10 +12007,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -12283,10 +12283,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -12408,10 +12408,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -12761,10 +12761,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -13138,10 +13138,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -13434,10 +13434,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -14233,10 +14233,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -14532,10 +14532,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -14727,10 +14727,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -14832,10 +14832,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -15720,10 +15720,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -16171,10 +16171,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -16258,10 +16258,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -16761,10 +16761,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -17328,10 +17328,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -17640,10 +17640,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -18244,10 +18244,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -19438,10 +19438,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -19649,10 +19649,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -19859,10 +19859,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -19970,10 +19970,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -20081,10 +20081,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -20288,10 +20288,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -21198,10 +21198,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -21843,10 +21843,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -22038,10 +22038,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }
@@ -22233,10 +22233,10 @@
           {
             "name": "page",
             "in": "query",
-            "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+            "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
             "schema": {
               "type": "integer",
-              "description": "Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.",
+              "description": "Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.",
               "format": "int32"
             }
           }

--- a/typescript/src/generated/schema.d.ts
+++ b/typescript/src/generated/schema.d.ts
@@ -7672,7 +7672,7 @@ export interface operations {
                 sort?: string;
                 /** @description asc|desc */
                 direction?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -7737,7 +7737,7 @@ export interface operations {
                 sort?: string;
                 /** @description asc|desc */
                 direction?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -7798,7 +7798,7 @@ export interface operations {
     ListClientReplies: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -8815,7 +8815,7 @@ export interface operations {
     ListCards: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -9473,7 +9473,7 @@ export interface operations {
                 "assignee_ids[]"?: number[];
                 /** @description Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
                 due?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -9539,7 +9539,7 @@ export interface operations {
                 "assignee_ids[]"?: number[];
                 /** @description Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
                 due?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -9605,7 +9605,7 @@ export interface operations {
                 "assignee_ids[]"?: number[];
                 /** @description Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
                 due?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -9671,7 +9671,7 @@ export interface operations {
                 "assignee_ids[]"?: number[];
                 /** @description Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
                 due?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -9801,7 +9801,7 @@ export interface operations {
                 "assignee_ids[]"?: number[];
                 /** @description Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
                 due?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -9860,7 +9860,7 @@ export interface operations {
     ListCampfires: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -9981,7 +9981,7 @@ export interface operations {
                 sort?: string;
                 /** @description asc|desc */
                 direction?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -10312,7 +10312,7 @@ export interface operations {
                 sort?: string;
                 /** @description asc|desc */
                 direction?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -10447,7 +10447,7 @@ export interface operations {
     GetEverythingCheckins: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -10678,7 +10678,7 @@ export interface operations {
     GetEverythingComments: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -11184,7 +11184,7 @@ export interface operations {
                 kind?: string;
                 /** @description Restrict to files created by the given people (repeatable). */
                 "people_ids[]"?: number[];
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -11243,7 +11243,7 @@ export interface operations {
     GetEverythingForwards: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -11563,7 +11563,7 @@ export interface operations {
     ListForwardReplies: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -11745,7 +11745,7 @@ export interface operations {
                 sort?: string;
                 /** @description asc|desc */
                 direction?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -12116,7 +12116,7 @@ export interface operations {
                 sort?: string;
                 /** @description asc|desc */
                 direction?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -12248,7 +12248,7 @@ export interface operations {
     GetEverythingMessages: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -12592,7 +12592,7 @@ export interface operations {
     ListMyBookmarks: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -12651,7 +12651,7 @@ export interface operations {
     ListMyDrafts: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -13280,7 +13280,7 @@ export interface operations {
     GetQuestionReminders: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -13400,7 +13400,7 @@ export interface operations {
     GetBubbleUps: {
         parameters: {
             query?: {
-                /** @description Page number. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -13517,7 +13517,7 @@ export interface operations {
     ListPeople: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -13821,7 +13821,7 @@ export interface operations {
             query?: {
                 /** @description active|archived|trashed */
                 status?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -13958,7 +13958,7 @@ export interface operations {
                 sort?: string;
                 /** @description asc|desc */
                 direction?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -14262,7 +14262,7 @@ export interface operations {
     ListGaugeNeedles: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -14403,7 +14403,7 @@ export interface operations {
     ListProjectPeople: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -14544,7 +14544,7 @@ export interface operations {
     GetProjectTimeline: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -14617,7 +14617,7 @@ export interface operations {
                 from?: string;
                 to?: string;
                 person_id?: number;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -14863,7 +14863,7 @@ export interface operations {
     ListQuestions: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -15124,7 +15124,7 @@ export interface operations {
     ListAnswers: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -15323,7 +15323,7 @@ export interface operations {
     GetAnswersByPerson: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -15910,7 +15910,7 @@ export interface operations {
     ListRecordingBoosts: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -16113,7 +16113,7 @@ export interface operations {
     ListComments: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -16245,7 +16245,7 @@ export interface operations {
     ListEvents: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -16306,7 +16306,7 @@ export interface operations {
     ListEventBoosts: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -16890,7 +16890,7 @@ export interface operations {
                 from?: string;
                 to?: string;
                 person_id?: number;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -17217,7 +17217,7 @@ export interface operations {
                  *     in the order specified instead of by risk level.
                  */
                 bucket_ids?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -17276,7 +17276,7 @@ export interface operations {
     GetProgressReport: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -17636,7 +17636,7 @@ export interface operations {
     GetPersonProgress: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -18025,7 +18025,7 @@ export interface operations {
             query?: {
                 /** @description active|archived|trashed */
                 status?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -18193,7 +18193,7 @@ export interface operations {
                  * @description Deprecated: prefer creator_ids[].
                  */
                 creator_id?: number;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -18638,7 +18638,7 @@ export interface operations {
             query?: {
                 /** @description active|archived|trashed */
                 status?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -19408,7 +19408,7 @@ export interface operations {
     ListTodolistGroups: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -19543,7 +19543,7 @@ export interface operations {
                 /** @description active|archived|trashed */
                 status?: string;
                 completed?: boolean;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -19682,7 +19682,7 @@ export interface operations {
                 "assignee_ids[]"?: number[];
                 /** @description Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
                 due?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -19748,7 +19748,7 @@ export interface operations {
                 "assignee_ids[]"?: number[];
                 /** @description Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
                 due?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -19814,7 +19814,7 @@ export interface operations {
                 "assignee_ids[]"?: number[];
                 /** @description Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
                 due?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -19944,7 +19944,7 @@ export interface operations {
                 "assignee_ids[]"?: number[];
                 /** @description Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
                 due?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -20580,7 +20580,7 @@ export interface operations {
             query?: {
                 /** @description active|archived|trashed */
                 status?: string;
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -21028,7 +21028,7 @@ export interface operations {
     ListDocuments: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -21160,7 +21160,7 @@ export interface operations {
     ListUploads: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;
@@ -21292,7 +21292,7 @@ export interface operations {
     ListVaults: {
         parameters: {
             query?: {
-                /** @description Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+                /** @description Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
                 page?: number;
             };
             header?: never;

--- a/typescript/src/generated/services/bookmarks.ts
+++ b/typescript/src/generated/services/bookmarks.ts
@@ -22,7 +22,7 @@ export type BookmarkStatus = components["schemas"]["BookmarkStatus"];
  * Options for listMyBookmarks.
  */
 export interface ListMyBookmarksBookmarkOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/boosts.ts
+++ b/typescript/src/generated/services/boosts.ts
@@ -21,7 +21,7 @@ export type Boost = components["schemas"]["Boost"];
  * Options for listForRecording.
  */
 export interface ListForRecordingBoostOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -37,7 +37,7 @@ export interface CreateForRecordingBoostRequest {
  * Options for listForEvent.
  */
 export interface ListForEventBoostOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/campfires.ts
+++ b/typescript/src/generated/services/campfires.ts
@@ -51,7 +51,7 @@ export interface UpdateChatbotCampfireRequest {
  * Options for list.
  */
 export interface ListCampfireOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -63,7 +63,7 @@ export interface ListLinesCampfireOptions extends PaginationOptions {
   sort?: "created_at" | "updated_at";
   /** Filter by direction */
   direction?: "asc" | "desc";
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -93,7 +93,7 @@ export interface ListUploadsCampfireOptions extends PaginationOptions {
   sort?: "created_at" | "updated_at";
   /** Filter by direction */
   direction?: "asc" | "desc";
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/cards.ts
+++ b/typescript/src/generated/services/cards.ts
@@ -45,7 +45,7 @@ export interface MoveCardRequest {
  * Options for list.
  */
 export interface ListCardOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/checkins.ts
+++ b/typescript/src/generated/services/checkins.ts
@@ -27,7 +27,7 @@ export type Person = components["schemas"]["Person"];
  * Options for reminders.
  */
 export interface RemindersCheckinOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -45,7 +45,7 @@ export interface UpdateAnswerCheckinRequest {
  * Options for listQuestions.
  */
 export interface ListQuestionsCheckinOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -77,7 +77,7 @@ export interface UpdateQuestionCheckinRequest {
  * Options for listAnswers.
  */
 export interface ListAnswersCheckinOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -101,7 +101,7 @@ export interface AnswerersCheckinOptions extends PaginationOptions {
  * Options for byPerson.
  */
 export interface ByPersonCheckinOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/client-approvals.ts
+++ b/typescript/src/generated/services/client-approvals.ts
@@ -24,7 +24,7 @@ export interface ListClientApprovalOptions extends PaginationOptions {
   sort?: "created_at" | "updated_at";
   /** Filter by direction */
   direction?: "asc" | "desc";
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/client-correspondences.ts
+++ b/typescript/src/generated/services/client-correspondences.ts
@@ -24,7 +24,7 @@ export interface ListClientCorrespondenceOptions extends PaginationOptions {
   sort?: "created_at" | "updated_at";
   /** Filter by direction */
   direction?: "asc" | "desc";
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/client-replies.ts
+++ b/typescript/src/generated/services/client-replies.ts
@@ -20,7 +20,7 @@ export type ClientReply = components["schemas"]["ClientReply"];
  * Options for list.
  */
 export interface ListClientReplyOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/comments.ts
+++ b/typescript/src/generated/services/comments.ts
@@ -29,7 +29,7 @@ export interface UpdateCommentRequest {
  * Options for list.
  */
 export interface ListCommentOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/documents.ts
+++ b/typescript/src/generated/services/documents.ts
@@ -31,7 +31,7 @@ export interface ReplaceDocumentRequest {
  * Options for list.
  */
 export interface ListDocumentOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/drafts.ts
+++ b/typescript/src/generated/services/drafts.ts
@@ -20,7 +20,7 @@ export type Draft = components["schemas"]["Draft"];
  * Options for listMyDrafts.
  */
 export interface ListMyDraftsDraftOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/events.ts
+++ b/typescript/src/generated/services/events.ts
@@ -20,7 +20,7 @@ export type Event = components["schemas"]["Event"];
  * Options for list.
  */
 export interface ListEventOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/everything.ts
+++ b/typescript/src/generated/services/everything.ts
@@ -35,7 +35,7 @@ Assignees on nested steps are not considered. */
   assigneeIds?: number[];
   /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
   due?: string;
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -48,7 +48,7 @@ Assignees on nested steps are not considered. */
   assigneeIds?: number[];
   /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
   due?: string;
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -61,7 +61,7 @@ Assignees on nested steps are not considered. */
   assigneeIds?: number[];
   /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
   due?: string;
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -74,7 +74,7 @@ Assignees on nested steps are not considered. */
   assigneeIds?: number[];
   /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
   due?: string;
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -98,7 +98,7 @@ Assignees on nested steps are not considered. */
   assigneeIds?: number[];
   /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
   due?: string;
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -106,7 +106,7 @@ Assignees on nested steps are not considered. */
  * Options for everythingCheckins.
  */
 export interface EverythingCheckinsEverythingOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -114,7 +114,7 @@ export interface EverythingCheckinsEverythingOptions extends PaginationOptions {
  * Options for everythingComments.
  */
 export interface EverythingCommentsEverythingOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -126,7 +126,7 @@ export interface EverythingFilesEverythingOptions extends PaginationOptions {
   kind?: string;
   /** Restrict to files created by the given people (repeatable). */
   peopleIds?: number[];
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -134,7 +134,7 @@ export interface EverythingFilesEverythingOptions extends PaginationOptions {
  * Options for everythingForwards.
  */
 export interface EverythingForwardsEverythingOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -142,7 +142,7 @@ export interface EverythingForwardsEverythingOptions extends PaginationOptions {
  * Options for everythingMessages.
  */
 export interface EverythingMessagesEverythingOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -155,7 +155,7 @@ Assignees on nested steps are not considered. */
   assigneeIds?: number[];
   /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
   due?: string;
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -168,7 +168,7 @@ Assignees on nested steps are not considered. */
   assigneeIds?: number[];
   /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
   due?: string;
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -181,7 +181,7 @@ Assignees on nested steps are not considered. */
   assigneeIds?: number[];
   /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
   due?: string;
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -205,7 +205,7 @@ Assignees on nested steps are not considered. */
   assigneeIds?: number[];
   /** Filter by due date: with, without, or overdue. Unrecognized values are ignored. */
   due?: string;
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/forwards.ts
+++ b/typescript/src/generated/services/forwards.ts
@@ -24,7 +24,7 @@ export type Inbox = components["schemas"]["Inbox"];
  * Options for listReplies.
  */
 export interface ListRepliesForwardOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -36,7 +36,7 @@ export interface ListForwardOptions extends PaginationOptions {
   sort?: "created_at" | "updated_at";
   /** Filter by direction */
   direction?: "asc" | "desc";
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/gauges.ts
+++ b/typescript/src/generated/services/gauges.ts
@@ -35,7 +35,7 @@ export interface ToggleGaugeGaugeRequest {
  * Options for listGaugeNeedles.
  */
 export interface ListGaugeNeedlesGaugeOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -58,7 +58,7 @@ export interface ListGaugesGaugeOptions extends PaginationOptions {
   /** Comma-separated list of project IDs. When provided, results are returned
 in the order specified instead of by risk level. */
   bucketIds?: string;
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/messages.ts
+++ b/typescript/src/generated/services/messages.ts
@@ -25,7 +25,7 @@ export interface ListMessageOptions extends PaginationOptions {
   sort?: "created_at" | "updated_at";
   /** Filter by direction */
   direction?: "asc" | "desc";
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/my-notifications.ts
+++ b/typescript/src/generated/services/my-notifications.ts
@@ -36,7 +36,7 @@ scheduled bubble-ups. */
  * Options for bubbleUps.
  */
 export interface BubbleUpsMyNotificationOptions extends PaginationOptions {
-  /** Page number. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/people.ts
+++ b/typescript/src/generated/services/people.ts
@@ -57,7 +57,7 @@ export interface UpdateMyProfilePeopleRequest {
  * Options for list.
  */
 export interface ListPeopleOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -73,7 +73,7 @@ export interface EnableOutOfOfficePeopleRequest {
  * Options for listForProject.
  */
 export interface ListForProjectPeopleOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/projects.ts
+++ b/typescript/src/generated/services/projects.ts
@@ -23,7 +23,7 @@ export type Project = components["schemas"]["Project"];
 export interface ListProjectOptions extends PaginationOptions {
   /** Filter by status */
   status?: "active" | "archived" | "trashed";
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/recordings.ts
+++ b/typescript/src/generated/services/recordings.ts
@@ -28,7 +28,7 @@ export interface ListRecordingOptions extends PaginationOptions {
   sort?: "created_at" | "updated_at";
   /** Filter by direction */
   direction?: "asc" | "desc";
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/reports.ts
+++ b/typescript/src/generated/services/reports.ts
@@ -22,7 +22,7 @@ export type Person = components["schemas"]["Person"];
  * Options for progress.
  */
 export interface ProgressReportOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -48,7 +48,7 @@ export interface AssignedReportOptions {
  * Options for personProgress.
  */
 export interface PersonProgressReportOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/schedules.ts
+++ b/typescript/src/generated/services/schedules.ts
@@ -61,7 +61,7 @@ export interface UpdateSettingsScheduleRequest {
 export interface ListEntriesScheduleOptions extends PaginationOptions {
   /** Filter by status */
   status?: "active" | "archived" | "trashed";
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/search.ts
+++ b/typescript/src/generated/services/search.ts
@@ -49,7 +49,7 @@ endpoint's `file_search_types`. */
    * @deprecated prefer creator_ids[].
    */
   creatorId?: number;
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/templates.ts
+++ b/typescript/src/generated/services/templates.ts
@@ -23,7 +23,7 @@ export type Template = components["schemas"]["Template"];
 export interface ListTemplateOptions extends PaginationOptions {
   /** Filter by status */
   status?: "active" | "archived" | "trashed";
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/timeline.ts
+++ b/typescript/src/generated/services/timeline.ts
@@ -20,7 +20,7 @@ export type TimelineEvent = components["schemas"]["TimelineEvent"];
  * Options for projectTimeline.
  */
 export interface ProjectTimelineTimelineOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/timesheets.ts
+++ b/typescript/src/generated/services/timesheets.ts
@@ -27,7 +27,7 @@ export interface ForProjectTimesheetOptions extends PaginationOptions {
   to?: string;
   /** Person id */
   personId?: number;
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 
@@ -41,7 +41,7 @@ export interface ForRecordingTimesheetOptions extends PaginationOptions {
   to?: string;
   /** Person id */
   personId?: number;
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/todolist-groups.ts
+++ b/typescript/src/generated/services/todolist-groups.ts
@@ -29,7 +29,7 @@ export interface RepositionTodolistGroupRequest {
  * Options for list.
  */
 export interface ListTodolistGroupOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/todolists.ts
+++ b/typescript/src/generated/services/todolists.ts
@@ -41,7 +41,7 @@ export interface RepositionTodolistRequest {
 export interface ListTodolistOptions extends PaginationOptions {
   /** Filter by status */
   status?: "active" | "archived" | "trashed";
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/todos.ts
+++ b/typescript/src/generated/services/todos.ts
@@ -45,7 +45,7 @@ export interface ListTodoOptions extends PaginationOptions {
   status?: "active" | "archived" | "trashed";
   /** Completed */
   completed?: boolean;
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/uploads.ts
+++ b/typescript/src/generated/services/uploads.ts
@@ -37,7 +37,7 @@ export interface ListVersionsUploadOptions extends PaginationOptions {
  * Options for list.
  */
 export interface ListUploadOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 

--- a/typescript/src/generated/services/vaults.ts
+++ b/typescript/src/generated/services/vaults.ts
@@ -29,7 +29,7 @@ export interface UpdateVaultRequest {
  * Options for list.
  */
 export interface ListVaultOptions extends PaginationOptions {
-  /** Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8. */
+  /** Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8. */
   page?: number;
 }
 


### PR DESCRIPTION
#617 removed the divergence in `page` semantics. It did not remove the 48 doc
comments that describe it, so the public surface of all six SDKs — IDE
autocomplete, godoc, KDoc, generated docs — still tells consumers the opposite
of the contract v0.13.0 exists to establish.

## Before / after

```diff
- Page number for paginating through results. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+ Page number for paginating through results. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
```

and the one short form, on `GetBubbleUpsInput`:

```diff
- Page number. Defaults to 1. Semantics vary by SDK; see SPEC section 8.
+ Page number. Defaults to 1. A positive value selects exactly that page, not a starting offset; see SPEC section 8.
```

The replacement is SPEC §8's own emphasis — "**A positive `page` selects
exactly that page. It is not a starting offset.**" (SPEC.md:858) — rather than
a third phrasing that would then need reconciling with §8 and with the six
READMEs #617 wrote. The `see SPEC section 8` pointer is kept as-is: it already
lands on correct text, because #617 rewrote that section.

## Occurrence count to zero

Two distinct strings carried the stale clause, not one:

| String | Before | After |
|---|---|---|
| `Page number for paginating through results. Defaults to 1. Semantics vary by SDK; …` | 47 | 0 |
| `Page number. Defaults to 1. Semantics vary by SDK; …` | 1 | 0 |
| **`Semantics vary`, anywhere in the repository** | **spec + generated + `openapi.json`** | **0** |

```
$ rg -c "Semantics vary" spec/basecamp.smithy
(no matches, exit 1)
$ git grep -c "Semantics vary"
(no matches)
```

`SPEC.md` carried no copy of the phrasing outside §8, so nothing there needed
touching — and §8 itself is #617's text and is left alone.

## No wire or signature change

`make generate` churned 98 generated files, which is the point: the comment has
to reach consumers' tooling to be worth fixing. But the churn is textual and
nothing else:

- **Operation count unchanged at 240**, before and after.
- **Every changed line in all 99 files** is one of the two old strings going
  out or its replacement coming in. Filtering the full diff for lines matching
  neither returns zero:
  ```
  $ git diff -U0 main | rg '^[+-]' | rg -v '^(\+\+\+|---)' \
      | rg -vc 'Semantics vary by SDK|selects exactly that page, not a starting offset'
  0
  ```
- `openapi.json` moves only `description` values.
- 598 insertions, 598 deletions — balanced, as a pure text swap must be.

Labelled `documentation`, not `breaking`: no wire surface, no signature, no
behavior moves. #617 already shipped the behavior; this only stops the docs
contradicting it.

## Coverage note

Go, Kotlin, Ruby, Swift and TypeScript all carried the stale text and are all
fixed. **Python carried no copy** — its generator emits no per-parameter
docstrings at all, so `page` is undocumented there rather than mis-documented.
Pre-existing and out of scope for a freeze-week doc fix, but worth naming: the
Python `page` keyword is the one surface this PR cannot reach.

## What was deliberately not changed

`Defaults to 1.` is retained. It is true of the wire parameter, which is what
this spec describes. It is worth knowing that at the SDK layer an absent `page`
means "auto-paginate the whole collection" for trait-carrying operations rather
than "page 1" — but that is not universal (`GetMyNotifications` declares `page`
and carries no pagination trait, per §8), so no single sentence covers all 48
sites, and it is a pre-existing imprecision rather than something #617 created.
Left for a separate change if it is judged worth making.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `page` parameter docs to reflect the unified contract: a positive `page` selects exactly that page, not a starting offset. Removes stale “Semantics vary by SDK” wording across all SDKs to match SPEC §8.

- **Bug Fixes**
  - Replaced old phrasing (47 long-form + 1 short) across `spec/basecamp.smithy`, `openapi.json`, and generated SDKs; kept the SPEC §8 reference.
  - Regenerated Go, Kotlin, Ruby, Swift, and TypeScript outputs so IDE/tooling show the correct docs; Python unchanged (no per-parameter docstrings).
  - No wire or signature changes; diffs touch `description`/doc comments only; operation count stays 240.

<sup>Written for commit f72f977cd1eaef37f512f77db2744d2f6ceda17d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

