### PR TITLE
ci: exclude java/class-name-matches-super-class from CodeQL

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -28,3 +28,11 @@ paths-ignore:
 query-filters:
   - exclude:
       kind: [diagnostic, metric]
+  # Kotlin composites deliberately share a name with the generated service they
+  # extend (SPEC.md §18 "Hand-Written Composite Methods"). This Java naming query
+  # flags the convention itself, so it fires for every current and future
+  # composite. The filter is global, but the id is Java-specific and the only
+  # .java sources here (spec/smithy-bare-arrays/) are outside `paths:` above and
+  # outside the java-kotlin build, so no other analysis loses coverage.
+  - exclude:
+      id: java/class-name-matches-super-class

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -33,6 +33,8 @@ query-filters:
   # flags the convention itself, so it fires for every current and future
   # composite. The filter is global, but the id is Java-specific and the only
   # .java sources here (spec/smithy-bare-arrays/) are outside `paths:` above and
-  # outside the java-kotlin build, so no other analysis loses coverage.
+  # outside the java-kotlin build, so no other analysis loses coverage. That
+  # holds only while those two conditions do: adding a Java tree to `paths:` or
+  # to the build would silently suppress this query there too.
   - exclude:
       id: java/class-name-matches-super-class


### PR DESCRIPTION
Post-merge residue from #391 (java-kotlin CodeQL re-enable, merged `fbfc5cdd4`). The analysis itself is healthy — `manual` build mode, CLI 2.26.2, `Build (Kotlin)` compiling `:basecamp-sdk:compileKotlinJvm`, `database finalize` succeeding, alerts landing on real `commonMain` files. What's left is a false-positive class.

## The alerts

Six Kotlin composite services trip `java/class-name-matches-super-class` (`note` severity, no security severity) for sharing a name with the generated service they wrap:

| Alert | File |
|---|---|
| 159 | `services/DocumentsService.kt` |
| 158 | `services/TodolistsService.kt` |
| 121 | `services/UploadsService.kt` |
| 120 | `services/TodosService.kt` |
| 119 | `services/CardsService.kt` |
| 162 (already dismissed) | `services/SchedulesService.kt` |

That shared name *is* the SPEC.md §18 hand-written-composite convention — the query flags the convention itself, so it recurs for every future composite. One `query-filters` exclusion retires the class.

## Scoping

`query-filters` is global, but the id is Java-specific and the repo's only `.java` sources (`spec/smithy-bare-arrays/`) sit outside the config's `paths:` allowlist *and* outside the java-kotlin build (`./gradlew :basecamp-sdk:compileKotlinJvm`), so they never enter a database. No other language's coverage changes.

Rejected alternatives: `paths-ignore` and the workflow's SARIF filter both target generated code, and these files are hand-written; narrowing `queries:` off `security-and-quality` would change coverage for all six languages.

## Deliberately not excluded

`java/local-variable-is-never-read` stays active. Its one open alert (118, `oauth/Device.kt` reported at line 1, message naming `tmp0_other_with_cast`) is a Kotlin compiler-synthesized `equals` temporary, not source code — dismissing that instance individually keeps the query catching genuine unread locals in hand-written Kotlin.

## Verification

This diff touches `.github/**`, which the `config` paths filter promotes to a full-language matrix, so this PR's own CodeQL run exercises the change:

- [ ] `Analyze (java-kotlin)` succeeds; `Filter generated-code alerts from SARIF` reports **1** finding rather than 7
- [ ] The other five `Analyze (*)` jobs report unchanged finding counts
- [ ] `GitHub Actions audit` stays green (no workflow file changed, so no actionlint delta expected)
- [ ] After merge: `gh api 'repos/basecamp/basecamp-sdk/code-scanning/alerts?state=open&per_page=100'` shows alert 118 as the only surviving `kotlin/` source alert

Note the SARIF count above is evidence about the *filter*, not about extraction — extraction health remains `database finalize` completing without exit 32.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude the CodeQL rule `java/class-name-matches-super-class` to stop false-positive notes on Kotlin composite services that intentionally share names with the generated services they wrap. The query is Java-only; our `.java` sources are outside CodeQL `paths` and the java-kotlin build so coverage is unchanged, and we noted that if either condition changes this query would be suppressed there too; other rules like `java/local-variable-is-never-read` remain active.

<sup>Written for commit 129b55decc924a8bcfca4a52398b06065dc38fbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

