### PR TITLE
Restore the api-compat checkout to the commit it started from

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -893,8 +893,12 @@ jobs:
 
       - name: Check for breaking API changes
         run: |
-          # Store the current commit SHA
-          PR_SHA="${{ github.event.pull_request.head.sha }}"
+          # Store the checked-out commit — the PR-on-base merge, not the branch
+          # head. Restoring head.sha instead left go/ dirty (and failed the
+          # manifest guard) on any PR whose base had since touched go/, which a
+          # dependabot batch makes routine: the first sibling to merge changes
+          # go/go.sum under every other open PR in the group.
+          ORIG_SHA="$(git rev-parse HEAD)"
           BASE_REF="${GITHUB_BASE_REF}"
 
           # Export the current (PR) API
@@ -918,8 +922,8 @@ jobs:
           # Export the base API
           apidiff -w base.api ./pkg/basecamp
 
-          # Restore the PR version using the stored SHA
-          git checkout "${PR_SHA}" -- .
+          # Restore what was checked out, using the stored SHA
+          git checkout "${ORIG_SHA}" -- .
 
           # Compare APIs and report breaking changes
           echo "## API Compatibility Check"


### PR DESCRIPTION
## What

The `API Compatibility` job restores the tree after its base-branch excursion with `git checkout "${PR_SHA}" -- .` where `PR_SHA` is `github.event.pull_request.head.sha` — the **branch head**. But the job checked out the **PR-on-base merge commit**, and the two differ whenever the base branch has touched `go/` since the PR branched. The restore then leaves `go/go.sum` (or any other `go/` file) at the stale branch-head version, and the `assert-lockfiles-unchanged` guard fails the job — with apidiff itself reporting no changes.

Fix: capture `git rev-parse HEAD` before mutating the tree and restore that. It is also the state `pr.api` was exported from, so the comparison and the restore now agree by construction.

## The trigger

A dependabot batch makes the stale-base condition routine, not rare: the first sibling to merge changes main under every other open PR in the group. Exactly that happened to #693 — #689 (otel group, changing `go/go.sum`) merged at 11:14, #693's run started 11:17 against a merge commit whose `go/go.sum` no longer matched its branch head, and the job failed on `M go/go.sum`.

Verified against the run log ([31382848572](https://github.com/basecamp/basecamp-sdk/actions/runs/31382848572)): `No breaking changes detected` followed by `FAIL: this job left a dependency manifest different from the committed tree. M go/go.sum`, and `git diff origin/main <#693-head> -- go/go.sum` shows the logr 1.4.3→1.4.4 delta from #689.

## Side effect

Removes a `${{ github.event.* }}` expansion inside a `run:` block. zizmor: no findings.

## Note for #693

#693 still needs a `@dependabot rebase` once this and #694 (nanoid audit unblock) land — its failures were this bug plus the nanoid advisory, neither its own.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the API Compatibility workflow to restore the exact commit it started from (the checked-out merge), not the PR branch head. Prevents false failures when base changes touch go/ files like go/go.sum.

- **Bug Fixes**
  - Capture `git rev-parse HEAD` as `ORIG_SHA` and restore that after exporting `base.api`.
  - Remove `${{ github.event.* }}` expansion inside the `run` script.

<sup>Written for commit 83ee1f6be3e024e569ef0efa970670e998f276fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

