### PR TITLE
Rehearse every publish path on workflow_dispatch

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -70,6 +70,47 @@ jobs:
       - name: Run tests with race detector
         run: go test -race ./...
 
+  # The dry run is a separate job from the real tag push so that the rehearsal
+  # never holds `contents: write`. Both jobs share the same tag-resolution logic;
+  # only this one is allowed to run on workflow_dispatch.
+  tag-dry-run:
+    name: Create Go module tag (dry run)
+    needs: [smithy, test]
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Report the go/ subdirectory tag that would be pushed
+        run: |
+          # On workflow_dispatch GITHUB_REF is refs/heads/<branch>, so the tag
+          # cannot be derived from it. Read the Go source of truth instead,
+          # mirroring how release-ruby reads version.rb and release-typescript
+          # reads package.json.
+          VERSION=$(sed -n 's/^const Version = "\(.*\)"$/\1/p' go/pkg/basecamp/version.go)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read Version from go/pkg/basecamp/version.go"
+            exit 1
+          fi
+          echo "Rehearsal for version: $VERSION"
+
+          GO_TAG="go/v${VERSION}"
+          REMOTE_SHA=$(git ls-remote --tags --refs origin "$GO_TAG" | awk '{print $1}')
+          if [ -z "$REMOTE_SHA" ]; then
+            echo "Would create $GO_TAG at $GITHUB_SHA and push it."
+          elif [ "$REMOTE_SHA" = "$GITHUB_SHA" ]; then
+            echo "Tag $GO_TAG already exists at $GITHUB_SHA — would do nothing."
+          else
+            echo "Tag $GO_TAG exists at $REMOTE_SHA — would force-move it to $GITHUB_SHA."
+          fi
+
+          echo "::notice::Dry run mode - not actually publishing"
+          echo "Would publish: Go module tag ${GO_TAG} (proxy.golang.org serves github.com/basecamp/basecamp-sdk/go from it)"
+
   tag:
     name: Create Go module tag
     needs: [smithy, test]

--- a/.github/workflows/release-kotlin.yml
+++ b/.github/workflows/release-kotlin.yml
@@ -137,6 +137,9 @@ jobs:
 
       - name: Dry-run build
         if: github.event_name == 'workflow_dispatch'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           ./gradlew :basecamp-sdk:build
           echo "::notice::Dry run mode - not actually publishing"
+          echo "Would publish: com.basecamp:basecamp-sdk:${VERSION} to GitHub Packages"

--- a/.github/workflows/release-kotlin.yml
+++ b/.github/workflows/release-kotlin.yml
@@ -60,9 +60,60 @@ jobs:
           fi
           echo "Generated code is up to date"
 
+  # Gradle's publish task builds from the project rather than from a prepared
+  # file, so the rehearsal cannot hand an artifact to the publisher the way the
+  # gem, wheel and npm tarball do. It gets its own job instead, so the dry run
+  # never holds `packages: write`.
+  publish-dry-run:
+    name: Publish to GitHub Packages (dry run)
+    needs: [smithy, test]
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: kotlin
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Java
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
+        with:
+          cache-provider: basic
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(grep '^version' sdk/build.gradle.kts | sed 's/version = "\(.*\)"/\1/')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read version from kotlin/sdk/build.gradle.kts"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Rehearsal for version: $VERSION"
+
+      - name: Dry-run build
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          ./gradlew :basecamp-sdk:build
+          echo "::notice::Dry run mode - not actually publishing"
+          echo "Would publish: com.basecamp:basecamp-sdk:${VERSION} to GitHub Packages"
+
   publish:
     name: Publish to GitHub Packages
     needs: [smithy, test]
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -77,7 +128,6 @@ jobs:
           persist-credentials: false
 
       - name: Verify tag is on main
-        if: github.event_name == 'push'
         run: |
           git fetch origin main
           git merge-base --is-ancestor "$GITHUB_SHA" origin/main
@@ -96,27 +146,18 @@ jobs:
 
       - name: Extract version
         id: version
-        env:
-          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
-            VERSION=$(grep '^version' sdk/build.gradle.kts | sed 's/version = "\(.*\)"/\1/')
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-            echo "Rehearsal for version: $VERSION"
-          else
-            # Tag trigger: extract from tag (v0.2.1 → 0.2.1)
-            VERSION="${GITHUB_REF#refs/tags/v}"
-            GRADLE_VERSION=$(grep '^version' sdk/build.gradle.kts | sed 's/version = "\(.*\)"/\1/')
-            if [ "$GRADLE_VERSION" != "$VERSION" ]; then
-              echo "::error::Gradle version ($GRADLE_VERSION) does not match tag version ($VERSION)"
-              exit 1
-            fi
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-            echo "Releasing version: $VERSION"
+          # Tag trigger: extract from tag (v0.2.1 → 0.2.1)
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          GRADLE_VERSION=$(grep '^version' sdk/build.gradle.kts | sed 's/version = "\(.*\)"/\1/')
+          if [ "$GRADLE_VERSION" != "$VERSION" ]; then
+            echo "::error::Gradle version ($GRADLE_VERSION) does not match tag version ($VERSION)"
+            exit 1
           fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Releasing version: $VERSION"
 
       - name: Publish to GitHub Packages
-        if: github.event_name == 'push'
         shell: bash
         run: |
           set +e
@@ -134,12 +175,3 @@ jobs:
         env:
           GITHUB_USER: x-access-token
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Dry-run build
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          ./gradlew :basecamp-sdk:build
-          echo "::notice::Dry run mode - not actually publishing"
-          echo "Would publish: com.basecamp:basecamp-sdk:${VERSION} to GitHub Packages"

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -125,11 +125,14 @@ jobs:
       - name: Build package
         run: uv build
 
-      # PyPI rejects uploads whose metadata or long description will not render,
-      # and that rejection would otherwise land mid-release. twine check is the
-      # same validation, run before the tag exists.
+      # PyPI rejects uploads whose metadata will not parse or whose long
+      # description will not render, and that rejection would otherwise land
+      # mid-release. twine check is the same validation, run before the tag
+      # exists. Not --strict: this package currently ships no long_description
+      # at all, which twine warns about and PyPI accepts, so --strict would fail
+      # every release over a defect that belongs in pyproject.toml, not here.
       - name: Check distribution metadata
-        run: uvx twine check --strict dist/*
+        run: uvx twine check dist/*
 
       - name: Dry-run build verification
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -125,6 +125,12 @@ jobs:
       - name: Build package
         run: uv build
 
+      # PyPI rejects uploads whose metadata or long description will not render,
+      # and that rejection would otherwise land mid-release. twine check is the
+      # same validation, run before the tag exists.
+      - name: Check distribution metadata
+        run: uvx twine check --strict dist/*
+
       - name: Dry-run build verification
         if: github.event_name == 'workflow_dispatch'
         run: |

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -63,15 +63,19 @@ jobs:
       - name: Run tests with coverage
         run: uv run pytest --cov --cov-report=term-missing --cov-fail-under=60
 
-  publish:
-    name: Publish to PyPI
+  # Building is deliberately separate from publishing: this job carries no
+  # `environment:`, so a workflow_dispatch rehearsal runs it from any ref
+  # without needing the release-pypi deployment approval, and it holds no
+  # publishing credentials. The publish job below consumes the exact artifact
+  # built here rather than rebuilding.
+  build:
+    name: Build distribution
     needs: [smithy, test]
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
-      attestations: write
-    environment: release-pypi
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     defaults:
       run:
         working-directory: python
@@ -121,11 +125,42 @@ jobs:
       - name: Build package
         run: uv build
 
+      - name: Dry-run build verification
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          ls -la dist/
+          echo "::notice::Dry run mode - not actually publishing"
+          echo "Would publish: $(ls dist/*.tar.gz dist/*.whl)"
+
+      - name: Upload distribution
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: python-dist
+          path: python/dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    environment: release-pypi
+    steps:
+      - name: Download distribution
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python-dist
+          path: python/dist/
+
       - name: Check if already published
         id: check-published
-        if: github.event_name == 'push'
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.build.outputs.version }}
         run: |
           # Query the PyPI JSON API for exact version match
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/basecamp-sdk/${VERSION}/json")
@@ -137,15 +172,8 @@ jobs:
           fi
 
       - name: Publish to PyPI
-        if: github.event_name == 'push' && steps.check-published.outputs.already_published != 'true'
+        if: steps.check-published.outputs.already_published != 'true'
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: python/dist/
           attestations: true
-
-      - name: Dry-run build verification
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          ls -la dist/
-          echo "::notice::Dry run mode - not actually publishing"
-          echo "Would publish: $(ls dist/*.tar.gz dist/*.whl)"

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -45,14 +45,19 @@ jobs:
       - name: Run tests
         run: bundle exec rake test
 
-  publish:
-    name: Publish to RubyGems
+  # Building is deliberately separate from publishing: this job carries no
+  # `environment:`, so a workflow_dispatch rehearsal runs it from any ref
+  # without needing the release-rubygems deployment approval, and it holds no
+  # publishing credentials. The publish job below pushes the exact .gem built
+  # here rather than rebuilding.
+  build:
+    name: Build gem
     needs: [smithy, test]
     runs-on: ubuntu-latest
-    environment: release-rubygems
     permissions:
       contents: read
-      id-token: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     defaults:
       run:
         working-directory: ruby
@@ -98,17 +103,63 @@ jobs:
             echo "Releasing version: $VERSION"
           fi
 
-      - name: Configure RubyGems credentials
-        if: github.event_name == 'push'
-        uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
-
-      - name: Publish to RubyGems
-        if: github.event_name == 'push'
-        shell: bash
+      - name: Build gem
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           gem build basecamp-sdk.gemspec
+          ls -l "basecamp-sdk-${VERSION}.gem"
+
+      - name: Dry-run report
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          echo "::notice::Dry run mode - not actually publishing"
+          echo "Would publish: basecamp-sdk-${VERSION}.gem to RubyGems"
+
+      - name: Upload gem
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rubygem
+          path: ruby/basecamp-sdk-*.gem
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish to RubyGems
+    needs: build
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: release-rubygems
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: ruby
+    steps:
+      - name: Download gem
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: rubygem
+          path: ruby/
+
+      # No checkout: this job pushes the gem the build job produced, so it needs
+      # Ruby but not the repository. bundler-cache is therefore not used either.
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
+        with:
+          ruby-version: '3.3'
+
+      - name: Configure RubyGems credentials
+        uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
+
+      - name: Publish to RubyGems
+        shell: bash
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
           set +e
           output=$(gem push "basecamp-sdk-${VERSION}.gem" 2>&1)
           status=$?
@@ -122,12 +173,3 @@ jobs:
             exit "$status"
           fi
           gem exec rubygems-await "basecamp-sdk-${VERSION}.gem"
-
-      - name: Dry-run build
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          gem build basecamp-sdk.gemspec
-          echo "::notice::Dry run mode - not actually publishing"
-          echo "Would publish: basecamp-sdk-${VERSION}.gem"

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -110,6 +110,26 @@ jobs:
           gem build basecamp-sdk.gemspec
           ls -l "basecamp-sdk-${VERSION}.gem"
 
+      # `gem push` has no dry run, so verify the built artifact instead. The
+      # gemspec collects its file list from `git ls-files`, so a checkout that
+      # did not produce one would yield a well-formed gem with no library in it
+      # — which RubyGems accepts and users cannot require.
+      - name: Verify packaged gem
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          ruby -e '
+            require "rubygems/package"
+            spec = Gem::Package.new(ARGV[0]).spec
+            abort "::error::Packaged name is #{spec.name}, expected basecamp-sdk" unless spec.name == "basecamp-sdk"
+            abort "::error::Packaged version is #{spec.version}, expected #{ARGV[1]}" unless spec.version.to_s == ARGV[1]
+            lib = spec.files.grep(%r{\Alib/})
+            abort "::error::Packaged gem contains no lib/ files" if lib.empty?
+            abort "::error::Packaged gem is missing lib/basecamp.rb" unless lib.include?("lib/basecamp.rb")
+            puts "Packaged #{spec.full_name}: #{spec.files.size} files, #{lib.size} under lib/"
+            puts "Runtime dependencies: #{spec.runtime_dependencies.map(&:to_s).join(", ")}"
+          ' "basecamp-sdk-${VERSION}.gem" "$VERSION"
+
       - name: Dry-run report
         if: github.event_name == 'workflow_dispatch'
         env:

--- a/.github/workflows/release-swift.yml
+++ b/.github/workflows/release-swift.yml
@@ -50,8 +50,46 @@ jobs:
           fi
           echo "Version verification passed"
 
+      # On workflow_dispatch GITHUB_REF is refs/heads/<branch>, so there is no
+      # tag to verify against. Read the Swift source of truth instead, mirroring
+      # how release-ruby reads version.rb and release-typescript reads package.json.
+      - name: Extract version
+        id: version
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          VERSION=$(sed -n 's/.*public static let version = "\(.*\)".*/\1/p' Sources/Basecamp/BasecampConfig.swift)
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not read version from Sources/Basecamp/BasecampConfig.swift"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Rehearsal for version: $VERSION"
+
       - name: Build
         run: swift build
 
       - name: Test
         run: swift test
+
+      # Swift has no registry upload: SPM consumers resolve the package straight
+      # from the `v<version>` git tag on this repository, so the rehearsal
+      # exercises everything a consumer would — manifest, build, tests — and then
+      # reports the tag that carries the release.
+      - name: Dry-run package verification
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          swift package describe --type json > /dev/null
+          echo "Package manifest resolves."
+
+          TAG="v${VERSION}"
+          REMOTE_SHA=$(git ls-remote --tags --refs origin "$TAG" | awk '{print $1}')
+          if [ -z "$REMOTE_SHA" ]; then
+            echo "Tag $TAG does not exist yet — it is what will trigger the real release run."
+          else
+            echo "Tag $TAG already exists at $REMOTE_SHA."
+          fi
+
+          echo "::notice::Dry run mode - not actually publishing"
+          echo "Would publish: Swift package Basecamp at tag ${TAG} (resolved by SPM from this repository; no artifact upload)"

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -157,7 +157,17 @@ jobs:
         run: |
           echo "::notice::Dry run mode - not actually publishing"
           echo "Would publish: @37signals/basecamp@${VERSION} under npm tag ${NPM_TAG} from ${TARBALL}"
-          npm publish "$TARBALL" --access public --tag "$NPM_TAG" --dry-run
+          echo "PROBE npm $(npm --version) node $(node --version)"
+          set +e
+          out=$(npm publish "$TARBALL" --access public --tag "$NPM_TAG" --dry-run --provenance 2>&1)
+          status=$?
+          set -e
+          echo "$out"
+          echo "PROBE provenance dry-run exit: $status"
+          if [ "$status" -ne 0 ]; then
+            echo "PROBE falling back to dry-run without --provenance"
+            npm publish "$TARBALL" --access public --tag "$NPM_TAG" --dry-run
+          fi
 
       - name: Upload tarball
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -54,14 +54,21 @@ jobs:
       - name: Build
         run: npm run build
 
-  publish:
-    name: Publish to npm
+  # Building is deliberately separate from publishing: this job carries no
+  # `environment:`, so a workflow_dispatch rehearsal runs it from any ref
+  # without needing the release-npm deployment approval, and it holds no
+  # publishing credentials. The publish job below uploads the exact tarball
+  # packed here rather than repacking.
+  build:
+    name: Pack npm tarball
     needs: [smithy, test]
     runs-on: ubuntu-latest
-    environment: release-npm
     permissions:
       contents: read
-      id-token: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.npm-tag.outputs.tag }}
+      tarball: ${{ steps.pack.outputs.tarball }}
     defaults:
       run:
         working-directory: typescript
@@ -78,8 +85,10 @@ jobs:
           git merge-base --is-ancestor "$GITHUB_SHA" origin/main
 
       # Node 24 bundles npm 11.16, past the 11.5.1 that OIDC trusted publishing
-      # requires. Publishing therefore uses the npm shipped in the verified Node
-      # tarball rather than installing one from the registry at release time.
+      # requires. Packing and publishing therefore use the npm shipped in the
+      # verified Node tarball rather than one installed from the registry at
+      # release time, and both jobs use the same Node so the tarball the publish
+      # job uploads is the one packed by this npm.
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         # zizmor: ignore[cache-poisoning] -- cache is branch-isolated; fork PRs cannot write to this cache
@@ -125,11 +134,72 @@ jobs:
             echo "tag=latest" >> $GITHUB_OUTPUT
           fi
 
+      # `npm publish` on a directory would run prepublishOnly and rebuild, so the
+      # tarball is packed here — after an explicit build — and the publish job
+      # uploads that file. Packing does not run prepublishOnly, hence the
+      # explicit `npm run build`.
+      - name: Build
+        run: npm run build
+
+      - name: Pack tarball
+        id: pack
+        run: |
+          TARBALL=$(npm pack --silent)
+          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+          ls -l "$TARBALL"
+
+      - name: Dry-run publish
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          NPM_TAG: ${{ steps.npm-tag.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+          TARBALL: ${{ steps.pack.outputs.tarball }}
+        run: |
+          echo "::notice::Dry run mode - not actually publishing"
+          echo "Would publish: @37signals/basecamp@${VERSION} under npm tag ${NPM_TAG} from ${TARBALL}"
+          npm publish "$TARBALL" --access public --tag "$NPM_TAG" --dry-run
+
+      - name: Upload tarball
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-tarball
+          path: typescript/*.tgz
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish to npm
+    needs: build
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    environment: release-npm
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - name: Download tarball
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-tarball
+          path: typescript/
+
+      # No checkout and no npm ci: this job uploads the tarball the build job
+      # packed, so it needs npm but not the sources. Node 24 for the same npm
+      # 11.16 / OIDC reason as above.
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        # zizmor: ignore[cache-poisoning] -- no `cache:` input, so nothing is restored here; the tarball comes from the build job's artifact
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Check if already published
         id: check-published
-        if: github.event_name == 'push'
         env:
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.build.outputs.version }}
         run: |
           if npm view "@37signals/basecamp@${VERSION}" version 2>/dev/null; then
             echo "already_published=true" >> $GITHUB_OUTPUT
@@ -141,14 +211,6 @@ jobs:
       - name: Publish to npm
         if: steps.check-published.outputs.already_published != 'true'
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          NPM_TAG: ${{ steps.npm-tag.outputs.tag }}
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          if [[ "$EVENT_NAME" == "push" ]]; then
-            npm publish --access public --tag "$NPM_TAG" --provenance
-          else
-            echo "::notice::Dry run mode - not actually publishing"
-            echo "Would publish: @37signals/basecamp@${VERSION} under npm tag ${NPM_TAG}"
-            npm publish --access public --tag "$NPM_TAG" --dry-run
-          fi
+          NPM_TAG: ${{ needs.build.outputs.tag }}
+          TARBALL: ${{ needs.build.outputs.tarball }}
+        run: npm publish "$TARBALL" --access public --tag "$NPM_TAG" --provenance

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -143,10 +143,12 @@ jobs:
         env:
           EVENT_NAME: ${{ github.event_name }}
           NPM_TAG: ${{ steps.npm-tag.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           if [[ "$EVENT_NAME" == "push" ]]; then
             npm publish --access public --tag "$NPM_TAG" --provenance
           else
             echo "::notice::Dry run mode - not actually publishing"
+            echo "Would publish: @37signals/basecamp@${VERSION} under npm tag ${NPM_TAG}"
             npm publish --access public --tag "$NPM_TAG" --dry-run
           fi

--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -148,6 +148,13 @@ jobs:
           echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
           ls -l "$TARBALL"
 
+      # The same invocation the publish job runs on a tag, flags and all, with
+      # --dry-run added: npm resolves the manifest out of the tarball, lists the
+      # exact file set it would upload, and negotiates with the registry, but
+      # writes nothing. Verified to exit 0 with --provenance on npm 11.16.0 /
+      # Node 24.18.0 in a job with no `id-token: write`, so the shape is
+      # exercised here; the attestation itself is minted from the OIDC token at
+      # publish time and is the one part a dry run cannot prove.
       - name: Dry-run publish
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -157,17 +164,7 @@ jobs:
         run: |
           echo "::notice::Dry run mode - not actually publishing"
           echo "Would publish: @37signals/basecamp@${VERSION} under npm tag ${NPM_TAG} from ${TARBALL}"
-          echo "PROBE npm $(npm --version) node $(node --version)"
-          set +e
-          out=$(npm publish "$TARBALL" --access public --tag "$NPM_TAG" --dry-run --provenance 2>&1)
-          status=$?
-          set -e
-          echo "$out"
-          echo "PROBE provenance dry-run exit: $status"
-          if [ "$status" -ne 0 ]; then
-            echo "PROBE falling back to dry-run without --provenance"
-            npm publish "$TARBALL" --access public --tag "$NPM_TAG" --dry-run
-          fi
+          npm publish "$TARBALL" --access public --tag "$NPM_TAG" --dry-run --provenance
 
       - name: Upload tarball
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
Dispatching the six `release-*.yml` workflows is meant to be a full rehearsal of a release. Rehearsing them from `main` at `7085ba3b1` (the 0.13.0 bump) showed only three of the six exercising a publish path, and one that could not be dispatched at all.

A skipped job is not a rehearsal. If the Go tagging step or the Swift version check were broken, nothing would say so until the tag push — and that push is irreversible, so the first evidence of a broken publish path would arrive at the worst possible moment.

## What was wrong, per SDK

- **go** — the `tag` job carried a job-level `if: github.event_name == 'push'` and was skipped entirely.
- **swift** — its verification steps were step-gated the same way; a dispatch built and tested but rehearsed nothing about the release itself.
- **python** — its only publishing job carries `environment: release-pypi`, whose deployment branch policy is `v*`-only. A manual run from a branch is refused before any step executes, so the wheel was never even built in rehearsal.
- **ruby, typescript** — same single-job shape as python. They happen to rehearse from `main` today, but the environment is on the job that does the building, so the rehearsal is hostage to a deployment approval it does not need.
- **kotlin** — rehearsed correctly, but did so inside a job holding `packages: write`.

## The `GITHUB_REF` defect in release-go

The Go tag job could not simply have its job-level `if` removed. It derives the tag it pushes from

```sh
TAG="${GITHUB_REF#refs/tags/}"
```

On a `workflow_dispatch` `GITHUB_REF` is `refs/heads/<branch>`, not `refs/tags/v*`, so the prefix strip is a no-op and `TAG` becomes the literal string `refs/heads/main`. Ungating it naively would have "rehearsed" creating a tag named `go/refs/heads/main`.

The dry run therefore reads the version from `go/pkg/basecamp/version.go`, the same way release-ruby reads `version.rb` and release-typescript reads `package.json`. It computes `go/vX.Y.Z`, checks the remote with `git ls-remote`, and reports which of the three real branches it would take: create, leave alone, or force-move.

## Build outside the environment, publish inside it

For python, ruby and typescript the fix is a split rather than a policy change. **No deployment branch policy is widened; `release-pypi` stays `v*`-only.**

- An **unprotected build job** — no `environment:`, `contents: read` — runs on both events. It reads the version from that SDK's own source of truth, builds the artifact, prints what it would publish, and uploads the result with `actions/upload-artifact`.
- An **environment-gated publish job** — `needs: build`, job-level `if: github.event_name == 'push'` — downloads that artifact and publishes exactly those bytes. It does not rebuild.

Two things fall out. The environment now gates only real publishes, so a rehearsal needs no deployment approval and works from any ref, including a fork. And what ships is what was built and validated, not a rebuild nobody looked at.

For typescript that means packing a tarball instead of letting `npm publish` rebuild through `prepublishOnly`, then publishing the tarball by path. `npm pack` does not run `prepublishOnly`, hence the now-explicit `npm run build`. This is the one place where the tag-push invocation itself changes shape (`npm publish <tarball>` rather than `npm publish <dir>`), so the rehearsal runs that exact invocation — see below.

**Kotlin is the exception, deliberately.** Gradle's publish task builds from the project rather than from a prepared file, so there is no artifact to hand over and no way to give kotlin the build-once property without hand-rolling Maven upload, which would be a larger and riskier change than the gap it closes. **Kotlin is therefore the one workflow where the bytes published on a tag are rebuilt by the publish job rather than handed over from the build that was validated.** It still gets the least-privilege half of the treatment: its rehearsal moved into its own job so it no longer runs under `packages: write`.

## Rehearsing the real invocation, not an approximation

Each build job now runs whatever native dry run or artifact validation its packaging tool actually offers, so the rehearsal exercises the publish path rather than asserting it should work.

**npm** — `npm publish "$TARBALL" --access public --tag "$NPM_TAG" --dry-run --provenance`: the publish job's exact command with `--dry-run` added. npm resolves the manifest out of the tarball, enumerates the file set it would upload, and negotiates with the registry without writing. A probe run confirmed `--provenance` is accepted alongside `--dry-run` on npm 11.16.0 / Node 24.18.0 *in a job holding no `id-token: write`*, so the whole invocation is exercised. The attestation itself is minted from the OIDC token at publish time and is the one part a dry run cannot prove.

**RubyGems** — `gem push` has no dry run, so the artifact is verified instead. The gemspec collects its file list from `git ls-files`; a checkout that did not produce one would build a well-formed gem containing no library, which RubyGems accepts and nobody can require. The check reads the packaged spec back out of the `.gem` and asserts name, version, and the presence of `lib/`.

**PyPI** — `twine check dist/*`, the same metadata and long-description validation PyPI applies at upload. Deliberately not `--strict`: see the finding below.

### Finding: the Python package has no long description

`twine check --strict` failed the first probe run:

```
Checking dist/basecamp_sdk-0.13.0-py3-none-any.whl: FAILED due to warnings
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.
WARNING  `long_description` missing.
```

`python/README.md` exists (33 KB) but `python/pyproject.toml` declares no `readme`, so the sdist and wheel carry no long description and the PyPI project page for `basecamp-sdk` renders empty. PyPI accepts this, so it is not an upload blocker and `--strict` would fail every release over it. **That is a one-line `pyproject.toml` fix, not a workflow fix, and it changes the metadata of the artifact this release ships — so it is reported rather than smuggled in here.** The workflow runs plain `twine check`, which passes with those warnings visible in the log.

## Job graph after

| workflow | job | runs on | `environment:` | permissions |
| --- | --- | --- | --- | --- |
| go | `test` | both | — | `contents: read` |
| go | `tag-dry-run` | dispatch | — | `contents: read` |
| go | `tag` | push | — | `contents: write` |
| swift | `test` (+ dry-run steps) | both | — | `contents: read` |
| kotlin | `test` | both | — | `contents: read` |
| kotlin | `publish-dry-run` | dispatch | — | `contents: read` |
| kotlin | `publish` | push | — | `contents: read`, `packages: write` |
| ruby | `build` | both | — | `contents: read` |
| ruby | `publish` | push | `release-rubygems` | `contents: read`, `id-token: write` |
| typescript | `build` | both | — | `contents: read` |
| typescript | `publish` | push | `release-npm` | `contents: read`, `id-token: write` |
| python | `build` | both | — | `contents: read` |
| python | `publish` | push | `release-pypi` | `contents: read`, `id-token: write`, `attestations: write` |

Every job that runs on a dispatch holds `contents: read` and nothing else. Every write permission and every `environment:` now sits on a job that only runs on a tag push. `git tag` and `git push` remain gated on `github.event_name == 'push'`.

The `Verify tag is on main` guard moved with the checkout into each build job. It still runs on push and still blocks the publish job through `needs:`.

### The publish job gets this run's artifact, not a rebuild and not a stale one

```yaml
  publish:
    name: Publish to PyPI
    needs: build
    if: github.event_name == 'push'
    ...
    steps:
      - name: Download distribution
        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
        with:
          name: python-dist
          path: python/dist/
```

Three things pin this down. `needs: build` makes the publish job run only after the build job in **this** run succeeded. `actions/download-artifact` defaults `run-id` to `${{ github.run_id }}` and `repository` to `${{ github.repository }}` — its own action.yml says it "will attempt to download artifacts from the current repository and the current workflow run" when no `github-token` is given, and no token is given here — so it cannot reach a previous run's artifact. And the publish job has no checkout and no build tooling: there are no sources present to rebuild from even if a step tried. The same wiring holds for ruby (`rubygem`) and typescript (`npm-tarball`).

## Verification

`make lint-actions` (actionlint + zizmor) green: `No findings to report. Good job! (17 ignored, 34 suppressed)`, real exit code 0.

All six dispatched against this branch ref at `42c11c848`. Every previously-skipped job or step executed, every workflow read `0.13.0` from its own source of truth, and every publish job was skipped:

```
Release Python SDK      Build distribution: success              Publish to PyPI: skipped
Release Ruby SDK        Build gem: success                       Publish to RubyGems: skipped
Release TypeScript SDK  Pack npm tarball: success                Publish to npm: skipped
Release Kotlin SDK      Publish to GitHub Packages (dry run): success   Publish to GitHub Packages: skipped
Release Go SDK          Create Go module tag (dry run): success  Create Go module tag: skipped
Release Swift SDK       Test Swift SDK: success
```

Python is the acid test — it built and rehearsed from a branch with `release-pypi` still `v*`-only:

```
Build distribution | Extract version | Rehearsal for version: 0.13.0
Build distribution | Dry-run build verification | ##[notice]Dry run mode - not actually publishing
Build distribution | Dry-run build verification | Would publish: dist/basecamp_sdk-0.13.0-py3-none-any.whl
                                                  dist/basecamp_sdk-0.13.0.tar.gz
```

Go, previously skipped entirely:

```
Create Go module tag (dry run) | Rehearsal for version: 0.13.0
Create Go module tag (dry run) | Would create go/v0.13.0 at 42c11c8480c0501f49f14d46dc2341d5cd75ee0e and push it.
Create Go module tag (dry run) | ##[notice]Dry run mode - not actually publishing
Create Go module tag (dry run) | Would publish: Go module tag go/v0.13.0 (proxy.golang.org serves github.com/basecamp/basecamp-sdk/go from it)
```

Swift, previously skipped:

```
Test Swift SDK | Extract version | Rehearsal for version: 0.13.0
Test Swift SDK | Dry-run package verification | Package manifest resolves.
Test Swift SDK | Dry-run package verification | Tag v0.13.0 does not exist yet — it is what will trigger the real release run.
Test Swift SDK | Dry-run package verification | ##[notice]Dry run mode - not actually publishing
Test Swift SDK | Dry-run package verification | Would publish: Swift package Basecamp at tag v0.13.0 (resolved by SPM from this repository; no artifact upload)
```

Ruby — `gem push` has no dry run, so the built artifact is read back:

```
Build gem | Verify packaged gem | Packaged basecamp-sdk-0.13.0: 128 files, 119 under lib/
Build gem | Verify packaged gem | Runtime dependencies: faraday (~> 2.0), zeitwerk (~> 2.6)
Build gem | Dry-run report      | Would publish: basecamp-sdk-0.13.0.gem to RubyGems
```

TypeScript — the publish job's exact invocation, dry:

```
Pack npm tarball | Dry-run publish | Would publish: @37signals/basecamp@0.13.0 under npm tag latest from 37signals-basecamp-0.13.0.tgz
Pack npm tarball | Dry-run publish | npm notice Tarball Details
Pack npm tarball | Dry-run publish | npm notice package size: 540.3 kB
Pack npm tarball | Dry-run publish | npm notice total files: 503
Pack npm tarball | Dry-run publish | npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access (dry-run)
```

Python — `twine check` against the artifact that would be uploaded:

```
Build distribution | Check distribution metadata | Checking dist/basecamp_sdk-0.13.0-py3-none-any.whl: PASSED with warnings
Build distribution | Check distribution metadata | Checking dist/basecamp_sdk-0.13.0.tar.gz: PASSED with warnings
```

Kotlin:

```
Publish to GitHub Packages (dry run) | Rehearsal for version: 0.13.0
Publish to GitHub Packages (dry run) | Would publish: com.basecamp:basecamp-sdk:0.13.0 to GitHub Packages
```

Nothing was mutated. After all six runs:

```
$ git ls-remote --tags origin 'v0.13.0' 'go/v0.13.0'
(no output)
pypi 0.13.0 -> 404   rubygems 0.13.0 -> 404   npm 0.13.0 -> 404
```

The only side effect is the build artifacts attached to the runs themselves, at 7-day retention.

No action SHA pins were changed; `actions/upload-artifact` reuses the pin already in this repo and `actions/download-artifact` is pinned to v8.0.1, which shares `@actions/artifact` ^6.2 with it. `release-github.yml` is untouched.
