### PR TITLE
Python: declare the README so the PyPI page is not blank

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "hatchling.build"
 name = "basecamp-sdk"
 version = "0.13.0"
 description = "Official Python SDK for the Basecamp API"
+readme = "README.md"
 requires-python = ">=3.11"
 license = "MIT"
 authors = [{ name = "37signals" }]


### PR DESCRIPTION
`python/pyproject.toml` never set `readme`, so hatchling built both the wheel and the sdist with **no long description**. PyPI accepts that and then renders an **empty project page** — and has done for every release so far.

`python/README.md` is 33 KB. It was simply never referenced. PEP 621 requires the field to be named explicitly; the other SDKs do not have this problem because their packaging picks the README up implicitly.

## How it surfaced

By adding `twine check` to the release rehearsal — the check is what made it visible, which is the argument for having it:

```
Checking dist/basecamp_sdk-0.13.0-py3-none-any.whl: FAILED due to warnings
WARNING  `long_description_content_type` missing. defaulting to `text/x-rst`.
WARNING  `long_description` missing.
```

Note the defaulted content type: even had a description been present, it would have been interpreted as reStructuredText and the Markdown would have rendered as garbage.

## After

```
Checking dist/basecamp_sdk-0.13.0-py3-none-any.whl: PASSED
Checking dist/basecamp_sdk-0.13.0.tar.gz: PASSED
```

Verified in the built wheel's metadata rather than trusting the linter:

```
Description-Content-Type: text/markdown
long description bytes: 33055
first line: # Basecamp Python SDK
```

## Why now

This changes the metadata of the artifact v0.13.0 publishes, so it belongs before the tag rather than after. It is one line and it is the difference between the SDK's PyPI page being its documentation and being blank.

Deliberately **not** folded into #673 (the release-workflow dry-run PR): that one changes CI plumbing and this changes a shipped artifact. They should be reviewable and revertable apart.

Not adding `--strict` to the rehearsal in this PR — #673 ships plain `twine check` so a future metadata warning is visible without failing a release. Tightening to `--strict` is worth considering once the tree is known clean, which after this it is.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declare `readme = "README.md"` in `python/pyproject.toml` so the package publishes a proper long description on PyPI instead of a blank page. This sets the content type to Markdown and makes `twine check` pass for wheels and sdists.

<sup>Written for commit 80e10febe2c5d6f1af6a14c78a6e832c93122b34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

