### PR TITLE
Event-feed conformance families, their gates, and the §23 G-SD repair

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -527,12 +527,17 @@ jobs:
 
       - name: Validate conformance fixtures against schema
         # Authoritative enforcement of conformance/schema.json (incl. the
-        # mockResponses oneOf). uv is already installed, so `make
-        # conformance-fixtures-check` runs check-jsonschema via uvx. Runs from
-        # repo root regardless of this job's working-directory: python.
+        # mockResponses oneOf) and the event-feed families' schemas — the
+        # aggregate `make conformance` target is not run in PR CI, so the
+        # fixture gates are invoked here directly. uv is already installed, so
+        # these targets run check-jsonschema via uvx. Runs from repo root
+        # regardless of this job's working-directory: python.
         if: matrix.python == '3.13'
         working-directory: .
-        run: make conformance-fixtures-check
+        run: |
+          make conformance-fixtures-check
+          make event-feed-fixtures-check
+          make event-feed-digest-fixtures-check
 
       - name: Run Python conformance tests
         if: matrix.python == '3.13'

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,17 @@
+# Gitleaks configuration — extends the built-in default rules.
+#
+# The one allowlist entry: srv1-prefixed checkpoint filter keys. `srv1-<16 hex>` is the
+# SDK's checkpoint-lineage namespace over BC3's PUBLISHED filter-digest vectors
+# (SPEC.md §23 "Checkpoint Identity"; the five digests are documented in BC3's
+# doc/api/sections/event_feed.md and recomputable from public canonical JSON).
+# They are entropy-shaped, which trips the generic-api-key rule, but they are contract
+# vocabulary, not secrets. Anchored to the exact shape so nothing else rides through.
+
+[extend]
+useDefault = true
+
+[allowlist]
+regexTarget = "secret"
+regexes = [
+  '''^srv1-[0-9a-f]{16}$''',
+]

--- a/Makefile
+++ b/Makefile
@@ -470,7 +470,7 @@ py-clean:
 # Conformance Test targets
 #------------------------------------------------------------------------------
 
-.PHONY: conformance conformance-runner-tests conformance-runner-tests-go conformance-runner-tests-python conformance-runner-tests-ruby conformance-runner-tests-kotlin conformance-runner-tests-swift check-runner-test-reachability conformance-go conformance-go-replay conformance-kotlin conformance-kotlin-replay conformance-typescript conformance-typescript-live conformance-ruby conformance-ruby-replay conformance-python conformance-python-replay conformance-swift conformance-build conformance-live conformance-canary oauth-fixtures-check oauth-token-fixtures-check conformance-fixtures-check
+.PHONY: conformance conformance-runner-tests conformance-runner-tests-go conformance-runner-tests-python conformance-runner-tests-ruby conformance-runner-tests-kotlin conformance-runner-tests-swift check-runner-test-reachability conformance-go conformance-go-replay conformance-kotlin conformance-kotlin-replay conformance-typescript conformance-typescript-live conformance-ruby conformance-ruby-replay conformance-python conformance-python-replay conformance-swift conformance-build conformance-live conformance-canary oauth-fixtures-check oauth-token-fixtures-check event-feed-fixtures-check event-feed-digest-fixtures-check conformance-fixtures-check
 
 # NOTE: conformance-swift and conformance-runner-tests-swift are defined in the
 # Swift SDK targets section below — their IS_MACOS conditional must parse after
@@ -495,6 +495,20 @@ oauth-token-fixtures-check:
 	@echo "==> Validating OAuth token fixtures..."
 	uvx --from 'check-jsonschema==$(CHECK_JSONSCHEMA_VERSION)' check-jsonschema \
 		--schemafile conformance/oauth-token/schema.json conformance/oauth-token/fixtures/*.json
+
+event-feed-fixtures-check:
+	@echo "==> Validating event-feed scenario fixtures..."
+	uvx --from 'check-jsonschema==$(CHECK_JSONSCHEMA_VERSION)' check-jsonschema \
+		--check-metaschema conformance/event-feed/schema.json
+	uvx --from 'check-jsonschema==$(CHECK_JSONSCHEMA_VERSION)' check-jsonschema \
+		--schemafile conformance/event-feed/schema.json conformance/event-feed/fixtures/*.json
+
+event-feed-digest-fixtures-check:
+	@echo "==> Validating event-feed srv1 digest vectors..."
+	uvx --from 'check-jsonschema==$(CHECK_JSONSCHEMA_VERSION)' check-jsonschema \
+		--check-metaschema conformance/event-feed-digest/schema.json
+	uvx --from 'check-jsonschema==$(CHECK_JSONSCHEMA_VERSION)' check-jsonschema \
+		--schemafile conformance/event-feed-digest/schema.json conformance/event-feed-digest/fixtures/*.json
 
 # Validate every conformance/tests/*.json entry against conformance/schema.json.
 # This is the AUTHORITATIVE enforcement of the per-case schema — including the
@@ -689,7 +703,7 @@ conformance-python-replay:
 	cd conformance/runner/python && uv sync && uv run python replay_runner.py
 
 # Run all conformance tests
-conformance: oauth-fixtures-check oauth-token-fixtures-check conformance-fixtures-check conformance-runner-tests conformance-go conformance-kotlin conformance-typescript conformance-ruby conformance-python conformance-swift
+conformance: oauth-fixtures-check oauth-token-fixtures-check event-feed-fixtures-check event-feed-digest-fixtures-check conformance-fixtures-check conformance-runner-tests conformance-go conformance-kotlin conformance-typescript conformance-ruby conformance-python conformance-swift
 	@echo "==> Conformance tests passed"
 
 # Orchestrate one canary pass against a single backend:
@@ -1323,6 +1337,8 @@ help:
 	@echo "  conformance-build          Build Go conformance test runner"
 	@echo "  oauth-fixtures-check       Validate OAuth discovery fixtures against their schema"
 	@echo "  oauth-token-fixtures-check Validate OAuth token wire-behavior fixtures against their schema"
+	@echo "  event-feed-fixtures-check Validate event-feed tier-2 scenario fixtures against their schema"
+	@echo "  event-feed-digest-fixtures-check Validate event-feed srv1 digest vectors against their schema"
 	@echo "  conformance-fixtures-check Validate conformance/tests fixtures against schema.json"
 	@echo "  check-runner-test-reachability  Assert every runner test file is reachable from discovery"
 	@echo "  check-replay-decoder-parity  Assert all five replay/dispatch tables cover the live fixture"

--- a/SPEC.md
+++ b/SPEC.md
@@ -2369,7 +2369,7 @@ typed error element is emitted), `Closed` (absorbing; no error element).
 | 21 | CatchingUp | Backoff | socket died mid-walk, or staleness expiry (per-page checkpoints already saved are kept) |
 | 22 | CatchingUp | Draining | `next` absent — the walk reached its frozen head → deliver the final page's events → save + announce its checkpoint (position-resume entries) → enter Draining. **Present-class amendment (present-class entries only — Entry Boundary below; position-resume entries unchanged):** the entry poll's returned position is HELD, not saved; the ownership cut — defined under Entry Boundary — is taken after entry into Draining. |
 | 23 | Draining | Streaming | buffer replayed through dedupe → `Observer.caught_up` → arm jittered `repair-poll`. **Present-class amendment:** the held entry position is saved only once the conjunctive save-ordering invariant holds; a `BufferOverflow` disposition of Terminate — or no handler — lands in Terminal(`buffer_overflow`) instead, with no Save. (A `FeedGap` cannot arise here: 410s arise from polls, which Draining never performs — a 410 on the entry walk was already dispatched at transition 17.) |
-| 24 | Streaming | CatchingUp | `repair-poll` fired → one walk from the durable position (60s ± 20%) |
+| 24 | Streaming | CatchingUp | `repair-poll` fired → one walk from the connector's current position (in-memory authoritative — Checkpoint discipline below; 60s ± 20%) |
 | 25 | Streaming | Backoff | `staleness` fired (7.5s without a frame) / socket error / disconnect `reconnect ≠ false` and not protocol-fatal (includes `remote`) |
 | 26 | Streaming | Terminal(`protocol_fatal`) | raw disconnect `invalid_event_stream_command` |
 | — | any non-absorbing | Closed | `close()` / cancellation / consumer break (universal edge) |
@@ -2384,7 +2384,8 @@ sit outside the 26 numbered rows for the same reason: the Terminal(`checkpoint_l
 Terminal(`usage`) edge (a re-consumed iterator); the Terminal(`invalid_continuation`) edge
 (fires between URL validation and the poll call, wherever a `next` continuation or 410
 `resume` URL is about to be followed — row 16's follow and row 17's Accept re-entry both
-pass through it; zero requests to the failing URL); the Terminal(`poll_failed`) edge (an
+pass through it, as does a redirect `Location` failing per-hop validation inside a poll
+seam call (Continuation and Resume URL Validation); zero requests to the failing URL); the Terminal(`poll_failed`) edge (an
 `unrecoverable`-kind poll error — Seam Contracts below — from any polling state, carrying
 the generated error); the Terminal(`mint_failed`) edge (an `unrecoverable`-kind mint
 error, from Minting, carrying the generated error); the Terminal(`invalid_cable_url`)
@@ -2429,7 +2430,10 @@ Interpretation, pinned:
 - **Checkpoint discipline:** only poll-page acceptance ever calls `save` (transitions 16/22–23
   per their amendments; re-entry walks save through 16 like any other pages). Streaming never
   saves — live event ids never advance the durable position. `save` failure is
-  `Observer.checkpoint_save_failed` and the feed continues. `load` happens exactly once,
+  `Observer.checkpoint_save_failed` and the feed continues. The connector's position
+  tracking is in-memory and authoritative for resume and repair within a run; the store
+  is write-through durability only — a failed `save` never regresses or blanks the live
+  cursor. `load` happens exactly once,
   on the first iteration **before the first mint**; its failure is
   Terminal(`checkpoint_load`) with zero wire attempts, because silently starting at the
   present would skip history.
@@ -2685,6 +2689,10 @@ SignalHandler : (Signal) → Accept | Terminate
   what distinguishes them.)
 - `Observer.gap` and `Observer.buffer_overflow` remain observability-only notifications.
   The semantic disposition lives exclusively in the handler.
+- **Dispatch timing:** a semantic signal is dispatched at the first consumer-context
+  opportunity after its condition arises, with "before the next `save`" as the outer
+  bound. Drop-time dispatch is therefore the normative expectation fixtures may rely
+  on — an implementation must not defer the signal to a later cut that may never come.
 
 **Only event-bearing frames are admitted to the live buffer** — pings, control frames, and
 unknown frame types update liveness and are discarded, never buffered — so the buffer is
@@ -2725,7 +2733,7 @@ Terminal reasons end iteration with exactly one typed error element:
 | `usage` | re-consumed iterator (the only `usage` condition that surfaces as an iteration element — construction-time validation failures raise language-native construction errors carrying the same code) |
 | `buffer_overflow` | live-buffer overflow with no registered handler, or a handler returning Terminate |
 | `feed_gap` | 410 with no registered handler, or a handler returning Terminate |
-| `invalid_continuation` | a `next` or 410 `resume` URL failed same-origin/downgrade validation (Continuation and Resume URL Validation below); no request is issued to it |
+| `invalid_continuation` | a `next` or 410 `resume` URL failed same-origin/downgrade validation (Continuation and Resume URL Validation below), or a redirect `Location` that fails the same validation; no request is issued to the failing URL |
 | `poll_failed` | an `unrecoverable`-kind poll error — a generated-operation outcome outside the feed's 400/409/410 matrix and the retryable classes (e.g. 404, 405, an unexpected shape) — passed through with the generated error attached |
 | `mint_failed` | an `unrecoverable`-kind mint error — a non-retryable `CreateStreamTicket` outcome other than 401/403 (e.g. 404, 422, a malformed success) — passed through with the generated error attached |
 | `invalid_cable_url` | the mint's `url` violates cable-URL policy (non-`wss://` outside localhost, a redirect on dial, unparseable) — recurring by construction on every re-mint, so it is surfaced, never retried into |
@@ -2781,7 +2789,8 @@ INTERFACE PollSource
 END
 
 RECORD Cursor           -- exactly one field set; the zero Cursor is the bare present entry
-  position : String?    -- durable resume/repair token
+  position : String?    -- resume/repair token (in-memory authoritative within a run;
+                        -- durable via write-through when saves succeed)
   since    : String?    -- "now", "0", or a decimal event id
   page_url : String?    -- absolute URL: a `next` continuation OR a 410 resume URL.
                         -- Same-origin + no-downgrade validated BEFORE any poll call
@@ -2849,8 +2858,14 @@ END
 -- assertion (`outstanding()`) rather than a test-only artifact.
 
 INTERFACE CheckpointStore
-  load(key: CheckpointKey) → (position: String, ok: Boolean)
-  save(key: CheckpointKey, position: String)
+  load(key: CheckpointKey) → Loaded(position) | Missing | Failed(error)
+  save(key: CheckpointKey, position: String) → Saved | Failed(error)
+  -- Tri-state by contract — a boolean/void shape cannot express the failures this
+  -- section dispatches on. Missing proceeds to a present-class entry (no stored cursor
+  -- is not an error). Failed on load is Terminal(`checkpoint_load`) with zero wire
+  -- attempts; collapsing it to Missing would silently start at the present and skip
+  -- history. Failed on save is `Observer.checkpoint_save_failed` with the feed
+  -- continuing — subsequent saves are still attempted (no save circuit-breaker).
 END
 
 RECORD CheckpointKey
@@ -2891,15 +2906,27 @@ Terminal(`invalid_continuation`) — no request is issued to the failing URL, an
 rejected URL is carried redacted (origin only) in the error. There is no retry and no
 handler for this condition: a hostile continuation is not an operable feed state.
 
+**Prevalidation does not cover redirects, so the poll seam must.** The underlying HTTP
+stacks auto-follow redirects (Go strips `Authorization` on a cross-origin hop but still
+egresses), which would falsify the zero-foreign-egress guarantee the moment a validated
+same-origin URL answers 3xx with a foreign `Location`. The Layer-1 adapter therefore
+**disables automatic redirect-following for `PollEvents`** (or per-hop validates every
+resolved `Location` under §8's hop-anchored rule): a 3xx from a validated URL yields its
+`Location` to the same same-origin + no-downgrade validation — cross-origin or downgraded
+→ Terminal(`invalid_continuation`) with zero egress to the foreign origin; same-origin →
+it may be followed, each hop under the same rule.
+
 The mint's cable `url` is deliberately **not** under this rule: it is server-directed
 cable topology, cross-host by design, dialed verbatim with its own credential (the
 short-lived ticket rides in the URL itself; no `Authorization` header is attached), and
 governed by its own invariants — `wss://` outside localhost, redirects refused, never
 logged (Security Invariants below).
 
-Required tier-2 coverage: a hostile cross-origin `next` mid-walk and a hostile 410
-`resume` URL each terminate with `invalid_continuation` and zero requests to the foreign
-origin.
+Required tier-2 coverage: a hostile cross-origin `next` mid-walk, a hostile 410
+`resume` URL, and a validated same-origin `next` answering 302 with a cross-origin
+`Location` each terminate with `invalid_continuation` and zero requests to the foreign
+origin; store-failure coverage proves Failed(load) terminates with zero wire attempts and
+Failed(save) continues with the observer signal and a subsequent save attempt.
 
 ### Clock, Timers, and Virtual Time `[conformance]`
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -2805,12 +2805,17 @@ RECORD PollPage         -- the body envelope IS the contract; never bind to resp
 END
 -- Poll errors carry a kind: transient | throttled(retry_after) | position_invalid |
 -- filter_invalid(server message) | filter_changed | gone(epoch_after_id, resume_url) |
--- unauthorized | unrecoverable(error).
+-- unauthorized | redirect_refused(location_origin) | unrecoverable(error).
 -- The adapter maps every §6/§7 outcome of the generated call onto exactly one kind:
 -- 429/503 and §7-retryable outcomes exhausted inside the seam → transient/throttled;
 -- the feed's 400/409/410 matrix → its four kinds; 401/403 (after the seam's own token
--- refresh and retry budget) → unauthorized; anything else non-retryable (404, 405,
--- unexpected shapes) → unrecoverable, carrying the generated error verbatim.
+-- refresh and retry budget) → unauthorized; a 3xx whose Location fails the per-hop
+-- same-origin/no-downgrade validation (auto-follow is disabled — Continuation and
+-- Resume URL Validation) → redirect_refused, carrying the refused Location redacted to
+-- its origin → Terminal(`invalid_continuation`), NEVER unrecoverable; anything else
+-- non-retryable (404, 405, unexpected shapes) → unrecoverable, carrying the generated
+-- error verbatim. A same-origin Location may be followed inside the seam under the same
+-- per-hop rule (no error surfaces).
 
 INTERFACE CableTransport
   dial(ws_url, cancellation, max_frame_bytes) → CableConn

--- a/conformance/event-feed-digest/README.md
+++ b/conformance/event-feed-digest/README.md
@@ -1,0 +1,33 @@
+# Event-feed srv1 digest and checkpoint flat-key vectors
+
+**PROVISIONAL(`8be5c67de5`).** The srv1 vector table is BC3's published contract, verified
+at that branch head; it freezes only when BC3 regenerates vectors at its merge-time gate
+(SPEC §23 "Provenance", class 1). The five digests here were additionally recomputed
+independently from the published canonicalization — `SHA-256(canonical_json)[0:16]` —
+and match byte-for-byte.
+
+## What lives here
+
+One fixture file, `fixtures/srv1-vectors.json`, validated against `schema.json` by
+`make event-feed-digest-fixtures-check`:
+
+- **`srv1_vectors`** — the published five-vector table (empty set; single type; unsorted
+  multi-list; `"01"` post-coercion dedup; the 100-id cap boundary), each carrying the
+  input filters, the exact canonical JSON, and the 16-hex digest.
+- **`flat_key_cases`** — `{origin, account_id, consumer_namespace, filters}` →
+  `filter_key` (`srv1-<hex>`) → the compact RFC 8259 JSON-array flat key, covering origin
+  canonicalization (lowercase scheme/host, default port stripped, non-default port
+  preserved).
+
+Every SDK asserts every case (Go `digest_test.go` first; the other five as their
+connectors land). The srv1 algorithm is **total over client-validated inputs** — catalog
+membership is server-owned and never client-validated (SPEC §23 "Checkpoint Identity"),
+so no quoted-string or non-ASCII vector exists here by design: the server rejects unknown
+types with the filter 400 before computing any digest.
+
+## Directory is a schema boundary
+
+This directory holds exactly one shape (digest/flat-key vectors). Scenario scripts live
+in the sibling `conformance/event-feed/`; operation-dispatch cases live in
+`conformance/tests/`. A new shape gets a new sibling directory, never a second schema
+here (the oauth/oauth-token precedent).

--- a/conformance/event-feed-digest/fixtures/srv1-vectors.json
+++ b/conformance/event-feed-digest/fixtures/srv1-vectors.json
@@ -1,0 +1,198 @@
+{
+  "description": "srv1 digest vectors (the published bc3 table) and checkpoint flat-key cases (SPEC §23 Checkpoint Identity). The srv1 algorithm is total over client-validated inputs; these vectors are the published server table. All six SDKs assert every case.",
+  "provisional": {
+    "verified_at": "8be5c67de5",
+    "freezes_at": "bc3 merge-time gate (regenerated vectors)"
+  },
+  "srv1_vectors": [
+    {
+      "name": "empty-set",
+      "filters": {},
+      "canonical_json": "[null,null,null]",
+      "digest": "fe44a8cccd89edae"
+    },
+    {
+      "name": "single-type",
+      "filters": {
+        "types": [
+          "message.created"
+        ]
+      },
+      "canonical_json": "[[\"message.created\"],null,null]",
+      "digest": "9eae6bbae1414746"
+    },
+    {
+      "name": "unsorted-multi-list",
+      "filters": {
+        "types": [
+          "todo.completed",
+          "message.created"
+        ],
+        "buckets": [
+          2,
+          1
+        ]
+      },
+      "canonical_json": "[[\"message.created\",\"todo.completed\"],[1,2],null]",
+      "digest": "00ed03e6196e77a2"
+    },
+    {
+      "name": "leading-zero-coercion-dedup",
+      "filters": {
+        "buckets": [
+          "1",
+          "01"
+        ]
+      },
+      "canonical_json": "[null,[1],null]",
+      "digest": "fb19e601cd033cad"
+    },
+    {
+      "name": "cap-boundary-100-ids",
+      "filters": {
+        "buckets": [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+          17,
+          18,
+          19,
+          20,
+          21,
+          22,
+          23,
+          24,
+          25,
+          26,
+          27,
+          28,
+          29,
+          30,
+          31,
+          32,
+          33,
+          34,
+          35,
+          36,
+          37,
+          38,
+          39,
+          40,
+          41,
+          42,
+          43,
+          44,
+          45,
+          46,
+          47,
+          48,
+          49,
+          50,
+          51,
+          52,
+          53,
+          54,
+          55,
+          56,
+          57,
+          58,
+          59,
+          60,
+          61,
+          62,
+          63,
+          64,
+          65,
+          66,
+          67,
+          68,
+          69,
+          70,
+          71,
+          72,
+          73,
+          74,
+          75,
+          76,
+          77,
+          78,
+          79,
+          80,
+          81,
+          82,
+          83,
+          84,
+          85,
+          86,
+          87,
+          88,
+          89,
+          90,
+          91,
+          92,
+          93,
+          94,
+          95,
+          96,
+          97,
+          98,
+          99,
+          100
+        ]
+      },
+      "canonical_json": "[null,[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100],null]",
+      "digest": "832adbc56aa7c8f2"
+    }
+  ],
+  "flat_key_cases": [
+    {
+      "name": "empty-set-default-origin",
+      "origin": "https://3.basecampapi.com",
+      "account_id": "5951425",
+      "consumer_namespace": "openclaw",
+      "filters": {},
+      "filter_key": "srv1-fe44a8cccd89edae",
+      "flat_key": "[\"https://3.basecampapi.com\",\"5951425\",\"openclaw\",\"srv1-fe44a8cccd89edae\"]"
+    },
+    {
+      "name": "origin-canonicalization-case-and-default-port",
+      "origin": "HTTPS://Example.Basecampapi.COM:443",
+      "account_id": "1",
+      "consumer_namespace": "agent-a",
+      "filters": {
+        "types": [
+          "message.created"
+        ]
+      },
+      "filter_key": "srv1-9eae6bbae1414746",
+      "flat_key": "[\"https://example.basecampapi.com\",\"1\",\"agent-a\",\"srv1-9eae6bbae1414746\"]"
+    },
+    {
+      "name": "nondefault-port-preserved",
+      "origin": "https://localhost:3001",
+      "account_id": "195539477",
+      "consumer_namespace": "dev",
+      "filters": {
+        "buckets": [
+          "1",
+          "01"
+        ]
+      },
+      "filter_key": "srv1-fb19e601cd033cad",
+      "flat_key": "[\"https://localhost:3001\",\"195539477\",\"dev\",\"srv1-fb19e601cd033cad\"]"
+    }
+  ]
+}

--- a/conformance/event-feed-digest/schema.json
+++ b/conformance/event-feed-digest/schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://basecamp.com/schemas/event-feed-digest.json",
+  "title": "Event-feed srv1 digest and checkpoint flat-key vectors",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "description",
+    "provisional",
+    "srv1_vectors",
+    "flat_key_cases"
+  ],
+  "properties": {
+    "description": {
+      "type": "string",
+      "minLength": 1
+    },
+    "provisional": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "verified_at",
+        "freezes_at"
+      ],
+      "properties": {
+        "verified_at": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{10,40}$"
+        },
+        "freezes_at": {
+          "const": "bc3 merge-time gate (regenerated vectors)"
+        }
+      }
+    },
+    "srv1_vectors": {
+      "type": "array",
+      "minItems": 5,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "filters",
+          "canonical_json",
+          "digest"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "filters": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "types": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "buckets": {
+                "type": "array",
+                "items": {
+                  "type": [
+                    "integer",
+                    "string"
+                  ]
+                }
+              },
+              "creators": {
+                "type": "array",
+                "items": {
+                  "type": [
+                    "integer",
+                    "string"
+                  ]
+                }
+              }
+            }
+          },
+          "canonical_json": {
+            "type": "string",
+            "pattern": "^\\["
+          },
+          "digest": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{16}$"
+          }
+        }
+      }
+    },
+    "flat_key_cases": {
+      "type": "array",
+      "minItems": 3,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "origin",
+          "account_id",
+          "consumer_namespace",
+          "filters",
+          "filter_key",
+          "flat_key"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "origin": {
+            "type": "string",
+            "minLength": 1
+          },
+          "account_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "consumer_namespace": {
+            "type": "string",
+            "minLength": 1
+          },
+          "filters": {
+            "$ref": "#/properties/srv1_vectors/items/properties/filters"
+          },
+          "filter_key": {
+            "type": "string",
+            "pattern": "^srv1-[0-9a-f]{16}$"
+          },
+          "flat_key": {
+            "type": "string",
+            "pattern": "^\\["
+          }
+        }
+      }
+    }
+  }
+}

--- a/conformance/event-feed/README.md
+++ b/conformance/event-feed/README.md
@@ -1,0 +1,315 @@
+# Event Feed connector tier-2 scenario fixtures
+
+> **PROVISIONAL — bc3-derived rows verified at bc3 `8be5c67de5`** (pre-merge; lineage
+> `ee19670c02`). Everything bc3-derived below is normative for SDK drafting but frozen
+> only at bc3's merge-time gate; the dependency table classifies each row and the PR-T
+> true-up checklist governs the re-verification. The SDK-owned contract rows (state
+> inventory, ownership cut, conjunctive save-ordering invariant, handler contract,
+> dedupe, timers, checkpoint identity, URL validation) are final as written and not
+> gated on bc3.
+
+Data-only, cross-language scenario scripts for the SPEC §23 Event Feed connector —
+tier 2 of the three-tier verification architecture: the cross-lane state machine,
+frame-level cable behavior, mint/connect/poll interleave, and virtual time. Tier 1
+(poll-lane wire behavior in `conformance/tests/`) is deferred on the generated
+`PollEvents` landing; tier 3 (LRU bounds, jitter formula, real-transport adapter
+contracts, test-clock semantics) is per-SDK native tests.
+
+Each fixture is one strictly-ordered interleaved script: HTTP exchanges, cable
+frames, time directives, and observations in a single `steps` array. **Strictness is
+the default and not optional** — every protocol action (a mint, poll, connect,
+outbound frame, client close, or checkpoint save) must be matched by an expect step,
+under the per-action-class rules in "Strictness semantics, per action class" below.
+That is what makes "zero reconnects after rejection", "no save before the retained
+drain", and "zero requests to a hostile origin" structural properties rather than
+heuristics. Observation directives (`expectDelivered`, `expectBuffered`,
+`expectTimers`, `expectState`, `expectSignal`, `expectHandlerInvocations`) are
+rendezvous assertions: the driver waits under a small wall-clock watchdog (~5s) while
+virtual time is frozen between directives, and an assertion that can no longer be
+satisfied fails hard — nothing here passes vacuously.
+
+## Strictness semantics, per action class (normative)
+
+The strict-match rule splits by action class; every driver implements exactly this:
+
+- **Arrival-strict — checkpoint saves and outbound frames** (the subscribe command,
+  the client close): observed while the current step is anything other than their
+  matching expect step, the scenario fails immediately. Rendezvous steps advance
+  atomically on satisfaction, so an action that becomes legal the instant a
+  rendezvous is satisfied matches the next step rather than failing against the
+  stale one.
+- **Parked — mint and poll seam calls**: an early seam call does not fail the
+  scenario on arrival; it PARKS, and calls are matched to their expect steps in
+  order. The scripted response is released only when the driver reaches the matching
+  expect step — until then the connector waits on its own call. A parked call still
+  unmatched when the script ends fails the scenario, and the seam-call counts in
+  `finally` count it either way.
+
+## Validation
+
+`schema.json` is the contract. `make event-feed-fixtures-check` validates the schema
+against the JSON Schema metaschema and every fixture against the schema, with a
+pinned `check-jsonschema` run through `uvx` (part of `make conformance`, so
+`make check` gates it).
+
+## Directory is a schema boundary
+
+This directory contains exactly one shape: tier-2 scenario scripts. If a second
+shape is ever needed, it gets a sibling directory with its own schema — never a
+second schema here. The srv1 digest vectors are exactly that sibling:
+`conformance/event-feed-digest/` (gated by `make event-feed-digest-fixtures-check`),
+following the `conformance/oauth/` / `conformance/oauth-token/` precedent.
+
+## Placeholder substitution
+
+Each SDK's harness substitutes these tokens with its own loopback origins and tokens
+**before** driving the scenario, and must guarantee distinctness across indices
+(`{{CABLE_URL:1}} ≠ {{CABLE_URL:2}}` is what gives fresh-ticket reconnect assertions
+teeth):
+
+| Placeholder | Meaning |
+|---|---|
+| `{{API_ORIGIN}}` | The HTTP loopback origin serving mint + poll. |
+| `{{TICKET:n}}` | The nth minted stream ticket (opaque; never logged). |
+| `{{CABLE_URL:n}}` | The nth mint's cable URL; the connector dials it verbatim. |
+| `{{POS:n}}` | The nth position token (durable resume/repair cursor). |
+| `{{NEXT:n}}` | The nth same-origin continuation URL. |
+
+Literal origins (e.g. `https://attacker.example.com`) are intentional and must
+**not** be substituted — the hostile-continuation fixtures depend on them staying
+foreign, and the harness must assert those hosts receive **zero** requests
+(structurally guaranteed: no expect step ever serves them).
+
+## Count semantics: seam calls, never wire attempts
+
+`finally.mintCount`, `finally.connectCount`, and every poll expectation count **seam
+calls** — one fully-governed generated call each, with its full SPEC §7 retry
+contract *inside* the seam. Scenarios never depend on advancing seam-internal time;
+the connector's own delays all flow through the injected Clock, which is why these
+scripts are deterministic.
+
+## Virtual-advance algorithm (normative)
+
+Every language's test clock must honor the same semantics, so a script means the
+same thing everywhere: **advancing virtual time fires due timers in deadline order,
+re-evaluating after each fire; timers scheduled during the advance whose deadlines
+land inside the window also fire; ties break by creation order.** `fireTimer` fires
+the earliest outstanding timer of the named kind *without* advancing the clock,
+asserting its scheduled delay against a `{min, max}` envelope — that is how jitter
+is asserted without a cross-language RNG seam (Go additionally pins the full-jitter
+formula exactly in tier 3; a degenerate always-0 RNG is caught only there — a
+documented divergence). Each language's test clock passes the shared semantics
+checklist (deadline order, reentrant scheduling within an advance, creation-order
+tie-break) before its tier-2 results count.
+
+## Contract notes the fixtures encode (SDK-owned, final)
+
+- **Connect-to-mint-URL-verbatim.** The connector never assembles cable topology
+  client-side; every `expectConnect.url` is the immediately preceding mint's `url`,
+  verbatim, query string included. A fresh ticket is minted on **every** reconnect
+  pass — the connector never stores a mint URL across attempts.
+- **Dedupe tracks actually-delivered event ids** — never position ordering. A
+  buffered live event with an id ≤ the current position is still delivered (it was
+  never served by poll); discarding live ids at or below the position is a named
+  mutant (fixture 20).
+- **The ownership cut** (present-class entries): after accepting the entry-poll
+  response, the state machine performs one **bounded admission pass** — receiving
+  from the frame pump's queue without blocking until the queue is momentarily empty
+  OR the pass has **dequeued** `liveBufferCapacity` frames of any kind, whichever
+  comes first. The bound counts dequeued frames, not admitted events (pings and
+  control frames dequeue without admitting; an event-counting bound would spin
+  forever under heartbeat replenishment). "Observed" means admitted into the
+  state-machine-owned buffer at or before the cut; `expectBuffered` asserts exactly
+  that.
+- **The semantic-handler contract.** Conditions that change what the feed can
+  promise (`BufferOverflow`, `FeedGap`) dispatch to a separate synchronous handler
+  returning Accept or Terminate. A registered handler is invoked **exactly once per
+  signal**, on the consumer's execution context, before its disposition takes
+  effect; no handler means the typed terminal (`buffer_overflow` / `feed_gap`), and
+  **a 410 never silently auto-continues**. Fixtures assert exact invocation records
+  `{kind, disposition}`; the default-terminal fixtures assert zero invocations —
+  the record is the only thing distinguishing handler-Terminate from no-handler.
+- **The conjunctive save-ordering invariant** (the published delivery promise, and
+  nothing stronger): `save(P)` only after ALL retained pre-cut events have been
+  accepted AND every pre-cut loss condition has been explicitly accepted; Terminate
+  — or no handler — means no save. A disjunctive form would let an accepted
+  overflow bypass delivery of the other retained events. **Explicitly excluded:
+  crash or cancellation before the first usable checkpoint** — on a first present
+  entry there is no older durable cursor, and on a 410 reset the old cursor is
+  unusable, so an event admitted pre-cut and lost to a crash before delivery and
+  save is unrecoverable, with no signal. Client-side ordering cannot manufacture
+  durability the server does not offer. **No blanket loss-prevention or global
+  delivery-completeness claim is published anywhere in this family** — such a claim
+  would contradict the exclusion; do not add one to a fixture description.
+- **Checkpoint saves are strict-matched.** Every `CheckpointStore.save` call must
+  match a current `expectCheckpoint` step, and `finally.checkpoints` re-checks the
+  full ordered ledger. A save observed while the script is still waiting on an
+  `expectDelivered` rendezvous fails the scenario — that ordering is the teeth of
+  delivery-precedes-checkpoint and of the conjunctive invariant.
+
+## Test-(d) split of duty
+
+Terminal rejection is proven in two halves. **This family's half** (fixture 04): on
+`reject_subscription` the connector cancels the deadline, explicitly closes the
+still-open socket (`expectClientClose`), surfaces `subscription_rejected`, and makes
+zero further mint/connect seam calls with an empty exact timer set. **bc3's half**
+(its own suite, landed at the verified head): the rejection residue server-side is
+heartbeat registration plus a persistent claim with **zero stream registrations
+ever**. Neither suite asserts the other's half.
+
+## Consumers
+
+Tier 2 drives the **real transport adapter** over an in-process loopback cable
+server wherever a lightweight one exists, with only the Clock faked; divergences are
+honest, recorded here and in SPEC Appendix F, and compensated by named tier-3 tests.
+
+| SDK | Driver | Lane / divergence |
+|---|---|---|
+| Go | `go/pkg/basecamp/eventfeed/scenario_conformance_test.go` | Real default transport over an in-process loopback ws server (`httptest`); fixtures consumed as data. Tier 3 additionally pins the full-jitter formula via an injected deterministic rand source. |
+| TypeScript | `typescript/tests/event-feed/scenario-conformance.test.ts` | Real transport under MSW `ws` interception. Default transport must use the global `WebSocket` (Node ≥ 22), never the `ws` package. The global API has no read limit, so `max_frame_bytes` is enforced at message receipt rather than during the read — accepted, documented divergence; an injected transport MAY truly bound reads. |
+| Python | `python/tests/event_feed/test_scenario_conformance.py` | Real transport over an in-process `websockets` loopback; connector transport ships under the optional `stream` extra. |
+| Ruby | `ruby/test/basecamp/event_feed_scenario_conformance_test.rb` | Real transport over a `websocket-driver` loopback; `websocket-driver` becomes a runtime dependency. |
+| Kotlin | `kotlin/sdk/src/jvmTest/kotlin/com/basecamp/sdk/EventFeedScenarioTest.kt` | **jvmTest-only** — ktor's `MockEngine` cannot mock WebSockets; a test-scoped ktor server drives the real ktor ws client. The state machine is additionally mirrored in commonTest tier 3 for the four acceptance scenarios. |
+| Swift | `swift/Tests/BasecampTests/EventFeedScenarioTests.swift` | **Fake-transport lane** — no lightweight in-process ws server exists without SwiftNIO; scenarios drive a `FakeCableTransport`. A macOS-gated tier-3 `URLSessionWebSocketTask` adapter contract test proves the real adapter honors the transport contract (verbatim frames, close mapping). |
+
+## Fixture inventory (PR 2)
+
+The four §23 acceptance behaviors: (a) fresh-ticket reconnect → 05; (b)
+confirmation gating → 02; (c) deadline teardown → 03; (d) terminal rejection → 04.
+Numbers 08–11, 13–15, and 18 are reserved for PR 4 (staleness, single-flight
+reconnect, reconnect-catchup-before-trust, poll/push dedupe overlap, backoff
+envelope growth, repair-poll jitter, identical-subscribe retransmit,
+revoked-mint threshold).
+
+| # | File | Proves |
+|---|---|---|
+| 01 | `01-happy-path-confirm-catchup-stream.json` | mint → connect → welcome → subscribe → confirm → catch-up walk → drain → stream; delivery/checkpoint ordering; live ids never checkpoint |
+| 02 | `02-confirmation-gating.json` | **(b)** zero deliveries, zero polls, zero saves before `confirm_subscription`; the pre-confirm event buffers and drains exactly once |
+| 03 | `03-confirmation-deadline-teardown.json` | **(c)** deadline teardown leaves exactly `{backoff}`; fresh ticket + new cable URL on retry |
+| 04 | `04-terminal-rejection.json` | **(d)** reject → explicit close of the open socket, `subscription_rejected`, zero reconnects, empty timer set |
+| 05 | `05-fresh-ticket-reconnect-after-ttl.json` | **(a)** sever past ticket TTL → newly minted ticket URL on reconnect; one catch-up poll before any live delivery is trusted |
+| 06 | `06-protocol-fatal-disconnect.json` | raw `invalid_event_stream_command` → Terminal(`protocol_fatal`), zero further mints — raw-frame interception |
+| 07 | `07-unauthorized-disconnect-reconnects.json` | `unauthorized` (pre-welcome, `reconnect:false`) → NOT terminal; fresh-ticket retry — reason-level dispatch, not `reconnect:false`-level |
+| 12 | `12-checkpoint-after-handoff.json` | per page: delivery strictly precedes that page's checkpoint save |
+| 16 | `16-gap-410-accepted-resume.json` | 410 with accepting handler: invocation `{feedGap, accept}`, resume via the provided URL, stream continues |
+| 17 | `17-remote-disconnect-remint.json` | `remote`/`reconnect:true` → re-mint + reconnect through existing Backoff transitions |
+| 19 | `19-present-entry-buffered-lower-id.json` | admitted straggler N (proven via `expectBuffered`) delivered BEFORE the present-entry position saves |
+| 20 | `20-present-entry-post-snapshot-straggler.json` | post-snapshot lower-id straggler delivered live + deduped; position never regresses |
+| 21 | `21-overflow-default-terminal.json` | no handler: overflow → Terminal(`buffer_overflow`), no save, zero invocations |
+| 22 | `22-overflow-accepted.json` | accepting handler: invocation recorded AND retained deliveries complete BEFORE the save — acceptance never bypasses retained deliveries |
+| 23 | `23-gap-410-default-terminal.json` | no handler: 410 → Terminal(`feed_gap`), zero invocations; its exact-set `finally` is the direct test of any auto-continue mutant |
+| 24 | `24-overflow-handler-terminate.json` | handler Terminate → Terminal(`buffer_overflow`), no save, invocation `{bufferOverflow, terminate}` — the branch distinct from no-handler |
+| 25 | `25-gap-handler-terminate.json` | handler Terminate on 410 → Terminal(`feed_gap`), no save, invocation `{feedGap, terminate}` |
+| 26 | `26-hostile-next-cross-origin.json` | cross-origin `next` mid-walk → Terminal(`invalid_continuation`), zero requests to the foreign origin |
+| 27 | `27-hostile-resume-cross-origin.json` | accepted 410 with a cross-origin `resume` → Terminal(`invalid_continuation`), zero foreign requests |
+| 28 | `28-checkpoint-load-failure.json` | store load Failed → Terminal(`checkpoint_load`) with ZERO wire attempts; distinct from Missing (which proceeds to a present entry) |
+| 29 | `29-checkpoint-save-failure-continues.json` | save Failed → feed continues and a SUBSEQUENT save is attempted (exact store-call script: no save circuit breaker) |
+| 30 | `30-continuation-redirect-cross-origin.json` | validated same-origin `next` answering 302 + cross-origin Location → Terminal(`invalid_continuation`), zero foreign egress |
+
+**Hostile-URL coverage note (stated author's choice, per the PR-1 review):** the
+downgrade (HTTPS→HTTP) variant is deliberately not a separate fixture here. Tier-2
+harness base origins are localhost HTTP under the §9 carve-out, so a downgrade is
+not reproducible at this seam; §23 routes continuation validation through §8's
+shared Same-Origin Validation Algorithm plus downgrade rejection, whose downgrade
+branch is already pinned by `conformance/tests/security.json` ("Protocol downgrade
+in Link header rejected"). This family pins the two feed-specific URL sources as
+cross-origin
+(`next` → 26, `resume` → 27) plus the redirect hop (30).
+
+## Fixture → server-behavior dependency table
+
+Every row a fixture encodes about bc3, with its provenance class. Class 1 (wire
+literals) freezes when bc3 regenerates transcripts at the rebased head; class 2
+(semantic behavior) is re-verified row-by-row at the gate; SDK-owned rows are not
+gated. Until the gate clears, **these fixtures are the only literal pins anywhere**
+for the reason strings — bc3's own connection test asserts the protocol-fatal
+reason via a constant, not the literal.
+
+| Server behavior | Class | Pinned by |
+|---|---|---|
+| Disconnect reason literal `unauthorized` (arrives only pre-welcome) | 1 (+ 2 for the pre-welcome timing) | 07 |
+| Disconnect reason literal `invalid_event_stream_command`, `reconnect:false` | 1 | 06 |
+| Disconnect reason literal `remote`, `reconnect:true` | 1 — **no transcript capture exists**; source-verified against the pinned Rails; its freeze rides bc3's disconnect-matrix re-verification plus the one requested capture frame | 17 |
+| Poll body envelope keys `events` / `position` / `next` | 1 | every fixture serving a 200 poll: 01, 02, 05, 07, 12, 16, 17, 19, 20, 22, 26, 29, 30 (mechanically derived from the fixture files; re-derive when the set changes) |
+| Mint response body `{ticket, expires_in, url}`, status 200 | 1 | every fixture with `expectMint` (all but 28) |
+| Subscribe identifier literals: channel `EventsChannel`, param spellings `types`/`buckets`/`creators`, comma-joined values | 1 | channel: every `expectSubscribe`; `types` spelling: 01 (its `expectSubscribe` pins `params` explicitly, single-valued); `buckets`/`creators` spellings + comma-joining: no PR-2 fixture — pinned at PR-4 (fixture 15, whose retransmit case also pins byte-identity of the identifier) |
+| 409 body: all three keys `error` / `position_digest` / `filters_digest` required; digest values bare 16-hex (no `srv1-` prefix), `error` content unconstrained | 1 | schema-pinned shape only (the 409 respond variant requires all three keys); **no PR-2 fixture serves a 409** — pinned live at PR-4 (the tier-1 dispatch case additionally owns the wire pin when tier 1 lands) |
+| 410 body keys `epoch_after_id` / `resume` | 1 | 16, 23, 25, 27 |
+| 400 position-vs-filter discriminating bodies (verbatim transcript shapes) | 1 | no PR-2 fixture — pinned at PR-4 (tier 1 additionally owns it when `PollEvents` lands); the schema's 400 variant requires a verbatim body and this table is its source of truth |
+| srv1 digest vectors (five-vector table) + canonicalization algorithm | 1 (vectors) / 2 (algorithm) | sibling family `conformance/event-feed-digest/` |
+| Maximum inbound frame (`EVENT_FEED_MAX_FRAME_BYTES`, 1 MiB), transport-enforced during the read | SDK-owned constant; enforcement seam-contractual | no PR-2 fixture — tier 3 + a later raw-bounds fixture |
+| Filter raw bounds: a filter list of > 1,000 elements or > 16 KB → filter 400 | 2 | unreachable through validated construction (the client caps at 100 ids); recorded, unpinned |
+| `since=now` / bare entry mints the cursor at the newest visible id; an empty entry page positions above an in-flight lower id N | 2 | 19, 20 |
+| Safety-horizon bound: position-relative, best-effort, ~30s — never wall-clock | 2 | premise of 19/20 (not directly assertable client-side; the entry-boundary fixtures encode its consequence) |
+| Frozen-head `next` predicate: absent `next` = the walk reached its head | 2 | every fixture whose walk ends on a 200 page without `next`: 01, 02, 05, 07, 12, 16, 17, 19, 20, 22, 29 (mechanically derived; re-derive when the set changes) |
+| 410 `resume` re-enters at `since=now` with the canonical filter set preserved | 2 | 16 (resume URL followed verbatim); 27 (hostile variant) |
+| 400-position / 409 re-entry semantics (`since=<last poll-served id>`, present-class fallback) | 2 | no PR-2 fixture — pinned at PR-4 |
+| Ticket statelessness + ~120s TTL (server-owned `expires_in`) | 2 | 05 (TTL-advance premise; `expires_in` never schedules anything) |
+| 3-second server heartbeat cadence (input to the 7500ms staleness policy) | 2 | no PR-2 fixture — PR 4 (staleness fixture 08) |
+| Subscribe retransmit contract (identical absorbed, different rejected) | 2 | no PR-2 fixture — PR 4 (fixture 15) |
+| Push payload 9-key shape incl. the `visible_to_clients` presence asymmetry (push carries it, poll rows omit it) | 2 | schema-enforced on every `serve message` (9 keys) and every poll envelope row (8 keys, `visible_to_clients` forbidden) |
+
+## Deliberate tier-2 slack (tier-3/PR-4 ownership)
+
+Gaps stated rather than latent — each is deliberate, with a named owner:
+
+- **400-body discrimination is unenforced in the schema** while the class-1 literal
+  shapes are PROVISIONAL: the 400 respond variant accepts any non-empty object, so a
+  fixture could ship a non-discriminating body. When the dependency-table 400 shapes
+  freeze, the schema's 400 branch becomes a oneOf of the two literal discriminating
+  shapes.
+- **Malformed mint SUCCESS** (SPEC: `mint_failed` on "a malformed success") is
+  inexpressible here — the 200 mint branch mandates the exact well-formed three-key
+  body. Tier 3 owns it.
+- **Start-entry modes** (beginning `since=0` / after-id `since=<id>`) have no config
+  surface in tier 2, so their entry-query pins are unreachable here — tier-1 wire
+  fixtures and PR 4 own them.
+- **The counter-reset kill** (reset on the first successful poll page, never on
+  `confirm_subscription`) lives in the PR-4 authorization block — see fixture 07's
+  deferral note in the authoring manifest.
+
+## PR-T true-up checklist (bc3 merge-time gate)
+
+Run when bc3's event-feed branch merges; the pin moves and PROVISIONAL drops only
+when every line is done:
+
+1. Record the bc3 merge SHA; regenerate transcripts at the rebased head; diff every
+   class-1 row above against them.
+2. Re-verify every class-2 row against the rebased source and docs, row by row —
+   transcript diffs cannot prove these.
+3. `remote`: confirm the disconnect-matrix re-verification covers it and land the
+   requested capture frame; only then does its row carry transcript provenance.
+4. Re-verify the srv1 five-vector table at the rebased head (sibling digest family).
+5. Re-confirm `CreateStreamTicket`'s `idempotent: true` (safe-to-retry sense) — flag
+   if changed.
+6. Update this README's banner SHA and the fixtures' provenance note; remove
+   PROVISIONAL.
+7. Any drifted row: fix fixtures, schema, and SPEC §23 together in the true-up PR —
+   never fixture-only.
+
+## Mutation kill matrix (fifteen)
+
+Each mutation is shown red against at least one fixture in the reference
+implementation PR's body before it counts.
+
+| # | Mutation | Killed by |
+|---|---|---|
+| 1 | `reuse-old-url` (reconnect dials the previous mint's URL) | 05 |
+| 2 | `deliver-before-confirm` | 02 |
+| 3 | `start-catchup-before-confirm` | 02 |
+| 4 | `leak-deadline-timer` (ghost watchdog survives teardown) | 03 |
+| 5 | `reconnect-after-reject` | 04 |
+| 6 | `checkpoint-before-handoff` (saves before the page's delivery) | 12 |
+| 7 | `retry-into-protocol-fatal` | 06 |
+| 8 | `save-present-position-before-buffer-drain` | 19 |
+| 9 | `discard-live-id-at-or-below-position` | 20 |
+| 10 | `checkpoint-after-silent-overflow` (saves despite the unhandled overflow) | 21 |
+| 11 | `accept-overflow-then-save-before-retained-drain` (acceptance as license to skip retained deliveries) | 22 |
+| 12 | `bypass-configured-handler` (handler registered but skipped; default-terminal applied) | 24, 25 (via `handlerInvocations` exact-set) |
+| 13 | `follow-cross-origin-continuation` (skips §8 validation, polls the hostile URL) | 26, 27 |
+| 14 | `collapse-load-error-to-missing` | 28 |
+| 15 | `follow-cross-origin-redirect` (follows a 302 to a foreign Location) | 30 — killed by **outcome divergence**: the mutant's redirect-follow happens inside the poll seam call, which the harness cannot instrument, and leads to a divergent end state; PLUS the harness obligation that the fixture's foreign origin is bound to a sentinel listener whose any-request fails the scenario |
+
+Auto-continue-past-unhandled-gap needs no separate mutation — fixture 23's
+exact-set `finally` is its direct test. Fixture 29's exact store-call script is the
+no-save-circuit-breaker pin, likewise not a numbered mutation.

--- a/conformance/event-feed/fixtures/01-happy-path-confirm-catchup-stream.json
+++ b/conformance/event-feed/fixtures/01-happy-path-confirm-catchup-stream.json
@@ -1,0 +1,190 @@
+{
+  "name": "01-happy-path-confirm-catchup-stream",
+  "description": "Full pipeline order on a position-resume entry with a types filter: mint, connect, welcome, subscribe (filter params pinned), confirm, then a catch-up walk with one continuation delivering and saving per page, a drain of a mid-walk live event admitted before the entry page was served (proven via the expectBuffered rendezvous), and finally streaming delivery. Live ids never appear in checkpoints; the checkpoint step for page 2 precedes the cumulative delivered assertion so the drain of the buffered event cannot race an intermediate expectDelivered.",
+  "config": {
+    "types": ["message.created"],
+    "position": "{{POS:0}}"
+  },
+  "steps": [
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:1}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectConnect": {
+        "url": "{{CABLE_URL:1}}"
+      }
+    },
+    {
+      "serve": {
+        "frame": "welcome"
+      }
+    },
+    {
+      "expectSubscribe": {
+        "channel": "EventsChannel",
+        "params": {
+          "types": "message.created"
+        }
+      }
+    },
+    {
+      "serve": {
+        "frame": "confirm"
+      }
+    },
+    {
+      "serve": {
+        "frame": "message",
+        "event": {
+          "id": 104,
+          "kind": "message",
+          "event_type": "message.created",
+          "action": "created",
+          "created_at": "2026-08-01T12:00:00Z",
+          "bucket_id": 2,
+          "creator_id": 3,
+          "recording_id": 900,
+          "visible_to_clients": false
+        }
+      }
+    },
+    {
+      "expectBuffered": {
+        "count": 1
+      }
+    },
+    {
+      "expectPoll": {
+        "query": {
+          "position": "{{POS:0}}",
+          "types": "message.created"
+        },
+        "respond": {
+          "status": 200,
+          "body": {
+            "events": [
+              {
+                "id": 101,
+                "kind": "message",
+                "event_type": "message.created",
+                "action": "created",
+                "created_at": "2026-08-01T12:00:00Z",
+                "bucket_id": 2,
+                "creator_id": 3,
+                "recording_id": 900
+              },
+              {
+                "id": 102,
+                "kind": "message",
+                "event_type": "message.created",
+                "action": "created",
+                "created_at": "2026-08-01T12:00:00Z",
+                "bucket_id": 2,
+                "creator_id": 3,
+                "recording_id": 900
+              }
+            ],
+            "position": "{{POS:1}}",
+            "next": "{{NEXT:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectDelivered": {
+        "exact": [101, 102]
+      }
+    },
+    {
+      "expectCheckpoint": {
+        "position": "{{POS:1}}"
+      }
+    },
+    {
+      "expectPoll": {
+        "url": "{{NEXT:1}}",
+        "respond": {
+          "status": 200,
+          "body": {
+            "events": [
+              {
+                "id": 103,
+                "kind": "message",
+                "event_type": "message.created",
+                "action": "created",
+                "created_at": "2026-08-01T12:00:00Z",
+                "bucket_id": 2,
+                "creator_id": 3,
+                "recording_id": 900
+              }
+            ],
+            "position": "{{POS:2}}"
+          }
+        }
+      }
+    },
+    {
+      "expectCheckpoint": {
+        "position": "{{POS:2}}"
+      }
+    },
+    {
+      "expectDelivered": {
+        "exact": [101, 102, 103, 104]
+      }
+    },
+    {
+      "expectState": {
+        "is": "streaming"
+      }
+    },
+    {
+      "serve": {
+        "frame": "message",
+        "event": {
+          "id": 105,
+          "kind": "message",
+          "event_type": "message.created",
+          "action": "created",
+          "created_at": "2026-08-01T12:00:00Z",
+          "bucket_id": 2,
+          "creator_id": 3,
+          "recording_id": 900,
+          "visible_to_clients": false
+        }
+      }
+    },
+    {
+      "expectDelivered": {
+        "exact": [101, 102, 103, 104, 105]
+      }
+    }
+  ],
+  "finally": {
+    "state": "streaming",
+    "mintCount": 1,
+    "connectCount": 1,
+    "delivered": {
+      "exact": [101, 102, 103, 104, 105]
+    },
+    "checkpoints": {
+      "exact": ["{{POS:1}}", "{{POS:2}}"]
+    },
+    "timers": {
+      "exact": {
+        "staleness": 1,
+        "repair-poll": 1
+      }
+    },
+    "socket": "open"
+  }
+}

--- a/conformance/event-feed/fixtures/02-confirmation-gating.json
+++ b/conformance/event-feed/fixtures/02-confirmation-gating.json
@@ -1,0 +1,122 @@
+{
+  "name": "02-confirmation-gating",
+  "description": "Acceptance test (b): a message frame lands before confirm_subscription; nothing is delivered, no poll and no save occur (their expect steps sit after the confirm), and the buffered event drains exactly once after the catch-up walk. The expectState awaiting_confirmation pin immediately before the confirm is the kill for start-catchup-before-confirm: an early poll parks rather than failing on arrival, but a mutant that started its walk is in catching_up and fails the state rendezvous. Position-resume entry, so the empty final page saves before the drain — the checkpoint step deliberately precedes the delivered step.",
+  "config": {
+    "position": "{{POS:0}}"
+  },
+  "steps": [
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:1}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectConnect": {
+        "url": "{{CABLE_URL:1}}"
+      }
+    },
+    {
+      "serve": {
+        "frame": "welcome"
+      }
+    },
+    {
+      "expectSubscribe": {
+        "channel": "EventsChannel"
+      }
+    },
+    {
+      "serve": {
+        "frame": "message",
+        "event": {
+          "id": 201,
+          "kind": "message",
+          "event_type": "message.created",
+          "action": "created",
+          "created_at": "2026-08-01T12:00:00Z",
+          "bucket_id": 2,
+          "creator_id": 3,
+          "recording_id": 900,
+          "visible_to_clients": false
+        }
+      }
+    },
+    {
+      "expectBuffered": {
+        "count": 1
+      }
+    },
+    {
+      "expectDelivered": {
+        "exact": []
+      }
+    },
+    {
+      "expectTimers": {
+        "exact": {
+          "confirmation-deadline": 1,
+          "staleness": 1
+        }
+      }
+    },
+    {
+      "expectState": {
+        "is": "awaiting_confirmation"
+      }
+    },
+    {
+      "serve": {
+        "frame": "confirm"
+      }
+    },
+    {
+      "expectPoll": {
+        "query": {
+          "position": "{{POS:0}}"
+        },
+        "respond": {
+          "status": 200,
+          "body": {
+            "events": [],
+            "position": "{{POS:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectCheckpoint": {
+        "position": "{{POS:1}}"
+      }
+    },
+    {
+      "expectDelivered": {
+        "exact": [201]
+      }
+    }
+  ],
+  "finally": {
+    "state": "streaming",
+    "mintCount": 1,
+    "connectCount": 1,
+    "delivered": {
+      "exact": [201]
+    },
+    "checkpoints": {
+      "exact": ["{{POS:1}}"]
+    },
+    "timers": {
+      "exact": {
+        "staleness": 1,
+        "repair-poll": 1
+      }
+    },
+    "socket": "open"
+  }
+}

--- a/conformance/event-feed/fixtures/03-confirmation-deadline-teardown.json
+++ b/conformance/event-feed/fixtures/03-confirmation-deadline-teardown.json
@@ -1,0 +1,106 @@
+{
+  "name": "03-confirmation-deadline-teardown",
+  "description": "Acceptance test (c): the confirmation deadline lapses without a confirm; the connector closes the socket and the disposed attempt leaves exactly {backoff} outstanding — the old deadline timer is gone and no ghost watchdog survives teardown. The retry then mints a FRESH ticket and dials the NEW cable URL ({{CABLE_URL:2}}, harness-guaranteed distinct from {{CABLE_URL:1}}), ending back in awaiting_confirmation.",
+  "steps": [
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:1}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectConnect": {
+        "url": "{{CABLE_URL:1}}"
+      }
+    },
+    {
+      "serve": {
+        "frame": "welcome"
+      }
+    },
+    {
+      "expectSubscribe": {
+        "channel": "EventsChannel"
+      }
+    },
+    {
+      "fireTimer": {
+        "kind": "confirmation-deadline",
+        "assertDelayMs": {
+          "min": 10000,
+          "max": 10000
+        }
+      }
+    },
+    {
+      "expectClientClose": {}
+    },
+    {
+      "expectTimers": {
+        "exact": {
+          "backoff": 1
+        }
+      }
+    },
+    {
+      "fireTimer": {
+        "kind": "backoff",
+        "assertDelayMs": {
+          "min": 0,
+          "max": 1000
+        }
+      }
+    },
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:2}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:2}}"
+          }
+        }
+      }
+    },
+    {
+      "expectConnect": {
+        "url": "{{CABLE_URL:2}}"
+      }
+    },
+    {
+      "serve": {
+        "frame": "welcome"
+      }
+    },
+    {
+      "expectSubscribe": {
+        "channel": "EventsChannel"
+      }
+    }
+  ],
+  "finally": {
+    "state": "awaiting_confirmation",
+    "mintCount": 2,
+    "connectCount": 2,
+    "delivered": {
+      "exact": []
+    },
+    "checkpoints": {
+      "exact": []
+    },
+    "timers": {
+      "exact": {
+        "confirmation-deadline": 1,
+        "staleness": 1
+      }
+    },
+    "socket": "open"
+  }
+}

--- a/conformance/event-feed/fixtures/04-terminal-rejection.json
+++ b/conformance/event-feed/fixtures/04-terminal-rejection.json
@@ -1,0 +1,23 @@
+{
+  "name": "04-terminal-rejection",
+  "description": "Acceptance test (d), this family's half of the split of duty: on reject_subscription the connector cancels the confirmation deadline, explicitly closes the still-open socket (expectClientClose), and surfaces Terminal(subscription_rejected) — rejection is always terminal. Zero further mint/connect seam calls (connectCount 1) and the empty exact timer set prove no armed backoff would ever fire a reconnect; a reconnect mint or dial is an unmatched action. bc3's half (rejection residue server-side) lives in its own suite; neither asserts the other's.",
+  "steps": [
+    {"expectMint": {"respond": {"status": 200, "body": {"ticket": "{{TICKET:1}}", "expires_in": 120, "url": "{{CABLE_URL:1}}"}}}},
+    {"expectConnect": {"url": "{{CABLE_URL:1}}"}},
+    {"serve": {"frame": "welcome"}},
+    {"expectSubscribe": {"channel": "EventsChannel"}},
+    {"serve": {"frame": "reject"}},
+    {"expectClientClose": {}},
+    {"expectError": {"reason": "subscription_rejected"}}
+  ],
+  "finally": {
+    "state": "terminal",
+    "mintCount": 1,
+    "connectCount": 1,
+    "delivered": {"exact": []},
+    "checkpoints": {"exact": []},
+    "timers": {"exact": {}},
+    "socket": "closed",
+    "error": {"reason": "subscription_rejected"}
+  }
+}

--- a/conformance/event-feed/fixtures/05-fresh-ticket-reconnect-after-ttl.json
+++ b/conformance/event-feed/fixtures/05-fresh-ticket-reconnect-after-ttl.json
@@ -1,0 +1,163 @@
+{
+  "name": "05-fresh-ticket-reconnect-after-ttl",
+  "description": "Acceptance test (a): stream established, then 121s of virtual silence (staleness and repair-poll overridden out of the window) exceeds the first ticket's server-owned expires_in (120) — which must schedule nothing client-side — before an abrupt sever. The reconnect pass mints a FRESH ticket and the second connect must bear the SECOND mint's URL ({{CABLE_URL:2}}, distinct by harness guarantee), and one catch-up poll from the durable position ({{POS:1}}) precedes any trusted live delivery. The timer exact-set after the sever also proves the repair-poll timer did not survive teardown. Kills: reuse-old-url.",
+  "config": {
+    "position": "{{POS:0}}",
+    "stalenessMs": 999999000,
+    "repairPollBaseMs": 999999000
+  },
+  "steps": [
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:1}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectConnect": {
+        "url": "{{CABLE_URL:1}}"
+      }
+    },
+    {
+      "serve": {
+        "frame": "welcome"
+      }
+    },
+    {
+      "expectSubscribe": {
+        "channel": "EventsChannel"
+      }
+    },
+    {
+      "serve": {
+        "frame": "confirm"
+      }
+    },
+    {
+      "expectPoll": {
+        "query": {
+          "position": "{{POS:0}}"
+        },
+        "respond": {
+          "status": 200,
+          "body": {
+            "events": [],
+            "position": "{{POS:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectCheckpoint": {
+        "position": "{{POS:1}}"
+      }
+    },
+    {
+      "expectState": {
+        "is": "streaming"
+      }
+    },
+    {
+      "advance": {
+        "ms": 121000
+      }
+    },
+    {
+      "sever": true
+    },
+    {
+      "expectTimers": {
+        "exact": {
+          "backoff": 1
+        }
+      }
+    },
+    {
+      "fireTimer": {
+        "kind": "backoff",
+        "assertDelayMs": {
+          "min": 0,
+          "max": 1000
+        }
+      }
+    },
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:2}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:2}}"
+          }
+        }
+      }
+    },
+    {
+      "expectConnect": {
+        "url": "{{CABLE_URL:2}}"
+      }
+    },
+    {
+      "serve": {
+        "frame": "welcome"
+      }
+    },
+    {
+      "expectSubscribe": {
+        "channel": "EventsChannel"
+      }
+    },
+    {
+      "serve": {
+        "frame": "confirm"
+      }
+    },
+    {
+      "expectPoll": {
+        "query": {
+          "position": "{{POS:1}}"
+        },
+        "respond": {
+          "status": 200,
+          "body": {
+            "events": [],
+            "position": "{{POS:2}}"
+          }
+        }
+      }
+    },
+    {
+      "expectCheckpoint": {
+        "position": "{{POS:2}}"
+      }
+    }
+  ],
+  "finally": {
+    "state": "streaming",
+    "mintCount": 2,
+    "connectCount": 2,
+    "delivered": {
+      "exact": []
+    },
+    "checkpoints": {
+      "exact": [
+        "{{POS:1}}",
+        "{{POS:2}}"
+      ]
+    },
+    "timers": {
+      "exact": {
+        "staleness": 1,
+        "repair-poll": 1
+      }
+    },
+    "socket": "open"
+  }
+}

--- a/conformance/event-feed/fixtures/06-protocol-fatal-disconnect.json
+++ b/conformance/event-feed/fixtures/06-protocol-fatal-disconnect.json
@@ -1,0 +1,66 @@
+{
+  "name": "06-protocol-fatal-disconnect",
+  "description": "Raw-frame interception: an Action Cable disconnect TEXT frame with reason invalid_event_stream_command (reconnect: false) lands in AwaitingConfirmation (transition 13) and is the server's own protocol verdict — Terminal(protocol_fatal), never retried into. The connector explicitly closes the still-open socket; mintCount 1 plus the empty exact timer set make zero further mints structural.",
+  "steps": [
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:1}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectConnect": {
+        "url": "{{CABLE_URL:1}}"
+      }
+    },
+    {
+      "serve": {
+        "frame": "welcome"
+      }
+    },
+    {
+      "expectSubscribe": {
+        "channel": "EventsChannel"
+      }
+    },
+    {
+      "serve": {
+        "frame": "disconnect",
+        "reason": "invalid_event_stream_command",
+        "reconnect": false
+      }
+    },
+    {
+      "expectClientClose": {}
+    },
+    {
+      "expectError": {
+        "reason": "protocol_fatal"
+      }
+    }
+  ],
+  "finally": {
+    "state": "terminal",
+    "mintCount": 1,
+    "connectCount": 1,
+    "delivered": {
+      "exact": []
+    },
+    "checkpoints": {
+      "exact": []
+    },
+    "timers": {
+      "exact": {}
+    },
+    "socket": "closed",
+    "error": {
+      "reason": "protocol_fatal"
+    }
+  }
+}

--- a/conformance/event-feed/fixtures/07-unauthorized-disconnect-reconnects.json
+++ b/conformance/event-feed/fixtures/07-unauthorized-disconnect-reconnects.json
@@ -1,0 +1,120 @@
+{
+  "name": "07-unauthorized-disconnect-reconnects",
+  "description": "The contrast case to fixture 06: the same reconnect:false flag, the opposite response — dispatch is on the REASON string, not the reconnect flag. An `unauthorized` disconnect arrives pre-welcome (no welcome frame is served before it) and is retriable: the connector closes the socket, arms backoff, and retries with a FRESH ticket and the second mint's cable URL. A mutant treating `unauthorized` as terminal fails the post-disconnect backoff expectation. Wire-literal pin (class 1): the `unauthorized` reason string plus its pre-welcome arrival timing. Entry is the bare present (the zero Cursor); the poll's exact-empty query pins the no-params form, and the present-class hold-then-save on an empty snapshot collapses to an ordinary save. PR-4 deferral: the counter-reset-on-first-successful-poll-page rule is NOT provable here — no auth failure ever follows the successful page — so its kill lives in the PR-4 authorization-threshold fixtures.",
+  "steps": [
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:1}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectConnect": {
+        "url": "{{CABLE_URL:1}}"
+      }
+    },
+    {
+      "serve": {
+        "frame": "disconnect",
+        "reason": "unauthorized",
+        "reconnect": false
+      }
+    },
+    {
+      "expectClientClose": {}
+    },
+    {
+      "expectTimers": {
+        "exact": {
+          "backoff": 1
+        }
+      }
+    },
+    {
+      "fireTimer": {
+        "kind": "backoff",
+        "assertDelayMs": {
+          "min": 0,
+          "max": 1000
+        }
+      }
+    },
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:2}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:2}}"
+          }
+        }
+      }
+    },
+    {
+      "expectConnect": {
+        "url": "{{CABLE_URL:2}}"
+      }
+    },
+    {
+      "serve": {
+        "frame": "welcome"
+      }
+    },
+    {
+      "expectSubscribe": {
+        "channel": "EventsChannel"
+      }
+    },
+    {
+      "serve": {
+        "frame": "confirm"
+      }
+    },
+    {
+      "expectPoll": {
+        "query": {
+          "exact": {}
+        },
+        "respond": {
+          "status": 200,
+          "body": {
+            "events": [],
+            "position": "{{POS:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectCheckpoint": {
+        "position": "{{POS:1}}"
+      }
+    }
+  ],
+  "finally": {
+    "state": "streaming",
+    "mintCount": 2,
+    "connectCount": 2,
+    "delivered": {
+      "exact": []
+    },
+    "checkpoints": {
+      "exact": [
+        "{{POS:1}}"
+      ]
+    },
+    "timers": {
+      "exact": {
+        "staleness": 1,
+        "repair-poll": 1
+      }
+    },
+    "socket": "open"
+  }
+}

--- a/conformance/event-feed/fixtures/12-checkpoint-after-handoff.json
+++ b/conformance/event-feed/fixtures/12-checkpoint-after-handoff.json
@@ -1,0 +1,138 @@
+{
+  "name": "12-checkpoint-after-handoff",
+  "description": "Per page of the catch-up walk, delivery strictly precedes that page's checkpoint save. Saves are strict-matched, so a save arriving while an expectDelivered rendezvous is still pending is an unmatched action and fails the scenario — killing checkpoint-before-handoff.",
+  "config": {
+    "position": "{{POS:0}}"
+  },
+  "steps": [
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:1}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectConnect": {
+        "url": "{{CABLE_URL:1}}"
+      }
+    },
+    {
+      "serve": {
+        "frame": "welcome"
+      }
+    },
+    {
+      "expectSubscribe": {
+        "channel": "EventsChannel"
+      }
+    },
+    {
+      "serve": {
+        "frame": "confirm"
+      }
+    },
+    {
+      "expectPoll": {
+        "query": {
+          "position": "{{POS:0}}"
+        },
+        "respond": {
+          "status": 200,
+          "body": {
+            "events": [
+              {
+                "id": 101,
+                "kind": "message",
+                "event_type": "message.created",
+                "action": "created",
+                "created_at": "2026-08-01T12:00:00Z",
+                "bucket_id": 2,
+                "creator_id": 3,
+                "recording_id": 900
+              },
+              {
+                "id": 102,
+                "kind": "message",
+                "event_type": "message.created",
+                "action": "created",
+                "created_at": "2026-08-01T12:00:00Z",
+                "bucket_id": 2,
+                "creator_id": 3,
+                "recording_id": 900
+              }
+            ],
+            "position": "{{POS:1}}",
+            "next": "{{NEXT:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectDelivered": {
+        "exact": [101, 102]
+      }
+    },
+    {
+      "expectCheckpoint": {
+        "position": "{{POS:1}}"
+      }
+    },
+    {
+      "expectPoll": {
+        "url": "{{NEXT:1}}",
+        "respond": {
+          "status": 200,
+          "body": {
+            "events": [
+              {
+                "id": 103,
+                "kind": "message",
+                "event_type": "message.created",
+                "action": "created",
+                "created_at": "2026-08-01T12:00:00Z",
+                "bucket_id": 2,
+                "creator_id": 3,
+                "recording_id": 900
+              }
+            ],
+            "position": "{{POS:2}}"
+          }
+        }
+      }
+    },
+    {
+      "expectDelivered": {
+        "exact": [101, 102, 103]
+      }
+    },
+    {
+      "expectCheckpoint": {
+        "position": "{{POS:2}}"
+      }
+    }
+  ],
+  "finally": {
+    "state": "streaming",
+    "mintCount": 1,
+    "connectCount": 1,
+    "delivered": {
+      "exact": [101, 102, 103]
+    },
+    "checkpoints": {
+      "exact": ["{{POS:1}}", "{{POS:2}}"]
+    },
+    "timers": {
+      "exact": {
+        "staleness": 1,
+        "repair-poll": 1
+      }
+    },
+    "socket": "open"
+  }
+}

--- a/conformance/event-feed/fixtures/16-gap-410-accepted-resume.json
+++ b/conformance/event-feed/fixtures/16-gap-410-accepted-resume.json
@@ -1,0 +1,119 @@
+{
+  "name": "16-gap-410-accepted-resume",
+  "description": "A 410 epoch gap with an accepting feedGap handler: Observer.gap fires, the handler is invoked exactly once with {feedGap, accept}, the provided resume URL is followed verbatim (a present-class re-entry at since=now preserving the canonical filter set), and the stream continues. The accept complement of fixture 23; with 24/25's records it corners bypass-configured-handler from the accept side. Wire pins: 410 body keys epoch_after_id/resume (class 1) and resume-follows-verbatim (class 2).",
+  "config": {
+    "position": "{{POS:0}}",
+    "signalDisposition": {
+      "feedGap": "accept"
+    }
+  },
+  "steps": [
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:1}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectConnect": {
+        "url": "{{CABLE_URL:1}}"
+      }
+    },
+    {
+      "serve": {
+        "frame": "welcome"
+      }
+    },
+    {
+      "expectSubscribe": {
+        "channel": "EventsChannel"
+      }
+    },
+    {
+      "serve": {
+        "frame": "confirm"
+      }
+    },
+    {
+      "expectPoll": {
+        "query": {
+          "position": "{{POS:0}}"
+        },
+        "respond": {
+          "status": 410,
+          "body": {
+            "error": "position expired",
+            "epoch_after_id": 100,
+            "resume": "{{API_ORIGIN}}/events.json?since=now"
+          }
+        }
+      }
+    },
+    {
+      "expectGap": {
+        "epochAfterId": 100
+      }
+    },
+    {
+      "expectHandlerInvocations": {
+        "exact": [
+          {
+            "kind": "feedGap",
+            "disposition": "accept"
+          }
+        ]
+      }
+    },
+    {
+      "expectPoll": {
+        "url": "{{API_ORIGIN}}/events.json?since=now",
+        "respond": {
+          "status": 200,
+          "body": {
+            "events": [],
+            "position": "{{POS:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectCheckpoint": {
+        "position": "{{POS:1}}"
+      }
+    }
+  ],
+  "finally": {
+    "state": "streaming",
+    "mintCount": 1,
+    "connectCount": 1,
+    "delivered": {
+      "exact": []
+    },
+    "checkpoints": {
+      "exact": [
+        "{{POS:1}}"
+      ]
+    },
+    "timers": {
+      "exact": {
+        "staleness": 1,
+        "repair-poll": 1
+      }
+    },
+    "socket": "open",
+    "handlerInvocations": {
+      "exact": [
+        {
+          "kind": "feedGap",
+          "disposition": "accept"
+        }
+      ]
+    }
+  }
+}

--- a/conformance/event-feed/fixtures/17-remote-disconnect-remint.json
+++ b/conformance/event-feed/fixtures/17-remote-disconnect-remint.json
@@ -1,0 +1,160 @@
+{
+  "name": "17-remote-disconnect-remint",
+  "description": "The disconnect matrix's fourth row: a `remote` disconnect with reconnect:true maps into the existing Backoff transitions — teardown, backoff, re-mint with a fresh ticket, reconnect to the NEW cable URL, and one catch-up poll from the durable position — no new state. The next mint succeeding is the healthy path; a genuinely revoked user's next mint failing is the designed revocation detection (not exercised here). This fixture is the only literal pin of the `remote` reason string anywhere until bc3's gate (source-verified; no transcript capture exists).",
+  "config": {
+    "position": "{{POS:0}}"
+  },
+  "steps": [
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:1}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectConnect": {
+        "url": "{{CABLE_URL:1}}"
+      }
+    },
+    {
+      "serve": {
+        "frame": "welcome"
+      }
+    },
+    {
+      "expectSubscribe": {
+        "channel": "EventsChannel"
+      }
+    },
+    {
+      "serve": {
+        "frame": "confirm"
+      }
+    },
+    {
+      "expectPoll": {
+        "query": {
+          "position": "{{POS:0}}"
+        },
+        "respond": {
+          "status": 200,
+          "body": {
+            "events": [],
+            "position": "{{POS:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectCheckpoint": {
+        "position": "{{POS:1}}"
+      }
+    },
+    {
+      "expectState": {
+        "is": "streaming"
+      }
+    },
+    {
+      "serve": {
+        "frame": "disconnect",
+        "reason": "remote",
+        "reconnect": true
+      }
+    },
+    {
+      "expectClientClose": {}
+    },
+    {
+      "expectTimers": {
+        "exact": {
+          "backoff": 1
+        }
+      }
+    },
+    {
+      "fireTimer": {
+        "kind": "backoff",
+        "assertDelayMs": {
+          "min": 0,
+          "max": 1000
+        }
+      }
+    },
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:2}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:2}}"
+          }
+        }
+      }
+    },
+    {
+      "expectConnect": {
+        "url": "{{CABLE_URL:2}}"
+      }
+    },
+    {
+      "serve": {
+        "frame": "welcome"
+      }
+    },
+    {
+      "expectSubscribe": {
+        "channel": "EventsChannel"
+      }
+    },
+    {
+      "serve": {
+        "frame": "confirm"
+      }
+    },
+    {
+      "expectPoll": {
+        "query": {
+          "position": "{{POS:1}}"
+        },
+        "respond": {
+          "status": 200,
+          "body": {
+            "events": [],
+            "position": "{{POS:2}}"
+          }
+        }
+      }
+    },
+    {
+      "expectCheckpoint": {
+        "position": "{{POS:2}}"
+      }
+    }
+  ],
+  "finally": {
+    "state": "streaming",
+    "mintCount": 2,
+    "connectCount": 2,
+    "delivered": {
+      "exact": []
+    },
+    "checkpoints": {
+      "exact": ["{{POS:1}}", "{{POS:2}}"]
+    },
+    "timers": {
+      "exact": {
+        "staleness": 1,
+        "repair-poll": 1
+      }
+    },
+    "socket": "open"
+  }
+}

--- a/conformance/event-feed/fixtures/19-present-entry-buffered-lower-id.json
+++ b/conformance/event-feed/fixtures/19-present-entry-buffered-lower-id.json
@@ -1,0 +1,25 @@
+{
+  "name": "19-present-entry-buffered-lower-id",
+  "description": "The entry boundary's core: an in-flight-at-entry straggler (id 41) is admitted to the live buffer — proven via the expectBuffered rendezvous BEFORE the entry page is served, the race-prevention mechanism — the empty present-entry poll positions above it (since=now empty-page-above-N), and 41 is delivered BEFORE that position saves: the held entry save plus the conjunctive save-ordering invariant. The ownership cut's 'observed' means admitted at or before the cut. Kills save-present-position-before-buffer-drain via strict-save: a save arriving while the expectDelivered rendezvous is pending is unmatched.",
+  "steps": [
+    {"expectMint": {"respond": {"status": 200, "body": {"ticket": "{{TICKET:1}}", "expires_in": 120, "url": "{{CABLE_URL:1}}"}}}},
+    {"expectConnect": {"url": "{{CABLE_URL:1}}"}},
+    {"serve": {"frame": "welcome"}},
+    {"expectSubscribe": {"channel": "EventsChannel"}},
+    {"serve": {"frame": "confirm"}},
+    {"serve": {"frame": "message", "event": {"id": 41, "kind": "message", "event_type": "message.created", "action": "created", "created_at": "2026-08-01T12:00:00Z", "bucket_id": 2, "creator_id": 3, "recording_id": 900, "visible_to_clients": false}}},
+    {"expectBuffered": {"count": 1}},
+    {"expectPoll": {"query": {"exact": {}}, "respond": {"status": 200, "body": {"events": [], "position": "{{POS:1}}"}}}},
+    {"expectDelivered": {"exact": [41]}},
+    {"expectCheckpoint": {"position": "{{POS:1}}"}}
+  ],
+  "finally": {
+    "state": "streaming",
+    "mintCount": 1,
+    "connectCount": 1,
+    "delivered": {"exact": [41]},
+    "checkpoints": {"exact": ["{{POS:1}}"]},
+    "timers": {"exact": {"staleness": 1, "repair-poll": 1}},
+    "socket": "open"
+  }
+}

--- a/conformance/event-feed/fixtures/20-present-entry-post-snapshot-straggler.json
+++ b/conformance/event-feed/fixtures/20-present-entry-post-snapshot-straggler.json
@@ -1,0 +1,138 @@
+{
+  "name": "20-present-entry-post-snapshot-straggler",
+  "description": "The entry boundary's other side: on a bare present entry, straggler 41 arrives AFTER the snapshot poll and its save — the server's documented best-effort case. It must be delivered live even though its id sits at or below the entry position (dedupe tracks actually-delivered ids, never position ordering — discarding it is the named mutant discard-live-id-at-or-below-position), a repeated push of the same id is suppressed (the duplicate-then-42 sequence makes dedupe non-racy: a delivered duplicate forces the exact sequence [41, 41, 42], which can never match), and the position never regresses — the checkpoint ledger ends unchanged at the entry save. Crash-window boundary: an event admitted pre-cut and lost to a crash before delivery and save is unrecoverable with no signal — the first-usable-checkpoint exclusion, since on a first present entry no older durable cursor exists. This fixture sits just outside that window: its straggler arrives post-snapshot, after the first usable checkpoint is durable, so its live delivery is fully asserted.",
+  "steps": [
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:1}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectConnect": {
+        "url": "{{CABLE_URL:1}}"
+      }
+    },
+    {
+      "serve": {
+        "frame": "welcome"
+      }
+    },
+    {
+      "expectSubscribe": {
+        "channel": "EventsChannel"
+      }
+    },
+    {
+      "serve": {
+        "frame": "confirm"
+      }
+    },
+    {
+      "expectPoll": {
+        "query": {
+          "exact": {}
+        },
+        "respond": {
+          "status": 200,
+          "body": {
+            "events": [],
+            "position": "{{POS:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectCheckpoint": {
+        "position": "{{POS:1}}"
+      }
+    },
+    {
+      "expectState": {
+        "is": "streaming"
+      }
+    },
+    {
+      "serve": {
+        "frame": "message",
+        "event": {
+          "id": 41,
+          "kind": "message",
+          "event_type": "message.created",
+          "action": "created",
+          "created_at": "2026-08-01T12:00:00Z",
+          "bucket_id": 2,
+          "creator_id": 3,
+          "recording_id": 900,
+          "visible_to_clients": false
+        }
+      }
+    },
+    {
+      "expectDelivered": {
+        "exact": [41]
+      }
+    },
+    {
+      "serve": {
+        "frame": "message",
+        "event": {
+          "id": 41,
+          "kind": "message",
+          "event_type": "message.created",
+          "action": "created",
+          "created_at": "2026-08-01T12:00:00Z",
+          "bucket_id": 2,
+          "creator_id": 3,
+          "recording_id": 900,
+          "visible_to_clients": false
+        }
+      }
+    },
+    {
+      "serve": {
+        "frame": "message",
+        "event": {
+          "id": 42,
+          "kind": "message",
+          "event_type": "message.created",
+          "action": "created",
+          "created_at": "2026-08-01T12:00:00Z",
+          "bucket_id": 2,
+          "creator_id": 3,
+          "recording_id": 900,
+          "visible_to_clients": false
+        }
+      }
+    },
+    {
+      "expectDelivered": {
+        "exact": [41, 42]
+      }
+    }
+  ],
+  "finally": {
+    "state": "streaming",
+    "mintCount": 1,
+    "connectCount": 1,
+    "delivered": {
+      "exact": [41, 42]
+    },
+    "checkpoints": {
+      "exact": ["{{POS:1}}"]
+    },
+    "timers": {
+      "exact": {
+        "staleness": 1,
+        "repair-poll": 1
+      }
+    },
+    "socket": "open"
+  }
+}

--- a/conformance/event-feed/fixtures/21-overflow-default-terminal.json
+++ b/conformance/event-feed/fixtures/21-overflow-default-terminal.json
@@ -1,0 +1,120 @@
+{
+  "name": "21-overflow-default-terminal",
+  "description": "No handler registered: buffer overflow is the typed terminal. Capacity 2 with three pre-confirm events (in AwaitingConfirmation, a buffer-holding state) drops the OLDEST (51); the signal carries the exact dropped ids and count, the connector explicitly closes the socket, and iteration ends Terminal(buffer_overflow). The entry poll never happens, so zero polls and zero saves are structural, and the handler-invocation record is exactly empty — the zero-invocation record is what proves the default-terminal path was taken rather than a bypassed handler. Drop-time dispatch (the signal fires at the first consumer-context opportunity after the drop, per the SPEC §23 Semantic Signals timing repair) is what makes the pre-cut expectSignal correct: a conformant implementation cannot defer the signal to a cut that never comes.",
+  "config": {
+    "liveBufferCapacity": 2
+  },
+  "steps": [
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:1}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectConnect": {
+        "url": "{{CABLE_URL:1}}"
+      }
+    },
+    {
+      "serve": {
+        "frame": "welcome"
+      }
+    },
+    {
+      "expectSubscribe": {
+        "channel": "EventsChannel"
+      }
+    },
+    {
+      "serve": {
+        "frame": "message",
+        "event": {
+          "id": 51,
+          "kind": "message",
+          "event_type": "message.created",
+          "action": "created",
+          "created_at": "2026-08-01T12:00:00Z",
+          "bucket_id": 2,
+          "creator_id": 3,
+          "recording_id": 900,
+          "visible_to_clients": false
+        }
+      }
+    },
+    {
+      "serve": {
+        "frame": "message",
+        "event": {
+          "id": 52,
+          "kind": "message",
+          "event_type": "message.created",
+          "action": "created",
+          "created_at": "2026-08-01T12:00:00Z",
+          "bucket_id": 2,
+          "creator_id": 3,
+          "recording_id": 900,
+          "visible_to_clients": false
+        }
+      }
+    },
+    {
+      "serve": {
+        "frame": "message",
+        "event": {
+          "id": 53,
+          "kind": "message",
+          "event_type": "message.created",
+          "action": "created",
+          "created_at": "2026-08-01T12:00:00Z",
+          "bucket_id": 2,
+          "creator_id": 3,
+          "recording_id": 900,
+          "visible_to_clients": false
+        }
+      }
+    },
+    {
+      "expectSignal": {
+        "kind": "bufferOverflow",
+        "droppedIds": [51],
+        "droppedCount": 1
+      }
+    },
+    {
+      "expectClientClose": {}
+    },
+    {
+      "expectError": {
+        "reason": "buffer_overflow"
+      }
+    }
+  ],
+  "finally": {
+    "state": "terminal",
+    "mintCount": 1,
+    "connectCount": 1,
+    "delivered": {
+      "exact": []
+    },
+    "checkpoints": {
+      "exact": []
+    },
+    "timers": {
+      "exact": {}
+    },
+    "socket": "closed",
+    "error": {
+      "reason": "buffer_overflow"
+    },
+    "handlerInvocations": {
+      "exact": []
+    }
+  }
+}

--- a/conformance/event-feed/fixtures/22-overflow-accepted.json
+++ b/conformance/event-feed/fixtures/22-overflow-accepted.json
@@ -1,0 +1,174 @@
+{
+  "name": "22-overflow-accepted",
+  "description": "Accepting handler on buffer overflow: the invocation {bufferOverflow, accept} is recorded exactly once, and acceptance is NOT license to skip retained deliveries — the retained exact set [52, 53] must complete before the held present-entry position saves (the conjunctive save-ordering invariant's accept branch). expectBuffered 2 asserts CURRENT OCCUPANCY (admitted minus dropped): three events admitted, 51 dropped, retained {52, 53} in the buffer pre-cut. Signal dispatch at drop time (first consumer-context opportunity) is pinned normative by SPEC §23; the rendezvous placement after the poll is scheduling slack only, not a semantic tolerance. The expectBuffered count of 2 is a current-occupancy rendezvous consistent with the retained set; the drop itself is proven by expectSignal's exact droppedIds plus the delivered exact set, not by the occupancy rendezvous alone.",
+  "config": {
+    "liveBufferCapacity": 2,
+    "signalDisposition": {
+      "bufferOverflow": "accept"
+    }
+  },
+  "steps": [
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:1}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectConnect": {
+        "url": "{{CABLE_URL:1}}"
+      }
+    },
+    {
+      "serve": {
+        "frame": "welcome"
+      }
+    },
+    {
+      "expectSubscribe": {
+        "channel": "EventsChannel"
+      }
+    },
+    {
+      "serve": {
+        "frame": "message",
+        "event": {
+          "id": 51,
+          "kind": "message",
+          "event_type": "message.created",
+          "action": "created",
+          "created_at": "2026-08-01T12:00:00Z",
+          "bucket_id": 2,
+          "creator_id": 3,
+          "recording_id": 900,
+          "visible_to_clients": false
+        }
+      }
+    },
+    {
+      "serve": {
+        "frame": "message",
+        "event": {
+          "id": 52,
+          "kind": "message",
+          "event_type": "message.created",
+          "action": "created",
+          "created_at": "2026-08-01T12:00:00Z",
+          "bucket_id": 2,
+          "creator_id": 3,
+          "recording_id": 900,
+          "visible_to_clients": false
+        }
+      }
+    },
+    {
+      "serve": {
+        "frame": "message",
+        "event": {
+          "id": 53,
+          "kind": "message",
+          "event_type": "message.created",
+          "action": "created",
+          "created_at": "2026-08-01T12:00:00Z",
+          "bucket_id": 2,
+          "creator_id": 3,
+          "recording_id": 900,
+          "visible_to_clients": false
+        }
+      }
+    },
+    {
+      "expectBuffered": {
+        "count": 2
+      }
+    },
+    {
+      "serve": {
+        "frame": "confirm"
+      }
+    },
+    {
+      "expectPoll": {
+        "query": {
+          "exact": {}
+        },
+        "respond": {
+          "status": 200,
+          "body": {
+            "events": [],
+            "position": "{{POS:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectSignal": {
+        "kind": "bufferOverflow",
+        "droppedIds": [
+          51
+        ],
+        "droppedCount": 1
+      }
+    },
+    {
+      "expectHandlerInvocations": {
+        "exact": [
+          {
+            "kind": "bufferOverflow",
+            "disposition": "accept"
+          }
+        ]
+      }
+    },
+    {
+      "expectDelivered": {
+        "exact": [
+          52,
+          53
+        ]
+      }
+    },
+    {
+      "expectCheckpoint": {
+        "position": "{{POS:1}}"
+      }
+    }
+  ],
+  "finally": {
+    "state": "streaming",
+    "mintCount": 1,
+    "connectCount": 1,
+    "delivered": {
+      "exact": [
+        52,
+        53
+      ]
+    },
+    "checkpoints": {
+      "exact": [
+        "{{POS:1}}"
+      ]
+    },
+    "timers": {
+      "exact": {
+        "staleness": 1,
+        "repair-poll": 1
+      }
+    },
+    "socket": "open",
+    "handlerInvocations": {
+      "exact": [
+        {
+          "kind": "bufferOverflow",
+          "disposition": "accept"
+        }
+      ]
+    }
+  }
+}

--- a/conformance/event-feed/fixtures/23-gap-410-default-terminal.json
+++ b/conformance/event-feed/fixtures/23-gap-410-default-terminal.json
@@ -1,0 +1,90 @@
+{
+  "name": "23-gap-410-default-terminal",
+  "description": "No handler configured: a 410 epoch gap is the typed terminal — a 410 never silently auto-continues. The exact-set finally is the direct test of any auto-continue mutant (following resume would be an unmatched poll; mintCount/state/timers pin the rest), and zero handler invocations are required by the schema's default-terminal pin. Observer.gap (expectGap) fires either way — observability is not disposition. Kills: auto-continue-past-unhandled-gap.",
+  "config": {
+    "position": "{{POS:0}}"
+  },
+  "steps": [
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:1}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectConnect": {
+        "url": "{{CABLE_URL:1}}"
+      }
+    },
+    {
+      "serve": {
+        "frame": "welcome"
+      }
+    },
+    {
+      "expectSubscribe": {
+        "channel": "EventsChannel"
+      }
+    },
+    {
+      "serve": {
+        "frame": "confirm"
+      }
+    },
+    {
+      "expectPoll": {
+        "query": {
+          "position": "{{POS:0}}"
+        },
+        "respond": {
+          "status": 410,
+          "body": {
+            "error": "position expired",
+            "epoch_after_id": 100,
+            "resume": "{{API_ORIGIN}}/events.json?since=now"
+          }
+        }
+      }
+    },
+    {
+      "expectGap": {
+        "epochAfterId": 100
+      }
+    },
+    {
+      "expectClientClose": {}
+    },
+    {
+      "expectError": {
+        "reason": "feed_gap"
+      }
+    }
+  ],
+  "finally": {
+    "state": "terminal",
+    "mintCount": 1,
+    "connectCount": 1,
+    "delivered": {
+      "exact": []
+    },
+    "checkpoints": {
+      "exact": []
+    },
+    "timers": {
+      "exact": {}
+    },
+    "socket": "closed",
+    "error": {
+      "reason": "feed_gap"
+    },
+    "handlerInvocations": {
+      "exact": []
+    }
+  }
+}

--- a/conformance/event-feed/fixtures/24-overflow-handler-terminate.json
+++ b/conformance/event-feed/fixtures/24-overflow-handler-terminate.json
@@ -1,0 +1,100 @@
+{
+  "name": "24-overflow-handler-terminate",
+  "description": "Buffer overflow with a registered handler returning Terminate: Terminal(buffer_overflow), no save, socket explicitly closed — visibly identical to fixture 21 EXCEPT the invocation record {bufferOverflow, terminate}, which is exactly what distinguishes a consulted handler from a bypassed one (kills bypass-configured-handler, with 25). Drop-time dispatch — the signal fires at the first consumer-context opportunity after the drop — is pinned normative by the SPEC §23 Semantic Signals timing repair, so the pre-cut expectSignal is correct as designed.",
+  "config": {
+    "liveBufferCapacity": 2,
+    "signalDisposition": { "bufferOverflow": "terminate" }
+  },
+  "steps": [
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:1}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:1}}"
+          }
+        }
+      }
+    },
+    { "expectConnect": { "url": "{{CABLE_URL:1}}" } },
+    { "serve": { "frame": "welcome" } },
+    { "expectSubscribe": { "channel": "EventsChannel" } },
+    {
+      "serve": {
+        "frame": "message",
+        "event": {
+          "id": 51,
+          "kind": "message",
+          "event_type": "message.created",
+          "action": "created",
+          "created_at": "2026-08-01T12:00:00Z",
+          "bucket_id": 2,
+          "creator_id": 3,
+          "recording_id": 900,
+          "visible_to_clients": false
+        }
+      }
+    },
+    {
+      "serve": {
+        "frame": "message",
+        "event": {
+          "id": 52,
+          "kind": "message",
+          "event_type": "message.created",
+          "action": "created",
+          "created_at": "2026-08-01T12:00:00Z",
+          "bucket_id": 2,
+          "creator_id": 3,
+          "recording_id": 900,
+          "visible_to_clients": false
+        }
+      }
+    },
+    {
+      "serve": {
+        "frame": "message",
+        "event": {
+          "id": 53,
+          "kind": "message",
+          "event_type": "message.created",
+          "action": "created",
+          "created_at": "2026-08-01T12:00:00Z",
+          "bucket_id": 2,
+          "creator_id": 3,
+          "recording_id": 900,
+          "visible_to_clients": false
+        }
+      }
+    },
+    {
+      "expectSignal": {
+        "kind": "bufferOverflow",
+        "droppedIds": [51],
+        "droppedCount": 1
+      }
+    },
+    {
+      "expectHandlerInvocations": {
+        "exact": [{ "kind": "bufferOverflow", "disposition": "terminate" }]
+      }
+    },
+    { "expectClientClose": {} },
+    { "expectError": { "reason": "buffer_overflow" } }
+  ],
+  "finally": {
+    "state": "terminal",
+    "mintCount": 1,
+    "connectCount": 1,
+    "delivered": { "exact": [] },
+    "checkpoints": { "exact": [] },
+    "timers": { "exact": {} },
+    "socket": "closed",
+    "error": { "reason": "buffer_overflow" },
+    "handlerInvocations": {
+      "exact": [{ "kind": "bufferOverflow", "disposition": "terminate" }]
+    }
+  }
+}

--- a/conformance/event-feed/fixtures/25-gap-handler-terminate.json
+++ b/conformance/event-feed/fixtures/25-gap-handler-terminate.json
@@ -1,0 +1,61 @@
+{
+  "name": "25-gap-handler-terminate",
+  "description": "The gap-flavored Terminate branch: a 410 epoch gap with a registered feedGap handler returning Terminate — Observer.gap fires (observability is not disposition), the handler is invoked exactly once with {feedGap, terminate}, and the connector goes Terminal(feed_gap) with no save (Terminate means no save; the empty checkpoint ledger plus strict-save pin it) and the resume URL never followed. Same visible outcome as fixture 23, distinguished by the invocation record — which is exactly what distinguishes a consulted handler from a bypassed default-terminal path (kills bypass-configured-handler, with 24).",
+  "config": {
+    "position": "{{POS:0}}",
+    "signalDisposition": { "feedGap": "terminate" }
+  },
+  "steps": [
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:1}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:1}}"
+          }
+        }
+      }
+    },
+    { "expectConnect": { "url": "{{CABLE_URL:1}}" } },
+    { "serve": { "frame": "welcome" } },
+    { "expectSubscribe": { "channel": "EventsChannel" } },
+    { "serve": { "frame": "confirm" } },
+    {
+      "expectPoll": {
+        "query": { "position": "{{POS:0}}" },
+        "respond": {
+          "status": 410,
+          "body": {
+            "error": "position expired",
+            "epoch_after_id": 100,
+            "resume": "{{API_ORIGIN}}/events.json?since=now"
+          }
+        }
+      }
+    },
+    { "expectGap": { "epochAfterId": 100 } },
+    { "expectSignal": { "kind": "feedGap", "epochAfterId": 100 } },
+    {
+      "expectHandlerInvocations": {
+        "exact": [{ "kind": "feedGap", "disposition": "terminate" }]
+      }
+    },
+    { "expectClientClose": {} },
+    { "expectError": { "reason": "feed_gap" } }
+  ],
+  "finally": {
+    "state": "terminal",
+    "mintCount": 1,
+    "connectCount": 1,
+    "delivered": { "exact": [] },
+    "checkpoints": { "exact": [] },
+    "timers": { "exact": {} },
+    "socket": "closed",
+    "error": { "reason": "feed_gap" },
+    "handlerInvocations": {
+      "exact": [{ "kind": "feedGap", "disposition": "terminate" }]
+    }
+  }
+}

--- a/conformance/event-feed/fixtures/26-hostile-next-cross-origin.json
+++ b/conformance/event-feed/fixtures/26-hostile-next-cross-origin.json
@@ -1,0 +1,103 @@
+{
+  "name": "26-hostile-next-cross-origin",
+  "description": "A cross-origin `next` mid-walk. Per transition 16's order the carrying page is delivered and saved first; the follow then fails SPEC §8 validation between URL validation and the poll call — Terminal(invalid_continuation) with zero requests to the foreign origin (structural: no step ever serves it, and the harness's servers own only their own origins). The hostile origin is a LITERAL, never substituted. The error carries the rejected URL redacted to origin (tier-3 pins the redaction; not fixture-assertable). Kills: follow-cross-origin-continuation (with 27).",
+  "config": {
+    "position": "{{POS:0}}"
+  },
+  "steps": [
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:1}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectConnect": {
+        "url": "{{CABLE_URL:1}}"
+      }
+    },
+    {
+      "serve": {
+        "frame": "welcome"
+      }
+    },
+    {
+      "expectSubscribe": {
+        "channel": "EventsChannel"
+      }
+    },
+    {
+      "serve": {
+        "frame": "confirm"
+      }
+    },
+    {
+      "expectPoll": {
+        "query": {
+          "position": "{{POS:0}}"
+        },
+        "respond": {
+          "status": 200,
+          "body": {
+            "events": [
+              {
+                "id": 61,
+                "kind": "message",
+                "event_type": "message.created",
+                "action": "created",
+                "created_at": "2026-08-01T12:00:00Z",
+                "bucket_id": 2,
+                "creator_id": 3,
+                "recording_id": 900
+              }
+            ],
+            "position": "{{POS:1}}",
+            "next": "https://attacker.example.com/events.json?page=2"
+          }
+        }
+      }
+    },
+    {
+      "expectDelivered": {
+        "exact": [61]
+      }
+    },
+    {
+      "expectCheckpoint": {
+        "position": "{{POS:1}}"
+      }
+    },
+    {
+      "expectClientClose": {}
+    },
+    {
+      "expectError": {
+        "reason": "invalid_continuation"
+      }
+    }
+  ],
+  "finally": {
+    "state": "terminal",
+    "mintCount": 1,
+    "connectCount": 1,
+    "delivered": {
+      "exact": [61]
+    },
+    "checkpoints": {
+      "exact": ["{{POS:1}}"]
+    },
+    "timers": {
+      "exact": {}
+    },
+    "socket": "closed",
+    "error": {
+      "reason": "invalid_continuation"
+    }
+  }
+}

--- a/conformance/event-feed/fixtures/27-hostile-resume-cross-origin.json
+++ b/conformance/event-feed/fixtures/27-hostile-resume-cross-origin.json
@@ -1,0 +1,60 @@
+{
+  "name": "27-hostile-resume-cross-origin",
+  "description": "The resume-side twin of fixture 26: a 410 epoch gap whose resume URL points at a foreign origin. The registered feedGap handler ACCEPTS the gap — reaching the resume-follow path requires acceptance; with no handler this would be Terminal(feed_gap) before any URL use — and the cross-origin resume URL then fails validation between URL validation and the poll call: Terminal(invalid_continuation), with zero requests to the foreign origin (structural: the hostile origin is a LITERAL, never substituted; no step ever serves it, and the harness's servers own only their own origins). The terminal reason is invalid_continuation, NOT feed_gap — the handler accepted; the URL failed. Kills follow-cross-origin-continuation (with 26).",
+  "config": {
+    "position": "{{POS:0}}",
+    "signalDisposition": { "feedGap": "accept" }
+  },
+  "steps": [
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:1}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:1}}"
+          }
+        }
+      }
+    },
+    { "expectConnect": { "url": "{{CABLE_URL:1}}" } },
+    { "serve": { "frame": "welcome" } },
+    { "expectSubscribe": { "channel": "EventsChannel" } },
+    { "serve": { "frame": "confirm" } },
+    {
+      "expectPoll": {
+        "query": { "position": "{{POS:0}}" },
+        "respond": {
+          "status": 410,
+          "body": {
+            "error": "position expired",
+            "epoch_after_id": 100,
+            "resume": "https://attacker.example.com/events.json?since=now"
+          }
+        }
+      }
+    },
+    { "expectGap": { "epochAfterId": 100 } },
+    {
+      "expectHandlerInvocations": {
+        "exact": [{ "kind": "feedGap", "disposition": "accept" }]
+      }
+    },
+    { "expectClientClose": {} },
+    { "expectError": { "reason": "invalid_continuation" } }
+  ],
+  "finally": {
+    "state": "terminal",
+    "mintCount": 1,
+    "connectCount": 1,
+    "delivered": { "exact": [] },
+    "checkpoints": { "exact": [] },
+    "timers": { "exact": {} },
+    "socket": "closed",
+    "error": { "reason": "invalid_continuation" },
+    "handlerInvocations": {
+      "exact": [{ "kind": "feedGap", "disposition": "accept" }]
+    }
+  }
+}

--- a/conformance/event-feed/fixtures/28-checkpoint-load-failure.json
+++ b/conformance/event-feed/fixtures/28-checkpoint-load-failure.json
@@ -1,0 +1,35 @@
+{
+  "name": "28-checkpoint-load-failure",
+  "description": "Store load scripted Failed: Terminal(checkpoint_load) on the first iteration with ZERO wire attempts — before the first mint. Distinct-from-Missing is the point: Missing proceeds to a present entry (and would mint — an unmatched action here). mintCount 0 + pollCount 0 + socket \"none\" plus strict interleave (any mint is unmatched → red) kill collapse-load-error-to-missing.",
+  "config": {
+    "checkpointStore": {
+      "load": "failed"
+    }
+  },
+  "steps": [
+    {
+      "expectError": {
+        "reason": "checkpoint_load"
+      }
+    }
+  ],
+  "finally": {
+    "state": "terminal",
+    "mintCount": 0,
+    "connectCount": 0,
+    "pollCount": 0,
+    "delivered": {
+      "exact": []
+    },
+    "checkpoints": {
+      "exact": []
+    },
+    "timers": {
+      "exact": {}
+    },
+    "socket": "none",
+    "error": {
+      "reason": "checkpoint_load"
+    }
+  }
+}

--- a/conformance/event-feed/fixtures/29-checkpoint-save-failure-continues.json
+++ b/conformance/event-feed/fixtures/29-checkpoint-save-failure-continues.json
@@ -1,0 +1,143 @@
+{
+  "name": "29-checkpoint-save-failure-continues",
+  "description": "Save failure is an observer notification, not a terminal: the feed continues, and a SUBSEQUENT save is attempted — the exact store-call script ([\"failed\", \"saved\"], fully consumed at finally) proves no save circuit breaker (C-R9). Entry is present-class via load \"missing\". The repair walk resumes from the connector's held in-memory position ({{POS:1}}) — per SPEC §23's checkpoint discipline the in-memory cursor is authoritative for resume/repair within a run; the store is write-through durability only, so the failed save never regresses or blanks the live cursor. finally.checkpoints records CALLS, so both positions appear even though only the second durably saved.",
+  "config": {
+    "checkpointStore": {
+      "load": "missing",
+      "save": [
+        "failed",
+        "saved"
+      ]
+    }
+  },
+  "steps": [
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:1}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectConnect": {
+        "url": "{{CABLE_URL:1}}"
+      }
+    },
+    {
+      "serve": {
+        "frame": "welcome"
+      }
+    },
+    {
+      "expectSubscribe": {
+        "channel": "EventsChannel"
+      }
+    },
+    {
+      "serve": {
+        "frame": "confirm"
+      }
+    },
+    {
+      "expectPoll": {
+        "query": {
+          "exact": {}
+        },
+        "respond": {
+          "status": 200,
+          "body": {
+            "events": [],
+            "position": "{{POS:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectCheckpoint": {
+        "position": "{{POS:1}}"
+      }
+    },
+    {
+      "expectSaveFailed": true
+    },
+    {
+      "expectState": {
+        "is": "streaming"
+      }
+    },
+    {
+      "fireTimer": {
+        "kind": "repair-poll",
+        "assertDelayMs": {
+          "min": 48000,
+          "max": 72000
+        }
+      }
+    },
+    {
+      "expectPoll": {
+        "query": {
+          "position": "{{POS:1}}"
+        },
+        "respond": {
+          "status": 200,
+          "body": {
+            "events": [
+              {
+                "id": 71,
+                "kind": "message",
+                "event_type": "message.created",
+                "action": "created",
+                "created_at": "2026-08-01T12:00:00Z",
+                "bucket_id": 2,
+                "creator_id": 3,
+                "recording_id": 900
+              }
+            ],
+            "position": "{{POS:2}}"
+          }
+        }
+      }
+    },
+    {
+      "expectDelivered": {
+        "exact": [
+          71
+        ]
+      }
+    },
+    {
+      "expectCheckpoint": {
+        "position": "{{POS:2}}"
+      }
+    }
+  ],
+  "finally": {
+    "state": "streaming",
+    "mintCount": 1,
+    "connectCount": 1,
+    "delivered": {
+      "exact": [
+        71
+      ]
+    },
+    "checkpoints": {
+      "exact": [
+        "{{POS:1}}",
+        "{{POS:2}}"
+      ]
+    },
+    "timers": {
+      "exact": {
+        "staleness": 1,
+        "repair-poll": 1
+      }
+    },
+    "socket": "open"
+  }
+}

--- a/conformance/event-feed/fixtures/30-continuation-redirect-cross-origin.json
+++ b/conformance/event-feed/fixtures/30-continuation-redirect-cross-origin.json
@@ -1,0 +1,114 @@
+{
+  "name": "30-continuation-redirect-cross-origin",
+  "description": "A VALIDATED same-origin `next` answers 302 with a cross-origin Location: the poll seam suppresses automatic redirect-following, and the foreign Location is Terminal(invalid_continuation) with zero egress to the foreign origin. {{NEXT:1}} substitutes same-origin, so the pre-poll validation PASSES and the second poll seam call is made (contrast fixture 26, where no request reaches the URL at all) — the redirect answer is where the per-hop rule bites. The Location host is literal, never substituted, never served: the harness binds it to a sentinel listener whose any-request fails the scenario. Kills follow-cross-origin-redirect.",
+  "config": {
+    "position": "{{POS:0}}"
+  },
+  "steps": [
+    {
+      "expectMint": {
+        "respond": {
+          "status": 200,
+          "body": {
+            "ticket": "{{TICKET:1}}",
+            "expires_in": 120,
+            "url": "{{CABLE_URL:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectConnect": {
+        "url": "{{CABLE_URL:1}}"
+      }
+    },
+    {
+      "serve": {
+        "frame": "welcome"
+      }
+    },
+    {
+      "expectSubscribe": {
+        "channel": "EventsChannel"
+      }
+    },
+    {
+      "serve": {
+        "frame": "confirm"
+      }
+    },
+    {
+      "expectPoll": {
+        "query": {
+          "position": "{{POS:0}}"
+        },
+        "respond": {
+          "status": 200,
+          "body": {
+            "events": [
+              {
+                "id": 61,
+                "kind": "message",
+                "event_type": "message.created",
+                "action": "created",
+                "created_at": "2026-08-01T12:00:00Z",
+                "bucket_id": 2,
+                "creator_id": 3,
+                "recording_id": 900
+              }
+            ],
+            "position": "{{POS:1}}",
+            "next": "{{NEXT:1}}"
+          }
+        }
+      }
+    },
+    {
+      "expectDelivered": {
+        "exact": [61]
+      }
+    },
+    {
+      "expectCheckpoint": {
+        "position": "{{POS:1}}"
+      }
+    },
+    {
+      "expectPoll": {
+        "url": "{{NEXT:1}}",
+        "respond": {
+          "status": 302,
+          "headers": {
+            "Location": "https://attacker.example.com/events.json"
+          }
+        }
+      }
+    },
+    {
+      "expectClientClose": {}
+    },
+    {
+      "expectError": {
+        "reason": "invalid_continuation"
+      }
+    }
+  ],
+  "finally": {
+    "state": "terminal",
+    "mintCount": 1,
+    "connectCount": 1,
+    "delivered": {
+      "exact": [61]
+    },
+    "checkpoints": {
+      "exact": ["{{POS:1}}"]
+    },
+    "timers": {
+      "exact": {}
+    },
+    "socket": "closed",
+    "error": {
+      "reason": "invalid_continuation"
+    }
+  }
+}

--- a/conformance/event-feed/schema.json
+++ b/conformance/event-feed/schema.json
@@ -1,0 +1,1530 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://basecamp.com/schemas/event-feed-scenario.json",
+  "title": "Event Feed Connector Tier-2 Scenario",
+  "description": "One strictly-ordered interleaved script driving the SPEC §23 connector over its five seams: HTTP exchanges (mint/poll), cable frames, time directives, and observations, in one `steps` array. Strict-matched actions (mint, connect, poll, outbound frame, client close, checkpoint save) must each match their expect step under the per-action-class rules in this family's README ('Strictness semantics, per action class': saves and outbound frames are arrival-strict; mint/poll seam calls are parked and matched in order); observation directives (delivered, buffered, timers, state, signals, handler invocations) are rendezvous assertions evaluated cumulatively under a small wall-clock watchdog while virtual time is frozen. All counts (mintCount, connectCount) count SEAM CALLS — one fully-governed generated call each, with SPEC §7 retries inside — never wire attempts. Time flows only through the injected Clock seam; the virtual-advance algorithm and the ownership-cut/dequeued-frames semantics are normative prose in this family's README and SPEC §23. Validated by `make event-feed-fixtures-check`.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "name",
+    "description",
+    "steps",
+    "finally"
+  ],
+  "properties": {
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+      "description": "Kebab-case fixture identifier, matching the file's NN-kebab.json basename."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "description": "What the scenario proves. Load-bearing where a contract boundary is documented in prose (e.g. fixture 20's crash-window boundary)."
+    },
+    "config": {
+      "$ref": "#/$defs/config"
+    },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/step"
+      }
+    },
+    "finally": {
+      "$ref": "#/$defs/finally"
+    }
+  },
+  "allOf": [
+    {
+      "description": "A configured signal disposition installs a recording handler, so the fixture MUST pin the exact invocation record — handler-Terminate is otherwise indistinguishable from no-handler-terminal.",
+      "if": {
+        "required": [
+          "config"
+        ],
+        "properties": {
+          "config": {
+            "required": [
+              "signalDisposition"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "finally": {
+            "required": [
+              "handlerInvocations"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "description": "A default-terminal semantic-signal fixture (terminal reason buffer_overflow or feed_gap with NO signalDisposition configured) MUST assert ZERO handler invocations — the exact-empty record is what proves the default path was taken rather than a skipped handler.",
+      "if": {
+        "required": [
+          "finally"
+        ],
+        "properties": {
+          "config": {
+            "not": {
+              "required": [
+                "signalDisposition"
+              ]
+            }
+          },
+          "finally": {
+            "required": [
+              "error"
+            ],
+            "properties": {
+              "error": {
+                "required": [
+                  "reason"
+                ],
+                "properties": {
+                  "reason": {
+                    "enum": [
+                      "buffer_overflow",
+                      "feed_gap"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "finally": {
+            "required": [
+              "handlerInvocations"
+            ],
+            "properties": {
+              "handlerInvocations": {
+                "properties": {
+                  "exact": {
+                    "const": []
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Forbidden-side pin: with NO signalDisposition configured no handler exists, so a finally.handlerInvocations record, when present, must be exactly empty — a non-empty record without a handler is unsatisfiable at runtime and invalid at load.",
+      "if": {
+        "properties": {
+          "config": {
+            "not": {
+              "required": [
+                "signalDisposition"
+              ]
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "finally": {
+            "properties": {
+              "handlerInvocations": {
+                "properties": {
+                  "exact": {
+                    "const": []
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "config": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "not": {
+        "description": "position and checkpointStore are mutually exclusive — an explicit start position and a stored-cursor load cannot both claim the entry.",
+        "required": [
+          "position",
+          "checkpointStore"
+        ]
+      },
+      "description": "Connector construction options for this scenario, mapped per-SDK to the §23 options table. Interval overrides exist so unrelated timers stay out of a script's advance window; the defaults are themselves pinned by dedicated fixtures (13/14, PR 4), so overrides cannot mask them. All values must pass §23 construction validation — tier-2 scenarios never exercise construction errors (those are language-native, zero-iteration, tier 3). position and checkpointStore are mutually exclusive (the `not` guard).",
+      "properties": {
+        "types": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^[^,\\s\"']+$"
+          },
+          "description": "Filter: event type strings (no commas, whitespace, or quotes — pattern-enforced, protecting the comma-joined subscribe identifier)."
+        },
+        "buckets": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 100,
+          "items": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "description": "Filter: bucket ids, ≤ 100, positive."
+        },
+        "creators": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 100,
+          "items": {
+            "type": "integer",
+            "minimum": 1
+          },
+          "description": "Filter: creator ids, ≤ 100, positive."
+        },
+        "position": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Start at-position entry (position-resume class: unamended per-page saves). Absent, with no checkpointStore load, the entry is the bare present (the zero Cursor — present-class, held entry save)."
+        },
+        "confirmationDeadlineMs": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Default 10000."
+        },
+        "repairPollBaseMs": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Repair interval base. Default 60000, ±20% jitter per cycle. Override large to keep repair-poll out of an advance window."
+        },
+        "backoffBaseMs": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Reconnect/poll-retry full-jitter base. Default 1000."
+        },
+        "backoffCapMs": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Local jitter-draw cap. Default 60000. Server-directed Retry-After is exempt per §7."
+        },
+        "stalenessMs": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Default 7500. Override large when a scenario advances virtual time without scripting frames."
+        },
+        "liveBufferCapacity": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Default 10000 events. Overflow fixtures set a small value so overflow is reachable in a handful of frames."
+        },
+        "dedupeCapacity": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Default 10000 delivered ids. Deliberately decoupled from liveBufferCapacity."
+        },
+        "signalDisposition": {
+          "type": "object",
+          "additionalProperties": false,
+          "minProperties": 1,
+          "description": "Per-signal recording handler the driver installs, returning the named disposition. An ABSENT key means NO handler is installed for that signal (the default-terminal path) — absence is load-bearing, never a default.",
+          "properties": {
+            "bufferOverflow": {
+              "enum": [
+                "accept",
+                "terminate"
+              ]
+            },
+            "feedGap": {
+              "enum": [
+                "accept",
+                "terminate"
+              ]
+            }
+          }
+        },
+        "checkpointStore": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "load"
+          ],
+          "description": "Scripted CheckpointStore the driver configures (with a fixed consumer namespace). Store calls are strict-matched: a save with no matching expectCheckpoint step, or scripted save outcomes left unconsumed at `finally`, fail the scenario.",
+          "properties": {
+            "load": {
+              "type": "string",
+              "pattern": "^(loaded:.+|missing|failed)$",
+              "description": "Outcome of the single load call (before the first mint): `loaded:<position>` resumes there; `missing` proceeds to a present entry; `failed` is Terminal(checkpoint_load) with ZERO wire attempts. The tri-state is the point — collapsing failed into missing is a named mutant."
+            },
+            "save": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "enum": [
+                  "saved",
+                  "failed"
+                ]
+              },
+              "description": "Per-call outcomes for save, in order. Absent: every save succeeds. Present: a save beyond the script, or an unconsumed scripted outcome at `finally`, fails the scenario — the exact store-call script is what proves a subsequent save is attempted after a failure (no save circuit breaker)."
+            }
+          }
+        }
+      }
+    },
+    "step": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "maxProperties": 1,
+      "description": "Exactly one directive per step.",
+      "properties": {
+        "expectMint": {
+          "$ref": "#/$defs/expectMint"
+        },
+        "expectConnect": {
+          "$ref": "#/$defs/expectConnect"
+        },
+        "serve": {
+          "$ref": "#/$defs/serveFrame"
+        },
+        "serverClose": {
+          "$ref": "#/$defs/serverClose"
+        },
+        "sever": {
+          "const": true,
+          "description": "Abrupt TCP drop of the cable connection — no close frame, no disconnect frame. Only `true` is valid; a falsy value would assert nothing."
+        },
+        "expectSubscribe": {
+          "$ref": "#/$defs/expectSubscribe"
+        },
+        "expectPoll": {
+          "$ref": "#/$defs/expectPoll"
+        },
+        "expectClientClose": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The connector must close the cable socket (client-initiated close observed at the loopback server). The directive key itself is the assertion; it takes no parameters."
+        },
+        "advance": {
+          "$ref": "#/$defs/advance"
+        },
+        "fireTimer": {
+          "$ref": "#/$defs/fireTimer"
+        },
+        "expectDelivered": {
+          "$ref": "#/$defs/exactIds"
+        },
+        "expectCheckpoint": {
+          "$ref": "#/$defs/expectCheckpoint"
+        },
+        "expectTimers": {
+          "$ref": "#/$defs/timerSet"
+        },
+        "expectState": {
+          "$ref": "#/$defs/expectState"
+        },
+        "expectError": {
+          "$ref": "#/$defs/errorExpect"
+        },
+        "expectGap": {
+          "$ref": "#/$defs/expectGap"
+        },
+        "expectBuffered": {
+          "$ref": "#/$defs/expectBuffered"
+        },
+        "expectSignal": {
+          "$ref": "#/$defs/expectSignal"
+        },
+        "expectHandlerInvocations": {
+          "$ref": "#/$defs/exactInvocations"
+        },
+        "expectSaveFailed": {
+          "const": true,
+          "description": "Rendezvous: Observer.checkpoint_save_failed has fired (the observer notification of a scripted `failed` save outcome). Only `true` is valid — a falsy value would assert nothing."
+        },
+        "expectPositionRejected": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind"
+          ],
+          "description": "Rendezvous: Observer.position_rejected fired with exactly this kind (the 400-position / 409 re-entry observability of state-table rows 18/19).",
+          "properties": {
+            "kind": {
+              "enum": [
+                "position_invalid",
+                "filter_changed"
+              ]
+            }
+          }
+        },
+        "expectDisconnectedInvalidFrame": {
+          "const": true,
+          "description": "Rendezvous: Observer.disconnected fired carrying the invalid-frame indication. Only `true` is valid — a falsy value would assert nothing."
+        }
+      }
+    },
+    "expectMint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "respond"
+      ],
+      "description": "The connector must make its next mint seam call (one governed CreateStreamTicket); the harness responds as scripted. A fresh ticket is minted on every reconnect pass — a reused mint URL fails the later expectConnect identity check.",
+      "properties": {
+        "respond": {
+          "$ref": "#/$defs/mintRespond"
+        }
+      }
+    },
+    "mintRespond": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "body"
+          ],
+          "description": "Successful mint. The three-key body is a class-1 wire literal (README dependency table).",
+          "properties": {
+            "status": {
+              "const": 200
+            },
+            "body": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "ticket",
+                "expires_in",
+                "url"
+              ],
+              "properties": {
+                "ticket": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Opaque; use {{TICKET:n}}."
+                },
+                "expires_in": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "description": "Server-owned (~120); NEVER used for client scheduling."
+                },
+                "url": {
+                  "type": "string",
+                  "minLength": 1,
+                  "description": "Use {{CABLE_URL:n}}; the connector dials it verbatim."
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status"
+          ],
+          "description": "Mint error. 401/403 increment the shared authorization counter; 429/5xx are transient/throttled (Retry-After floors the next backoff delay); 404/422 are unrecoverable → Terminal(mint_failed).",
+          "properties": {
+            "status": {
+              "enum": [
+                401,
+                403,
+                404,
+                422,
+                429,
+                500,
+                502,
+                503,
+                504
+              ]
+            },
+            "headers": {
+              "$ref": "#/$defs/retryAfterHeaders"
+            },
+            "body": {
+              "type": "object"
+            }
+          }
+        }
+      ]
+    },
+    "expectConnect": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "url"
+      ],
+      "description": "The connector must dial exactly this URL (the mint's url, verbatim — query string included). Harnesses guarantee {{CABLE_URL:n}} distinctness across indices, which is what gives fresh-ticket assertions teeth. `outcome` scripts how the dial is answered; absent means accept.",
+      "properties": {
+        "url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "outcome": {
+          "description": "How the loopback answers the dial. Absent means accept (the upgrade succeeds and the cable session opens).",
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "accept"
+              ],
+              "description": "Explicit accept — identical to omitting `outcome`.",
+              "properties": {
+                "accept": {
+                  "const": true
+                }
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "refuse"
+              ],
+              "description": "The HTTP upgrade is refused / the dial fails — a dial transient → state-table transition 7, Backoff.",
+              "properties": {
+                "refuse": {
+                  "const": "upgrade-failure"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "redirectTo"
+              ],
+              "description": "The dial answers a redirect to this URL — the transport-detected cable-URL policy violation → Terminal(invalid_cable_url); the redirect target is never dialed.",
+              "properties": {
+                "redirectTo": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "serveFrame": {
+      "description": "The loopback cable server sends one frame. Pings are always scripted, never automatic — staleness scenarios depend on ping timing, and auto-pinging under virtual time is circular. confirm/reject/message auto-echo the captured subscribe identifier unless `identifier` overrides it (mismatch cases).",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "frame"
+          ],
+          "properties": {
+            "frame": {
+              "const": "welcome"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "frame"
+          ],
+          "properties": {
+            "frame": {
+              "const": "ping"
+            },
+            "message": {
+              "type": "integer",
+              "description": "Optional epoch payload — both wire ping forms are legal."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "frame"
+          ],
+          "properties": {
+            "frame": {
+              "const": "confirm"
+            },
+            "identifier": {
+              "type": "string",
+              "description": "Override the auto-echoed identifier (uncorrelated-frame cases)."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "frame"
+          ],
+          "properties": {
+            "frame": {
+              "const": "reject"
+            },
+            "identifier": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "frame",
+            "reason",
+            "reconnect"
+          ],
+          "description": "Action Cable disconnect TEXT frame (not a WebSocket close). Reason strings are class-1 wire literals: unauthorized, remote, invalid_event_stream_command; other strings exercise the unknown-reason socket-drop rule.",
+          "properties": {
+            "frame": {
+              "const": "disconnect"
+            },
+            "reason": {
+              "type": "string",
+              "minLength": 1
+            },
+            "reconnect": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "frame",
+            "event"
+          ],
+          "description": "Correlated broadcast carrying one push-payload event. All 9 payload keys required — push rows carry visible_to_clients; strict decoders must never trip on fixture data.",
+          "properties": {
+            "frame": {
+              "const": "message"
+            },
+            "event": {
+              "$ref": "#/$defs/pushEvent"
+            },
+            "identifier": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "frame",
+            "text"
+          ],
+          "description": "Escape hatch: raw text sent verbatim (malformed-frame and unknown-type cases).",
+          "properties": {
+            "frame": {
+              "const": "raw"
+            },
+            "text": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "serverClose": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "code"
+      ],
+      "description": "Server-initiated WebSocket close (with a close frame; contrast `sever`).",
+      "properties": {
+        "code": {
+          "type": "integer"
+        },
+        "reason": {
+          "type": "string"
+        }
+      }
+    },
+    "expectSubscribe": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "channel"
+      ],
+      "description": "The connector's subscribe command, compared STRUCTURALLY (parsed identifier JSON) — key order may differ per language. `params` is the exact expected filter param set; absent params means the identifier carries only the channel key.",
+      "properties": {
+        "channel": {
+          "const": "EventsChannel"
+        },
+        "params": {
+          "type": "object",
+          "additionalProperties": false,
+          "minProperties": 1,
+          "description": "Comma-joined filter values as identifier params (class-1 spellings: types/buckets/creators).",
+          "properties": {
+            "types": {
+              "type": "string",
+              "minLength": 1
+            },
+            "buckets": {
+              "type": "string",
+              "minLength": 1
+            },
+            "creators": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "identicalToPrevious": {
+          "const": true,
+          "description": "Additionally requires BYTE-identity with the previous subscribe on this connection (the retransmit-absorption case). Only `true` is valid — a false would assert nothing."
+        }
+      }
+    },
+    "expectPoll": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "respond"
+      ],
+      "anyOf": [
+        {
+          "required": [
+            "url"
+          ]
+        },
+        {
+          "required": [
+            "query"
+          ]
+        }
+      ],
+      "description": "The connector must make its next poll seam call (one governed PollEvents); the harness responds as scripted. At least one of url/query must pin the request — a poll expectation that pins nothing is invalid.",
+      "properties": {
+        "url": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The poll must target exactly this absolute URL — a followed {{NEXT:n}} continuation or a 410 resume URL, verbatim."
+        },
+        "query": {
+          "$ref": "#/$defs/pollQuery"
+        },
+        "respond": {
+          "$ref": "#/$defs/pollRespond"
+        }
+      }
+    },
+    "pollQuery": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "minProperties": 1,
+          "description": "Subset pin: each named param must appear with exactly this value; unnamed params are unconstrained.",
+          "properties": {
+            "position": {
+              "type": "string",
+              "minLength": 1
+            },
+            "since": {
+              "type": "string",
+              "minLength": 1
+            },
+            "types": {
+              "type": "string",
+              "minLength": 1
+            },
+            "buckets": {
+              "type": "string",
+              "minLength": 1
+            },
+            "creators": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "exact"
+          ],
+          "description": "Exact pin: the request's full query must equal this param set. {\"exact\": {}} pins the bare-entry no-params form non-vacuously.",
+          "properties": {
+            "exact": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "position": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "since": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "types": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "buckets": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "creators": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "pollRespond": {
+      "description": "The BODY ENVELOPE {events, position, next} is the contract — never response headers; `headers` exists only for Retry-After (throttle/transient forms) and Location (the 302 redirect form).",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "body"
+          ],
+          "description": "Successful page. Absent `next` means the walk reached its frozen head.",
+          "properties": {
+            "status": {
+              "const": 200
+            },
+            "body": {
+              "$ref": "#/$defs/pollEnvelope"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "headers"
+          ],
+          "description": "Redirect on a continuation (fixture 30): the seam suppresses automatic following; a cross-origin/downgraded Location is Terminal(invalid_continuation) with zero egress. Harness obligation: the fixture's foreign origin is bound to a sentinel listener — any request reaching it fails the scenario.",
+          "properties": {
+            "status": {
+              "const": 302
+            },
+            "headers": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "Location"
+              ],
+              "properties": {
+                "Location": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "body"
+          ],
+          "description": "400: the body must mirror bc3's transcript-captured position-vs-filter discriminating shapes VERBATIM (class-1; README dependency table, PROVISIONAL). Position-400 re-enters since=; filter-400 is Terminal(filter_invalid).",
+          "properties": {
+            "status": {
+              "const": 400
+            },
+            "body": {
+              "type": "object",
+              "minProperties": 1
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "body"
+          ],
+          "description": "409 filter conflict. All three body keys are required on the wire (C-R4; events_controller renders error alongside both digests). Digests are bare 16-hex srv1 (the server never emits the srv1- prefix); only the digest VALUES are class-1-pinned — error content is unconstrained prose.",
+          "properties": {
+            "status": {
+              "const": 409
+            },
+            "body": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "error",
+                "position_digest",
+                "filters_digest"
+              ],
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "position_digest": {
+                  "type": "string",
+                  "pattern": "^[0-9a-f]{16}$"
+                },
+                "filters_digest": {
+                  "type": "string",
+                  "pattern": "^[0-9a-f]{16}$"
+                }
+              },
+              "description": "BC3's enriched 409: all three keys are required on the wire (events_controller renders error alongside both digests — C-R4). Only the digest VALUES are class-1-pinned (bare 16-hex srv1); error content is unconstrained prose."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "body"
+          ],
+          "description": "410 epoch gap. `resume` re-enters at since=now with the canonical filter set preserved (class-2 semantics).",
+          "properties": {
+            "status": {
+              "const": 410
+            },
+            "body": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "epoch_after_id",
+                "resume"
+              ],
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "epoch_after_id": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "resume": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status"
+          ],
+          "description": "Transient/throttled poll outcome: retried inside CatchingUp on the poll-retry timer; Retry-After is waited exactly, cap-exempt per §7.",
+          "properties": {
+            "status": {
+              "enum": [
+                429,
+                500,
+                502,
+                503,
+                504
+              ]
+            },
+            "headers": {
+              "$ref": "#/$defs/retryAfterHeaders"
+            },
+            "body": {
+              "type": "object"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status"
+          ],
+          "description": "Unauthorized poll — rides the reconnect cycle, increments the shared authorization counter (SPEC §23); counter-behavior fixtures live in the PR-4 authorization block.",
+          "properties": {
+            "status": {
+              "enum": [
+                401,
+                403
+              ]
+            },
+            "body": {
+              "type": "object",
+              "minProperties": 1
+            }
+          }
+        }
+      ]
+    },
+    "pollEnvelope": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "events",
+        "position"
+      ],
+      "properties": {
+        "events": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/pollEvent"
+          }
+        },
+        "position": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The only thing that ever advances the checkpoint. Use {{POS:n}}."
+        },
+        "next": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Continuation URL, bound to this walk, never persisted. Use {{NEXT:n}} for same-origin; hostile fixtures use literal foreign origins."
+        }
+      }
+    },
+    "pollEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "event_type",
+        "action",
+        "created_at",
+        "bucket_id",
+        "creator_id",
+        "recording_id"
+      ],
+      "description": "Poll-lane event row: 8 keys, and visible_to_clients MUST be absent — additionalProperties:false enforces the push/poll presence asymmetry (class-2).",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "event_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action": {
+          "type": "string",
+          "minLength": 1
+        },
+        "created_at": {
+          "type": "string",
+          "minLength": 1
+        },
+        "bucket_id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "creator_id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "recording_id": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "pushEvent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind",
+        "event_type",
+        "action",
+        "created_at",
+        "bucket_id",
+        "creator_id",
+        "recording_id",
+        "visible_to_clients"
+      ],
+      "description": "Push-payload event: all 9 keys required, including visible_to_clients (presence-bearing; absent ≠ false).",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "kind": {
+          "type": "string",
+          "minLength": 1
+        },
+        "event_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "action": {
+          "type": "string",
+          "minLength": 1
+        },
+        "created_at": {
+          "type": "string",
+          "minLength": 1
+        },
+        "bucket_id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "creator_id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "recording_id": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "visible_to_clients": {
+          "type": "boolean"
+        }
+      }
+    },
+    "retryAfterHeaders": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "Retry-After": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "advance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "ms"
+      ],
+      "description": "Advance virtual now by ms, firing due timers in deadline order per the normative virtual-advance algorithm (README): re-evaluate after each fire; timers scheduled during the advance whose deadlines land inside the window also fire; ties break by creation order.",
+      "properties": {
+        "ms": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "fireTimer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind"
+      ],
+      "description": "Fire the earliest outstanding timer of this kind WITHOUT advancing the clock; fails hard if no such timer exists (never vacuous). assertDelayMs pins the fired timer's scheduled delay against a {min,max} envelope — how jitter is asserted without a cross-language RNG seam.",
+      "properties": {
+        "kind": {
+          "$ref": "#/$defs/timerKind"
+        },
+        "assertDelayMs": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "min",
+            "max"
+          ],
+          "description": "Inclusive envelope for the fired timer's scheduled delay. min ≤ max is a harness-load invariant (the schema cannot express it; drivers fail the fixture at load).",
+          "properties": {
+            "min": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "max": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        }
+      }
+    },
+    "timerKind": {
+      "enum": [
+        "handshake-deadline",
+        "confirmation-deadline",
+        "backoff",
+        "staleness",
+        "repair-poll",
+        "poll-retry"
+      ],
+      "description": "The six kebab-case timer kinds of SPEC §23 — a closed set."
+    },
+    "timerSet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "exact"
+      ],
+      "description": "EXACT-set comparison of outstanding (unfired, unstopped) timers by kind, via the Clock seam's enumerable registry. {\"exact\": {}} asserts none — a leaked deadline timer, ghost watchdog, or duplicated backoff each break exactness.",
+      "properties": {
+        "exact": {
+          "type": "object",
+          "propertyNames": {
+            "$ref": "#/$defs/timerKind"
+          },
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      }
+    },
+    "expectCheckpoint": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "position"
+      ],
+      "description": "The next observed CheckpointStore save call must carry exactly this position. Saves are STRICT-matched: a save observed while the current step is anything else fails the scenario — that ordering is the teeth of checkpoint-after-delivery and of the conjunctive save-ordering invariant. The step matches the CALL; a scripted `failed` outcome still matches (Observer.checkpoint_save_failed fires; the feed continues).",
+      "properties": {
+        "position": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "expectState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "is"
+      ],
+      "properties": {
+        "is": {
+          "$ref": "#/$defs/stateName"
+        }
+      }
+    },
+    "stateName": {
+      "enum": [
+        "idle",
+        "backoff",
+        "minting",
+        "connecting",
+        "awaiting_welcome",
+        "awaiting_confirmation",
+        "catching_up",
+        "draining",
+        "streaming",
+        "terminal",
+        "closed"
+      ],
+      "description": "SPEC §23's 11-state inventory, snake_case."
+    },
+    "errorExpect": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "reason"
+      ],
+      "description": "The typed terminal error element ending iteration (exactly one). `category` is optional and asserted only where the §6 mapping is unambiguous cross-SDK.",
+      "properties": {
+        "reason": {
+          "$ref": "#/$defs/terminalReason"
+        },
+        "category": {
+          "enum": [
+            "usage",
+            "validation",
+            "auth_required",
+            "api_error",
+            "network"
+          ]
+        }
+      }
+    },
+    "terminalReason": {
+      "enum": [
+        "subscription_rejected",
+        "protocol_fatal",
+        "filter_invalid",
+        "authorization_failed",
+        "checkpoint_load",
+        "usage",
+        "buffer_overflow",
+        "feed_gap",
+        "invalid_continuation",
+        "poll_failed",
+        "mint_failed",
+        "invalid_cable_url"
+      ],
+      "description": "SPEC §23's terminal taxonomy — a closed set. auth_revoked is deliberately reserved, not used."
+    },
+    "expectGap": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "epochAfterId"
+      ],
+      "description": "Observer.gap observability notification (fires on every 410, whatever the disposition). Distinct from expectSignal, which asserts the semantic signal record.",
+      "properties": {
+        "epochAfterId": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "expectBuffered": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "count"
+      ],
+      "description": "Rendezvous: waits under the wall-clock watchdog until the state-machine-owned live buffer's CURRENT OCCUPANCY — events admitted minus events dropped — equals exactly `count`, then proceeds. Admission is the ownership-cut's 'observed' definition. Never vacuous — fails if the count is not reached. This is how a fixture proves an event entered the buffer BEFORE a later step serves its poll response.",
+      "properties": {
+        "count": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "expectSignal": {
+      "description": "The semantic-signal record, distinct from the epoch-shaped expectGap: dropped is unambiguous (exact ids + count).",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "droppedIds",
+            "droppedCount"
+          ],
+          "properties": {
+            "kind": {
+              "const": "bufferOverflow"
+            },
+            "droppedIds": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "integer",
+                "minimum": 1
+              }
+            },
+            "droppedCount": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "The harness asserts droppedCount == droppedIds.length at load — a disagreement fails the fixture, never passes silently."
+            }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "epochAfterId"
+          ],
+          "properties": {
+            "kind": {
+              "const": "feedGap"
+            },
+            "epochAfterId": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        }
+      ]
+    },
+    "exactIds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "exact"
+      ],
+      "description": "Cumulative, exact, ordered delivered-id assertion. The driver waits until the delivered sequence equals `exact`; a sequence that can no longer equal it (overshoot, wrong order, a duplicate delivery) fails. {\"exact\": []} is the non-vacuous nothing-delivered-yet assertion.",
+      "properties": {
+        "exact": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      }
+    },
+    "exactPositions": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "exact"
+      ],
+      "description": "The exact ordered sequence of positions passed to CheckpointStore.save (calls, regardless of scripted outcome).",
+      "properties": {
+        "exact": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "exactInvocations": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "exact"
+      ],
+      "description": "The exact ordered record of semantic-handler invocations {kind, disposition} — a registered handler is invoked exactly once per signal, synchronously, before its disposition takes effect. {\"exact\": []} asserts zero invocations (the default-terminal proof).",
+      "properties": {
+        "exact": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "kind",
+              "disposition"
+            ],
+            "properties": {
+              "kind": {
+                "enum": [
+                  "bufferOverflow",
+                  "feedGap"
+                ]
+              },
+              "disposition": {
+                "enum": [
+                  "accept",
+                  "terminate"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "finally": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state"
+      ],
+      "description": "End-of-scenario assertions, evaluated after the last step under the wall-clock watchdog. mintCount/connectCount count SEAM CALLS, never wire attempts.",
+      "properties": {
+        "state": {
+          "$ref": "#/$defs/stateName"
+        },
+        "mintCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "connectCount": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "pollCount": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Poll SEAM calls — one fully-governed generated PollEvents call each, with SPEC §7 retries inside — never wire attempts."
+        },
+        "timers": {
+          "$ref": "#/$defs/timerSet"
+        },
+        "socket": {
+          "enum": [
+            "none",
+            "open",
+            "closed"
+          ],
+          "description": "none: no dial ever happened; closed: a socket existed and is closed."
+        },
+        "delivered": {
+          "$ref": "#/$defs/exactIds"
+        },
+        "checkpoints": {
+          "$ref": "#/$defs/exactPositions"
+        },
+        "error": {
+          "$ref": "#/$defs/errorExpect"
+        },
+        "handlerInvocations": {
+          "$ref": "#/$defs/exactInvocations"
+        }
+      },
+      "allOf": [
+        {
+          "description": "A Terminal fixture MUST state its zero-further-reconnect evidence: seam-observed connect count, exact timer set (no armed backoff that would fire later), socket disposition, and the typed reason. A terminal-failure fixture that forgot these is invalid, not silently weaker.",
+          "if": {
+            "required": [
+              "state"
+            ],
+            "properties": {
+              "state": {
+                "const": "terminal"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "connectCount",
+              "timers",
+              "socket",
+              "error"
+            ]
+          }
+        },
+        {
+          "description": "A streaming end-state must pin what was delivered.",
+          "if": {
+            "required": [
+              "state"
+            ],
+            "properties": {
+              "state": {
+                "const": "streaming"
+              }
+            }
+          },
+          "then": {
+            "required": [
+              "delivered"
+            ]
+          }
+        },
+        {
+          "description": "Only a Terminal end-state carries an error element — Closed is a clean stop by contract, and no other state has surfaced one.",
+          "if": {
+            "required": [
+              "error"
+            ]
+          },
+          "then": {
+            "properties": {
+              "state": {
+                "const": "terminal"
+              }
+            },
+            "required": [
+              "state"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
PR 2 of the Event Feed Connector program (#606 filed the registry entry; #614 merged the SPEC §23 contract). This lands the conformance surface the §23 contract is tested against — and the small SPEC §23 repair that closes the G-SD gate reopened by #614's two post-merge findings.

## The tier-2 scenario family — `conformance/event-feed/`

A 22-fixture scenario suite against its own schema (the oauth/oauth-token parallel-family precedent), covering:

- the four acceptance behaviors — fresh-ticket reconnect, confirmation gating, deadline teardown, terminal rejection (01–05)
- reason-level disconnect dispatch: protocol-fatal terminal vs `unauthorized` fresh-ticket retry vs `remote` re-mint (06, 07, 17)
- checkpoint-after-handoff and the 410-accepted/resumed path (12, 16)
- **present-class entry sequencing** against §23's bounded ownership cut: the buffered-lower-id delivery-before-save proof, the post-snapshot straggler boundary (19, 20)
- **the semantic-signal handler contract** with exact handler-invocation records: overflow and gap, each through no-handler-terminal, accepted, and Terminate dispositions — the invocation records are what make handler-Terminate distinguishable from the no-handler default (21–25)
- **continuation security**: hostile cross-origin `next`, hostile 410 `resume`, and a validated same-origin `next` answering 302 with a foreign `Location` — each `invalid_continuation` with zero requests to the foreign origin (26, 27, 30)
- **checkpoint-store failure semantics**: load-failure terminal with zero wire attempts (distinct from Missing), save-failure continuing with the observer signal and a subsequent save attempt (28, 29)

The README carries the **PROVISIONAL(`8be5c67de5`)** posture: a fixture→server-behavior dependency table (wire literals and semantic rows, each naming its pinning fixtures), the PR-T true-up checklist for BC3's merge-time gate, per-action strictness semantics, the per-SDK consumers table, and the **fifteen-mutation kill matrix** for the PR-3 reference implementation. Counts are seam calls, never wire attempts.

## The digest family — `conformance/event-feed-digest/`

BC3's published srv1 five-vector table — **every digest independently recomputed from the published canonicalization and matching byte-for-byte** — plus checkpoint flat-key cases covering origin canonicalization. The srv1 algorithm is total over client-validated inputs; catalog membership is server-owned.

## Gates

`event-feed-fixtures-check` and `event-feed-digest-fixtures-check`, each metaschema-validating its schema then validating every fixture, wired into `.PHONY` and as `conformance:` prerequisites so `make check` carries them.

**Red-first evidence** (both captured with REAL_EXIT discipline):
- A deliberately invalid fixture (`finally.state` terminal without `connectCount`) fails the gate: `RED_REAL_EXIT=2`, the fixture named in the output; removed, gate green again.
- A synthetic 409 body missing `error` is rejected by the schema (`NEG_REAL_EXIT=1`, `'error' is a required property`) — the negative proof for the enriched-409 contract below.

**Deliberately no §19/§21/Appendix-D rows** for these parallel families — they follow the oauth-family precedent (inventory in the family README + §23's Verification subsection; fixture-schema gates ride the `conformance` row). The tier-1 `event-feed-poll.json` takes its rows when it lands with the generated layer.

## The SPEC §23 repair (a stated exception to conformance-only — this is the G-SD closure)

#614's final review landed 69 seconds after its merge with two real findings, both bound to this PR (its two threads were left open deliberately and resolve here):

1. **CheckpointStore becomes tri-state**: `load(key) → Loaded(position) | Missing | Failed(error)`, `save(key, position) → Saved | Failed(error)`. The merged `(position, ok)`/void shapes could not express the failures §23 dispatches on — `checkpoint_load` (terminal, zero wire attempts; collapsing Failed to Missing would silently skip history) and `checkpoint_save_failed` (observer signal, feed continues, no save circuit-breaker).
2. **Redirect suppression on the poll seam**: prevalidating a continuation does not validate its redirects — the HTTP stacks auto-follow (Go strips `Authorization` cross-origin but still egresses), which falsified the zero-foreign-egress guarantee. The seam disables auto-follow for `PollEvents` (or per-hop validates every resolved `Location` under §8's hop-anchored rule); a failing `Location` is `invalid_continuation` with zero egress. Fixture 30 pins it; the kill basis (outcome divergence + the sentinel-listener harness obligation) is stated honestly in the README.

Plus three review-hardening pins that keep the fixtures deterministic: semantic-signal dispatch timing (first consumer-context opportunity; "before the next `save`" as the outer bound), in-memory position authority within a run (the store is write-through durability only — a failed save never regresses the live cursor; transition 24 and the Cursor comment reconciled), and the terminal table's `invalid_continuation` row covering failing redirect `Location`s.

## Verification

- Full `make check` green (`REAL_EXIT=0`) on the pre-rebase sealed head and re-run green on exactly this rebased head. The run also confirmed `check-fixture-coverage`/`validate-api-gaps` are untouched by the new directories.
- The schema went through a freeze gate before fixture authoring: metaschema validation plus a four-lens adversarial review (25 findings, all fixed — including making unauthorized-poll responses, dial outcomes, and observer assertions expressible), then a four-lens assembly review of the committed tree (8 findings, all fixed), then the 409 required-trio repair with its negative proof.
- All 22 fixtures batch-validate against the frozen schema in one run (`REAL_EXIT=0`); the committed schema is byte-identical to the frozen lineage copy.
- Spec-train census at open: no other open PR touches SPEC.md/COORDINATION.md/Makefile/openapi.json/smithy/api-gaps/conformance.

Merging this closes the reopened G-SD gate and unblocks PR 3 (the Go reference connector, which must go green on all 22 fixtures with each of the fifteen mutants shown red). Fixture freezing still waits on BC3's merge-time gate (`8be5c67de5` is a verification record, never the provenance pin); PR-4's reserved fixtures (08–11, 13–15, 18, and the authorization block) land after it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds event‑feed conformance suites and digest vectors, wires their gates into `make check`, repairs SPEC §23 around checkpoint failures and continuation safety, and runs the new gates in PR CI.

- **New Features**
  - `conformance/event-feed/`: 22 schema‑validated fixtures for acceptance flows, reason‑based disconnects, present‑class entry sequencing, semantic signal handlers, hostile `next`/`resume`/redirects, and checkpoint‑store failures.
  - `conformance/event-feed-digest/`: srv1 digest vectors (independently recomputed) plus checkpoint flat‑key cases.
  - Gates `event-feed-fixtures-check` and `event-feed-digest-fixtures-check` added and made `conformance` prerequisites so `make check` validates schemas and all fixtures.
  - PR CI now runs `event-feed-fixtures-check` and `event-feed-digest` directly so fixture validation is enforced on every PR.

- **Bug Fixes**
  - SPEC §23: CheckpointStore is tri‑state (load → Loaded|Missing|Failed; save → Saved|Failed) to support `checkpoint_load` and `checkpoint_save_failed`.
  - Poll seam suppresses automatic redirect following; cross‑origin continuations/redirects now fail with `invalid_continuation` and zero egress.
  - New poll seam kind `redirect_refused(location_origin)`: 3xx with a failing Location maps to `invalid_continuation` (never `poll_failed`), with origin redacted.
  - Added `.gitleaks.toml` to allowlist `srv1-[0-9a-f]{16}` checkpoint filter keys, avoiding false positives in gitleaks on digest fixtures.

<sup>Written for commit 2fdcc737b7250ebb1f7808e1ec6291323534b3cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

