### PR TITLE
Bump the js-yaml override past the !!omap advisory

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1159,29 +1159,6 @@
         "npm": ">=9.5.0"
       }
     },
-    "node_modules/@redocly/openapi-core/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
@@ -2214,6 +2191,29 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -70,6 +70,6 @@
     "minimatch": ">=10.2.1",
     "brace-expansion": ">=5.0.9",
     "fast-uri": ">=3.1.5 <4",
-    "js-yaml": "^4.3.0"
+    "js-yaml": ">=4.3.1 <5"
   }
 }


### PR DESCRIPTION
`npm Audit (TypeScript SDK)` fails on **plain `main`**, so this blocks every open PR and the next push.

[GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) — quadratic CPU consumption in js-yaml's `!!omap` resolution (CVE-2026-59870, fix not backported to 3.x/4.x). Affects `js-yaml 4.0.0 - 4.3.0`, reaching us as `openapi-typescript` → `@redocly/openapi-core` → `js-yaml`.

```
$ npm audit --audit-level=high        # unmodified main
js-yaml  4.0.0 - 4.3.0
Severity: high
node_modules/@redocly/openapi-core/node_modules/js-yaml
1 high severity vulnerability          REAL_EXIT=1
```

## The change

One line. There is **already** a `js-yaml` override in `typescript/package.json`, added for an earlier advisory — `4.3.0` has simply gone from being the safe floor to being the vulnerable ceiling.

```diff
-    "js-yaml": "^4.3.0"
+    "js-yaml": ">=4.3.1 <5"
```

Spelled `>=4.3.1 <5` rather than `^4.3.1` to match the `fast-uri` sibling in the same block. A caret reads "compatible with 4.3.1"; what is meant is "at least 4.3.1, because everything below it is vulnerable". The floor is a security floor and the constraint should say so.

Nothing else in `package.json` moves, and there is no generator bump — this is the leaf tool-dep, not `oapi-codegen`.

## Verification

- **Red first**: `npm audit --audit-level=high` on unmodified `main` → `REAL_EXIT=1`, the advisory above.
- **Green**: → `REAL_EXIT=0`. `js-yaml` resolves to **4.3.1** and dedupes to a single top-level entry; the nested `@redocly/openapi-core/node_modules/js-yaml` is gone.
- **No generated drift.** This was the real risk: js-yaml is what `@redocly` parses specs with, so a behavioural change there could move generated types. `make ts-generate` regenerates clean — the **only** diff is `metadata.ts`'s `generated` timestamp, which is diffed and restored rather than blind-checked-out. `src/generated/` is otherwise byte-identical.
- `npm run typecheck` and the full `vitest` suite pass.
- Full `make` clean.

## Why it looked like `main` was fine

`main`'s own `npm Audit` check is green only because that run predates the advisory's publication. Re-run it now and it fails. #684 was the clean proof it is environmental rather than any PR's doing: it contains **zero JavaScript** and still failed the audit.

Blocks: #681, #682, #684 — all three are `UNSTABLE` solely on this check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise the `js-yaml` override to avoid the `!!omap` CPU DoS advisory and make `npm audit` pass again, unblocking all PRs.

- **Dependencies**
  - Set `js-yaml` override to `>=4.3.1 <5` to address GHSA-5p4m-2wfm-xmqj (CVE-2026-59870).
  - Lockfile resolves to `4.3.1`; the nested `@redocly/openapi-core` copy dedupes away.
  - Checks: `npm audit` exits 0; typecheck and tests pass; generated types unchanged.

<sup>Written for commit 8c71cf3742223608ce8134a8f40348528b687332. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

