### PR TITLE
ExpiresAt absence: zero-time sentinel, Expiry(), and wrapper-aware timestamp guards

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -144,6 +144,53 @@ Add a `limit_exceeded` branch that surfaces the limit to the user and does not
 retry. This SDK's own Kotlin test suite hit the compile error, which is what the
 exhaustive `when` in `ErrorTest` exists to produce.
 
+### Go: an absent expiry reads as absent, not as an instant (#662)
+
+Two silent behavior changes on `AuthorizationInfo.ExpiresAt` (`FlexTime`), and
+neither gives you a compile error:
+
+- **A wire `expires_at: 0` now decodes to the zero time.** Previously it
+  decoded to `time.Unix(0, 0)` — a *valid* 1970 date with `IsZero() == false`,
+  so "no expiry" read as "expired 56 years ago". No production issuer has ever
+  sent `0` (BC3 tokens validate presence; legacy Signal tokens self-default an
+  expiry), so this is hardening against the RFC 7591 collision — `0` means
+  "never expires" in bc3's own `client_secret_expires_at` — not a live-bug fix.
+  Code that deliberately round-tripped `0` through `FlexTime` gets the zero
+  time back instead.
+- **A zero `FlexTime` marshals as `null`.** Previously it marshaled as the
+  fabricated instant `"0001-01-01T00:00:00Z"`, indistinguishable from data the
+  server sent. If you re-serialize `AuthorizationInfo` and consume `expires_at`
+  downstream, expect `null` where that sentinel used to be.
+
+New, not breaking: `info.Expiry() (time.Time, bool)` is the documented front
+door — `ok` is false when the document stated no expiry (absent field, explicit
+`null`, or legacy `0` alike). Prefer it over reading `ExpiresAt` directly.
+
+### Go: `TimelineEventData.StartsAt`/`EndsAt` became `*types.FlexibleTime`
+
+The same class as v0.13.0's [four Go pointer entries](#go): the generated
+counterpart is `*types.FlexibleTime` (the bounds are required-and-nullable —
+`schedule_entry_*` events always carry them, but the value may be `null`), and
+the hand-written struct flattened them to value types, fabricating
+`0001-01-01T00:00:00Z` for a null bound on re-marshal.
+
+**This compiles unchanged and panics at runtime on the wrong payload.** Go
+promotes value-receiver methods through the pointer, so
+`ev.Data.StartsAt.IsZero()` still builds — and nil-panics when the API sent
+`null`. Nil-check first:
+
+```go
+// Before
+if !ev.Data.StartsAt.IsZero() { start := ev.Data.StartsAt.Time; ... }
+
+// After
+if ev.Data.StartsAt != nil { start := ev.Data.StartsAt.Time; ... }
+```
+
+A nil bound re-marshals as `null` (the key stays, matching the wire contract);
+a null bound previously decoded to the zero time, so `IsZero()`-based absence
+checks translate to nil checks.
+
 ---
 
 # v0.13.0

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -164,7 +164,8 @@ neither gives you a compile error:
 
 New, not breaking: `info.Expiry() (time.Time, bool)` is the documented front
 door — `ok` is false when the document stated no expiry (absent field, explicit
-`null`, or legacy `0` alike). Prefer it over reading `ExpiresAt` directly.
+`null`, or a wire `0` alike; all defensive, per the above — no production
+issuer emits any of them). Prefer it over reading `ExpiresAt` directly.
 
 ### Go: `TimelineEventData.StartsAt`/`EndsAt` became `*types.FlexibleTime`
 

--- a/go/README.md
+++ b/go/README.md
@@ -70,7 +70,7 @@ for _, a := range info.Accounts {
 account := client.ForAccount(fmt.Sprint(info.Accounts[0].ID))
 ```
 
-`info.Expiry()` tells you how long the token has left, which is the quickest way to confirm a static token has not lapsed. `ok` is false when the document states no expiry — Launchpad omits `expires_at` for a non-expiring token:
+`info.Expiry()` tells you how long the token has left, which is the quickest way to confirm a static token has not lapsed. `ok` is false when the document states no expiry — both production issuers always state one today, so that branch is robustness for whatever `GetInfoOptions.Endpoint` points at:
 
 ```go
 if expiry, ok := info.Expiry(); ok && time.Until(expiry) < 0 {

--- a/go/README.md
+++ b/go/README.md
@@ -70,7 +70,13 @@ for _, a := range info.Accounts {
 account := client.ForAccount(fmt.Sprint(info.Accounts[0].ID))
 ```
 
-`info.ExpiresAt` tells you how long the token has left, which is the quickest way to confirm a static token has not lapsed.
+`info.Expiry()` tells you how long the token has left, which is the quickest way to confirm a static token has not lapsed. `ok` is false when the document states no expiry — Launchpad omits `expires_at` for a non-expiring token:
+
+```go
+if expiry, ok := info.Expiry(); ok && time.Until(expiry) < 0 {
+    log.Fatal("token has lapsed")
+}
+```
 
 ## Quick Start
 

--- a/go/pkg/basecamp/authorization.go
+++ b/go/pkg/basecamp/authorization.go
@@ -10,6 +10,10 @@ import (
 
 // FlexTime is a time.Time that can unmarshal from either a Unix timestamp (integer)
 // or an RFC 3339 string. This supports both BC3 OAuth 2.1 (integer) and Launchpad (string).
+//
+// The zero value means "no expiry known": an absent field, an explicit null,
+// and the integer 0 all decode to it, and it marshals back as null. Check
+// IsZero() before treating the instant as real.
 type FlexTime struct {
 	time.Time
 }
@@ -25,6 +29,16 @@ func (ft *FlexTime) UnmarshalJSON(data []byte) error {
 	// Try as integer (Unix timestamp) first
 	var unix int64
 	if err := json.Unmarshal(data, &unix); err == nil {
+		if unix == 0 {
+			// bc3 renders `expires_at.to_i`, so a wire 0 would be its spelling
+			// of an unstated expiry, and RFC 7591 gives 0 the meaning "never
+			// expires" (bc3's own client_secret_expires_at). Either way,
+			// "expired at the 1970 epoch" — a *valid* time.Unix(0, 0) instant —
+			// is the one wrong reading. Treat it as "no expiry known",
+			// matching TypeScript's parseExpiresAt.
+			ft.Time = time.Time{}
+			return nil
+		}
 		ft.Time = time.Unix(unix, 0)
 		return nil
 	}
@@ -41,6 +55,17 @@ func (ft *FlexTime) UnmarshalJSON(data []byte) error {
 	}
 
 	return fmt.Errorf("expires_at must be a Unix timestamp or RFC 3339 string, got: %s", string(data))
+}
+
+// MarshalJSON implements json.Marshaler for FlexTime.
+// Zero times marshal as null; non-zero times use time.Time's JSON encoding.
+// Without this, a zero ExpiresAt would re-marshal as the fabricated instant
+// 0001-01-01T00:00:00Z, indistinguishable from a timestamp the server sent.
+func (ft FlexTime) MarshalJSON() ([]byte, error) {
+	if ft.IsZero() {
+		return []byte("null"), nil
+	}
+	return ft.Time.MarshalJSON()
 }
 
 // Identity represents the authenticated user's identity from the authorization endpoint.
@@ -76,6 +101,8 @@ type AuthorizedAccount struct {
 
 // AuthorizationInfo contains the complete authorization response.
 type AuthorizationInfo struct {
+	// ExpiresAt is the token's expiry. Its zero value means the document did
+	// not state one; prefer Expiry(), which makes that case explicit.
 	ExpiresAt FlexTime            `json:"expires_at"`
 	Identity  Identity            `json:"identity"`
 	Accounts  []AuthorizedAccount `json:"accounts"`
@@ -91,6 +118,13 @@ type AuthorizationInfo struct {
 	// unfiltered rather than empty. An empty account list reports true: it is no
 	// evidence about the issuer either way. Not a wire field.
 	ProductFilterApplied bool `json:"-"`
+}
+
+// Expiry returns the token's expiry instant. ok is false when the
+// authorization document did not state one — the zero ExpiresAt covers an
+// absent field, an explicit null, and bc3's legacy `0` rendering alike.
+func (a *AuthorizationInfo) Expiry() (t time.Time, ok bool) {
+	return a.ExpiresAt.Time, !a.ExpiresAt.IsZero()
 }
 
 // GetInfoOptions specifies options for fetching authorization info.

--- a/go/pkg/basecamp/authorization.go
+++ b/go/pkg/basecamp/authorization.go
@@ -122,7 +122,9 @@ type AuthorizationInfo struct {
 
 // Expiry returns the token's expiry instant. ok is false when the
 // authorization document did not state one — the zero ExpiresAt covers an
-// absent field, an explicit null, and bc3's legacy `0` rendering alike.
+// absent field, an explicit null, and a wire `0` alike. No production
+// issuer emits any of those today; the branch is robustness for the
+// endpoints GetInfoOptions.Endpoint can reach.
 func (a *AuthorizationInfo) Expiry() (t time.Time, ok bool) {
 	return a.ExpiresAt.Time, !a.ExpiresAt.IsZero()
 }

--- a/go/pkg/basecamp/authorization_test.go
+++ b/go/pkg/basecamp/authorization_test.go
@@ -113,9 +113,10 @@ func TestAuthorizationService_GetInfo(t *testing.T) {
 				if len(info.Accounts) != tt.wantCount {
 					t.Errorf("GetInfo() returned %d accounts, want %d", len(info.Accounts), tt.wantCount)
 				}
-				// Every success fixture here omits expires_at, as Launchpad
-				// does for a non-expiring token. Absence must read as "no
-				// expiry known", not as a fabricated instant.
+				// Every success fixture here omits expires_at — a synthetic
+				// shape (production issuers always state one) that exercises
+				// the absence sentinel: it must read as "no expiry known",
+				// not as a fabricated instant.
 				if !info.ExpiresAt.IsZero() {
 					t.Errorf("ExpiresAt = %v for a document without expires_at, want zero", info.ExpiresAt.Time)
 				}
@@ -436,7 +437,7 @@ func TestFlexTime_UnmarshalJSON(t *testing.T) {
 }
 
 // TestAuthorizationInfo_NoExpiryKnown pins the sentinel contract for #662: an
-// absent expires_at, an explicit null, and bc3's legacy `0` rendering all
+// absent expires_at, an explicit null, and a wire `0` all
 // decode to the zero ExpiresAt, report Expiry() ok=false, and re-marshal as
 // null — never as 0001-01-01T00:00:00Z, and never as a valid 1970 date.
 //

--- a/go/pkg/basecamp/authorization_test.go
+++ b/go/pkg/basecamp/authorization_test.go
@@ -113,6 +113,15 @@ func TestAuthorizationService_GetInfo(t *testing.T) {
 				if len(info.Accounts) != tt.wantCount {
 					t.Errorf("GetInfo() returned %d accounts, want %d", len(info.Accounts), tt.wantCount)
 				}
+				// Every success fixture here omits expires_at, as Launchpad
+				// does for a non-expiring token. Absence must read as "no
+				// expiry known", not as a fabricated instant.
+				if !info.ExpiresAt.IsZero() {
+					t.Errorf("ExpiresAt = %v for a document without expires_at, want zero", info.ExpiresAt.Time)
+				}
+				if expiry, ok := info.Expiry(); ok {
+					t.Errorf("Expiry() = (%v, true) for a document without expires_at, want ok=false", expiry)
+				}
 			}
 		})
 	}
@@ -270,6 +279,11 @@ func TestAuthorizationService_GetInfo_BC5DocumentShape(t *testing.T) {
 	if got := info.ExpiresAt.UTC().Format(time.RFC3339); got != "2036-01-29T09:55:56Z" {
 		t.Errorf("ExpiresAt = %s, want 2036-01-29T09:55:56Z", got)
 	}
+	if expiry, ok := info.Expiry(); !ok {
+		t.Error("Expiry() ok = false for a document with a real expires_at, want true")
+	} else if !expiry.Equal(time.Unix(2085213356, 0)) {
+		t.Errorf("Expiry() = %v, want %v", expiry, time.Unix(2085213356, 0))
+	}
 	if info.Identity.EmailAddress != "" {
 		t.Errorf("Identity.EmailAddress = %q, want \"\" — a BC5 document omits it", info.Identity.EmailAddress)
 	}
@@ -348,7 +362,13 @@ func TestFlexTime_UnmarshalJSON(t *testing.T) {
 		name    string
 		input   string
 		wantErr bool
-		wantSec int64 // expected Unix timestamp
+		wantSec int64 // expected Unix timestamp, when wantZero is false
+		// wantZero asserts the zero time — "no expiry known". null and integer 0
+		// both land here: bc3 renders `expires_at.to_i`, so a wire 0 would be its
+		// spelling of an unstated expiry, and RFC 7591 already gives 0 the meaning
+		// "never expires" (bc3's own client_secret_expires_at) — the one reading
+		// that must not survive is "expired at the 1970 epoch".
+		wantZero bool
 	}{
 		{
 			name:    "unix timestamp integer",
@@ -369,10 +389,10 @@ func TestFlexTime_UnmarshalJSON(t *testing.T) {
 			wantSec: 1705314600,
 		},
 		{
-			name:    "zero timestamp",
-			input:   `0`,
-			wantErr: false,
-			wantSec: 0,
+			name:     "zero timestamp - treated as zero time, not the 1970 epoch",
+			input:    `0`,
+			wantErr:  false,
+			wantZero: true,
 		},
 		{
 			name:    "invalid string format",
@@ -380,10 +400,10 @@ func TestFlexTime_UnmarshalJSON(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "null value - treated as zero time",
-			input:   `null`,
-			wantErr: false,
-			wantSec: 0,
+			name:     "null value - treated as zero time",
+			input:    `null`,
+			wantErr:  false,
+			wantZero: true,
 		},
 		{
 			name:    "boolean value",
@@ -403,14 +423,57 @@ func TestFlexTime_UnmarshalJSON(t *testing.T) {
 			}
 
 			if !tt.wantErr {
-				// For zero time (null), check IsZero() instead of Unix()
-				if tt.wantSec == 0 && tt.input == `null` {
+				if tt.wantZero {
 					if !ft.IsZero() {
-						t.Errorf("FlexTime.IsZero() = false, want true for null input")
+						t.Errorf("FlexTime.IsZero() = false for input %s, want true — got %v", tt.input, ft.Time)
 					}
 				} else if ft.Unix() != tt.wantSec {
 					t.Errorf("FlexTime.Unix() = %d, want %d", ft.Unix(), tt.wantSec)
 				}
+			}
+		})
+	}
+}
+
+// TestAuthorizationInfo_NoExpiryKnown pins the sentinel contract for #662: an
+// absent expires_at, an explicit null, and bc3's legacy `0` rendering all
+// decode to the zero ExpiresAt, report Expiry() ok=false, and re-marshal as
+// null — never as 0001-01-01T00:00:00Z, and never as a valid 1970 date.
+//
+// AuthorizationInfo is deliberately NOT in timestampCarriers(): that table
+// asserts key *omission* on re-marshal, and expires_at is a value field whose
+// honest re-marshal of "no expiry known" is an explicit null.
+func TestAuthorizationInfo_NoExpiryKnown(t *testing.T) {
+	cases := []struct {
+		name string
+		doc  string
+	}{
+		{"absent", `{"identity":{"id":1},"accounts":[]}`},
+		{"null", `{"expires_at":null,"identity":{"id":1},"accounts":[]}`},
+		{"integer zero", `{"expires_at":0,"identity":{"id":1},"accounts":[]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var info AuthorizationInfo
+			if err := json.Unmarshal([]byte(tc.doc), &info); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+			if !info.ExpiresAt.IsZero() {
+				t.Errorf("ExpiresAt = %v, want zero — %s must read as \"no expiry known\"", info.ExpiresAt.Time, tc.name)
+			}
+			if expiry, ok := info.Expiry(); ok {
+				t.Errorf("Expiry() = (%v, true), want ok=false for %s expires_at", expiry, tc.name)
+			}
+			b, err := json.Marshal(info)
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+			var out map[string]json.RawMessage
+			if err := json.Unmarshal(b, &out); err != nil {
+				t.Fatalf("re-unmarshal %s: %v", b, err)
+			}
+			if got := string(out["expires_at"]); got != "null" {
+				t.Errorf("expires_at re-marshaled as %s, want null", got)
 			}
 		})
 	}

--- a/go/pkg/basecamp/optional_timestamps_test.go
+++ b/go/pkg/basecamp/optional_timestamps_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/basecamp/basecamp-sdk/go/pkg/generated"
+	"github.com/basecamp/basecamp-sdk/go/pkg/types"
 )
 
 // Optional timestamps on the hand-written wrapper surface must be *time.Time.
@@ -244,26 +245,19 @@ func TestNilOptionalTimestampPanicsOnValueReceiverCall(t *testing.T) {
 // guard stays: it catches an inert `,omitempty` on a wrapper struct that has no
 // generated counterpart at all, which the cross-reference cannot see.
 func TestNoValueTypedOptionalTimestamps(t *testing.T) {
-	entries, err := os.ReadDir(".")
-	if err != nil {
-		t.Fatalf("read package dir: %v", err)
-	}
+	wrappers := timeWrapperNames(t,
+		parseGoFiles(t, packageGoFiles(t, ".")),
+		parseGoFiles(t, packageGoFiles(t, filepath.Join("..", "types"))))
 
 	fset := token.NewFileSet()
-	var files []*ast.File
-	for _, e := range entries {
-		name := e.Name()
-		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
-			continue
-		}
-		f, err := parser.ParseFile(fset, filepath.Join(".", name), nil, 0)
+	paths := packageGoFiles(t, ".")
+	files := make([]*ast.File, 0, len(paths))
+	for _, path := range paths {
+		f, err := parser.ParseFile(fset, path, nil, 0)
 		if err != nil {
-			t.Fatalf("parse %s: %v", name, err)
+			t.Fatalf("parse %s: %v", path, err)
 		}
 		files = append(files, f)
-	}
-	if len(files) == 0 {
-		t.Fatal("parsed zero non-test .go files — the guard is scanning the wrong directory")
 	}
 
 	var (
@@ -277,7 +271,7 @@ func TestNoValueTypedOptionalTimestamps(t *testing.T) {
 				return true
 			}
 			for _, f := range st.Fields.List {
-				if !isValueTime(f.Type) {
+				if !isTimeLike(f.Type, wrappers) {
 					continue
 				}
 				scanned++
@@ -293,7 +287,7 @@ func TestNoValueTypedOptionalTimestamps(t *testing.T) {
 					continue
 				}
 				violations = append(violations,
-					fmt.Sprintf("%s: %s time.Time `%s`", fset.Position(f.Pos()), fieldNames(f), tag))
+					fmt.Sprintf("%s: %s %s `%s`", fset.Position(f.Pos()), fieldNames(f), timeTypeName(f.Type), tag))
 			}
 			return true
 		})
@@ -309,7 +303,8 @@ func TestNoValueTypedOptionalTimestamps(t *testing.T) {
 	sort.Strings(violations)
 	for _, v := range violations {
 		t.Errorf("optional timestamp is value-typed and cannot represent absence "+
-			"(`,omitempty` is inert for a struct, so the key is emitted as 0001-01-01T00:00:00Z): %s", v)
+			"(`,omitempty` is inert for a struct, so the key is emitted on every re-marshal — "+
+			"as a fabricated 0001-01-01T00:00:00Z for time.Time, or at best null for a named wrapper): %s", v)
 	}
 }
 
@@ -321,11 +316,12 @@ type timestampField struct {
 	file    string
 }
 
-// collectTimestampFields keys every time.Time / *time.Time struct field by
-// (struct name, json key). The json key is the pairing axis rather than the Go
-// field name: the wrapper renames fields (Id → ID) but the wire key is the
-// thing both sides must agree about.
-func collectTimestampFields(t *testing.T, files map[string]*ast.File) map[[2]string]timestampField {
+// collectTimestampFields keys every timestamp-typed struct field by
+// (struct name, json key) — time.Time and the named time wrappers (FlexTime,
+// types.FlexibleTime, types.Date), in both value and pointer form. The json
+// key is the pairing axis rather than the Go field name: the wrapper renames
+// fields (Id → ID) but the wire key is the thing both sides must agree about.
+func collectTimestampFields(t *testing.T, files map[string]*ast.File, wrappers map[string]bool) map[[2]string]timestampField {
 	t.Helper()
 	out := map[[2]string]timestampField{}
 	for path, file := range files {
@@ -342,9 +338,9 @@ func collectTimestampFields(t *testing.T, files map[string]*ast.File) map[[2]str
 				if f.Tag == nil || len(f.Names) == 0 {
 					continue
 				}
-				value := isValueTime(f.Type)
+				value := isTimeLike(f.Type, wrappers)
 				star, isStar := f.Type.(*ast.StarExpr)
-				pointer := isStar && isValueTime(star.X)
+				pointer := isStar && isTimeLike(star.X, wrappers)
 				if !value && !pointer {
 					continue
 				}
@@ -407,6 +403,14 @@ func parseGoFiles(t *testing.T, paths []string) map[string]*ast.File {
 // So the pairing here is by struct name + json key, which is blind to the
 // converter tiers and therefore covers all of them.
 //
+// Both this guard and TestNoValueTypedOptionalTimestamps originally keyed on
+// the literal `time.Time` selector, so the named time wrappers (FlexTime,
+// types.FlexibleTime, types.Date) were invisible to them — which is how
+// TimelineEventData.StartsAt/EndsAt sat value-typed against a pointer-typed
+// generated counterpart with neither guard able to see it (#662). The
+// predicate is now isTimeLike, which resolves the wrappers by final type name
+// on both sides of the pairing.
+//
 // Scoped to timestamps deliberately. The wrapper flattens optional
 // *string/*bool/*int to value types on purpose; a nil-capability rule applied
 // broadly reports ~345 intentional fields. Timestamps are the principled
@@ -426,10 +430,14 @@ func TestNoWrapperTimestampNarrowerThanGenerated(t *testing.T) {
 		wrapperPaths = append(wrapperPaths, name)
 	}
 
-	wrapper := collectTimestampFields(t, parseGoFiles(t, wrapperPaths))
+	wrapperFiles := parseGoFiles(t, wrapperPaths)
+	wrappers := timeWrapperNames(t, wrapperFiles,
+		parseGoFiles(t, packageGoFiles(t, filepath.Join("..", "types"))))
+
+	wrapper := collectTimestampFields(t, wrapperFiles, wrappers)
 	gen := collectTimestampFields(t, parseGoFiles(t, []string{
 		filepath.Join("..", "generated", "client.gen.go"),
-	}))
+	}), wrappers)
 
 	if len(wrapper) == 0 || len(gen) == 0 {
 		t.Fatalf("collected %d wrapper and %d generated timestamp fields — the walk is broken, not the surface",
@@ -450,7 +458,7 @@ func TestNoWrapperTimestampNarrowerThanGenerated(t *testing.T) {
 			continue
 		}
 		violations = append(violations, fmt.Sprintf(
-			"%s.%s (json:%q, %s) is time.Time but generated.%s.%s is *time.Time",
+			"%s.%s (json:%q, %s) is value-typed but generated.%s.%s is a pointer",
 			key[0], w.field, key[1], w.file, key[0], g.field))
 	}
 
@@ -467,6 +475,54 @@ func TestNoWrapperTimestampNarrowerThanGenerated(t *testing.T) {
 	}
 }
 
+// TestNamedTimeWrappersMarshalZeroAsNull is the behavioral root guard for the
+// class #662 named. AuthorizationInfo.ExpiresAt is exactly the field the two
+// AST guards above can never reach — it has no generated counterpart to pair
+// with and a bare `json:"expires_at"` tag, so it is structurally invisible to
+// both, widened or not. What actually protects it, and every future field like
+// it, is the wrappers' own marshaling contract: a named time wrapper's zero
+// value means "the wire didn't state one" and must marshal as null, never as a
+// fabricated instant (0001-01-01T00:00:00Z, or a 1970 date via the epoch).
+//
+// The table is cross-checked against the same wrapper discovery the AST guards
+// use, so a new embedded-time.Time wrapper type cannot ship without a row here.
+func TestNamedTimeWrappersMarshalZeroAsNull(t *testing.T) {
+	cases := []struct {
+		name string
+		zero any
+	}{
+		{"FlexTime", FlexTime{}},
+		{"FlexibleTime", types.FlexibleTime{}},
+		{"Date", types.Date{}},
+	}
+
+	wrappers := timeWrapperNames(t,
+		parseGoFiles(t, packageGoFiles(t, ".")),
+		parseGoFiles(t, packageGoFiles(t, filepath.Join("..", "types"))))
+	covered := map[string]bool{}
+	for _, c := range cases {
+		covered[c.name] = true
+	}
+	for name := range wrappers {
+		if !covered[name] {
+			t.Errorf("time wrapper %s has no zero-marshals-as-null case — add its zero value to this table", name)
+		}
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			b, err := json.Marshal(c.zero)
+			if err != nil {
+				t.Fatalf("marshal zero %s: %v", c.name, err)
+			}
+			if string(b) != "null" {
+				t.Errorf("zero %s marshaled as %s, want null — a zero named time wrapper means "+
+					"\"absent on the wire\" and must not re-marshal as a fabricated instant", c.name, b)
+			}
+		})
+	}
+}
+
 // isValueTime reports whether expr is the type `time.Time` exactly — not
 // *time.Time, not []time.Time, not a named alias.
 func isValueTime(expr ast.Expr) bool {
@@ -476,6 +532,101 @@ func isValueTime(expr ast.Expr) bool {
 	}
 	ident, ok := sel.X.(*ast.Ident)
 	return ok && ident.Name == "time"
+}
+
+// packageGoFiles returns the non-test .go files in dir.
+func packageGoFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+	var paths []string
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		paths = append(paths, filepath.Join(dir, name))
+	}
+	if len(paths) == 0 {
+		t.Fatalf("found zero non-test .go files in %s — the guard is scanning the wrong directory", dir)
+	}
+	return paths
+}
+
+// timeWrapperNames discovers the named time-wrapper types of this surface:
+// every struct type in the given files that embeds a value time.Time. Today
+// that is FlexTime (this package) and types.FlexibleTime. types.Date is added
+// explicitly: it does not embed a time.Time — it stores year/month/day ints —
+// but it occupies the same optionality class (zero value means "unset",
+// marshals as null), so a value-typed Date field is just as much a timestamp
+// declaration as the embedded-time wrappers are.
+func timeWrapperNames(t *testing.T, fileSets ...map[string]*ast.File) map[string]bool {
+	t.Helper()
+	out := map[string]bool{"Date": true}
+	discovered := 0
+	for _, files := range fileSets {
+		for _, file := range files {
+			ast.Inspect(file, func(n ast.Node) bool {
+				ts, ok := n.(*ast.TypeSpec)
+				if !ok {
+					return true
+				}
+				st, ok := ts.Type.(*ast.StructType)
+				if !ok {
+					return true
+				}
+				for _, f := range st.Fields.List {
+					if len(f.Names) == 0 && isValueTime(f.Type) {
+						out[ts.Name.Name] = true
+						discovered++
+					}
+				}
+				return true
+			})
+		}
+	}
+	// A discovery that finds nothing reports an empty wrapper set forever.
+	// FlexTime and types.FlexibleTime both embed a time.Time; if neither was
+	// seen, the walk broke, not the surface.
+	if discovered == 0 {
+		t.Fatal("discovered zero embedded-time.Time wrapper types — the walk is broken, not the surface")
+	}
+	return out
+}
+
+// isTimeLike reports whether expr is a value-typed timestamp declaration:
+// `time.Time` itself, or one of the named time wrappers by final type name —
+// which matches both the same-package spelling (`FlexTime`) and the selector
+// spelling (`types.FlexibleTime`), so the generated client's fields resolve
+// through the same predicate as the wrapper surface's.
+func isTimeLike(expr ast.Expr, wrappers map[string]bool) bool {
+	if isValueTime(expr) {
+		return true
+	}
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return wrappers[e.Name]
+	case *ast.SelectorExpr:
+		if _, ok := e.X.(*ast.Ident); ok {
+			return wrappers[e.Sel.Name]
+		}
+	}
+	return false
+}
+
+// timeTypeName renders expr for a violation message.
+func timeTypeName(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.SelectorExpr:
+		if x, ok := e.X.(*ast.Ident); ok {
+			return x.Name + "." + e.Sel.Name
+		}
+	}
+	return "time.Time"
 }
 
 // hasOmitempty reports whether any tag key carries the omitempty option. Every

--- a/go/pkg/basecamp/timeline.go
+++ b/go/pkg/basecamp/timeline.go
@@ -50,12 +50,16 @@ type TimelineEvent struct {
 }
 
 // TimelineEventData carries schedule-entry timing for schedule_entry_* events.
-// StartsAt and EndsAt are date-or-timestamp (types.FlexibleTime): a full ISO
-// 8601 timestamp for timed entries, or a bare date when AllDay is true.
+// StartsAt and EndsAt are date-or-timestamp (*types.FlexibleTime): a full ISO
+// 8601 timestamp for timed entries, or a bare date when AllDay is true. The
+// bounds are required-and-nullable — always present, value may be null — so
+// nil means the API sent null, and re-marshals as null rather than a
+// fabricated instant. Nil-check before calling time methods on them: the
+// promoted calls compile unchanged and panic at runtime on a null bound.
 type TimelineEventData struct {
-	AllDay   bool               `json:"all_day"`
-	StartsAt types.FlexibleTime `json:"starts_at"`
-	EndsAt   types.FlexibleTime `json:"ends_at"`
+	AllDay   bool                `json:"all_day"`
+	StartsAt *types.FlexibleTime `json:"starts_at"`
+	EndsAt   *types.FlexibleTime `json:"ends_at"`
 }
 
 // TimelineAttachment is a single timeline-event attachment: an optional-field
@@ -523,8 +527,8 @@ func timelineEventFromGenerated(ge generated.TimelineEvent) TimelineEvent {
 	if ge.Data != nil {
 		e.Data = &TimelineEventData{
 			AllDay:   ge.Data.AllDay,
-			StartsAt: deref(ge.Data.StartsAt),
-			EndsAt:   deref(ge.Data.EndsAt),
+			StartsAt: ge.Data.StartsAt,
+			EndsAt:   ge.Data.EndsAt,
 		}
 	}
 

--- a/go/pkg/basecamp/timeline_test.go
+++ b/go/pkg/basecamp/timeline_test.go
@@ -193,6 +193,9 @@ func TestTimelineEvent_AdditiveFields(t *testing.T) {
 		t.Error("expected all_day true")
 	}
 	wantDate := time.Date(2025, 10, 30, 0, 0, 0, 0, time.UTC)
+	if ev.Data.StartsAt == nil || ev.Data.EndsAt == nil {
+		t.Fatalf("expected non-nil bounds, got starts=%v ends=%v", ev.Data.StartsAt, ev.Data.EndsAt)
+	}
 	if !ev.Data.StartsAt.Equal(wantDate) {
 		t.Errorf("expected StartsAt %v, got %v", wantDate, ev.Data.StartsAt)
 	}
@@ -281,8 +284,9 @@ func TestTimelineEvent_AdditiveFields(t *testing.T) {
 
 // TestTimelineEventData_NullBounds verifies a schedule-entry event whose timing
 // bounds are JSON null decodes cleanly (the bounds are required-and-nullable:
-// always present, value may be null). Go decodes null to the zero FlexibleTime;
-// the static SDKs type the bounds `string | null` so they don't fail to decode.
+// always present, value may be null). Go decodes null to a nil pointer, which
+// re-marshals as null rather than a fabricated instant; the static SDKs type
+// the bounds `string | null` so they don't fail to decode.
 func TestTimelineEventData_NullBounds(t *testing.T) {
 	data := `[{"id":9,"created_at":"2024-03-15T10:31:00Z","kind":"schedule_entry_created","data":{"all_day":true,"starts_at":null,"ends_at":null}}]`
 	var events []TimelineEvent
@@ -295,8 +299,17 @@ func TestTimelineEventData_NullBounds(t *testing.T) {
 	if !events[0].Data.AllDay {
 		t.Error("expected all_day true")
 	}
-	if !events[0].Data.StartsAt.IsZero() || !events[0].Data.EndsAt.IsZero() {
-		t.Errorf("expected null bounds to decode as zero time, got starts=%v ends=%v", events[0].Data.StartsAt, events[0].Data.EndsAt)
+	if events[0].Data.StartsAt != nil || events[0].Data.EndsAt != nil {
+		t.Errorf("expected null bounds to decode as nil, got starts=%v ends=%v", events[0].Data.StartsAt, events[0].Data.EndsAt)
+	}
+	// Null in, null out: the bounds are required-and-nullable, so the keys must
+	// survive re-marshal carrying null, not a fabricated instant.
+	b, err := json.Marshal(events[0].Data)
+	if err != nil {
+		t.Fatalf("re-marshal: %v", err)
+	}
+	if string(b) != `{"all_day":true,"starts_at":null,"ends_at":null}` {
+		t.Errorf("expected null bounds to re-marshal as null, got %s", b)
 	}
 }
 

--- a/spec/api-gaps/bc5-authorization-document-shape.md
+++ b/spec/api-gaps/bc5-authorization-document-shape.md
@@ -200,11 +200,27 @@ adds no runtime edge to the known `base.ts`/`client.ts` cycle. In it:
 
 **Go** — `AuthorizedAccount.Resource` and `AuthorizationInfo.Scope` added
 (`,omitempty`), plus the same `FilterProduct` correction and
-`ProductFilterApplied`. `ExpiresAt` is deliberately untouched: **issue #662**
-owns pointerizing it (it currently fabricates `0001-01-01T00:00:00Z`) and
-widening the `isValueTime` guard, and `FlexTime` already decodes both spellings,
-so the brief's Go timestamp ask was met before this. Doing it here would collide
-with a breaking change #662 should make on its own terms.
+`ProductFilterApplied`. `ExpiresAt` was deliberately untouched here and closed
+by **issue #662** on its own terms — not by pointerizing (`encoding/json`
+allocates on any non-null token, so a wire `0` can never become a nil pointer
+without struct-level machinery) but by a zero-time sentinel: `FlexTime` keeps
+its value type, absent / `null` / `0` all decode to the zero time, the zero
+marshals back as `null` instead of fabricating `0001-01-01T00:00:00Z`, and
+`AuthorizationInfo.Expiry() (time.Time, bool)` is the documented front door.
+The `isValueTime` guards were widened to recognize the named time wrappers,
+plus a behavioral guard that every named wrapper marshals its zero as null —
+the AST guards structurally cannot reach `ExpiresAt` (no generated
+counterpart, bare tag), so the marshaling contract is what protects it.
+
+One premise correction against bc3 source: a nil expiry rendering as `0` —
+claimed for TS above — is unreachable today. BC3 tokens carry `null: false`
+plus presence validation and are always set at mint (10-year PATs are the
+"non-expiring" case and still carry real timestamps); legacy Signal tokens
+lazily self-default (`expires_at ||= expires_in.from_now`). So `.to_i` has
+never emitted `0` in production and Launchpad never omits the field either;
+the `0` handling on both sides is defense-in-depth against the RFC 7591
+collision (bc3's own `client_secret_expires_at: 0` means "never expires" — the
+exact inverse of "expired at epoch"), not a live-bug fix.
 
 **Ruby** — `AuthorizationService#get`'s `@example` no longer reads
 `identity.email_address`, which is `nil` against bc3. The sharper fix is in the


### PR DESCRIPTION
Closes #662.

## What this fixes

**`AuthorizationInfo.ExpiresAt` fabricated `0001-01-01T00:00:00Z`** for an absent or null `expires_at` — the #562/#615/#620 failure mode, on the field whose whole purpose is answering "is this credential still good". And a second, distinct bug exploration surfaced: **a wire `expires_at: 0` decoded to `time.Unix(0, 0)`** — a *valid* 1970 instant with `IsZero() == false` — so "no expiry" read as "expired 56 years ago". TypeScript already collapses `0`/`null`/absent into one "no expiry known" class (`parseExpiresAt`'s Invalid-Date sentinel); Go did not.

### The model: zero-time sentinel + comma-ok accessor

`FlexTime` stays a value type. Absent, `null`, and `0` all decode to the zero time; the zero marshals back as `null`; and `AuthorizationInfo.Expiry() (time.Time, bool)` is the documented front door (`ok == false` when the document stated no expiry). This matches TS's sentinel, `oauth.Token.ExpiresAt`, and `Credentials.ExpiresAt <= 0` — no pointer, no panic class, no compile break.

Pointerization was considered and fails its own stress test: `encoding/json` allocates on any non-null token, so a wire `0` can never become a nil `*FlexTime` without struct-level unmarshal machinery — you keep either the 1970 bug or two absence spellings.

### Premise correction (from bc3 source)

#681's brief claimed a nil expiry arrives as `0`. It cannot, today: BC3 tokens carry `null: false` plus presence validation and are always set at mint (10-year PATs are the "non-expiring" case and still carry real timestamps), and legacy Signal tokens lazily self-default (`expires_at ||= expires_in.from_now`). Launchpad never omits the field either. So the `0` handling is **defense-in-depth against the RFC 7591 collision** — bc3's own `client_secret_expires_at: 0` means "never expires", the exact inverse of "expired at epoch" — not a live-bug fix. The brief now records this.

## The guard blind spot, and what actually closes it

Both AST timestamp guards keyed on the literal `time.Time` selector, so the named wrappers (`FlexTime`, `types.FlexibleTime`, `types.Date`) were invisible to them. The predicate is now `isTimeLike`: wrappers discovered by parsing the package and `../types` for structs embedding a value `time.Time` (plus `types.Date`, same optionality class), matched by final type name on both sides of the (wrapper, generated) pairing.

The widened guard caught exactly one real narrowing — **`TimelineEventData.StartsAt`/`EndsAt`**, hand-written value `types.FlexibleTime` flattening the generated `*types.FlexibleTime` (required-and-nullable) through `deref()`. Pointerized here, mirroring the generated field's bare tag: nil means the API sent null and re-marshals as null. Same class as #658; same Class-B migration hazard (promoted method calls compile and nil-panic), documented in MIGRATING.md.

But `ExpiresAt` itself stays structurally out of reach of both AST guards forever — no generated counterpart to pair with, bare tag. What protects that class at the root is behavioral: **`TestNamedTimeWrappersMarshalZeroAsNull`** asserts every named time wrapper marshals its zero as `null`, with the table cross-checked against the same wrapper discovery so a new wrapper type cannot ship without a row.

## Verification

Red proofs first, against the un-fixed tree, `REAL_EXIT` captured from log files:

1. `TestFlexTime_UnmarshalJSON` 0-case rewritten to expect `IsZero()` — **failed on main**: `FlexTime.IsZero() = false for input 0 … got 1969-12-31 16:00:00 -0800 PST`.
2. `TestNamedTimeWrappersMarshalZeroAsNull` — **failed on main**: `zero FlexTime marshaled as "0001-01-01T00:00:00Z", want null` (FlexibleTime and Date already passed; the fix is FlexTime's `MarshalJSON`).
3. Widened `TestNoWrapperTimestampNarrowerThanGenerated` — **failed on main naming exactly `TimelineEventData.StartsAt`/`EndsAt`** (value-typed vs generated pointer), before the pointerization commit; green after. No other violations surfaced — `ScheduleEntry`'s bounds pair value-to-value with their generated counterparts.

The new Launchpad-fixture absence assertions and `Expiry()` tests are assertions on new surface, not red proofs; the red proofs are 1–3.

Then: full `make` green (`REAL_EXIT=0`; the first pass failed only on a `prealloc` lint in the new guard code, fixed and re-run). Drift checks unchanged: 91 wrapper pairs walked, 1206 generated fields verified, no critical drift, no UNWRAPPED/MISSING movement. No generated artifacts in the diff — this is entirely the hand-written Go lane plus test guards: no Smithy, no `openapi.json`, no count pins.

## Migration surface

Under the existing `# Unreleased` MIGRATING.md section:

- FlexTime `0` → zero time: **Class A** (silent behavior change; previously a valid 1970 date).
- Zero marshals `null` (was `0001-01-01T00:00:00Z`): **Class A**.
- `TimelineEventData.StartsAt`/`EndsAt` → pointers: **Class B** (compiles via promoted methods, nil-panics on a null bound).
- `Expiry()`: additive, not counted.

## Companion

A bc3 PR converges `/authorization.json`'s `expires_at` on ISO-8601 (it is the only integer-epoch timestamp in bc3's entire public JSON API, contradicts the endpoint's own "mirrors Launchpad" intent, and collides with RFC 7591's `0`) and documents the endpoint in `doc/api` — the missing piece holding `spec/api-gaps/bc5-authorization-document-shape.md` at `partial-coverage`. Non-blocking: both Go and TS already accept both spellings. Link: basecamp/bc3#12646.

Side note: #667 (v0.13.0 freeze) closed as stale; v0.13.0 shipped 2026-08-07.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle absent expiry correctly by treating `0`/`null`/absent `expires_at` as “no expiry” and marshaling zero as `null`. Adds `AuthorizationInfo.Expiry()` and pointerizes `TimelineEventData` bounds; timestamp guards now recognize named wrappers. Docs clarified this is defensive hardening (production issuers don’t send `0`/`null`/absent).

- **Bug Fixes**
  - `FlexTime`: decode `0`/`null`/absent to zero time; zero marshals as `null` (no more `0001-01-01T00:00:00Z` or “expired at 1970”).
  - Added `AuthorizationInfo.Expiry() (time.Time, bool)` for safe expiry reads.
  - Guards: include time-like wrappers (`FlexTime`, `types.FlexibleTime`, `types.Date`) and assert zero named wrappers marshal as `null`.

- **Migration**
  - `TimelineEventData.StartsAt`/`EndsAt` are now `*types.FlexibleTime`; nil-check before using them. Nil re-marshals as `null`.
  - `expires_at: 0` now reads as “no expiry”. Prefer `info.Expiry()` over accessing `ExpiresAt` directly.

<sup>Written for commit 04273816231d448f4188eee7bb61add3063339af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

