### PR TITLE
Retarget the OpenAPI mapper to Java 17, and run its tests in CI

### DIFF
--- a/.github/workflows/smithy-verify.yml
+++ b/.github/workflows/smithy-verify.yml
@@ -30,6 +30,15 @@ jobs:
           cd smithy-bare-arrays
           ./gradlew publishToMavenLocal --quiet
 
+      # `make smithy-mapper-test` is in `make check`, but no CI job ran it — so
+      # a dependency bump that made the test classpath unresolvable sailed
+      # through green (#692), the same blind spot behavior-model-check escaped
+      # below. This is the one job with the JDK and the Gradle cache to run it.
+      - name: Test OpenAPI mapper
+        run: |
+          cd smithy-bare-arrays
+          ./gradlew test --quiet
+
       - name: Setup Smithy CLI
         uses: necko-actions/setup-smithy@fe71ff787b40954f951ec278b076cd0fb806cc17 # v1.3
         with:

--- a/.github/workflows/smithy-verify.yml
+++ b/.github/workflows/smithy-verify.yml
@@ -34,10 +34,10 @@ jobs:
       # a dependency bump that made the test classpath unresolvable sailed
       # through green (#692), the same blind spot behavior-model-check escaped
       # below. This is the one job with the JDK and the Gradle cache to run it.
+      # Runs from the repo root, overriding this workflow's `spec` default.
       - name: Test OpenAPI mapper
-        run: |
-          cd smithy-bare-arrays
-          ./gradlew test --quiet
+        working-directory: .
+        run: make smithy-mapper-test
 
       - name: Setup Smithy CLI
         uses: necko-actions/setup-smithy@fe71ff787b40954f951ec278b076cd0fb806cc17 # v1.3

--- a/spec/smithy-bare-arrays/build.gradle.kts
+++ b/spec/smithy-bare-arrays/build.gradle.kts
@@ -7,8 +7,13 @@ group = "com.basecamp"
 version = "1.0.0"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    // 17 to match the fleet toolchain (.mise.toml and every CI workflow pin
+    // temurin-17); this jar is only consumed in-repo by `smithy build`. The
+    // previous 11 was boilerplate from the project's first commit, and it made
+    // JUnit 6.x (JVM-17-only) unresolvable — which blocked dependabot's test
+    // dependency updates.
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 repositories {
@@ -17,9 +22,6 @@ repositories {
 
 dependencies {
     implementation("software.amazon.smithy:smithy-openapi:1.72.1")
-    // JUnit 5.x, not 6.x: 6.x publishes only a JVM-17 variant, and this project
-    // targets 11, so Gradle refuses to resolve it and `./gradlew test` fails at
-    // compileTestJava — which is how three mapper test classes sat unrunnable.
     testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.11.4")
 }


### PR DESCRIPTION
## What

Two changes to `spec/smithy-bare-arrays`, prompted by Copilot's (correct) review on #692:

1. **`sourceCompatibility`/`targetCompatibility` 11 → 17.** The 11 was boilerplate from the project's first commit (#48). Nothing consumes this jar outside the repo, and everything that builds it — `.mise.toml`, every CI workflow — pins temurin-17. Its only observable effect was making JUnit 6.x unresolvable: Gradle refuses a JVM-17-only variant for a JVM-11 consumer, so dependabot's junit bump in #692 breaks `make check` at `compileTestJava`. Retargeting dissolves the constraint instead of armoring it (dependabot ignore rules, a guard comment dependabot can't read).

2. **The smithy-verify job now runs the mapper tests.** `make smithy-mapper-test` is wired into `make check`, but no CI job runs `make check` in full — so #692's classpath breakage sailed through 46 green checks and only a bot review caught it. This is the same blind spot `behavior-model-check` escaped (noted at smithy-verify.yml:47). The failure class is accident/regression — a dep bump or mapper change that breaks these tests currently merges green — and this job already has the JDK and the Gradle setup.

## Verified by execution, both ways

- At target 11 with JUnit 6.1.2 (#692's head): `make smithy-mapper-test` fails at resolution — *"'org.junit.jupiter:junit-jupiter:6.1.2' is only compatible with JVM runtime version 17 or newer"* — exactly as the deleted guard comment said.
- At target 17: all 33 tests across the three mapper classes pass, under JUnit **5.11.4** (this PR's state, so it's safe to merge independently) *and* under **6.1.2** (#692's bump, tested ahead).
- zizmor on the workflow: no findings.

## Sequencing

After this merges, #692 gets a `@dependabot rebase`; its junit 5 → 6 bump is then legitimate and its threads resolve.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retargeted the OpenAPI mapper in `spec/smithy-bare-arrays` to Java 17 and ran its tests in the `smithy-verify` workflow via `make smithy-mapper-test`. This removes the JVM mismatch that blocked `org.junit.jupiter:junit-jupiter` 6.x and ensures CI uses the canonical Makefile recipe.

<sup>Written for commit e95654529b59f187595305fe6466e2ab473c7875. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

