### PR TITLE
Registry: settle the recurrence pre-modeling gate and the dock-doors disposition

### DIFF
--- a/spec/api-gaps/external-links-doors.md
+++ b/spec/api-gaps/external-links-doors.md
@@ -46,8 +46,16 @@ etc.). New `doc/api/sections/external_links.md` documents:
   `/:account_id/dock/tools/:id.json`: `GET` (get), `PUT` with a `title` (rename), and
   `DELETE` (trash — soft-deletes the door, `status` → `"deleted"`). The legacy
   `DELETE /:account_id/buckets/:bucket_id/dock/doors/:id.json` is an alias.
-- **No JSON update path** for `url`/`service`/`description` — a `PUT` to the
-  tool returns **406**; changes go through the HTML redirector only.
+- **No JSON update path** for `url`/`service`/`description`. A prior revision of
+  this entry said "a `PUT` to the tool returns 406" — that is wrong, and it
+  matters because it maligns an operation the SDK ships. `PUT /dock/tools/:id.json`
+  is the **rename** and returns `200 OK`; it just doesn't reach these three
+  fields. It is the door-scoped `PUT /buckets/:b/dock/doors/:id.json` that
+  returns **406**, and it does so *after* applying the change —
+  `Docks::DoorsController#update` calls `@recording.update!` before a
+  `respond_to` block that offers only `turbo_stream` and `html`, so content
+  negotiation fails on a record that has already been written. Callers change
+  these fields in the web app, or trash the link and create a new one.
 
 The same PR adds `Door` to the documented `type` enum for
 `GET /:account_id/projects/recordings.json` in `recordings.md`.
@@ -86,8 +94,9 @@ the contract is now documented and must be tracked to keep detection honest.
 - External links are deliberately omitted from a project's `dock` array, so
   the "discover via dock" advice does not surface them — the `type=Door` list
   is the canonical enumeration.
-- There is no JSON update path for `url`/`service`/`description` (PUT → 406);
-  updates go through the HTML redirector only.
+- There is no JSON update path for `url`/`service`/`description`. The 406 comes
+  from the door-scoped `PUT`, not from `UpdateTool` — see the corrected bullet
+  under "What's missing".
 
 ## SDK absorption plan when this lands
 
@@ -130,8 +139,91 @@ image are recorded as residual gaps below.
   `absorbed-in-sdk`.
 - **Create-and-discover composite (SPEC §18) — deferred.** It depends on a
   shippable `CreateExternalLink`, so it is out of scope until create lands.
-- **No JSON update path** for `url`/`service`/`description` (PUT → 406): never
-  modeled, by contract.
+- **No JSON update path** for `url`/`service`/`description`: never modeled, by
+  contract. The door-scoped `PUT` returns 406 (see above).
+
+### Disposition of the two allowlisted door routes — decided 2026-08-03
+
+[`spec/bc3-route-allowlist.yml`](../bc3-route-allowlist.yml) carries two
+`bc3_routes_not_modeled` entries pointing here. `partial-coverage` is the
+honest *status* — list, get, rename, and trash are absorbed; create is not — but
+it was being read as an open question about these two routes. It is not. They
+have different answers, and both are settled below. Verified against `bc3` at
+the revision pinned in [`spec/api-provenance.json`](../api-provenance.json).
+
+**What `routes.rb` draws.** `config/routes.rb` has a bare `resources :doors`
+inside `resource :dock` inside the bucket scope — no `only:`, no `except:`, so
+all seven default actions exist at `/buckets/:id/dock/doors`. Drawn is not the
+same as API-reachable: `api_request?` keys on `request.host == BC3.api_host` and
+`restrict_view_paths_to_api_root` then limits view paths to `app/views/api`. The
+only door template under that root is
+`app/views/api/doors/_door.json.jbuilder` — a **partial**, rendered by the
+recordings projection for the `type=Door` list. There is no
+`app/views/api/doors/index.json.jbuilder` and no `show`, so `Docks::DoorsController#index`
+(an empty action) is drawn but **not renderable** under the API host. It is
+absent from the allowlist only because
+[`spec/bc3-routes.json`](../bc3-routes.json) is extracted from
+`doc/api/sections/*.md` and the doc does not bullet it.
+
+**`test/api` agrees.** There is no `test/api` coverage of the door-scoped routes
+at all. Doors are exercised only through the flat dock-tool routes
+(`test/api/docks/tools_controller_api_test.rb` — show, rename, and trash a door
+recording via `docks_tool_url`) and through the `type=Door` recordings query
+(`test/api/projects/recordings_controller_api_test.rb`, which asserts the full
+door shape: external `url`, `service.code`, `description`). Every door surface
+bc3 tests as an API is a surface this SDK already models. With `routes.rb` and
+`test/api` agreeing, `doc/api` is safe here as negative evidence.
+
+#### `GET /buckets/:id/dock/doors/:id` — permanently out of scope
+
+Not deferred. **Never modelable**, and the allowlist disposition is changed from
+`registry:` to `out_of_scope:` to say so at the point of use.
+
+`Docks::DoorsController#show` is one line — `redirect_to @recording.door.url`.
+`doc/api/sections/external_links.md` states the same thing in the affirmative:
+"The legacy bucket-scoped route is a redirector rather than a JSON resource:
+`GET /buckets/1/dock/doors/2.json` responds with `302 Found` and a `Location`
+header pointing at the external link's outside `url`." It is template-less, so
+it technically survives the view-path restriction — which is exactly why the
+"drawn *and* renderable" test alone does not settle it. It renders nothing
+because it returns nothing: there is no representation, at any content type,
+ever.
+
+Modeling it would mean shipping an SDK operation whose success value is a
+cross-origin redirect to a **user-supplied third-party URL**. The redirect
+target is attacker-influenced by construction — anyone who can create an
+external link chooses it. The transport spike recorded above found that four of
+the six SDK transports (Go, TypeScript, Kotlin, Swift) follow redirects by
+default, so the natural implementation issues an outbound request to that
+address. Cross-origin auth stripping is what keeps the Bearer token off it, and
+that is a property of each HTTP stack's defaults rather than something this SDK
+asserts. An SDK should not turn a credentialed client into a general-purpose
+fetcher of arbitrary URLs, and there is no upside to weigh against it: the
+external `url` is already delivered as a plain field by the modeled `type=Door`
+`ListRecordings` query. This does not become absorbable if the create question
+is solved later.
+
+#### `POST /buckets/:id/dock/doors` — real route, keeps the registry disposition
+
+This one **is** a real API route: drawn, template-less by redirect rather than by
+omission, and documented with a JSON request body, a parameter table, and a cURL
+example. It stays dispositioned to this entry, and the reason it is unmodeled is
+cost, not principle — spelled out under "Residual gaps" above and unchanged by
+this reassessment. Two independent blockers, either of which alone is
+disqualifying:
+
+1. The 302/empty-body/no-ID response needs coordinated per-operation redirect
+   suppression plus 302-as-success handling across all six generated transports.
+   That is a cross-cutting transport change, not an additive absorption.
+2. `door[image]` is `multipart/form-data` only and is unmodeled regardless.
+
+`sdk_demand` is `low` and external links are a legacy dock surface, so nothing
+here argues for paying that cost soon. If it is ever paid, the create-and-discover
+composite (SPEC §18) becomes available in the same PR, since discovery of the new
+ID already works through `ListRecordings`.
+
+**Next reader:** the open item on this entry is create, and only create. `GET`
+on the door-scoped route is closed. Do not re-litigate the door redirector.
 
 ## Compatibility
 

--- a/spec/api-gaps/schedule-recurrence-writes.md
+++ b/spec/api-gaps/schedule-recurrence-writes.md
@@ -95,7 +95,7 @@ turns that into a diagnosable error.
 `has_many_occurrences?` is `schedule_with_time_zone.first(2).size == 2`
 (`app/models/schedule/entry/occurrences.rb`). A perfectly valid pattern whose
 `recurs_until` leaves room for only one occurrence takes the same discard path.
-This is documented nowhere in `doc/api` and is a modelling-relevant behavior:
+This is documented nowhere in `doc/api` and is a modeling-relevant behavior:
 "valid per the parameter table" is not sufficient for the entry to come back
 recurring.
 

--- a/spec/api-gaps/schedule-recurrence-writes.md
+++ b/spec/api-gaps/schedule-recurrence-writes.md
@@ -44,63 +44,266 @@ on the existing create/update endpoints:
 - The remaining `recurrence_schedule` attributes shown in the read payload
   (`hour`, `minute`, `start_date`, `duration`, `end_date`) are **derived**
   from `starts_at`/`ends_at`/`recurs_until` and **ignored on input**.
-- An **invalid `recurrence_schedule` is silently discarded on create** — for
-  malformed/other invalid shapes the entry is created without recurring (no
-  validation error). This does **not** apply to *uncomputable* schedules
-  (`week_instance: 0` and the like), which BC3 #12362 now rejects with a
-  validation error at create time (see below); silent-discard covers only the
-  remaining invalid shapes.
+- An **invalid `recurrence_schedule` is silently discarded on create** — the
+  entry is created without recurring and the response simply omits
+  `recurrence_schedule` (no validation error, still `201`). This is **one
+  uniform rule with no error branch**: it covers uncomputable schedules
+  (`week_instance: 0` and the like) exactly as it covers every other invalid
+  shape. See the correction below — an earlier revision of this entry claimed
+  #12362 carved uncomputable schedules out into a wire-visible validation
+  error, and that is wrong.
 - Update: adding a `recurrence_schedule` makes a non-recurring entry recur.
   An entry that **already recurs can't be changed** through the update
   endpoint — it redirects to the entry's first occurrence, like Get a
   schedule entry does.
 
-**`week_instance: 0` now rejected server-side**: BC3 **#12362**
-(`ec17b83c`, "Reject recurrence schedules whose occurrences can't be
-computed") merged and now rejects `week_instance: 0` (and other
-uncomputable schedules) at create time — previously it spun a worker
-indefinitely. An SDK-side guard is therefore **no longer mandatory**; `0`
-is a normal validation error on the wire, not a hang. Modeling `frequency`
-as an enum and bounding the recurrence integers remains good hygiene, but
-it is no longer load-bearing for hang avoidance.
+**Correction — what BC3 #12362 actually changed.** #12362 (`ec17b83c`,
+"Reject recurrence schedules whose occurrences can't be computed", merged
+2026-07-22) tightened `RecurrenceSchedule`'s *model validations*: `week_instance`
+inclusion went from `(-1..4)` to `[ -1, 1, 2, 3, 4 ]`, a new
+`days_must_fit_frequency` validation was added, and `days=` stopped silently
+dropping uncoercible members. It changed **no controller and no view** — its
+diff touches `app/models/recurrence.rb`, `app/models/recurrence_schedule.rb`,
+one HTML field partial, and model tests.
+
+The wire consequence follows from
+`Schedule::Entry::Recurrable#ensure_valid_recurrence_schedule`, a `before_save`
+that predates #12362 and was untouched by it:
+
+```ruby
+unless recurrence_schedule.valid? && has_many_occurrences?
+  self.recurrence_schedule = self.recurs_until = self.time_zone_name = nil
+end
+```
+
+Ruby short-circuits `&&`, so making `valid?` false is precisely what stops
+`has_many_occurrences?` from being reached — that is the hang fix. The record
+then saves with the recurrence nilled out. So `week_instance: 0` is **silently
+discarded, not rejected**: the caller gets `201` with a non-recurring entry, the
+same outcome as any other invalid shape. Nothing on the wire distinguishes the
+two, which is why there is no error branch to model.
+
+An SDK-side guard remains **not mandatory** (there is no hang to avoid), but the
+reason stated in the prior revision — "`0` is a normal validation error on the
+wire" — was never true. Modeling `frequency` as an enum and bounding the
+recurrence integers is still worthwhile, now for a different reason: silent
+discard means a client that sends a bad value gets a plausible-looking success
+and a silently non-recurring entry. Client-side bounds are the only thing that
+turns that into a diagnosable error.
+
+**Also silently discarded: patterns yielding fewer than two occurrences.**
+`has_many_occurrences?` is `schedule_with_time_zone.first(2).size == 2`
+(`app/models/schedule/entry/occurrences.rb`). A perfectly valid pattern whose
+`recurs_until` leaves room for only one occurrence takes the same discard path.
+This is documented nowhere in `doc/api` and is a modelling-relevant behavior:
+"valid per the parameter table" is not sufficient for the entry to come back
+recurring.
 
 ## Why it matters
 
 Recurring events are table stakes for calendar integrations. The SDK can
-read `recurrence_schedule` but can't create or update recurring entries, so
-any integration syncing an external calendar into Basecamp has to fan a
-recurring series out into individual entries — which then don't behave as a
-series in the product.
+neither create nor update recurring entries — and, as the correction under
+"Suggested API shape" records, it cannot read the recurrence either: nothing in
+`spec/basecamp.smithy` models `recurrence_schedule`. So any integration syncing
+an external calendar into Basecamp has to fan a recurring series out into
+individual entries — which then don't behave as a series in the product — and
+cannot even tell that an entry it reads back is part of one.
 
 ## Suggested API shape
 
 Additive optional members on the existing `CreateScheduleEntry` /
 `UpdateScheduleEntry` inputs: a `recurrence_schedule` structure (enum-typed
 `frequency`; integer list `days`; bounded integers per the table) plus
-top-level `recurs_until: ISO8601Date`. Response shapes unchanged (the read
-side already models `recurrence_schedule`).
+top-level `recurs_until: ISO8601Date`.
+
+**Correction — the response side is not already modeled.** A prior revision of
+this entry said "Response shapes unchanged (the read side already models
+`recurrence_schedule`)". It does not. There is **no occurrence of `recurrence`
+in `spec/basecamp.smithy` or `openapi.json`** other than four doc-comment
+mentions of *recurring* entries redirecting, and `ScheduleEntry` carries no
+`recurrence_schedule` member. Absorption therefore has to add the output
+structure as well as the input one — that is scope, not a blocker, but the plan
+must budget for it.
+
+The output structure is fully determined by
+`RecurrenceSchedule#as_json` → `attributes` → `pattern_attributes` +
+`window_attributes`, which is a fixed **ten**-key object emitted on every
+recurring entry:
+
+| Key | Source | Note |
+|---|---|---|
+| `frequency` | submitted | the nine-value enum; always populated |
+| `days` | submitted or derived | sorted integer list; see the derivation below. May be `null` for `every_day`/`every_weekday`, which have canonical defaults |
+| `hour`, `minute` | derived | always populated: from `starts_at` in the entry's time zone, or `0`/`0` when `all_day` |
+| `week_instance` | submitted | reader returns `null` unless `frequency` is `every_month`/`custom_month` |
+| `week_interval` | submitted | reader returns `null` unless `frequency` is `custom_week` |
+| `month_interval` | submitted | reader returns `null` unless `frequency` is `custom_month` |
+| `start_date` | derived | `starts_at` as a date |
+| `duration` | derived | integer **seconds**, present only when `ends_at` was supplied |
+| `end_date` | derived | `recurs_until`, or `null` |
+
+All ten keys are always **present**; most are nullable. `frequency`, `hour`,
+`minute`, and `start_date` are always populated on a recurring entry; the other
+six must be modeled nullable, because the frequency-gated readers return `nil`
+for the inapplicable frequencies rather than omitting the key and `as_json`
+emits the full hash regardless. **`doc/api` under-describes this** — the
+illustrative `recurrence_schedule` object in `schedule_entries.md` shows seven
+keys, omitting `week_interval`, `month_interval`, and `duration`. That block sits
+*outside* the `<!-- START ... -->` / `<!-- END ... -->` markers that delimit the
+#11629 live-regenerated snapshots, so it is hand-authored prose, not a captured
+wire echo. Model from the source cited below, not from that example.
 
 ## Implementation notes for BC3
 
 - Shipped in docs — `schedules/entries_controller.rb` handles the params.
 - #12362 (`ec17b83c`, merged) is the server-side guard for uncomputable
-  schedules (`week_instance: 0` et al.); it now rejects them at create time.
-  Silent-discard-on-invalid on create for *other* invalid recurrence shapes
-  is documented, not a bug.
+  schedules (`week_instance: 0` et al.). It stops the create-time hang by
+  making them fail `RecurrenceSchedule#valid?`; the resulting wire behavior is
+  the pre-existing silent discard, **not** a validation error. See the
+  correction under "What's missing".
+- Silent-discard-on-invalid on create is documented, not a bug — but the
+  sub-two-occurrences case is undocumented. `doc/api/sections/schedule_entries.md`
+  is worth a follow-up sentence there.
+
+### Source citations at the pinned revision
+
+Everything the absorption needs is readable offline at the `bc3` revision in
+[`spec/api-provenance.json`](../api-provenance.json). These are the four
+load-bearing files:
+
+| Claim | File | Mechanism |
+|---|---|---|
+| Which keys are accepted on input | `app/controllers/schedules/entries/base_controller.rb` | `params.require(:schedule_entry).permit(..., :recurs_until, recurrence_schedule: [ :frequency, :week_instance, :week_interval, :month_interval, days: [] ])` |
+| `hour`/`minute`/`start_date`/`duration`/`end_date` ignored on input | same permit list | they are **absent from it** — strong parameters filters them before the model is ever constructed |
+| those five derived on output | `app/models/schedule/entry/recurrable.rb` | `sync_recurrence_schedule_dates`, a `before_validation` that assigns `start_date`/`hour`/`minute` from `starts_at`, `duration` from `ends_at`, `end_date` from `recurs_until` |
+| `days` overwritten for most frequencies | same method | assigned `start_date.wday` for `every_week`/`every_other_week`/`custom_week`/`every_month` and for `custom_month` **with** a `week_instance`; `start_date.day` for `every_day_of_month`. A submitted `days` survives only for `every_day`, `every_weekday`, `every_year`, and `custom_month` **without** a `week_instance` |
+| silent discard on invalid | same file | `ensure_valid_recurrence_schedule`, a `before_save` gated on `new_record? && recurring?` |
+| the response key set | `app/models/recurrence_schedule.rb` | `as_json` → `attributes` → `pattern_attributes` + `window_attributes` (ten keys) |
+| the validation bounds | same file | `frequency` inclusion (nine values), `days` length `1..7` unless yearly, `days_must_fit_frequency`, `hour` `0..23`, `minute` `0..59`, `week_instance` `[-1,1,2,3,4]`, `week_interval` / `month_interval` `2..12` |
+| the echo is `as_json` verbatim | `app/views/api/schedules/entries/_entry.json.jbuilder` | `json.recurrence_schedule recording.recordable.recurrence_schedule`, emitted only `if recording.recurring?` |
 
 ## SDK absorption plan when this lands
 
-- Vehicle: the §Q absorption queue's **PR-5**. Docs are merged, so the doc
-  gate is cleared, but the **wire-echo probe remains a pre-modeling gate**:
-  before modeling, probe a live BC5 create with each frequency family and
-  diff the echoed `recurrence_schedule` against the doc (the derived-fields
-  and silent-discard semantics make doc-only modeling risky).
-- Model `frequency` as an enum (nine values above). BC3 #12362
-  (`ec17b83c`) has merged, so `week_instance: 0` is now a server-side
-  validation error rather than a hang; an SDK-side guard is optional
-  hygiene, no longer a hard requirement.
+- Vehicle: the §Q absorption queue's **PR-5**. Docs are merged, so the doc gate
+  is cleared.
+- Model `frequency` as an enum (nine values above), model the ten-key response
+  structure per the table under "Suggested API shape", and bound the recurrence
+  integers client-side — not to avoid a hang (#12362 removed that) but because
+  the server's failure mode is a silent discard that a caller cannot otherwise
+  detect.
 - Status flips to `absorbed-in-sdk` with the absorption PR (which adds the
   Smithy refs).
-- Pairwise check: BC4 accepts the same create/update routes but recurrence
-  behavior on BC4 is unverified — probe both rails before asserting
-  pairwise invariants.
+
+### Pre-modeling gate: reassessed 2026-08-03
+
+A prior revision made a **live wire-echo probe a hard pre-modeling gate**, on
+two rails: probe BC5, and probe BC4 "before asserting pairwise invariants".
+Both halves are re-decided here.
+
+**The BC4 half is unsatisfiable and is withdrawn — not deferred, withdrawn.**
+BC5 replaced BC4 in production; there is no live BC4 backend to compare
+against. That is recorded in
+[`COORDINATION.md`](../../COORDINATION.md) twice — contract decision 1
+("BC5 replaced BC4 in production — there is no live BC4 backend to compare
+against, so the pairwise machinery was removed") and contract decision 3
+("settled by release: BC5 replaced BC4 in production, so there is no live BC4
+backend to shim") — and again in the `conformance-canary` recipe in the
+`Makefile` ("BC5 replaced BC4 in production, so there is one live backend …
+The former pairwise BC4↔BC5 comparison is retired"). The pairwise engine went
+out with PR #308 and is recoverable from git history if a reachable legacy
+backend ever returns. Keeping a gate that no operator can discharge is how a
+registry entry rots into permanent-blocked; that is why this is written down
+rather than quietly dropped.
+
+**What replaced it, and what it found.** The pairwise *question* — does BC4
+accept the same recurrence contract? — survives the loss of the live rail,
+because the `four` branch source is still pinned at
+`compatibility.bc3-four` = `9d73959a` (2026-06-12) in
+[`spec/api-provenance.json`](../api-provenance.json). Diffing the three
+load-bearing files between that pin and the `bc3` pin answers it offline, and
+the answer is: **the write contract is identical on both rails.** The
+`recurrence_schedule` permit list is byte-identical. `RecurrenceSchedule`'s
+`attr_accessor` set, `attributes`, `pattern_attributes`, `window_attributes`,
+and `as_json` are unchanged, so the echoed key set is the same. The recurrence
+deltas are exactly #12362's tightenings (`week_instance` `(-1..4)` →
+`[ -1, 1, 2, 3, 4 ]`, the new `days_must_fit_frequency`, the `days=` coercion
+change), plus `ensure_valid_recurrence_schedule` narrowing from every save to
+`new_record?`, plus `duration` being computed separately for the timed and
+all-day branches. Nothing there changes what an SDK would model. Prefer this
+source diff to a live pairwise probe permanently: it is free, offline,
+reproducible from the pins, and it is the only form of the check that can still
+be run.
+
+**The BC5 half is downgraded from a hard gate to an optional post-absorption
+check.** The gate existed because "the derived-fields and silent-discard
+semantics make doc-only modeling risky". That premise is correct — but the
+alternative to a live probe is not doc-only modeling, it is **source-at-the-pin
+modeling**, which is what the rest of this registry already does. Both claims
+the gate was protecting are *structural*, not behavioral, and both are settled
+by the citations table above:
+
+- **Derived fields are not "observed to be ignored", they are unreachable.**
+  `hour`, `minute`, `start_date`, `duration`, and `end_date` do not appear in
+  the controller's `permit` list, so strong parameters drops them before a
+  `RecurrenceSchedule` is ever constructed. A probe cannot make this more true;
+  it can only re-confirm it from the outside.
+- **Silent discard is one `before_save` guard**, and reading it corrected two
+  errors this entry had been carrying (#12362 does not produce a validation
+  error, and sub-two-occurrence patterns discard as well). The probe was
+  supposed to catch drift like that. Reading the source caught it instead, at
+  zero cost and with no production writes.
+
+Reading the source also caught the thing the probe was *most* likely to catch
+and the doc was *least* likely to state: `spec/basecamp.smithy` does not model
+`recurrence_schedule` at all, and `doc/api`'s illustrative echo is missing three
+of the ten keys. A live probe would have surfaced the second of those. The
+source read surfaced both.
+
+**Verdict: doc-only modeling is not defensible here; source-at-the-pin modeling
+is; the live probe is not required to start.** Absorb against the cited files,
+and treat the probe as post-absorption verification if anyone wants it.
+
+**Residual risk this accepts.** Two things the source cannot prove: the exact
+JSON encoding of the derived values (`start_date`/`end_date` render as
+`"YYYY-MM-DD"`; `duration` as integer seconds), and that production BC5 is
+running the pinned revision. The first is cheap to model conservatively and
+cheap to correct. The second is the standing assumption behind every entry in
+this registry — singling this one out for a live proof is an inconsistent bar,
+not a higher one.
+
+### If someone wants the probe anyway — what it costs
+
+Written down so this is a decision someone can approve or decline, rather than
+an open-ended blocker. It is **not** a gate on absorption.
+
+- **Credentials.** `BASECAMP_TOKEN`, `BASECAMP_ACCOUNT_ID`, `BASECAMP_HOST`
+  against production BC5, plus a project the caller can write to. None are
+  configured in this repo's environment.
+- **No harness to ride.** All 31 cases in
+  [`conformance/tests/live-my-surface.json`](../../conformance/tests/live-my-surface.json)
+  are `GET` and tagged `read-only`; the live canary has no mutation lane at all.
+  The probe is a bespoke script, not a canary case.
+- **Coverage.** Nine creates, one per frequency family — `every_day`,
+  `every_weekday`, `every_week`, `every_other_week`, `every_month`,
+  `every_day_of_month`, `every_year`, `custom_week`, `custom_month` — since the
+  `days`/`week_instance` derivation branches on frequency. Add three negatives:
+  `week_instance: 0`, a `days` member outside the frequency's range, and a
+  `recurs_until` close enough to `starts_at` to yield a single occurrence. All
+  three should return `201` with `recurrence_schedule` **absent**.
+- **What to diff.** The echoed `recurrence_schedule` against the ten-key table
+  above — key set first (does the response really carry `week_interval`,
+  `month_interval`, and `duration` as nulls?), then per-key: `days`
+  canonicalization, `hour`/`minute` against the submitted `starts_at`,
+  `duration` as integer seconds, `start_date`/`end_date` string format. Diff
+  against the source-derived table, not against `doc/api`'s seven-key example,
+  which is already known to be incomplete.
+- **Blast radius and cleanup.** These are real records in a live account, and a
+  recurring entry is not one artifact: it fans out into occurrences and can
+  notify participants and subscribers. Two levers cut this down — create with
+  `status: "drafted"` (documented, and the recurrence machinery still runs, so
+  the echo is unaffected), and pass no `participant_ids`. Cleanup is a
+  `DELETE` per created entry, and the operator should confirm the project's
+  schedule and the account timeline are clean afterward.
+- **Authorization.** Production mutations against a live account need an owner's
+  sign-off before anyone runs this. Nothing in this entry constitutes that
+  sign-off.

--- a/spec/bc3-route-allowlist.yml
+++ b/spec/bc3-route-allowlist.yml
@@ -187,12 +187,29 @@ bc3_routes_not_modeled:
     path: /vaults/:id/google_documents
     tracking_issue: 551
 
-  # -- dock doors: registered, status partial-coverage (door create documented,
-  #    door show not) --
+  # -- dock doors: the two door-scoped routes get DIFFERENT dispositions, decided
+  #    2026-08-03. The show route is a redirector and can never be modeled, so it
+  #    is out_of_scope, not registered. Only create remains open, and it stays
+  #    registered against the partial-coverage entry. Full reasoning, verified
+  #    against the pinned bc3 revision, is in the entry's "Disposition of the two
+  #    allowlisted door routes" section.
+  #
+  #    Door index is drawn (bare `resources :doors`, no only:/except:) but has no
+  #    app/views/api template, so it is not renderable under the API host. It is
+  #    absent here only because spec/bc3-routes.json is extracted from doc/api,
+  #    which does not bullet it. --
 
   - method: GET
     path: /dock/doors/:id
-    registry: spec/api-gaps/external-links-doors.md
+    out_of_scope: >-
+      A redirector, not a JSON resource. Docks::DoorsController#show is
+      `redirect_to @recording.door.url`, and doc/api/sections/external_links.md
+      documents the response as 302 with a Location header pointing at the
+      external link's outside URL — there is no representation at any content
+      type. Modeling it would make a credentialed client follow a redirect to a
+      user-supplied third-party address (four of six SDK transports follow
+      redirects by default), and the external URL is already delivered as a
+      plain field by the modeled type=Door ListRecordings query.
   - method: POST
     path: /dock/doors
     registry: spec/api-gaps/external-links-doors.md


### PR DESCRIPTION
Two `spec/api-gaps` entries were each leaving a reader with an open question instead of a decision, and both were carrying claims that don't survive checking against bc3 at the pinned revision. Documentation only — **no `spec/basecamp.smithy` or `openapi.json` changes** (the spec train is held by the #544 lane).

## 1. `schedule-recurrence-writes.md` — the pre-modeling gate

The entry made a live wire-echo probe a **hard pre-modeling gate** on two rails. Both are re-decided.

### The BC4 rail is withdrawn — unsatisfiable, not deferred

No operator can discharge it. BC5 replaced BC4 in production, so there is no live BC4 backend; `COORDINATION.md` records this twice (contract decisions 1 and 3) and the `conformance-canary` recipe records it again. The pairwise machinery went out with PR #308 and is recoverable from git history if a reachable legacy backend ever returns. That history is written down rather than deleted — a gate nobody can satisfy is how an entry rots into permanent-blocked.

**The pairwise *question* survives offline.** The `four` branch is still pinned at `compatibility.bc3-four` = `9d73959a`. Diffing the three load-bearing files against the `bc3` pin answers it for free: the `recurrence_schedule` permit list is **byte-identical** on both rails, and `RecurrenceSchedule`'s `attr_accessor` / `attributes` / `as_json` are unchanged, so the echoed key set is the same. The only recurrence deltas are #12362's tightenings plus `ensure_valid_recurrence_schedule` narrowing to `new_record?`. Nothing there changes what an SDK would model. The entry now says to prefer this source diff permanently.

### The BC5 rail is downgraded to optional post-absorption verification

The gate's premise — "doc-only modeling is risky here" — is **correct**. But the alternative to a live probe isn't doc-only modeling, it's **source-at-the-pin modeling**, which is what the rest of this registry already does. Both claims the gate protected are structural, not behavioral:

- **Derived fields aren't "observed to be ignored", they're unreachable.** `hour`, `minute`, `start_date`, `duration`, `end_date` are absent from the controller's `permit` list, so strong parameters drops them before a `RecurrenceSchedule` is ever constructed.
- **Silent discard is one `before_save` guard**, readable in ~4 lines.

Reading that source also caught what the probe was supposed to catch:

| Entry claimed | Actually |
|---|---|
| #12362 "rejects with a validation error at create time"; "`0` is a normal validation error on the wire" | #12362 changed **no controller and no view**. It makes `valid?` false, which short-circuits `&&` so `has_many_occurrences?` is never reached — *that* is the hang fix. The record then takes the pre-existing **silent-discard** path. `week_instance: 0` returns `201` with a non-recurring entry, indistinguishable from any other invalid shape. One uniform rule, no error branch to model. |
| "the read side already models `recurrence_schedule`" | **It does not.** Zero occurrences of `recurrence_schedule` in `spec/basecamp.smithy` or `openapi.json`; `ScheduleEntry` has no such member. Absorption must add the **output** structure too. |
| — (new) | A valid pattern yielding **fewer than two occurrences** is silently discarded as well (`has_many_occurrences?`). Undocumented in `doc/api`. |

The response structure is now documented as the **ten**-key object `as_json` actually emits, with per-key nullability. `doc/api`'s illustrative example shows **seven** — omitting `week_interval`, `month_interval`, `duration` — and sits *outside* the `<!-- START -->`/`<!-- END -->` markers that delimit the #11629 live-regenerated snapshots, so it's hand-authored prose, not a captured wire echo. A source-citations table pins every claim to its file and mechanism.

**Verdict: doc-only modeling is not defensible; source-at-the-pin modeling is; the probe is not required to start.** Residual risk accepted is stated explicitly (JSON encoding of derived values; production running the pinned revision — the standing assumption behind every entry here). The probe's cost is written down anyway — nine frequency families, three negatives, what to diff, credentials, blast radius, and the two levers that shrink it (`status: "drafted"`, no `participant_ids`) — so it stays an approvable decision rather than an open blocker. **No live calls were made and none are authorized.**

## 2. `external-links-doors.md` — dock doors disposition

**Kept, but split** — the two allowlisted routes have genuinely different answers and were sharing one disposition.

**`GET /buckets/:id/dock/doors/:id` → `out_of_scope`, permanently.** `Docks::DoorsController#show` is `redirect_to @recording.door.url`; `doc/api` says so affirmatively ("a redirector rather than a JSON resource… `302 Found` and a `Location` header"). It's template-less, so "drawn **and** renderable" alone doesn't condemn it — what does is that modeling it means shipping an operation whose success value is a **cross-origin redirect to a user-supplied third-party URL**, attacker-influenced by construction, in four of six transports that follow redirects by default. No upside: `ListRecordings?type=Door` already returns that `url` as a plain field. Disposition moved `registry:` → `out_of_scope:` so the reasoning sits at the point of use.

**`POST /buckets/:id/dock/doors` → keeps `registry:`.** A real API route (drawn, template-less by redirect, documented with a JSON body and cURL). Unmodeled on **cost, not principle** — the 302/empty-body/no-ID contract needs cross-cutting transport changes across six SDKs, and `door[image]` is multipart-only. Now stated as a closed decision with a "next reader" note: create is the only open item; don't re-litigate the redirector.

Route facts verified at the pin: bare `resources :doors` (no `only:`/`except:`) draws all seven actions; the only template under `app/views/api` is the `_door` **partial**, so `#index` is drawn but **not renderable**; `test/api` covers doors *only* through the flat dock-tool routes and the `type=Door` recordings query — every door surface bc3 tests as an API is one this SDK already models.

**Also corrected:** the entry claimed "a `PUT` to the tool returns 406", which maligns a shipped operation. `UpdateTool` renames and returns **200**. The **406** comes from the door-scoped `PUT`, which calls `@recording.update!` *before* a `respond_to` offering only `turbo_stream`/`html` — so it writes the record and then fails content negotiation.

## Verification

`PRE_SHA == POST_SHA == 87360ffd4661e7616a58b27ad46c0ff69a8b2846` (bc3 pin `2c0dafba13` unchanged).

- `make validate-api-gaps` — **REAL_EXIT=0**, "Validated 32 api-gap entries and allowlist — clean"
- `make bc3-route-parity` — **REAL_EXIT=0**, "240 SDK routes vs 369 bc3 routes… Direction 2: 16 dispositions"
- **Red proof** that the disposition is load-bearing: removing the `POST /dock/doors` entry gives `REAL_EXIT=2` and `bc3 documents POST /buckets/:id/dock/doors … with no SDK operation and no allowlist entry`. Restored from a scratch copy, re-run green.

Exit codes were written into a log and grepped back, never read from a pipeline.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Settles two API gaps: removes the hard pre-modeling probe for recurrence (model from source at the pin) and splits dock door routes, marking GET as out_of_scope and keeping POST registered. Docs-only; no changes to `spec/basecamp.smithy` or `openapi.json`. Also aligns spelling to American English.

- **Recurrence schedule**
  - Withdraws the BC4 probe (no live backend) and downgrades the BC5 probe to optional post-absorption verification. Model from source-at-the-pin.
  - Documents the 10-key response `as_json` emits; derived keys are ignored on input. Read side does not model `recurrence_schedule`, so absorption must add the output shape and bound integers client-side.
  - Corrects behavior: invalid schedules, including `week_instance: 0`, and patterns with fewer than two occurrences are silently discarded (still 201).

- **Dock doors**
  - `GET /buckets/:id/dock/doors/:id` → out_of_scope. It’s a redirector to a user-supplied URL; value already available via `ListRecordings?type=Door`. Allowlist updated to reflect this.
  - `POST /buckets/:id/dock/doors` stays registered. Unmodeled due to 302/no-body redirect handling and multipart `door[image]`; low demand.
  - Corrects doc: 406 comes from the door-scoped PUT (applies change, then fails negotiation), while `PUT /dock/tools/:id.json` renames and returns 200.

<sup>Written for commit 68ec429a622e914f884ec813df25cd325fd8232c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

