### PR TITLE
Python was in no security tooling at all

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -8,6 +8,7 @@ paths:
   - ruby/
   - swift/
   - kotlin/
+  - python/
 
 paths-ignore:
   # Generated SDK code (fix in the generator or spec, not here).
@@ -21,6 +22,13 @@ paths-ignore:
   - ruby/lib/basecamp/generated/
   - swift/Sources/Basecamp/Generated/
   - kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/
+  # python/src/basecamp/generated/ is deliberately NOT listed. It holds two
+  # hand-written files — services/_base.py and services/_async_base.py, the HTTP,
+  # retry and pagination plumbing (AGENTS.md exempts them from the generator) —
+  # i.e. exactly the code most worth scanning. paths-ignore has no negation, so
+  # excluding the directory would silently drop them. If generated Python turns
+  # out to be noisy, narrow it in codeql.yml's SARIF filter instead: that step is
+  # a jq test() regex and can express "generated/ but not services/_".
   # Test infrastructure
   - conformance/
   - kotlin/conformance/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,6 +41,8 @@ jobs:
               - 'swift/**'
             kotlin:
               - 'kotlin/**'
+            python:
+              - 'python/**'
             actions:
               - '.github/**'
             config:
@@ -56,6 +58,7 @@ jobs:
           RUBY: ${{ steps.filter.outputs.ruby }}
           SWIFT: ${{ steps.filter.outputs.swift }}
           KOTLIN: ${{ steps.filter.outputs.kotlin }}
+          PYTHON: ${{ steps.filter.outputs.python }}
           ACTIONS: ${{ steps.filter.outputs.actions }}
           CONFIG: ${{ steps.filter.outputs.config }}
         run: |
@@ -67,6 +70,7 @@ jobs:
             add go manual
             add javascript none
             add ruby none
+            add python none
             add java-kotlin manual
             swift=true
           else
@@ -74,6 +78,7 @@ jobs:
             if [ "$GO" = "true" ]; then add go manual; fi
             if [ "$TS" = "true" ]; then add javascript none; fi
             if [ "$RUBY" = "true" ]; then add ruby none; fi
+            if [ "$PYTHON" = "true" ]; then add python none; fi
             if [ "$KOTLIN" = "true" ]; then add java-kotlin manual; fi
             swift=$SWIFT
           fi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -298,6 +298,62 @@ jobs:
         working-directory: .
         run: ./scripts/assert-lockfiles-unchanged --verify-clean
 
+  trivy-python:
+    name: Trivy (Python SDK)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # Full-severity SARIF for Security-tab visibility; the gate step below enforces policy.
+      # (In SARIF mode the action reports all severities unless limit-severities-for-sarif is set.)
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: 'fs'
+          scan-ref: './python'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-python-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        if: always()
+        continue-on-error: true
+        with:
+          sarif_file: 'trivy-python-results.sarif'
+          category: 'trivy-python'
+
+      # Table mode passes the severity filter through, so this gates on HIGH/CRITICAL only.
+      - name: Fail on HIGH/CRITICAL vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_SKIP_DB_UPDATE: true
+        with:
+          scan-type: 'fs'
+          scan-ref: './python'
+          severity: 'HIGH,CRITICAL'
+          exit-code: '1'
+          ignore-unfixed: true
+          format: 'table'
+          skip-setup-trivy: true
+          cache: 'false'
+
+      # Ground truth, and the authoritative check: the static parser predicts
+      # that nothing writes a lockfile, this observes whether anything did. A CI
+      # checkout starts pristine, so the committed tree is the baseline. Catches
+      # a manifest that was modified AND one CREATED where none was tracked, and
+      # runs on failure too, so a job cannot fail and hide what it dirtied.
+      - name: Dependency manifests unchanged by this job
+        if: always()
+        working-directory: .
+        run: ./scripts/assert-lockfiles-unchanged --verify-clean
+
   bundler-audit:
     name: Bundler Audit (Ruby SDK)
     runs-on: ubuntu-latest

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -47,9 +47,14 @@ quote-style = "double"
 docstring-code-format = true
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "UP", "B", "SIM"]
+# "S" is flake8-bandit — the Python SDK's only static security linting.
+select = ["E", "F", "I", "UP", "B", "SIM", "S"]
 
 [tool.ruff.lint.per-file-ignores]
+# Tests assert freely and pass fake credentials as literals: S101 (assert),
+# S105/S106 (hardcoded "password" strings and kwargs, e.g. access_token=,
+# client_secret=, secret=). All fixture noise, none of it shipped.
+"tests/**" = ["S101", "S105", "S106"]
 "src/basecamp/generated/**" = ["E501", "I001", "F401"]
 "src/basecamp/generated/types.py" = ["E501", "UP", "I001", "F401"]
 

--- a/python/src/basecamp/_async_http.py
+++ b/python/src/basecamp/_async_http.py
@@ -379,7 +379,8 @@ class AsyncHttpClient:
         if server_retry_after and server_retry_after > 0:
             return float(server_retry_after)
         base = saturating_backoff(self._config.base_delay, attempt)
-        jitter = random.random() * self._config.max_jitter
+        # Backoff jitter spreads retries; it is a fairness device, not a security primitive.
+        jitter = random.random() * self._config.max_jitter  # noqa: S311
         return base + jitter
 
     def _is_retryable_operation(self, operation: str) -> bool:

--- a/python/src/basecamp/_http.py
+++ b/python/src/basecamp/_http.py
@@ -377,7 +377,8 @@ class HttpClient:
         if server_retry_after and server_retry_after > 0:
             return float(server_retry_after)
         base = saturating_backoff(self._config.base_delay, attempt)
-        jitter = random.random() * self._config.max_jitter
+        # Backoff jitter spreads retries; it is a fairness device, not a security primitive.
+        jitter = random.random() * self._config.max_jitter  # noqa: S311
         return base + jitter
 
     def _is_retryable_operation(self, operation: str) -> bool:

--- a/python/src/basecamp/async_auth.py
+++ b/python/src/basecamp/async_auth.py
@@ -47,7 +47,8 @@ class AsyncOAuthTokenProvider:
     ``token.resource``) instead of this provider.
     """
 
-    TOKEN_URL = "https://launchpad.37signals.com/authorization/token"
+    # Public OAuth token endpoint URL, not a credential.
+    TOKEN_URL = "https://launchpad.37signals.com/authorization/token"  # noqa: S105
 
     def __init__(
         self,

--- a/python/src/basecamp/auth.py
+++ b/python/src/basecamp/auth.py
@@ -46,7 +46,8 @@ class OAuthTokenProvider:
     ``token.resource``) instead of this provider.
     """
 
-    TOKEN_URL = "https://launchpad.37signals.com/authorization/token"
+    # Public OAuth token endpoint URL, not a credential.
+    TOKEN_URL = "https://launchpad.37signals.com/authorization/token"  # noqa: S105
 
     def __init__(
         self,

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -608,7 +608,8 @@ def _build_token(data: dict[str, Any], status: int) -> OAuthToken:
     # malformed. Uniform across all five SDKs.
     token_type = data.get("token_type")
     if token_type is None:
-        token_type = "Bearer"
+        # RFC 6750 authentication scheme name, not a credential.
+        token_type = "Bearer"  # noqa: S105
     elif not isinstance(token_type, str) or not token_type:
         raise OAuthError("api_error", "Device token response token_type must be a non-empty string", http_status=status)
 

--- a/python/src/basecamp/oauth/exchange.py
+++ b/python/src/basecamp/oauth/exchange.py
@@ -182,7 +182,8 @@ def _parse_token_response(response: httpx.Response) -> OAuthToken:
     # must be a non-empty string — matching the device-flow parser (SPEC §16).
     token_type = data.get("token_type")
     if token_type is None:
-        token_type = "Bearer"
+        # RFC 6750 authentication scheme name, not a credential.
+        token_type = "Bearer"  # noqa: S105
     elif not isinstance(token_type, str) or not token_type:
         raise OAuthError(
             "api_error",

--- a/python/src/basecamp/oauth/token.py
+++ b/python/src/basecamp/oauth/token.py
@@ -9,7 +9,8 @@ class OAuthToken:
     """OAuth 2 access token response."""
 
     access_token: str
-    token_type: str = "Bearer"
+    # RFC 6750 authentication scheme name, not a credential.
+    token_type: str = "Bearer"  # noqa: S105
     refresh_token: str | None = None
     expires_in: int | None = None
     expires_at: float | None = field(default=None)

--- a/python/src/basecamp/services/documents.py
+++ b/python/src/basecamp/services/documents.py
@@ -97,9 +97,8 @@ class _DocumentEditBase:
     @property
     def result(self) -> dict[str, Any]:
         """The updated document, available after the ``with`` block exits cleanly."""
-        if not self._completed:
+        if not self._completed or self._result is None:
             raise RuntimeError("edit has not completed")
-        assert self._result is not None
         return self._result
 
 

--- a/python/src/basecamp/services/schedules.py
+++ b/python/src/basecamp/services/schedules.py
@@ -249,9 +249,8 @@ class _ScheduleEntryEditBase:
     @property
     def result(self) -> dict[str, Any]:
         """The updated entry, available after the ``with`` block exits cleanly."""
-        if not self._completed:
+        if not self._completed or self._result is None:
             raise RuntimeError("edit has not completed")
-        assert self._result is not None
         return self._result
 
 

--- a/python/src/basecamp/services/todolists.py
+++ b/python/src/basecamp/services/todolists.py
@@ -251,9 +251,8 @@ class _TodolistEditBase:
     @property
     def result(self) -> dict[str, Any]:
         """The updated todolist, available after the ``with`` block exits cleanly."""
-        if not self._completed:
+        if not self._completed or self._result is None:
             raise RuntimeError("edit has not completed")
-        assert self._result is not None
         return self._result
 
 

--- a/python/src/basecamp/services/todos.py
+++ b/python/src/basecamp/services/todos.py
@@ -112,9 +112,8 @@ class _TodoEditBase:
     @property
     def result(self) -> dict[str, Any]:
         """The updated todo, available after the ``with`` block exits cleanly."""
-        if not self._completed:
+        if not self._completed or self._result is None:
             raise RuntimeError("edit has not completed")
-        assert self._result is not None
         return self._result
 
 


### PR DESCRIPTION
## HOLD — do not merge until the v0.13.0 tag lands (#667)

`main` is frozen. This is prepared and held. It should land **before** the Link-header PR, because it converts "Python is unscanned" from an assertion into a measured fact.

## What was wrong

`.github/workflows/codeql.yml` was created 2026-02-28 as *"Add CodeQL analysis for all 5 SDK languages"* (`a99fdc357`, #132). The Python SDK arrived 2026-03-24 as the sixth (`e1fe52925`, #200) and was never retrofitted.

Python appears in **none** of:

- the CodeQL language matrix
- `codeql-config.yml`'s `paths:`
- `security.yml` — which runs Trivy ×3, npm audit, bundler-audit, Gradle dependency check, Swift dependency audit, `govulncheck` and `gosec`

`ruff`'s `select` was `["E","F","I","UP","B","SIM"]`, so no bandit rules either. No note, no issue, no SPEC line records this as a decision — it is an omission, not a choice.

It is not academic. The six SDKs' `Link`-header parsers split cleanly, and Python's is unflagged **only because nothing looks at it**:

| SDK | Approach | Status |
|---|---|---|
| Go / Swift / Kotlin | index scan | linear |
| TypeScript | `/<([^>]+)>/` | quadratic — alert 43 |
| Ruby | `/<([^>]+)>/` | quadratic — alert 48 |
| Python | `re.search(r"<([^>]+)>")` | quadratic — **unflagged** |

The repo already treats that header as attacker-influenced (`isSameOrigin` exists "to prevent SSRF via poisoned Link headers"), so an unscanned ReDoS on it is inconsistent with the threat model the code has already adopted. The follow-up PR fixes the parsing itself; this PR is what makes the Python instance visible.

## The three changes

**1. CodeQL.** A `python` paths-filter entry, a `PYTHON` env var, and `add python none` in *both* branches of the matrix builder. Python is buildless, so unlike Go and Kotlin it needs no build step. `python/` joins `paths:`.

Deliberately **no** Python `paths-ignore`. `python/src/basecamp/generated/` holds two *hand-written* files — `services/_base.py` and `services/_async_base.py`, the HTTP, retry and pagination plumbing that AGENTS.md exempts from the generator — i.e. exactly the code most worth scanning. CodeQL path filters have no negation, so a directory exclusion would silently drop them. The config now says this, and points at `codeql.yml`'s jq SARIF filter as the place to narrow if generated Python turns out to be noisy (that step is a `test()` regex and *can* express "generated/ but not `services/_`").

**2. Trivy.** A `trivy-python` job cloned from `trivy-ruby`, keeping all four steps of the existing shape: full-severity SARIF upload under category `trivy-python`, the HIGH/CRITICAL table gate, and `assert-lockfiles-unchanged --verify-clean`. Trivy `fs` picks up `python/uv.lock`.

**3. ruff bandit.** `"S"` added to `select`. 1935 hits; 1924 are test-fixture noise cleared by one `tests/**` ignore.

> Note: the ignore list is `["S101", "S105", "S106"]`, not the `["S101","S106"]` originally scoped — tests also carry 23 `S105` hits (fake `access_token=`, `secret=`, `TOKEN_ENDPOINT` literals), same genus as S106.

Of the 11 hits in `src/`:

- **4× S101**, all the same shape: `assert self._result is not None`, narrowing a `dict | None` for mypy immediately after an explicit `raise` that already enforces the real invariant. `_result` is assigned immediately before `_completed = True` on every path, so the assert is pure narrowing. But `python -O` strips `assert`, so instead of suppressing them the None check folds into the raise that was already there — same behaviour, now actually enforced under `-O`, no `noqa`, and mypy still narrows.
- **5× S105 / 2× S311** — `TOKEN_URL` (a public endpoint), `token_type = "Bearer"` (the RFC 6750 scheme name), and `random.random()` for retry-backoff jitter. False positives; targeted `noqa` with the reason on the preceding line, since ruff parses trailing text after a noqa code unreliably.

`generated/` has zero S hits, so its per-file-ignores are unchanged.

## Out of scope, noted

`python/scripts/` is not linted by CI at all — `test.yml` lints only `src/ tests/`. Same gap as root `scripts/`.

## Verification

- `ruff check src/ tests/` clean; `ruff format --check` clean (160 files)
- `mypy src/` clean over 39 files — this is the proof the raise-based narrowing works
- 1178 tests pass, 4 skipped
- `actionlint` and `zizmor` both clean on the two changed workflows
- Matrix builder extracted from the workflow and simulated across four cases: push (full matrix, python present), config-touch PR (full matrix), python-only PR (python alone), ruby-only PR (python correctly absent)
- `uv.lock` untouched, so `assert-lockfiles-unchanged` stays clean

This PR touches `.github/**`, which the `config` filter promotes to a full matrix — so its own run exercises the new job. Reviewers: confirm an `Analyze (python)` job appears and succeeds, and read `python.sarif: N findings` off its filter step. Compare **interpreted-query rosters** rather than finding counts — PR runs are diff-informed and main runs are not, so counts are not comparable across the two.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Python SDK to our security tooling so it’s scanned like the other languages. This enables `CodeQL`, `Trivy`, and `ruff` bandit checks, and tightens a few guards to satisfy new rules.

- New Features
  - `CodeQL`: add `python/**` to the matrix and include `python/` in `paths` (no `paths-ignore` so the hand-written `services/_base.py` files are scanned).
  - `Trivy`: new job for `python/` with SARIF upload, HIGH/CRITICAL gate, and lockfile integrity check.
  - Linting: enable `ruff` bandit (`"S"`); ignore `tests/**` for `S101/S105/S106`; add targeted `noqa` for public constants (`S105`) and backoff jitter (`S311`).
  - Code fixes: replace `assert`-based result checks with explicit raises to keep behavior under `-O` and pass `S101`.

<sup>Written for commit 162005f6ac55860e4588c34b4e90be18dcd5959a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

