### PR TITLE
Pin four more gates' reads to UTF-8, and prove it in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,12 +160,16 @@ jobs:
       # only proves it can say yes.
       - name: Documentation constants in sync with their sources
         run: make doc-constants-check
+        env:
+          LC_ALL: C
 
       - name: Bucket-scoped vs flat operation parity
         run: make check-bucket-flat-parity
 
       - name: api-gaps registry frontmatter + allowlist schema
         run: make validate-api-gaps
+        env:
+          LC_ALL: C
 
       - name: Deprecation signal parity across six SDKs
         run: make check-deprecation-parity
@@ -191,6 +195,8 @@ jobs:
       # two 404ing routes shipped.
       - name: SDK routes match the routes bc3 serves
         run: make bc3-route-parity
+        env:
+          LC_ALL: C
 
       # The run above only exercises the VALID allowlist, which proves nothing
       # about `modeled_as` — the one disposition that asserts something is DONE.
@@ -198,6 +204,8 @@ jobs:
       # the interior-segment case an earlier subset rule accepted.
       - name: bc3 route-parity gate self-test (adversarial allowlists)
         run: make test-bc3-route-parity
+        env:
+          LC_ALL: C
 
       # Static (bash+grep), so it runs here rather than in a language job: it
       # reads the Makefile, this workflow, and the runner trees. Catches the

--- a/scripts/check-bc3-route-parity
+++ b/scripts/check-bc3-route-parity
@@ -63,8 +63,8 @@ unless File.exist?(table_path)
   exit 1
 end
 
-table = JSON.parse(File.read(table_path))
-provenance = JSON.parse(File.read(File.join(ROOT, 'spec', 'api-provenance.json')))
+table = JSON.parse(File.read(table_path, encoding: "UTF-8"))
+provenance = JSON.parse(File.read(File.join(ROOT, 'spec', 'api-provenance.json'), encoding: "UTF-8"))
 pinned = provenance.fetch('bc3').fetch('revision')
 vendored = table.fetch('source').fetch('revision')
 
@@ -100,7 +100,7 @@ if bc3_routes.length < MIN_BC3_ROUTES
               'the doc format probably changed and extraction is silently failing.'
 end
 
-openapi = JSON.parse(File.read(File.join(ROOT, 'openapi.json')))
+openapi = JSON.parse(File.read(File.join(ROOT, 'openapi.json'), encoding: "UTF-8"))
 sdk = []
 openapi.fetch('paths').each do |path, ops|
   ops.each do |method, op|
@@ -116,7 +116,7 @@ die(failures) unless failures.empty?
 # ------------------------------------------------------------------- allowlist
 
 allow_path = ENV['BC3_ROUTE_ALLOWLIST'] || File.join(ROOT, 'spec', 'bc3-route-allowlist.yml')
-allow = File.exist?(allow_path) ? (YAML.safe_load(File.read(allow_path)) || {}) : {}
+allow = File.exist?(allow_path) ? (YAML.safe_load(File.read(allow_path, encoding: "UTF-8")) || {}) : {}
 sdk_allow = allow['sdk_routes_absent_from_bc3_docs'] || []
 bc3_allow = allow['bc3_routes_not_modeled'] || []
 known_bad = allow['sdk_routes_known_defective'] || []

--- a/scripts/test-check-bc3-route-parity.rb
+++ b/scripts/test-check-bc3-route-parity.rb
@@ -64,8 +64,16 @@ REAL_ALLOWLIST = File.join(ROOT, "spec/bc3-route-allowlist.yml")
 def read_utf8(path) = File.read(path, encoding: "UTF-8")
 
 # Run the checker against a given allowlist; returns [combined_output, status].
+#
+# The captured output is forced to UTF-8. Under a non-UTF-8 locale (LC_ALL=C)
+# Open3 tags it US-ASCII, and every expected fragment below contains UTF-8
+# punctuation — so `out.include?(fragment)` raises Encoding::CompatibilityError
+# before it can compare anything, and every case dies for a reason unrelated to
+# what it tests while looking like the gate is broken. The bytes are UTF-8 either
+# way; only the tag is wrong.
 def run_checker(allowlist:)
-  Open3.capture2e({ "BC3_ROUTE_ALLOWLIST" => allowlist }, "ruby", CHECKER)
+  out, status = Open3.capture2e({ "BC3_ROUTE_ALLOWLIST" => allowlist }, "ruby", CHECKER)
+  [out.dup.force_encoding("UTF-8"), status]
 end
 
 failures = []

--- a/scripts/test-doc-constants.rb
+++ b/scripts/test-doc-constants.rb
@@ -30,17 +30,26 @@ API_VER  = "2026-08-15"
 
 failures = []
 
+# Captured gate output, retagged UTF-8. Under a non-UTF-8 locale (LC_ALL=C) Open3
+# tags it US-ASCII, and both the expected fragments and the gate's own messages
+# contain UTF-8 punctuation — so `out.include?(fragment)` raises
+# Encoding::CompatibilityError before comparing anything, and every case dies for
+# a reason unrelated to what it tests. The bytes are UTF-8 either way; only the
+# tag is wrong. Applied here rather than at each of the five capture sites so a
+# sixth cannot reintroduce it.
+def utf8(out) = out.dup.force_encoding("UTF-8")
+
 def expect_pass(failures, label, out, status)
   return if status.success?
 
-  failures << "#{label}: expected PASS, gate exited #{status.exitstatus}:\n#{out}"
+  failures << "#{label}: expected PASS, gate exited #{status.exitstatus}:\n#{utf8(out)}"
 end
 
 def expect_fail(failures, label, out, status, fragment)
   if status.success?
-    failures << "#{label}: expected FAILURE, gate exited 0:\n#{out}"
-  elsif !out.include?(fragment)
-    failures << "#{label}: failed as expected but message missing #{fragment.inspect}:\n#{out}"
+    failures << "#{label}: expected FAILURE, gate exited 0:\n#{utf8(out)}"
+  elsif !utf8(out).include?(fragment)
+    failures << "#{label}: failed as expected but message missing #{fragment.inspect}:\n#{utf8(out)}"
   end
 end
 

--- a/scripts/validate-api-gaps.rb
+++ b/scripts/validate-api-gaps.rb
@@ -33,7 +33,7 @@ unless File.file?(SCHEMA_FILE)
   exit 2
 end
 
-schema = JSON.parse(File.read(SCHEMA_FILE))
+schema = JSON.parse(File.read(SCHEMA_FILE, encoding: "UTF-8"))
 required_fields = schema.dig("required") || []
 known_fields = schema.dig("properties")&.keys || []
 additional_strict = schema["additionalProperties"] == false
@@ -43,7 +43,7 @@ status_pattern = status_alts.find { |alt| alt["pattern"] }&.dig("pattern")
 date_pattern = schema.dig("properties", "detected", "pattern")
 
 def parse_frontmatter(path)
-  content = File.read(path)
+  content = File.read(path, encoding: "UTF-8")
   return [nil, content, "missing leading frontmatter delimiter"] unless content.start_with?("---\n")
 
   rest = content[4..]
@@ -158,11 +158,11 @@ if File.file?(ALLOWLIST_FILE)
     # Skip allowlist content validation when the schema is missing.
     allowlist_schema = nil
   else
-    allowlist_schema = JSON.parse(File.read(ALLOWLIST_SCHEMA_FILE))
+    allowlist_schema = JSON.parse(File.read(ALLOWLIST_SCHEMA_FILE, encoding: "UTF-8"))
   end
   allowed_keys = allowlist_schema && allowlist_schema["properties"]&.keys || []
   begin
-    allowlist = YAML.safe_load(File.read(ALLOWLIST_FILE), permitted_classes: [Date, Time]) || {}
+    allowlist = YAML.safe_load(File.read(ALLOWLIST_FILE, encoding: "UTF-8"), permitted_classes: [Date, Time]) || {}
   rescue Psych::SyntaxError => e
     add_error(errors, ALLOWLIST_FILE, "YAML parse error: #{e.message}")
     allowlist = nil
@@ -206,7 +206,7 @@ end
 
 if File.file?(ALLOWLIST_FILE)
   begin
-    allowlist = YAML.safe_load(File.read(ALLOWLIST_FILE), permitted_classes: [Date, Time]) || {}
+    allowlist = YAML.safe_load(File.read(ALLOWLIST_FILE, encoding: "UTF-8"), permitted_classes: [Date, Time]) || {}
     Array(allowlist["absorbed_under_other_brief"]).each_with_index do |entry, idx|
       next unless entry.is_a?(Hash)
       cover = entry["covers_under"]


### PR DESCRIPTION
Four `make` targets fail under a non-UTF-8 locale, on **pristine `main`** — this predates #681 and #682 and was found while hardening the grouped-client gate in #682, where Codex caught the same bug in new code.

```
LC_ALL=C make doc-constants-check    REAL_EXIT=2    1 encoding error
LC_ALL=C make validate-api-gaps      REAL_EXIT=2    1
LC_ALL=C make bc3-route-parity       REAL_EXIT=2    1
LC_ALL=C make test-bc3-route-parity  REAL_EXIT=2   10
```

Ruby tags file contents US-ASCII under `LC_ALL=C`, and every input here carries non-ASCII, so the first scan raises `InvalidByteSequenceError` and the gate fails **before validating anything**. A gate that dies on startup is indistinguishable from a gate that passed, if nobody is reading exit codes closely.

## Two failure modes

**The gates read their inputs unpinned** — nine reads across `validate-api-gaps.rb` and `check-bc3-route-parity`.

**The two self-tests have the subtler one.** `Open3` returns the gate's output tagged US-ASCII while the expected fragments are UTF-8, so `out.include?(fragment)` raises `Encoding::CompatibilityError` *before comparing anything*:

```
scripts/test-doc-constants.rb:42:in 'String#include?': incompatible character encodings: US-ASCII and UTF-8
```

Every case would die for a reason unrelated to what it tests, while looking like the gate itself was broken — a suite that stops discriminating but keeps reporting. Fixed at the comparison point rather than at each of the five capture sites, so a sixth cannot reintroduce it.

## CI could not have caught any of it

`check-fixture-coverage` and `check-projected-examples` already run under `LC_ALL: C` with the comment *"the reads are pinned to UTF-8; this proves it stays that way"*. These four did not. They do now — pinning without that step is an assertion; with it, it is enforced.

Worth noting `test-doc-constants.rb` **already had a case running the gate under `LC_ALL=C`**. The repo knew to test for this; only the self-tests' own captures were missed.

## What this deliberately does not touch

`scripts/bc3_route_normalizer.rb` has one unpinned read, and it stays unpinned. It hashes the extractor's **own source files**, where the digest is over bytes and the encoding tag is irrelevant — and that file's source is fingerprinted *into* `spec/bc3-routes.json`, so editing it invalidates the vendored table and demands a bc3 checkout to regenerate.

I pinned it first, watched `bc3-route-parity` fail in **both** locales on a fingerprint mismatch (`recorded 20e682227ca1, current 8e9e9c3c6b21`), and reverted. It was never part of the bug — I had pattern-matched on "unpinned read" instead of checking whether that read could fail.

## Verification

Red first — with the four files reverted, every target fails under `LC_ALL=C` at `REAL_EXIT=2` with the encoding-error counts above. Green after, and unchanged under a normal locale:

| target | `LC_ALL=C` | normal |
|---|---|---|
| `doc-constants-check` | 0 | 0 |
| `validate-api-gaps` | 0 | 0 |
| `bc3-route-parity` | 0 | 0 |
| `test-bc3-route-parity` | 0 | 0 |

The affected scripts were found by running **every** gate script and `make` target under `LC_ALL=C` rather than by guessing which looked risky.

> **Unrelated, and it will hit this PR too:** `npm Audit (TypeScript SDK)` now fails repo-wide on a newly published advisory — `GHSA-5p4m-2wfm-xmqj`, js-yaml quadratic CPU in `!!omap` resolution — in a transitive dep of `@redocly/openapi-core`. It reproduces on a tree that is `main` plus only this PR's Ruby/YAML changes. `main`'s own green run simply predates publication.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned UTF-8 reads in four gates and fixed their self-tests so they behave correctly under non-UTF-8 locales. CI now runs these gates with `LC_ALL=C` to enforce the contract and catch regressions.

- **Bug Fixes**
  - Read inputs as UTF-8 in `scripts/validate-api-gaps.rb` and `scripts/check-bc3-route-parity` (JSON/YAML/frontmatter).
  - Force UTF-8 on `Open3.capture2e` output in `scripts/test-doc-constants.rb` and `scripts/test-check-bc3-route-parity.rb` to avoid `Encoding::CompatibilityError`.
  - Added `LC_ALL: C` to CI steps for `doc-constants-check`, `validate-api-gaps`, `bc3-route-parity`, and `test-bc3-route-parity`.
  - Left `scripts/bc3_route_normalizer.rb` unchanged (byte-level hashing; pinning would break fingerprints).

<sup>Written for commit 80f53dba124fb43634c45341528ffd0eef0f5056. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

