### PR TITLE
State the hop-2 download guard as one dialable-URL predicate

### DIFF
--- a/ruby/lib/basecamp/client.rb
+++ b/ruby/lib/basecamp/client.rb
@@ -618,18 +618,22 @@ module Basecamp
     def fetch_signed_download(url)
       # The Location target is server-supplied, and this unauthenticated hop
       # has no same_origin? gate to refuse it (a signed URL is legitimately
-      # cross-origin), so illegible targets must be refused here: URI.parse
-      # raises URI::InvalidComponentError on a scheme-only "mailto:" — the
-      # value Security.resolve_url returns verbatim — and Net::HTTP can only
-      # dial http(s). Both are ApiError, matching the legible refusals Go and
-      # TypeScript surface when their dial rejects the scheme.
+      # cross-origin), so illegible targets must be refused here — as
+      # ApiError, matching the legible refusals Go and TypeScript surface
+      # when their dial rejects the scheme. One predicate states the whole
+      # invariant — a dialable absolute HTTP(S) URL — because piecemeal
+      # guards kept leaking: "it parses" admitted "ftp://", and "scheme is
+      # http(s)" admitted hostless "http:foo", which Net::HTTP::Get rejects
+      # with a raw ArgumentError before the dial (nothing is ever sent).
+      # URI.parse types the scheme (URI::HTTPS < URI::HTTP), and a nil or
+      # empty host ("http:foo", "http:///x") is undialable.
       uri = begin
         URI.parse(url)
       rescue URI::Error
-        raise ApiError.new("redirect to invalid download URL: #{Security.truncate(url)}")
+        nil
       end
-      unless %w[http https].include?(uri.scheme&.downcase)
-        raise ApiError.new("redirect to non-HTTP(S) download URL: #{Security.truncate(url)}")
+      unless uri.is_a?(URI::HTTP) && uri.host && !uri.host.empty?
+        raise ApiError.new("redirect to undialable download URL: #{Security.truncate(url)}")
       end
 
       http_client = Net::HTTP.new(uri.host, uri.port)

--- a/ruby/test/basecamp/download_test.rb
+++ b/ruby/test/basecamp/download_test.rb
@@ -174,7 +174,7 @@ class DownloadTest < Minitest::Test
     error = assert_raises(Basecamp::ApiError) do
       @account.download_url("https://3.basecampapi.com/12345/attachments/abc/download/file.txt")
     end
-    assert_match(/invalid download URL/, error.message)
+    assert_match(/undialable download URL/, error.message)
   end
 
   def test_download_url_redirect_to_non_http_scheme_is_refused
@@ -185,7 +185,22 @@ class DownloadTest < Minitest::Test
     error = assert_raises(Basecamp::ApiError) do
       @account.download_url("https://3.basecampapi.com/12345/attachments/abc/download/file.txt")
     end
-    assert_match(/non-HTTP\(S\) download URL/, error.message)
+    assert_match(/undialable download URL/, error.message)
+  end
+
+  # "http:foo" parses with scheme "http" but a nil host, so a scheme-only
+  # check let it reach Net::HTTP::Get.new, which raises a raw ArgumentError
+  # ("no host component for URI") outside the dial rescue — an unclassified
+  # crash, though never a request: the error fires before anything is sent.
+  def test_download_url_redirect_to_hostless_location_is_refused
+    stub_request(:get, "#{base_url}/12345/attachments/abc/download/file.txt")
+      .with(headers: { "Authorization" => "Bearer #{access_token}" })
+      .to_return(status: 302, headers: { "Location" => "http:foo" })
+
+    error = assert_raises(Basecamp::ApiError) do
+      @account.download_url("https://3.basecampapi.com/12345/attachments/abc/download/file.txt")
+    end
+    assert_match(/undialable download URL/, error.message)
   end
 
   # -- Error tests --


### PR DESCRIPTION
Follow-up to #704, from the one comment Copilot *suppressed* on its re-review there: `http:foo` parses with scheme `http` but a nil host, passed the scheme-only guard, and reached `Net::HTTP::Get.new` — which raises a raw `ArgumentError: no host component for URI` outside the dial rescue. An unclassified crash from a server-supplied `Location`, though never a request: the error fires before anything is sent, so this was an error-legibility gap, not an exploitable dial (verified empirically, including that no loopback request occurs).

Rather than add a third piecemeal guard ("…and has a host") beside "it parses" and "scheme is http(s)", this replaces both with the single invariant they were converging on: **the hop-2 target must be a dialable absolute HTTP(S) URL** — `uri.is_a?(URI::HTTP) && uri.host && !uri.host.empty?` (URI::HTTPS subclasses URI::HTTP; parse failure ⇒ nil ⇒ refused), one unified `ApiError` message. Probed partition: `https://ok.example/f` dials; `mailto:`, `ftp://h/f`, `http:foo`, `http:///x`, `https://` all refuse.

Red proof: the hostless-`Location` regression test fails against #704's code with the raw `ArgumentError`; green after, with the two existing redirect-refusal tests updated to the unified message. Full Ruby suite green (1411 runs, 0 failures), rubocop clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the hop-2 download redirect guard into one predicate that only allows dialable absolute HTTP(S) URLs. Prevents hostless or non-HTTP(S) Locations from raising raw errors and standardizes the refusal message.

- **Bug Fixes**
  - Replace piecemeal checks with `uri.is_a?(URI::HTTP)` and non-empty `uri.host` (parse errors now fail this predicate).
  - Standardize error to "redirect to undialable download URL" and add a regression test for hostless `http:foo`.

<sup>Written for commit e971df1b7cca42f5d6122b44eeee5d2416dc7823. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

