### PR TITLE
Close the authorization-document brief: bc3 #12646 shipped and documented

### DIFF
--- a/scripts/validate-api-gaps.rb
+++ b/scripts/validate-api-gaps.rb
@@ -103,6 +103,15 @@ def validate_frontmatter(meta, file, required_fields, known_fields, additional_s
       unless section.is_a?(String) && !section.empty?
         add_error(errors, file, "status=confirmed-not-api-resource requires bc3_refs.bc3_plan_section")
       end
+    when "covered-outside-spec"
+      # Terminal state for surfaces the architecture deliberately keeps outside
+      # the OpenAPI spec (OAuth): absorbed-in-sdk's smithy_refs can never exist,
+      # so the coverage claim must point at the sanctioned hand-written surface
+      # instead — otherwise it could not rot-check at all.
+      covering = meta.dig("bc3_refs", "related_existing_api")
+      if !covering.is_a?(Array) || covering.empty?
+        add_error(errors, file, "status=covered-outside-spec requires non-empty bc3_refs.related_existing_api naming the covering hand-written surface")
+      end
     when /\Aaddressed-in-bc3-pr-\d+\z/
       pr = meta["bc3_pr"]
       if pr.nil? || pr.to_s.empty?

--- a/spec/api-gaps/README.md
+++ b/spec/api-gaps/README.md
@@ -17,7 +17,10 @@ making the absorption journey publicly auditable.
    updates to `addressed-in-bc3-pr-N`.
 3. **Absorb**: SDK opens a follow-up PR adding the Smithy operations and
    regenerated SDK code. Frontmatter updates to `absorbed-in-sdk` with
-   Smithy structure refs.
+   Smithy structure refs. Surfaces the architecture deliberately keeps
+   outside the OpenAPI spec (OAuth, SPEC §16) can never take this step —
+   they close as `covered-outside-spec` instead, pointing at the covering
+   hand-written surface via `bc3_refs.related_existing_api`.
 4. **Archive**: entries more than a year past `absorbed-in-sdk` may be moved
    to `archive/` for tidiness; they remain readable as historical record.
 
@@ -31,6 +34,7 @@ making the absorption journey publicly auditable.
 | `confirmed-not-api-resource` | BC3 confirmed UI-only / not part of the API surface; entry retained as classification record. |
 | `addressed-in-bc3-pr-N` | BC3 has shipped a JSON API contract; SDK absorption pending. |
 | `absorbed-in-sdk` | SDK has absorbed the contract via Smithy + regenerated code. |
+| `covered-outside-spec` | Terminal. Contract shipped upstream and covered by the SDK's sanctioned hand-written surface (`bc3_refs.related_existing_api`); deliberately outside the OpenAPI spec, so `absorbed-in-sdk` can never apply. |
 
 ## Entries (current)
 
@@ -70,7 +74,7 @@ making the absorption journey publicly auditable.
 | [event-feed](event-feed.md) | no-json-contract | n/a | high |
 | [project-archive-unarchive](project-archive-unarchive.md) | absorbed-in-sdk | master | medium |
 | [notifications-sort-pings-first](notifications-sort-pings-first.md) | partial-coverage | master | low |
-| [bc5-authorization-document-shape](bc5-authorization-document-shape.md) | addressed-in-bc3-pr-12646 | master | medium |
+| [bc5-authorization-document-shape](bc5-authorization-document-shape.md) | covered-outside-spec | master | medium |
 
 > Statuses reflect how BC3's **BC5 API train** actually shipped (8 PRs merged
 > to `master`, 2026-07-18..21); BC3 #10947 closed unmerged, superseded by the

--- a/spec/api-gaps/README.md
+++ b/spec/api-gaps/README.md
@@ -70,7 +70,7 @@ making the absorption journey publicly auditable.
 | [event-feed](event-feed.md) | no-json-contract | n/a | high |
 | [project-archive-unarchive](project-archive-unarchive.md) | absorbed-in-sdk | master | medium |
 | [notifications-sort-pings-first](notifications-sort-pings-first.md) | partial-coverage | master | low |
-| [bc5-authorization-document-shape](bc5-authorization-document-shape.md) | partial-coverage | master | medium |
+| [bc5-authorization-document-shape](bc5-authorization-document-shape.md) | addressed-in-bc3-pr-12646 | master | medium |
 
 > Statuses reflect how BC3's **BC5 API train** actually shipped (8 PRs merged
 > to `master`, 2026-07-18..21); BC3 #10947 closed unmerged, superseded by the

--- a/spec/api-gaps/bc5-authorization-document-shape.md
+++ b/spec/api-gaps/bc5-authorization-document-shape.md
@@ -1,6 +1,6 @@
 ---
 gap: bc5-authorization-document-shape
-status: addressed-in-bc3-pr-12646
+status: covered-outside-spec
 detected: 2026-08-05
 sdk_demand: medium
 bc3_pr: 12646
@@ -253,8 +253,9 @@ the bc3 half:
   PR. The self-referential controller-test assertions were replaced with
   shape assertions (`String` + `Time.iso8601` parse-back), proven failing
   against the old view. **No SDK change needed**: Go's `FlexTime` and TS's
-  `parseExpiresAt` accept both spellings, and Ruby/Python pass the value
-  through untyped.
+  `parseExpiresAt` accept both spellings; Ruby passes the value through
+  untyped; Python never reaches bc3's document at all (hardcoded to the
+  Launchpad URL — see above), so nothing changes for it.
 - **bc3 documents its own document.** `doc/api/sections/authentication.md`
   gained a "Get authorization from Basecamp" section — both token types, the
   RFC 8707 `resource` indicator, the `scope` presence rule (every
@@ -262,10 +263,13 @@ the bc3 half:
   scopes), the identity-id-only shape, the DPoP-bound request form, ISO 8601
   `expires_at`. Mirrored to the public repo via bc-api #435.
 
-This status is **terminal**: no absorption PR will follow, because this surface
-is deliberately outside the OpenAPI spec (the same reason `absorbed-in-sdk`
-fails validation here — no `smithy_refs` can exist). At repin time, treat this
-entry as registered-and-done rather than pending absorption.
+The status is `covered-outside-spec` — the registry's terminal state for
+surfaces the architecture deliberately keeps outside the OpenAPI spec, added
+for this entry as its first instance. No absorption PR will follow and none is
+pending: `absorbed-in-sdk` can never apply (no `smithy_refs` can exist), and
+the coverage claim points instead at the sanctioned hand-written surface named
+in `bc3_refs.related_existing_api`, which the validator now requires for this
+status.
 
 Left open upstream, deliberately, as flagged on #12646:
 

--- a/spec/api-gaps/bc5-authorization-document-shape.md
+++ b/spec/api-gaps/bc5-authorization-document-shape.md
@@ -1,9 +1,9 @@
 ---
 gap: bc5-authorization-document-shape
-status: partial-coverage
+status: addressed-in-bc3-pr-12646
 detected: 2026-08-05
 sdk_demand: medium
-bc3_pr: 9471
+bc3_pr: 12646
 bc3_refs:
   introduced_in: BC3 #9471, the modern OAuth 2.1 stack (merged eac8b2b476)
   routes:
@@ -165,10 +165,11 @@ the kind of `FlexTime` special-casing Go already needed.
 
 ## What shipped (#681)
 
-The SDK half of this brief is closed. `status` stays `partial-coverage` because
-the other half is bc3's and has not moved: bc3 still does not document its own
-authorization document, so `doc/api/sections/authentication.md` describes only
-Launchpad's payload and the two shapes are still undeclared. Nothing here is
+The SDK half of this brief closed here. `status` stayed `partial-coverage` at
+the time because the other half was bc3's and had not moved: bc3 did not yet
+document its own authorization document, so `doc/api/sections/authentication.md`
+described only Launchpad's payload and the two shapes were undeclared. That
+half has since closed too — see "Closed (bc3 #12646)" below. Nothing here is
 generated — OAuth is outside the OpenAPI spec by design — so there are no
 `smithy_refs` to point at and `absorbed-in-sdk` would fail
 `scripts/validate-api-gaps.rb` for exactly that reason.
@@ -240,3 +241,41 @@ is still open and is a feature, not a fix.
 Both fixtures asked for by the absorption plan exist: the pre-existing
 Launchpad-shaped ones and new BC5-shaped ones in all three SDKs that have a
 typed or tested surface, each asserting the epoch-seconds `expires_at`.
+
+## Closed (bc3 #12646)
+
+bc3 **#12646** (merged `71b43f3d9fa`, deployed to production 2026-08-11) closed
+the bc3 half:
+
+- **`expires_at` converged on ISO 8601.** The view renders the raw `Time`
+  instead of `.to_i` — the epoch integer was the only one in bc3's entire
+  public JSON API, incidental to RFC 7662's mandatory `exp` written in the same
+  PR. The self-referential controller-test assertions were replaced with
+  shape assertions (`String` + `Time.iso8601` parse-back), proven failing
+  against the old view. **No SDK change needed**: Go's `FlexTime` and TS's
+  `parseExpiresAt` accept both spellings, and Ruby/Python pass the value
+  through untyped.
+- **bc3 documents its own document.** `doc/api/sections/authentication.md`
+  gained a "Get authorization from Basecamp" section — both token types, the
+  RFC 8707 `resource` indicator, the `scope` presence rule (every
+  Basecamp-issued token carries one, PATs included; legacy tokens predate
+  scopes), the identity-id-only shape, the DPoP-bound request form, ISO 8601
+  `expires_at`. Mirrored to the public repo via bc-api #435.
+
+This status is **terminal**: no absorption PR will follow, because this surface
+is deliberately outside the OpenAPI spec (the same reason `absorbed-in-sdk`
+fails validation here — no `smithy_refs` can exist). At repin time, treat this
+entry as registered-and-done rather than pending absorption.
+
+Left open upstream, deliberately, as flagged on #12646:
+
+- Whether bc3's document should carry Launchpad's `accounts[].product` /
+  `app_href` — a product decision (resource indicators vs product selection).
+- `href` renders `BC3.uri` (the web origin) while Launchpad's contract — and
+  the doc example — use the account's API base. Raised on the PR with a
+  recommended fix (`BC3.protocol` + `BC3.api_host`); the owner resolved the
+  thread, so the call on if/when to converge it is made upstream, not here.
+
+The wider question both instances belong to, named on the PR: which fields of
+bc3's authorization document are contract-bound to mirror Launchpad's — one
+decision, not per-field rounds.

--- a/spec/api-gaps/schema.json
+++ b/spec/api-gaps/schema.json
@@ -18,7 +18,8 @@
           "partial-coverage",
           "ambiguous",
           "confirmed-not-api-resource",
-          "absorbed-in-sdk"
+          "absorbed-in-sdk",
+          "covered-outside-spec"
         ] },
         { "type": "string", "pattern": "^addressed-in-bc3-pr-[0-9]+$" }
       ]


### PR DESCRIPTION
bc3 [#12646](https://github.com/basecamp/bc3/pull/12646) (merged `71b43f3d9fa`, deployed to production 2026-08-11) closed the half this brief was held open for:

- **`expires_at` converged on ISO 8601** — the only integer-epoch timestamp in bc3's public JSON API is gone. **No SDK change needed**: Go `FlexTime` and TS `parseExpiresAt` accept both spellings; Ruby passes the value through untyped; Python never reaches bc3's document (hardcoded Launchpad URL).
- **bc3 documents its own authorization document** in `doc/api/sections/authentication.md`, mirrored publicly via bc-api #435 — the exit criterion that held this brief at `partial-coverage` since #681.

Status: `partial-coverage` → **`covered-outside-spec`**, a new terminal status for surfaces the architecture deliberately keeps outside the OpenAPI spec — added on review feedback rather than overloading `addressed-in-bc3-pr-N` (defined as "SDK absorption pending", which would have reported pending work forever). Schema, validator, lifecycle doc and status table move together; the validator requires `bc3_refs.related_existing_api` for the new status (the coverage claim must name the covering hand-written surface) and that rule was negative-tested. The README index row moves with it; the range-triage blockquote naming the original registration is history and stays untouched.

Recorded as deliberately left open upstream (flagged and owned on #12646): the `product`/`app_href` product decision, and `href` rendering the web origin where Launchpad's contract and the doc example use the API base.

Registry/docs + validator only: `validate-api-gaps` and `doc-constants-check` both clean; no generated artifacts, no count pins. Follow-up PR (per review): refresh the BC5-shaped fixtures and parser doc comments that still present epoch seconds as bc3's current spelling.