### PR TITLE
Raise the fast-uri override past the 4.x vulnerable range

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -900,9 +900,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -920,9 +917,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -940,9 +934,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -960,9 +951,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -980,9 +968,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1000,9 +985,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1020,9 +1002,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1040,9 +1019,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2019,9 +1995,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
-      "integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
+      "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
       "dev": true,
       "funding": [
         {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -68,7 +68,7 @@
   "overrides": {
     "minimatch": ">=10.2.1",
     "brace-expansion": ">=5.0.9",
-    "fast-uri": ">=3.1.3",
+    "fast-uri": ">=4.1.2",
     "js-yaml": "^4.3.0"
   }
 }


### PR DESCRIPTION
**`npm Audit (TypeScript SDK)` is failing on `main`**, so every PR opened against it inherits a red check. This blocks the v0.13.0 freeze.

GHSA-7p8r-x3mc-p8w7 — high severity, `fast-uri` host confusion via a backslash authority introducer.

## Why this reads as a regression, not a gap

An override already existed at `>=3.1.3`. The advisory patches **three separate lines**:

| Vulnerable range | Patched |
|---|---|
| `< 2.4.4` | 2.4.4 |
| `>= 3.0.0, < 3.1.5` | 3.1.5 |
| `>= 4.0.0, < 4.1.2` | **4.1.2** |

`>=3.1.3` satisfies none of them — and, worse, leaves npm free to resolve **4.1.1**, which sits inside the third range. An open-ended floor constrains only the low end.

Bumping to `>=3.1.5` alone reproduces exactly that failure. Measured, not reasoned:

```console
override >=3.1.3  ->  resolved 4.1.1  ->  npm audit REAL_EXIT=1
override >=3.1.5  ->  resolved 4.1.1  ->  npm audit REAL_EXIT=1
override >=4.1.2  ->  resolved 4.1.2  ->  npm audit REAL_EXIT=0, "found 0 vulnerabilities"
```

Run with `--audit-level=high`, the same threshold CI uses. 4.1.2 is the current latest.

## Worth a look beyond this fix

Three sibling overrides in that block are written the same open-ended way:

```json
"minimatch": ">=10.2.1",
"brace-expansion": ">=5.0.9",
"js-yaml": "^4.3.0"
```

A `>=x.y.z` floor cannot stop a later major from walking into a *newer* vulnerable range, and the override will not look stale while it happens — which is precisely what occurred here. Worth deciding whether these should be bounded rather than open-ended. Not changed in this PR: one advisory, one fix, and the others are not currently failing.

Related: `brace-expansion` needed the same treatment two days ago (#616), which is a second data point for the same pattern.

## Verification

`fast-uri` is a transitive dependency of the **TypeScript toolchain**, not a runtime dependency of the SDK, so there is no consumer-visible change. Verified regardless:

```console
make ts-check                REAL_EXIT=0    79 files, 1280 tests passed
make conformance-typescript  REAL_EXIT=0    210 passed, 2 skipped (pre-existing)
```

Only `typescript/package.json` and `typescript/package-lock.json` are touched. Committed bytes verified against the working tree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the `fast-uri` override to `>=4.1.2` and updates the lockfile so `npm audit` passes on `main` (GHSA-7p8r-x3mc-p8w7). This fixes the failing TypeScript SDK audit check and unblocks the v0.13.0 freeze.

- **Dependencies**
  - Set `fast-uri` override to `>=4.1.2`; previous `>=3.1.3` allowed vulnerable `4.1.1`.
  - Updated lockfile to resolve `fast-uri@4.1.2`.
  - `npm audit --audit-level=high` now reports 0 vulnerabilities; toolchain-only change, no runtime impact.

<sup>Written for commit 634cc2e23b9fff56570ee25987b7f564e99b6dc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

