### PR TITLE
Schedules: the carve-out seeds ARE guarded; correct the Ruby comment denying it

### DIFF
--- a/ruby/lib/basecamp/services/schedules_extensions.rb
+++ b/ruby/lib/basecamp/services/schedules_extensions.rb
@@ -267,13 +267,18 @@ module Basecamp
       #   sets the key but the value may be null — so absent or null is
       #   genuinely empty.
       #
-      # The carve-outs are seeded for *reading* only, so a block can inspect
-      # them before deciding; nothing here puts them on the wire. +url+ is
+      # The carve-outs are seeded for *reading*, so a block can inspect the
+      # current join link, highlight and participants before deciding; seeding
+      # alone puts nothing on the wire. They are guarded all the same, because
+      # "reaches the wire only when addressed" is not "never reaches the wire":
+      # dirty tracking is by setter invocation, so <tt>entry.url = entry.url</tt>
+      # is an address like any other and sends whatever the seed held — and a
+      # block that merely inspects a corrupt seed decides on garbage. +url+ is
       # seeded from +join_url+, never from +url+ (see the module docs).
-      # +highlighted+ is taken verbatim: it is optional, absent from the reduced
-      # calendar partial +GetUpcomingSchedule+ renders, and — unlike every other
-      # member — cannot reach the wire unless the caller assigns it, so there is
-      # nothing to refuse a malformed value on behalf of.
+      # +highlighted+ takes the *optional* boolean guard: the member is absent
+      # from the reduced calendar partial +GetUpcomingSchedule+ renders, so a
+      # missing one is genuinely "not highlighted" rather than malformed — but a
+      # <tt>"yes"</tt> or a +1+ is refused, not coerced.
       def fields_from_entry(entry)
         body = MergeSafe.require_hash(
           entry, record: RECORD, operation: "GetScheduleEntry", escape: ESCAPE_HATCH


### PR DESCRIPTION
`fields_from_entry`'s docstring told the reader that `highlighted` is unguarded — one line above the guard that reads it:

> `+highlighted+` is taken verbatim: it is optional, absent from the reduced calendar partial `+GetUpcomingSchedule+` renders, and — unlike every other member — cannot reach the wire unless the caller assigns it, **so there is nothing to refuse a malformed value on behalf of**.

```ruby
highlighted: MergeSafe.writable_boolean(body, "highlighted", record: RECORD, escape: ESCAPE_HATCH)
```

`writable_boolean` deliberately refuses a wrong-typed `highlighted` before the full-replace PUT. **The code is right; the comment contradicted it.** A valid review finding on #632 that shipped inside a suppressed-comment block.

## Three things were wrong

- **"taken verbatim"** — it is not. `writable_boolean` admits absent/nil as `false` and refuses `"yes"` or `1` rather than coercing them.
- **"unlike every other member"** — `participant_ids` and `url` are carve-outs too, read through `writable_id_list` and `writable_string` for exactly the same reason.
- **The inference** — "reaches the wire only when addressed" is not "never reaches the wire." Dirty tracking is by *setter invocation*, deliberately (module docs, `ScheduleEntryFields`), so assigning a seed straight back is an address like any other and sends whatever the seed held. `test_edit_entry_sends_a_carve_out_assigned_its_own_read_back_value` asserts precisely that. And a block that only *inspects* a corrupt seed still decides on garbage.

## The corrected text

The right account already existed for the other two seeds — the schedules test says "a block inspecting a corrupt value would decide on garbage", and Python's `_carve_out_seeds` docstring says "the values are still guarded, because `entry.url = entry.url` is a legitimate write and would otherwise carry a malformed value into the PUT." The Ruby comment now states that for all three, and gives `highlighted` its real justification: the member is *optional* because the reduced calendar partial behind `GetUpcomingSchedule` omits it, so absence is genuinely "not highlighted" — the wrong type still is not.

## The general point

Asked to check whether the sibling carve-out comments make the same claim: **within Ruby they do not.** `url` (seeded from `join_url`, never from `url`), `participant_ids` and `notify` ("nothing in the response seeds a directive") are all accurate and unchanged. TypeScript and Python are correct too.

**One copy of the same sentence lives outside this PR's scope**, verbatim, in `kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/SchedulesService.kt:317-322`. Kotlin's `"taken verbatim"` is *accurate* there — kotlinx.serialization is the typed decoder, so no hand-written guard is needed — but the stated *reason* ("cannot reach the wire unless the caller assigns it") is the same wrong one, and "unlike every other member" is wrong there too: `url` and `participantIds` are carve-outs with the same setter-based dirty tracking. Left for a follow-up rather than widening a Ruby-comments PR into a Kotlin build.

## Scope and verification

Ruby comments only — no spec, no generated files, no behaviour.

`make rb-check` (drift + tests + rubocop) at `ad9a33bd4`, `PRE_SHA == POST_SHA == 017a79016`:

```
No drift detected.
1358 runs, 30434 assertions, 0 failures, 0 errors, 0 skips
151 files inspected, no offenses detected
==> Ruby SDK checks passed
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrected Ruby comments in `fields_from_entry` to state that carve-out seeds (`highlighted`, `url`, `participant_ids`) are guarded, removing the false “taken verbatim” claim. Clarifies `highlighted` is optional yet type-checked and notes setter-based dirty tracking; comments only, no behavior changes.

<sup>Written for commit ad9a33bd4a8c27137dc9e1ffbba041f0dc708200. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

