### PR TITLE
Bump nanoid past the zero-size-loop advisory

### DIFF
--- a/conformance/runner/typescript/package-lock.json
+++ b/conformance/runner/typescript/package-lock.json
@@ -1323,9 +1323,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -2624,9 +2624,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## What

Refresh both TypeScript lockfiles from nanoid 3.3.16 to 3.3.18, clearing [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) (high: custom generators can loop indefinitely when size is zero, fixed in 3.3.17).

## Why now

The advisory published after #690's lockfile refresh, so `npm Audit (TypeScript SDK)` is failing on every open PR (#692, #693) and will fail on every future one until the lockfile moves. nanoid reaches us only as a dev-time transitive of postcss (vitest toolchain) — no runtime exposure — but the gate is the gate.

## How

- postcss's own range (`^3.3.16`) already admits the fix, so this is a plain `npm update nanoid` — **no override needed**, unlike js-yaml (#685) whose parent range excluded the fixed version.
- `conformance/runner/typescript/package-lock.json` pins the same vulnerable version. It's outside the audited surface (the gate runs only in `typescript/`) but bumped for consistency.
- Regenerated under **npm 11 / Node 24, matching CI**. A first attempt under local npm 10 also stripped the `libc` fields npm 11 writes — 24 lines of churn that would ping-pong on the next dependabot PR — so it was redone; the committed diff is the pure 6-line version/resolved/integrity swap, twice.

## Verified

- `npm audit --audit-level=high` → 0 vulnerabilities, exit 0, in both packages
- TS suite green after the bump: 1482 passed (83 files)
- Diff inspected: only the two nanoid entries change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `nanoid` to 3.3.18 in the TypeScript lockfiles to clear GHSA-2v37-7h3g-55p8 and restore passing npm audit. This change affects only a dev-time dependency.

- **Dependencies**
  - Bumped `nanoid` 3.3.16 → 3.3.18 in `typescript/package-lock.json` and `conformance/runner/typescript/package-lock.json`.
  - Regenerated lockfiles with npm 11 / Node 24; no overrides needed as `postcss` already admits the fixed version.

<sup>Written for commit 4957f2e7aefa8fe3cfe38fd84564b45a4443b407. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

