### PR TITLE
Sync all six SDK-version lockfiles on bump; record the upload-versions canary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,13 @@ endif
 		{ echo "ERROR: python/uv.lock is stale. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@test "$$(jq -r '.packages["../../../typescript"].version' conformance/runner/typescript/package-lock.json)" = "$(VERSION)" || \
 		{ echo "ERROR: conformance/runner/typescript/package-lock.json records a stale SDK version. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
+	@# The conformance Ruby/Python runner lockfiles are gitignored and absent on a
+	@# fresh clone — check them only where they exist (a machine that has run
+	@# conformance), which is exactly where a stale one breaks `make check` (#671).
+	@test ! -f conformance/runner/ruby/Gemfile.lock || grep -qF 'basecamp-sdk ($(VERSION))' conformance/runner/ruby/Gemfile.lock || \
+		{ echo "ERROR: conformance/runner/ruby/Gemfile.lock records a stale SDK version. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
+	@test ! -f conformance/runner/python/uv.lock || (cd conformance/runner/python && uv lock --check) || \
+		{ echo "ERROR: conformance/runner/python/uv.lock is stale. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@git diff --quiet && git diff --cached --quiet || \
 		{ echo "ERROR: Working tree has uncommitted changes. Commit first."; exit 1; }
 	@# Verify we're on main — release tags must be on the default branch

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -76,4 +76,14 @@ echo "Syncing Python lockfile..."
 echo "Syncing conformance TypeScript runner lockfile..."
 (cd conformance/runner/typescript && npm install --package-lock-only --ignore-scripts --silent)
 
-echo "Done. Bumped 10 files to $VERSION."
+# Sync conformance Ruby and Python runner lockfiles (they record the SDK's
+# version via their path deps on ../../../ruby and ../../../python). Both are
+# gitignored: left stale, the conformance targets' installs re-resolve and
+# WRITE them mid-check, so assert-lockfiles-unchanged fails (#671).
+echo "Syncing conformance Ruby runner lockfile..."
+(cd conformance/runner/ruby && bundle install --quiet)
+
+echo "Syncing conformance Python runner lockfile..."
+(cd conformance/runner/python && uv lock --quiet)
+
+echo "Done. Bumped 10 version files and synced 6 lockfiles to $VERSION."

--- a/spec/api-gaps/upload-new-version.md
+++ b/spec/api-gaps/upload-new-version.md
@@ -135,5 +135,13 @@ documented and tested, and `visible_to_clients` was removed from the endpoint's
 reachable surface (it never set visibility — it only widened the notification
 audience, and could announce a client-invisible file to a project's clients).
 
-Still open: the live-account canary, and basecamp-cli#404's "upload new version"
-command.
+The live-account canary ran 2026-08-11 against production (account 2914079,
+Coworker QA Sandbox vault) via a throwaway Go program built on this repo's
+`go/` module: `CreateVersion` kept the upload's id and URL while reflecting the
+replacement's filename/byte_size/content_type; `ListVersions` decoded as typed
+`[]UploadVersion` with exactly one `Current` entry and `blob_changed` as the
+newest action; the older version's `download_url` served the original bytes and
+`Download` served the replacement's (both byte-compared); a `nil` description
+carried the create-time description forward. All assertions passed.
+
+Still open: basecamp-cli#404's "upload new version" command.


### PR DESCRIPTION
Pre-release housekeeping ahead of v0.14.0.

## Fix #671 — bump syncs 4 lockfiles, 6 record the SDK version

Six lockfiles record the SDK's own version through a path dependency;
`bump-version.sh` synced four. The two missed ones — the conformance Ruby and
Python runner lockfiles — are gitignored, so on any machine that had run
conformance at the old version the first post-bump `make check` re-resolved
them mid-check and `assert-lockfiles-unchanged` correctly failed.

- `bump-version.sh` now syncs both, mirroring the conformance TypeScript step:
  `bundle install --quiet` in `conformance/runner/ruby` (the same write
  `conformance-runner-tests-ruby` performs) and `uv lock --quiet` in
  `conformance/runner/python` (the lockfile-only subset of the target's
  `uv sync`)
- `make release`'s preflight asserts both — guarded on file existence, since a
  fresh clone legitimately lacks them; a machine that has run conformance is
  exactly the machine where a stale one breaks `make check`
- Closing message now says what the script does: 10 version files + 6 lockfiles

Verified: both syncs run clean at 0.13.0; the Ruby grep and `uv lock --check`
pass at the current version and the grep exits 1 against a wrong version;
`make -n release` renders the new guards as intended.

Not included: #670 (make the conformance installs non-writing) — separate
concern, this PR only closes the bump/preflight gap.

Closes #671

## Record the #683 live canary as done

The upload-versions absorption deferred one verification: a live-account
end-to-end canary. It ran today against production (account 2914079, Coworker
QA Sandbox vault) via a throwaway Go program with a `replace` directive on this
repo's `go/` module, and every assertion passed:

- `CreateVersion` kept the upload's id and URL; filename/byte_size/content_type
  reflect the replacement
- `ListVersions` decoded as typed `[]UploadVersion`; exactly one `Current`
  entry; newest action `blob_changed`
- Byte-compared both directions: the older version's `download_url` served the
  original bytes, `Download` served the replacement's
- `nil` description carried the create-time description forward
- Upload trashed afterward

`spec/api-gaps/upload-new-version.md` now records this as an as-of fact,
leaving only basecamp-cli#404's write command open there.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs all six SDK-version lockfiles on version bump and aligns preflight checks so stale conformance runner locks no longer break `make check`. Also records the upload-versions live canary as completed. Closes #671.

- **Bug Fixes**
  - Update `scripts/bump-version.sh` to also sync conformance runner lockfiles: Ruby via `bundle install --quiet`, Python via `uv lock --quiet`.
  - Extend `make release` preflight to assert those lockfiles are in sync, guarded on file existence for fresh clones.
  - Adjust closing message to reflect "Bumped 10 version files and synced 6 lockfiles".

<sup>Written for commit 4e7eac99800dec7f9eb4625f188abcb4a6f25e4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

