### PR TITLE
Handle bc3's own authorization document, not just Launchpad's

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -2018,11 +2018,14 @@ Two behavioural changes ride along, neither of which the compiler will flag:
   A BC5 document carries no `product` on any account, so
   `getInfo({ filterProduct: "bc3" })` matched nothing and returned `[]` — while
   the accounts it was meant to filter existed and were what you needed the
-  `href` from. When *no* account in the document carries a `product`, the filter
-  is now reported inapplicable: every account is returned and the new
-  `AuthorizationInfo.productFilterApplied` is `false`. When at least one account
-  does carry a `product` the filter applies exactly as before, so an empty
-  result still means "nothing matched".
+  `href` from. When the document carries at least one account and *none* of them
+  carries a `product`, the filter is now reported inapplicable: every account is
+  returned and the new `AuthorizationInfo.productFilterApplied` is `false`. When
+  at least one account does carry a `product` the filter applies exactly as
+  before, so an empty result still means "nothing matched". An **empty** account
+  list — what Launchpad returns for an identity with no currently accessible
+  accounts — reports `applied: true`: the list is empty either way, and an empty
+  list is no evidence that the issuer omits `product`.
 
 Go gets the same `filterProduct` correction and the same two additive fields
 (`AuthorizedAccount.Resource`, `AuthorizationInfo.Scope`, plus

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -29,7 +29,7 @@ it passes your tests and fails in production.
 |---|---:|---:|---:|
 | [Go](#go) | 33 | **12** | **4** |
 | [Swift](#swift) | 22 | **10** | 0 |
-| [TypeScript](#typescript) | 18 | 9 | 0 |
+| [TypeScript](#typescript) | 19 | 9 | 0 |
 | [Python](#python) | 16 | 8 | 0 |
 | [Ruby](#ruby) | 20 | 10 | 1 |
 | [Kotlin](#kotlin) | 17 | 6 | 1 |
@@ -48,6 +48,13 @@ earlier in this same release with #628, so from a v0.12.0 consumer's position
 there is no member that changed from optional to required; there are two new
 members that happen to be required from the start. It reshapes the #628 break
 rather than adding one, and that is where this guide documents it.
+
+#PLACEHOLDER **does** add one, and it is the only row in the table above measured
+past `70d576bd8`: it takes TypeScript from 18 breaking changes to 19. It adds
+nothing to either "no signal" column — it is four required-to-optional field
+relaxations, which `tsc` catches under `strictNullChecks` — so the 61/55/6 totals
+below are unmoved. See
+[Four `Identity` and `AuthorizedAccount` fields became optional](#four-identity-and-authorizedaccount-fields-became-optional-placeholder).
 
 Every claim below was read out of `git diff v0.12.0..main`, not out of a PR
 body.
@@ -1966,6 +1973,63 @@ survive because a sibling verb still lives there, so
 `paths["/todos/{todoId}"]["delete"]` resolves to `never | undefined` and compiles
 clean. Grep for those five names rather than trusting tsc. The 422 re-tags are
 exactly `UpdateMyNote` and `UpdateMyPreferences`.
+
+### Four `Identity` and `AuthorizedAccount` fields became optional (#PLACEHOLDER)
+
+`Identity.firstName`, `.lastName`, `.emailAddress` and `AuthorizedAccount.product`
+went from required `string` to `string | undefined`; `AuthorizedAccount.appHref`
+went from required `string` to optional. Under `strictNullChecks`, anything
+assigning one to a `string` or calling a method on it is now a compile error:
+
+```ts
+// v0.12.0 — compiled
+const email: string = info.identity.emailAddress;
+const initial = info.identity.firstName.charAt(0);
+
+// main — TS2322 / TS18048 ("possibly undefined")
+const email: string = info.identity.emailAddress ?? "";
+const initial = info.identity.firstName?.charAt(0) ?? "";
+```
+
+This is a **correction, not a restriction.** Those fields are Launchpad's. bc3
+serves its own `GET /authorization.json` from a different template, and it emits
+`identity.id` and nothing else of the identity, and no `product` or `app_href` on
+accounts. You reach that document by passing `endpoint:` to
+`authorization.getInfo()` — the documented way to point at a BC5 issuer — and at
+v0.12.0 the four fields were typed `string` and arrived `undefined`. The type was
+lying; it now describes both issuers.
+
+`AuthorizedAccount.resource` (the RFC 8707 indicator, BC5 only) and a top-level
+`AuthorizationInfo.scope` are new and optional, so they break nothing.
+
+The same change lands on `discoverIdentity()`, which returns the same
+`AuthorizationInfo`. It had already drifted from `AuthorizationService`'s copy of
+this mapping — `app_href` was optional in one and required in the other — and
+both now share one parser in `oauth/authorization-document.ts`.
+
+Two behavioural changes ride along, neither of which the compiler will flag:
+
+- **`expires_at` is read as epoch seconds when it arrives as a number.** bc3
+  renders `@token.expires_at.to_i`. v0.12.0 passed that integer straight to
+  `new Date()`, which reads it as *milliseconds* — so a token expiring in 2036
+  parsed as a date in **1970**, and every "is my token still valid" check said
+  no. A string is still parsed as ISO-8601, unchanged.
+- **`filterProduct` no longer empties the list when the filter cannot apply.**
+  A BC5 document carries no `product` on any account, so
+  `getInfo({ filterProduct: "bc3" })` matched nothing and returned `[]` — while
+  the accounts it was meant to filter existed and were what you needed the
+  `href` from. When *no* account in the document carries a `product`, the filter
+  is now reported inapplicable: every account is returned and the new
+  `AuthorizationInfo.productFilterApplied` is `false`. When at least one account
+  does carry a `product` the filter applies exactly as before, so an empty
+  result still means "nothing matched".
+
+Go gets the same `filterProduct` correction and the same two additive fields
+(`AuthorizedAccount.Resource`, `AuthorizationInfo.Scope`, plus
+`ProductFilterApplied`); its timestamp already decoded both spellings via
+`FlexTime`. Nothing there is a compile break — Go's fields were already
+zero-valued rather than required. Ruby and Python return the raw document
+unchanged. See `spec/api-gaps/bc5-authorization-document-shape.md`.
 
 ## Behavioural
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -49,12 +49,12 @@ there is no member that changed from optional to required; there are two new
 members that happen to be required from the start. It reshapes the #628 break
 rather than adding one, and that is where this guide documents it.
 
-#PLACEHOLDER **does** add one, and it is the only row in the table above measured
+#681 **does** add one, and it is the only row in the table above measured
 past `70d576bd8`: it takes TypeScript from 18 breaking changes to 19. It adds
 nothing to either "no signal" column — it is four required-to-optional field
 relaxations, which `tsc` catches under `strictNullChecks` — so the 61/55/6 totals
 below are unmoved. See
-[Four `Identity` and `AuthorizedAccount` fields became optional](#four-identity-and-authorizedaccount-fields-became-optional-placeholder).
+[Four `Identity` and `AuthorizedAccount` fields became optional](#four-identity-and-authorizedaccount-fields-became-optional-681).
 
 Every claim below was read out of `git diff v0.12.0..main`, not out of a PR
 body.
@@ -1974,7 +1974,7 @@ survive because a sibling verb still lives there, so
 clean. Grep for those five names rather than trusting tsc. The 422 re-tags are
 exactly `UpdateMyNote` and `UpdateMyPreferences`.
 
-### Four `Identity` and `AuthorizedAccount` fields became optional (#PLACEHOLDER)
+### Four `Identity` and `AuthorizedAccount` fields became optional (#681)
 
 `Identity.firstName`, `.lastName`, `.emailAddress` and `AuthorizedAccount.product`
 went from required `string` to `string | undefined`; `AuthorizedAccount.appHref`

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -49,11 +49,11 @@ there is no member that changed from optional to required; there are two new
 members that happen to be required from the start. It reshapes the #628 break
 rather than adding one, and that is where this guide documents it.
 
-#681 **does** add one, and it is the only row in the table above measured
-past `70d576bd8`: it takes TypeScript from 18 breaking changes to 19. It adds
-nothing to either "no signal" column — it is five required-to-optional field
-relaxations, which `tsc` catches under `strictNullChecks` — so the 61/55/6 totals
-below are unmoved. See
+#681 **does** add one, and it is the only row in the table above measured past
+the baseline this document states: it takes TypeScript from 18 breaking changes
+to 19. It adds nothing to either "no signal" column — it is five
+required-to-optional field relaxations, which `tsc` catches under
+`strictNullChecks` — so the 61/55/6 totals below are unmoved. See
 [Five `Identity` and `AuthorizedAccount` fields became optional](#five-identity-and-authorizedaccount-fields-became-optional-681).
 
 Every claim below was read out of `git diff v0.12.0..main`, not out of a PR

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -51,10 +51,10 @@ rather than adding one, and that is where this guide documents it.
 
 #681 **does** add one, and it is the only row in the table above measured
 past `70d576bd8`: it takes TypeScript from 18 breaking changes to 19. It adds
-nothing to either "no signal" column — it is four required-to-optional field
+nothing to either "no signal" column — it is five required-to-optional field
 relaxations, which `tsc` catches under `strictNullChecks` — so the 61/55/6 totals
 below are unmoved. See
-[Four `Identity` and `AuthorizedAccount` fields became optional](#four-identity-and-authorizedaccount-fields-became-optional-681).
+[Five `Identity` and `AuthorizedAccount` fields became optional](#five-identity-and-authorizedaccount-fields-became-optional-681).
 
 Every claim below was read out of `git diff v0.12.0..main`, not out of a PR
 body.
@@ -1974,12 +1974,12 @@ survive because a sibling verb still lives there, so
 clean. Grep for those five names rather than trusting tsc. The 422 re-tags are
 exactly `UpdateMyNote` and `UpdateMyPreferences`.
 
-### Four `Identity` and `AuthorizedAccount` fields became optional (#681)
+### Five `Identity` and `AuthorizedAccount` fields became optional (#681)
 
-`Identity.firstName`, `.lastName`, `.emailAddress` and `AuthorizedAccount.product`
-went from required `string` to `string | undefined`; `AuthorizedAccount.appHref`
-went from required `string` to optional. Under `strictNullChecks`, anything
-assigning one to a `string` or calling a method on it is now a compile error:
+Five fields went from required `string` to optional:
+`Identity.firstName`, `.lastName`, `.emailAddress`, `AuthorizedAccount.product`
+and `AuthorizedAccount.appHref`. Under `strictNullChecks`, anything assigning one
+to a `string` or calling a method on it is now a compile error:
 
 ```ts
 // v0.12.0 — compiled
@@ -1996,8 +1996,14 @@ serves its own `GET /authorization.json` from a different template, and it emits
 `identity.id` and nothing else of the identity, and no `product` or `app_href` on
 accounts. You reach that document by passing `endpoint:` to
 `authorization.getInfo()` — the documented way to point at a BC5 issuer — and at
-v0.12.0 the four fields were typed `string` and arrived `undefined`. The type was
+v0.12.0 all five were typed `string` and arrived `undefined`. The type was
 lying; it now describes both issuers.
+
+`appHref` is the one to grep for rather than reason about. `discoverIdentity()`
+coerced a missing `app_href` to `""` while `AuthorizationService` typed it
+required — so at v0.12.0 the same field was already reaching consumers as an
+empty string from one call site and as `undefined` from the other, and only the
+latter was a type error waiting to happen. It is now honestly optional on both.
 
 `AuthorizedAccount.resource` (the RFC 8707 indicator, BC5 only) and a top-level
 `AuthorizationInfo.scope` are new and optional, so they break nothing.

--- a/go/pkg/basecamp/authorization.go
+++ b/go/pkg/basecamp/authorization.go
@@ -86,9 +86,10 @@ type AuthorizationInfo struct {
 
 	// ProductFilterApplied reports whether a requested GetInfoOptions.FilterProduct
 	// was actually applied. It is meaningful only when FilterProduct was set: false
-	// then means the document carried no product on any account — a BC5 document —
-	// so the filter was inapplicable and Accounts is unfiltered rather than empty.
-	// Not a wire field.
+	// then means the document carried at least one account and no product on any of
+	// them — a BC5 document — so the filter was inapplicable and Accounts is
+	// unfiltered rather than empty. An empty account list reports true: it is no
+	// evidence about the issuer either way. Not a wire field.
 	ProductFilterApplied bool `json:"-"`
 }
 
@@ -189,8 +190,15 @@ func (s *AuthorizationService) GetInfo(ctx context.Context, opts *GetInfoOptions
 	// list the caller is about to pick an HREF out of, which is silently wrong
 	// rather than merely unhelpful. Report the filter inapplicable instead, and
 	// leave the accounts alone.
+	//
+	// An EMPTY account list is filterable, not inapplicable. "No account carries a
+	// product" is vacuously true of an empty slice, but Launchpad returns an empty
+	// list for an identity with no currently accessible accounts, and that document
+	// filters fine. The returned list is empty either way; what would differ is the
+	// claim — reporting the filter inapplicable asserts "this issuer cannot filter
+	// by product" on no evidence.
 	if opts != nil && opts.FilterProduct != "" {
-		filterable := false
+		filterable := len(info.Accounts) == 0
 		for _, acct := range info.Accounts {
 			if acct.Product != "" {
 				filterable = true

--- a/go/pkg/basecamp/authorization.go
+++ b/go/pkg/basecamp/authorization.go
@@ -44,6 +44,10 @@ func (ft *FlexTime) UnmarshalJSON(data []byte) error {
 }
 
 // Identity represents the authenticated user's identity from the authorization endpoint.
+//
+// Only ID is emitted by both issuers. A BC5 issuer's own document carries nothing
+// but the identity id — it drops the PII the API docs already say not to use for
+// identifying users — so FirstName, LastName and EmailAddress are "" there.
 type Identity struct {
 	ID           int64  `json:"id"`
 	FirstName    string `json:"first_name"`
@@ -52,12 +56,19 @@ type Identity struct {
 }
 
 // AuthorizedAccount represents a Basecamp account the user has access to.
+//
+// Product and AppHREF are Launchpad's and are "" against a BC5 issuer; Resource
+// is a BC5 issuer's and is "" against Launchpad.
 type AuthorizedAccount struct {
-	ID       int64  `json:"id"`
-	Name     string `json:"name"`
-	Product  string `json:"product"`
-	HREF     string `json:"href"`
-	AppHREF  string `json:"app_href"`
+	ID      int64  `json:"id"`
+	Name    string `json:"name"`
+	Product string `json:"product"`
+	HREF    string `json:"href"`
+	AppHREF string `json:"app_href"`
+	// Resource is the RFC 8707 resource indicator for this account
+	// (urn:bc:account:<id>), emitted by BC5 issuers only. Pass it as the
+	// "resource" parameter when requesting a token scoped to this account.
+	Resource string `json:"resource,omitempty"`
 	Hidden   bool   `json:"hidden,omitempty"`
 	Expired  bool   `json:"expired,omitempty"`
 	Featured bool   `json:"featured,omitempty"`
@@ -68,6 +79,17 @@ type AuthorizationInfo struct {
 	ExpiresAt FlexTime            `json:"expires_at"`
 	Identity  Identity            `json:"identity"`
 	Accounts  []AuthorizedAccount `json:"accounts"`
+	// Scope is the token's granted scope. BC5 issuers only, and only for
+	// BC3-issued tokens — legacy Signal tokens predate scopes, so an empty
+	// Scope is not an error.
+	Scope string `json:"scope,omitempty"`
+
+	// ProductFilterApplied reports whether a requested GetInfoOptions.FilterProduct
+	// was actually applied. It is meaningful only when FilterProduct was set: false
+	// then means the document carried no product on any account — a BC5 document —
+	// so the filter was inapplicable and Accounts is unfiltered rather than empty.
+	// Not a wire field.
+	ProductFilterApplied bool `json:"-"`
 }
 
 // GetInfoOptions specifies options for fetching authorization info.
@@ -79,6 +101,11 @@ type GetInfoOptions struct {
 	// FilterProduct filters accounts to only those matching this product.
 	// Common values: "bc3" (Basecamp), "bcx" (Basecamp 2), "hey" (HEY).
 	// If empty, all accounts are returned.
+	//
+	// A BC5 issuer's document carries no product on any account, so the filter
+	// cannot apply there. In that case all accounts are returned and
+	// AuthorizationInfo.ProductFilterApplied is false, rather than the empty
+	// list a literal filter would produce.
 	FilterProduct string
 }
 
@@ -157,15 +184,29 @@ func (s *AuthorizationService) GetInfo(ctx context.Context, opts *GetInfoOptions
 		return nil, fmt.Errorf("parsing authorization response: %w", err)
 	}
 
-	// Filter accounts by product if requested
+	// Filter accounts by product if requested. A document whose accounts carry no
+	// product at all cannot be filtered by product: matching nothing would empty a
+	// list the caller is about to pick an HREF out of, which is silently wrong
+	// rather than merely unhelpful. Report the filter inapplicable instead, and
+	// leave the accounts alone.
 	if opts != nil && opts.FilterProduct != "" {
-		filtered := make([]AuthorizedAccount, 0, len(info.Accounts))
+		filterable := false
 		for _, acct := range info.Accounts {
-			if acct.Product == opts.FilterProduct {
-				filtered = append(filtered, acct)
+			if acct.Product != "" {
+				filterable = true
+				break
 			}
 		}
-		info.Accounts = filtered
+		info.ProductFilterApplied = filterable
+		if filterable {
+			filtered := make([]AuthorizedAccount, 0, len(info.Accounts))
+			for _, acct := range info.Accounts {
+				if acct.Product == opts.FilterProduct {
+					filtered = append(filtered, acct)
+				}
+			}
+			info.Accounts = filtered
+		}
 	}
 
 	return &info, nil

--- a/go/pkg/basecamp/authorization_test.go
+++ b/go/pkg/basecamp/authorization_test.go
@@ -214,6 +214,39 @@ func TestAuthorizationService_GetInfo_ProductFilterAppliedWhenFilterable(t *test
 	}
 }
 
+// Launchpad returns an empty account list for an identity with no currently
+// accessible accounts. "No account carries a product" is vacuously true there,
+// but the document is perfectly filterable — reporting the filter inapplicable
+// would assert "this issuer cannot filter by product" on no evidence at all.
+func TestAuthorizationService_GetInfo_EmptyAccountListIsFilterable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"identity": map[string]any{"id": 123},
+			"accounts": []map[string]any{},
+		})
+	}))
+	defer server.Close()
+
+	client := newBC5AuthorizationClient(t, server)
+
+	info, err := client.Authorization().GetInfo(t.Context(), &GetInfoOptions{
+		Endpoint:      server.URL + "/authorization.json",
+		FilterProduct: "bc3",
+	})
+	if err != nil {
+		t.Fatalf("GetInfo() unexpected error: %v", err)
+	}
+
+	if len(info.Accounts) != 0 {
+		t.Errorf("GetInfo() returned %d accounts, want 0", len(info.Accounts))
+	}
+	if !info.ProductFilterApplied {
+		t.Error("GetInfo() reported ProductFilterApplied = false on an empty list, want true — " +
+			"an empty list is no evidence that the issuer omits product")
+	}
+}
+
 // The rest of the BC5 shape: the resource indicator, the scope, the epoch-seconds
 // timestamp Go's FlexTime already handled, and the Launchpad-only fields that
 // degrade to "" rather than erroring.

--- a/go/pkg/basecamp/authorization_test.go
+++ b/go/pkg/basecamp/authorization_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestAuthorizationService_GetInfo(t *testing.T) {
@@ -114,6 +115,139 @@ func TestAuthorizationService_GetInfo(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// bc5AuthorizationDocument is what a BC5 (bc3) issuer serves from
+// app/views/api/authorizations/show.json.jbuilder: identity id only, no product
+// or app_href on accounts, an RFC 8707 resource indicator instead, a top-level
+// scope, and expires_at as integer epoch seconds.
+//
+// Go reaches this document exactly the way TypeScript does — by passing an
+// Endpoint override, which is the documented way to point at a BC5 issuer.
+func bc5AuthorizationDocument() map[string]any {
+	return map[string]any{
+		"identity": map[string]any{"id": 123},
+		"accounts": []map[string]any{
+			{"id": 1, "name": "Acme Corp", "href": "https://bc5.example.com/1", "resource": "urn:bc:account:1"},
+			{"id": 2, "name": "Second Account", "href": "https://bc5.example.com/2", "resource": "urn:bc:account:2"},
+		},
+		"scope": "read write",
+		// 2036-01-29T09:55:56Z as epoch seconds.
+		"expires_at": 2085213356,
+	}
+}
+
+func newBC5AuthorizationServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(bc5AuthorizationDocument())
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func newBC5AuthorizationClient(t *testing.T, server *httptest.Server) *Client {
+	t.Helper()
+	cfg := DefaultConfig()
+	cfg.BaseURL = server.URL
+	return NewClient(cfg, &StaticTokenProvider{Token: "test-token"}, WithHTTPClient(server.Client()))
+}
+
+// A BC5 document carries no product on any account. Filtering it by product
+// matches nothing, so a literal filter empties a list the caller is about to pick
+// an HREF out of. Report the filter inapplicable and return the accounts instead.
+func TestAuthorizationService_GetInfo_ProductFilterInapplicableOnBC5Document(t *testing.T) {
+	server := newBC5AuthorizationServer(t)
+	client := newBC5AuthorizationClient(t, server)
+
+	info, err := client.Authorization().GetInfo(t.Context(), &GetInfoOptions{
+		Endpoint:      server.URL + "/authorization.json",
+		FilterProduct: "bc3",
+	})
+	if err != nil {
+		t.Fatalf("GetInfo() unexpected error: %v", err)
+	}
+
+	if len(info.Accounts) != 2 {
+		t.Errorf("GetInfo() returned %d accounts, want 2 — the filter is inapplicable, not unmatched", len(info.Accounts))
+	}
+	if info.ProductFilterApplied {
+		t.Error("GetInfo() reported ProductFilterApplied = true, want false on a document with no product")
+	}
+	if info.Accounts[0].HREF != "https://bc5.example.com/1" {
+		t.Errorf("GetInfo() account HREF = %q, want https://bc5.example.com/1", info.Accounts[0].HREF)
+	}
+}
+
+// The converse: a Launchpad document is filterable, so a filter that matches
+// nothing genuinely means nothing matched, and must still return empty.
+func TestAuthorizationService_GetInfo_ProductFilterAppliedWhenFilterable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"identity": map[string]any{"id": 123},
+			"accounts": []map[string]any{
+				{"id": 1, "name": "Basecamp Account", "product": "bc3"},
+				{"id": 2, "name": "HEY Account", "product": "hey"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := newBC5AuthorizationClient(t, server)
+
+	info, err := client.Authorization().GetInfo(t.Context(), &GetInfoOptions{
+		Endpoint:      server.URL + "/authorization.json",
+		FilterProduct: "nope",
+	})
+	if err != nil {
+		t.Fatalf("GetInfo() unexpected error: %v", err)
+	}
+
+	if len(info.Accounts) != 0 {
+		t.Errorf("GetInfo() returned %d accounts, want 0 — the filter applies and matched nothing", len(info.Accounts))
+	}
+	if !info.ProductFilterApplied {
+		t.Error("GetInfo() reported ProductFilterApplied = false, want true on a document carrying products")
+	}
+}
+
+// The rest of the BC5 shape: the resource indicator, the scope, the epoch-seconds
+// timestamp Go's FlexTime already handled, and the Launchpad-only fields that
+// degrade to "" rather than erroring.
+func TestAuthorizationService_GetInfo_BC5DocumentShape(t *testing.T) {
+	server := newBC5AuthorizationServer(t)
+	client := newBC5AuthorizationClient(t, server)
+
+	info, err := client.Authorization().GetInfo(t.Context(), &GetInfoOptions{
+		Endpoint: server.URL + "/authorization.json",
+	})
+	if err != nil {
+		t.Fatalf("GetInfo() unexpected error: %v", err)
+	}
+
+	if got := info.Accounts[0].Resource; got != "urn:bc:account:1" {
+		t.Errorf("Resource = %q, want urn:bc:account:1", got)
+	}
+	if info.Scope != "read write" {
+		t.Errorf("Scope = %q, want %q", info.Scope, "read write")
+	}
+	if got := info.ExpiresAt.UTC().Format(time.RFC3339); got != "2036-01-29T09:55:56Z" {
+		t.Errorf("ExpiresAt = %s, want 2036-01-29T09:55:56Z", got)
+	}
+	if info.Identity.EmailAddress != "" {
+		t.Errorf("Identity.EmailAddress = %q, want \"\" — a BC5 document omits it", info.Identity.EmailAddress)
+	}
+	if info.Accounts[0].Product != "" || info.Accounts[0].AppHREF != "" {
+		t.Errorf("Product/AppHREF = %q/%q, want empty — Launchpad-only fields",
+			info.Accounts[0].Product, info.Accounts[0].AppHREF)
+	}
+	// ProductFilterApplied is only meaningful when a filter was requested; with
+	// no filter it stays at its zero value.
+	if info.ProductFilterApplied {
+		t.Error("ProductFilterApplied = true with no filter requested, want false")
 	}
 }
 

--- a/ruby/lib/basecamp/services/authorization_service.rb
+++ b/ruby/lib/basecamp/services/authorization_service.rb
@@ -5,11 +5,20 @@ module Basecamp
     # Service for authorization operations.
     # This is the only service that doesn't require an account context.
     #
+    # The document's shape depends on which issuer served it. Discovery selects a
+    # BC5 issuer whenever one is advertised, and a BC5 issuer serves its *own*
+    # document (+app/views/api/authorizations/show.json.jbuilder+), which is not
+    # Launchpad's: it carries +identity.id+ and nothing else of the identity, no
+    # +product+ or +app_href+ on accounts, an RFC 8707 +resource+ indicator
+    # instead, a top-level +scope+ for BC3-issued tokens, and +expires_at+ as
+    # integer epoch seconds rather than ISO-8601. Only +identity.id+,
+    # +accounts[].id+, +accounts[].name+ and +accounts[].href+ are common to both.
+    #
     # @example Get authorization info
     #   auth = client.authorization.get
-    #   puts "Identity: #{auth["identity"]["email_address"]}"
+    #   puts "Identity: #{auth["identity"]["id"]}"
     #   auth["accounts"].each do |account|
-    #     puts "Account: #{account["name"]} (#{account["id"]})"
+    #     puts "Account: #{account["name"]} (#{account["href"]})"
     #   end
     class AuthorizationService < BaseService
       # Gets authorization information for the current user.

--- a/ruby/test/basecamp/services/authorization_service_test.rb
+++ b/ruby/test/basecamp/services/authorization_service_test.rb
@@ -38,17 +38,22 @@ class AuthorizationServiceTest < Minitest::Test
 
   # --- Happy path: a discovered (same-origin) issuer is used -----------------
 
+  # A discovered issuer serves ITS OWN document, so these two tests are fed
+  # sample_bc5_authorization, not Launchpad's body. A test that proves the SDK
+  # reached bc3's issuer while feeding it Launchpad's payload would pass even if
+  # the SDK could not read a BC5 document at all.
+
   def test_get_authorization_uses_discovered_issuer
     # Resource metadata advertises exactly one non-Launchpad issuer (here the API
     # host itself, so the authorization.json fetch stays same-origin), and its AS
     # metadata binds by code-point.
     stub_resource_metadata(authorization_servers: [ BASE_URL, LAUNCHPAD_URL ])
     stub_as_metadata(BASE_URL)
-    stub_get("/authorization.json", response_body: sample_authorization)
+    stub_get("/authorization.json", response_body: sample_bc5_authorization)
 
     auth = @client.authorization.get
 
-    assert_equal "Test", auth["identity"]["first_name"]
+    assert_equal 1, auth["identity"]["id"]
     assert_not_requested :get, "#{LAUNCHPAD_URL}/authorization.json"
   end
 
@@ -59,14 +64,38 @@ class AuthorizationServiceTest < Minitest::Test
     stub_resource_metadata(authorization_servers: [ BC5_ISSUER, LAUNCHPAD_URL ])
     stub_as_metadata(BC5_ISSUER)
     bc5_auth = stub_request(:get, "#{BC5_ISSUER}/authorization.json")
-      .to_return(status: 200, body: sample_authorization.to_json,
+      .to_return(status: 200, body: sample_bc5_authorization.to_json,
         headers: { "Content-Type" => "application/json" })
 
     auth = @client.authorization.get
 
-    assert_equal "test@example.com", auth["identity"]["email_address"]
+    assert_equal 1, auth["identity"]["id"]
     assert_requested(bc5_auth)
     assert_not_requested :get, "#{LAUNCHPAD_URL}/authorization.json"
+  end
+
+  # The BC5 document survives the round trip intact — including the three fields
+  # Launchpad never sends and the epoch-seconds expires_at. Ruby returns the
+  # parsed Hash verbatim, so what this really pins is that nothing in the fetch
+  # path reshapes, coerces, or drops a field it does not recognise.
+  def test_get_authorization_returns_bc5_document_fields_verbatim
+    stub_resource_metadata(authorization_servers: [ BC5_ISSUER, LAUNCHPAD_URL ])
+    stub_as_metadata(BC5_ISSUER)
+    stub_request(:get, "#{BC5_ISSUER}/authorization.json")
+      .to_return(status: 200, body: sample_bc5_authorization.to_json,
+        headers: { "Content-Type" => "application/json" })
+
+    auth = @client.authorization.get
+
+    assert_equal "urn:bc:account:12345", auth["accounts"].first["resource"]
+    assert_equal "read write", auth["scope"]
+    assert_equal 2_085_213_356, auth["expires_at"]
+    # Launchpad-only fields are absent, not empty — a consumer reading
+    # identity.email_address here gets nil, which is what the service's own
+    # @example used to show.
+    assert_nil auth["identity"]["email_address"]
+    assert_nil auth["accounts"].first["product"]
+    assert_nil auth["accounts"].first["app_href"]
   end
 
   # --- Hard failures after BC5 advertisement raise, never hit Launchpad ------

--- a/ruby/test/test_helper.rb
+++ b/ruby/test/test_helper.rb
@@ -222,7 +222,10 @@ module TestHelpers
     }
   end
 
-  # Sample authorization data
+  # Sample authorization data as *Launchpad* serves it.
+  #
+  # Use this only for tests whose issuer is Launchpad. A BC5 issuer serves a
+  # different document; see {#sample_bc5_authorization}.
   def sample_authorization
     {
       "expires_at" => "2025-01-01T00:00:00Z",
@@ -240,6 +243,31 @@ module TestHelpers
           "href" => "https://3.basecampapi.com/12345"
         }
       ]
+    }
+  end
+
+  # Sample authorization data as a *BC5* issuer serves it, per bc3's
+  # app/views/api/authorizations/show.json.jbuilder.
+  #
+  # Feeding Launchpad's body to a test that proves discovery reached a BC5 issuer
+  # makes the test agree with itself and with nothing else: it would pass just as
+  # well if the SDK could not read a BC5 document at all. The differences are the
+  # point — identity id only, no product or app_href, an RFC 8707 resource
+  # indicator, a top-level scope, and expires_at as integer epoch seconds.
+  def sample_bc5_authorization
+    {
+      "identity" => { "id" => 1 },
+      "accounts" => [
+        {
+          "id" => 12_345,
+          "name" => "Test Account",
+          "href" => "https://bc5.example.test/12345",
+          "resource" => "urn:bc:account:12345"
+        }
+      ],
+      "scope" => "read write",
+      # 2036-01-29T09:55:56Z as epoch seconds.
+      "expires_at" => 2_085_213_356
     }
   end
 end

--- a/spec/api-gaps/bc5-authorization-document-shape.md
+++ b/spec/api-gaps/bc5-authorization-document-shape.md
@@ -75,8 +75,14 @@ Blast radius differs per SDK, and the untyped ones are the lucky ones:
   point at a BC5 issuer.
 - **Go** already tolerates the timestamp: `FlexTime.UnmarshalJSON`
   (`go/pkg/basecamp/authorization.go:25-43`) tries integer Unix first, then
-  RFC 3339. Its string fields degrade to `""`. Its endpoint is Launchpad-only
-  today.
+  RFC 3339. Its string fields degrade to `""`.
+
+  > **Correction.** This brief originally said Go's "endpoint is Launchpad-only
+  > today". That was wrong. `GetInfoOptions.Endpoint` overrides it exactly as
+  > TypeScript's `endpoint:` option does, so Go reaches bc3's document by the
+  > same documented route — and `FilterProduct` therefore had the same
+  > empty-list defect TypeScript did, which the "Go already tolerates it"
+  > reading hid. Both are fixed together; see below.
 - **Python** returns a raw `dict` from a hardcoded `LAUNCHPAD_AUTHORIZATION_URL`,
   so it neither reaches the document nor mistypes it.
 - **Kotlin and Swift** have no authorization-document service at all.
@@ -156,3 +162,61 @@ the kind of `FlexTime` special-casing Go already needed.
 - Consider whether Kotlin and Swift should gain an authorization-document
   surface; they have discovery but no way to read the document discovery points
   them at.
+
+## What shipped (#PLACEHOLDER)
+
+The SDK half of this brief is closed. `status` stays `partial-coverage` because
+the other half is bc3's and has not moved: bc3 still does not document its own
+authorization document, so `doc/api/sections/authentication.md` describes only
+Launchpad's payload and the two shapes are still undeclared. Nothing here is
+generated — OAuth is outside the OpenAPI spec by design — so there are no
+`smithy_refs` to point at and `absorbed-in-sdk` would fail
+`scripts/validate-api-gaps.rb` for exactly that reason.
+
+**TypeScript** — the two duplicated mappings became one shared parser,
+`typescript/src/oauth/authorization-document.ts`, imported by both
+`services/authorization.ts` and `oauth/identity.ts`. It is a leaf module: it
+imports nothing from the SDK, so `identity.ts` taking a *value* dependency on it
+adds no runtime edge to the known `base.ts`/`client.ts` cycle. In it:
+
+- `expires_at` branches on `typeof`. A number is epoch **seconds**
+  (`new Date(n * 1000)`); v0.12.0's `new Date(n)` read it as milliseconds and
+  produced a 1970 date. `0` — bc3's `.to_i` rendering of a nil expiry, never
+  `null` — parses to an Invalid Date rather than to 1970.
+- `Identity.firstName`/`lastName`/`emailAddress` and
+  `AuthorizedAccount.product`/`appHref` are optional; `resource` and a
+  top-level `scope` are new. This is a **breaking type change** and has a
+  `MIGRATING.md` entry.
+- `filterProduct` takes the third of the brief's three options: when *no*
+  account carries a `product`, the filter is inapplicable, all accounts are
+  returned, and `AuthorizationInfo.productFilterApplied` is `false`. When at
+  least one does, the filter applies unchanged, so an empty result still means
+  "nothing matched" — the two situations stay distinguishable, which returning
+  `[]` for both did not allow.
+
+**Go** — `AuthorizedAccount.Resource` and `AuthorizationInfo.Scope` added
+(`,omitempty`), plus the same `FilterProduct` correction and
+`ProductFilterApplied`. `ExpiresAt` is deliberately untouched: **issue #662**
+owns pointerizing it (it currently fabricates `0001-01-01T00:00:00Z`) and
+widening the `isValueTime` guard, and `FlexTime` already decodes both spellings,
+so the brief's Go timestamp ask was met before this. Doing it here would collide
+with a breaking change #662 should make on its own terms.
+
+**Ruby** — `AuthorizationService#get`'s `@example` no longer reads
+`identity.email_address`, which is `nil` against bc3. The sharper fix is in the
+tests: `test_helper.rb`'s `sample_authorization` is Launchpad-shaped and the
+BC5-issuer tests were being served it, so *the tests proving the SDK reaches
+bc3's issuer were feeding it Launchpad's body* and would have passed even if the
+SDK could not read a BC5 document. A `sample_bc5_authorization` helper now backs
+those, plus one test pinning the three BC5-only fields through the round trip.
+
+**Python, Kotlin, Swift — considered, no change.** Recorded here so the next
+reader does not re-derive it. Python returns a raw `dict` from a hardcoded
+`LAUNCHPAD_AUTHORIZATION_URL`: it neither reaches bc3's document nor types it, so
+there is nothing to relax and no reachable defect. Kotlin and Swift have no
+authorization-document surface at all — the last bullet above, giving them one,
+is still open and is a feature, not a fix.
+
+Both fixtures asked for by the absorption plan exist: the pre-existing
+Launchpad-shaped ones and new BC5-shaped ones in all three SDKs that have a
+typed or tested surface, each asserting the epoch-seconds `expires_at`.

--- a/spec/api-gaps/bc5-authorization-document-shape.md
+++ b/spec/api-gaps/bc5-authorization-document-shape.md
@@ -187,12 +187,16 @@ adds no runtime edge to the known `base.ts`/`client.ts` cycle. In it:
   `AuthorizedAccount.product`/`appHref` are optional; `resource` and a
   top-level `scope` are new. This is a **breaking type change** and has a
   `MIGRATING.md` entry.
-- `filterProduct` takes the third of the brief's three options: when *no*
-  account carries a `product`, the filter is inapplicable, all accounts are
-  returned, and `AuthorizationInfo.productFilterApplied` is `false`. When at
-  least one does, the filter applies unchanged, so an empty result still means
-  "nothing matched" — the two situations stay distinguishable, which returning
-  `[]` for both did not allow.
+- `filterProduct` takes the third of the brief's three options: when the
+  document carries at least one account and *none* of them carries a `product`,
+  the filter is inapplicable, all accounts are returned, and
+  `AuthorizationInfo.productFilterApplied` is `false`. When at least one does,
+  the filter applies unchanged, so an empty result still means "nothing
+  matched" — the two situations stay distinguishable, which returning `[]` for
+  both did not allow. An **empty** account list reports `applied: true`:
+  Launchpad returns one for an identity with no currently accessible accounts,
+  the result is empty either way, and `false` there would assert "this issuer
+  cannot filter by product" on no evidence.
 
 **Go** — `AuthorizedAccount.Resource` and `AuthorizationInfo.Scope` added
 (`,omitempty`), plus the same `FilterProduct` correction and

--- a/spec/api-gaps/bc5-authorization-document-shape.md
+++ b/spec/api-gaps/bc5-authorization-document-shape.md
@@ -163,7 +163,7 @@ the kind of `FlexTime` special-casing Go already needed.
   surface; they have discovery but no way to read the document discovery points
   them at.
 
-## What shipped (#PLACEHOLDER)
+## What shipped (#681)
 
 The SDK half of this brief is closed. `status` stays `partial-coverage` because
 the other half is bc3's and has not moved: bc3 still does not document its own

--- a/spec/api-gaps/notifications-sort-pings-first.md
+++ b/spec/api-gaps/notifications-sort-pings-first.md
@@ -116,3 +116,31 @@ not the column.
 - Update the counts in `SPEC.md`, `SECURITY.md` and
   `scripts/check-idempotency-parity` — a PUT is naturally idempotent and lands in
   both the idempotent and union counts.
+
+## Deferred (2026-08-06): absorb only after a `doc/api` PR to bc3
+
+Considered for absorption alongside the authorization-document brief and
+deliberately deferred, so the analysis is not re-derived from scratch next time.
+
+bc3 documents this resource **nowhere**: zero hits for `my/notifications` and
+zero for `sort_pings_first` across all of `doc/api/`. The trap is that
+`doc/api/sections/my_notifications.md` **exists** and is entirely about the
+*feed* (`/my/readings.json`) — it collides with the controller name exactly as
+`GetMyNotifications` collides with the settings resource, which is the
+conflation this brief already warns about, arriving one level up in the
+evidence rather than in the modelling.
+
+The consequence is mechanical: SDK operations here would be routes the SDK draws
+and `doc/api` does not, so they trip route-parity **direction 1** twice and need
+`sdk_routes_absent_from_bc3_docs` waivers. That list enforces almost nothing —
+its `reason:` is review-only — so the waiver is a claim a reviewer accepts, not
+one a gate checks. Both existing entries at least have a documented sibling
+resource, making "the docs are merely incomplete here" checkable against
+something. This resource has **no documented sibling at all**, so the same
+sentence would be materially weaker, and the gate would not know the difference.
+
+Absorbing first and waiving would therefore spend the waiver list's credibility
+to skip the cheaper fix. **The right first move is a `doc/api` PR to bc3** — the
+first bullet of "Implementation notes for BC3" above — after which the route
+becomes visible to `spec/bc3-routes.json` and the SDK side needs no waiver at
+all. Status stays `partial-coverage`; nothing else changes.

--- a/typescript/src/oauth/authorization-document.ts
+++ b/typescript/src/oauth/authorization-document.ts
@@ -63,8 +63,8 @@ export interface AuthorizedAccount {
    * Product type (e.g. `"bc3"` for Basecamp, `"hey"` for HEY).
    *
    * Launchpad only. A BC5 issuer serves one product by construction and omits
-   * this, which is why {@link filterAccountsByProduct} treats a document with no
-   * `product` anywhere as one the filter cannot apply to.
+   * this, which is why {@link filterAccountsByProduct} treats a non-empty
+   * document with no `product` anywhere as one the filter cannot apply to.
    */
   product?: string;
   /** API URL for this account. Emitted by both issuers. */
@@ -111,9 +111,10 @@ export interface AuthorizationInfo {
    * Whether a requested `product` filter was actually applied.
    *
    * Only meaningful when a product filter was requested. `false` means the
-   * document carried no `product` on any account — a BC5 document — so the
-   * filter was inapplicable and `accounts` is unfiltered rather than empty.
-   * See {@link filterAccountsByProduct}.
+   * document carried at least one account and no `product` on any of them — a
+   * BC5 document — so the filter was inapplicable and `accounts` is unfiltered
+   * rather than empty. An empty account list reports `true`: it is no evidence
+   * about the issuer either way. See {@link filterAccountsByProduct}.
    */
   productFilterApplied?: boolean;
 }
@@ -188,12 +189,22 @@ export function parseExpiresAt(value: string | number | null | undefined): Date 
  *
  * When at least one account carries a `product`, the filter is meaningful and is
  * applied normally — an empty result then genuinely means "no account matched".
+ *
+ * An **empty** account list is the edge that needs saying out loud. "No account
+ * carries a `product`" is vacuously true of `[]`, which would report the filter
+ * inapplicable — but Launchpad returns `accounts: []` for an identity with no
+ * currently accessible accounts, and that document is perfectly filterable. The
+ * result is the same list either way, so nothing observable changes; what changes
+ * is the claim the flag makes, and `applied: false` would assert "this issuer
+ * cannot filter by product" on no evidence at all. An empty list carries no
+ * evidence about the issuer, so treat the filter as applied: filtering nothing by
+ * anything yields nothing, which is exactly what happened.
  */
 export function filterAccountsByProduct(
   accounts: AuthorizedAccount[],
   product: string
 ): { accounts: AuthorizedAccount[]; applied: boolean } {
-  const filterable = accounts.some((a) => a.product !== undefined);
+  const filterable = accounts.length === 0 || accounts.some((a) => a.product !== undefined);
   if (!filterable) {
     return { accounts, applied: false };
   }

--- a/typescript/src/oauth/authorization-document.ts
+++ b/typescript/src/oauth/authorization-document.ts
@@ -1,0 +1,249 @@
+/**
+ * The authorization document, as served by both issuers.
+ *
+ * Two different services fetch this document — {@link ../services/authorization.js | AuthorizationService}
+ * and {@link ./identity.js | discoverIdentity} — and they used to carry a copy of
+ * the mapping each. The copies had already drifted apart (`app_href` was required
+ * in one and optional in the other), which is exactly how a shape fix gets applied
+ * to one caller and missed on the other. The mapping lives here once.
+ *
+ * This module is a leaf on purpose: it imports nothing from the SDK, so either
+ * caller can take a *value* dependency on it without adding a runtime edge to the
+ * `base.ts` / `client.ts` cycle.
+ *
+ * ## Two issuers, two shapes
+ *
+ * Launchpad and a BC5 (bc3) issuer both serve `GET /authorization.json`, and the
+ * documents are not the same shape. bc3 renders its own from
+ * `app/views/api/authorizations/show.json.jbuilder`:
+ *
+ * | Field | Launchpad | BC5 |
+ * |---|---|---|
+ * | `identity.first_name` / `last_name` / `email_address` | present | absent |
+ * | `accounts[].product` / `app_href` | present | absent |
+ * | `accounts[].resource` | absent | present (RFC 8707 indicator) |
+ * | `scope` | absent | present, BC3-issued tokens only |
+ * | `expires_at` | ISO-8601 string | integer epoch **seconds** |
+ *
+ * Every field either issuer omits is typed optional here. The union is modelled
+ * rather than either shape alone, because a consumer reaches a BC5 issuer just by
+ * passing `endpoint:`, and BC5 issuers serving their own document is the intended
+ * end state.
+ *
+ * @see spec/api-gaps/bc5-authorization-document-shape.md
+ */
+
+/**
+ * The authenticated user's identity.
+ *
+ * Only `id` is guaranteed. A BC5 issuer emits nothing but the identity id — it
+ * deliberately drops the PII that the API docs already say not to use for
+ * identifying users — so the name and email fields are absent there.
+ */
+export interface Identity {
+  /** User's unique identifier. Emitted by both issuers. */
+  id: number;
+  /** User's first name. Launchpad only — `undefined` from a BC5 issuer. */
+  firstName?: string;
+  /** User's last name. Launchpad only — `undefined` from a BC5 issuer. */
+  lastName?: string;
+  /** User's email address. Launchpad only — `undefined` from a BC5 issuer. */
+  emailAddress?: string;
+}
+
+/**
+ * A Basecamp account the user has access to.
+ */
+export interface AuthorizedAccount {
+  /** Account's unique identifier. */
+  id: number;
+  /** Account name. */
+  name: string;
+  /**
+   * Product type (e.g. `"bc3"` for Basecamp, `"hey"` for HEY).
+   *
+   * Launchpad only. A BC5 issuer serves one product by construction and omits
+   * this, which is why {@link filterAccountsByProduct} treats a document with no
+   * `product` anywhere as one the filter cannot apply to.
+   */
+  product?: string;
+  /** API URL for this account. Emitted by both issuers. */
+  href: string;
+  /** Web app URL for this account. Launchpad only. */
+  appHref?: string;
+  /**
+   * RFC 8707 resource indicator for this account (`urn:bc:account:<id>`).
+   *
+   * BC5 issuers only. Pass it as the `resource` parameter when requesting a
+   * token scoped to this account.
+   */
+  resource?: string;
+  /** Whether the account is hidden from the user's view. */
+  hidden?: boolean;
+  /** Whether the account subscription has expired. */
+  expired?: boolean;
+  /** Whether this is the user's featured/primary account. */
+  featured?: boolean;
+}
+
+/**
+ * Authorization information response.
+ */
+export interface AuthorizationInfo {
+  /**
+   * Token expiration timestamp.
+   *
+   * Parsed from either issuer's spelling — see {@link parseExpiresAt}.
+   */
+  expiresAt: Date;
+  /** The authenticated user's identity. */
+  identity: Identity;
+  /** List of accounts the user can access. */
+  accounts: AuthorizedAccount[];
+  /**
+   * The token's granted scope.
+   *
+   * BC5 issuers only, and only for BC3-issued tokens — legacy Signal tokens
+   * predate scopes, so its absence is not an error.
+   */
+  scope?: string;
+  /**
+   * Whether a requested `product` filter was actually applied.
+   *
+   * Only meaningful when a product filter was requested. `false` means the
+   * document carried no `product` on any account — a BC5 document — so the
+   * filter was inapplicable and `accounts` is unfiltered rather than empty.
+   * See {@link filterAccountsByProduct}.
+   */
+  productFilterApplied?: boolean;
+}
+
+/**
+ * The raw wire document, covering both issuers.
+ *
+ * Every field that *either* issuer omits is optional, so this type describes what
+ * can actually arrive rather than what one issuer happens to send. `identity` and
+ * `accounts` are the two that stay required: both issuers emit both, so a document
+ * missing either is malformed, and throwing on it beats inventing an empty account
+ * list that a caller cannot distinguish from a real one.
+ */
+export interface RawAuthorizationDocument {
+  /** ISO-8601 string (Launchpad) or integer epoch seconds (BC5). */
+  expires_at?: string | number | null;
+  /** Both issuers always emit this, so it stays required — see the note below. */
+  identity: {
+    id: number;
+    first_name?: string;
+    last_name?: string;
+    email_address?: string;
+  };
+  /** Both issuers always emit this, so it stays required — see the note below. */
+  accounts: Array<{
+    id: number;
+    name: string;
+    product?: string;
+    href: string;
+    app_href?: string;
+    resource?: string;
+    hidden?: boolean;
+    expired?: boolean;
+    featured?: boolean;
+  }>;
+  scope?: string;
+}
+
+/**
+ * Parses `expires_at` from either issuer's spelling.
+ *
+ * Launchpad sends an ISO-8601 string; bc3 sends `@token.expires_at.to_i`, an
+ * integer epoch **seconds**. The distinction is the whole point of branching on
+ * `typeof`: `new Date(2085213356)` treats the number as *milliseconds* and yields
+ * a date in 1970 — a wrong answer rather than an exception, which then reads as
+ * an expired credential rather than a schema mismatch.
+ *
+ * bc3 renders `.to_i`, so a nil expiry arrives as `0`, never `null`. A `0`, a
+ * `null` and an absent field are all "no expiry known" and produce an Invalid
+ * Date, which is what a `Date`-typed field can say about the absence.
+ */
+export function parseExpiresAt(value: string | number | null | undefined): Date {
+  if (typeof value === "number") {
+    // Epoch seconds, not milliseconds. `0` is bc3's rendering of a nil expiry.
+    return value === 0 ? new Date(NaN) : new Date(value * 1000);
+  }
+  if (typeof value === "string" && value !== "") {
+    return new Date(value);
+  }
+  return new Date(NaN);
+}
+
+/**
+ * Filters accounts by product, or reports that it could not.
+ *
+ * A BC5 document carries no `product` on any account, so filtering it by product
+ * matches nothing. Returning `[]` there is silently wrong — the accounts exist,
+ * and the caller's next step is to pick a `href` out of a list the SDK just
+ * emptied. Instead: when *no* account in the document carries a `product`, the
+ * filter is inapplicable, and all accounts are returned with `applied: false` so
+ * a caller that cares can tell the two situations apart.
+ *
+ * When at least one account carries a `product`, the filter is meaningful and is
+ * applied normally — an empty result then genuinely means "no account matched".
+ */
+export function filterAccountsByProduct(
+  accounts: AuthorizedAccount[],
+  product: string
+): { accounts: AuthorizedAccount[]; applied: boolean } {
+  const filterable = accounts.some((a) => a.product !== undefined);
+  if (!filterable) {
+    return { accounts, applied: false };
+  }
+  return { accounts: accounts.filter((a) => a.product === product), applied: true };
+}
+
+/**
+ * Maps a raw authorization document to {@link AuthorizationInfo}.
+ *
+ * Optionally applies a product filter; see {@link filterAccountsByProduct} for
+ * what happens when the document cannot be filtered by product.
+ */
+export function parseAuthorizationDocument(
+  raw: RawAuthorizationDocument,
+  options: { filterProduct?: string } = {}
+): AuthorizationInfo {
+  let accounts: AuthorizedAccount[] = raw.accounts.map((a) => ({
+    id: a.id,
+    name: a.name,
+    product: a.product,
+    href: a.href,
+    appHref: a.app_href,
+    resource: a.resource,
+    hidden: a.hidden,
+    expired: a.expired,
+    featured: a.featured,
+  }));
+
+  let productFilterApplied: boolean | undefined;
+  if (options.filterProduct !== undefined && options.filterProduct !== "") {
+    const filtered = filterAccountsByProduct(accounts, options.filterProduct);
+    accounts = filtered.accounts;
+    productFilterApplied = filtered.applied;
+  }
+
+  const info: AuthorizationInfo = {
+    expiresAt: parseExpiresAt(raw.expires_at),
+    identity: {
+      id: raw.identity.id,
+      firstName: raw.identity.first_name,
+      lastName: raw.identity.last_name,
+      emailAddress: raw.identity.email_address,
+    },
+    accounts,
+  };
+  if (raw.scope !== undefined) {
+    info.scope = raw.scope;
+  }
+  if (productFilterApplied !== undefined) {
+    info.productFilterApplied = productFilterApplied;
+  }
+  return info;
+}

--- a/typescript/src/oauth/identity.ts
+++ b/typescript/src/oauth/identity.ts
@@ -3,34 +3,21 @@
  *
  * Fetches authorization information (identity and accounts) from
  * the Launchpad endpoint without requiring a full client instance.
+ *
+ * The endpoint is fixed to Launchpad here — unlike
+ * {@link ../services/authorization.js | AuthorizationService.getInfo}, which
+ * accepts an `endpoint:` override and so can be pointed at a BC5 issuer. Both
+ * share one mapping regardless; see `./authorization-document.js` for why the two
+ * documents differ and how the shared parser reconciles them.
  */
 
 import { BasecampError } from "../errors.js";
 import type { TokenProvider } from "../client.js";
-import type { AuthorizationInfo } from "../services/authorization.js";
-
-/**
- * Raw authorization response from the Launchpad API.
- */
-interface RawAuthorizationResponse {
-  expires_at: string;
-  identity: {
-    id: number;
-    first_name: string;
-    last_name: string;
-    email_address: string;
-  };
-  accounts: Array<{
-    id: number;
-    name: string;
-    product: string;
-    href: string;
-    app_href?: string;
-    hidden?: boolean;
-    expired?: boolean;
-    featured?: boolean;
-  }>;
-}
+import {
+  parseAuthorizationDocument,
+  type AuthorizationInfo,
+  type RawAuthorizationDocument,
+} from "./authorization-document.js";
 
 const AUTHORIZATION_ENDPOINT = "https://launchpad.37signals.com/authorization.json";
 
@@ -82,30 +69,12 @@ export async function discoverIdentity(accessToken: TokenProvider): Promise<Auth
     });
   }
 
-  let raw: RawAuthorizationResponse;
+  let raw: RawAuthorizationDocument;
   try {
-    raw = (await response.json()) as RawAuthorizationResponse;
+    raw = (await response.json()) as RawAuthorizationDocument;
   } catch {
     throw new BasecampError("api_error", "Identity discovery returned invalid JSON");
   }
 
-  return {
-    expiresAt: new Date(raw.expires_at),
-    identity: {
-      id: raw.identity.id,
-      firstName: raw.identity.first_name,
-      lastName: raw.identity.last_name,
-      emailAddress: raw.identity.email_address,
-    },
-    accounts: raw.accounts.map((a) => ({
-      id: a.id,
-      name: a.name,
-      product: a.product,
-      href: a.href,
-      appHref: a.app_href ?? "",
-      hidden: a.hidden,
-      expired: a.expired,
-      featured: a.featured,
-    })),
-  };
+  return parseAuthorizationDocument(raw);
 }

--- a/typescript/src/oauth/index.ts
+++ b/typescript/src/oauth/index.ts
@@ -134,3 +134,11 @@ export {
 export {
   discoverIdentity,
 } from "./identity.js";
+
+// The authorization document, shared by discoverIdentity and AuthorizationService
+export {
+  parseAuthorizationDocument,
+  parseExpiresAt,
+  filterAccountsByProduct,
+  type RawAuthorizationDocument,
+} from "./authorization-document.js";

--- a/typescript/src/services/authorization.ts
+++ b/typescript/src/services/authorization.ts
@@ -9,54 +9,19 @@ import { BaseService, type RawClient } from "./base.js";
 import type { BasecampHooks } from "../hooks.js";
 import type { AuthStrategy } from "../auth-strategy.js";
 import { requireSecureEndpoint } from "../security.js";
+import {
+  parseAuthorizationDocument,
+  type AuthorizationInfo,
+  type RawAuthorizationDocument,
+} from "../oauth/authorization-document.js";
 
-/**
- * The authenticated user's identity.
- */
-export interface Identity {
-  /** User's unique identifier */
-  id: number;
-  /** User's first name */
-  firstName: string;
-  /** User's last name */
-  lastName: string;
-  /** User's email address */
-  emailAddress: string;
-}
-
-/**
- * A Basecamp account the user has access to.
- */
-export interface AuthorizedAccount {
-  /** Account's unique identifier */
-  id: number;
-  /** Account name */
-  name: string;
-  /** Product type (e.g., "bc3" for Basecamp, "hey" for HEY) */
-  product: string;
-  /** API URL for this account */
-  href: string;
-  /** Web app URL for this account */
-  appHref: string;
-  /** Whether the account is hidden from the user's view */
-  hidden?: boolean;
-  /** Whether the account subscription has expired */
-  expired?: boolean;
-  /** Whether this is the user's featured/primary account */
-  featured?: boolean;
-}
-
-/**
- * Authorization information response.
- */
-export interface AuthorizationInfo {
-  /** Token expiration timestamp */
-  expiresAt: Date;
-  /** The authenticated user's identity */
-  identity: Identity;
-  /** List of accounts the user can access */
-  accounts: AuthorizedAccount[];
-}
+// The document types live in the leaf module alongside the parser that produces
+// them, and are re-exported here so this remains their public import path.
+export type {
+  Identity,
+  AuthorizedAccount,
+  AuthorizationInfo,
+} from "../oauth/authorization-document.js";
 
 /**
  * Options for fetching authorization information.
@@ -65,36 +30,21 @@ export interface GetAuthorizationInfoOptions {
   /**
    * Override the default authorization endpoint URL.
    * Defaults to "https://launchpad.37signals.com/authorization.json"
+   *
+   * This is also how you point at a BC5 issuer, whose document is a different
+   * shape — see `../oauth/authorization-document.js`.
    */
   endpoint?: string;
   /**
    * Filter accounts by product type.
    * Common values: "bc3" (Basecamp), "bcx" (Basecamp 2), "hey" (HEY)
+   *
+   * A BC5 document carries no `product` on any account, so the filter cannot
+   * apply there. In that case all accounts are returned and
+   * `AuthorizationInfo.productFilterApplied` is `false`, rather than the empty
+   * list a literal filter would produce.
    */
   filterProduct?: string;
-}
-
-/**
- * Raw authorization response from the API.
- */
-interface RawAuthorizationResponse {
-  expires_at: string;
-  identity: {
-    id: number;
-    first_name: string;
-    last_name: string;
-    email_address: string;
-  };
-  accounts: Array<{
-    id: number;
-    name: string;
-    product: string;
-    href: string;
-    app_href: string;
-    hidden?: boolean;
-    expired?: boolean;
-    featured?: boolean;
-  }>;
 }
 
 const DEFAULT_AUTHORIZATION_ENDPOINT = "https://launchpad.37signals.com/authorization.json";
@@ -102,8 +52,10 @@ const DEFAULT_AUTHORIZATION_ENDPOINT = "https://launchpad.37signals.com/authoriz
 /**
  * Service for authorization-related operations.
  *
- * This service communicates with the Launchpad authorization endpoint
- * rather than the standard Basecamp API.
+ * This service communicates with an authorization endpoint — Launchpad by
+ * default, or a BC5 issuer via `endpoint:` — rather than the standard Basecamp
+ * API. The two serve different-shaped documents; see
+ * `../oauth/authorization-document.js`.
  *
  * @example
  * ```ts
@@ -116,9 +68,11 @@ const DEFAULT_AUTHORIZATION_ENDPOINT = "https://launchpad.37signals.com/authoriz
  *
  * // Get all accounts
  * const info = await client.authorization.getInfo();
- * console.log(`Logged in as ${info.identity.firstName}`);
+ * console.log(`Logged in as identity ${info.identity.id}`);
  *
- * // Filter to only Basecamp accounts
+ * // Filter to only Basecamp accounts. Against a BC5 issuer, whose accounts
+ * // carry no `product`, this returns every account with
+ * // `productFilterApplied === false` instead of an empty list.
  * const bc3Info = await client.authorization.getInfo({ filterProduct: "bc3" });
  * for (const account of bc3Info.accounts) {
  *   console.log(account.name);
@@ -153,12 +107,13 @@ export class AuthorizationService extends BaseService {
    * ```ts
    * const info = await authService.getInfo();
    *
-   * console.log(`User: ${info.identity.firstName} ${info.identity.lastName}`);
-   * console.log(`Email: ${info.identity.emailAddress}`);
+   * // A BC5 issuer emits only `identity.id`; the name and email fields are
+   * // Launchpad's and are `undefined` there.
+   * console.log(`User: ${info.identity.id}`);
    * console.log(`Token expires: ${info.expiresAt}`);
    *
    * for (const account of info.accounts) {
-   *   console.log(`${account.name} (${account.product})`);
+   *   console.log(`${account.name}: ${account.href}`);
    * }
    * ```
    */
@@ -192,35 +147,9 @@ export class AuthorizationService extends BaseService {
           return { data: undefined, error: undefined, response };
         }
 
-        const raw = (await response.json()) as RawAuthorizationResponse;
+        const raw = (await response.json()) as RawAuthorizationDocument;
 
-        // Transform to our clean types
-        let accounts = raw.accounts.map((a) => ({
-          id: a.id,
-          name: a.name,
-          product: a.product,
-          href: a.href,
-          appHref: a.app_href,
-          hidden: a.hidden,
-          expired: a.expired,
-          featured: a.featured,
-        }));
-
-        // Filter by product if requested
-        if (options.filterProduct) {
-          accounts = accounts.filter((a) => a.product === options.filterProduct);
-        }
-
-        const data: AuthorizationInfo = {
-          expiresAt: new Date(raw.expires_at),
-          identity: {
-            id: raw.identity.id,
-            firstName: raw.identity.first_name,
-            lastName: raw.identity.last_name,
-            emailAddress: raw.identity.email_address,
-          },
-          accounts,
-        };
+        const data = parseAuthorizationDocument(raw, { filterProduct: options.filterProduct });
 
         return { data, error: undefined, response };
       }

--- a/typescript/tests/services/authorization.test.ts
+++ b/typescript/tests/services/authorization.test.ts
@@ -36,6 +36,35 @@ const sampleAuthResponse = () => ({
   ],
 });
 
+/**
+ * A BC5 (bc3) issuer's own authorization document, per
+ * `app/views/api/authorizations/show.json.jbuilder`: identity id only, no
+ * `product` or `app_href` on accounts, an RFC 8707 `resource` indicator instead,
+ * a top-level `scope`, and `expires_at` as integer epoch *seconds*.
+ */
+const sampleBc5AuthResponse = () => ({
+  identity: { id: 100 },
+  accounts: [
+    {
+      id: 1,
+      name: "Acme Corp",
+      href: "https://bc5.example.com/1",
+      resource: "urn:bc:account:1",
+    },
+    {
+      id: 2,
+      name: "Second Account",
+      href: "https://bc5.example.com/2",
+      resource: "urn:bc:account:2",
+    },
+  ],
+  scope: "read write",
+  // 2036-01-29T09:55:56Z as epoch seconds. Read as milliseconds: 1970-01-25.
+  expires_at: 2085213356,
+});
+
+const BC5_URL = "https://bc5.example.com/authorization.json";
+
 describe("AuthorizationService", () => {
   let client: BasecampClient;
 
@@ -78,6 +107,28 @@ describe("AuthorizationService", () => {
       expect(info.accounts[0]!.product).toBe("bc3");
     });
 
+    it("reports the filter as applied when the document carries products", async () => {
+      server.use(http.get(LAUNCHPAD_URL, () => HttpResponse.json(sampleAuthResponse())));
+
+      const info = await client.authorization.getInfo({ filterProduct: "bc3" });
+      expect(info.productFilterApplied).toBe(true);
+    });
+
+    it("returns an empty list when a filterable document genuinely has no match", async () => {
+      server.use(http.get(LAUNCHPAD_URL, () => HttpResponse.json(sampleAuthResponse())));
+
+      const info = await client.authorization.getInfo({ filterProduct: "nope" });
+      expect(info.accounts).toHaveLength(0);
+      expect(info.productFilterApplied).toBe(true);
+    });
+
+    it("leaves productFilterApplied unset when no filter was requested", async () => {
+      server.use(http.get(LAUNCHPAD_URL, () => HttpResponse.json(sampleAuthResponse())));
+
+      const info = await client.authorization.getInfo();
+      expect(info.productFilterApplied).toBeUndefined();
+    });
+
     it("should throw on 401 error", async () => {
       server.use(
         http.get(LAUNCHPAD_URL, () => {
@@ -86,6 +137,47 @@ describe("AuthorizationService", () => {
       );
 
       await expect(client.authorization.getInfo()).rejects.toThrow(BasecampError);
+    });
+  });
+
+  // A BC5 issuer is reached exactly the way the docs say to reach one: by passing
+  // `endpoint:`. Everything below is the shape that arrives when you do.
+  describe("getInfo against a BC5 issuer's own document", () => {
+    beforeEach(() => {
+      server.use(http.get(BC5_URL, () => HttpResponse.json(sampleBc5AuthResponse())));
+    });
+
+    it("reads expires_at as epoch seconds, not milliseconds", async () => {
+      const info = await client.authorization.getInfo({ endpoint: BC5_URL });
+
+      // Read as milliseconds, 2085213356 lands in January 1970 — a wrong date
+      // rather than an exception, which then reads as an expired credential.
+      expect(info.expiresAt.getUTCFullYear()).toBe(2036);
+      expect(info.expiresAt.toISOString()).toBe("2036-01-29T09:55:56.000Z");
+    });
+
+    it("does not empty the account list when no account carries a product", async () => {
+      const info = await client.authorization.getInfo({
+        endpoint: BC5_URL,
+        filterProduct: "bc3",
+      });
+
+      // The filter cannot apply to a document with no `product` anywhere, so it
+      // is reported inapplicable rather than silently matching nothing.
+      expect(info.accounts).toHaveLength(2);
+      expect(info.productFilterApplied).toBe(false);
+      expect(info.accounts[0]!.href).toBe("https://bc5.example.com/1");
+    });
+
+    it("surfaces the resource indicator and scope, and omits Launchpad-only fields", async () => {
+      const info = await client.authorization.getInfo({ endpoint: BC5_URL });
+
+      expect(info.accounts[0]!.resource).toBe("urn:bc:account:1");
+      expect(info.scope).toBe("read write");
+      expect(info.identity.id).toBe(100);
+      expect(info.identity.emailAddress).toBeUndefined();
+      expect(info.accounts[0]!.product).toBeUndefined();
+      expect(info.accounts[0]!.appHref).toBeUndefined();
     });
   });
 

--- a/typescript/tests/services/authorization.test.ts
+++ b/typescript/tests/services/authorization.test.ts
@@ -122,6 +122,23 @@ describe("AuthorizationService", () => {
       expect(info.productFilterApplied).toBe(true);
     });
 
+    it("treats an empty Launchpad account list as filterable, not inapplicable", async () => {
+      // Launchpad returns accounts: [] for an identity with no currently
+      // accessible accounts. "No account carries a product" is vacuously true of
+      // an empty list, but this document filters fine — reporting the filter
+      // inapplicable would assert "this issuer cannot filter by product" on no
+      // evidence, which is the one thing the flag is supposed to mean.
+      server.use(
+        http.get(LAUNCHPAD_URL, () =>
+          HttpResponse.json({ ...sampleAuthResponse(), accounts: [] })
+        )
+      );
+
+      const info = await client.authorization.getInfo({ filterProduct: "bc3" });
+      expect(info.accounts).toHaveLength(0);
+      expect(info.productFilterApplied).toBe(true);
+    });
+
     it("leaves productFilterApplied unset when no filter was requested", async () => {
       server.use(http.get(LAUNCHPAD_URL, () => HttpResponse.json(sampleAuthResponse())));
 


### PR DESCRIPTION
Closes the SDK half of `spec/api-gaps/bc5-authorization-document-shape.md`.

## The problem

BC3 #9471 has a BC5 issuer serving its own `GET /authorization.json`, rendered from `app/views/api/authorizations/show.json.jbuilder`. Its shape is not Launchpad's:

| Field | Launchpad | bc3 |
|---|---|---|
| `identity.first_name` / `last_name` / `email_address` | present | **absent** |
| `accounts[].product` / `app_href` | present | **absent** |
| `accounts[].resource` | absent | **present** — RFC 8707 indicator |
| `scope` | absent | present, BC3-issued tokens only |
| `expires_at` | ISO-8601 string | **integer epoch seconds** (`.to_i`, so a nil expiry renders `0`, never `null`) |

This is the *first* request a consumer makes after obtaining a token — it is how they find their account `href`. A mismatch does not surface as a clean error. It surfaces as `undefined` identity fields, an empty account list, and a token that looks like it expired in 1970. Each reads as a credential problem rather than a schema problem.

Hand-written OAuth lane only: **no Smithy, no regeneration, no count pin moves.** OAuth is outside the OpenAPI spec by design (AGENTS.md). `git status` after `make` is clean of every generated artifact.

## What changed

**TypeScript** — the mapping existed twice, in `services/authorization.ts` and `oauth/identity.ts`, and the copies had **already drifted**: `app_href` was optional in one and required in the other. They now share one parser in a new **leaf** module, `typescript/src/oauth/authorization-document.ts` — a leaf specifically so `identity.ts` taking a *value* dependency adds no runtime edge to the known `base.ts`/`client.ts` cycle.

- `expires_at` branches on `typeof`. `new Date(2085213356)` reads the number as **milliseconds** and yields 1970, silently.
- The five Launchpad-only fields become optional (`Identity.firstName`, `.lastName`, `.emailAddress`, `AuthorizedAccount.product`, `.appHref`); `resource` and `scope` are new.
- `filterProduct` takes the third of the brief's three options: when *no* account carries a `product`, the filter is inapplicable — all accounts are returned with `productFilterApplied: false`, rather than the `[]` that emptied the very list the caller was about to pick an `href` out of. When at least one account does carry a `product`, the filter applies unchanged, so an empty result still means "nothing matched".

**Breaking for TS consumers** (five required → optional). `MIGRATING.md` entry added, and the TypeScript row in its summary table goes 18 → 19.

**Go** — the brief said Go's endpoint was "Launchpad-only today". That is **wrong**: `GetInfoOptions.Endpoint` overrides it exactly as TypeScript's `endpoint:` does, so Go reaches bc3's document by the same documented route and had the **same `FilterProduct` defect**. Fixed here, with additive `Resource` and `Scope` fields. `ExpiresAt` is deliberately untouched — #662 owns pointerizing it, and `FlexTime` already decodes both spellings, so the brief's Go timestamp ask was already met.

**Ruby** — the `@example` showed `identity.email_address`, `nil` against bc3. The sharper catch is in the tests: `sample_authorization` is Launchpad-shaped and the BC5-issuer tests were being served it. *The tests proving the SDK reaches bc3's issuer were feeding it Launchpad's body*, and would have passed even if the SDK could not read a BC5 document at all.

**Python, Kotlin, Swift** — considered, no change, recorded in the brief so it is not re-derived. Python is untyped and Launchpad-only; Kotlin and Swift have no authorization-document surface.

The brief keeps `status: partial-coverage` — the SDK half closes, but bc3 still does not document its own document, and `absorbed-in-sdk` would fail `scripts/validate-api-gaps.rb`, which demands a non-empty `smithy_refs` (there is no Smithy here).

## Verification

Each fix was shown **red against un-fixed code** first, with the un-fixed sources swapped in via `git show origin/main:<path>` (never `git stash` — the stash stack is shared across worktrees here):

| Proof | Failure against un-fixed code | `REAL_EXIT` |
|---|---|---|
| TS `expires_at: 2085213356` | `expected 1970 to be 2036` | 1 |
| TS `filterProduct` on a BC5 document | `expected [] to have a length of 2` | 1 |
| Go `FilterProduct` on a BC5 document | `returned 0 accounts, want 2` | 1 |
| Ruby BC5 body on the BC5-issuer path | both original assertions fail | 1 |

The Go proof is behaviour-only on purpose — it references no new struct field, so it compiles against the un-fixed source and fails on the *assertion* rather than the type.

`make` clean, `REAL_EXIT=0`. Ruby 1394 runs / 0 failures; TS 1470 tests. `validate-api-gaps` clean at 35 entries.

> One note for whoever runs this in a **fresh worktree**: the first `make` exits 2 on `assert-lockfiles-unchanged`, naming `conformance/runner/python/uv.lock` and `conformance/runner/ruby/Gemfile.lock`. Both are **untracked and gitignored**; they do not exist when the guard snapshots and the conformance runner creates them mid-run, so absent → present reads as "modified". It reproduces identically on an unrelated branch and clears on the second run. Not this PR's, but the guard arguably should not count a file it has never seen as modified.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full support for bc3’s BC5 issuer `GET /authorization.json` and unifies parsing across TypeScript, Go, and Ruby so identity/account discovery works with both issuers. Fixes token expiry parsing and product filtering (including treating empty account lists as filterable) to prevent 1970 dates and accidental empty results.

- **New Features**
  - TypeScript: shared leaf parser at `typescript/src/oauth/authorization-document.ts`; reads numeric `expires_at` as epoch seconds; adds `AuthorizationInfo.scope`, `AuthorizationInfo.productFilterApplied`, and `AuthorizedAccount.resource`; used by both `discoverIdentity` and `AuthorizationService`; re-exported via `oauth/index.ts`.
  - Product filtering: if at least one account exists and none has `product`, return all accounts and set `productFilterApplied: false`; if any account has `product`, apply the filter as before; if the account list is empty, treat it as filterable and set `productFilterApplied: true`.
  - Go: supports BC5 via `GetInfoOptions.Endpoint`; adds `AuthorizedAccount.Resource`, `AuthorizationInfo.Scope`, and `ProductFilterApplied`; applies the same product-filter behavior including the empty-list case.
  - Ruby: examples/tests now use a BC5-shaped sample; pin BC5-only fields (`resource`, `scope`, epoch-seconds `expires_at`) and confirm Launchpad-only fields are absent.

- **Migration**
  - TypeScript breaking change: five fields are now optional — `Identity.firstName`, `Identity.lastName`, `Identity.emailAddress`, `AuthorizedAccount.product`, and `AuthorizedAccount.appHref`. Update code to handle `undefined`. `MIGRATING.md` updated; TS break count is now 19.

<sup>Written for commit 42c80fbb8917779d864141b763b8d003a8eac27c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

