### PR TITLE
Two maxPages guards that disagreed with their siblings

### DIFF
--- a/python/src/basecamp/config.py
+++ b/python/src/basecamp/config.py
@@ -115,7 +115,12 @@ class Config:
         # had, and Ruby already rejects via ``is_a?(Integer)``. Go, Kotlin and
         # Swift get it from the compiler. A float like 2.5 is refused for the
         # same reason: a cap has to be a number the counter can arrive at.
-        if not isinstance(self.max_pages, int) or self.max_pages <= 0:
+        # ``bool`` is excluded for the same reason as ``max_retries`` above: it
+        # is a subclass of ``int``, so ``max_pages=True`` otherwise passes and
+        # yields a cap of ``True``, which every paginator reads as 1 — silently
+        # returning the first page as the whole collection. ``False`` was
+        # already refused, but only incidentally, by being ``0``.
+        if isinstance(self.max_pages, bool) or not isinstance(self.max_pages, int) or self.max_pages <= 0:
             raise ValueError("max_pages must be a positive integer")
 
     @classmethod

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -75,6 +75,17 @@ class TestValidation:
         with pytest.raises(ValueError, match="max_pages must be a positive integer"):
             Config(max_pages=2.5)
 
+    def test_max_pages_bool_raises(self):
+        # ``bool`` is a subclass of ``int``, so a bare isinstance check accepts
+        # ``True`` and yields a cap of ``True`` -- which ``range(1, cap + 1)``
+        # and ``page < cap`` both read as 1, silently capping every paginator at
+        # a single page. ``False`` was already rejected only incidentally, by
+        # being ``0``. ``max_retries`` above excludes bool for the same reason.
+        with pytest.raises(ValueError, match="max_pages must be a positive integer"):
+            Config(max_pages=True)
+        with pytest.raises(ValueError, match="max_pages must be a positive integer"):
+            Config(max_pages=False)
+
     def test_max_pages_positive_integer_allowed(self):
         assert Config(max_pages=25).max_pages == 25
 

--- a/typescript/src/client.ts
+++ b/typescript/src/client.ts
@@ -334,9 +334,17 @@ export function createBasecampClient(options: BasecampClientOptions): BasecampCl
   // reached only later, inside `BaseService`'s `page < this.maxPages` loops, far
   // from the call that misconfigured it. Same predicate, same error, checked
   // once at construction — see assertValidMaxPages for what each rejected value
-  // does to the bound. Only when the caller supplied one: `undefined` must keep
-  // falling through to DEFAULT_MAX_PAGES.
-  if (maxPages !== undefined) {
+  // does to the bound. Only when the caller supplied one: an absent cap must
+  // keep falling through to DEFAULT_MAX_PAGES.
+  //
+  // `!= null`, matching BaseService's guard exactly. This value is not consumed
+  // here — it is handed straight to every service below, where `maxPages ??
+  // DEFAULT_MAX_PAGES` treats an explicit `null` as absent. A `!== undefined`
+  // test here made the two doors disagree on that single value: the factory
+  // threw where the equivalent direct service construction defaulted. Whichever
+  // way "not supplied" is defined, both guards have to define it the same way,
+  // because the same `??` is downstream of both.
+  if (maxPages != null) {
     assertValidMaxPages(maxPages);
   }
 

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -749,6 +749,28 @@ describe("BasecampClient", () => {
 
       expect((service as unknown as { maxPages: number }).maxPages).toBe(DEFAULT_MAX_PAGES);
     });
+
+    // Both doors have to agree on what "not supplied" means. BaseService guards
+    // `maxPages != null` so that an explicit `null` falls through to the same
+    // `?? DEFAULT_MAX_PAGES` the guard's own comment points at; the factory
+    // guarded `!== undefined`, so the two disagreed on exactly one value and
+    // `createBasecampClient({ maxPages: null })` threw where the equivalent
+    // direct construction defaulted. `null` is outside the declared type but
+    // reachable from untyped JS, which is the only place the disagreement
+    // could ever have been observed — hence the casts.
+    it("treats an explicit null maxPages as not supplied, in both doors alike", () => {
+      const raw = createBasecampClient({ accountId: "12345", accessToken: "test-token" }).raw;
+
+      const client = createBasecampClient({
+        accountId: "12345",
+        accessToken: "test-token",
+        maxPages: null as unknown as number,
+      });
+      const service = new ProjectsService(raw, undefined, undefined, null as unknown as number);
+
+      expect((client.projects as unknown as { maxPages: number }).maxPages).toBe(DEFAULT_MAX_PAGES);
+      expect((service as unknown as { maxPages: number }).maxPages).toBe(DEFAULT_MAX_PAGES);
+    });
   });
 
   describe("hooks integration", () => {


### PR DESCRIPTION
#678 validated the pagination cap at every construction path across six SDKs. Two of those guards do not say what the guard beside them says. Both were found in that PR's last review round, which merged before it was addressed, so both are on `main` now and would otherwise ship in v0.13.0.

### Python: `max_pages=True` is accepted

`bool` is a subclass of `int`, so `isinstance(self.max_pages, int)` passes for `True`. `Config(max_pages=True)` was accepted and yielded a cap of `True` — which `range(1, cap + 1)` in `_base.py` and `page < cap` in the Link-following loop both read as **1**, silently returning the first page as if it were the whole collection. `False` was refused, but only incidentally, by being `0`.

Reproduced against `origin/main` before the fix:

```
max_pages=True  -> ACCEPTED, cap=True, range(1, cap+1)=[1]
max_pages=False -> rejected: max_pages must be a positive integer
```

The `max_retries` clause four lines above already excludes bool for exactly this reason. This one just did not.

### TypeScript: the factory and the service disagreed on `null`

`client.ts` guarded `maxPages !== undefined`; `services/base.ts` guards `maxPages != null`. Both hand the value to the same `maxPages ?? DEFAULT_MAX_PAGES`, so they have to agree on what "not supplied" means — and they disagreed on exactly one value:

| call | before | after |
|---|---|---|
| `createBasecampClient({ maxPages: null })` | **throws** | defaults |
| `new ProjectsService(raw, undefined, undefined, null)` | defaults | defaults |

`null` is outside the declared type but reachable from untyped JS, which is the only place the disagreement was observable. The factory now matches the service.

**The two standalone helpers are deliberately unchanged.** `fetchAllPages` and `paginateAll` validate unconditionally, and should: their `maxPages: number = DEFAULT_MAX_PAGES` default parameter fires only on `undefined`, so `null` genuinely cannot fall through to a default there and has to be rejected. Making them `!= null` would introduce a silent default where the value cannot default.

### Red proofs

Both tests were shown to fail against the un-fixed code before the fix went in, not merely to pass after it.

- Python — `Failed: DID NOT RAISE <class 'ValueError'>` at `tests/test_config.py`, `REAL_EXIT=1`.
- TypeScript — `BasecampError: maxPages must be a positive integer no larger than 9007199254740991, got null`, thrown from `assertValidMaxPages` by way of `createBasecampClient src/client.ts:340`, `REAL_EXIT=1`.

### Local verification

| check | result |
|---|---|
| `pytest` | 1200 passed, 4 skipped |
| `ruff check` / `ruff format --check` / `mypy` | clean |
| `vitest` | 83 files, 1465 passed |
| `tsc --noEmit` / `oxlint` | clean |

Blocks the v0.13.0 tag. The third defect from the same review round is a factual error in `SPEC.md` §2 step 5 about which SDKs are recoverable; it is documentation about already-shipped behaviour and ships in the release-prep commit rather than here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two `maxPages` validation edge cases to keep pagination caps consistent across SDKs. Prevents Python from treating `True` as `1` and aligns TypeScript factory behavior with services for `null`.

- **Bug Fixes**
  - Python: Exclude `bool` from `max_pages` validation. `Config(max_pages=True|False)` now raises.
  - TypeScript: Change `createBasecampClient` guard to `maxPages != null` to match services. `null` now defaults via `maxPages ?? DEFAULT_MAX_PAGES`.
  - Tests: Added coverage for both cases.

<sup>Written for commit 6b8aef7d85ffc9e5ce6318c8dc8d3fe70e94f02c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

