### PR TITLE
Delete five locals nothing reads

### DIFF
--- a/ruby/test/basecamp/oauth_device_test.rb
+++ b/ruby/test/basecamp/oauth_device_test.rb
@@ -853,7 +853,6 @@ class OAuthDeviceTest < Minitest::Test
     # Adapter-only: the SSRF guard refuses middleware it cannot verify
     # redirect-free (Faraday.new's default stack includes UrlEncoded).
     connection = Faraday.new { |f| f.adapter :net_http }
-    _waits, sleeper = recording_sleeper
     started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     error = assert_raises(Basecamp::Oauth::DeviceFlowError) do
       Basecamp::Oauth::DeviceFlow.request_device_authorization(

--- a/typescript/scripts/generate-services.ts
+++ b/typescript/scripts/generate-services.ts
@@ -574,14 +574,6 @@ function resolveRef(ref: string): string {
   return ref.split("/").pop() || "";
 }
 
-function resolveSchema(schemaOrRef: Schema): Schema | undefined {
-  if (schemaOrRef.$ref) {
-    const refName = resolveRef(schemaOrRef.$ref);
-    return globalSchemas[refName];
-  }
-  return schemaOrRef;
-}
-
 function getSchemaProperties(schemaRef: string): { properties: Record<string, Schema>; required: string[] } {
   const schema = globalSchemas[schemaRef];
   if (!schema) return { properties: {}, required: [] };
@@ -1162,7 +1154,7 @@ function generateMethod(op: ParsedOperation, serviceName: string): string[] {
   const resourceName = singularize(serviceName);
 
   // Build param string and types
-  const { paramString, hasOptions, hasRequest, requestInterfaceName, optionsInterfaceName } = buildMethodSignature(op, resourceName);
+  const { paramString, hasOptions, hasRequest } = buildMethodSignature(op, resourceName);
 
   // Return type
   const returnType = buildReturnType(op, serviceName);

--- a/typescript/tests/auth-strategy.test.ts
+++ b/typescript/tests/auth-strategy.test.ts
@@ -1,7 +1,7 @@
 /**
  * AuthStrategy tests
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { http, HttpResponse } from "msw";
 import { server } from "./setup.js";
 import { BearerAuth, bearerAuth } from "../src/auth-strategy.js";


### PR DESCRIPTION
## HOLD — do not merge until the v0.13.0 tag lands (#667)

Independent of the other security-scanning PRs; can land any time after the freeze lifts.

## What

CodeQL's `js/unused-local-variable` and `rb/useless-assignment-to-local` — alerts 86, 87, 88, 89 and 115. All five are genuinely unread, so they are worth deleting rather than dismissing.

| File | Symbol | Note |
|---|---|---|
| `typescript/scripts/generate-services.ts` | `resolveSchema` | declared, never called |
| `typescript/scripts/generate-services.ts` | `requestInterfaceName`, `optionsInterfaceName` | destructured out of `buildMethodSignature`, unused in `generateMethod` |
| `typescript/tests/auth-strategy.test.ts` | `vi` import | no `vi.*` call in the file |
| `ruby/test/basecamp/oauth_device_test.rb` | `sleeper` | line 856 |

Two details worth stating:

- The two interface names are still **returned by** and **used inside** `buildMethodSignature`. Only the unused destructure at the call site goes.
- Every other `recording_sleeper` call site threads the value through as `sleeper:`. This one does not, and `recording_sleeper` is pure (it builds an array and a lambda), so the whole line goes rather than being renamed to `_sleeper`.

## Why lint didn't catch them

This turned out to differ by language, and neither is a gap in how the linters are invoked:

- **TypeScript.** The lint script is `oxlint src --ignore-pattern 'src/generated/**'` — it lints `src` only. Both `scripts/` and `tests/` sit outside the target, which accounts for all three TS findings. (Same shape as the root `scripts/` gap, and as `python/scripts/` noted in #676.)
- **Ruby.** `Lint/UselessAssignment` is `Enabled: false` in the shared `rubocop-37signals` house style. Running `rubocop --only Lint/UselessAssignment` *does* flag line 856; a default run reports no offenses.

So this is code the linters are configured not to look at, found by the layer that does — which is a small argument for the scanning layer earning its keep.

## Verification

- `tsc --noEmit` clean
- `npm run lint` clean
- `npx tsx scripts/generate-services.ts` re-run produces a **byte-identical** tree — 53 services, 247 operations, empty `git status` under `typescript/src/generated/`. This is the one that matters: the generator's output must not move.
- `auth-strategy.test.ts` — 9 tests pass
- `oauth_device_test.rb` — 82 runs, 294 assertions, 0 failures

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove five unused locals reported by CodeQL across TS scripts/tests and a Ruby test. No behavior change; generator output unchanged and all tests pass.

- **Refactors**
  - `typescript/scripts/generate-services.ts`: delete unused `resolveSchema`; stop destructuring unused `requestInterfaceName` and `optionsInterfaceName`.
  - `typescript/tests/auth-strategy.test.ts`: remove unused `vi` import.
  - `ruby/test/basecamp/oauth_device_test.rb`: remove unused `sleeper` assignment.

<sup>Written for commit 39822d600fe8e5ad0ee7c30d98a5aff0d2ee667c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

