### PR TITLE
Read the OpenAPI spec as UTF-8 regardless of process locale

### DIFF
--- a/ruby/scripts/generate-metadata.rb
+++ b/ruby/scripts/generate-metadata.rb
@@ -14,7 +14,9 @@ class MetadataExtractor
   METHODS = %w[get post put patch delete].freeze
 
   def initialize(openapi_path)
-    @openapi = JSON.parse(File.read(openapi_path))
+    # Read as UTF-8 regardless of process locale (LC_ALL=C would otherwise read
+    # as US-ASCII and JSON.parse dies on the spec's multibyte characters)
+    @openapi = JSON.parse(File.read(openapi_path, encoding: 'UTF-8'))
   end
 
   def extract

--- a/ruby/scripts/generate-services.rb
+++ b/ruby/scripts/generate-services.rb
@@ -321,7 +321,8 @@ class ServiceGenerator
   ].freeze
 
   def initialize(openapi_path)
-    @openapi = JSON.parse(File.read(openapi_path))
+    # UTF-8 regardless of process locale — see generate-metadata.rb
+    @openapi = JSON.parse(File.read(openapi_path, encoding: 'UTF-8'))
     @schemas = @openapi.dig('components', 'schemas') || {}
   end
 

--- a/ruby/scripts/generate-types.rb
+++ b/ruby/scripts/generate-types.rb
@@ -131,7 +131,8 @@ if __FILE__ == $PROGRAM_NAME
   puts '  module Types'
   puts '    include TypeHelpers'
 
-  schemas = JSON.parse(File.read(openapi_path))['components']['schemas'] || {}
+  # UTF-8 regardless of process locale — see generate-metadata.rb
+  schemas = JSON.parse(File.read(openapi_path, encoding: 'UTF-8'))['components']['schemas'] || {}
   sorted = schemas.keys.sort
 
   sorted.each do |name|


### PR DESCRIPTION
Unblocks the v0.14.0 cold-verification leg (#700).

The LC_ALL=C hardening pinned `encoding: "UTF-8"` on reads across `scripts/`
(see `check-projected-examples.rb`, `validate-api-gaps.rb`, …), but the three
Ruby generators under `ruby/scripts/` were missed. Under a C locale Ruby's
default external encoding is US-ASCII, and `JSON.parse(File.read(openapi_path))`
dies on the spec's first multibyte character:

```
lib/json/common.rb:364:in 'String#encode': "\xE2" on US-ASCII (Encoding::InvalidByteSequenceError)
```

Surfaced by `rb-check-drift` failing during a cold `make check` on a build
server over non-interactive ssh (no locale exported). Notably, `rb-check-drift`
runs in **no CI job** — only in local `make check` — so green CI never
disproved this; the per-step `LC_ALL: C` pins in `test.yml` don't reach it
either. Whether the Ruby drift check should join CI (and run under `LC_ALL: C`
like its hardened siblings) is a real question, but a separate one from this
fix — flagged here rather than smuggled in.

Verified, both directions under `LC_ALL=C`: the pre-fix `generate-metadata.rb`
exits 1 with exactly the error above; the pinned `generate-metadata.rb` and
`generate-types.rb` exit 0 (`generate-services.rb` gets exercised by the full
`rb-check-drift` rerun on the build server once this lands).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force UTF-8 when reading the OpenAPI spec in the Ruby generators to prevent JSON parse errors under `LC_ALL=C`. This fixes `rb-check-drift` failures in cold `make check` and unblocks the v0.14.0 cold-verification leg (#700).

- **Bug Fixes**
  - Read the spec as UTF-8 in `ruby/scripts/generate-metadata.rb`, `ruby/scripts/generate-services.rb`, and `ruby/scripts/generate-types.rb`.
  - Avoids US-ASCII default under C locale that raised `Encoding::InvalidByteSequenceError` on multibyte characters.

<sup>Written for commit aec43fa1dcfc51fa710287e11e342dc8ce2b62df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

