### PR TITLE
Route-parity allowlist: verify tracking issues are still OPEN (#613)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,6 +120,11 @@ jobs:
         with:
           ruby-version: "3.3"
 
+      # Offline and first: the gate below is a no-op whenever the allowlist
+      # references no issues, so this is what proves it rejects anything.
+      - name: Self-test the known-defect gate
+        run: make test-check-known-defect-issues-open
+
       - name: Referenced tracking issues are still open
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,31 @@ jobs:
         if: always()
         working-directory: .
         run: ./scripts/assert-lockfiles-unchanged --verify-clean
+  # Its own job purely to scope the token: this is the only check that needs
+  # `issues: read`, and folding it into Spec Gates would hand that permission to
+  # every gate in it. Cannot live in `make check` either — issue state needs the
+  # network, and check-bc3-route-parity's guarantee is that it has no skip path.
+  known-defect-issues:
+    name: Known-defect tracking issues are open
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
+        with:
+          ruby-version: "3.3"
+
+      - name: Referenced tracking issues are still open
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make check-known-defect-issues-open
+
   spec-gates:
     name: Spec Gates
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ url-routes-check:
 	@rm -f go/pkg/basecamp/url-routes.json.tmp
 	@echo "url-routes.json is up to date"
 
-.PHONY: bc3-routes bc3-route-parity test-bc3-route-parity bc3-routes-check
+.PHONY: bc3-routes bc3-route-parity test-bc3-route-parity bc3-routes-check check-known-defect-issues-open
 
 # Regenerate spec/bc3-routes.json — the vendored table of routes bc3 actually
 # serves, extracted from its API docs at the pinned provenance revision.
@@ -102,6 +102,18 @@ bc3-routes:
 bc3-route-parity:
 	@echo "==> Checking bc3 route parity..."
 	@./scripts/check-bc3-route-parity
+
+# The allowlist discharges claims by pointing at an issue number, and the gate
+# above only checks that the number IS a number. #588 auto-closed while nine
+# live 404s still pointed at it and that gate stayed green throughout. This
+# verifies the referenced issues are still OPEN.
+#
+# Deliberately NOT in `check-targets` and NOT folded into the gate above: issue
+# state needs the network, and that gate's whole guarantee is that it has no
+# skip path. This one runs as its own CI job and fails closed.
+check-known-defect-issues-open:
+	@echo "==> Checking known-defect tracking issues are open..."
+	@./scripts/check-known-defect-issues-open
 
 # Drive that gate from outside with adversarial allowlists. The live run only
 # exercises the VALID file, so nothing proves `modeled_as` — the one disposition

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ url-routes-check:
 	@rm -f go/pkg/basecamp/url-routes.json.tmp
 	@echo "url-routes.json is up to date"
 
-.PHONY: bc3-routes bc3-route-parity test-bc3-route-parity bc3-routes-check check-known-defect-issues-open
+.PHONY: bc3-routes bc3-route-parity test-bc3-route-parity bc3-routes-check check-known-defect-issues-open test-check-known-defect-issues-open
 
 # Regenerate spec/bc3-routes.json — the vendored table of routes bc3 actually
 # serves, extracted from its API docs at the pinned provenance revision.
@@ -114,6 +114,17 @@ bc3-route-parity:
 check-known-defect-issues-open:
 	@echo "==> Checking known-defect tracking issues are open..."
 	@./scripts/check-known-defect-issues-open
+
+# Drive that gate from outside. Its live run is a no-op today — the allowlist
+# references no issues — so without this NOTHING exercises the closed-issue
+# rejection, the fail-closed path, or the second reference shape. Offline: PATH
+# is stripped to a stub `gh` answering from a canned table, because a self-test
+# that asked GitHub would assert against whatever is true this morning.
+#
+# Offline, but deliberately NOT in `check-targets` either: it belongs with the
+# gate it tests, and that gate is a CI job of its own.
+test-check-known-defect-issues-open:
+	@ruby ./scripts/test-check-known-defect-issues-open
 
 # Drive that gate from outside with adversarial allowlists. The live run only
 # exercises the VALID file, so nothing proves `modeled_as` — the one disposition

--- a/scripts/check-bc3-route-parity
+++ b/scripts/check-bc3-route-parity
@@ -124,6 +124,12 @@ scope_aliases = allow['scope_aliases'] || []
 
 # Known defects must stay attributable. An unattributed "we know" is just a
 # waiver with better manners.
+#
+# This can only check the number is a number — issue STATE needs the network,
+# and this gate is offline by construction (see header). scripts/check-known-
+# defect-issues-open verifies the referenced issues are still open, as its own
+# CI job; #588 auto-closed with nine live 404s pointing at it and this loop
+# stayed green throughout, because "is an Integer" was the entire test.
 known_bad.each do |e|
   next if e['issue'].is_a?(Integer)
   failures << "sdk_routes_known_defective entry #{e['method']} #{e['path']} has no numeric `issue:` — " \

--- a/scripts/check-known-defect-issues-open
+++ b/scripts/check-known-defect-issues-open
@@ -1,0 +1,103 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Verify that every issue the bc3 route allowlist leans on is still OPEN.
+#
+# The allowlist discharges two claims by pointing at an issue number:
+#
+#   sdk_routes_known_defective[].issue   "we know this route 404s, #N owns it"
+#   bc3_routes_not_modeled[].tracking_issue
+#                                        "an OPEN issue owns absorbing it"
+#
+# check-bc3-route-parity already requires those to be numeric. A number is not a
+# tracker: #588 auto-closed while nine live 404s still pointed at it, and that
+# gate stayed green the whole time because "is an Integer" was the entire test.
+# The allowlist's own comment says "an OPEN issue owns absorbing it" — this is
+# what makes that word load-bearing instead of decorative.
+#
+# WHY THIS IS NOT IN check-bc3-route-parity, AND NOT IN `make check`
+#
+# That gate is offline by construction and says so in its header: it needs no
+# bc3 checkout and no secret, "so it cannot skip. A gate that skips when its
+# input is absent is how two 404ing routes shipped." Issue state is only
+# knowable over the network, so folding this in would hand that gate a skip path
+# — reintroducing the exact failure mode it was built to prevent. It lives here
+# instead, as its own CI job, and it FAILS CLOSED: if it cannot reach the API it
+# fails rather than passing quietly, because an unverifiable "we know" claim is
+# indistinguishable from an untracked defect.
+#
+# No-op when the allowlist references no issues at all, which is today's state.
+#
+# Usage: ./check-known-defect-issues-open
+#        BC3_ROUTE_ALLOWLIST=... ./check-known-defect-issues-open   (self-test)
+
+require 'json'
+require 'yaml'
+
+ROOT = File.expand_path('..', __dir__)
+REPO = ENV['GITHUB_REPOSITORY'] || 'basecamp/basecamp-sdk'
+
+allow_path = ENV['BC3_ROUTE_ALLOWLIST'] || File.join(ROOT, 'spec', 'bc3-route-allowlist.yml')
+unless File.exist?(allow_path)
+  warn "ERROR: allowlist not found at #{allow_path}"
+  exit 1
+end
+allow = YAML.safe_load(File.read(allow_path)) || {}
+
+# (issue number, human-readable site) pairs, so a failure names the entry that
+# has to change rather than just the number.
+refs = []
+(allow['sdk_routes_known_defective'] || []).each do |e|
+  next unless e['issue'].is_a?(Integer)
+  refs << [e['issue'], "sdk_routes_known_defective #{e['method']} #{e['path']}"]
+end
+(allow['bc3_routes_not_modeled'] || []).each do |e|
+  next unless e['tracking_issue'].is_a?(Integer)
+  refs << [e['tracking_issue'], "bc3_routes_not_modeled #{e['method']} #{e['path']}"]
+end
+
+if refs.empty?
+  puts '  ✓ bc3 route allowlist references no tracking issues — nothing to verify'
+  exit 0
+end
+
+# Fail closed: no gh, no verification, no pass.
+unless system('command -v gh > /dev/null 2>&1')
+  warn 'ERROR: gh CLI not found, so issue state cannot be verified.'
+  warn '  This check fails closed by design — an unverifiable "a known issue owns'
+  warn '  this" claim is exactly the untracked defect it exists to catch.'
+  exit 1
+end
+
+failures = []
+states = {}
+
+refs.map(&:first).uniq.sort.each do |number|
+  out = `gh api repos/#{REPO}/issues/#{number} --jq .state 2>&1`
+  unless $?.success?
+    failures << "could not read ##{number} from #{REPO}: #{out.strip.lines.first}"
+    next
+  end
+  states[number] = out.strip
+end
+
+refs.each do |number, site|
+  state = states[number]
+  next if state.nil? || state == 'open'
+  failures << "#{site} points at ##{number}, which is #{state.upcase}. " \
+              'A closed issue tracks nothing: reopen it, repoint the entry at the ' \
+              'issue that now owns the defect, or remove the entry because the ' \
+              'route is fixed.'
+end
+
+unless failures.empty?
+  warn "\nKnown-defect tracking issues are not all open:\n\n"
+  failures.each { |f| warn "  ✗ #{f}" }
+  warn ''
+  exit 1
+end
+
+refs.each do |number, site|
+  puts "  ✓ ##{number} open — #{site}"
+end
+puts "  ✓ all #{refs.map(&:first).uniq.length} referenced tracking issue(s) open"

--- a/scripts/check-known-defect-issues-open
+++ b/scripts/check-known-defect-issues-open
@@ -29,13 +29,25 @@
 # No-op when the allowlist references no issues at all, which is today's state.
 #
 # Usage: ./check-known-defect-issues-open
-#        BC3_ROUTE_ALLOWLIST=... ./check-known-defect-issues-open   (self-test)
+#        BC3_ROUTE_ALLOWLIST=... KNOWN_DEFECT_ISSUE_REPO=... \
+#          ./check-known-defect-issues-open                        (self-test)
+#
+# Exercised offline by scripts/test-check-known-defect-issues-open.
 
 require 'json'
 require 'yaml'
 
 ROOT = File.expand_path('..', __dir__)
-REPO = ENV['GITHUB_REPOSITORY'] || 'basecamp/basecamp-sdk'
+
+# The repository is a constant, NOT derived from the workflow environment. The
+# issue numbers are properties of the committed allowlist — they are this
+# repository's numbering — while GITHUB_REPOSITORY names whoever is running CI.
+# On a fork those differ, and reading the fork would look up its own unrelated
+# issue #N, or none at all: fork CI would fail (or worse, pass) on a fact about
+# the fork rather than about the allowlist under test. KNOWN_DEFECT_ISSUE_REPO
+# is the one override, and it exists so the self-test can point the lookup at a
+# stub rather than the network.
+REPO = ENV['KNOWN_DEFECT_ISSUE_REPO'] || 'basecamp/basecamp-sdk'
 
 allow_path = ENV['BC3_ROUTE_ALLOWLIST'] || File.join(ROOT, 'spec', 'bc3-route-allowlist.yml')
 unless File.exist?(allow_path)

--- a/scripts/test-check-known-defect-issues-open
+++ b/scripts/test-check-known-defect-issues-open
@@ -1,0 +1,291 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Self-test for scripts/check-known-defect-issues-open.
+#
+# The gate is deliberately ONLINE — issue state is only knowable over the
+# network, and it fails closed when it cannot ask. Its self-test must be the
+# opposite: offline and deterministic, or CI would be asserting the gate's logic
+# against whatever GitHub happens to say today. So every case here runs the real
+# checker with PATH pointing at a stub `gh` that answers from a canned table,
+# driven through the checker's two env overrides:
+#
+#   BC3_ROUTE_ALLOWLIST      the allowlist to read (tmp files; the tracked file
+#                            is never written to)
+#   KNOWN_DEFECT_ISSUE_REPO  the repo to look issues up in
+#
+# The allowlists below are synthetic. This gate reads only `issue`,
+# `tracking_issue`, `method` and `path`, so a fabricated entry exercises exactly
+# what it inspects — unlike test-check-bc3-route-parity, which must use real
+# operationIds because it is asserting facts about routes this SDK ships.
+#
+# The stub also LOGS the API path it was asked for, which is what pins the
+# repository to a constant: case 7 sets GITHUB_REPOSITORY to a fork, the way a
+# fork's CI does, and asserts the lookup still went to basecamp/basecamp-sdk.
+# The issue numbers are properties of the committed allowlist, not of whoever
+# runs CI, so a fork must not resolve them against its own numbering.
+#
+# KNOWN_DEFECT_CHECKER names the checker under test (default
+# scripts/check-known-defect-issues-open), so a deliberately-mutated copy can be
+# driven through the same suite to prove the suite is not vacuous:
+#
+#   cp scripts/check-known-defect-issues-open /tmp/m   # mutate the COPY
+#   KNOWN_DEFECT_CHECKER=/tmp/m ruby scripts/test-check-known-defect-issues-open
+#
+# Never mutate the tracked file. Removing a guard from the copy must turn exactly
+# these red, and nothing else:
+#
+#   guard removed in the copy                      cases that must go red
+#   -------------------------------------------    ----------------------
+#   REPO back to ENV['GITHUB_REPOSITORY']          7a, 8a
+#   closed state no longer fails                   4, 5
+#   bc3_routes_not_modeled refs not collected      2, 2a, 5
+#   fail-closed when gh is absent                  9
+#
+# Run directly (`ruby scripts/test-check-known-defect-issues-open`) or via
+# `make test-check-known-defect-issues-open`.
+
+require "yaml"
+require "tmpdir"
+require "open3"
+require "rbconfig"
+
+# Per-case lines go to stdout and the failure report to stderr. Unsynced, stdout
+# block-buffers when redirected to a file and the report lands ahead of the cases
+# it summarizes — which is exactly when someone is reading the log.
+$stdout.sync = true
+
+ROOT = File.expand_path("..", __dir__)
+CHECKER = File.expand_path(ENV.fetch("KNOWN_DEFECT_CHECKER", "scripts/check-known-defect-issues-open"), ROOT)
+RUBY = RbConfig.ruby
+
+# The stub `gh`. Answers `gh api repos/<owner>/<name>/issues/<n> --jq .state`
+# from GH_STUB_STATES ("101=open,202=closed"), records the path it was asked for
+# in GH_STUB_LOG, and fails outright when GH_STUB_FAIL is set. /bin/sh is an
+# absolute path, so this still runs when PATH holds nothing but the stub dir —
+# which is also why it uses only shell builtins: no basename, no tr, nothing
+# that would have to be found on the PATH the suite deliberately emptied.
+GH_STUB = <<~'SH'
+  #!/bin/sh
+  if [ -n "$GH_STUB_LOG" ]; then echo "$2" >> "$GH_STUB_LOG"; fi
+  if [ -n "$GH_STUB_FAIL" ]; then
+    echo "gh: HTTP 404: Not Found (https://api.github.com/$2)" >&2
+    exit 1
+  fi
+  number=${2##*/}
+  IFS=,
+  for pair in $GH_STUB_STATES; do
+    case "$pair" in
+      "$number="*) echo "${pair#*=}"; exit 0 ;;
+    esac
+  done
+  echo "gh: no stub state for issue $number" >&2
+  exit 1
+SH
+
+failures = []
+
+# Run the checker with a PATH that contains ONLY the stub dir (or nothing at
+# all, when gh is meant to be absent), so the real gh can never answer. The
+# interpreter is invoked by absolute path for the same reason. Returns
+# [combined_output, status, gh_log_lines].
+def run_checker(allowlist:, states: nil, gh_fail: false, repo: nil, github_repository: nil)
+  Dir.mktmpdir("known-defect-selftest") do |dir|
+    path_dir = File.join(dir, "bin")
+    Dir.mkdir(path_dir)
+    gh_log = File.join(dir, "gh-calls.log")
+
+    unless states.nil? && !gh_fail
+      gh = File.join(path_dir, "gh")
+      File.write(gh, GH_STUB)
+      File.chmod(0o755, gh)
+    end
+
+    allow_path = File.join(dir, "bc3-route-allowlist.yml")
+    File.write(allow_path, YAML.dump(allowlist))
+
+    env = {
+      "PATH" => path_dir,
+      "BC3_ROUTE_ALLOWLIST" => allow_path,
+      "GH_STUB_LOG" => gh_log,
+      "GH_STUB_STATES" => states,
+      "GH_STUB_FAIL" => (gh_fail ? "1" : nil),
+      "KNOWN_DEFECT_ISSUE_REPO" => repo,
+      "GITHUB_REPOSITORY" => github_repository
+    }
+
+    out, status = Open3.capture2e(env, RUBY, CHECKER)
+    calls = File.exist?(gh_log) ? File.read(gh_log).split("\n") : []
+    [ out, status, calls ]
+  end
+end
+
+def expect_pass(failures, label, out, status, fragment = nil)
+  if !status.success?
+    puts "  FAIL  #{label}"
+    failures << "#{label}: expected PASS but checker exited #{status.exitstatus}:\n#{out}"
+  elsif fragment && !out.include?(fragment)
+    puts "  FAIL  #{label}"
+    failures << "#{label}: passed but message missing #{fragment.inspect}:\n#{out}"
+  else
+    puts "  PASS  #{label}"
+  end
+end
+
+def expect_fail(failures, label, out, status, fragment)
+  if status.success?
+    puts "  FAIL  #{label}"
+    failures << "#{label}: expected FAILURE but checker passed:\n#{out}"
+  elsif !out.include?(fragment)
+    puts "  FAIL  #{label}"
+    failures << "#{label}: failed as expected but message missing #{fragment.inspect}:\n#{out}"
+  else
+    puts "  PASS  #{label}"
+  end
+end
+
+def defective(issue)
+  { "method" => "GET", "path" => "/buckets/:id/widgets/:id", "issue" => issue }
+end
+
+def not_modeled(issue)
+  { "method" => "POST", "path" => "/projects/:id/widgets", "tracking_issue" => issue }
+end
+
+puts "==> known-defect tracking-issue self-test (checker: #{CHECKER.sub("#{ROOT}/", '')})"
+
+# --- 1. Empty allowlist: no refs, no network, no-op -----------------------------
+#
+# Today's state. The gate must not invent work — or a failure — out of an
+# allowlist that discharges nothing by issue number.
+
+out, status, calls = run_checker(allowlist: { "sdk_routes_known_defective" => [], "bc3_routes_not_modeled" => [] })
+expect_pass(failures, "1. empty allowlist is a no-op", out, status,
+            "references no tracking issues")
+unless calls.empty?
+  puts "  FAIL  1a. empty allowlist makes no API calls"
+  failures << "1a: expected no gh calls, got #{calls.inspect}"
+end
+
+# --- 2. Both list shapes are collected ------------------------------------------
+#
+# The two dispositions spell their reference differently — `issue:` on a known
+# defect, `tracking_issue:` on an unmodeled route. Reading only one shape would
+# leave the other silently unverified, which is the failure this gate exists to
+# end. Both numbers must be looked up and both reported.
+
+out, status, calls = run_checker(
+  allowlist: { "sdk_routes_known_defective" => [ defective(101) ],
+               "bc3_routes_not_modeled" => [ not_modeled(202) ] },
+  states: "101=open,202=open"
+)
+expect_pass(failures, "2. both list shapes collected: issue and tracking_issue", out, status,
+            "all 2 referenced tracking issue(s) open")
+[ 101, 202 ].each do |n|
+  next if calls.any? { |c| c.end_with?("/issues/#{n}") }
+  puts "  FAIL  2a. ##{n} looked up"
+  failures << "2a: expected a lookup of ##{n}, gh saw #{calls.inspect}"
+end
+
+# --- 3. Open issue passes --------------------------------------------------------
+
+out, status, = run_checker(
+  allowlist: { "sdk_routes_known_defective" => [ defective(101) ] },
+  states: "101=open"
+)
+expect_pass(failures, "3. an OPEN issue passes", out, status, "✓ #101 open")
+
+# --- 4. Closed issue fails, and the message names the entry ----------------------
+#
+# THE ONE THAT MATTERS. #588 auto-closed while nine live 404s still pointed at
+# it. A number is not a tracker; this is the case that makes "open" load-bearing.
+# The fragment pins the SITE, not just the number, because a failure that names
+# only "#101" leaves the reader to grep the allowlist for which entry rotted.
+
+out, status, = run_checker(
+  allowlist: { "sdk_routes_known_defective" => [ defective(101) ] },
+  states: "101=closed"
+)
+expect_fail(failures, "4. a CLOSED issue fails and names the entry", out, status,
+            "sdk_routes_known_defective GET /buckets/:id/widgets/:id points at #101, which is CLOSED")
+
+# --- 5. Closed on the other shape too --------------------------------------------
+#
+# Collecting a reference and ENFORCING it are separate steps; case 2 proves the
+# first for both shapes, this proves the second.
+
+out, status, = run_checker(
+  allowlist: { "sdk_routes_known_defective" => [ defective(101) ],
+               "bc3_routes_not_modeled" => [ not_modeled(202) ] },
+  states: "101=open,202=closed"
+)
+expect_fail(failures, "5. a CLOSED tracking_issue fails and names the entry", out, status,
+            "bc3_routes_not_modeled POST /projects/:id/widgets points at #202, which is CLOSED")
+
+# --- 6. Unreadable issue fails closed --------------------------------------------
+#
+# gh is present but the API says no. An unverifiable "a known issue owns this"
+# claim is indistinguishable from an untracked defect, so it is not a pass.
+
+out, status, = run_checker(
+  allowlist: { "sdk_routes_known_defective" => [ defective(101) ] },
+  gh_fail: true
+)
+expect_fail(failures, "6. an unreadable issue fails closed", out, status,
+            "could not read #101 from basecamp/basecamp-sdk")
+
+# --- 7. The repository is a constant, not the workflow's ---------------------------
+#
+# A fork's CI sets GITHUB_REPOSITORY to the fork. The issue numbers come from the
+# committed allowlist and mean nothing in the fork's numbering, so the lookup has
+# to ignore it. Deriving the repo from the environment made fork CI fail on an
+# upstream issue that was open the whole time.
+
+out, status, calls = run_checker(
+  allowlist: { "sdk_routes_known_defective" => [ defective(101) ] },
+  states: "101=open",
+  github_repository: "someone-else/basecamp-sdk-fork"
+)
+expect_pass(failures, "7. GITHUB_REPOSITORY does not redirect the lookup", out, status)
+if calls.any? { |c| c.include?("someone-else") } || !calls.any? { |c| c.include?("repos/basecamp/basecamp-sdk/") }
+  puts "  FAIL  7a. lookup went to the canonical repo"
+  failures << "7a: expected a basecamp/basecamp-sdk lookup and no fork lookup, gh saw #{calls.inspect}"
+end
+
+# --- 8. The one sanctioned override still works -----------------------------------
+#
+# Without it this suite could not exist: case 6's message and every stub lookup
+# above depend on the repo being steerable by something OTHER than the ambient
+# workflow variable.
+
+out, status, calls = run_checker(
+  allowlist: { "sdk_routes_known_defective" => [ defective(101) ] },
+  states: "101=open",
+  repo: "example/override"
+)
+expect_pass(failures, "8. KNOWN_DEFECT_ISSUE_REPO redirects the lookup", out, status)
+unless calls.any? { |c| c.include?("repos/example/override/") }
+  puts "  FAIL  8a. lookup honored KNOWN_DEFECT_ISSUE_REPO"
+  failures << "8a: expected an example/override lookup, gh saw #{calls.inspect}"
+end
+
+# --- 9. No gh at all fails closed --------------------------------------------------
+#
+# PATH holds nothing, so `command -v gh` finds nothing. The gate must not treat
+# "I could not ask" as "nothing is wrong" — that skip path is precisely why this
+# check is not folded into the offline route-parity gate.
+
+out, status, = run_checker(allowlist: { "sdk_routes_known_defective" => [ defective(101) ] })
+expect_fail(failures, "9. missing gh fails closed", out, status,
+            "gh CLI not found")
+
+# --- Report ------------------------------------------------------------------------
+
+if failures.empty?
+  puts "==> known-defect tracking-issue self-test passed — 9 cases"
+  exit 0
+else
+  warn "known-defect tracking-issue self-test FAILED:"
+  failures.each { |f| warn "  - #{f}" }
+  exit 1
+end


### PR DESCRIPTION
Closes #613.

## The gap

`spec/bc3-route-allowlist.yml` discharges two claims by pointing at an issue number:

| Key | The claim it makes |
|---|---|
| `sdk_routes_known_defective[].issue` | "we know this route 404s, #N owns it" |
| `bc3_routes_not_modeled[].tracking_issue` | the file's own words: "an **open** issue owns absorbing it" |

`check-bc3-route-parity` validated only `e['issue'].is_a?(Integer)`. **#588 auto-closed while nine live 404s still pointed at it, and the gate was green the whole time.** Its own failure text says *"a known defect without a tracking issue is an untracked defect"* — but a number is not a tracker, and nothing made the word "open" load-bearing.

## Why this is a new check and not a new line in that gate

`check-bc3-route-parity`'s header is explicit, and it is the reason this could not go inside it:

> Runs fully **OFFLINE** against the vendored `spec/bc3-routes.json`, so it is in `make check` and in CI with no bc3 checkout and no secret. That is deliberate: **a gate that skips when its input is missing cannot prevent anything, and skipping is exactly how this class of defect survived.**

Issue state is only knowable over the network. Folding it in would have given that gate a secret dependency and a skip path — reintroducing the precise failure mode it exists to refuse. So:

- **Its own CI job**, scoped to `issues: read`. Spec Gates keeps `contents: read`; the new permission does not leak to the ~20 gates in it.
- **Not in `check-targets`.** That set stays offline and stays **41**.
- **Fails closed.** No `gh`, no verification, no pass — an unverifiable "a known issue owns this" is indistinguishable from an untracked defect.

## Scope

Covers **both** key shapes, not just the one #613 names. `tracking_issue` has an identical failure mode and the allowlist comment already asserts openness for it.

Both lists reference **zero** issues today, so this is a no-op until someone adds an entry — which is exactly the moment it starts mattering.

## Proof

Against the real historical case, an entry pointing at the closed **#588**:

```
  ✗ sdk_routes_known_defective GET /buckets/:id/chats/:id/lines.json points at #588,
    which is CLOSED. A closed issue tracks nothing: reopen it, repoint the entry at
    the issue that now owns the defect, or remove the entry because the route is fixed.
REAL_EXIT=1
```

Positive control — open issues in both key shapes:

```
  ✓ #613 open — sdk_routes_known_defective GET /example.json
  ✓ #531 open — bc3_routes_not_modeled GET /other.json
REAL_EXIT=0
```

Empty allowlist (today's real state): `✓ ... references no tracking issues — nothing to verify`, exit 0.

## Verification

`make lint-actions bc3-route-parity test-bc3-route-parity check-known-defect-issues-open`, real exit code written to a marker and grepped back:

```
zizmor: No findings to report. Good job! (15 ignored, 34 suppressed)
==> bc3 route parity OK: 247 SDK routes vs 369 bc3 routes at bc3 4e34dc83eb.
==> bc3 route-parity self-test passed — 1 positive + 9 negative cases
MARKER_613_REAL_EXIT=0
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CI check to ensure issues referenced in `spec/bc3-route-allowlist.yml` are OPEN, preventing stale “known defect” entries from masking real 404s. Pins lookups to `basecamp/basecamp-sdk` and adds an offline self-test; the offline `check-bc3-route-parity` gate stays unchanged.

- **New Features**
  - Added `scripts/check-known-defect-issues-open` to validate `sdk_routes_known_defective[].issue` and `bc3_routes_not_modeled[].tracking_issue`; fails closed if `gh` or the API is unavailable.
  - Introduced a dedicated `known-defect-issues` workflow job with `issues: read`; runs a deterministic self-test before the live check and is not part of `check-targets`.
  - Added `scripts/test-check-known-defect-issues-open` and `make test-check-known-defect-issues-open` to stub `gh` and cover open/closed, unreadable issues, both key shapes, repo pin, and missing `gh`.
  - Pinned issue lookups to `basecamp/basecamp-sdk`; overridable via `KNOWN_DEFECT_ISSUE_REPO` for tests, not derived from `GITHUB_REPOSITORY` to avoid fork CI misreads.

<sup>Written for commit 1a2dfe5d1fe14fb8e079501c7abff79d8c1cd434. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

