### PR TITLE
Gate the Go grouped client, which nothing was watching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,14 +183,23 @@ jobs:
       # against the hand-written go/pkg/basecamp wrappers; nothing watched the
       # GROUPED client until this gate, which is how ArchiveProject and
       # UnarchiveProject shipped missing from it through two green `make` runs.
+      #
+      # Under LC_ALL=C so CI exercises the non-UTF-8-locale path (the reads are
+      # pinned to UTF-8; this proves it stays that way). All three inputs carry
+      # non-ASCII text, so an unpinned read raises InvalidByteSequenceError and
+      # the gate fails before validating anything.
       - name: Every operation accounted for on the Go grouped client
         run: make check-grouped-client-coverage
+        env:
+          LC_ALL: C
 
       # The run above only ever exercises the PASSING case. This drives
       # adversarial inventories through the same gate, including the
       # unaccounted-new-operation case that is the whole reason it exists.
       - name: Grouped-client coverage gate self-test (adversarial inventories)
         run: make test-check-grouped-client-coverage
+        env:
+          LC_ALL: C
 
       - name: README env-var tables match what the SDKs actually read
         run: make check-readme-env-vars

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,6 +179,19 @@ jobs:
       - name: Kotlin service drift (static; jq/grep, no JVM)
         run: make kt-check-drift
 
+      # The third Go surface. go-check-drift compares generated operations
+      # against the hand-written go/pkg/basecamp wrappers; nothing watched the
+      # GROUPED client until this gate, which is how ArchiveProject and
+      # UnarchiveProject shipped missing from it through two green `make` runs.
+      - name: Every operation accounted for on the Go grouped client
+        run: make check-grouped-client-coverage
+
+      # The run above only ever exercises the PASSING case. This drives
+      # adversarial inventories through the same gate, including the
+      # unaccounted-new-operation case that is the whole reason it exists.
+      - name: Grouped-client coverage gate self-test (adversarial inventories)
+        run: make test-check-grouped-client-coverage
+
       - name: README env-var tables match what the SDKs actually read
         run: make check-readme-env-vars
 

--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ doc-constants-check:
 # Go SDK targets (delegates to go/Makefile)
 #------------------------------------------------------------------------------
 
-.PHONY: go-test go-lint go-check go-clean go-check-drift go-check-wrapper-drift go-check-generated-drift
+.PHONY: go-test go-lint go-check go-clean go-check-drift go-check-wrapper-drift go-check-generated-drift check-grouped-client-coverage test-check-grouped-client-coverage
 
 go-test:
 	@$(MAKE) -C go test
@@ -327,6 +327,29 @@ go-check-drift:
 go-check-generated-drift:
 	@echo "==> Checking generated Go client drift..."
 	@./scripts/check-go-generated-drift.sh
+
+# Total accounting for the GROUPED generated client (generated.Client.Todos(),
+# .Projects(), …). The third Go surface, and the one nothing else watches:
+# go-check-drift compares generated operations against the hand-written
+# go/pkg/basecamp wrappers, go-check-wrapper-drift compares their fields, and
+# neither looks at the `$$opid` chain in go/templates/client.tmpl. ArchiveProject
+# and UnarchiveProject shipped missing from it through TWO fully green `make`
+# runs; a human reviewer caught it, and a gate should have.
+#
+# Every operationId must appear exactly once across go/grouped-client-inventory.yml.
+# "Expose every operation in the tag" is NOT the invariant — the grouped surface is
+# deliberately curated, and that rule is false for 14 of its 15 services.
+check-grouped-client-coverage:
+	@echo "==> Checking Go grouped-client coverage..."
+	@./scripts/check-grouped-client-coverage
+
+# Drive that gate from outside with adversarial inventories. Its live run only
+# ever exercises the PASSING case, so nothing there proves it rejects anything —
+# and a coverage gate that cannot fail converts "nobody checked" into "the gate
+# says it is fine". Each case drives the real checker through its env seams
+# against synthetic inputs in a tmpdir; the tracked tree is never written to.
+test-check-grouped-client-coverage:
+	@ruby ./scripts/test-check-grouped-client-coverage.rb
 
 # Check for field-level drift between generated structs and hand-written
 # wrappers in go/pkg/basecamp/. Sibling of go-check-drift; that check is
@@ -1303,7 +1326,7 @@ check:
 	 if [ $$rc -ne 0 ]; then exit $$rc; fi; \
 	 echo "==> All checks passed"
 
-check-targets: lint-actions sync-spec-version-check smithy-check smithy-mapper-test behavior-model-check provenance-check sync-api-version-check doc-constants-check url-routes-check bc3-route-parity test-bc3-route-parity go-check-drift go-check-wrapper-drift go-check-generated-drift auth-routable-check kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity check-fixture-coverage kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-idempotency-parity check-write-semantics-parity check-retry-metadata-parity check-runner-test-reachability check-replay-decoder-parity check-readme-env-vars test-check-readme-env-vars lint-npm-lockfile-writes test-lint-npm-lockfile-writes test-assert-sdk-built test-assert-lockfiles-unchanged check-projected-examples
+check-targets: lint-actions sync-spec-version-check smithy-check smithy-mapper-test behavior-model-check provenance-check sync-api-version-check doc-constants-check url-routes-check bc3-route-parity test-bc3-route-parity go-check-drift go-check-wrapper-drift go-check-generated-drift check-grouped-client-coverage test-check-grouped-client-coverage auth-routable-check kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity check-fixture-coverage kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-idempotency-parity check-write-semantics-parity check-retry-metadata-parity check-runner-test-reachability check-replay-decoder-parity check-readme-env-vars test-check-readme-env-vars lint-npm-lockfile-writes test-lint-npm-lockfile-writes test-assert-sdk-built test-assert-lockfiles-unchanged check-projected-examples
 	@:
 
 # Clean all build artifacts
@@ -1336,6 +1359,8 @@ help:
 	@echo "  go-check         Run all Go checks"
 	@echo "  go-check-drift           Check service layer drift vs generated client (operation-level)"
 	@echo "  go-check-wrapper-drift   Check wrapper struct drift vs generated structs (field-level)"
+	@echo "  check-grouped-client-coverage       Check every operation is accounted for on the grouped client"
+	@echo "  test-check-grouped-client-coverage  Self-test that gate with adversarial inventories"
 	@echo "  go-check-generated-drift Check generated client.gen.go is current (regenerate + diff)"
 	@echo "  go-clean         Remove Go build artifacts"
 	@echo ""

--- a/go/grouped-client-inventory.yml
+++ b/go/grouped-client-inventory.yml
@@ -35,45 +35,45 @@ grouped:
       methods: ["List"]
   CardsService:
     - operation: CreateCard
-      methods: ["CreateWithBody"]
+      methods: ["CreateWithBody", "Create"]
     - operation: GetCard
       methods: ["Get"]
     - operation: ListCards
       methods: ["List"]
     - operation: MoveCard
-      methods: ["MoveWithBody"]
+      methods: ["MoveWithBody", "Move"]
     - operation: UpdateCard
-      methods: ["UpdateVerbatimWithBody"]
+      methods: ["UpdateVerbatimWithBody", "UpdateVerbatim"]
   CommentsService:
     - operation: CreateComment
-      methods: ["CreateWithBody"]
+      methods: ["CreateWithBody", "Create"]
     - operation: GetComment
       methods: ["Get"]
     - operation: ListComments
       methods: ["List"]
     - operation: UpdateComment
-      methods: ["UpdateWithBody"]
+      methods: ["UpdateWithBody", "Update"]
   DocumentsService:
     - operation: CreateDocument
-      methods: ["CreateWithBody"]
+      methods: ["CreateWithBody", "Create"]
     - operation: GetDocument
       methods: ["Get"]
     - operation: ListDocuments
       methods: ["List"]
     - operation: ReplaceDocument
-      methods: ["ReplaceWithBody"]
+      methods: ["ReplaceWithBody", "Replace"]
   EventsService:
     - operation: ListEvents
       methods: ["List"]
   MessagesService:
     - operation: CreateMessage
-      methods: ["CreateWithBody"]
+      methods: ["CreateWithBody", "Create"]
     - operation: GetMessage
       methods: ["Get"]
     - operation: ListMessages
       methods: ["List"]
     - operation: UpdateMessage
-      methods: ["UpdateWithBody"]
+      methods: ["UpdateWithBody", "Update"]
   PeopleService:
     - operation: GetMyProfile
       methods: ["GetMyProfile"]
@@ -85,7 +85,7 @@ grouped:
     - operation: ArchiveProject
       methods: ["Archive"]
     - operation: CreateProject
-      methods: ["CreateWithBody"]
+      methods: ["CreateWithBody", "Create"]
     - operation: GetProject
       methods: ["Get"]
     - operation: ListProjects
@@ -95,7 +95,7 @@ grouped:
     - operation: UnarchiveProject
       methods: ["Unarchive"]
     - operation: UpdateProject
-      methods: ["UpdateWithBody"]
+      methods: ["UpdateWithBody", "Update"]
   RecordingsService:
     - operation: ArchiveRecording
       methods: ["Archive"]
@@ -107,7 +107,7 @@ grouped:
       methods: ["Unarchive"]
   SchedulesService:
     - operation: CreateScheduleEntry
-      methods: ["CreateEntryWithBody"]
+      methods: ["CreateEntryWithBody", "CreateEntry"]
     - operation: GetSchedule
       methods: ["Get"]
     - operation: GetScheduleEntry
@@ -115,10 +115,10 @@ grouped:
     - operation: ListScheduleEntries
       methods: ["ListEntries"]
     - operation: ReplaceScheduleEntry
-      methods: ["ReplaceEntryWithBody"]
+      methods: ["ReplaceEntryWithBody", "ReplaceEntry"]
   TemplatesService:
     - operation: CreateTemplate
-      methods: ["CreateWithBody"]
+      methods: ["CreateWithBody", "Create"]
     - operation: DeleteTemplate
       methods: ["Delete"]
     - operation: GetTemplate
@@ -126,41 +126,41 @@ grouped:
     - operation: ListTemplates
       methods: ["List"]
     - operation: UpdateTemplate
-      methods: ["UpdateWithBody"]
+      methods: ["UpdateWithBody", "Update"]
   TodosService:
     - operation: CompleteTodo
       methods: ["Complete"]
     - operation: CreateTodo
-      methods: ["CreateWithBody"]
+      methods: ["CreateWithBody", "Create"]
     - operation: GetTodo
       methods: ["Get"]
     - operation: ListTodos
       methods: ["List"]
     - operation: ReplaceTodo
-      methods: ["ReplaceWithBody"]
+      methods: ["ReplaceWithBody", "Replace"]
     - operation: UncompleteTodo
       methods: ["Uncomplete"]
   UploadsService:
     - operation: CreateUpload
-      methods: ["CreateWithBody"]
+      methods: ["CreateWithBody", "Create"]
     - operation: GetUpload
       methods: ["Get"]
     - operation: ListUploads
       methods: ["List"]
     - operation: UpdateUpload
-      methods: ["UpdateWithBody"]
+      methods: ["UpdateWithBody", "Update"]
   VaultsService:
     - operation: CreateVault
-      methods: ["CreateWithBody"]
+      methods: ["CreateWithBody", "Create"]
     - operation: GetVault
       methods: ["Get"]
     - operation: ListVaults
       methods: ["List"]
     - operation: UpdateVault
-      methods: ["UpdateWithBody"]
+      methods: ["UpdateWithBody", "Update"]
   WebhooksService:
     - operation: CreateWebhook
-      methods: ["CreateWithBody"]
+      methods: ["CreateWithBody", "Create"]
     - operation: DeleteWebhook
       methods: ["Delete"]
     - operation: GetWebhook
@@ -168,7 +168,7 @@ grouped:
     - operation: ListWebhooks
       methods: ["List"]
     - operation: UpdateWebhook
-      methods: ["UpdateWithBody"]
+      methods: ["UpdateWithBody", "Update"]
 
 # Operations deliberately absent from the grouped surface. Bulk, but pure data:
 # this list is what makes the accounting total, and therefore what makes a new

--- a/go/grouped-client-inventory.yml
+++ b/go/grouped-client-inventory.yml
@@ -1,0 +1,367 @@
+# Total accounting for the Go GROUPED generated client.
+#
+# The grouped surface is `generated.Client.Todos()`, `.Projects()`, and so on:
+# a curated ergonomic layer emitted by the `$opid` chain in
+# go/templates/client.tmpl. It is NOT the flat generated client, and it is NOT
+# the hand-written go/pkg/basecamp wrappers — `make go-check-drift` compares
+# generated operations against those wrappers and never looks here, which is how
+# ArchiveProject and UnarchiveProject shipped missing from the grouped client
+# through two fully green `make` runs (#679).
+#
+# THE INVARIANT: every operationId in openapi.json appears EXACTLY ONCE across
+# this file — either under `grouped:` or in `not_grouped:`. A new operation lands
+# in neither and fails loudly, forcing a decision about whether it belongs on the
+# grouped surface.
+#
+# Why not "every operation in a service's tag must be exposed"? Because that is
+# false for 14 of the 15 services today and always has been. The grouped surface
+# is deliberately curated: Projects is exhaustive over its tag, Todos exposes 6
+# of 18, Card Tables 5 of 21. Total accounting is the invariant that actually
+# holds, and it is the same device as spec/doc-constants.json's committed marker
+# counts — both adding and deleting fail until someone restates the number.
+#
+# `method` is recorded data, not derived: arms deliberately rename (MoveCard ->
+# Move, UpdateCard -> UpdateVerbatim, justified at client.tmpl:1613), so the
+# method name cannot be computed from the operationId.
+#
+# Regenerate nothing by hand — run `make check-grouped-client-coverage` and
+# follow what it says.
+
+grouped:
+  CampfiresService:
+    - operation: GetCampfire
+      methods: ["Get"]
+    - operation: ListCampfires
+      methods: ["List"]
+  CardsService:
+    - operation: CreateCard
+      methods: ["CreateWithBody"]
+    - operation: GetCard
+      methods: ["Get"]
+    - operation: ListCards
+      methods: ["List"]
+    - operation: MoveCard
+      methods: ["MoveWithBody"]
+    - operation: UpdateCard
+      methods: ["UpdateVerbatimWithBody"]
+  CommentsService:
+    - operation: CreateComment
+      methods: ["CreateWithBody"]
+    - operation: GetComment
+      methods: ["Get"]
+    - operation: ListComments
+      methods: ["List"]
+    - operation: UpdateComment
+      methods: ["UpdateWithBody"]
+  DocumentsService:
+    - operation: CreateDocument
+      methods: ["CreateWithBody"]
+    - operation: GetDocument
+      methods: ["Get"]
+    - operation: ListDocuments
+      methods: ["List"]
+    - operation: ReplaceDocument
+      methods: ["ReplaceWithBody"]
+  EventsService:
+    - operation: ListEvents
+      methods: ["List"]
+  MessagesService:
+    - operation: CreateMessage
+      methods: ["CreateWithBody"]
+    - operation: GetMessage
+      methods: ["Get"]
+    - operation: ListMessages
+      methods: ["List"]
+    - operation: UpdateMessage
+      methods: ["UpdateWithBody"]
+  PeopleService:
+    - operation: GetMyProfile
+      methods: ["GetMyProfile"]
+    - operation: GetPerson
+      methods: ["Get"]
+    - operation: ListPeople
+      methods: ["List"]
+  ProjectsService:
+    - operation: ArchiveProject
+      methods: ["Archive"]
+    - operation: CreateProject
+      methods: ["CreateWithBody"]
+    - operation: GetProject
+      methods: ["Get"]
+    - operation: ListProjects
+      methods: ["List"]
+    - operation: TrashProject
+      methods: ["Trash"]
+    - operation: UnarchiveProject
+      methods: ["Unarchive"]
+    - operation: UpdateProject
+      methods: ["UpdateWithBody"]
+  RecordingsService:
+    - operation: ArchiveRecording
+      methods: ["Archive"]
+    - operation: ListRecordings
+      methods: ["List"]
+    - operation: TrashRecording
+      methods: ["Trash"]
+    - operation: UnarchiveRecording
+      methods: ["Unarchive"]
+  SchedulesService:
+    - operation: CreateScheduleEntry
+      methods: ["CreateEntryWithBody"]
+    - operation: GetSchedule
+      methods: ["Get"]
+    - operation: GetScheduleEntry
+      methods: ["GetEntry"]
+    - operation: ListScheduleEntries
+      methods: ["ListEntries"]
+    - operation: ReplaceScheduleEntry
+      methods: ["ReplaceEntryWithBody"]
+  TemplatesService:
+    - operation: CreateTemplate
+      methods: ["CreateWithBody"]
+    - operation: DeleteTemplate
+      methods: ["Delete"]
+    - operation: GetTemplate
+      methods: ["Get"]
+    - operation: ListTemplates
+      methods: ["List"]
+    - operation: UpdateTemplate
+      methods: ["UpdateWithBody"]
+  TodosService:
+    - operation: CompleteTodo
+      methods: ["Complete"]
+    - operation: CreateTodo
+      methods: ["CreateWithBody"]
+    - operation: GetTodo
+      methods: ["Get"]
+    - operation: ListTodos
+      methods: ["List"]
+    - operation: ReplaceTodo
+      methods: ["ReplaceWithBody"]
+    - operation: UncompleteTodo
+      methods: ["Uncomplete"]
+  UploadsService:
+    - operation: CreateUpload
+      methods: ["CreateWithBody"]
+    - operation: GetUpload
+      methods: ["Get"]
+    - operation: ListUploads
+      methods: ["List"]
+    - operation: UpdateUpload
+      methods: ["UpdateWithBody"]
+  VaultsService:
+    - operation: CreateVault
+      methods: ["CreateWithBody"]
+    - operation: GetVault
+      methods: ["Get"]
+    - operation: ListVaults
+      methods: ["List"]
+    - operation: UpdateVault
+      methods: ["UpdateWithBody"]
+  WebhooksService:
+    - operation: CreateWebhook
+      methods: ["CreateWithBody"]
+    - operation: DeleteWebhook
+      methods: ["Delete"]
+    - operation: GetWebhook
+      methods: ["Get"]
+    - operation: ListWebhooks
+      methods: ["List"]
+    - operation: UpdateWebhook
+      methods: ["UpdateWithBody"]
+
+# Operations deliberately absent from the grouped surface. Bulk, but pure data:
+# this list is what makes the accounting total, and therefore what makes a new
+# operation fail instead of passing unnoticed.
+#
+# There is no per-entry reason here because there is one reason for all of them:
+# the grouped client is a curated convenience layer, not a mirror of the API.
+# If you move an operation OUT of this list, you are asserting it now belongs on
+# the grouped surface and must add the matching arm to client.tmpl.
+not_grouped:
+  - CreateAnswer
+  - CreateAttachment
+  - CreateBookmark
+  - CreateCampfireLine
+  - CreateCampfireUpload
+  - CreateCardColumn
+  - CreateCardStep
+  - CreateChatbot
+  - CreateCloudFile
+  - CreateEventBoost
+  - CreateFolder
+  - CreateGaugeNeedle
+  - CreateGoogleDocument
+  - CreateLineupMarker
+  - CreateMessageType
+  - CreateProjectFromTemplate
+  - CreateQuestion
+  - CreateRecordingBoost
+  - CreateTimesheetEntry
+  - CreateTodolist
+  - CreateTodolistGroup
+  - CreateTodosetTodo
+  - CreateTool
+  - CreateWormhole
+  - DeleteBookmark
+  - DeleteBoost
+  - DeleteCampfireLine
+  - DeleteChatbot
+  - DeleteFolder
+  - DeleteLineupMarker
+  - DeleteMessageType
+  - DeleteTool
+  - DeleteWormhole
+  - DeprioritizeAssignment
+  - DestroyGaugeNeedle
+  - DestroyTimesheetEntry
+  - DisableCardColumnOnHold
+  - DisableOutOfOffice
+  - DisableTool
+  - EnableCardColumnOnHold
+  - EnableOutOfOffice
+  - EnableTool
+  - GetAccount
+  - GetAnswer
+  - GetAnswersByPerson
+  - GetAssignedTodos
+  - GetBookmark
+  - GetBoost
+  - GetBubbleUps
+  - GetCalendar
+  - GetCampfireLine
+  - GetCardColumn
+  - GetCardStep
+  - GetCardTable
+  - GetChatbot
+  - GetClientApproval
+  - GetClientCorrespondence
+  - GetClientReply
+  - GetCloudFile
+  - GetEverythingCheckins
+  - GetEverythingComments
+  - GetEverythingCompletedCards
+  - GetEverythingCompletedTodos
+  - GetEverythingFiles
+  - GetEverythingForwards
+  - GetEverythingMessages
+  - GetEverythingNoDueDateCards
+  - GetEverythingNoDueDateTodos
+  - GetEverythingNotNowCards
+  - GetEverythingOpenCards
+  - GetEverythingOpenTodos
+  - GetEverythingOverdueCards
+  - GetEverythingOverdueTodos
+  - GetEverythingUnassignedCards
+  - GetEverythingUnassignedTodos
+  - GetFolder
+  - GetForward
+  - GetForwardReply
+  - GetGaugeNeedle
+  - GetGoogleDocument
+  - GetHillChart
+  - GetInbox
+  - GetMessageBoard
+  - GetMessageType
+  - GetMyAssignments
+  - GetMyCompletedAssignments
+  - GetMyDueAssignments
+  - GetMyNote
+  - GetMyNotifications
+  - GetMyPreferences
+  - GetOutOfOffice
+  - GetOverdueTodos
+  - GetPersonProgress
+  - GetProgressReport
+  - GetProjectConstruction
+  - GetProjectTimeline
+  - GetProjectTimesheet
+  - GetQuestion
+  - GetQuestionReminders
+  - GetQuestionnaire
+  - GetRecordingTimesheet
+  - GetScheduleEntryOccurrence
+  - GetSearchMetadata
+  - GetSubscription
+  - GetTimesheetEntry
+  - GetTimesheetReport
+  - GetTodolistOrGroup
+  - GetTodoset
+  - GetTool
+  - GetUpcomingSchedule
+  - ListAnswers
+  - ListAssignablePeople
+  - ListCampfireLines
+  - ListCampfireUploads
+  - ListChatbots
+  - ListClientApprovals
+  - ListClientCorrespondences
+  - ListClientReplies
+  - ListEventBoosts
+  - ListFolders
+  - ListForwardReplies
+  - ListForwards
+  - ListGaugeNeedles
+  - ListGauges
+  - ListLineupMarkers
+  - ListMessageTypes
+  - ListMyBookmarks
+  - ListMyDrafts
+  - ListPingablePeople
+  - ListProjectPeople
+  - ListQuestionAnswerers
+  - ListQuestions
+  - ListRecordingBoosts
+  - ListTodolistGroups
+  - ListTodolists
+  - ListUploadVersions
+  - MarkAsRead
+  - MoveCardColumn
+  - PauseQuestion
+  - PinMessage
+  - PrioritizeAssignment
+  - RemoveAccountLogo
+  - ReorderUpNext
+  - RepositionCardStep
+  - RepositionTodo
+  - RepositionTodolist
+  - RepositionTodolistGroup
+  - RepositionTool
+  - ResumeQuestion
+  - Search
+  - SetCardColumnColor
+  - SetCardStepCompletion
+  - SetClientVisibility
+  - Subscribe
+  - SubscribeToCardColumn
+  - ToggleGauge
+  - UnpinMessage
+  - Unsubscribe
+  - UnsubscribeFromCardColumn
+  - UpdateAccountLogo
+  - UpdateAccountName
+  - UpdateAnswer
+  - UpdateCalendar
+  - UpdateCampfireLine
+  - UpdateCardColumn
+  - UpdateCardStep
+  - UpdateChatbot
+  - UpdateCloudFile
+  - UpdateFolder
+  - UpdateGaugeNeedle
+  - UpdateGoogleDocument
+  - UpdateHillChartSettings
+  - UpdateLineupMarker
+  - UpdateMessageType
+  - UpdateMyNote
+  - UpdateMyPreferences
+  - UpdateMyProfile
+  - UpdateProjectAccess
+  - UpdateQuestion
+  - UpdateQuestionNotificationSettings
+  - UpdateScheduleSettings
+  - UpdateSubscription
+  - UpdateTimesheetEntry
+  - UpdateTodolistOrGroup
+  - UpdateTool
+  - UpdateWormhole

--- a/go/pkg/basecamp/projects_test.go
+++ b/go/pkg/basecamp/projects_test.go
@@ -473,16 +473,22 @@ func TestProjectsService_UnarchiveAtProjectLimit(t *testing.T) {
 
 // The low-level grouped client surface (generated.Client.Projects()) is emitted
 // from an explicit per-operation switch in go/templates/client.tmpl, NOT from the
-// operation list — so adding an operation to the spec does not add it here, and
-// nothing catches the omission: go-check-drift compares generated operations
-// against this package's wrappers and never looks at the grouped surface.
+// operation list — so adding an operation to the spec does not add it here.
 // ArchiveProject and UnarchiveProject shipped without their template cases for
 // exactly that reason (caught in review on #679), leaving ProjectsService
 // asymmetric with RecordingsService, which has both.
 //
-// These method-value references are the cheap guard: they are compile-time only,
-// so a regressed template breaks the build here instead of silently shipping a
-// grouped client that cannot reach the operation.
+// The omission itself is now gated repo-wide by
+// scripts/check-grouped-client-coverage, which requires every operation in
+// openapi.json to be accounted for in go/grouped-client-inventory.yml as either
+// grouped or deliberately not grouped. That is the check that would have caught
+// #679, and it covers all 15 grouped services rather than these three methods.
+//
+// These method-value references are kept anyway, because they prove a different
+// thing at no cost: that the method is actually CALLABLE with the shape the
+// caller expects. The gate reads the template and the generated file as text; a
+// method that generates but does not compile against its own signature is
+// something only the compiler can say.
 var (
 	_ = (*generated.ProjectsService).Archive
 	_ = (*generated.ProjectsService).Unarchive

--- a/scripts/check-grouped-client-coverage
+++ b/scripts/check-grouped-client-coverage
@@ -1,0 +1,291 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Guard: every operation is explicitly accounted for on the Go GROUPED client.
+#
+# The grouped surface is `generated.Client.Todos()`, `.Projects()`, and so on — a
+# curated ergonomic layer emitted by the `{{if eq $opid "X"}}` chain in
+# go/templates/client.tmpl. Nothing else in `make` looks at it. `go-check-drift`
+# compares generated operations against the hand-written go/pkg/basecamp wrappers,
+# which is a different surface; ArchiveProject and UnarchiveProject shipped missing
+# from the grouped client and survived TWO fully green `make` runs before a human
+# reviewer caught it (#679). The next operation added to a grouped service hits the
+# same hole.
+#
+# WHAT THIS IS NOT. "Every operation in a grouped service's tag must be exposed"
+# is not the invariant: it is false for 14 of the 15 services today. Projects is
+# exhaustive over its tag; Todos exposes 6 of 18, Card Tables 5 of 21, People 3 of
+# 16, and 9 tags have no grouped presence at all. Curation is the design.
+#
+# Nor is a plain inventory of what IS exposed enough. A newly-added operation would
+# be absent from both the inventory and the template, the two would agree, and the
+# gate would pass — the #679 miss exactly.
+#
+# THE INVARIANT IS TOTAL ACCOUNTING. Every operationId in openapi.json appears
+# EXACTLY ONCE across go/grouped-client-inventory.yml's `grouped:` and
+# `not_grouped:`. A new operation lands in neither and fails loudly, forcing a
+# decision. Same device as spec/doc-constants.json's committed marker counts, where
+# both adding and deleting fail until someone restates the number.
+#
+# Method names are recorded data, never derived: arms deliberately rename (MoveCard
+# -> Move, UpdateCard -> UpdateVerbatim, justified at client.tmpl:1613). Keying on
+# the operationId is what makes that safe.
+#
+# Env seams (for scripts/test-check-grouped-client-coverage.rb — the tracked tree
+# is never written to):
+#   GROUPED_CLIENT_INVENTORY  path to the inventory YAML
+#   GROUPED_CLIENT_TEMPLATE   path to client.tmpl
+#   GROUPED_CLIENT_OPENAPI    path to openapi.json
+#   GROUPED_CLIENT_GENERATED  path to client.gen.go
+#
+# Usage: scripts/check-grouped-client-coverage
+
+require "json"
+require "yaml"
+
+ROOT = File.expand_path("..", __dir__)
+
+INVENTORY_PATH = ENV["GROUPED_CLIENT_INVENTORY"] || File.join(ROOT, "go/grouped-client-inventory.yml")
+TEMPLATE_PATH  = ENV["GROUPED_CLIENT_TEMPLATE"]  || File.join(ROOT, "go/templates/client.tmpl")
+OPENAPI_PATH   = ENV["GROUPED_CLIENT_OPENAPI"]   || File.join(ROOT, "openapi.json")
+GENERATED_PATH = ENV["GROUPED_CLIENT_GENERATED"] || File.join(ROOT, "go/pkg/generated/client.gen.go")
+
+# Extraction floors. Every input here is parsed with a regex, and a regex that
+# stops matching returns an empty set rather than an error — which reads as "all
+# clear" and is how a gate silently stops gating. A floor turns that into a
+# failure. The numbers are deliberately far below the real values (249 operations,
+# 63 arms, 15 services): they catch total extraction collapse, not drift.
+MIN_OPERATIONS = 200
+MIN_ARMS = 40
+MIN_SERVICES = 10
+
+failures = []
+
+def die(failures)
+  warn "FAIL: Go grouped-client coverage"
+  warn ""
+  failures.each { |f| warn "  - #{f}" }
+  warn ""
+  warn "  The grouped client is go/templates/client.tmpl's `$opid` chain; the"
+  warn "  accounting lives in go/grouped-client-inventory.yml."
+  exit 1
+end
+
+# ----------------------------------------------------------------- openapi.json
+
+unless File.exist?(OPENAPI_PATH)
+  die(["#{OPENAPI_PATH} not found"])
+end
+
+spec = JSON.parse(File.read(OPENAPI_PATH))
+spec_ops = spec.fetch("paths").flat_map { |_path, item|
+  item.filter_map { |_verb, op| op["operationId"] if op.is_a?(Hash) && op["operationId"] }
+}
+
+if spec_ops.length < MIN_OPERATIONS
+  die(["only #{spec_ops.length} operations read from openapi.json (floor #{MIN_OPERATIONS}) — " \
+       "extraction is probably broken, not the spec"])
+end
+
+dupe_spec = spec_ops.tally.select { |_, n| n > 1 }.keys
+unless dupe_spec.empty?
+  die(["openapi.json declares duplicate operationIds: #{dupe_spec.sort.join(', ')}"])
+end
+spec_ops = spec_ops.to_set
+
+# -------------------------------------------------------------- client.tmpl
+
+unless File.exist?(TEMPLATE_PATH)
+  die(["#{TEMPLATE_PATH} not found"])
+end
+
+# Walk the {{if eq $opid "X"}} / {{else if eq $opid "X"}} chain. Each arm runs
+# until the next arm, and the `func (s *XxxService) Name(` lines inside it are
+# what that arm emits. A `range .Bodies` variant spells its name with a template
+# action (`Create{{.Suffix}}`), which does not match and is not recorded — the
+# WithBody form beside it is the anchor, and it is enough to prove the arm fired.
+template_arms = {}
+current = nil
+File.foreach(TEMPLATE_PATH) do |line|
+  if (m = line.match(/\{\{(?:else )?if eq \$opid "([^"]+)"\}\}/))
+    current = { opid: m[1], service: nil, methods: [] }
+    template_arms[m[1]] = current
+  elsif current && (m = line.match(/^func \(s \*(\w+Service)\) (\w+)\(/))
+    current[:service] ||= m[1]
+    current[:methods] << m[2]
+  end
+end
+
+if template_arms.length < MIN_ARMS
+  die(["only #{template_arms.length} `$opid` arms read from #{File.basename(TEMPLATE_PATH)} " \
+       "(floor #{MIN_ARMS}) — the chain's syntax probably changed and extraction is silently failing"])
+end
+
+template_arms.each_value do |arm|
+  next unless arm[:service].nil?
+  failures << "client.tmpl arm for `#{arm[:opid]}` emits no `func (s *XxxService)` — " \
+              "an arm that produces no method is dead template."
+end
+
+# ------------------------------------------------------------- client.gen.go
+#
+# Anchor on the ACCESSOR, not on `type \w+Service struct`: CloudFileService and
+# DoorService are unrelated schema types in the same file and would be read as
+# grouped services.
+generated_services = []
+generated_methods = []
+if File.exist?(GENERATED_PATH)
+  File.foreach(GENERATED_PATH) do |line|
+    if (m = line.match(/^func \(c \*Client\) \w+\(\) \*(\w+Service) \{/))
+      generated_services << m[1]
+    elsif (m = line.match(/^func \(s \*(\w+Service)\) (\w+)\(/))
+      generated_methods << [m[1], m[2]]
+    end
+  end
+
+  if generated_services.length < MIN_SERVICES
+    die(["only #{generated_services.length} grouped service accessors read from " \
+         "#{File.basename(GENERATED_PATH)} (floor #{MIN_SERVICES}) — extraction is probably broken"])
+  end
+else
+  # The generated client is a build artifact; a fresh clone has it, but do not
+  # hard-fail a tree that has not generated yet. Say so rather than passing quietly.
+  warn "note: #{GENERATED_PATH} not found — skipping the generated-output cross-check"
+end
+generated_services = generated_services.to_set
+generated_methods = generated_methods.to_set
+
+# ----------------------------------------------------------------- inventory
+
+unless File.exist?(INVENTORY_PATH)
+  die(["#{INVENTORY_PATH} not found — this file IS the accounting"])
+end
+
+inventory = begin
+  YAML.safe_load(File.read(INVENTORY_PATH)) || {}
+rescue Psych::Exception => e
+  # A malformed inventory is a gate failure, not a crash. Aliases in particular
+  # are rejected by safe_load, and an unhandled Psych backtrace buries the one
+  # line that says which file to look at.
+  die(["#{INVENTORY_PATH} is not loadable YAML: #{e.message}"])
+end
+grouped = inventory["grouped"] || {}
+not_grouped = inventory["not_grouped"] || []
+
+unless grouped.is_a?(Hash)
+  die(["inventory `grouped:` must be a mapping of service name to entries"])
+end
+unless not_grouped.is_a?(Array)
+  die(["inventory `not_grouped:` must be a list of operationIds"])
+end
+
+inventory_grouped = {} # opid => { service:, methods: }
+grouped.each do |service, entries|
+  (entries || []).each do |entry|
+    opid = entry["operation"]
+    if opid.nil?
+      failures << "inventory `grouped: #{service}:` has an entry with no `operation:`."
+      next
+    end
+    if inventory_grouped.key?(opid)
+      failures << "`#{opid}` is listed twice under `grouped:` " \
+                  "(#{inventory_grouped[opid][:service]} and #{service}) — " \
+                  "every operation is accounted for exactly once."
+      next
+    end
+    inventory_grouped[opid] = { service: service, methods: Array(entry["methods"]) }
+  end
+end
+
+dupe_ungrouped = not_grouped.tally.select { |_, n| n > 1 }.keys
+dupe_ungrouped.each do |opid|
+  failures << "`#{opid}` is listed twice under `not_grouped:` — " \
+              "every operation is accounted for exactly once."
+end
+
+# ------------------------------------------------------- the total accounting
+
+both = inventory_grouped.keys & not_grouped
+both.sort.each do |opid|
+  failures << "`#{opid}` is in BOTH `grouped:` (#{inventory_grouped[opid][:service]}) and " \
+              "`not_grouped:` — it is one or the other, not both."
+end
+
+accounted = (inventory_grouped.keys + not_grouped).to_set
+
+# THE #679 CASE. A new operation is in openapi.json and in neither bucket.
+(spec_ops - accounted).sort.each do |opid|
+  arm = template_arms[opid]
+  where = arm ? "`#{arm[:service]}`" : "the right service"
+  failures << "new operation `#{opid}` is unaccounted for — expose it on #{where} in " \
+              "go/templates/client.tmpl and add it under `grouped:`, or add it to " \
+              "`not_grouped:` if it deliberately stays off the grouped client."
+end
+
+(accounted - spec_ops).sort.each do |opid|
+  failures << "`#{opid}` is in the inventory but not in openapi.json — stale, remove it."
+end
+
+# -------------------------------------------- inventory vs. the actual template
+
+(inventory_grouped.keys.to_set - template_arms.keys.to_set).sort.each do |opid|
+  failures << "`#{opid}` is listed under `grouped: #{inventory_grouped[opid][:service]}:` but " \
+              "go/templates/client.tmpl has no `$opid` arm for it — " \
+              "either add the arm or move it to `not_grouped:`."
+end
+
+(template_arms.keys.to_set - inventory_grouped.keys.to_set).sort.each do |opid|
+  next unless spec_ops.include?(opid) # already reported as stale above otherwise
+  failures << "go/templates/client.tmpl exposes `#{opid}` on " \
+              "`#{template_arms[opid][:service]}` but it is not under `grouped:` — " \
+              "record it there."
+end
+
+inventory_grouped.each do |opid, entry|
+  arm = template_arms[opid]
+  next if arm.nil? || arm[:service].nil?
+
+  if arm[:service] != entry[:service]
+    failures << "`#{opid}` is recorded under `grouped: #{entry[:service]}:` but client.tmpl " \
+                "emits it on `#{arm[:service]}`."
+  end
+
+  missing_methods = arm[:methods].to_set - entry[:methods].to_set
+  missing_methods.sort.each do |method|
+    failures << "`#{opid}` emits `#{entry[:service]}.#{method}` in client.tmpl but that method " \
+                "is not in its inventory `methods:` — method names are recorded, not derived."
+  end
+
+  phantom_methods = entry[:methods].to_set - arm[:methods].to_set
+  phantom_methods.sort.each do |method|
+    failures << "`#{opid}` records method `#{method}` but client.tmpl's arm does not emit it."
+  end
+end
+
+# ------------------------------------------ inventory vs. the generated output
+#
+# The template is the intent; client.gen.go is whether the intent survived
+# generation. #679's arms were added to the template AND regenerated, so this
+# cross-check would not have caught it on its own — the total accounting above is
+# what does. This catches the different failure where an arm exists but generates
+# nothing.
+unless generated_services.empty?
+  inventory_grouped.each do |opid, entry|
+    unless generated_services.include?(entry[:service])
+      failures << "`#{opid}` is recorded on `#{entry[:service]}`, which has no " \
+                  "`func (c *Client) ...() *#{entry[:service]}` accessor in the generated client."
+      next
+    end
+    entry[:methods].each do |method|
+      next if generated_methods.include?([entry[:service], method])
+      failures << "`#{entry[:service]}.#{method}` (#{opid}) is in the inventory but absent from " \
+                  "the generated client — regenerate, or the arm is not firing."
+    end
+  end
+end
+
+die(failures) unless failures.empty?
+
+puts "OK: Go grouped-client coverage — #{spec_ops.size} operations fully accounted for " \
+     "(#{inventory_grouped.size} grouped across #{grouped.size} services, " \
+     "#{not_grouped.size} deliberately not grouped)"

--- a/scripts/check-grouped-client-coverage
+++ b/scripts/check-grouped-client-coverage
@@ -128,11 +128,19 @@ end
 # resolved name for each, and the generated-output cross-check below is what
 # actually proves the method still exists.
 template_arms = {}
+duplicate_arms = []
 current = nil
 File.foreach(TEMPLATE_PATH, encoding: "UTF-8") do |line|
   if (m = line.match(/\{\{(?:else )?if eq \$opid "([^"]+)"\}\}/))
+    # A repeated `$opid` in the chain — a copy-pasted arm — is unreachable: Go
+    # evaluates the FIRST matching branch and never reaches the second. Assigning
+    # into the hash keeps the LAST one, so without this the gate would compare the
+    # inventory against a branch that never runs, and an identical duplicate would
+    # be invisible dead template. The inventory has the same check; the template
+    # deserves it symmetrically.
+    duplicate_arms << m[1] if template_arms.key?(m[1])
     current = { opid: m[1], service: nil, methods: [], dynamic_prefixes: [] }
-    template_arms[m[1]] = current
+    template_arms[m[1]] ||= current
   elsif current && (m = line.match(/^func \(s \*(\w+Service)\) (\w+)\(/))
     current[:service] ||= m[1]
     current[:methods] << m[2]
@@ -145,6 +153,12 @@ end
 if template_arms.length < MIN_ARMS
   die(["only #{template_arms.length} `$opid` arms read from #{File.basename(TEMPLATE_PATH)} " \
        "(floor #{MIN_ARMS}) — the chain's syntax probably changed and extraction is silently failing"])
+end
+
+duplicate_arms.uniq.sort.each do |opid|
+  failures << "go/templates/client.tmpl has more than one `$opid` arm for `#{opid}` — " \
+              "Go takes the first matching branch, so the later one is unreachable dead " \
+              "template. Delete the duplicate."
 end
 
 template_arms.each_value do |arm|

--- a/scripts/check-grouped-client-coverage
+++ b/scripts/check-grouped-client-coverage
@@ -109,18 +109,36 @@ end
 
 # Walk the {{if eq $opid "X"}} / {{else if eq $opid "X"}} chain. Each arm runs
 # until the next arm, and the `func (s *XxxService) Name(` lines inside it are
-# what that arm emits. A `range .Bodies` variant spells its name with a template
-# action (`Create{{.Suffix}}`), which does not match and is not recorded — the
-# WithBody form beside it is the anchor, and it is enough to prove the arm fired.
+# what that arm emits.
+#
+# A body-bearing arm emits TWO kinds of method, and both have to be tracked:
+#
+#   func (s *TodosService) CreateWithBody(...)      <- literal, matches directly
+#   func (s *TodosService) Create{{.Suffix}}(...)   <- inside {{range .Bodies}}
+#
+# The second is the typed, public one people actually call (`Todos().Create`),
+# and its name is a template action, so it cannot be read literally — only its
+# PREFIX can. Recording just the `WithBody` anchor was not enough: deleting the
+# `{{range .Bodies}}` block removes `Create` from the generated client while
+# `CreateWithBody` survives, so template, inventory and generated output would
+# all still agree and the gate would pass having lost a public method. There are
+# 23 such variants, a quarter of the 86 grouped methods.
+#
+# So dynamic lines are captured by prefix, the inventory must record the concrete
+# resolved name for each, and the generated-output cross-check below is what
+# actually proves the method still exists.
 template_arms = {}
 current = nil
 File.foreach(TEMPLATE_PATH, encoding: "UTF-8") do |line|
   if (m = line.match(/\{\{(?:else )?if eq \$opid "([^"]+)"\}\}/))
-    current = { opid: m[1], service: nil, methods: [] }
+    current = { opid: m[1], service: nil, methods: [], dynamic_prefixes: [] }
     template_arms[m[1]] = current
   elsif current && (m = line.match(/^func \(s \*(\w+Service)\) (\w+)\(/))
     current[:service] ||= m[1]
     current[:methods] << m[2]
+  elsif current && (m = line.match(/^func \(s \*(\w+Service)\) (\w+)\{\{/))
+    current[:service] ||= m[1]
+    current[:dynamic_prefixes] << m[2]
   end
 end
 
@@ -273,8 +291,26 @@ inventory_grouped.each do |opid, entry|
                 "is not in its inventory `methods:` — method names are recorded, not derived."
   end
 
-  phantom_methods = entry[:methods].to_set - arm[:methods].to_set
+  # A dynamic `Name{{.Suffix}}` line cannot be matched by name, only by prefix, so
+  # require the inventory to carry at least one recorded method under that prefix
+  # beyond the literal ones. That recorded name is then checked against the
+  # generated client below, which is what makes deleting a `{{range .Bodies}}`
+  # block fail instead of silently dropping a public method.
+  literal = arm[:methods].to_set
+  arm[:dynamic_prefixes].uniq.sort.each do |prefix|
+    typed = entry[:methods].reject { |m| literal.include?(m) }.select { |m| m.start_with?(prefix) }
+    next unless typed.empty?
+    failures << "`#{opid}` emits a typed `#{entry[:service]}.#{prefix}{{.Suffix}}` variant in " \
+                "client.tmpl (inside `{{range .Bodies}}`) but its inventory `methods:` records " \
+                "no `#{prefix}…` method beyond the WithBody form — record the resolved name, or " \
+                "the typed method can vanish from the generated client unnoticed."
+  end
+
+  # Phantom check, minus anything a dynamic prefix legitimately explains.
+  explained = ->(m) { arm[:dynamic_prefixes].any? { |p| m.start_with?(p) } }
+  phantom_methods = entry[:methods].to_set - literal
   phantom_methods.sort.each do |method|
+    next if explained.call(method)
     failures << "`#{opid}` records method `#{method}` but client.tmpl's arm does not emit it."
   end
 end
@@ -303,6 +339,7 @@ end
 
 die(failures) unless failures.empty?
 
+method_count = inventory_grouped.values.sum { |e| e[:methods].size }
 puts "OK: Go grouped-client coverage — #{spec_ops.size} operations fully accounted for " \
-     "(#{inventory_grouped.size} grouped across #{grouped.size} services, " \
+     "(#{inventory_grouped.size} grouped across #{grouped.size} services via #{method_count} methods, " \
      "#{not_grouped.size} deliberately not grouped)"

--- a/scripts/check-grouped-client-coverage
+++ b/scripts/check-grouped-client-coverage
@@ -31,6 +31,13 @@
 # -> Move, UpdateCard -> UpdateVerbatim, justified at client.tmpl:1613). Keying on
 # the operationId is what makes that safe.
 #
+# Every read is pinned to UTF-8. Under a non-UTF-8 locale (LC_ALL=C) Ruby tags file
+# contents US-ASCII, and client.tmpl, openapi.json and the inventory all carry
+# non-ASCII text — so the first scan raises InvalidByteSequenceError and the gate
+# fails before validating anything. Both CI steps run under LC_ALL=C so that stays
+# proven rather than asserted, matching check-fixture-coverage and
+# check-projected-examples.
+#
 # Env seams (for scripts/test-check-grouped-client-coverage.rb — the tracked tree
 # is never written to):
 #   GROUPED_CLIENT_INVENTORY  path to the inventory YAML
@@ -78,7 +85,7 @@ unless File.exist?(OPENAPI_PATH)
   die(["#{OPENAPI_PATH} not found"])
 end
 
-spec = JSON.parse(File.read(OPENAPI_PATH))
+spec = JSON.parse(File.read(OPENAPI_PATH, encoding: "UTF-8"))
 spec_ops = spec.fetch("paths").flat_map { |_path, item|
   item.filter_map { |_verb, op| op["operationId"] if op.is_a?(Hash) && op["operationId"] }
 }
@@ -107,7 +114,7 @@ end
 # WithBody form beside it is the anchor, and it is enough to prove the arm fired.
 template_arms = {}
 current = nil
-File.foreach(TEMPLATE_PATH) do |line|
+File.foreach(TEMPLATE_PATH, encoding: "UTF-8") do |line|
   if (m = line.match(/\{\{(?:else )?if eq \$opid "([^"]+)"\}\}/))
     current = { opid: m[1], service: nil, methods: [] }
     template_arms[m[1]] = current
@@ -136,7 +143,7 @@ end
 generated_services = []
 generated_methods = []
 if File.exist?(GENERATED_PATH)
-  File.foreach(GENERATED_PATH) do |line|
+  File.foreach(GENERATED_PATH, encoding: "UTF-8") do |line|
     if (m = line.match(/^func \(c \*Client\) \w+\(\) \*(\w+Service) \{/))
       generated_services << m[1]
     elsif (m = line.match(/^func \(s \*(\w+Service)\) (\w+)\(/))
@@ -163,7 +170,7 @@ unless File.exist?(INVENTORY_PATH)
 end
 
 inventory = begin
-  YAML.safe_load(File.read(INVENTORY_PATH)) || {}
+  YAML.safe_load(File.read(INVENTORY_PATH, encoding: "UTF-8")) || {}
 rescue Psych::Exception => e
   # A malformed inventory is a gate failure, not a crash. Aliases in particular
   # are rejected by safe_load, and an unhandled Psych backtrace buries the one

--- a/scripts/check-grouped-client-coverage
+++ b/scripts/check-grouped-client-coverage
@@ -236,10 +236,19 @@ end
 end
 
 (template_arms.keys.to_set - inventory_grouped.keys.to_set).sort.each do |opid|
-  next unless spec_ops.include?(opid) # already reported as stale above otherwise
-  failures << "go/templates/client.tmpl exposes `#{opid}` on " \
-              "`#{template_arms[opid][:service]}` but it is not under `grouped:` — " \
-              "record it there."
+  if spec_ops.include?(opid)
+    failures << "go/templates/client.tmpl exposes `#{opid}` on " \
+                "`#{template_arms[opid][:service]}` but it is not under `grouped:` — " \
+                "record it there."
+  else
+    # A dead arm, and nothing else here sees it. The stale-inventory check above
+    # walks `accounted`, so once an operation is removed from openapi.json AND
+    # from the inventory, its surviving `$opid` arm is in no set that check
+    # compares — it would sit in client.tmpl forever with the gate green.
+    failures << "go/templates/client.tmpl still has a `$opid` arm for `#{opid}` " \
+                "(on `#{template_arms[opid][:service]}`), which is no longer in " \
+                "openapi.json — remove the dead arm."
+  end
 end
 
 inventory_grouped.each do |opid, entry|

--- a/scripts/check-grouped-client-coverage
+++ b/scripts/check-grouped-client-coverage
@@ -41,6 +41,7 @@
 # Usage: scripts/check-grouped-client-coverage
 
 require "json"
+require "set"
 require "yaml"
 
 ROOT = File.expand_path("..", __dir__)

--- a/scripts/check-grouped-client-coverage
+++ b/scripts/check-grouped-client-coverage
@@ -322,7 +322,17 @@ end
 # cross-check would not have caught it on its own — the total accounting above is
 # what does. This catches the different failure where an arm exists but generates
 # nothing.
+#
+# BOTH DIRECTIONS, for the same reason the operation-level accounting is total.
+# Recorded-implies-generated alone leaves a generated method nobody recorded, and
+# an unrecorded method is one that can later disappear with nothing noticing —
+# which is the #679 failure mode at method granularity. It is reachable without
+# anyone touching this gate: a grouped operation that gains a second supported
+# request content type makes `{{range .Bodies}}` emit an extra suffixed method,
+# and the dynamic-prefix check above is satisfied by the variant already
+# recorded. So every method on a grouped service must be accounted for too.
 unless generated_services.empty?
+  recorded_pairs = Set.new
   inventory_grouped.each do |opid, entry|
     unless generated_services.include?(entry[:service])
       failures << "`#{opid}` is recorded on `#{entry[:service]}`, which has no " \
@@ -330,10 +340,17 @@ unless generated_services.empty?
       next
     end
     entry[:methods].each do |method|
+      recorded_pairs << [entry[:service], method]
       next if generated_methods.include?([entry[:service], method])
       failures << "`#{entry[:service]}.#{method}` (#{opid}) is in the inventory but absent from " \
                   "the generated client — regenerate, or the arm is not firing."
     end
+  end
+
+  (generated_methods - recorded_pairs).sort.each do |service, method|
+    failures << "the generated client exposes `#{service}.#{method}` but no `grouped:` entry " \
+                "records it — add it to the owning operation's `methods:`, or an unrecorded " \
+                "method can vanish again without this gate noticing."
   end
 end
 

--- a/scripts/test-check-grouped-client-coverage.rb
+++ b/scripts/test-check-grouped-client-coverage.rb
@@ -1,0 +1,293 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Negative-case self-test for scripts/check-grouped-client-coverage.
+#
+# The gate's own `make check` run only ever exercises the PASSING case, so nothing
+# there proves it rejects anything. This repo treats an ungated gate as no gate,
+# and a coverage gate that cannot fail is worse than none: it converts "nobody
+# checked" into "the gate says it is fine".
+#
+# Every case drives the real checker through its four env seams
+# (GROUPED_CLIENT_INVENTORY / _TEMPLATE / _OPENAPI / _GENERATED) against synthetic
+# inputs in a tmpdir. The tracked tree is never written to.
+#
+# GROUPED_COVERAGE_CHECKER names the checker under test (default
+# scripts/check-grouped-client-coverage), so a deliberately-mutated copy can be
+# driven through the same suite to prove the suite is not vacuous:
+#
+#   mkdir -p /tmp/m/scripts
+#   ln -s "$PWD/openapi.json" /tmp/m/openapi.json
+#   ln -s "$PWD/go"           /tmp/m/go
+#   cp scripts/check-grouped-client-coverage /tmp/m/scripts/   # mutate the COPY
+#   GROUPED_COVERAGE_CHECKER=/tmp/m/scripts/check-grouped-client-coverage \
+#     ruby scripts/test-check-grouped-client-coverage.rb
+#
+# The copy resolves ROOT from its own __dir__, so it needs a ROOT holding
+# openapi.json and go/ — symlinks are fine. Skip that and every case fails,
+# including the positive control, which looks like a devastating mutation and is
+# really just a checker that cannot find its inputs. Never mutate the tracked file.
+#
+# Every guard in the checker is pinned by EXACTLY one case, and every case by
+# exactly one guard — measured, not assumed. Removing a guard from the copy must
+# turn exactly this red and nothing else:
+#
+#   guard removed in the copy                        case that must go red
+#   ---------------------------------------------    ---------------------
+#   unaccounted-operation check (THE #679 MISS)      1
+#   template-arm-not-in-inventory check              2
+#   in-both-buckets check                            3
+#   stale-inventory-entry check                      4
+#   inventory-vs-template service agreement          5
+#   `grouped:`-entry-with-no-template-arm check      6
+#   arm-emits-unrecorded-method check                7
+#   inventory-records-phantom-method check           8
+#   extraction floor on template arms                9
+#   duplicate `grouped:` entry check                 10
+#
+# Case 2 is the #679 replay in its realistic form and is caught by the
+# template-arm check rather than the unaccounted check, because by then the arms
+# exist. Case 1 is the form where they do not. Both matter: #679 shipped with
+# NEITHER, and whichever gets written first, the other guard catches the rest.
+#
+# Run directly (`ruby scripts/test-check-grouped-client-coverage.rb`) or via
+# `make test-grouped-client-coverage`.
+
+require "json"
+require "yaml"
+require "tmpdir"
+require "open3"
+
+# Per-case lines go to stdout and the failure report to stderr. Unsynced, stdout
+# block-buffers when redirected to a file and the report lands ahead of the cases
+# it summarizes — which is exactly when someone is reading the log.
+$stdout.sync = true
+
+ROOT = File.expand_path("..", __dir__)
+CHECKER = File.expand_path(
+  ENV.fetch("GROUPED_COVERAGE_CHECKER", "scripts/check-grouped-client-coverage"), ROOT
+)
+REAL_INVENTORY = File.join(ROOT, "go/grouped-client-inventory.yml")
+REAL_TEMPLATE  = File.join(ROOT, "go/templates/client.tmpl")
+REAL_OPENAPI   = File.join(ROOT, "openapi.json")
+
+def read_utf8(path) = File.read(path, encoding: "UTF-8")
+
+REAL_OPS = JSON.parse(read_utf8(REAL_OPENAPI)).fetch("paths").flat_map { |_p, item|
+  item.filter_map { |_v, op| op["operationId"] if op.is_a?(Hash) && op["operationId"] }
+}.freeze
+
+# A spec carrying exactly the given operationIds. The checker only ever reads
+# operationIds out of openapi.json, so a synthetic spec exercises it identically
+# while staying small enough to build per case.
+def synthetic_spec(ops)
+  { "openapi" => "3.0.3", "info" => { "title" => "t", "version" => "0" },
+    "paths" => ops.each_with_object({}) { |op, h| h["/synthetic/#{op}"] = { "get" => { "operationId" => op } } } }
+end
+
+# Run the checker with any subset of its inputs overridden. Anything not passed
+# falls through to the real tracked file.
+def run_checker(inventory: nil, template: nil, openapi: nil, generated: nil)
+  env = {}
+  env["GROUPED_CLIENT_INVENTORY"] = inventory if inventory
+  env["GROUPED_CLIENT_TEMPLATE"]  = template  if template
+  env["GROUPED_CLIENT_OPENAPI"]   = openapi   if openapi
+  # The generated cross-check is not what any case here is about, and pointing it
+  # at a nonexistent path makes the checker skip it — so a synthetic inventory
+  # entry is not ALSO reported as missing from client.gen.go, which would let a
+  # case pass on the wrong message.
+  env["GROUPED_CLIENT_GENERATED"] = generated || "/nonexistent/client.gen.go"
+  Open3.capture2e(env, "ruby", CHECKER)
+end
+
+# Build a case's temp inputs, run, and clean up. `inventory` and `spec_ops` are
+# deep copies, so a mutation cannot leak into a later case.
+def with_inputs(spec_ops: nil, template: nil)
+  Dir.mktmpdir("grouped-client-coverage-test") do |dir|
+    inventory = Marshal.load(Marshal.dump(YAML.safe_load(read_utf8(REAL_INVENTORY))))
+    yield inventory
+
+    inv_path = File.join(dir, "inventory.yml")
+    File.write(inv_path, YAML.dump(inventory))
+
+    spec_path = nil
+    if spec_ops
+      spec_path = File.join(dir, "openapi.json")
+      File.write(spec_path, JSON.generate(synthetic_spec(spec_ops)))
+    end
+
+    tmpl_path = nil
+    if template
+      tmpl_path = File.join(dir, "client.tmpl")
+      File.write(tmpl_path, template)
+    end
+
+    run_checker(inventory: inv_path, openapi: spec_path, template: tmpl_path)
+  end
+end
+
+def grouped_entry(inventory, opid)
+  inventory.fetch("grouped").each do |service, entries|
+    entry = (entries || []).find { |e| e["operation"] == opid }
+    return [service, entry] if entry
+  end
+  raise "no `grouped:` entry for #{opid} in #{REAL_INVENTORY}"
+end
+
+failures = []
+
+def expect_pass(failures, label, out, status)
+  if status.success?
+    puts "  PASS  #{label}"
+  else
+    puts "  FAIL  #{label}"
+    failures << "#{label}: expected PASS but checker failed:\n#{out}"
+  end
+end
+
+def expect_fail(failures, label, out, status, fragment)
+  if status.success?
+    puts "  FAIL  #{label}"
+    failures << "#{label}: expected FAILURE but checker passed:\n#{out}"
+  elsif !out.include?(fragment)
+    puts "  FAIL  #{label}"
+    failures << "#{label}: failed as expected but message missing #{fragment.inspect}:\n#{out}"
+  else
+    puts "  PASS  #{label}"
+  end
+end
+
+puts "==> grouped-client coverage self-test (checker: #{CHECKER.sub("#{ROOT}/", '')})"
+
+# --- Positive control ----------------------------------------------------------
+#
+# First, and load-bearing: if the real inventory does not pass, every negative
+# case below fails for a reason that has nothing to do with the mutation.
+
+out, status = run_checker(generated: File.join(ROOT, "go/pkg/generated/client.gen.go"))
+expect_pass(failures, "positive control: the real inventory passes", out, status)
+
+# --- 1. A new operation, in neither bucket -- THE #679 MISS --------------------
+#
+# The whole reason this gate exists. An operation is added to the spec and to no
+# grouped service. Under a plain "inventory of what is exposed", the inventory and
+# the template would agree that it is absent and the gate would pass.
+
+out, status = with_inputs(spec_ops: REAL_OPS + ["ResurrectProject"]) { |_inv| }
+expect_fail(failures, "1. new operation accounted for nowhere (#679)", out, status,
+            "new operation `ResurrectProject` is unaccounted for")
+
+# --- 2. The literal #679 replay -----------------------------------------------
+#
+# Case 1 with the real names: an operation that IS grouped today, removed from the
+# inventory to stand in for the state before anyone recorded it. It must be named.
+
+out, status = with_inputs do |inv|
+  service, entry = grouped_entry(inv, "ArchiveProject")
+  inv["grouped"][service].delete(entry)
+end
+expect_fail(failures, "2. ArchiveProject dropped from the inventory", out, status,
+            "go/templates/client.tmpl exposes `ArchiveProject` on `ProjectsService` " \
+            "but it is not under `grouped:`")
+
+# --- 3. Accounted for twice ----------------------------------------------------
+
+out, status = with_inputs { |inv| inv["not_grouped"] << "ArchiveProject" }
+expect_fail(failures, "3. operation in both `grouped:` and `not_grouped:`", out, status,
+            "`ArchiveProject` is in BOTH `grouped:`")
+
+# --- 4. Stale inventory entry --------------------------------------------------
+#
+# An operation removed from the spec — #504 removed GetEverythingBoosts this way —
+# must not linger in the accounting, or the totals stop meaning anything.
+
+out, status = with_inputs { |inv| inv["not_grouped"] << "GetEverythingBoosts" }
+expect_fail(failures, "4. inventory entry absent from openapi.json", out, status,
+            "`GetEverythingBoosts` is in the inventory but not in openapi.json — stale")
+
+# --- 5. Recorded on the wrong service ------------------------------------------
+#
+# The inventory says one service, client.tmpl emits another. Silent otherwise:
+# both files parse, both list the operation, and they disagree about where it is.
+
+out, status = with_inputs do |inv|
+  service, entry = grouped_entry(inv, "ArchiveProject")
+  inv["grouped"][service].delete(entry)
+  inv["grouped"]["TodosService"] << entry
+end
+expect_fail(failures, "5. operation recorded on the wrong service", out, status,
+            "`ArchiveProject` is recorded under `grouped: TodosService:` but client.tmpl " \
+            "emits it on `ProjectsService`")
+
+# --- 6. Inventory claims a grouping the template does not have -----------------
+#
+# The converse of case 2, and the one that would let someone "fix" a failure by
+# editing only the inventory. Moving an operation out of `not_grouped:` asserts it
+# is on the grouped surface; if no arm emits it, the assertion is false.
+
+out, status = with_inputs do |inv|
+  inv["not_grouped"].delete("GetProject") if inv["not_grouped"].include?("GetProject")
+  target = inv["not_grouped"].first
+  inv["not_grouped"].delete(target)
+  inv["grouped"]["ProjectsService"] << { "operation" => target, "methods" => ["Get"] }
+end
+expect_fail(failures, "6. `grouped:` entry with no template arm", out, status,
+            "go/templates/client.tmpl has no `$opid` arm for it")
+
+# --- 7. Arm emits a method the inventory does not record -----------------------
+
+out, status = with_inputs do |inv|
+  _service, entry = grouped_entry(inv, "ArchiveProject")
+  entry["methods"] = []
+end
+expect_fail(failures, "7. arm emits an unrecorded method", out, status,
+            "is not in its inventory `methods:` — method names are recorded, not derived")
+
+# --- 8. Inventory records a method no arm emits --------------------------------
+#
+# The renames (MoveCard -> Move, UpdateCard -> UpdateVerbatim) mean method names
+# are data rather than something the gate can recompute, so a wrong name is
+# otherwise unfalsifiable.
+
+out, status = with_inputs do |inv|
+  _service, entry = grouped_entry(inv, "ArchiveProject")
+  entry["methods"] = entry["methods"] + ["Unarchive"]
+end
+expect_fail(failures, "8. inventory records a phantom method", out, status,
+            "records method `Unarchive` but client.tmpl's arm does not emit it")
+
+# --- 9. Template extraction collapses ------------------------------------------
+#
+# If the `$opid` chain's syntax changes, the regex matches nothing and returns an
+# empty arm set. Without a floor that reads as "no drift" and the gate goes quiet
+# — the failure mode a coverage gate can least afford.
+
+out, status = with_inputs(template: "// a client template with no $opid chain at all\n") { |_inv| }
+expect_fail(failures, "9. template extraction returns nothing", out, status,
+            "the chain's syntax probably changed and extraction is silently failing")
+
+# --- 10. The same operation grouped twice --------------------------------------
+
+out, status = with_inputs do |inv|
+  _service, entry = grouped_entry(inv, "ArchiveProject")
+  # A DEEP copy, not the same object: YAML.dump emits an alias for any repeated
+  # reference, safe_load rejects aliases, and the case would then prove only that
+  # the checker rejects aliases. `entry.dup` is not enough — the shared `methods`
+  # array aliases on its own.
+  inv["grouped"]["TodosService"] << Marshal.load(Marshal.dump(entry))
+end
+expect_fail(failures, "10. duplicate `grouped:` entry", out, status,
+            "`ArchiveProject` is listed twice under `grouped:`")
+
+# --- Report --------------------------------------------------------------------
+
+puts
+if failures.empty?
+  puts "==> grouped-client coverage self-test: all cases passed"
+  exit 0
+else
+  warn "==> grouped-client coverage self-test: #{failures.length} case(s) failed"
+  warn ""
+  failures.each { |f| warn "  #{f}\n\n" }
+  exit 1
+end

--- a/scripts/test-check-grouped-client-coverage.rb
+++ b/scripts/test-check-grouped-client-coverage.rb
@@ -28,9 +28,11 @@
 # including the positive control, which looks like a devastating mutation and is
 # really just a checker that cannot find its inputs. Never mutate the tracked file.
 #
-# Every guard in the checker is pinned by EXACTLY one case, and every case by
-# exactly one guard — measured, not assumed. Removing a guard from the copy must
-# turn exactly this red and nothing else:
+# Every guard in the checker is pinned by at least one case, and the mapping below
+# is measured — mutate the guard in a copy, record which cases go red — rather than
+# reasoned about. It is mostly one-to-one; where it is not, the table says so, and
+# the two exceptions were both found by measuring after writing down the tidy
+# version. Removing a guard from the copy must turn exactly this red:
 #
 #   guard removed in the copy                        case that must go red
 #   ---------------------------------------------    ---------------------
@@ -63,6 +65,15 @@
 # template-arm check rather than the unaccounted check, because by then the arms
 # exist. Case 1 is the form where they do not. Both matter: #679 shipped with
 # NEITHER, and whichever gets written first, the other guard catches the rest.
+#
+# WHAT THIS SUITE IS NOT. Five of these cases — 11, 12, 13, 14, 15 — exist because
+# a reviewer found a hole this suite had not thought of, on a gate whose whole
+# premise is that an ungated gate is no gate. Every one was the same species the
+# gate exists to catch: a one-way containment check, an unexamined `next`, a
+# method surface measured at 86 and recorded at 63, a duplicate check written for
+# one input and not its twin. The suite passing means these fifteen things are
+# checked. It has never meant the list is complete, and the list's own history is
+# the argument against reading it that way.
 #
 # Run directly (`ruby scripts/test-check-grouped-client-coverage.rb`) or via
 # `make test-grouped-client-coverage`.

--- a/scripts/test-check-grouped-client-coverage.rb
+++ b/scripts/test-check-grouped-client-coverage.rb
@@ -41,10 +41,21 @@
 #   inventory-vs-template service agreement          5
 #   `grouped:`-entry-with-no-template-arm check      6
 #   arm-emits-unrecorded-method check                7
-#   inventory-records-phantom-method check           8
+#   inventory-records-phantom-method check           8 and 13
 #   extraction floor on template arms                9
 #   duplicate `grouped:` entry check                 10
 #   dead-template-arm check                          11
+#   dynamic-prefix (typed body variant) check        12
+#   the `explained` filter on the phantom check      positive control
+#
+# The last two rows are the measured result, not the tidy one I first wrote. The
+# phantom check catches both a genuinely invented method (8) and a typed variant
+# whose `{{range .Bodies}}` block was deleted (13) — it is one guard with two
+# cases, and neutering it turns both red. The `explained` filter beside it does
+# the opposite job: it stops the same check from misreporting the 23 legitimate
+# typed variants as phantoms, so deleting it breaks the POSITIVE control rather
+# than any negative case. A filter that prevents false positives can only be
+# pinned by a case that is supposed to pass.
 #
 # Case 2 is the #679 replay in its realistic form and is caught by the
 # template-arm check rather than the unaccounted check, because by then the arms
@@ -288,6 +299,35 @@ out, status = with_inputs(spec_ops: REAL_OPS - ["ArchiveProject"]) do |inv|
 end
 expect_fail(failures, "11. dead template arm for an operation dropped from the spec", out, status,
             "still has a `$opid` arm for `ArchiveProject`")
+
+# --- 12. Typed `{{range .Bodies}}` variant dropped from the inventory ----------
+#
+# A body-bearing arm emits both `CreateWithBody` (literal) and `Create{{.Suffix}}`
+# (dynamic). Recording only the WithBody anchor covered 63 of the 86 grouped
+# methods and left the 23 typed variants — the ones people actually call — outside
+# the accounting entirely.
+
+out, status = with_inputs do |inv|
+  _service, entry = grouped_entry(inv, "CreateTodo")
+  entry["methods"] = entry["methods"].reject { |m| m == "Create" }
+end
+expect_fail(failures, "12. typed body variant missing from the inventory", out, status,
+            "records no `Create…` method beyond the WithBody form")
+
+# --- 13. The `{{range .Bodies}}` block deleted from the template ---------------
+#
+# The other direction, and the regression this pair exists for: regeneration drops
+# the public `Todos().Create` while `CreateWithBody` survives. Before the typed
+# variants were recorded, template, inventory and generated output all still
+# agreed and the gate passed having lost a public method.
+
+mutated = read_utf8(REAL_TEMPLATE).sub(
+  /\{\{range \.Bodies\}\}\{\{if \.IsSupportedByClient\}\}\nfunc \(s \*TodosService\) Create\{\{\.Suffix\}\}.*?\n\{\{end\}\}\{\{end\}\}\n/m, ""
+)
+raise "template mutation for case 13 did not apply" if mutated == read_utf8(REAL_TEMPLATE)
+out, status = with_inputs(template: mutated) { |_inv| }
+expect_fail(failures, "13. typed body variant deleted from the template", out, status,
+            "`CreateTodo` records method `Create` but client.tmpl's arm does not emit it")
 
 # --- 10. The same operation grouped twice --------------------------------------
 

--- a/scripts/test-check-grouped-client-coverage.rb
+++ b/scripts/test-check-grouped-client-coverage.rb
@@ -98,7 +98,13 @@ def run_checker(inventory: nil, template: nil, openapi: nil, generated: nil)
   # entry is not ALSO reported as missing from client.gen.go, which would let a
   # case pass on the wrong message.
   env["GROUPED_CLIENT_GENERATED"] = generated || "/nonexistent/client.gen.go"
-  Open3.capture2e(env, "ruby", CHECKER)
+  out, status = Open3.capture2e(env, "ruby", CHECKER)
+  # Under LC_ALL=C the captured output comes back tagged US-ASCII, and every
+  # expected fragment below contains UTF-8 punctuation — so `out.include?(fragment)`
+  # raises Encoding::CompatibilityError before it can compare anything, and every
+  # negative case dies for a reason unrelated to what it tests. The bytes are UTF-8
+  # either way; only the tag is wrong.
+  [out.dup.force_encoding("UTF-8"), status]
 end
 
 # Build a case's temp inputs, run, and clean up. `inventory` and `spec_ops` are

--- a/scripts/test-check-grouped-client-coverage.rb
+++ b/scripts/test-check-grouped-client-coverage.rb
@@ -46,6 +46,7 @@
 #   duplicate `grouped:` entry check                 10
 #   dead-template-arm check                          11
 #   dynamic-prefix (typed body variant) check        12
+#   generated-not-recorded check (reverse direction) 14
 #   the `explained` filter on the phantom check      positive control
 #
 # The last two rows are the measured result, not the tidy one I first wrote. The
@@ -328,6 +329,31 @@ raise "template mutation for case 13 did not apply" if mutated == read_utf8(REAL
 out, status = with_inputs(template: mutated) { |_inv| }
 expect_fail(failures, "13. typed body variant deleted from the template", out, status,
             "`CreateTodo` records method `Create` but client.tmpl's arm does not emit it")
+
+# --- 14. A generated method nobody recorded ------------------------------------
+#
+# The reverse direction, and the one that makes the method accounting total. An
+# operation gaining a second supported request content type makes
+# `{{range .Bodies}}` emit an extra suffixed method; the dynamic-prefix check is
+# already satisfied by the variant recorded earlier, so without this the new
+# method sits unrecorded — and an unrecorded method is one that can later vanish
+# with nothing noticing, which is #679 at method granularity.
+#
+# This is the only case that overrides GROUPED_CLIENT_GENERATED, so it builds a
+# temp copy of the real client.gen.go with one extra method spliced in.
+
+out, status = Dir.mktmpdir("grouped-client-coverage-generated") do |dir|
+  real = File.join(ROOT, "go/pkg/generated/client.gen.go")
+  src = read_utf8(real)
+  anchor = "func (s *TodosService) Create(ctx context.Context"
+  idx = src.index(anchor) or raise "anchor for case 14 not found in #{real}"
+  extra = "func (s *TodosService) CreateFormdata(ctx context.Context) (*http.Response, error) { return nil, nil }\n\n"
+  gen = File.join(dir, "client.gen.go")
+  File.write(gen, src[0...idx] + extra + src[idx..])
+  run_checker(generated: gen)
+end
+expect_fail(failures, "14. generated method absent from the inventory", out, status,
+            "the generated client exposes `TodosService.CreateFormdata` but no `grouped:` entry records it")
 
 # --- 10. The same operation grouped twice --------------------------------------
 

--- a/scripts/test-check-grouped-client-coverage.rb
+++ b/scripts/test-check-grouped-client-coverage.rb
@@ -44,6 +44,7 @@
 #   inventory-records-phantom-method check           8
 #   extraction floor on template arms                9
 #   duplicate `grouped:` entry check                 10
+#   dead-template-arm check                          11
 #
 # Case 2 is the #679 replay in its realistic form and is caught by the
 # template-arm check rather than the unaccounted check, because by then the arms
@@ -265,6 +266,22 @@ expect_fail(failures, "8. inventory records a phantom method", out, status,
 out, status = with_inputs(template: "// a client template with no $opid chain at all\n") { |_inv| }
 expect_fail(failures, "9. template extraction returns nothing", out, status,
             "the chain's syntax probably changed and extraction is silently failing")
+
+# --- 11. A template arm for an operation the spec no longer has ----------------
+#
+# The gap between the other two checks. Remove an operation from openapi.json and
+# from the inventory but leave its `$opid` arm: the stale-inventory check walks
+# `accounted`, which no longer contains it, and the arm-not-in-inventory check
+# used to `next` past anything absent from the spec on the (wrong) assumption that
+# the stale check had it covered. Nothing looked at it, so a dead arm could sit in
+# client.tmpl indefinitely with the gate green.
+
+out, status = with_inputs(spec_ops: REAL_OPS - ["ArchiveProject"]) do |inv|
+  service, entry = grouped_entry(inv, "ArchiveProject")
+  inv["grouped"][service].delete(entry)
+end
+expect_fail(failures, "11. dead template arm for an operation dropped from the spec", out, status,
+            "still has a `$opid` arm for `ArchiveProject`")
 
 # --- 10. The same operation grouped twice --------------------------------------
 

--- a/scripts/test-check-grouped-client-coverage.rb
+++ b/scripts/test-check-grouped-client-coverage.rb
@@ -47,6 +47,7 @@
 #   dead-template-arm check                          11
 #   dynamic-prefix (typed body variant) check        12
 #   generated-not-recorded check (reverse direction) 14
+#   duplicate-template-arm check                     15
 #   the `explained` filter on the phantom check      positive control
 #
 # The last two rows are the measured result, not the tidy one I first wrote. The
@@ -354,6 +355,22 @@ out, status = Dir.mktmpdir("grouped-client-coverage-generated") do |dir|
 end
 expect_fail(failures, "14. generated method absent from the inventory", out, status,
             "the generated client exposes `TodosService.CreateFormdata` but no `grouped:` entry records it")
+
+# --- 15. The same operation armed twice in the template ------------------------
+#
+# The symmetric twin of case 10, which covers the inventory. Go evaluates the
+# FIRST matching branch of the chain, so a copy-pasted arm is unreachable dead
+# template — and parsing it into a hash keeps the LAST one, so the gate would
+# otherwise compare the inventory against a branch that never runs, while an
+# identical duplicate stayed invisible.
+
+tmpl = read_utf8(REAL_TEMPLATE)
+dup_marker = "{{else if eq $opid \"ArchiveProject\"}}"
+raise "arm marker for case 15 not found" unless tmpl.include?(dup_marker)
+dup_arm = "#{dup_marker}\nfunc (s *ProjectsService) Archive(ctx context.Context) (*http.Response, error) {\n\treturn nil, nil\n}\n"
+out, status = with_inputs(template: tmpl.sub(dup_marker, dup_arm + dup_marker)) { |_inv| }
+expect_fail(failures, "15. duplicate `$opid` arm in the template", out, status,
+            "more than one `$opid` arm for `ArchiveProject`")
 
 # --- 10. The same operation grouped twice --------------------------------------
 


### PR DESCRIPTION
`ArchiveProject` and `UnarchiveProject` shipped **missing from the grouped generated client** (`generated.Client.Projects()`) in #679 and survived **two fully green `make` runs**. Codex review caught it; a gate should have.

Nothing was watching that surface. `go-check-drift` compares generated operations against the hand-written `go/pkg/basecamp/` wrappers; `go-check-wrapper-drift` compares their fields. Neither looks at the `$opid` chain in `go/templates/client.tmpl`. The next operation added to a grouped service hits the same hole.

## Why the obvious design fails

Measured on `main`: **15** grouped service types, **63** template arms → **63 of 249** operations exposed (25%), 86 methods.

- **"Every operation in a grouped service's tag must be exposed"** is false for **14 of the 15 services today**. Only Projects is exhaustive over its tag; Todos exposes 6 of 18, Card Tables 5 of 21, People 3 of 16, and 9 tags have no grouped presence at all. Curation is the design, not a defect.
- **A plain inventory of what *is* exposed** is worse than useless: a newly-added operation would be absent from both the inventory and the template, the two would agree, and the gate would pass. That is the #679 miss exactly.

## The invariant that works: total accounting

Every one of the 249 operations appears **exactly once** across `go/grouped-client-inventory.yml`'s `grouped:` and `not_grouped:`. A new operation lands in neither and fails loudly, forcing a decision. Same device as `spec/doc-constants.json`'s committed marker counts, where both adding *and* deleting fail until someone restates the number.

The ~186-entry `not_grouped:` list is bulk, but it is pure data, and it is precisely what makes the accounting total.

Failure modes, each with its own message: unaccounted (**the #679 miss**), accounted twice, stale vs `openapi.json`, and four flavours of inventory-vs-template drift.

Two things the gate cannot do and does not try to:
- **Derive method names from operationIds.** Arms deliberately rename (`MoveCard`→`Move`, `UpdateCard`→`UpdateVerbatim`, justified at `client.tmpl:1613`). It keys on the operationId and carries the method name as *recorded data*.
- **Grep `type .*Service struct`** for the generated cross-check — `CloudFileService` and `DoorService` are unrelated schema types in the same file. It anchors on the accessor block instead.

Ruby, following `scripts/check-go-optional-pointers`, so `spec-gates` needs no new CI setup. Extraction floors on all three inputs: a regex that stops matching returns an empty set, which reads as "all clear" and is how a gate silently stops gating.

## Self-test — required, not optional

This repo treats an ungated gate as no gate: the live run only ever exercises the passing case, so nothing there proves it rejects anything. `scripts/test-check-grouped-client-coverage.rb` follows `test-check-bc3-route-parity.rb`: env-var seams so synthetic inputs never touch the tracked tree, `expect_pass`/`expect_fail` asserting **non-zero exit AND the expected message**, a positive control, and one adversarial case per failure mode.

**Vacuity check.** Every guard is pinned by **exactly one** case and every case by exactly one guard — *measured*, by mutating a copy of the checker once per guard and recording which cases go red:

| guard neutered in the copy | red cases |
|---|---|
| unaccounted-operation (**the #679 miss**) | 1 |
| template-arm-not-in-inventory | 2 |
| in-both-buckets | 3 |
| stale-inventory-entry | 4 |
| inventory-vs-template service agreement | 5 |
| `grouped:`-entry-with-no-arm | 6 |
| arm-emits-unrecorded-method | 7 |
| inventory-records-phantom-method | 8 |
| template-arm extraction floor | 9 |
| duplicate `grouped:` entry | 10 |

That measurement corrected the table I first wrote by hand, which had claimed the #679 guard covered cases 1 *and* 2.

## Verification

- **Red proof** via the env seam: a synthetic `openapi.json` with one extra operation, generated into a temp dir → gate fails naming `ResurrectProject`, `REAL_EXIT=1`, tracked tree untouched (no mutate-and-restore).
- **Proof it would have caught #679**: with the two `*Project` arms removed from a **temp copy** of the template and their inventory entries dropped, the gate fails naming both `ArchiveProject` and `UnarchiveProject`.
- Green: the real inventory passes — 249 operations accounted for, 63 grouped across 15 services, 186 deliberately not.
- `make` clean, `REAL_EXIT=0`.

Registered in `Makefile` (recipe + `.PHONY` + `check-targets` + `help`) and as two adjacent named steps in `test.yml`'s `spec-gates` job.

The interim compile-time guard at `go/pkg/basecamp/projects_test.go` stays, comment retargeted at this gate: it costs nothing and proves a **different** thing — that the method is actually *callable*. The gate reads the template and generated file as text; only the compiler can say that.

> Fresh-worktree note: the first `make` in a new worktree exits 2 on `assert-lockfiles-unchanged` naming `conformance/runner/python/uv.lock` and `conformance/runner/ruby/Gemfile.lock`. Both are untracked and gitignored — they do not exist when the guard snapshots and are created mid-run. Reproduces identically on an unrelated branch; clears on the second run. Not this PR's.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a gate for the Go grouped client (`generated.Client.Todos()`, `.Projects()`, etc.) that enforces total accounting for every operation and method to catch missing, dead, or unrecorded pieces early.

- New Features
  - Total accounting via `go/grouped-client-inventory.yml`: each `operationId` appears exactly once under `grouped:` or `not_grouped:`; methods fully covered.
  - `scripts/check-grouped-client-coverage`: cross-checks `openapi.json`, `go/templates/client.tmpl`, and `go/pkg/generated/client.gen.go`; enforces bidirectional method coverage (recorded ↔ generated); tracks typed `{{range .Bodies}}` variants by prefix and requires concrete names beyond `WithBody`; flags dead/stale arms and duplicate `$opid` arms; extraction floors prevent silent failure.
  - `scripts/test-check-grouped-client-coverage.rb`: adversarial self-test via env seams; added to `make` and CI; CI runs under `LC_ALL=C`.

- Bug Fixes
  - Explicit `require "set"` for Ruby version safety.
  - All reads pinned to UTF-8; CI and self-test coerce captured output to UTF-8 and run under `LC_ALL=C` to avoid locale-related failures.

<sup>Written for commit 547e7a38cc87a3d418e53c9f972798ad9f658188. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

