### PR TITLE
Kotlin: stop coercing a wrong-typed scalar into a String (#598)

### DIFF
--- a/conformance/tests/todos_write.json
+++ b/conformance/tests/todos_write.json
@@ -550,7 +550,7 @@
   },
   {
     "name": "update-kill: an array description is refused before the full-replace PUT",
-    "description": "The merge-safe update GETs the todo, reads every writable field, and PUTs the FULL representation back — so a value read is a value written, on a call that only set the content. A malformed one must be refused BEFORE the PUT, which is exactly what requestCount: 1 pins: the moment a second request appears, the malformed value has already landed on a full-replace endpoint.\n\nThis is the CORRUPTION half of #576. Neither `or \"\"` (Python) nor `|| \"\"` (Ruby) nor `?? \"\"` (TypeScript) coalesces a non-empty array, so on main all three PUT `\"description\": [\"x\"]` to the todo — an array where the rich-text body belongs.\n\nThe kill case for #576, and the reason it lives here rather than in six per-language test files: the defect survived five consecutive review passes because each pass fixed one instance. A shared fixture catches every instance at once, in every runner, permanently — and it did: writing it surfaced the Kotlin scalar-coercion hole above, which five language-specific passes had missed.\n\nAll six SDKs must refuse it, by two different mechanisms, which is why the value under test is a JSON array/object rather than a scalar. Go, Kotlin and Swift decode into a typed model: json.Unmarshal, kotlinx.serialization and Codable all reject a structural mismatch. TypeScript, Python and Ruby have no decoder at all — schema.d.ts is erased at build time, and the generated Python and Ruby services return an untyped dict/Hash — so they carry an explicit guard. A scalar (42, false) would NOT discriminate in Kotlin: its client-wide Json { isLenient = true } coerces one into a String field, so the composite decodes \"42\" and writes it back. That is the same defect one layer down and is tracked separately; it cannot be fixed by a per-composite guard, because by the time the composite runs the coercion has already happened.\n\nerrorRaised rather than errorType: a hand-written guard raises api_error while a decoder raises its own language's decode failure, so no single canonical code is assertable. What all six agree on is that the call fails at all — which, paired with requestCount: 1, is the whole contract.",
+    "description": "The merge-safe update GETs the todo, reads every writable field, and PUTs the FULL representation back — so a value read is a value written, on a call that only set the content. A malformed one must be refused BEFORE the PUT, which is exactly what requestCount: 1 pins: the moment a second request appears, the malformed value has already landed on a full-replace endpoint.\n\nThis is the CORRUPTION half of #576. Neither `or \"\"` (Python) nor `|| \"\"` (Ruby) nor `?? \"\"` (TypeScript) coalesces a non-empty array, so on main all three PUT `\"description\": [\"x\"]` to the todo — an array where the rich-text body belongs.\n\nThe kill case for #576, and the reason it lives here rather than in six per-language test files: the defect survived five consecutive review passes because each pass fixed one instance. A shared fixture catches every instance at once, in every runner, permanently — and it did: writing it surfaced the Kotlin scalar-coercion hole above, which five language-specific passes had missed.\n\nAll six SDKs must refuse it, by two different mechanisms. Go, Kotlin and Swift decode into a typed model: json.Unmarshal, kotlinx.serialization and Codable all reject a structural mismatch. TypeScript, Python and Ruby have no decoder at all — schema.d.ts is erased at build time, and the generated Python and Ruby services return an untyped dict/Hash — so they carry an explicit guard. The value under test is an array/object rather than a scalar for a reason that has since been removed: a scalar (42, false) did NOT discriminate in Kotlin, whose client-wide Json { isLenient = true } coerced one into a String field, so the composite decoded \"42\" and wrote it back. That was the same defect one layer down, and no per-composite guard could close it — by the time the composite ran, the coercion had already happened. #598 dropped isLenient, and the bare-scalar sibling below now pins the scalar half in all six runners.\n\nerrorRaised rather than errorType: a hand-written guard raises api_error while a decoder raises its own language's decode failure, so no single canonical code is assertable. What all six agree on is that the call fails at all — which, paired with requestCount: 1, is the whole contract.",
     "operation": "UpdateTodo",
     "method": "PUT",
     "path": "/todos/{todoId}",
@@ -714,7 +714,7 @@
   },
   {
     "name": "update-kill: an empty-object description is refused, not coalesced to empty",
-    "description": "The ERASURE half of #576, and the half whose absence produced this issue's original wrong verdict. Python's `or \"\"` turns every falsey non-string — {} included — into \"\", and on a full-replace endpoint that empty value is written back over the real description: the field the composite exists to preserve, wiped by a call that only set the content. Ruby and TypeScript reach the same endpoint by the other road and forward `{}` verbatim. Testing for corruption alone would miss the erasure; testing for erasure alone is what let TypeScript be called structurally safe.\n\nThe kill case for #576, and the reason it lives here rather than in six per-language test files: the defect survived five consecutive review passes because each pass fixed one instance. A shared fixture catches every instance at once, in every runner, permanently — and it did: writing it surfaced the Kotlin scalar-coercion hole above, which five language-specific passes had missed.\n\nAll six SDKs must refuse it, by two different mechanisms, which is why the value under test is a JSON array/object rather than a scalar. Go, Kotlin and Swift decode into a typed model: json.Unmarshal, kotlinx.serialization and Codable all reject a structural mismatch. TypeScript, Python and Ruby have no decoder at all — schema.d.ts is erased at build time, and the generated Python and Ruby services return an untyped dict/Hash — so they carry an explicit guard. A scalar (42, false) would NOT discriminate in Kotlin: its client-wide Json { isLenient = true } coerces one into a String field, so the composite decodes \"42\" and writes it back. That is the same defect one layer down and is tracked separately; it cannot be fixed by a per-composite guard, because by the time the composite runs the coercion has already happened.\n\nerrorRaised rather than errorType: a hand-written guard raises api_error while a decoder raises its own language's decode failure, so no single canonical code is assertable. What all six agree on is that the call fails at all — which, paired with requestCount: 1, is the whole contract.",
+    "description": "The ERASURE half of #576, and the half whose absence produced this issue's original wrong verdict. Python's `or \"\"` turns every falsey non-string — {} included — into \"\", and on a full-replace endpoint that empty value is written back over the real description: the field the composite exists to preserve, wiped by a call that only set the content. Ruby and TypeScript reach the same endpoint by the other road and forward `{}` verbatim. Testing for corruption alone would miss the erasure; testing for erasure alone is what let TypeScript be called structurally safe.\n\nThe kill case for #576, and the reason it lives here rather than in six per-language test files: the defect survived five consecutive review passes because each pass fixed one instance. A shared fixture catches every instance at once, in every runner, permanently — and it did: writing it surfaced the Kotlin scalar-coercion hole above, which five language-specific passes had missed.\n\nAll six SDKs must refuse it, by two different mechanisms. Go, Kotlin and Swift decode into a typed model: json.Unmarshal, kotlinx.serialization and Codable all reject a structural mismatch. TypeScript, Python and Ruby have no decoder at all — schema.d.ts is erased at build time, and the generated Python and Ruby services return an untyped dict/Hash — so they carry an explicit guard. The value under test is an array/object rather than a scalar for a reason that has since been removed: a scalar (42, false) did NOT discriminate in Kotlin, whose client-wide Json { isLenient = true } coerced one into a String field, so the composite decoded \"42\" and wrote it back. That was the same defect one layer down, and no per-composite guard could close it — by the time the composite ran, the coercion had already happened. #598 dropped isLenient, and the bare-scalar sibling below now pins the scalar half in all six runners.\n\nerrorRaised rather than errorType: a hand-written guard raises api_error while a decoder raises its own language's decode failure, so no single canonical code is assertable. What all six agree on is that the call fails at all — which, paired with requestCount: 1, is the whole contract.",
     "operation": "UpdateTodo",
     "method": "PUT",
     "path": "/todos/{todoId}",
@@ -744,6 +744,168 @@
           "bookmark_url": "https://3.basecampapi.com/999/my/bookmarks/abc123.json",
           "content": "Buy milk",
           "description": {},
+          "due_on": "2024-03-01",
+          "starts_on": "2024-02-01",
+          "completed": false,
+          "comments_count": 0,
+          "position": 1,
+          "parent": {
+            "id": 2,
+            "title": "Todolist",
+            "type": "Todolist",
+            "url": "https://3.basecampapi.com/999/buckets/1/todolists/2.json",
+            "app_url": "https://3.basecamp.com/999/buckets/1/todolists/2"
+          },
+          "bucket": {
+            "id": 1,
+            "name": "Project",
+            "type": "Project"
+          },
+          "creator": {
+            "id": 1,
+            "name": "Test User",
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z"
+          },
+          "assignees": [
+            {
+              "id": 100,
+              "name": "Jane Doe",
+              "created_at": "2024-01-01T00:00:00Z",
+              "updated_at": "2024-01-01T00:00:00Z"
+            }
+          ],
+          "completion_subscribers": [
+            {
+              "id": 555,
+              "name": "Sub Scriber",
+              "created_at": "2024-01-01T00:00:00Z",
+              "updated_at": "2024-01-01T00:00:00Z"
+            }
+          ],
+          "description_attachments": []
+        }
+      },
+      {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "id": 456,
+          "status": "active",
+          "visible_to_clients": false,
+          "created_at": "2024-01-15T10:00:00Z",
+          "updated_at": "2024-01-15T10:00:00Z",
+          "title": "Buy milk",
+          "inherits_status": true,
+          "type": "Todo",
+          "url": "https://3.basecampapi.com/999/buckets/1/todos/456.json",
+          "app_url": "https://3.basecamp.com/999/buckets/1/todos/456",
+          "bookmark_url": "https://3.basecampapi.com/999/my/bookmarks/abc123.json",
+          "content": "Buy milk",
+          "description": "<p>From the store</p>",
+          "due_on": "2024-03-01",
+          "starts_on": "2024-02-01",
+          "completed": false,
+          "comments_count": 0,
+          "position": 1,
+          "parent": {
+            "id": 2,
+            "title": "Todolist",
+            "type": "Todolist",
+            "url": "https://3.basecampapi.com/999/buckets/1/todolists/2.json",
+            "app_url": "https://3.basecamp.com/999/buckets/1/todolists/2"
+          },
+          "bucket": {
+            "id": 1,
+            "name": "Project",
+            "type": "Project"
+          },
+          "creator": {
+            "id": 1,
+            "name": "Test User",
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:00Z"
+          },
+          "assignees": [
+            {
+              "id": 100,
+              "name": "Jane Doe",
+              "created_at": "2024-01-01T00:00:00Z",
+              "updated_at": "2024-01-01T00:00:00Z"
+            }
+          ],
+          "completion_subscribers": [
+            {
+              "id": 555,
+              "name": "Sub Scriber",
+              "created_at": "2024-01-01T00:00:00Z",
+              "updated_at": "2024-01-01T00:00:00Z"
+            }
+          ],
+          "description_attachments": []
+        }
+      }
+    ],
+    "assertions": [
+      {
+        "type": "errorRaised"
+      },
+      {
+        "type": "requestCount",
+        "expected": 1
+      },
+      {
+        "type": "requestMethod",
+        "expected": "GET",
+        "index": 0
+      },
+      {
+        "type": "requestPath",
+        "expected": "/999/todos/456",
+        "index": 0
+      }
+    ],
+    "tags": [
+      "todos",
+      "write",
+      "merge",
+      "malformed"
+    ]
+  },
+  {
+    "name": "update-kill: a bare-scalar description is refused before the full-replace PUT",
+    "description": "The bare-scalar half of the two kill cases above, and the case that could not exist until #598.\n\nSame contract, same shape: the merge-safe update GETs the todo, reads every writable field, and PUTs the FULL representation back, so a malformed value must be refused BEFORE the PUT — which is what requestCount: 1 pins.\n\nWhat changed is that a bare JSON scalar now discriminates in all six runners. It used to discriminate in only five: Kotlin's client-wide Json carried isLenient = true, which relaxes RFC-4627 far enough to read a JSON number or boolean into a declared String, so `\"description\": 42` decoded to \"42\" and the composite PUT that fabricated value back on a call that only set the content. No per-composite guard could see it — by the time the composite ran, the value was an ordinary String — which is why the sibling cases above use an array and an object instead, and why this one had no home. #598 removed isLenient (keeping coerceInputValues, which never had anything to say about a scalar type; kotlin/.../DecoderStrictnessTest.kt pins which flag does what), so kotlinx.serialization now rejects the number exactly as json.Unmarshal and Codable already did, and as the hand-written writableString/write_string guards in TypeScript, Python and Ruby already did.\n\nSo this fixture is the cross-language regression guard for the fix: re-adding isLenient turns Kotlin green-to-red here, in the shared harness, rather than only in a Kotlin unit test.\n\nerrorRaised rather than errorType, for the same reason as its siblings: a hand-written guard raises api_error while a decoder raises its own language's decode failure, so no single canonical code is assertable. What all six agree on is that the call fails at all — which, paired with requestCount: 1, is the whole contract.",
+    "operation": "UpdateTodo",
+    "method": "PUT",
+    "path": "/todos/{todoId}",
+    "pathParams": {
+      "todoId": 456
+    },
+    "requestBody": {
+      "content": "New title"
+    },
+    "mockResponses": [
+      {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "id": 456,
+          "status": "active",
+          "visible_to_clients": false,
+          "created_at": "2024-01-15T10:00:00Z",
+          "updated_at": "2024-01-15T10:00:00Z",
+          "title": "Buy milk",
+          "inherits_status": true,
+          "type": "Todo",
+          "url": "https://3.basecampapi.com/999/buckets/1/todos/456.json",
+          "app_url": "https://3.basecamp.com/999/buckets/1/todos/456",
+          "bookmark_url": "https://3.basecampapi.com/999/my/bookmarks/abc123.json",
+          "content": "Buy milk",
+          "description": 42,
           "due_on": "2024-03-01",
           "starts_on": "2024-02-01",
           "completed": false,

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampClient.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampClient.kt
@@ -164,8 +164,10 @@ class BasecampClient internal constructor(
     //
     // `coerceInputValues` stays. It is a different mechanism (an explicit null
     // becomes the declared default for a non-nullable property) and is not
-    // implicated: DecoderStrictnessTest pins both behaviours so this comment
-    // cannot drift from the semantics.
+    // implicated. DecoderStrictnessTest pins what each flag does on its own
+    // instances, and `theClientsOwnDecoderRefusesAWrongTypedScalar` decodes
+    // through THIS one, so re-adding `isLenient` here goes red rather than
+    // leaving the guarantee resting on this comment.
     internal val json: Json = Json {
         ignoreUnknownKeys = true
         coerceInputValues = true

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampClient.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampClient.kt
@@ -153,9 +153,21 @@ class BasecampClient internal constructor(
     /** Whether the SDK created (and therefore owns) the underlying HttpClient. */
     private val ownsHttpClient = externalHttpClient == null
 
+    // NO `isLenient` here, deliberately (#598). It relaxes RFC-4627 far enough
+    // that a JSON number or boolean is read into a declared String:
+    // `"description": 42` decoded to "42", and the merge-safe composites then
+    // PUT that fabricated value back to a full-replace endpoint on a call that
+    // never mentioned the field. The coercion happened inside the decoder, so a
+    // guard in TodosService/CardsService — the shape that fixed Python, Ruby and
+    // TypeScript in #597 — could not see it: by the time the composite ran, the
+    // value was an ordinary String.
+    //
+    // `coerceInputValues` stays. It is a different mechanism (an explicit null
+    // becomes the declared default for a non-nullable property) and is not
+    // implicated: DecoderStrictnessTest pins both behaviours so this comment
+    // cannot drift from the semantics.
     internal val json: Json = Json {
         ignoreUnknownKeys = true
-        isLenient = true
         coerceInputValues = true
     }
 

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/DocumentsService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/DocumentsService.kt
@@ -95,9 +95,9 @@ class DocumentsService(client: AccountClient) :
      * catching [BasecampException] would miss it entirely and it carries no
      * hint. Wrap it, so a malformed response looks the same in every SDK.
      *
-     * (The client-wide `coerceInputValues`/`isLenient` scalar hole means a bare
-     * JSON scalar is coerced rather than rejected. That is a cross-service gap
-     * tracked out of #576, not something this composite can close.)
+     * (Bare JSON scalars are refused as well as structural mismatches. They
+     * were not until #598 removed the client-wide `isLenient`, which rendered a
+     * number or boolean as a String before this composite could ever see it.)
      */
     private suspend fun fetchDocument(documentId: Long): Document =
         try {
@@ -118,11 +118,11 @@ class DocumentsService(client: AccountClient) :
      *
      * No hand-written type guard here, unlike the Todolists composite: `get`
      * returns a decoded [Document], so kotlinx.serialization has already
-     * rejected a structurally wrong-typed field before this runs. (The
-     * client-wide `coerceInputValues`/`isLenient` scalar hole is a known
-     * cross-service gap tracked out of #576, not something this composite can
-     * close.) `content` is nullable on the model — absent or JSON null is
-     * genuinely empty, and `""` is what the server already holds.
+     * rejected a wrong-typed field before this runs — a bare scalar as well as
+     * a structural mismatch, since #598 removed the client-wide `isLenient`
+     * that used to render a number or boolean as a String. `content` is
+     * nullable on the model — absent or JSON null is genuinely empty, and `""`
+     * is what the server already holds.
      *
      * `title` is the exception, and it needs a hand-written check the decoder
      * cannot supply. The field is non-nullable on the model, so an absent or

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/SchedulesService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/SchedulesService.kt
@@ -277,9 +277,9 @@ class SchedulesService(client: AccountClient) :
      * entirely and it carries no hint. Wrap it, so a malformed response looks
      * the same in every SDK.
      *
-     * (The client-wide `coerceInputValues`/`isLenient` scalar hole means a bare
-     * JSON scalar is coerced rather than rejected. That is a cross-service gap
-     * tracked out of #576, not something this composite can close.)
+     * (Bare JSON scalars are refused as well as structural mismatches. They
+     * were not until #598 removed the client-wide `isLenient`, which rendered a
+     * number or boolean as a String before this composite could ever see it.)
      */
     private suspend fun fetchEntry(entryId: Long): ScheduleEntry =
         try {

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/TodolistsService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/TodolistsService.kt
@@ -100,9 +100,9 @@ class TodolistsService(client: AccountClient) :
      * entirely and it carries no hint. Wrap it, so a malformed response looks
      * the same in every SDK.
      *
-     * (The client-wide `coerceInputValues`/`isLenient` scalar hole means a bare
-     * JSON scalar is coerced rather than rejected. That is a cross-service gap
-     * tracked out of #576, not something this composite can close.)
+     * (Bare JSON scalars are refused as well as structural mismatches. They
+     * were not until #598 removed the client-wide `isLenient`, which rendered a
+     * number or boolean as a String before this composite could ever see it.)
      */
     private suspend fun fetchTodolist(id: Long): Todolist =
         try {

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/CardsServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/CardsServiceTest.kt
@@ -6,6 +6,7 @@ import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.jsonObject
@@ -13,6 +14,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -31,7 +33,11 @@ class CardsServiceTest {
 
     private val json = Json { ignoreUnknownKeys = true }
 
-    private fun cardJson(dueOn: String? = "2024-02-01"): String = """{
+    private fun cardJson(dueOn: String? = "2024-02-01"): String =
+        cardJsonRawDueOn(dueOn?.let { "\"$it\"" } ?: "null")
+
+    /** [cardJson] with `due_on` spliced in as raw JSON, so it can be a non-string. */
+    private fun cardJsonRawDueOn(dueOn: String): String = """{
         "id": 42,
         "status": "active",
         "visible_to_clients": false,
@@ -42,7 +48,7 @@ class CardsServiceTest {
         "type": "Kanban::Card",
         "url": "https://3.basecampapi.com/12345/card_tables/cards/42",
         "app_url": "https://3.basecamp.com/12345/card_tables/cards/42",
-        "due_on": ${dueOn?.let { "\"$it\"" } ?: "null"},
+        "due_on": $dueOn,
         "description_attachments": [],
         "parent": {
             "id": 2,
@@ -181,6 +187,46 @@ class CardsServiceTest {
         assertContains(body, "\"content\":\"\"")
         assertContains(body, "\"assignee_ids\":[]")
         assertContains(body, "\"due_on\":\"\"")
+    }
+
+    /**
+     * The Cards half of #598, in the only shape it still has.
+     *
+     * The issue framed this as a read-modify-write hazard: a `due_on` read back
+     * off a preservation GET was coerced into `"42"` and PUT forward. #647
+     * deleted that GET — `update` is one PUT now, and the three Cards kill cases
+     * went with it — so what is left is the response decode. `Card.dueOn` is a
+     * `String?`, and under the client-wide `isLenient` a bare-scalar `due_on`
+     * coming back from the server decoded into `"42"`/`"false"` and reached the
+     * caller as an ordinary String, indistinguishable from a real date. The
+     * shared decoder refuses it now, which is what makes the fix reach Cards and
+     * not only the Todolists composite that still does a genuine read-back.
+     */
+    @Test
+    fun updateRefusesABareScalarDueOnFromTheWire() = runTest {
+        for (malformed in listOf("42", "false")) {
+            val methods = mutableListOf<String>()
+            val client = testBasecampClient {
+                accessToken("test-token")
+                engine = MockEngine { request ->
+                    methods.add(request.method.value)
+                    respond(
+                        content = cardJsonRawDueOn(malformed),
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+                    )
+                }
+            }
+
+            assertFailsWith<SerializationException>(
+                "a bare-scalar due_on ($malformed) must be refused, not rendered as text",
+            ) {
+                client.forAccount("12345").cards.update(42, title = "Renamed")
+            }
+
+            assertEquals(listOf("PUT"), methods, "the refusal is in the decode, so the PUT still happens once")
+            client.close()
+        }
     }
 
     @Test

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/DecoderStrictnessTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/DecoderStrictnessTest.kt
@@ -1,5 +1,8 @@
 package com.basecamp.sdk
 
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respondOk
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
@@ -48,21 +51,21 @@ class DecoderStrictnessTest {
     // culprit and dropping `isLenient` alone would not be enough.
     @Test
     fun coerceInputValuesDoesNotCoerceAScalarType() {
-        assertFailsWith<Exception> {
+        assertFailsWith<SerializationException> {
             coercing.decodeFromString<Probe>("""{"description": 42}""")
         }
     }
 
     @Test
     fun strictRejectsNumberForString() {
-        assertFailsWith<Exception> {
+        assertFailsWith<SerializationException> {
             strict.decodeFromString<Probe>("""{"description": 42}""")
         }
     }
 
     @Test
     fun strictRejectsBooleanForString() {
-        assertFailsWith<Exception> {
+        assertFailsWith<SerializationException> {
             strict.decodeFromString<Probe>("""{"description": false}""")
         }
     }
@@ -79,7 +82,7 @@ class DecoderStrictnessTest {
 
     @Test
     fun withoutCoerceInputValuesAnExplicitNullIsRejected() {
-        assertFailsWith<Exception> {
+        assertFailsWith<SerializationException> {
             strict.decodeFromString<NonNullProbe>("""{"description": null}""")
         }
     }
@@ -98,11 +101,43 @@ class DecoderStrictnessTest {
     // correctly called safe, and it must stay that way.
     @Test
     fun structuralMismatchIsRejectedEvenWhenLenient() {
-        assertFailsWith<Exception> {
+        assertFailsWith<SerializationException> {
             lenient.decodeFromString<Probe>("""{"description": []}""")
         }
-        assertFailsWith<Exception> {
+        assertFailsWith<SerializationException> {
             lenient.decodeFromString<Probe>("""{"description": {}}""")
+        }
+    }
+
+    /**
+     * Everything above decodes through a `Json` built in this file, which pins
+     * kotlinx.serialization's flag semantics but says nothing about how the SDK
+     * is configured. This one decodes through the instance `BasecampClient`
+     * actually builds and hands to every service, so re-adding `isLenient`
+     * there turns it red rather than leaving the fix pinned only by a comment.
+     */
+    @Test
+    fun theClientsOwnDecoderRefusesAWrongTypedScalar() {
+        val client = testBasecampClient {
+            accessToken("test-token")
+            engine = MockEngine { respondOk() }
+        }
+        try {
+            assertFailsWith<SerializationException> {
+                client.json.decodeFromString<Probe>("""{"description": 42}""")
+            }
+            assertFailsWith<SerializationException> {
+                client.json.decodeFromString<Probe>("""{"description": false}""")
+            }
+            // And `coerceInputValues` is still on, which is the other half of
+            // the configuration the comment claims: an explicit null becomes the
+            // declared default for a non-nullable property.
+            assertEquals(
+                "default",
+                client.json.decodeFromString<NonNullProbe>("""{"description": null}""").description,
+            )
+        } finally {
+            client.close()
         }
     }
 }

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/DecoderStrictnessTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/DecoderStrictnessTest.kt
@@ -1,0 +1,108 @@
+package com.basecamp.sdk
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+/**
+ * Which decoder flag actually coerces a wrong-typed scalar (#598)?
+ *
+ * The bug report and the release plan disagreed about the cause — one blamed
+ * `coerceInputValues`, the other `isLenient`. They are not interchangeable, and
+ * removing the wrong one ships a no-op as a fix. These tests pin the semantics
+ * so the answer is in the tree rather than in anyone's recollection:
+ *
+ *  - `isLenient` relaxes RFC-4627 and accepts unquoted/loosely-typed literals,
+ *    so a JSON number or boolean is read into a declared String.
+ *  - `coerceInputValues` coerces `null` (and unknown enum values) to the
+ *    declared default for a non-nullable property. It has nothing to say about
+ *    a number-where-a-String-belongs.
+ */
+class DecoderStrictnessTest {
+    @Serializable
+    private data class Probe(val description: String? = null)
+
+    @Serializable
+    private data class NonNullProbe(val description: String = "default")
+
+    private val lenient = Json { ignoreUnknownKeys = true; isLenient = true }
+    private val coercing = Json { ignoreUnknownKeys = true; coerceInputValues = true }
+    private val strict = Json { ignoreUnknownKeys = true }
+
+    // The defect: a number on the wire becomes a String the composite cannot
+    // tell from a real one, and then gets PUT back to a full-replace endpoint.
+    @Test
+    fun lenientCoercesNumberIntoString() {
+        assertEquals("42", lenient.decodeFromString<Probe>("""{"description": 42}""").description)
+    }
+
+    @Test
+    fun lenientCoercesBooleanIntoString() {
+        assertEquals("false", lenient.decodeFromString<Probe>("""{"description": false}""").description)
+    }
+
+    // The flag the plan blamed. If this threw, `coerceInputValues` would be the
+    // culprit and dropping `isLenient` alone would not be enough.
+    @Test
+    fun coerceInputValuesDoesNotCoerceAScalarType() {
+        assertFailsWith<Exception> {
+            coercing.decodeFromString<Probe>("""{"description": 42}""")
+        }
+    }
+
+    @Test
+    fun strictRejectsNumberForString() {
+        assertFailsWith<Exception> {
+            strict.decodeFromString<Probe>("""{"description": 42}""")
+        }
+    }
+
+    @Test
+    fun strictRejectsBooleanForString() {
+        assertFailsWith<Exception> {
+            strict.decodeFromString<Probe>("""{"description": false}""")
+        }
+    }
+
+    // What `coerceInputValues` IS for, and therefore what dropping it would
+    // change: an explicit null into a non-nullable property with a default.
+    @Test
+    fun coerceInputValuesRewritesNullToTheDeclaredDefault() {
+        assertEquals(
+            "default",
+            coercing.decodeFromString<NonNullProbe>("""{"description": null}""").description,
+        )
+    }
+
+    @Test
+    fun withoutCoerceInputValuesAnExplicitNullIsRejected() {
+        assertFailsWith<Exception> {
+            strict.decodeFromString<NonNullProbe>("""{"description": null}""")
+        }
+    }
+
+    // A nullable property takes an explicit null on every config — this is the
+    // shape the SDK's own models use, and it is why dropping coerceInputValues
+    // is survivable.
+    @Test
+    fun nullableFieldsAcceptExplicitNullEverywhere() {
+        assertNull(strict.decodeFromString<Probe>("""{"description": null}""").description)
+        assertNull(lenient.decodeFromString<Probe>("""{"description": null}""").description)
+        assertNull(coercing.decodeFromString<Probe>("""{"description": null}""").description)
+    }
+
+    // Structural mismatches were already refused — this is the half #576
+    // correctly called safe, and it must stay that way.
+    @Test
+    fun structuralMismatchIsRejectedEvenWhenLenient() {
+        assertFailsWith<Exception> {
+            lenient.decodeFromString<Probe>("""{"description": []}""")
+        }
+        assertFailsWith<Exception> {
+            lenient.decodeFromString<Probe>("""{"description": {}}""")
+        }
+    }
+}

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/DocumentsServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/DocumentsServiceTest.kt
@@ -81,9 +81,9 @@ class DocumentsServiceTest {
     // entirely. The composite normalizes it, so a malformed response looks the
     // same in every SDK.
     //
-    // An ARRAY, not a scalar: the client-wide `coerceInputValues`/`isLenient`
-    // settings coerce a bare JSON scalar into a String rather than rejecting
-    // it (a cross-service gap tracked out of #576). An array is refused.
+    // An ARRAY here, but a bare scalar would be refused too since #598 dropped
+    // the client-wide `isLenient`, which used to render a JSON number or
+    // boolean as a String instead of rejecting it. See `DecoderStrictnessTest`.
     @Test
     fun updateNormalizesADecodeFailure() = runTest {
         val capture = WriteCapture()

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/SchedulesServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/SchedulesServiceTest.kt
@@ -472,9 +472,9 @@ class SchedulesServiceTest {
         ) { account -> account.schedules.updateEntry(1069479523, description = "<div>New.</div>") }
     }
 
-    // An ARRAY, not a scalar: the client-wide `coerceInputValues`/`isLenient`
-    // settings coerce a bare JSON scalar into a String rather than rejecting it
-    // (a cross-service gap tracked out of #576). An array is refused.
+    // An ARRAY here, but a bare scalar would be refused too since #598 dropped
+    // the client-wide `isLenient`, which used to render a JSON number or
+    // boolean as a String instead of rejecting it. See `DecoderStrictnessTest`.
     @Test
     fun updateRefusesAWrongTypedSummary() = runTest {
         assertRefusesRead(

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TodolistsServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TodolistsServiceTest.kt
@@ -314,11 +314,11 @@ class TodolistsServiceTest {
      * composite still owns is the SPEC §6 shape — a raw `SerializationException`
      * is not it, and a caller catching `BasecampException` would miss it.
      *
-     * ARRAYS and OBJECTS, not bare scalars: the client-wide
-     * `coerceInputValues`/`isLenient` settings coerce a bare JSON scalar into a
-     * String rather than rejecting it (a cross-service gap tracked out of #576;
-     * see `updateCoercesABareScalarDescription`). An array or object is
-     * refused.
+     * Arrays and objects here; bare scalars in the sibling below. Both are
+     * refused now. Structural mismatches always were, but a bare JSON scalar
+     * used to be coerced into a String by the client-wide `isLenient`, which
+     * #598 removed — see `updateRefusesABareScalarDescriptionBeforeWriting` for
+     * that half and `DecoderStrictnessTest` for which flag did what.
      */
     @Test
     fun updateRefusesAMalformedDescriptionBeforeWriting() = runTest {
@@ -347,27 +347,37 @@ class TodolistsServiceTest {
     }
 
     /**
-     * The bare-scalar half of the case above, pinned rather than dropped.
+     * The bare-scalar half of the case above — now refused, not coerced (#598).
      *
-     * A JSON number or boolean where a String belongs is still malformed, but
-     * the client-wide `isLenient`/`coerceInputValues` settings render it as
-     * text instead of refusing it, so the composite resends the coerced value.
-     * That is a CROSS-SERVICE gap (#576) — the Documents composite has it too —
-     * not something a todolist-specific guard should paper over: the pre-#544
-     * hand-written `JsonElement` reader closed it here and nowhere else. This
-     * test records the exact behavior so closing #576 flips it visibly.
+     * This test used to assert the opposite, and said so: it pinned the coerced
+     * PUT "so closing #576 flips it visibly." Dropping the client-wide
+     * `isLenient` flipped it. A JSON number or boolean where a String belongs no
+     * longer renders as text; it is refused before the PUT, exactly like the
+     * array and object cases above.
+     *
+     * Booleans as well as numbers, because `isLenient` accepted both, and each
+     * produced a differently-shaped fabrication ("42" vs "false").
      */
     @Test
-    fun updateCoercesABareScalarDescription() = runTest {
-        val capture = WriteCapture()
-        val client = captureClient(capture, getBody = todolistBody(description = "42"))
+    fun updateRefusesABareScalarDescriptionBeforeWriting() = runTest {
+        for (malformed in listOf("42", "false")) {
+            val capture = WriteCapture()
+            val client = captureClient(capture, getBody = todolistBody(description = malformed))
 
-        client.forAccount("12345").todolists.update(42, UpdateTodolistBody(name = "Renamed list"))
+            val error = assertFailsWith<BasecampException.Api> {
+                client.forAccount("12345").todolists
+                    .update(42, UpdateTodolistBody(name = "Renamed list"))
+            }
 
-        assertEquals(listOf("GET", "PUT"), capture.methods)
-        assertEquals("42", capture.putBody!!["description"]?.jsonPrimitive?.content)
-
-        client.close()
+            assertEquals(null, error.httpStatus)
+            assertEquals(false, error.retryable)
+            assertTrue(error.hint != null, "expected a hint naming the escape hatch")
+            assertEquals(
+                listOf("GET"), capture.methods,
+                "the PUT must never be issued for a bare-scalar description ($malformed)",
+            )
+            client.close()
+        }
     }
 
     /** The same guard protects the edit closure, which also resends the field. */


### PR DESCRIPTION
Closes #598.

Kotlin's client-wide `Json` carried `isLenient = true`. That relaxes RFC-4627 far enough to read a JSON number or boolean into a declared `String`, so `"description": 42` decoded to `"42"` — and the merge-safe composites then PUT that fabricated value back to a full-replace endpoint on a call that never mentioned the field. The coercion happens inside the decoder, so the per-composite guard that fixed Python, Ruby and TypeScript in #597 is structurally incapable of catching it: by the time the composite runs, the value is an ordinary `String` with no way to know whether the wire carried `42` or `"42"`.

The fix is one line: drop `isLenient`, keep `coerceInputValues`.

## The flag attribution — `isLenient`, not `coerceInputValues`

The issue text and the release plan disagreed about the cause. They are not interchangeable, and removing the wrong one ships a no-op as a fix. The issue was right.

`kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/DecoderStrictnessTest.kt` is new and pins the semantics of each flag in isolation, so the answer lives in the tree rather than in anyone's recollection:

- `lenientCoercesNumberIntoString` / `lenientCoercesBooleanIntoString` — `isLenient` alone produces `"42"` and `"false"` from `42` and `false`. **This is the defect.**
- `coerceInputValuesDoesNotCoerceAScalarType` — `coerceInputValues` alone **throws** on `{"description": 42}`. It is not implicated, and dropping it would have been a no-op fix.
- `coerceInputValuesRewritesNullToTheDeclaredDefault` / `withoutCoerceInputValuesAnExplicitNullIsRejected` — what `coerceInputValues` is actually for: an explicit `null` into a non-nullable property with a default. That is why it stays.
- `nullableFieldsAcceptExplicitNullEverywhere` — the shape the SDK's own generated models use, so keeping or dropping `coerceInputValues` is invisible to them.
- `structuralMismatchIsRejectedEvenWhenLenient` — arrays and objects were always refused. That is the half #576 correctly called safe, and it stays that way.

## The tripwire flipped

`TodolistsServiceTest` carried a test that asserted the defect on purpose, and said so in its own doc comment:

> This is a CROSS-SERVICE gap (#576) — the Documents composite has it too — not something a todolist-specific guard should paper over [...] This test records the exact behavior **so closing #576 flips it visibly.**

It asserted `assertEquals(listOf("GET", "PUT"), capture.methods)` and `assertEquals("42", capture.putBody!!["description"])` — the coerced value landing on the wire.

It is now `updateRefusesABareScalarDescriptionBeforeWriting` and asserts the refusal: no PUT is issued, and the caller gets a statusless, non-retryable `BasecampException.Api` carrying a hint — for both a number (`42`) and a boolean (`false`), because `isLenient` accepted both and each produced a differently-shaped fabrication. That flip is the evidence the fix landed, on exactly the terms the original author asked for.

**Todolists is a third affected service**, beyond the Todos and Cards that #576 and #598 named. Documents and Schedules are the same composite shape and their comments are corrected here too.

## Conformance: a bare-scalar kill case, and it needs no per-language skip

#598 anticipated a Kotlin-only fixture, since "no single value discriminates for both Kotlin (which needs a structural shape) and TypeScript Cards (which needs a falsey scalar)." That was true of the code as it stood. **The decoder fix removes the asymmetry**, so the fixture is better than anticipated: with `isLenient` gone, all six SDKs refuse a non-string scalar — Go, Kotlin and Swift in their model decoders (`json.Unmarshal`, kotlinx.serialization, `Codable`), and TypeScript, Python and Ruby in the hand-written `writableString`/`write_string` guards, whose non-string branch always covered `42`. So `conformance/tests/todos_write.json` gains

> `update-kill: a bare-scalar description is refused before the full-replace PUT`

as an ordinary six-runner case with **zero entries added to any runner's skip map**. Confirmed executing, not silently skipped, in all six: Go/Kotlin/Ruby/Python/Swift each print a PASS line, and TypeScript (which is non-verbose in the suite) was checked directly with `npx vitest run -t 'bare-scalar' --reporter=verbose` → `✓ conformance/todos_write.json > update-kill: a bare-scalar description is refused before the full-replace PUT`.

`conformance/check_kill_case_controls.py` passes: the new body is the existing `update-merge` control's body with exactly one field perturbed, same as its array and object siblings.

### It is a kill case, not decoration

Restoring `isLenient = true` locally and re-running `make conformance-kotlin`:

```
  FAIL: update-kill: a bare-scalar description is refused before the full-replace PUT
        Expected the call to fail, but it succeeded
Passed: 175, Failed: 1, Skipped: 1, Total: 177
MARKER_KT598_RED_EXIT=2
```

Reverted immediately; the committed tree has no `isLenient` assignment (`git grep isLenient` under `kotlin/sdk/src/commonMain` returns comment lines only).

## Prose the fix falsified

Corrected only where the claim is now false — comments describing the scalar hole as an open cross-service gap, several of which also named the wrong flag pair:

- `TodolistsServiceTest.updateRefusesAMalformedDescriptionBeforeWriting` — said arrays/objects were used *because* bare scalars get coerced; now cross-references the sibling.
- `DocumentsServiceTest`, `SchedulesServiceTest` — same "An ARRAY, not a scalar" rationale.
- `DocumentsService.kt` (×2), `SchedulesService.kt`, `TodolistsService.kt` — "(The client-wide `coerceInputValues`/`isLenient` scalar hole means a bare JSON scalar is coerced rather than rejected [...] not something this composite can close.)"
- `conformance/tests/todos_write.json` — the two existing kill-case descriptions asserted a scalar "would NOT discriminate in Kotlin".

`SPEC.md:1091` mentions `coerceInputValues = true` in the `FlexibleIntSerializer` discussion and is still accurate — that flag is unchanged — so it is left alone. Same for `ReplayRunner.kt`, whose stricter replay `Json` is unaffected.

## Verification

Full suite run twice on the final tree, exit code captured via a marker written into the log and grepped back rather than trusted from a mid-run "BUILD SUCCESSFUL":

```
make kt-check conformance
MARKER_KT598_REAL_EXIT=0    (run 1)
MARKER_KT598_REAL_EXIT=0    (run 2)
```

Kotlin SDK checks passed and every runner was green. An earlier revision of this description claimed `Passed: 176, Failed: 0, Skipped: 1, Total: 177` "in each runner" — that is Kotlin's and Swift's tally, not a shared one. The runners do not report a common shape, and their skip counts differ. The real per-runner numbers, from a fresh `make conformance` on the final tree:

| Runner | Passed | Failed | Skipped | Total |
|---|---|---|---|---|
| Go | 175 | 0 | 2 | 177 |
| Kotlin | 176 | 0 | 1 | 177 |
| TypeScript | 219 | 0 | 2 | 221 |
| Ruby | 166 | 0 | 11 | 177 |
| Python | 177 | 0 | 0 | 177 |
| Swift | 176 | 0 | 1 | 177 |

```
MARKER_CONFORMANCE_EXIT=0
```

TypeScript counts differently — it runs two suites, so 221 is not comparable to the others' 177. No test other than the deliberate tripwire needed flipping.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Kotlin from coercing wrong-typed scalars into Strings by removing `isLenient` from the client-wide `Json`. Numbers/booleans are now rejected before any write, aligning Kotlin with the other SDKs and closing #598.

- **Bug Fixes**
  - Removed `isLenient` from the client-wide `Json`; kept `coerceInputValues` for explicit nulls.
  - Strengthened tests: `DecoderStrictnessTest` pins each flag and now decodes through `BasecampClient.json` to guard the actual config.
  - Todolists: flipped the scalar test to assert refusal before PUT; updated Documents and Schedules tests and comments.
  - Cards: added a test to refuse a bare-scalar `due_on` from the server response.
  - Conformance: added a bare-scalar kill case to `conformance/tests/todos_write.json`; passes in all six SDKs with no skips.

<sup>Written for commit 0c3b16a9f74b06ec5d7c0e51279688ebc58ea4cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

