### PR TITLE
Build hygiene: clean never deletes tracked files, UTF-8-pinned reads, tracked runner lockfiles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -531,6 +531,10 @@ jobs:
       - name: Run Ruby conformance tests
         if: matrix.ruby == '3.3'
         working-directory: conformance/runner/ruby
+        # Frozen: the runner Gemfile.lock is tracked (#670), so the install
+        # must fail fast rather than rewrite it.
+        env:
+          BUNDLE_FROZEN: 'true'
         run: |
           bundle install
           ruby runner.rb
@@ -626,8 +630,10 @@ jobs:
       - name: Run Python conformance tests
         if: matrix.python == '3.13'
         working-directory: conformance/runner/python
+        # --locked: the runner uv.lock is tracked (#670), so a missing or
+        # out-of-date lockfile must fail the install, not regenerate it.
         run: |
-          uv sync --python ${{ matrix.python }}
+          uv sync --locked --python ${{ matrix.python }}
           uv run --python ${{ matrix.python }} python runner.py
 
       - name: Run Python conformance runner unit tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -517,6 +517,15 @@ jobs:
         run: ../scripts/check-ruby-service-drift.sh
 
       - name: Test
+        if: matrix.ruby != '3.3'
+        run: bundle exec rake test
+
+      # File reads are pinned to encoding: "UTF-8"; this leg proves it stays
+      # that way by running the suite under the C locale (#702).
+      - name: Test (LC_ALL=C)
+        if: matrix.ruby == '3.3'
+        env:
+          LC_ALL: C
         run: bundle exec rake test
 
       - name: Run Ruby conformance tests

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ spec/build/
 # Conformance test runner artifacts
 conformance/runner/go/conformance-runner
 conformance/runner/go/go
-conformance/runner/ruby/Gemfile.lock
 conformance/runner/typescript/node_modules
 # Vitest writes its results cache under whichever node_modules is closest to the
 # cwd, which is not always a package directory — ignore the tree everywhere so a
@@ -57,7 +56,6 @@ scripts/*.pyc
 conformance/runner/python/.venv/
 conformance/runner/python/**/__pycache__/
 conformance/runner/python/**/*.pyc
-conformance/runner/python/uv.lock
 
 # TypeScript SDK build artifacts
 typescript/coverage/

--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ doc-constants-check:
 # Go SDK targets (delegates to go/Makefile)
 #------------------------------------------------------------------------------
 
-.PHONY: go-test go-lint go-check go-clean go-check-drift go-check-wrapper-drift go-check-generated-drift check-grouped-client-coverage test-check-grouped-client-coverage
+.PHONY: go-test go-lint go-check go-clean go-clean-generated go-check-drift go-check-wrapper-drift go-check-generated-drift check-grouped-client-coverage test-check-grouped-client-coverage
 
 go-test:
 	@$(MAKE) -C go test
@@ -320,6 +320,11 @@ go-check:
 
 go-clean:
 	@$(MAKE) -C go clean
+
+# Remove the TRACKED generated Go client so `make -C go generate` rebuilds it.
+# Deliberately not part of `clean`: clean must never delete tracked files (#668).
+go-clean-generated:
+	@$(MAKE) -C go clean-generated
 
 # Check for drift between generated client and service layer
 go-check-drift:
@@ -1373,6 +1378,7 @@ help:
 	@echo "  test-check-grouped-client-coverage  Self-test that gate with adversarial inventories"
 	@echo "  go-check-generated-drift Check generated client.gen.go is current (regenerate + diff)"
 	@echo "  go-clean         Remove Go build artifacts"
+	@echo "  go-clean-generated  Remove the tracked generated Go client (explicit opt-in)"
 	@echo ""
 	@echo "TypeScript SDK:"
 	@echo "  ts-generate           Generate types and metadata from OpenAPI"

--- a/Makefile
+++ b/Makefile
@@ -238,12 +238,11 @@ endif
 		{ echo "ERROR: python/uv.lock is stale. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@test "$$(jq -r '.packages["../../../typescript"].version' conformance/runner/typescript/package-lock.json)" = "$(VERSION)" || \
 		{ echo "ERROR: conformance/runner/typescript/package-lock.json records a stale SDK version. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
-	@# The conformance Ruby/Python runner lockfiles are gitignored and absent on a
-	@# fresh clone — check them only where they exist (a machine that has run
-	@# conformance), which is exactly where a stale one breaks `make check` (#671).
-	@test ! -f conformance/runner/ruby/Gemfile.lock || grep -qF 'basecamp-sdk ($(VERSION))' conformance/runner/ruby/Gemfile.lock || \
+	@# The conformance Ruby/Python runner lockfiles are tracked (#670), so they
+	@# are always present; a stale one breaks the frozen conformance installs (#671).
+	@grep -qF 'basecamp-sdk ($(VERSION))' conformance/runner/ruby/Gemfile.lock || \
 		{ echo "ERROR: conformance/runner/ruby/Gemfile.lock records a stale SDK version. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
-	@test ! -f conformance/runner/python/uv.lock || (cd conformance/runner/python && uv lock --check) || \
+	@(cd conformance/runner/python && uv lock --check) || \
 		{ echo "ERROR: conformance/runner/python/uv.lock is stale. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@git diff --quiet && git diff --cached --quiet || \
 		{ echo "ERROR: Working tree has uncommitted changes. Commit first."; exit 1; }
@@ -653,9 +652,15 @@ conformance-runner-tests-go:
 
 # Bare `pytest` discovers test_*.py and *_test.py under the runner directory.
 # Collecting nothing is exit 5, so an empty suite fails rather than green-passes.
+#
+# The runner lockfiles (Gemfile.lock, uv.lock) are TRACKED (#670), so every
+# install here runs frozen: `uv sync --locked` fails if uv.lock is missing or
+# out of date, and BUNDLE_FROZEN=true installs from Gemfile.lock without
+# writing it back — a version bump or dependency change must regenerate the
+# lockfile in the same commit instead of rewriting it silently at run time.
 conformance-runner-tests-python:
 	@echo "==> Running Python conformance runner unit tests..."
-	cd conformance/runner/python && uv sync --quiet && uv run python -m pytest -q
+	cd conformance/runner/python && uv sync --locked --quiet && uv run python -m pytest -q
 
 # Ruby has no runner-level test task, so discovery is hand-rolled here.
 #
@@ -676,7 +681,7 @@ conformance-runner-tests-python:
 # loudly, not report success over zero files.
 conformance-runner-tests-ruby:
 	@echo "==> Running Ruby conformance runner unit tests..."
-	@cd conformance/runner/ruby && bundle install --quiet && \
+	@cd conformance/runner/ruby && BUNDLE_FROZEN=true bundle install --quiet && \
 	files=$$(find . \( -name vendor -o -name .bundle \) -prune -o \
 		-type f -name '*_test.rb' -print | sort); \
 	if [ -z "$$files" ]; then \
@@ -748,10 +753,12 @@ conformance-typescript-live: ts-build
 	@echo "==> Running TypeScript live canary..."
 	cd conformance/runner/typescript && npm ci && BASECAMP_LIVE=1 npm test
 
-# Run Ruby conformance tests
+# Run Ruby conformance tests. Frozen install: the runner Gemfile.lock is
+# tracked (#670), so the install must never rewrite it — see
+# conformance-runner-tests-python for the full rationale.
 conformance-ruby:
 	@echo "==> Running Ruby conformance tests..."
-	cd conformance/runner/ruby && bundle install --quiet && ruby runner.rb
+	cd conformance/runner/ruby && BUNDLE_FROZEN=true bundle install --quiet && ruby runner.rb
 
 # Run Ruby wire-replay against snapshots written by the TS live runner.
 # Required env: WIRE_REPLAY_DIR, BASECAMP_BACKEND. Opt-in: not in `make check`.
@@ -759,12 +766,13 @@ conformance-ruby-replay:
 	@echo "==> Running Ruby wire-replay runner..."
 	@test -n "$$WIRE_REPLAY_DIR" || (echo "WIRE_REPLAY_DIR is required" >&2; exit 1)
 	@test -n "$$BASECAMP_BACKEND" || (echo "BASECAMP_BACKEND is required" >&2; exit 1)
-	cd conformance/runner/ruby && bundle install --quiet && ruby replay-runner.rb
+	cd conformance/runner/ruby && BUNDLE_FROZEN=true bundle install --quiet && ruby replay-runner.rb
 
-# Run Python conformance tests
+# Run Python conformance tests. Frozen install: the runner uv.lock is tracked
+# (#670) — see conformance-runner-tests-python for the full rationale.
 conformance-python:
 	@echo "==> Running Python conformance tests..."
-	cd conformance/runner/python && uv sync && uv run python runner.py
+	cd conformance/runner/python && uv sync --locked && uv run python runner.py
 
 # Run Python wire-replay against snapshots written by the TS live runner.
 # Required env: WIRE_REPLAY_DIR, BASECAMP_BACKEND. Opt-in: not in `make check`.
@@ -772,7 +780,7 @@ conformance-python-replay:
 	@echo "==> Running Python wire-replay runner..."
 	@test -n "$$WIRE_REPLAY_DIR" || (echo "WIRE_REPLAY_DIR is required" >&2; exit 1)
 	@test -n "$$BASECAMP_BACKEND" || (echo "BASECAMP_BACKEND is required" >&2; exit 1)
-	cd conformance/runner/python && uv sync && uv run python replay_runner.py
+	cd conformance/runner/python && uv sync --locked && uv run python replay_runner.py
 
 # Run all conformance tests
 conformance: oauth-fixtures-check oauth-token-fixtures-check event-feed-fixtures-check event-feed-digest-fixtures-check conformance-fixtures-check conformance-runner-tests conformance-go conformance-kotlin conformance-typescript conformance-ruby conformance-python conformance-swift

--- a/conformance/runner/python/uv.lock
+++ b/conformance/runner/python/uv.lock
@@ -1,0 +1,197 @@
+version = 1
+revision = 3
+requires-python = ">=3.11"
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "basecamp-conformance-python"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "basecamp-sdk" },
+    { name = "respx" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "basecamp-sdk", editable = "../../../python" },
+    { name = "respx", specifier = ">=0.22" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8" }]
+
+[[package]]
+name = "basecamp-sdk"
+version = "0.14.0"
+source = { editable = "../../../python" }
+dependencies = [
+    { name = "httpx" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "httpx", specifier = ">=0.27,<1" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=1.10" },
+    { name = "pytest", specifier = ">=8" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "pytest-cov", specifier = ">=6" },
+    { name = "respx", specifier = ">=0.22" },
+    { name = "ruff", specifier = ">=0.4" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]

--- a/conformance/runner/ruby/Gemfile.lock
+++ b/conformance/runner/ruby/Gemfile.lock
@@ -1,0 +1,76 @@
+PATH
+  remote: ../../../ruby
+  specs:
+    basecamp-sdk (0.14.0)
+      faraday (~> 2.0)
+      zeitwerk (~> 2.6)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    bigdecimal (4.1.2)
+    crack (1.0.1)
+      bigdecimal
+      rexml
+    drb (2.2.3)
+    faraday (2.14.3)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.4)
+      net-http (~> 0.5)
+    hashdiff (1.2.1)
+    json (2.21.2)
+    logger (1.7.0)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    prism (1.9.0)
+    public_suffix (7.0.5)
+    rexml (3.4.4)
+    uri (1.1.1)
+    webmock (3.26.2)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    zeitwerk (2.8.3)
+
+PLATFORMS
+  arm64-darwin
+  arm64-darwin-23
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  basecamp-sdk!
+  json
+  minitest
+  webmock (~> 3.0)
+
+CHECKSUMS
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  basecamp-sdk (0.14.0)
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
+  bundler (4.0.17) sha256=214e21431b5665dd2f99df8a5511c6b151d7a72e8015c8b38f8b775b61cbb6c1
+  crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
+  faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
+  hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
+  json (2.21.2) sha256=1f1d3b7cf2b3ba1a69beca0bb6db13d5438b80bff3cd54cdaaa620b9b07c1c6a
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
+  net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+  uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+  webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
+  zeitwerk (2.8.3) sha256=2c85125a8467ce069e20123d1e709a08955c9d29c118c25b46b7b7fafdbb92e5
+
+BUNDLED WITH
+  4.0.17

--- a/conformance/runner/ruby/replay-runner.rb
+++ b/conformance/runner/ruby/replay-runner.rb
@@ -86,7 +86,9 @@ class ReplayRunner
     @backend = backend
     @fixture_path = fixture_path
     @walker = Basecamp::Conformance::SchemaWalker.new(openapi_path)
-    @fixture = JSON.parse(File.read(fixture_path)).select { |t| t["mode"] == "live" }
+    # Fixture and snapshot reads are pinned to UTF-8 regardless of process
+    # locale (LC_ALL=C would otherwise read as US-ASCII).
+    @fixture = JSON.parse(File.read(fixture_path, encoding: "UTF-8")).select { |t| t["mode"] == "live" }
   end
 
   def run
@@ -149,7 +151,7 @@ class ReplayRunner
     if Dir.exist?(wire_dir)
       Dir.glob(File.join(wire_dir, "*.json")).each do |f|
         snap = begin
-          JSON.parse(File.read(f))
+          JSON.parse(File.read(f, encoding: "UTF-8"))
         rescue Errno::ENOENT, IOError, SystemCallError => e
           msgs << "Snapshot #{File.basename(f)} could not be read: #{e.class}: #{e.message}."
           next
@@ -205,7 +207,7 @@ class ReplayRunner
 
   def read_snapshot(test_name)
     path = File.join(@replay_dir, @backend, "wire", "#{safe_name(test_name)}.json")
-    JSON.parse(File.read(path))
+    JSON.parse(File.read(path, encoding: "UTF-8"))
   end
 
   def decode_snapshot(snapshot)

--- a/conformance/runner/ruby/replay_runner_test.rb
+++ b/conformance/runner/ruby/replay_runner_test.rb
@@ -40,8 +40,9 @@ end
 class DecoderCoverageTest < Minitest::Test
   LIVE_FIXTURE = File.expand_path("../../tests/live-my-surface.json", __dir__)
 
+  # UTF-8 regardless of process locale (LC_ALL=C would otherwise read as US-ASCII)
   def live_operations
-    ops = JSON.parse(File.read(LIVE_FIXTURE))
+    ops = JSON.parse(File.read(LIVE_FIXTURE, encoding: "UTF-8"))
       .select { |t| t["mode"] == "live" }
       .map { |t| t["operation"] }
       .uniq

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -1371,7 +1371,8 @@ class ConformanceRunner
     results = []
 
     files.each do |file|
-      tests = JSON.parse(File.read(file))
+      # UTF-8 regardless of process locale (LC_ALL=C would otherwise read as US-ASCII)
+      tests = JSON.parse(File.read(file, encoding: "UTF-8"))
       # Live tests are TS-only (canonical wire-capturer); accept only mock
       # so unresolved ${PROJECT_ID} fixtures and live-only operations don't
       # surface as mock failures or false passes — and any future mode added

--- a/go/Makefile
+++ b/go/Makefile
@@ -100,6 +100,12 @@ verify:
 clean:
 	rm -f coverage.out coverage.html
 	rm -f bench-baseline.txt bench-current.txt
+
+# Remove the generated client so `make generate` rebuilds it from scratch.
+# pkg/generated/client.gen.go is TRACKED, so removing it must be an explicit
+# opt-in — `clean` must never delete tracked files (issue #668).
+.PHONY: clean-generated
+clean-generated:
 	rm -f pkg/generated/*.gen.go
 
 # Run all checks (local development gate)

--- a/ruby/lib/basecamp/config.rb
+++ b/ruby/lib/basecamp/config.rb
@@ -178,7 +178,9 @@ module Basecamp
     # @param path [String] path to JSON config file
     # @return [Config]
     def self.from_file(path)
-      data = JSON.parse(File.read(path))
+      # UTF-8 regardless of process locale — JSON is UTF-8 (RFC 8259), and
+      # LC_ALL=C would otherwise read as US-ASCII.
+      data = JSON.parse(File.read(path, encoding: "UTF-8"))
       config = new(
         base_url: data["base_url"] || DEFAULT_BASE_URL,
         timeout: data["timeout"] || DEFAULT_TIMEOUT,

--- a/ruby/lib/basecamp/http.rb
+++ b/ruby/lib/basecamp/http.rb
@@ -493,8 +493,10 @@ module Basecamp
     # Memoized per-operation retry metadata, keyed by canonical operation ID.
     # Benign-race memoization: concurrent first loads compute identical values.
     def self.operation_retry(operation)
+      # UTF-8 regardless of process locale — JSON is UTF-8 (RFC 8259), and
+      # LC_ALL=C would otherwise read as US-ASCII.
       @operation_metadata ||= JSON.parse(
-        File.read(File.join(__dir__, "generated", "metadata.json"))
+        File.read(File.join(__dir__, "generated", "metadata.json"), encoding: "UTF-8")
       ).fetch("operations").freeze
       @operation_metadata.dig(operation, "retry")
     end

--- a/ruby/test/basecamp/oauth_resource_discovery_test.rb
+++ b/ruby/test/basecamp/oauth_resource_discovery_test.rb
@@ -22,9 +22,11 @@ class OAuthResourceDiscoveryTest < Minitest::Test
   WELL_KNOWN_RESOURCE = "/.well-known/oauth-protected-resource"
   WELL_KNOWN_AS = "/.well-known/oauth-authorization-server"
 
-  # Generate one test method per fixture file.
+  # Generate one test method per fixture file. Read as UTF-8 regardless of
+  # process locale — under LC_ALL=C this class-body read would otherwise load
+  # the non-ASCII fixtures as US-ASCII and abort the whole suite.
   Dir.glob(File.join(FIXTURE_DIR, "*.json")).sort.each do |path|
-    fixture = JSON.parse(File.read(path))
+    fixture = JSON.parse(File.read(path, encoding: "UTF-8"))
     # The oversized-body scenario needs a genuine streaming transport; it is
     # exercised by a dedicated test below (WebMock delivers the body as one
     # chunk, so it can't demonstrate a bounded read).

--- a/ruby/test/basecamp/oauth_token_conformance_test.rb
+++ b/ruby/test/basecamp/oauth_token_conformance_test.rb
@@ -16,8 +16,9 @@ class OAuthTokenConformanceTest < Minitest::Test
   fixtures = Dir.glob(File.join(FIXTURE_DIR, "*.json")).sort
   raise "no fixtures found in #{FIXTURE_DIR}" if fixtures.empty?
 
+  # UTF-8 regardless of process locale — see oauth_resource_discovery_test.rb
   fixtures.each do |path|
-    fixture = JSON.parse(File.read(path))
+    fixture = JSON.parse(File.read(path, encoding: "UTF-8"))
     define_method("test_fixture_#{File.basename(path, '.json').tr('-', '_')}") do
       assert_equal "refreshToken", fixture["operation"]
 

--- a/ruby/test/basecamp/services/webhooks_service_test.rb
+++ b/ruby/test/basecamp/services/webhooks_service_test.rb
@@ -99,7 +99,9 @@ class WebhooksServiceTest < Minitest::Test
   end
 
   def test_get_with_recent_deliveries
-    fixture = JSON.parse(File.read(File.expand_path("../../../../spec/fixtures/webhooks/get.json", __dir__)))
+    # UTF-8 regardless of process locale (LC_ALL=C would otherwise read as US-ASCII)
+    path = File.expand_path("../../../../spec/fixtures/webhooks/get.json", __dir__)
+    fixture = JSON.parse(File.read(path, encoding: "UTF-8"))
 
     stub_request(:get, %r{https://3\.basecampapi\.com/12345/webhooks/\d+})
       .to_return(status: 200, body: fixture.to_json, headers: { "Content-Type" => "application/json" })

--- a/ruby/test/basecamp/webhooks/event_test.rb
+++ b/ruby/test/basecamp/webhooks/event_test.rb
@@ -7,8 +7,9 @@ class Basecamp::Webhooks::EventTest < Minitest::Test
     File.expand_path("../../../../spec/fixtures/webhooks", __dir__)
   end
 
+  # UTF-8 regardless of process locale (LC_ALL=C would otherwise read as US-ASCII)
   def load_fixture(name)
-    JSON.parse(File.read(File.join(fixtures_dir, name)))
+    JSON.parse(File.read(File.join(fixtures_dir, name), encoding: "UTF-8"))
   end
 
   def test_parses_todo_created_event

--- a/ruby/test/basecamp/webhooks/receiver_test.rb
+++ b/ruby/test/basecamp/webhooks/receiver_test.rb
@@ -8,8 +8,9 @@ class Basecamp::Webhooks::ReceiverTest < Minitest::Test
     File.expand_path("../../../../spec/fixtures/webhooks", __dir__)
   end
 
+  # UTF-8 regardless of process locale (LC_ALL=C would otherwise read as US-ASCII)
   def fixture_body(name)
-    File.read(File.join(fixtures_dir, name))
+    File.read(File.join(fixtures_dir, name), encoding: "UTF-8")
   end
 
   def empty_headers

--- a/scripts/assert-lockfiles-unchanged
+++ b/scripts/assert-lockfiles-unchanged
@@ -104,8 +104,10 @@ case "${1:-}" in
     echo >&2
     printf '%s\n' \
       "Nothing \`make check\` runs may write a lockfile — a dirty tree blocks the" \
-      "release flow, and what gets written depends on which npm ran it (#612)." \
-      "Use \`npm ci\`, which installs from the lockfile without writing it back." >&2
+      "release flow, and what gets written depends on which tool version ran it" \
+      "(#612). Install from the lockfile without writing it back: \`npm ci\` for" \
+      "npm, \`BUNDLE_FROZEN=true bundle install\` for bundler, \`uv sync --locked\`" \
+      "for uv; \`go\` rewrites go.sum only when go.mod drifts — tidy and commit." >&2
     exit 1
     ;;
   --verify-clean)
@@ -125,7 +127,10 @@ case "${1:-}" in
     echo >&2
     printf '%s\n' \
       "Nothing in CI may write a lockfile. A dirty tree blocks the release flow," \
-      "and what gets written depends on which npm ran it (#612). Use \`npm ci\`." >&2
+      "and what gets written depends on which tool version ran it (#612). Install" \
+      "from the lockfile without writing it back: \`npm ci\` for npm," \
+      "\`BUNDLE_FROZEN=true bundle install\` for bundler, \`uv sync --locked\` for" \
+      "uv; \`go\` rewrites go.sum only when go.mod drifts — tidy and commit." >&2
     exit 1
     ;;
   *)

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -78,8 +78,9 @@ echo "Syncing conformance TypeScript runner lockfile..."
 
 # Sync conformance Ruby and Python runner lockfiles (they record the SDK's
 # version via their path deps on ../../../ruby and ../../../python). Both are
-# gitignored: left stale, the conformance targets' installs re-resolve and
-# WRITE them mid-check, so assert-lockfiles-unchanged fails (#671).
+# tracked and installed frozen (#670): left stale, the conformance targets'
+# installs fail fast instead of rewriting them mid-check (#671). This is the
+# sanctioned rewriter, so it stays unfrozen.
 echo "Syncing conformance Ruby runner lockfile..."
 (cd conformance/runner/ruby && bundle install --quiet)
 


### PR DESCRIPTION
Three build-hygiene fixes, one commit per issue.

Closes #668. Closes #702. Closes #670.

## `make clean` never deletes tracked files (#668)

`go/Makefile`'s `clean` removed `pkg/generated/*.gen.go`, deleting the tracked `client.gen.go` — the only `*-clean` target in the repo that touched a tracked file, and nothing in `make check` regenerates it. The `rm` moves to an explicit opt-in target (`make go-clean-generated` at the root, `clean-generated` in `go/`).

Red proof (scratch worktree on un-fixed main): `make clean` → `git status --porcelain` shows ` D go/pkg/generated/client.gen.go`. Post-fix: empty porcelain, and `make go-clean-generated && make -C go generate && git diff --exit-code go/pkg/generated` round-trips clean.

## Ruby reads pinned to UTF-8 regardless of locale (#702)

Under `LC_ALL=C`, unpinned `File.read` returns US-ASCII and non-ASCII fixtures raise. `ruby/test/basecamp/oauth_resource_discovery_test.rb` fires **today**: a class-body load error aborts the whole suite under the C locale. Every remaining unpinned read now carries `encoding: "UTF-8"` (per the 2287c7544 idiom): 5 test files, the conformance runner + replay runner (+ its test, found by sweep — one site beyond the issue), and two shipped-lib reads (`http.rb`, `config.rb` — JSON is UTF-8 per RFC 8259, so those are format-correctness). `Encoding.default_external` was deliberately rejected: it masks the locale instead of fixing the reads.

CI: the ruby 3.3 matrix leg now runs the suite under `LC_ALL: C` so the pins can't silently regress; the other rubies keep the normal locale.

Red proof: `LC_ALL=C bundle exec rake test` aborts at load pre-fix (exit 1); post-fix green under both locales (1411 runs), and `LC_ALL=C make conformance-ruby` passes (183).

## Runner lockfiles tracked and installs frozen (#670)

`conformance/runner/ruby/Gemfile.lock` and `conformance/runner/python/uv.lock` were gitignored while the TS runner's package-lock.json is tracked — so the local lockfile gate saw them but CI's `--verify-clean` (`git status --porcelain`) was structurally blind, and Linux runs silently rewrote them (PLATFORMS append + bundler-4 CHECKSUMS). Now:

- Both lockfiles tracked, regenerated fresh at 0.14.0 (the ignored ruby one still said 0.13.0), with `x86_64-linux`/`arm64-darwin` platforms locked in so macOS and Linux converge.
- All bundler recipes run `BUNDLE_FROZEN=true`; all uv recipes run `uv sync --locked` (`--locked` fails on missing **or stale**, unlike `--frozen`) — in the Makefile and in the two CI install steps, so a drift fails fast with a legible message instead of at the job-end gate.
- `--deployment` and `.bundle/config` deliberately avoided (vendored gems / untracked state).
- The release guard's `test ! -f` escape hatches (which existed only because the files used to be absent on fresh clones) are removed, and `scripts/assert-lockfiles-unchanged`'s remediation text now covers all four ecosystems.

Red proof: on un-fixed code, garbage written to both lockfiles left `--verify-clean` reporting "manifests match" (the blindness, live); post-fix the same garbage trips it. Byte-stability verified by sha256 before/after the three conformance targets on macOS **and** x86_64 Linux (thelio) — the PLATFORMS-append mechanism defeated.

Full `make check` green on this branch, including its own record→run→verify lockfile pass ("9 files, byte-identical").

Note: the ruby lockfile carries an extra `arm64-darwin-23` platform entry from the generating machine's bundler alongside generic `arm64-darwin`; harmless under frozen installs and byte-stable on both OSes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves build hygiene: `make clean` no longer deletes tracked files, Ruby JSON reads are pinned to UTF-8, and runner lockfiles are tracked with frozen installs for reproducible CI and fast drift detection.

- **Bug Fixes**
  - `go/Makefile` stops removing tracked `pkg/generated/client.gen.go`; added explicit `clean-generated`/`go-clean-generated` for opt-in rebuilds.
  - All Ruby `File.read` calls that parse JSON now use `encoding: "UTF-8"` (library, runners, tests); CI runs Ruby 3.3 with `LC_ALL=C` to prevent regressions.

- **Build/CI**
  - Track `conformance/runner/ruby/Gemfile.lock` and `conformance/runner/python/uv.lock`; installs run frozen via `BUNDLE_FROZEN=true` and `uv sync --locked` in Makefiles and CI.
  - Updated release checks and guidance to cover `npm ci`, `BUNDLE_FROZEN=true bundle install`, `uv sync --locked`, and `go` tidy; removed ignores for the lockfiles.

<sup>Written for commit 1c73cf68bbd79f9bd9634875862f12a6dd6425c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

