### PR TITLE
BC5 fixtures speak ISO 8601; integer epoch stays covered as compat

### DIFF
--- a/go/pkg/basecamp/authorization.go
+++ b/go/pkg/basecamp/authorization.go
@@ -8,8 +8,9 @@ import (
 	"time"
 )
 
-// FlexTime is a time.Time that can unmarshal from either a Unix timestamp (integer)
-// or an RFC 3339 string. This supports both BC3 OAuth 2.1 (integer) and Launchpad (string).
+// FlexTime is a time.Time that can unmarshal from either an RFC 3339 string —
+// the spelling both issuers send today — or a Unix timestamp (integer), bc3's
+// rendering before bc3 #12646 converged it, kept accepted as compatibility.
 //
 // The zero value means "no expiry known": an absent field, an explicit null,
 // and the integer 0 all decode to it, and it marshals back as null. Check

--- a/go/pkg/basecamp/authorization.go
+++ b/go/pkg/basecamp/authorization.go
@@ -31,12 +31,13 @@ func (ft *FlexTime) UnmarshalJSON(data []byte) error {
 	var unix int64
 	if err := json.Unmarshal(data, &unix); err == nil {
 		if unix == 0 {
-			// bc3 renders `expires_at.to_i`, so a wire 0 would be its spelling
-			// of an unstated expiry, and RFC 7591 gives 0 the meaning "never
-			// expires" (bc3's own client_secret_expires_at). Either way,
-			// "expired at the 1970 epoch" — a *valid* time.Unix(0, 0) instant —
-			// is the one wrong reading. Treat it as "no expiry known",
-			// matching TypeScript's parseExpiresAt.
+			// bc3 rendered `expires_at.to_i` before bc3 #12646, so a wire 0
+			// would have been its spelling of an unstated expiry, and RFC 7591
+			// gives 0 the meaning "never expires" (bc3's own
+			// client_secret_expires_at). Either way, "expired at the 1970
+			// epoch" — a *valid* time.Unix(0, 0) instant — is the one wrong
+			// reading. Treat it as "no expiry known", matching TypeScript's
+			// parseExpiresAt.
 			ft.Time = time.Time{}
 			return nil
 		}

--- a/go/pkg/basecamp/authorization_test.go
+++ b/go/pkg/basecamp/authorization_test.go
@@ -131,7 +131,9 @@ func TestAuthorizationService_GetInfo(t *testing.T) {
 // bc5AuthorizationDocument is what a BC5 (bc3) issuer serves from
 // app/views/api/authorizations/show.json.jbuilder: identity id only, no product
 // or app_href on accounts, an RFC 8707 resource indicator instead, a top-level
-// scope, and expires_at as integer epoch seconds.
+// scope, and expires_at as an ISO 8601 string (integer epoch seconds before
+// bc3 #12646 converged it; TestAuthorizationInfo_UnmarshalWithIntExpiresAt
+// keeps the integer spelling covered).
 //
 // Go reaches this document exactly the way TypeScript does — by passing an
 // Endpoint override, which is the documented way to point at a BC5 issuer.
@@ -142,9 +144,8 @@ func bc5AuthorizationDocument() map[string]any {
 			{"id": 1, "name": "Acme Corp", "href": "https://bc5.example.com/1", "resource": "urn:bc:account:1"},
 			{"id": 2, "name": "Second Account", "href": "https://bc5.example.com/2", "resource": "urn:bc:account:2"},
 		},
-		"scope": "read write",
-		// 2036-01-29T09:55:56Z as epoch seconds.
-		"expires_at": 2085213356,
+		"scope":      "read write",
+		"expires_at": "2036-01-29T09:55:56Z",
 	}
 }
 
@@ -540,7 +541,10 @@ func TestAuthorizationInfo_UnmarshalWithStringExpiresAt(t *testing.T) {
 }
 
 func TestAuthorizationInfo_UnmarshalWithIntExpiresAt(t *testing.T) {
-	// BC3 OAuth 2.1 returns expires_at as Unix timestamp integer
+	// bc3 rendered expires_at as integer epoch seconds before bc3 #12646
+	// converged it on ISO 8601. The integer spelling stays accepted — recorded
+	// documents and older deploys still carry it — and this test is what keeps
+	// that compatibility covered now that the BC5 fixture speaks ISO 8601.
 	jsonData := `{
 		"expires_at": 2085213356,
 		"identity": {

--- a/go/pkg/basecamp/authorization_test.go
+++ b/go/pkg/basecamp/authorization_test.go
@@ -258,9 +258,10 @@ func TestAuthorizationService_GetInfo_EmptyAccountListIsFilterable(t *testing.T)
 	}
 }
 
-// The rest of the BC5 shape: the resource indicator, the scope, the epoch-seconds
-// timestamp Go's FlexTime already handled, and the Launchpad-only fields that
-// degrade to "" rather than erroring.
+// The rest of the BC5 shape: the resource indicator, the scope, the ISO 8601
+// expires_at bc3 sends since bc3 #12646, and the Launchpad-only fields that
+// degrade to "" rather than erroring. Integer-epoch compatibility is covered
+// separately by TestAuthorizationInfo_UnmarshalWithIntExpiresAt.
 func TestAuthorizationService_GetInfo_BC5DocumentShape(t *testing.T) {
 	server := newBC5AuthorizationServer(t)
 	client := newBC5AuthorizationClient(t, server)
@@ -366,10 +367,10 @@ func TestFlexTime_UnmarshalJSON(t *testing.T) {
 		wantErr bool
 		wantSec int64 // expected Unix timestamp, when wantZero is false
 		// wantZero asserts the zero time — "no expiry known". null and integer 0
-		// both land here: bc3 renders `expires_at.to_i`, so a wire 0 would be its
-		// spelling of an unstated expiry, and RFC 7591 already gives 0 the meaning
-		// "never expires" (bc3's own client_secret_expires_at) — the one reading
-		// that must not survive is "expired at the 1970 epoch".
+		// both land here: bc3's pre-#12646 `expires_at.to_i` rendering made a
+		// wire 0 its spelling of an unstated expiry, and RFC 7591 gives 0 the
+		// meaning "never expires" (bc3's own client_secret_expires_at) — the one
+		// reading that must not survive is "expired at the 1970 epoch".
 		wantZero bool
 	}{
 		{

--- a/ruby/lib/basecamp/services/authorization_service.rb
+++ b/ruby/lib/basecamp/services/authorization_service.rb
@@ -11,9 +11,10 @@ module Basecamp
     # Launchpad's: it carries +identity.id+ and nothing else of the identity, no
     # +product+ or +app_href+ on accounts, an RFC 8707 +resource+ indicator
     # instead, and a top-level +scope+ for BC3-issued tokens. Only +identity.id+,
-    # +accounts[].id+, +accounts[].name+ and +accounts[].href+ are common to both.
-    # +expires_at+ is an ISO-8601 string from either issuer (integer epoch
-    # seconds from bc3 before bc3 #12646 — passed through verbatim either way).
+    # +accounts[].id+, +accounts[].name+, +accounts[].href+ and +expires_at+ are
+    # common to both; +expires_at+ is an ISO-8601 string from either issuer
+    # (integer epoch seconds from bc3 before bc3 #12646 — passed through
+    # verbatim either way).
     #
     # @example Get authorization info
     #   auth = client.authorization.get

--- a/ruby/lib/basecamp/services/authorization_service.rb
+++ b/ruby/lib/basecamp/services/authorization_service.rb
@@ -10,9 +10,10 @@ module Basecamp
     # document (+app/views/api/authorizations/show.json.jbuilder+), which is not
     # Launchpad's: it carries +identity.id+ and nothing else of the identity, no
     # +product+ or +app_href+ on accounts, an RFC 8707 +resource+ indicator
-    # instead, a top-level +scope+ for BC3-issued tokens, and +expires_at+ as
-    # integer epoch seconds rather than ISO-8601. Only +identity.id+,
+    # instead, and a top-level +scope+ for BC3-issued tokens. Only +identity.id+,
     # +accounts[].id+, +accounts[].name+ and +accounts[].href+ are common to both.
+    # +expires_at+ is an ISO-8601 string from either issuer (integer epoch
+    # seconds from bc3 before bc3 #12646 — passed through verbatim either way).
     #
     # @example Get authorization info
     #   auth = client.authorization.get

--- a/ruby/test/basecamp/services/authorization_service_test.rb
+++ b/ruby/test/basecamp/services/authorization_service_test.rb
@@ -89,7 +89,7 @@ class AuthorizationServiceTest < Minitest::Test
 
     assert_equal "urn:bc:account:12345", auth["accounts"].first["resource"]
     assert_equal "read write", auth["scope"]
-    assert_equal 2_085_213_356, auth["expires_at"]
+    assert_equal "2036-01-29T09:55:56Z", auth["expires_at"]
     # Launchpad-only fields are absent, not empty — a consumer reading
     # identity.email_address here gets nil, which is what the service's own
     # @example used to show.

--- a/ruby/test/basecamp/services/authorization_service_test.rb
+++ b/ruby/test/basecamp/services/authorization_service_test.rb
@@ -74,10 +74,10 @@ class AuthorizationServiceTest < Minitest::Test
     assert_not_requested :get, "#{LAUNCHPAD_URL}/authorization.json"
   end
 
-  # The BC5 document survives the round trip intact — including the three fields
-  # Launchpad never sends and the epoch-seconds expires_at. Ruby returns the
-  # parsed Hash verbatim, so what this really pins is that nothing in the fetch
-  # path reshapes, coerces, or drops a field it does not recognise.
+  # The BC5 document survives the round trip intact — including the two fields
+  # Launchpad never sends (resource and scope). Ruby returns the parsed Hash
+  # verbatim, so what this really pins is that nothing in the fetch path
+  # reshapes, coerces, or drops a field it does not recognise.
   def test_get_authorization_returns_bc5_document_fields_verbatim
     stub_resource_metadata(authorization_servers: [ BC5_ISSUER, LAUNCHPAD_URL ])
     stub_as_metadata(BC5_ISSUER)

--- a/ruby/test/test_helper.rb
+++ b/ruby/test/test_helper.rb
@@ -253,7 +253,9 @@ module TestHelpers
   # makes the test agree with itself and with nothing else: it would pass just as
   # well if the SDK could not read a BC5 document at all. The differences are the
   # point — identity id only, no product or app_href, an RFC 8707 resource
-  # indicator, a top-level scope, and expires_at as integer epoch seconds.
+  # indicator, and a top-level scope. (expires_at was integer epoch seconds
+  # before bc3 #12646 converged it on ISO 8601; Ruby passes it through verbatim
+  # either way.)
   def sample_bc5_authorization
     {
       "identity" => { "id" => 1 },
@@ -266,8 +268,7 @@ module TestHelpers
         }
       ],
       "scope" => "read write",
-      # 2036-01-29T09:55:56Z as epoch seconds.
-      "expires_at" => 2_085_213_356
+      "expires_at" => "2036-01-29T09:55:56Z"
     }
   end
 end

--- a/typescript/src/oauth/authorization-document.ts
+++ b/typescript/src/oauth/authorization-document.ts
@@ -129,7 +129,10 @@ export interface AuthorizationInfo {
  * list that a caller cannot distinguish from a real one.
  */
 export interface RawAuthorizationDocument {
-  /** ISO-8601 string (Launchpad) or integer epoch seconds (BC5). */
+  /**
+   * ISO-8601 string from either issuer; integer epoch seconds is BC5's
+   * pre-#12646 spelling, kept accepted as compatibility.
+   */
   expires_at?: string | number | null;
   /** Both issuers always emit this, so it stays required — see the note below. */
   identity: {

--- a/typescript/src/oauth/authorization-document.ts
+++ b/typescript/src/oauth/authorization-document.ts
@@ -23,7 +23,7 @@
  * | `accounts[].product` / `app_href` | present | absent |
  * | `accounts[].resource` | absent | present (RFC 8707 indicator) |
  * | `scope` | absent | present, BC3-issued tokens only |
- * | `expires_at` | ISO-8601 string | integer epoch **seconds** |
+ * | `expires_at` | ISO-8601 string | ISO-8601 string (integer epoch **seconds** before bc3 #12646; still accepted) |
  *
  * Every field either issuer omits is typed optional here. The union is modelled
  * rather than either shape alone, because a consumer reaches a BC5 issuer just by
@@ -154,17 +154,21 @@ export interface RawAuthorizationDocument {
 }
 
 /**
- * Parses `expires_at` from either issuer's spelling.
+ * Parses `expires_at` from any spelling either issuer has ever used.
  *
- * Launchpad sends an ISO-8601 string; bc3 sends `@token.expires_at.to_i`, an
- * integer epoch **seconds**. The distinction is the whole point of branching on
- * `typeof`: `new Date(2085213356)` treats the number as *milliseconds* and yields
- * a date in 1970 — a wrong answer rather than an exception, which then reads as
- * an expired credential rather than a schema mismatch.
+ * Both issuers send an ISO-8601 string today; bc3 sent `@token.expires_at.to_i`
+ * — integer epoch **seconds** — before bc3 #12646 converged it, and the integer
+ * spelling stays accepted (recorded documents, older deploys). The `typeof`
+ * branch matters because `new Date(2085213356)` treats the number as
+ * *milliseconds* and yields a date in 1970 — a wrong answer rather than an
+ * exception, which then reads as an expired credential rather than a schema
+ * mismatch.
  *
- * bc3 renders `.to_i`, so a nil expiry arrives as `0`, never `null`. A `0`, a
- * `null` and an absent field are all "no expiry known" and produce an Invalid
- * Date, which is what a `Date`-typed field can say about the absence.
+ * A `0`, a `null` and an absent field are all "no expiry known" and produce an
+ * Invalid Date, which is what a `Date`-typed field can say about absence. No
+ * production issuer emits any of the three — bc3 tokens validate presence and
+ * are always set at mint — so the `0` handling is defensive, guarding the
+ * RFC 7591 collision where `0` means "never expires".
  */
 export function parseExpiresAt(value: string | number | null | undefined): Date {
   if (typeof value === "number") {

--- a/typescript/src/oauth/authorization-document.ts
+++ b/typescript/src/oauth/authorization-document.ts
@@ -175,7 +175,8 @@ export interface RawAuthorizationDocument {
  */
 export function parseExpiresAt(value: string | number | null | undefined): Date {
   if (typeof value === "number") {
-    // Epoch seconds, not milliseconds. `0` is bc3's rendering of a nil expiry.
+    // Epoch seconds, not milliseconds. `0` is the defensive no-expiry sentinel
+    // (RFC 7591 gives 0 the meaning "never expires"); no issuer emits it.
     return value === 0 ? new Date(NaN) : new Date(value * 1000);
   }
   if (typeof value === "string" && value !== "") {

--- a/typescript/tests/services/authorization.test.ts
+++ b/typescript/tests/services/authorization.test.ts
@@ -40,7 +40,9 @@ const sampleAuthResponse = () => ({
  * A BC5 (bc3) issuer's own authorization document, per
  * `app/views/api/authorizations/show.json.jbuilder`: identity id only, no
  * `product` or `app_href` on accounts, an RFC 8707 `resource` indicator instead,
- * a top-level `scope`, and `expires_at` as integer epoch *seconds*.
+ * a top-level `scope`, and `expires_at` as an ISO-8601 string (integer epoch
+ * *seconds* before bc3 #12646 converged it; the compat case below keeps the
+ * integer spelling covered).
  */
 const sampleBc5AuthResponse = () => ({
   identity: { id: 100 },
@@ -59,8 +61,7 @@ const sampleBc5AuthResponse = () => ({
     },
   ],
   scope: "read write",
-  // 2036-01-29T09:55:56Z as epoch seconds. Read as milliseconds: 1970-01-25.
-  expires_at: 2085213356,
+  expires_at: "2036-01-29T09:55:56Z",
 });
 
 const BC5_URL = "https://bc5.example.com/authorization.json";
@@ -164,11 +165,26 @@ describe("AuthorizationService", () => {
       server.use(http.get(BC5_URL, () => HttpResponse.json(sampleBc5AuthResponse())));
     });
 
-    it("reads expires_at as epoch seconds, not milliseconds", async () => {
+    it("parses the ISO-8601 expires_at bc3 sends since #12646", async () => {
       const info = await client.authorization.getInfo({ endpoint: BC5_URL });
 
-      // Read as milliseconds, 2085213356 lands in January 1970 — a wrong date
-      // rather than an exception, which then reads as an expired credential.
+      expect(info.expiresAt.getUTCFullYear()).toBe(2036);
+      expect(info.expiresAt.toISOString()).toBe("2036-01-29T09:55:56.000Z");
+    });
+
+    it("still accepts the pre-#12646 integer epoch spelling, as seconds not milliseconds", async () => {
+      // bc3 rendered `expires_at.to_i` before bc3 #12646; recorded documents
+      // and older deploys still carry the integer. Read as milliseconds,
+      // 2085213356 lands in January 1970 — a wrong date rather than an
+      // exception, which then reads as an expired credential.
+      server.use(
+        http.get(BC5_URL, () =>
+          HttpResponse.json({ ...sampleBc5AuthResponse(), expires_at: 2085213356 }),
+        ),
+      );
+
+      const info = await client.authorization.getInfo({ endpoint: BC5_URL });
+
       expect(info.expiresAt.getUTCFullYear()).toBe(2036);
       expect(info.expiresAt.toISOString()).toBe("2036-01-29T09:55:56.000Z");
     });


### PR DESCRIPTION
Follow-up to #707's review (Codex): bc3 [#12646](https://github.com/basecamp/bc3/pull/12646) converged `/authorization.json`'s `expires_at` on ISO 8601, but the BC5-shaped fixtures in Go/TS/Ruby still presented integer epoch seconds as bc3's *current* document, and the TS/Ruby parser doc comments told consumers bc3 sends an integer.

- **Fixtures → ISO string** (same instant, `2036-01-29T09:55:56Z`, so downstream assertions hold unchanged).
- **Integer compat retained deliberately**: Go's `TestAuthorizationInfo_UnmarshalWithIntExpiresAt` + `FlexTime` int cases (comments now name them as the compat coverage), and a **new TS case** serving the pre-#12646 integer spelling through the BC5 endpoint — keeping the seconds-not-milliseconds assertion alive. Ruby passes the value through untyped, so it has no numeric parse path to cover.
- **Doc comments updated** in `typescript/src/oauth/authorization-document.ts` and `ruby/lib/basecamp/services/authorization_service.rb`; the TS one also dropped #681's incorrect "a nil expiry arrives as 0" claim (unreachable — bc3 tokens validate presence and are always set at mint), restated as the defensive RFC 7591 framing.

Verified: Go authorization/FlexTime tests, TS `authorization.test.ts` (incl. the new compat case), and the full Ruby suite (1410 runs, 0 failures, `REAL_EXIT=0`) all green. Test/doc-comment-only — no runtime behavior change, no generated artifacts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update BC5-shaped fixtures to use ISO-8601 `expires_at` to match bc3’s updated `/authorization.json` (bc3 #12646), while keeping integer epoch seconds supported for compatibility. Tests and docs only; no runtime behavior or generated artifacts change.

- **Refactors**
  - Switched BC5 fixtures in Go/TypeScript/Ruby to "2036-01-29T09:55:56Z"; kept integer-seconds compat via Go tests and a new TypeScript case (Ruby passes through).
  - Finished the doc sweep: Go `FlexTime`/tests describe ISO‑8601 as current; TypeScript `RawAuthorizationDocument.expires_at` and `parseExpiresAt` docs clarify ISO‑8601 from both issuers with `0` as an RFC 7591 defensive sentinel; Ruby service/tests now list `expires_at` among the common fields and update BC5 test headers.

<sup>Written for commit 0faa1a9b96b5f089882f09188963127e5eed5fe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

