### PR TITLE
Emit real docstrings on Python generated service methods

### DIFF
--- a/python/scripts/gen_common.py
+++ b/python/scripts/gen_common.py
@@ -3,6 +3,8 @@ generate_types.py)."""
 
 from __future__ import annotations
 
+import re
+
 
 def escape_py_string(value: str) -> str:
     """Escape arbitrary text for safe interpolation into a Python string or
@@ -10,15 +12,18 @@ def escape_py_string(value: str) -> str:
 
     Escapes backslashes, double-quotes (so the text can't close a triple-quoted
     docstring), and the control characters that would otherwise split the
-    emitted source line or form an invalid escape (e.g. a lone ``\\u``). The
-    result stays on one line and is syntactically valid for any input, so a
-    deprecation reason sourced from a multi-line OpenAPI description can't break
-    the generated module.
+    emitted source line or form an invalid escape (e.g. a lone ``\\u``). Any
+    remaining C0 control or DEL is dropped — a literal NUL in particular makes
+    the whole module uncompilable ("source code string cannot contain null
+    bytes"). The result stays on one line and is syntactically valid for any
+    input, so a deprecation reason sourced from a multi-line OpenAPI
+    description can't break the generated module.
     """
-    return (
+    value = (
         value.replace("\\", "\\\\")
         .replace('"', '\\"')
         .replace("\n", "\\n")
         .replace("\r", "\\r")
         .replace("\t", "\\t")
     )
+    return re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", value)

--- a/python/scripts/generate_services.py
+++ b/python/scripts/generate_services.py
@@ -398,12 +398,20 @@ def extract_body_params(
     required_fields = set(schema.get("required", []))
     params = []
     for name, prop in schema["properties"].items():
+        # A bare `$ref` property carries no description of its own — read it
+        # off the referenced schema (single-level: the spec has no ref-to-ref
+        # chains). A sibling description on the property itself still wins.
+        description = prop.get("description")
+        if description is None and "$ref" in prop:
+            target = resolve_schema_ref(prop, schemas)
+            if target:
+                description = target.get("description")
         params.append({
             "name": name,
             "python_name": safe_python_name(to_snake_case(name)),
             "type": schema_to_python_type(prop),
             "required": name in required_fields,
-            "description": prop.get("description"),
+            "description": description,
         })
     return params
 
@@ -633,7 +641,8 @@ def build_params(op: dict) -> list[dict]:
     if op["has_pagination"]:
         max_items_doc = (
             "Client-side cap on the number of items collected across pages; "
-            "None means no item cap. Collection is always bounded by config.max_pages."
+            "None or a non-positive value means no item cap. "
+            "Collection is always bounded by config.max_pages."
         )
         # SPEC section 8: a positive `page` pins a single page, so the
         # follow loop stops after one request. Only worth saying on the

--- a/python/scripts/generate_services.py
+++ b/python/scripts/generate_services.py
@@ -552,16 +552,20 @@ def escape_docstring_text(text: str) -> str:
     string literals), this keeps real newlines: it escapes backslashes (so no
     accidental escape sequences form), neutralizes any embedded triple-quote
     that would close the docstring early, and normalizes the control characters
-    that would confuse the emitted source. The closing delimiter is always
-    emitted on its own line, so a trailing double-quote in the text is safe.
+    that would confuse the emitted source. Any remaining C0 control or DEL is
+    dropped — a literal NUL in particular makes the whole module uncompilable
+    ("source code string cannot contain null bytes"). The closing delimiter is
+    always emitted on its own line, so a trailing double-quote in the text is
+    safe.
     """
-    return (
+    text = (
         text.replace("\\", "\\\\")
         .replace('"""', '\\"\\"\\"')
         .replace("\r\n", "\n")
         .replace("\r", "\n")
         .replace("\t", "    ")
     )
+    return re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", text)
 
 
 def _split_paragraphs(text: str) -> list[str]:
@@ -574,8 +578,10 @@ def _fallback_param_doc(python_name: str) -> str:
     Path params carry no descriptions in the OpenAPI spec at all, so this
     humanized fallback ("project_id" -> "The project id.") is what documents
     them — matching the Ruby and TypeScript generators' fallback convention.
+    The trailing underscore a Python-keyword collision appends (``from_``) is
+    stripped before humanizing, so it reads "The from." not "The from .".
     """
-    return f"The {python_name.replace('_', ' ')}."
+    return f"The {python_name.rstrip('_').replace('_', ' ')}."
 
 
 def build_params(op: dict) -> list[dict]:
@@ -625,19 +631,35 @@ def build_params(op: dict) -> list[dict]:
     # Paginated operations take a client-side cap on collected items,
     # matching the maxItems pagination option in the other SDKs.
     if op["has_pagination"]:
-        add(
-            "max_items: int | None = None",
-            "max_items",
-            "Client-side cap on the total number of items collected across pages; None collects every page.",
+        max_items_doc = (
+            "Client-side cap on the number of items collected across pages; "
+            "None means no item cap. Collection is always bounded by config.max_pages."
         )
+        # SPEC section 8: a positive `page` pins a single page, so the
+        # follow loop stops after one request. Only worth saying on the
+        # operations that actually take a `page` param.
+        if any(q["python_name"] == "page" for q in op["query_params"]):
+            max_items_doc += " A positive page argument fetches exactly that one page."
+        add("max_items: int | None = None", "max_items", max_items_doc)
 
     return params
 
 
 def _wrap_args_entry(python_name: str, description: str) -> list[str]:
-    """Wrap one Args entry to Google style: entry at 12 spaces, continuations at 16."""
+    """Wrap one Args entry to Google style: entry at 12 spaces, continuations at 16.
+
+    Long tokens and hyphenated words stay whole (descriptions carry URLs,
+    ``x-header-…`` names, and ``Module::Class`` references that must not be
+    split mid-token); an over-long token overflows its line instead.
+    """
     text = " ".join(escape_docstring_text(description).split())
-    wrapped = textwrap.wrap(f"{python_name}: {text}", width=88, subsequent_indent="    ") or [f"{python_name}:"]
+    wrapped = textwrap.wrap(
+        f"{python_name}: {text}",
+        width=88,
+        subsequent_indent="    ",
+        break_long_words=False,
+        break_on_hyphens=False,
+    ) or [f"{python_name}:"]
     return [f"            {line}" for line in wrapped]
 
 

--- a/python/scripts/generate_services.py
+++ b/python/scripts/generate_services.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import re
 import sys
+import textwrap
 from pathlib import Path
 
 # Make the shared generator helper importable whether this file is run as a
@@ -402,6 +403,7 @@ def extract_body_params(
             "python_name": safe_python_name(to_snake_case(name)),
             "type": schema_to_python_type(prop),
             "required": name in required_fields,
+            "description": prop.get("description"),
         })
     return params
 
@@ -429,6 +431,7 @@ def parse_operation(
                 "name": p["name"],
                 "python_name": to_snake_case(p["name"]),
                 "type": schema_to_python_type(p.get("schema")),
+                "description": p.get("description"),
             })
 
     # Query params
@@ -448,6 +451,7 @@ def parse_operation(
                 "required": p.get("required", False),
                 "deprecated": bool(p.get("deprecated") or schema.get("deprecated")),
                 "deprecation_reason": p.get("x-deprecated-reason") or schema.get("x-deprecated-reason"),
+                "description": p.get("description"),
             })
 
     # Body params
@@ -485,6 +489,7 @@ def parse_operation(
 
     return {
         "operation_id": operation_id,
+        "description": operation.get("description") or "",
         "method_name": method_name,
         "http_method": http_method,
         "path": convert_path(path),
@@ -540,68 +545,165 @@ def python_type_hint(param_type: str) -> str:
     }.get(param_type, "str")
 
 
-def deprecation_docstring(op: dict) -> list[str]:
-    """Emit a method docstring flagging deprecated query params.
+def escape_docstring_text(text: str) -> str:
+    """Escape multi-line text for interpolation into a triple-quoted docstring.
 
-    Documentation-only (see #406): a TypedDict/kwarg has no per-parameter
-    deprecation directive, and an RST ``.. deprecated::`` inside a ``:param:``
-    is malformed, so this is a real prose docstring listing each deprecated
-    parameter and its replacement. Emitted only when the operation has at least
-    one deprecated param, keyed on that flag rather than a specific method name.
+    Unlike ``escape_py_string`` (which flattens to a single line for plain
+    string literals), this keeps real newlines: it escapes backslashes (so no
+    accidental escape sequences form), neutralizes any embedded triple-quote
+    that would close the docstring early, and normalizes the control characters
+    that would confuse the emitted source. The closing delimiter is always
+    emitted on its own line, so a trailing double-quote in the text is safe.
     """
-    deprecated = [q for q in op["query_params"] if q.get("deprecated")]
-    if not deprecated:
-        return []
-    lines = ['        """Deprecated parameters (prefer the replacement):', ""]
-    for q in deprecated:
-        reason = escape_py_string(q.get("deprecation_reason") or "deprecated")
-        lines.append(f"        - {q['name']}: {reason}")
-    lines.append('        """')
-    return lines
+    return (
+        text.replace("\\", "\\\\")
+        .replace('"""', '\\"\\"\\"')
+        .replace("\r\n", "\n")
+        .replace("\r", "\n")
+        .replace("\t", "    ")
+    )
 
 
-def build_params(op: dict) -> list[str]:
-    """Build keyword-only parameter list for a method."""
-    params: list[str] = []
+def _split_paragraphs(text: str) -> list[str]:
+    return [p.strip("\n") for p in re.split(r"\n\s*\n", text.strip()) if p.strip()]
+
+
+def _fallback_param_doc(python_name: str) -> str:
+    """Derived Args line for a parameter the spec leaves undescribed.
+
+    Path params carry no descriptions in the OpenAPI spec at all, so this
+    humanized fallback ("project_id" -> "The project id.") is what documents
+    them — matching the Ruby and TypeScript generators' fallback convention.
+    """
+    return f"The {python_name.replace('_', ' ')}."
+
+
+def build_params(op: dict) -> list[dict]:
+    """Build the keyword-only parameter list for a method.
+
+    Returns one dict per parameter, in signature order: ``sig`` is the
+    signature fragment, ``python_name``/``description`` feed the docstring's
+    Args section — a single ordered list so the two can never disagree.
+    """
+    params: list[dict] = []
+
+    def add(sig: str, python_name: str, description: str | None) -> None:
+        params.append({"sig": sig, "python_name": python_name, "description": description})
 
     # Path params — use the schema type, not a blanket int | str
     for p in op["path_params"]:
-        params.append(f"{p['python_name']}: {p['type']}")
+        add(f"{p['python_name']}: {p['type']}", p["python_name"], p.get("description"))
 
     # Binary upload params
     if op["has_binary_body"]:
-        params.append("content: bytes")
-        params.append("content_type: str")
+        add("content: bytes", "content", "Raw bytes of the file to upload.")
+        add("content_type: str", "content_type", 'MIME content type of the upload (e.g. "image/png").')
     elif op.get("has_multipart_body"):
-        params.append("content: bytes")
-        params.append("filename: str")
-        params.append("content_type: str")
+        add("content: bytes", "content", "Raw bytes of the file to upload.")
+        add("filename: str", "filename", "Filename for the uploaded file.")
+        add("content_type: str", "content_type", 'MIME content type of the upload (e.g. "image/png").')
     elif op["has_body"]:
         required = [b for b in op["body_params"] if b["required"]]
         optional = [b for b in op["body_params"] if not b["required"]]
         for b in required:
             hint = python_type_hint(b["type"])
-            params.append(f"{b['python_name']}: {hint}")
+            add(f"{b['python_name']}: {hint}", b["python_name"], b.get("description"))
         for b in optional:
             hint = python_type_hint(b["type"])
-            params.append(f"{b['python_name']}: {hint} | None = None")
+            add(f"{b['python_name']}: {hint} | None = None", b["python_name"], b.get("description"))
 
     # Query params
     required_qp = [q for q in op["query_params"] if q["required"]]
     optional_qp = [q for q in op["query_params"] if not q["required"]]
     for q in required_qp:
         hint = python_type_hint(q["type"])
-        params.append(f"{q['python_name']}: {hint}")
+        add(f"{q['python_name']}: {hint}", q["python_name"], q.get("description"))
     for q in optional_qp:
         hint = python_type_hint(q["type"])
-        params.append(f"{q['python_name']}: {hint} | None = None")
+        add(f"{q['python_name']}: {hint} | None = None", q["python_name"], q.get("description"))
 
     # Paginated operations take a client-side cap on collected items,
     # matching the maxItems pagination option in the other SDKs.
     if op["has_pagination"]:
-        params.append("max_items: int | None = None")
+        add(
+            "max_items: int | None = None",
+            "max_items",
+            "Client-side cap on the total number of items collected across pages; None collects every page.",
+        )
 
     return params
+
+
+def _wrap_args_entry(python_name: str, description: str) -> list[str]:
+    """Wrap one Args entry to Google style: entry at 12 spaces, continuations at 16."""
+    text = " ".join(escape_docstring_text(description).split())
+    wrapped = textwrap.wrap(f"{python_name}: {text}", width=88, subsequent_indent="    ") or [f"{python_name}:"]
+    return [f"            {line}" for line in wrapped]
+
+
+def _deprecation_section(op: dict) -> list[str]:
+    """Docstring section flagging deprecated query params.
+
+    Documentation-only (see #406): a TypedDict/kwarg has no per-parameter
+    deprecation directive, and an RST ``.. deprecated::`` inside a ``:param:``
+    is malformed, so this is real prose listing each deprecated parameter and
+    its replacement. Emitted only when the operation has at least one
+    deprecated param, keyed on that flag rather than a specific method name.
+    """
+    deprecated = [q for q in op["query_params"] if q.get("deprecated")]
+    if not deprecated:
+        return []
+    lines = ["        Deprecated parameters (prefer the replacement):", ""]
+    for q in deprecated:
+        reason = escape_py_string(q.get("deprecation_reason") or "deprecated")
+        lines.append(f"        - {q['name']}: {reason}")
+    return lines
+
+
+def method_docstring(op: dict, params: list[dict]) -> list[str]:
+    """Emit the method docstring: summary, extended description, deprecation
+    note, and a Google-style Args section.
+
+    The summary is the operation description's whole first paragraph (never
+    the Ruby generators' first-line truncation — first lines here are usually
+    unterminated summary phrases), with a period appended when the paragraph
+    lacks terminal punctuation. Remaining paragraphs follow verbatim, except
+    the "**Pagination**" boilerplate on paginated operations: it instructs
+    manual Link-header following, which these methods do automatically —
+    ``max_items`` in Args documents the collected-pages behavior instead.
+    """
+    description = escape_docstring_text(op["description"]).strip() or f"{op['operation_id']} operation."
+    paragraphs = _split_paragraphs(description)
+    if op["has_pagination"]:
+        paragraphs = [p for p in paragraphs if not p.lstrip().startswith("**Pagination**")]
+
+    summary = paragraphs[0] if paragraphs else f"{op['operation_id']} operation."
+    if summary[-1] not in ".!?":
+        summary += "."
+
+    body: list[str] = []
+    for paragraph in [summary] + paragraphs[1:]:
+        if body:
+            body.append("")
+        body.extend(f"        {line.rstrip()}".rstrip() for line in paragraph.split("\n"))
+
+    deprecation = _deprecation_section(op)
+    if deprecation:
+        body.append("")
+        body.extend(deprecation)
+
+    if params:
+        body.append("")
+        body.append("        Args:")
+        for p in params:
+            body.extend(_wrap_args_entry(p["python_name"], p["description"] or _fallback_param_doc(p["python_name"])))
+
+    if len(body) == 1:
+        return [f'        """{body[0].strip()}"""']
+    lines = [f'        """{body[0].strip()}']
+    lines.extend(body[1:])
+    lines.append('        """')
+    return lines
 
 
 def build_info_kwargs(op: dict, service_name: str) -> str:
@@ -798,9 +900,10 @@ def generate_service_file(service: dict) -> str:
         lines.append("")
         params = build_params(op)
         ret = return_type(op)
-        sig_params = ", ".join(["self"] + ([f"*, {', '.join(params)}"] if params else []))
+        sig_fragments = [p["sig"] for p in params]
+        sig_params = ", ".join(["self"] + ([f"*, {', '.join(sig_fragments)}"] if params else []))
         lines.append(f"    def {op['method_name']}({sig_params}) -> {ret}:")
-        lines.extend(deprecation_docstring(op))
+        lines.extend(method_docstring(op, params))
         body = generate_method_body(op, name, is_async=False)
         lines.extend(body)
 
@@ -812,9 +915,10 @@ def generate_service_file(service: dict) -> str:
         lines.append("")
         params = build_params(op)
         ret = return_type(op)
-        sig_params = ", ".join(["self"] + ([f"*, {', '.join(params)}"] if params else []))
+        sig_fragments = [p["sig"] for p in params]
+        sig_params = ", ".join(["self"] + ([f"*, {', '.join(sig_fragments)}"] if params else []))
         lines.append(f"    async def {op['method_name']}({sig_params}) -> {ret}:")
-        lines.extend(deprecation_docstring(op))
+        lines.extend(method_docstring(op, params))
         body = generate_method_body(op, name, is_async=True)
         lines.extend(body)
 

--- a/python/src/basecamp/generated/services/account.py
+++ b/python/src/basecamp/generated/services/account.py
@@ -12,6 +12,7 @@ from basecamp.hooks import OperationInfo
 
 class AccountService(BaseService):
     def get_account(self) -> dict[str, Any]:
+        """Get the account for the current access token."""
         return self._request(
             OperationInfo(service="account", operation="get_account", is_mutation=False),
             "GET",
@@ -20,6 +21,15 @@ class AccountService(BaseService):
         )
 
     def update_account_logo(self, *, content: bytes, filename: str, content_type: str) -> None:
+        """Upload or replace the account logo.
+        Accepted formats: PNG, JPEG, GIF, WebP, AVIF, HEIC. Maximum 5 MB.
+        Owners and admins only.
+
+        Args:
+            content: Raw bytes of the file to upload.
+            filename: Filename for the uploaded file.
+            content_type: MIME content type of the upload (e.g. "image/png").
+        """
         self._request_multipart_void(
             OperationInfo(service="account", operation="update_account_logo", is_mutation=True),
             "PUT",
@@ -32,6 +42,7 @@ class AccountService(BaseService):
         )
 
     def remove_account_logo(self) -> None:
+        """Remove the account logo. Only administrators and account owners can use this endpoint."""
         self._request_void(
             OperationInfo(service="account", operation="remove_account_logo", is_mutation=True),
             "DELETE",
@@ -40,6 +51,11 @@ class AccountService(BaseService):
         )
 
     def update_account_name(self, *, name: str) -> dict[str, Any]:
+        """Rename the current account. Only account owners can use this endpoint.
+
+        Args:
+            name: The name.
+        """
         return self._request(
             OperationInfo(service="account", operation="update_account_name", is_mutation=True),
             "PUT",
@@ -51,6 +67,7 @@ class AccountService(BaseService):
 
 class AsyncAccountService(AsyncBaseService):
     async def get_account(self) -> dict[str, Any]:
+        """Get the account for the current access token."""
         return await self._request(
             OperationInfo(service="account", operation="get_account", is_mutation=False),
             "GET",
@@ -59,6 +76,15 @@ class AsyncAccountService(AsyncBaseService):
         )
 
     async def update_account_logo(self, *, content: bytes, filename: str, content_type: str) -> None:
+        """Upload or replace the account logo.
+        Accepted formats: PNG, JPEG, GIF, WebP, AVIF, HEIC. Maximum 5 MB.
+        Owners and admins only.
+
+        Args:
+            content: Raw bytes of the file to upload.
+            filename: Filename for the uploaded file.
+            content_type: MIME content type of the upload (e.g. "image/png").
+        """
         await self._request_multipart_void(
             OperationInfo(service="account", operation="update_account_logo", is_mutation=True),
             "PUT",
@@ -71,6 +97,7 @@ class AsyncAccountService(AsyncBaseService):
         )
 
     async def remove_account_logo(self) -> None:
+        """Remove the account logo. Only administrators and account owners can use this endpoint."""
         await self._request_void(
             OperationInfo(service="account", operation="remove_account_logo", is_mutation=True),
             "DELETE",
@@ -79,6 +106,11 @@ class AsyncAccountService(AsyncBaseService):
         )
 
     async def update_account_name(self, *, name: str) -> dict[str, Any]:
+        """Rename the current account. Only account owners can use this endpoint.
+
+        Args:
+            name: The name.
+        """
         return await self._request(
             OperationInfo(service="account", operation="update_account_name", is_mutation=True),
             "PUT",

--- a/python/src/basecamp/generated/services/attachments.py
+++ b/python/src/basecamp/generated/services/attachments.py
@@ -12,6 +12,13 @@ from basecamp.hooks import OperationInfo
 
 class AttachmentsService(BaseService):
     def create(self, *, content: bytes, content_type: str, name: str) -> dict[str, Any]:
+        """Create an attachment (upload a file for embedding).
+
+        Args:
+            content: Raw bytes of the file to upload.
+            content_type: MIME content type of the upload (e.g. "image/png").
+            name: The name.
+        """
         return self._request_raw(
             OperationInfo(service="attachments", operation="create", is_mutation=True),
             "/attachments.json",
@@ -24,6 +31,13 @@ class AttachmentsService(BaseService):
 
 class AsyncAttachmentsService(AsyncBaseService):
     async def create(self, *, content: bytes, content_type: str, name: str) -> dict[str, Any]:
+        """Create an attachment (upload a file for embedding).
+
+        Args:
+            content: Raw bytes of the file to upload.
+            content_type: MIME content type of the upload (e.g. "image/png").
+            name: The name.
+        """
         return await self._request_raw(
             OperationInfo(service="attachments", operation="create", is_mutation=True),
             "/attachments.json",

--- a/python/src/basecamp/generated/services/automation.py
+++ b/python/src/basecamp/generated/services/automation.py
@@ -12,6 +12,7 @@ from basecamp.hooks import OperationInfo
 
 class AutomationService(BaseService):
     def list_lineup_markers(self) -> ListResult:
+        """List all lineup markers for the account."""
         return self._request_list(
             OperationInfo(service="automation", operation="list_lineup_markers", is_mutation=False),
             "/lineup/markers.json",
@@ -21,6 +22,7 @@ class AutomationService(BaseService):
 
 class AsyncAutomationService(AsyncBaseService):
     async def list_lineup_markers(self) -> ListResult:
+        """List all lineup markers for the account."""
         return await self._request_list(
             OperationInfo(service="automation", operation="list_lineup_markers", is_mutation=False),
             "/lineup/markers.json",

--- a/python/src/basecamp/generated/services/bookmarks.py
+++ b/python/src/basecamp/generated/services/bookmarks.py
@@ -19,9 +19,9 @@ class BookmarksService(BaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="bookmarks", operation="list_my_bookmarks", is_mutation=False),
@@ -82,9 +82,9 @@ class AsyncBookmarksService(AsyncBaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="bookmarks", operation="list_my_bookmarks", is_mutation=False),

--- a/python/src/basecamp/generated/services/bookmarks.py
+++ b/python/src/basecamp/generated/services/bookmarks.py
@@ -19,8 +19,9 @@ class BookmarksService(BaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="bookmarks", operation="list_my_bookmarks", is_mutation=False),
@@ -81,8 +82,9 @@ class AsyncBookmarksService(AsyncBaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="bookmarks", operation="list_my_bookmarks", is_mutation=False),

--- a/python/src/basecamp/generated/services/bookmarks.py
+++ b/python/src/basecamp/generated/services/bookmarks.py
@@ -12,6 +12,16 @@ from basecamp.hooks import OperationInfo
 
 class BookmarksService(BaseService):
     def list_my_bookmarks(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List the current user's bookmarks, most recently bookmarked first (paginated).
+        A bookmark is a personal link between the current user and a single recording,
+        visible only to its creator; each entry wraps the shared recording projection.
+
+        Args:
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="bookmarks", operation="list_my_bookmarks", is_mutation=False),
             "/my/bookmarks.json",
@@ -21,6 +31,11 @@ class BookmarksService(BaseService):
         )
 
     def get_bookmark(self, *, recording_id: int) -> dict[str, Any]:
+        """Report whether the current user has bookmarked the recording.
+
+        Args:
+            recording_id: The recording id.
+        """
         return self._request(
             OperationInfo(service="bookmarks", operation="get_bookmark", is_mutation=False, resource_id=recording_id),
             "GET",
@@ -29,6 +44,12 @@ class BookmarksService(BaseService):
         )
 
     def create_bookmark(self, *, recording_id: int) -> dict[str, Any]:
+        """Bookmark a recording for the current user.
+        Idempotent: re-bookmarking returns the existing bookmark, never a duplicate.
+
+        Args:
+            recording_id: The recording id.
+        """
         return self._request(
             OperationInfo(service="bookmarks", operation="create_bookmark", is_mutation=True, resource_id=recording_id),
             "POST",
@@ -37,6 +58,12 @@ class BookmarksService(BaseService):
         )
 
     def delete_bookmark(self, *, recording_id: int) -> None:
+        """Remove the current user's bookmark from a recording (returns 204 No Content).
+        Idempotent: deleting an absent bookmark also returns 204.
+
+        Args:
+            recording_id: The recording id.
+        """
         self._request_void(
             OperationInfo(service="bookmarks", operation="delete_bookmark", is_mutation=True, resource_id=recording_id),
             "DELETE",
@@ -47,6 +74,16 @@ class BookmarksService(BaseService):
 
 class AsyncBookmarksService(AsyncBaseService):
     async def list_my_bookmarks(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List the current user's bookmarks, most recently bookmarked first (paginated).
+        A bookmark is a personal link between the current user and a single recording,
+        visible only to its creator; each entry wraps the shared recording projection.
+
+        Args:
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="bookmarks", operation="list_my_bookmarks", is_mutation=False),
             "/my/bookmarks.json",
@@ -56,6 +93,11 @@ class AsyncBookmarksService(AsyncBaseService):
         )
 
     async def get_bookmark(self, *, recording_id: int) -> dict[str, Any]:
+        """Report whether the current user has bookmarked the recording.
+
+        Args:
+            recording_id: The recording id.
+        """
         return await self._request(
             OperationInfo(service="bookmarks", operation="get_bookmark", is_mutation=False, resource_id=recording_id),
             "GET",
@@ -64,6 +106,12 @@ class AsyncBookmarksService(AsyncBaseService):
         )
 
     async def create_bookmark(self, *, recording_id: int) -> dict[str, Any]:
+        """Bookmark a recording for the current user.
+        Idempotent: re-bookmarking returns the existing bookmark, never a duplicate.
+
+        Args:
+            recording_id: The recording id.
+        """
         return await self._request(
             OperationInfo(service="bookmarks", operation="create_bookmark", is_mutation=True, resource_id=recording_id),
             "POST",
@@ -72,6 +120,12 @@ class AsyncBookmarksService(AsyncBaseService):
         )
 
     async def delete_bookmark(self, *, recording_id: int) -> None:
+        """Remove the current user's bookmark from a recording (returns 204 No Content).
+        Idempotent: deleting an absent bookmark also returns 204.
+
+        Args:
+            recording_id: The recording id.
+        """
         await self._request_void(
             OperationInfo(service="bookmarks", operation="delete_bookmark", is_mutation=True, resource_id=recording_id),
             "DELETE",

--- a/python/src/basecamp/generated/services/boosts.py
+++ b/python/src/basecamp/generated/services/boosts.py
@@ -46,8 +46,9 @@ class BoostsService(BaseService):
             recording_id: The recording id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(
@@ -86,8 +87,9 @@ class BoostsService(BaseService):
             event_id: The event id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="boosts", operation="list_event_boosts", is_mutation=False, resource_id=event_id),
@@ -150,8 +152,9 @@ class AsyncBoostsService(AsyncBaseService):
             recording_id: The recording id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(
@@ -190,8 +193,9 @@ class AsyncBoostsService(AsyncBaseService):
             event_id: The event id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="boosts", operation="list_event_boosts", is_mutation=False, resource_id=event_id),

--- a/python/src/basecamp/generated/services/boosts.py
+++ b/python/src/basecamp/generated/services/boosts.py
@@ -46,9 +46,9 @@ class BoostsService(BaseService):
             recording_id: The recording id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(
@@ -87,9 +87,9 @@ class BoostsService(BaseService):
             event_id: The event id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="boosts", operation="list_event_boosts", is_mutation=False, resource_id=event_id),
@@ -152,9 +152,9 @@ class AsyncBoostsService(AsyncBaseService):
             recording_id: The recording id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(
@@ -193,9 +193,9 @@ class AsyncBoostsService(AsyncBaseService):
             event_id: The event id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="boosts", operation="list_event_boosts", is_mutation=False, resource_id=event_id),

--- a/python/src/basecamp/generated/services/boosts.py
+++ b/python/src/basecamp/generated/services/boosts.py
@@ -12,6 +12,11 @@ from basecamp.hooks import OperationInfo
 
 class BoostsService(BaseService):
     def get_boost(self, *, boost_id: int) -> dict[str, Any]:
+        """Get a single boost.
+
+        Args:
+            boost_id: The boost id.
+        """
         return self._request(
             OperationInfo(service="boosts", operation="get_boost", is_mutation=False, resource_id=boost_id),
             "GET",
@@ -20,6 +25,11 @@ class BoostsService(BaseService):
         )
 
     def delete_boost(self, *, boost_id: int) -> None:
+        """Delete a boost.
+
+        Args:
+            boost_id: The boost id.
+        """
         self._request_void(
             OperationInfo(service="boosts", operation="delete_boost", is_mutation=True, resource_id=boost_id),
             "DELETE",
@@ -30,6 +40,15 @@ class BoostsService(BaseService):
     def list_recording_boosts(
         self, *, recording_id: int, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List boosts on a recording.
+
+        Args:
+            recording_id: The recording id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(
                 service="boosts", operation="list_recording_boosts", is_mutation=False, resource_id=recording_id
@@ -41,6 +60,12 @@ class BoostsService(BaseService):
         )
 
     def create_recording_boost(self, *, recording_id: int, content: str) -> dict[str, Any]:
+        """Create a boost on a recording.
+
+        Args:
+            recording_id: The recording id.
+            content: The content.
+        """
         return self._request(
             OperationInfo(
                 service="boosts", operation="create_recording_boost", is_mutation=True, resource_id=recording_id
@@ -54,6 +79,16 @@ class BoostsService(BaseService):
     def list_event_boosts(
         self, *, recording_id: int, event_id: int, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List boosts on a specific event within a recording.
+
+        Args:
+            recording_id: The recording id.
+            event_id: The event id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="boosts", operation="list_event_boosts", is_mutation=False, resource_id=event_id),
             f"/recordings/{recording_id}/events/{event_id}/boosts.json",
@@ -63,6 +98,13 @@ class BoostsService(BaseService):
         )
 
     def create_event_boost(self, *, recording_id: int, event_id: int, content: str) -> dict[str, Any]:
+        """Create a boost on a specific event within a recording.
+
+        Args:
+            recording_id: The recording id.
+            event_id: The event id.
+            content: The content.
+        """
         return self._request(
             OperationInfo(service="boosts", operation="create_event_boost", is_mutation=True, resource_id=event_id),
             "POST",
@@ -74,6 +116,11 @@ class BoostsService(BaseService):
 
 class AsyncBoostsService(AsyncBaseService):
     async def get_boost(self, *, boost_id: int) -> dict[str, Any]:
+        """Get a single boost.
+
+        Args:
+            boost_id: The boost id.
+        """
         return await self._request(
             OperationInfo(service="boosts", operation="get_boost", is_mutation=False, resource_id=boost_id),
             "GET",
@@ -82,6 +129,11 @@ class AsyncBoostsService(AsyncBaseService):
         )
 
     async def delete_boost(self, *, boost_id: int) -> None:
+        """Delete a boost.
+
+        Args:
+            boost_id: The boost id.
+        """
         await self._request_void(
             OperationInfo(service="boosts", operation="delete_boost", is_mutation=True, resource_id=boost_id),
             "DELETE",
@@ -92,6 +144,15 @@ class AsyncBoostsService(AsyncBaseService):
     async def list_recording_boosts(
         self, *, recording_id: int, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List boosts on a recording.
+
+        Args:
+            recording_id: The recording id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(
                 service="boosts", operation="list_recording_boosts", is_mutation=False, resource_id=recording_id
@@ -103,6 +164,12 @@ class AsyncBoostsService(AsyncBaseService):
         )
 
     async def create_recording_boost(self, *, recording_id: int, content: str) -> dict[str, Any]:
+        """Create a boost on a recording.
+
+        Args:
+            recording_id: The recording id.
+            content: The content.
+        """
         return await self._request(
             OperationInfo(
                 service="boosts", operation="create_recording_boost", is_mutation=True, resource_id=recording_id
@@ -116,6 +183,16 @@ class AsyncBoostsService(AsyncBaseService):
     async def list_event_boosts(
         self, *, recording_id: int, event_id: int, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List boosts on a specific event within a recording.
+
+        Args:
+            recording_id: The recording id.
+            event_id: The event id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="boosts", operation="list_event_boosts", is_mutation=False, resource_id=event_id),
             f"/recordings/{recording_id}/events/{event_id}/boosts.json",
@@ -125,6 +202,13 @@ class AsyncBoostsService(AsyncBaseService):
         )
 
     async def create_event_boost(self, *, recording_id: int, event_id: int, content: str) -> dict[str, Any]:
+        """Create a boost on a specific event within a recording.
+
+        Args:
+            recording_id: The recording id.
+            event_id: The event id.
+            content: The content.
+        """
         return await self._request(
             OperationInfo(service="boosts", operation="create_event_boost", is_mutation=True, resource_id=event_id),
             "POST",

--- a/python/src/basecamp/generated/services/calendars.py
+++ b/python/src/basecamp/generated/services/calendars.py
@@ -33,7 +33,8 @@ class CalendarsService(BaseService):
 
         Args:
             calendar_id: The calendar id.
-            calendar: The calendar.
+            calendar: The writable calendar payload — the wire body is the nested {calendar:
+                {color}} envelope.
         """
         return self._request(
             OperationInfo(service="calendars", operation="update_calendar", is_mutation=True, resource_id=calendar_id),
@@ -67,7 +68,8 @@ class AsyncCalendarsService(AsyncBaseService):
 
         Args:
             calendar_id: The calendar id.
-            calendar: The calendar.
+            calendar: The writable calendar payload — the wire body is the nested {calendar:
+                {color}} envelope.
         """
         return await self._request(
             OperationInfo(service="calendars", operation="update_calendar", is_mutation=True, resource_id=calendar_id),

--- a/python/src/basecamp/generated/services/calendars.py
+++ b/python/src/basecamp/generated/services/calendars.py
@@ -12,6 +12,13 @@ from basecamp.hooks import OperationInfo
 
 class CalendarsService(BaseService):
     def get_calendar(self, *, calendar_id: int) -> dict[str, Any]:
+        """Get a calendar by its bucket id. A Calendar is a top-level BC5 bucketable
+        (distinct from a project) exposing display metadata and a link to its
+        underlying schedule resource. Shipped scope is show + update only.
+
+        Args:
+            calendar_id: The calendar id.
+        """
         return self._request(
             OperationInfo(service="calendars", operation="get_calendar", is_mutation=False, resource_id=calendar_id),
             "GET",
@@ -20,6 +27,14 @@ class CalendarsService(BaseService):
         )
 
     def update_calendar(self, *, calendar_id: int, calendar: dict) -> dict[str, Any]:
+        """Update a calendar's display color. An unknown color returns 422 with a JSON
+        errors payload keyed by field ({"errors": {"color": ["is not a valid
+        color"]}}) — the controller rejects invalid enum values up front.
+
+        Args:
+            calendar_id: The calendar id.
+            calendar: The calendar.
+        """
         return self._request(
             OperationInfo(service="calendars", operation="update_calendar", is_mutation=True, resource_id=calendar_id),
             "PUT",
@@ -31,6 +46,13 @@ class CalendarsService(BaseService):
 
 class AsyncCalendarsService(AsyncBaseService):
     async def get_calendar(self, *, calendar_id: int) -> dict[str, Any]:
+        """Get a calendar by its bucket id. A Calendar is a top-level BC5 bucketable
+        (distinct from a project) exposing display metadata and a link to its
+        underlying schedule resource. Shipped scope is show + update only.
+
+        Args:
+            calendar_id: The calendar id.
+        """
         return await self._request(
             OperationInfo(service="calendars", operation="get_calendar", is_mutation=False, resource_id=calendar_id),
             "GET",
@@ -39,6 +61,14 @@ class AsyncCalendarsService(AsyncBaseService):
         )
 
     async def update_calendar(self, *, calendar_id: int, calendar: dict) -> dict[str, Any]:
+        """Update a calendar's display color. An unknown color returns 422 with a JSON
+        errors payload keyed by field ({"errors": {"color": ["is not a valid
+        color"]}}) — the controller rejects invalid enum values up front.
+
+        Args:
+            calendar_id: The calendar id.
+            calendar: The calendar.
+        """
         return await self._request(
             OperationInfo(service="calendars", operation="update_calendar", is_mutation=True, resource_id=calendar_id),
             "PUT",

--- a/python/src/basecamp/generated/services/campfires.py
+++ b/python/src/basecamp/generated/services/campfires.py
@@ -17,8 +17,9 @@ class CampfiresService(BaseService):
         Args:
             bucket_id: The bucket id.
             campfire_id: The campfire id.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages.
         """
         return self._request_paginated(
             OperationInfo(
@@ -132,9 +133,9 @@ class CampfiresService(BaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="campfires", operation="list", is_mutation=False),
@@ -174,9 +175,9 @@ class CampfiresService(BaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="campfires", operation="list_lines", is_mutation=False, resource_id=campfire_id),
@@ -267,9 +268,9 @@ class CampfiresService(BaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="campfires", operation="list_uploads", is_mutation=False, resource_id=campfire_id),
@@ -305,8 +306,9 @@ class AsyncCampfiresService(AsyncBaseService):
         Args:
             bucket_id: The bucket id.
             campfire_id: The campfire id.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages.
         """
         return await self._request_paginated(
             OperationInfo(
@@ -420,9 +422,9 @@ class AsyncCampfiresService(AsyncBaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="campfires", operation="list", is_mutation=False),
@@ -462,9 +464,9 @@ class AsyncCampfiresService(AsyncBaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="campfires", operation="list_lines", is_mutation=False, resource_id=campfire_id),
@@ -555,9 +557,9 @@ class AsyncCampfiresService(AsyncBaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="campfires", operation="list_uploads", is_mutation=False, resource_id=campfire_id),

--- a/python/src/basecamp/generated/services/campfires.py
+++ b/python/src/basecamp/generated/services/campfires.py
@@ -17,8 +17,8 @@ class CampfiresService(BaseService):
         Args:
             bucket_id: The bucket id.
             campfire_id: The campfire id.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages.
         """
         return self._request_paginated(
             OperationInfo(
@@ -132,8 +132,9 @@ class CampfiresService(BaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="campfires", operation="list", is_mutation=False),
@@ -173,8 +174,9 @@ class CampfiresService(BaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="campfires", operation="list_lines", is_mutation=False, resource_id=campfire_id),
@@ -265,8 +267,9 @@ class CampfiresService(BaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="campfires", operation="list_uploads", is_mutation=False, resource_id=campfire_id),
@@ -302,8 +305,8 @@ class AsyncCampfiresService(AsyncBaseService):
         Args:
             bucket_id: The bucket id.
             campfire_id: The campfire id.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages.
         """
         return await self._request_paginated(
             OperationInfo(
@@ -417,8 +420,9 @@ class AsyncCampfiresService(AsyncBaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="campfires", operation="list", is_mutation=False),
@@ -458,8 +462,9 @@ class AsyncCampfiresService(AsyncBaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="campfires", operation="list_lines", is_mutation=False, resource_id=campfire_id),
@@ -550,8 +555,9 @@ class AsyncCampfiresService(AsyncBaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="campfires", operation="list_uploads", is_mutation=False, resource_id=campfire_id),

--- a/python/src/basecamp/generated/services/campfires.py
+++ b/python/src/basecamp/generated/services/campfires.py
@@ -12,6 +12,14 @@ from basecamp.hooks import OperationInfo
 
 class CampfiresService(BaseService):
     def list_chatbots(self, *, bucket_id: int, campfire_id: int, max_items: int | None = None) -> ListResult:
+        """List all chatbots for a campfire.
+
+        Args:
+            bucket_id: The bucket id.
+            campfire_id: The campfire id.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(
                 service="campfires",
@@ -28,6 +36,14 @@ class CampfiresService(BaseService):
     def create_chatbot(
         self, *, bucket_id: int, campfire_id: int, service_name: str, command_url: str | None = None
     ) -> dict[str, Any]:
+        """Create a new chatbot for a campfire.
+
+        Args:
+            bucket_id: The bucket id.
+            campfire_id: The campfire id.
+            service_name: The service name.
+            command_url: The command url.
+        """
         return self._request(
             OperationInfo(
                 service="campfires",
@@ -43,6 +59,13 @@ class CampfiresService(BaseService):
         )
 
     def get_chatbot(self, *, bucket_id: int, campfire_id: int, chatbot_id: int) -> dict[str, Any]:
+        """Get a chatbot by ID.
+
+        Args:
+            bucket_id: The bucket id.
+            campfire_id: The campfire id.
+            chatbot_id: The chatbot id.
+        """
         return self._request(
             OperationInfo(
                 service="campfires",
@@ -59,6 +82,15 @@ class CampfiresService(BaseService):
     def update_chatbot(
         self, *, bucket_id: int, campfire_id: int, chatbot_id: int, service_name: str, command_url: str | None = None
     ) -> dict[str, Any]:
+        """Update an existing chatbot.
+
+        Args:
+            bucket_id: The bucket id.
+            campfire_id: The campfire id.
+            chatbot_id: The chatbot id.
+            service_name: The service name.
+            command_url: The command url.
+        """
         return self._request(
             OperationInfo(
                 service="campfires",
@@ -74,6 +106,13 @@ class CampfiresService(BaseService):
         )
 
     def delete_chatbot(self, *, bucket_id: int, campfire_id: int, chatbot_id: int) -> None:
+        """Delete a chatbot.
+
+        Args:
+            bucket_id: The bucket id.
+            campfire_id: The campfire id.
+            chatbot_id: The chatbot id.
+        """
         self._request_void(
             OperationInfo(
                 service="campfires",
@@ -88,6 +127,14 @@ class CampfiresService(BaseService):
         )
 
     def list(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List all campfires across the account.
+
+        Args:
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="campfires", operation="list", is_mutation=False),
             "/chats.json",
@@ -97,6 +144,11 @@ class CampfiresService(BaseService):
         )
 
     def get(self, *, campfire_id: int) -> dict[str, Any]:
+        """Get a campfire by ID.
+
+        Args:
+            campfire_id: The campfire id.
+        """
         return self._request(
             OperationInfo(service="campfires", operation="get", is_mutation=False, resource_id=campfire_id),
             "GET",
@@ -113,6 +165,17 @@ class CampfiresService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """List all lines (messages) in a campfire.
+
+        Args:
+            campfire_id: The campfire id.
+            sort: created_at|updated_at
+            direction: asc|desc
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="campfires", operation="list_lines", is_mutation=False, resource_id=campfire_id),
             f"/chats/{campfire_id}/lines.json",
@@ -122,6 +185,13 @@ class CampfiresService(BaseService):
         )
 
     def create_line(self, *, campfire_id: int, content: str, content_type: str | None = None) -> dict[str, Any]:
+        """Create a new line (message) in a campfire.
+
+        Args:
+            campfire_id: The campfire id.
+            content: The content.
+            content_type: The content type.
+        """
         return self._request(
             OperationInfo(service="campfires", operation="create_line", is_mutation=True, resource_id=campfire_id),
             "POST",
@@ -131,6 +201,12 @@ class CampfiresService(BaseService):
         )
 
     def get_line(self, *, campfire_id: int, line_id: int) -> dict[str, Any]:
+        """Get a campfire line by ID.
+
+        Args:
+            campfire_id: The campfire id.
+            line_id: The line id.
+        """
         return self._request(
             OperationInfo(service="campfires", operation="get_line", is_mutation=False, resource_id=line_id),
             "GET",
@@ -139,6 +215,16 @@ class CampfiresService(BaseService):
         )
 
     def update_line(self, *, campfire_id: int, line_id: int, content: str) -> None:
+        """Update an existing campfire line; the content is always treated as rich text (HTML).
+        The server coerces every edited line to rich text and ignores any content
+        type hint. Only the line's creator may edit it, and only text and
+        rich-text lines are editable.
+
+        Args:
+            campfire_id: The campfire id.
+            line_id: The line id.
+            content: The new line content, interpreted as rich text (HTML)
+        """
         self._request_void(
             OperationInfo(service="campfires", operation="update_line", is_mutation=True, resource_id=line_id),
             "PUT",
@@ -148,6 +234,13 @@ class CampfiresService(BaseService):
         )
 
     def delete_line(self, *, campfire_id: int, line_id: int) -> None:
+        """Delete a campfire line; allowed for the line's creator or an admin.
+        The API responds 403 Forbidden otherwise.
+
+        Args:
+            campfire_id: The campfire id.
+            line_id: The line id.
+        """
         self._request_void(
             OperationInfo(service="campfires", operation="delete_line", is_mutation=True, resource_id=line_id),
             "DELETE",
@@ -164,6 +257,17 @@ class CampfiresService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """List uploaded files in a campfire.
+
+        Args:
+            campfire_id: The campfire id.
+            sort: created_at|updated_at
+            direction: asc|desc
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="campfires", operation="list_uploads", is_mutation=False, resource_id=campfire_id),
             f"/chats/{campfire_id}/uploads.json",
@@ -173,6 +277,14 @@ class CampfiresService(BaseService):
         )
 
     def create_upload(self, *, campfire_id: int, content: bytes, content_type: str, name: str) -> dict[str, Any]:
+        """Upload a file to a campfire.
+
+        Args:
+            campfire_id: The campfire id.
+            content: Raw bytes of the file to upload.
+            content_type: MIME content type of the upload (e.g. "image/png").
+            name: Filename for the uploaded file (e.g. "report.pdf").
+        """
         return self._request_raw(
             OperationInfo(service="campfires", operation="create_upload", is_mutation=True, resource_id=campfire_id),
             f"/chats/{campfire_id}/uploads.json",
@@ -185,6 +297,14 @@ class CampfiresService(BaseService):
 
 class AsyncCampfiresService(AsyncBaseService):
     async def list_chatbots(self, *, bucket_id: int, campfire_id: int, max_items: int | None = None) -> ListResult:
+        """List all chatbots for a campfire.
+
+        Args:
+            bucket_id: The bucket id.
+            campfire_id: The campfire id.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(
                 service="campfires",
@@ -201,6 +321,14 @@ class AsyncCampfiresService(AsyncBaseService):
     async def create_chatbot(
         self, *, bucket_id: int, campfire_id: int, service_name: str, command_url: str | None = None
     ) -> dict[str, Any]:
+        """Create a new chatbot for a campfire.
+
+        Args:
+            bucket_id: The bucket id.
+            campfire_id: The campfire id.
+            service_name: The service name.
+            command_url: The command url.
+        """
         return await self._request(
             OperationInfo(
                 service="campfires",
@@ -216,6 +344,13 @@ class AsyncCampfiresService(AsyncBaseService):
         )
 
     async def get_chatbot(self, *, bucket_id: int, campfire_id: int, chatbot_id: int) -> dict[str, Any]:
+        """Get a chatbot by ID.
+
+        Args:
+            bucket_id: The bucket id.
+            campfire_id: The campfire id.
+            chatbot_id: The chatbot id.
+        """
         return await self._request(
             OperationInfo(
                 service="campfires",
@@ -232,6 +367,15 @@ class AsyncCampfiresService(AsyncBaseService):
     async def update_chatbot(
         self, *, bucket_id: int, campfire_id: int, chatbot_id: int, service_name: str, command_url: str | None = None
     ) -> dict[str, Any]:
+        """Update an existing chatbot.
+
+        Args:
+            bucket_id: The bucket id.
+            campfire_id: The campfire id.
+            chatbot_id: The chatbot id.
+            service_name: The service name.
+            command_url: The command url.
+        """
         return await self._request(
             OperationInfo(
                 service="campfires",
@@ -247,6 +391,13 @@ class AsyncCampfiresService(AsyncBaseService):
         )
 
     async def delete_chatbot(self, *, bucket_id: int, campfire_id: int, chatbot_id: int) -> None:
+        """Delete a chatbot.
+
+        Args:
+            bucket_id: The bucket id.
+            campfire_id: The campfire id.
+            chatbot_id: The chatbot id.
+        """
         await self._request_void(
             OperationInfo(
                 service="campfires",
@@ -261,6 +412,14 @@ class AsyncCampfiresService(AsyncBaseService):
         )
 
     async def list(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List all campfires across the account.
+
+        Args:
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="campfires", operation="list", is_mutation=False),
             "/chats.json",
@@ -270,6 +429,11 @@ class AsyncCampfiresService(AsyncBaseService):
         )
 
     async def get(self, *, campfire_id: int) -> dict[str, Any]:
+        """Get a campfire by ID.
+
+        Args:
+            campfire_id: The campfire id.
+        """
         return await self._request(
             OperationInfo(service="campfires", operation="get", is_mutation=False, resource_id=campfire_id),
             "GET",
@@ -286,6 +450,17 @@ class AsyncCampfiresService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """List all lines (messages) in a campfire.
+
+        Args:
+            campfire_id: The campfire id.
+            sort: created_at|updated_at
+            direction: asc|desc
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="campfires", operation="list_lines", is_mutation=False, resource_id=campfire_id),
             f"/chats/{campfire_id}/lines.json",
@@ -295,6 +470,13 @@ class AsyncCampfiresService(AsyncBaseService):
         )
 
     async def create_line(self, *, campfire_id: int, content: str, content_type: str | None = None) -> dict[str, Any]:
+        """Create a new line (message) in a campfire.
+
+        Args:
+            campfire_id: The campfire id.
+            content: The content.
+            content_type: The content type.
+        """
         return await self._request(
             OperationInfo(service="campfires", operation="create_line", is_mutation=True, resource_id=campfire_id),
             "POST",
@@ -304,6 +486,12 @@ class AsyncCampfiresService(AsyncBaseService):
         )
 
     async def get_line(self, *, campfire_id: int, line_id: int) -> dict[str, Any]:
+        """Get a campfire line by ID.
+
+        Args:
+            campfire_id: The campfire id.
+            line_id: The line id.
+        """
         return await self._request(
             OperationInfo(service="campfires", operation="get_line", is_mutation=False, resource_id=line_id),
             "GET",
@@ -312,6 +500,16 @@ class AsyncCampfiresService(AsyncBaseService):
         )
 
     async def update_line(self, *, campfire_id: int, line_id: int, content: str) -> None:
+        """Update an existing campfire line; the content is always treated as rich text (HTML).
+        The server coerces every edited line to rich text and ignores any content
+        type hint. Only the line's creator may edit it, and only text and
+        rich-text lines are editable.
+
+        Args:
+            campfire_id: The campfire id.
+            line_id: The line id.
+            content: The new line content, interpreted as rich text (HTML)
+        """
         await self._request_void(
             OperationInfo(service="campfires", operation="update_line", is_mutation=True, resource_id=line_id),
             "PUT",
@@ -321,6 +519,13 @@ class AsyncCampfiresService(AsyncBaseService):
         )
 
     async def delete_line(self, *, campfire_id: int, line_id: int) -> None:
+        """Delete a campfire line; allowed for the line's creator or an admin.
+        The API responds 403 Forbidden otherwise.
+
+        Args:
+            campfire_id: The campfire id.
+            line_id: The line id.
+        """
         await self._request_void(
             OperationInfo(service="campfires", operation="delete_line", is_mutation=True, resource_id=line_id),
             "DELETE",
@@ -337,6 +542,17 @@ class AsyncCampfiresService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """List uploaded files in a campfire.
+
+        Args:
+            campfire_id: The campfire id.
+            sort: created_at|updated_at
+            direction: asc|desc
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="campfires", operation="list_uploads", is_mutation=False, resource_id=campfire_id),
             f"/chats/{campfire_id}/uploads.json",
@@ -346,6 +562,14 @@ class AsyncCampfiresService(AsyncBaseService):
         )
 
     async def create_upload(self, *, campfire_id: int, content: bytes, content_type: str, name: str) -> dict[str, Any]:
+        """Upload a file to a campfire.
+
+        Args:
+            campfire_id: The campfire id.
+            content: Raw bytes of the file to upload.
+            content_type: MIME content type of the upload (e.g. "image/png").
+            name: Filename for the uploaded file (e.g. "report.pdf").
+        """
         return await self._request_raw(
             OperationInfo(service="campfires", operation="create_upload", is_mutation=True, resource_id=campfire_id),
             f"/chats/{campfire_id}/uploads.json",

--- a/python/src/basecamp/generated/services/card_columns.py
+++ b/python/src/basecamp/generated/services/card_columns.py
@@ -12,6 +12,14 @@ from basecamp.hooks import OperationInfo
 
 class CardColumnsService(BaseService):
     def set_color(self, *, bucket_id: int, column_id: int, color: str) -> dict[str, Any]:
+        """Set the color of a column.
+
+        Args:
+            bucket_id: The bucket id.
+            column_id: The column id.
+            color: Valid colors: white, red, orange, yellow, green, blue, aqua, purple, gray, pink,
+                brown
+        """
         return self._request(
             OperationInfo(
                 service="cardcolumns",
@@ -27,6 +35,12 @@ class CardColumnsService(BaseService):
         )
 
     def enable_on_hold(self, *, bucket_id: int, column_id: int) -> dict[str, Any]:
+        """Enable on-hold section in a column.
+
+        Args:
+            bucket_id: The bucket id.
+            column_id: The column id.
+        """
         return self._request(
             OperationInfo(
                 service="cardcolumns",
@@ -41,6 +55,12 @@ class CardColumnsService(BaseService):
         )
 
     def disable_on_hold(self, *, bucket_id: int, column_id: int) -> dict[str, Any]:
+        """Disable on-hold section in a column.
+
+        Args:
+            bucket_id: The bucket id.
+            column_id: The column id.
+        """
         return self._request(
             OperationInfo(
                 service="cardcolumns",
@@ -55,6 +75,11 @@ class CardColumnsService(BaseService):
         )
 
     def get(self, *, column_id: int) -> dict[str, Any]:
+        """Get a card column by ID.
+
+        Args:
+            column_id: The column id.
+        """
         return self._request(
             OperationInfo(service="cardcolumns", operation="get", is_mutation=False, resource_id=column_id),
             "GET",
@@ -63,6 +88,13 @@ class CardColumnsService(BaseService):
         )
 
     def update(self, *, column_id: int, title: str | None = None, description: str | None = None) -> dict[str, Any]:
+        """Update an existing column.
+
+        Args:
+            column_id: The column id.
+            title: The title.
+            description: The description.
+        """
         return self._request(
             OperationInfo(service="cardcolumns", operation="update", is_mutation=True, resource_id=column_id),
             "PUT",
@@ -72,6 +104,11 @@ class CardColumnsService(BaseService):
         )
 
     def subscribe_to_column(self, *, column_id: int) -> None:
+        """Subscribe to a card column (watch for changes).
+
+        Args:
+            column_id: The column id.
+        """
         self._request_void(
             OperationInfo(
                 service="cardcolumns", operation="subscribe_to_column", is_mutation=True, resource_id=column_id
@@ -82,6 +119,11 @@ class CardColumnsService(BaseService):
         )
 
     def unsubscribe_from_column(self, *, column_id: int) -> None:
+        """Unsubscribe from a card column (stop watching for changes).
+
+        Args:
+            column_id: The column id.
+        """
         self._request_void(
             OperationInfo(
                 service="cardcolumns", operation="unsubscribe_from_column", is_mutation=True, resource_id=column_id
@@ -92,6 +134,13 @@ class CardColumnsService(BaseService):
         )
 
     def create(self, *, card_table_id: int, title: str, description: str | None = None) -> dict[str, Any]:
+        """Create a column in a card table.
+
+        Args:
+            card_table_id: The card table id.
+            title: The title.
+            description: The description.
+        """
         return self._request(
             OperationInfo(service="cardcolumns", operation="create", is_mutation=True, resource_id=card_table_id),
             "POST",
@@ -101,6 +150,14 @@ class CardColumnsService(BaseService):
         )
 
     def move(self, *, card_table_id: int, source_id: int, target_id: int, position: int | None = None) -> None:
+        """Move a column within a card table.
+
+        Args:
+            card_table_id: The card table id.
+            source_id: The source id.
+            target_id: The target id.
+            position: The position.
+        """
         self._request_void(
             OperationInfo(service="cardcolumns", operation="move", is_mutation=True, resource_id=card_table_id),
             "POST",
@@ -112,6 +169,14 @@ class CardColumnsService(BaseService):
 
 class AsyncCardColumnsService(AsyncBaseService):
     async def set_color(self, *, bucket_id: int, column_id: int, color: str) -> dict[str, Any]:
+        """Set the color of a column.
+
+        Args:
+            bucket_id: The bucket id.
+            column_id: The column id.
+            color: Valid colors: white, red, orange, yellow, green, blue, aqua, purple, gray, pink,
+                brown
+        """
         return await self._request(
             OperationInfo(
                 service="cardcolumns",
@@ -127,6 +192,12 @@ class AsyncCardColumnsService(AsyncBaseService):
         )
 
     async def enable_on_hold(self, *, bucket_id: int, column_id: int) -> dict[str, Any]:
+        """Enable on-hold section in a column.
+
+        Args:
+            bucket_id: The bucket id.
+            column_id: The column id.
+        """
         return await self._request(
             OperationInfo(
                 service="cardcolumns",
@@ -141,6 +212,12 @@ class AsyncCardColumnsService(AsyncBaseService):
         )
 
     async def disable_on_hold(self, *, bucket_id: int, column_id: int) -> dict[str, Any]:
+        """Disable on-hold section in a column.
+
+        Args:
+            bucket_id: The bucket id.
+            column_id: The column id.
+        """
         return await self._request(
             OperationInfo(
                 service="cardcolumns",
@@ -155,6 +232,11 @@ class AsyncCardColumnsService(AsyncBaseService):
         )
 
     async def get(self, *, column_id: int) -> dict[str, Any]:
+        """Get a card column by ID.
+
+        Args:
+            column_id: The column id.
+        """
         return await self._request(
             OperationInfo(service="cardcolumns", operation="get", is_mutation=False, resource_id=column_id),
             "GET",
@@ -165,6 +247,13 @@ class AsyncCardColumnsService(AsyncBaseService):
     async def update(
         self, *, column_id: int, title: str | None = None, description: str | None = None
     ) -> dict[str, Any]:
+        """Update an existing column.
+
+        Args:
+            column_id: The column id.
+            title: The title.
+            description: The description.
+        """
         return await self._request(
             OperationInfo(service="cardcolumns", operation="update", is_mutation=True, resource_id=column_id),
             "PUT",
@@ -174,6 +263,11 @@ class AsyncCardColumnsService(AsyncBaseService):
         )
 
     async def subscribe_to_column(self, *, column_id: int) -> None:
+        """Subscribe to a card column (watch for changes).
+
+        Args:
+            column_id: The column id.
+        """
         await self._request_void(
             OperationInfo(
                 service="cardcolumns", operation="subscribe_to_column", is_mutation=True, resource_id=column_id
@@ -184,6 +278,11 @@ class AsyncCardColumnsService(AsyncBaseService):
         )
 
     async def unsubscribe_from_column(self, *, column_id: int) -> None:
+        """Unsubscribe from a card column (stop watching for changes).
+
+        Args:
+            column_id: The column id.
+        """
         await self._request_void(
             OperationInfo(
                 service="cardcolumns", operation="unsubscribe_from_column", is_mutation=True, resource_id=column_id
@@ -194,6 +293,13 @@ class AsyncCardColumnsService(AsyncBaseService):
         )
 
     async def create(self, *, card_table_id: int, title: str, description: str | None = None) -> dict[str, Any]:
+        """Create a column in a card table.
+
+        Args:
+            card_table_id: The card table id.
+            title: The title.
+            description: The description.
+        """
         return await self._request(
             OperationInfo(service="cardcolumns", operation="create", is_mutation=True, resource_id=card_table_id),
             "POST",
@@ -203,6 +309,14 @@ class AsyncCardColumnsService(AsyncBaseService):
         )
 
     async def move(self, *, card_table_id: int, source_id: int, target_id: int, position: int | None = None) -> None:
+        """Move a column within a card table.
+
+        Args:
+            card_table_id: The card table id.
+            source_id: The source id.
+            target_id: The target id.
+            position: The position.
+        """
         await self._request_void(
             OperationInfo(service="cardcolumns", operation="move", is_mutation=True, resource_id=card_table_id),
             "POST",

--- a/python/src/basecamp/generated/services/card_steps.py
+++ b/python/src/basecamp/generated/services/card_steps.py
@@ -12,6 +12,13 @@ from basecamp.hooks import OperationInfo
 
 class CardStepsService(BaseService):
     def reposition(self, *, card_id: int, source_id: int, position: int) -> None:
+        """Reposition a step within a card.
+
+        Args:
+            card_id: The card id.
+            source_id: The source id.
+            position: 0-indexed position
+        """
         self._request_void(
             OperationInfo(service="cardsteps", operation="reposition", is_mutation=True, resource_id=card_id),
             "POST",
@@ -23,6 +30,14 @@ class CardStepsService(BaseService):
     def create(
         self, *, card_id: int, title: str, due_on: str | None = None, assignee_ids: list[int] | None = None
     ) -> dict[str, Any]:
+        """Create a step on a card.
+
+        Args:
+            card_id: The card id.
+            title: The title.
+            due_on: The due on.
+            assignee_ids: The assignee ids.
+        """
         return self._request(
             OperationInfo(service="cardsteps", operation="create", is_mutation=True, resource_id=card_id),
             "POST",
@@ -32,6 +47,11 @@ class CardStepsService(BaseService):
         )
 
     def get(self, *, step_id: int) -> dict[str, Any]:
+        """Get a step by ID.
+
+        Args:
+            step_id: The step id.
+        """
         return self._request(
             OperationInfo(service="cardsteps", operation="get", is_mutation=False, resource_id=step_id),
             "GET",
@@ -47,6 +67,14 @@ class CardStepsService(BaseService):
         due_on: str | None = None,
         assignee_ids: list[int] | None = None,
     ) -> dict[str, Any]:
+        """Update an existing step.
+
+        Args:
+            step_id: The step id.
+            title: The title.
+            due_on: The due on.
+            assignee_ids: The assignee ids.
+        """
         return self._request(
             OperationInfo(service="cardsteps", operation="update", is_mutation=True, resource_id=step_id),
             "PUT",
@@ -56,6 +84,12 @@ class CardStepsService(BaseService):
         )
 
     def set_completion(self, *, step_id: int, completion: str) -> dict[str, Any]:
+        """Set card step completion status (PUT with completion: "on" to complete, "" to uncomplete).
+
+        Args:
+            step_id: The step id.
+            completion: Set to "on" to complete the step, "" (empty) to uncomplete
+        """
         return self._request(
             OperationInfo(service="cardsteps", operation="set_completion", is_mutation=True, resource_id=step_id),
             "PUT",
@@ -67,6 +101,13 @@ class CardStepsService(BaseService):
 
 class AsyncCardStepsService(AsyncBaseService):
     async def reposition(self, *, card_id: int, source_id: int, position: int) -> None:
+        """Reposition a step within a card.
+
+        Args:
+            card_id: The card id.
+            source_id: The source id.
+            position: 0-indexed position
+        """
         await self._request_void(
             OperationInfo(service="cardsteps", operation="reposition", is_mutation=True, resource_id=card_id),
             "POST",
@@ -78,6 +119,14 @@ class AsyncCardStepsService(AsyncBaseService):
     async def create(
         self, *, card_id: int, title: str, due_on: str | None = None, assignee_ids: list[int] | None = None
     ) -> dict[str, Any]:
+        """Create a step on a card.
+
+        Args:
+            card_id: The card id.
+            title: The title.
+            due_on: The due on.
+            assignee_ids: The assignee ids.
+        """
         return await self._request(
             OperationInfo(service="cardsteps", operation="create", is_mutation=True, resource_id=card_id),
             "POST",
@@ -87,6 +136,11 @@ class AsyncCardStepsService(AsyncBaseService):
         )
 
     async def get(self, *, step_id: int) -> dict[str, Any]:
+        """Get a step by ID.
+
+        Args:
+            step_id: The step id.
+        """
         return await self._request(
             OperationInfo(service="cardsteps", operation="get", is_mutation=False, resource_id=step_id),
             "GET",
@@ -102,6 +156,14 @@ class AsyncCardStepsService(AsyncBaseService):
         due_on: str | None = None,
         assignee_ids: list[int] | None = None,
     ) -> dict[str, Any]:
+        """Update an existing step.
+
+        Args:
+            step_id: The step id.
+            title: The title.
+            due_on: The due on.
+            assignee_ids: The assignee ids.
+        """
         return await self._request(
             OperationInfo(service="cardsteps", operation="update", is_mutation=True, resource_id=step_id),
             "PUT",
@@ -111,6 +173,12 @@ class AsyncCardStepsService(AsyncBaseService):
         )
 
     async def set_completion(self, *, step_id: int, completion: str) -> dict[str, Any]:
+        """Set card step completion status (PUT with completion: "on" to complete, "" to uncomplete).
+
+        Args:
+            step_id: The step id.
+            completion: Set to "on" to complete the step, "" (empty) to uncomplete
+        """
         return await self._request(
             OperationInfo(service="cardsteps", operation="set_completion", is_mutation=True, resource_id=step_id),
             "PUT",

--- a/python/src/basecamp/generated/services/card_tables.py
+++ b/python/src/basecamp/generated/services/card_tables.py
@@ -12,6 +12,11 @@ from basecamp.hooks import OperationInfo
 
 class CardTablesService(BaseService):
     def get(self, *, card_table_id: int) -> dict[str, Any]:
+        """Get a card table by ID.
+
+        Args:
+            card_table_id: The card table id.
+        """
         return self._request(
             OperationInfo(service="cardtables", operation="get", is_mutation=False, resource_id=card_table_id),
             "GET",
@@ -22,6 +27,11 @@ class CardTablesService(BaseService):
 
 class AsyncCardTablesService(AsyncBaseService):
     async def get(self, *, card_table_id: int) -> dict[str, Any]:
+        """Get a card table by ID.
+
+        Args:
+            card_table_id: The card table id.
+        """
         return await self._request(
             OperationInfo(service="cardtables", operation="get", is_mutation=False, resource_id=card_table_id),
             "GET",

--- a/python/src/basecamp/generated/services/cards.py
+++ b/python/src/basecamp/generated/services/cards.py
@@ -73,8 +73,9 @@ class CardsService(BaseService):
             column_id: The column id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="cards", operation="list", is_mutation=False, resource_id=column_id),
@@ -174,8 +175,9 @@ class AsyncCardsService(AsyncBaseService):
             column_id: The column id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="cards", operation="list", is_mutation=False, resource_id=column_id),

--- a/python/src/basecamp/generated/services/cards.py
+++ b/python/src/basecamp/generated/services/cards.py
@@ -12,6 +12,11 @@ from basecamp.hooks import OperationInfo
 
 class CardsService(BaseService):
     def get(self, *, card_id: int) -> dict[str, Any]:
+        """Get a card by ID.
+
+        Args:
+            card_id: The card id.
+        """
         return self._request(
             OperationInfo(service="cards", operation="get", is_mutation=False, resource_id=card_id),
             "GET",
@@ -28,6 +33,15 @@ class CardsService(BaseService):
         due_on: str | None = None,
         assignee_ids: list[int] | None = None,
     ) -> dict[str, Any]:
+        """Update an existing card.
+
+        Args:
+            card_id: The card id.
+            title: The title.
+            content: The content.
+            due_on: The due on.
+            assignee_ids: The assignee ids.
+        """
         return self._request(
             OperationInfo(service="cards", operation="update_verbatim", is_mutation=True, resource_id=card_id),
             "PUT",
@@ -37,6 +51,13 @@ class CardsService(BaseService):
         )
 
     def move(self, *, card_id: int, column_id: int, position: int | None = None) -> None:
+        """Move a card to a different column.
+
+        Args:
+            card_id: The card id.
+            column_id: The column id.
+            position: 1-indexed position within the destination column. Defaults to 1 (top).
+        """
         self._request_void(
             OperationInfo(service="cards", operation="move", is_mutation=True, resource_id=card_id),
             "POST",
@@ -46,6 +67,15 @@ class CardsService(BaseService):
         )
 
     def list(self, *, column_id: int, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List cards in a column.
+
+        Args:
+            column_id: The column id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="cards", operation="list", is_mutation=False, resource_id=column_id),
             f"/card_tables/lists/{column_id}/cards.json",
@@ -63,6 +93,15 @@ class CardsService(BaseService):
         due_on: str | None = None,
         notify: bool | None = None,
     ) -> dict[str, Any]:
+        """Create a card in a column.
+
+        Args:
+            column_id: The column id.
+            title: The title.
+            content: The content.
+            due_on: The due on.
+            notify: The notify.
+        """
         return self._request(
             OperationInfo(service="cards", operation="create", is_mutation=True, resource_id=column_id),
             "POST",
@@ -74,6 +113,11 @@ class CardsService(BaseService):
 
 class AsyncCardsService(AsyncBaseService):
     async def get(self, *, card_id: int) -> dict[str, Any]:
+        """Get a card by ID.
+
+        Args:
+            card_id: The card id.
+        """
         return await self._request(
             OperationInfo(service="cards", operation="get", is_mutation=False, resource_id=card_id),
             "GET",
@@ -90,6 +134,15 @@ class AsyncCardsService(AsyncBaseService):
         due_on: str | None = None,
         assignee_ids: list[int] | None = None,
     ) -> dict[str, Any]:
+        """Update an existing card.
+
+        Args:
+            card_id: The card id.
+            title: The title.
+            content: The content.
+            due_on: The due on.
+            assignee_ids: The assignee ids.
+        """
         return await self._request(
             OperationInfo(service="cards", operation="update_verbatim", is_mutation=True, resource_id=card_id),
             "PUT",
@@ -99,6 +152,13 @@ class AsyncCardsService(AsyncBaseService):
         )
 
     async def move(self, *, card_id: int, column_id: int, position: int | None = None) -> None:
+        """Move a card to a different column.
+
+        Args:
+            card_id: The card id.
+            column_id: The column id.
+            position: 1-indexed position within the destination column. Defaults to 1 (top).
+        """
         await self._request_void(
             OperationInfo(service="cards", operation="move", is_mutation=True, resource_id=card_id),
             "POST",
@@ -108,6 +168,15 @@ class AsyncCardsService(AsyncBaseService):
         )
 
     async def list(self, *, column_id: int, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List cards in a column.
+
+        Args:
+            column_id: The column id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="cards", operation="list", is_mutation=False, resource_id=column_id),
             f"/card_tables/lists/{column_id}/cards.json",
@@ -125,6 +194,15 @@ class AsyncCardsService(AsyncBaseService):
         due_on: str | None = None,
         notify: bool | None = None,
     ) -> dict[str, Any]:
+        """Create a card in a column.
+
+        Args:
+            column_id: The column id.
+            title: The title.
+            content: The content.
+            due_on: The due on.
+            notify: The notify.
+        """
         return await self._request(
             OperationInfo(service="cards", operation="create", is_mutation=True, resource_id=column_id),
             "POST",

--- a/python/src/basecamp/generated/services/cards.py
+++ b/python/src/basecamp/generated/services/cards.py
@@ -73,9 +73,9 @@ class CardsService(BaseService):
             column_id: The column id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="cards", operation="list", is_mutation=False, resource_id=column_id),
@@ -175,9 +175,9 @@ class AsyncCardsService(AsyncBaseService):
             column_id: The column id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="cards", operation="list", is_mutation=False, resource_id=column_id),

--- a/python/src/basecamp/generated/services/checkins.py
+++ b/python/src/basecamp/generated/services/checkins.py
@@ -19,8 +19,9 @@ class CheckinsService(BaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="checkins", operation="reminders", is_mutation=False),
@@ -83,8 +84,9 @@ class CheckinsService(BaseService):
             questionnaire_id: The questionnaire id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(
@@ -156,8 +158,9 @@ class CheckinsService(BaseService):
             question_id: The question id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="checkins", operation="list_answers", is_mutation=False, resource_id=question_id),
@@ -188,8 +191,8 @@ class CheckinsService(BaseService):
 
         Args:
             question_id: The question id.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages.
         """
         return self._request_paginated(
             OperationInfo(service="checkins", operation="answerers", is_mutation=False, resource_id=question_id),
@@ -208,8 +211,9 @@ class CheckinsService(BaseService):
             person_id: The person id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="checkins", operation="by_person", is_mutation=False, resource_id=person_id),
@@ -277,8 +281,9 @@ class AsyncCheckinsService(AsyncBaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="checkins", operation="reminders", is_mutation=False),
@@ -341,8 +346,9 @@ class AsyncCheckinsService(AsyncBaseService):
             questionnaire_id: The questionnaire id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(
@@ -416,8 +422,9 @@ class AsyncCheckinsService(AsyncBaseService):
             question_id: The question id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="checkins", operation="list_answers", is_mutation=False, resource_id=question_id),
@@ -448,8 +455,8 @@ class AsyncCheckinsService(AsyncBaseService):
 
         Args:
             question_id: The question id.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages.
         """
         return await self._request_paginated(
             OperationInfo(service="checkins", operation="answerers", is_mutation=False, resource_id=question_id),
@@ -468,8 +475,9 @@ class AsyncCheckinsService(AsyncBaseService):
             person_id: The person id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="checkins", operation="by_person", is_mutation=False, resource_id=person_id),

--- a/python/src/basecamp/generated/services/checkins.py
+++ b/python/src/basecamp/generated/services/checkins.py
@@ -12,6 +12,16 @@ from basecamp.hooks import OperationInfo
 
 class CheckinsService(BaseService):
     def reminders(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """Get pending check-in reminders for the current user.
+
+        Returns questions that are pending a response from the authenticated user.
+
+        Args:
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="checkins", operation="reminders", is_mutation=False),
             "/my/question_reminders.json",
@@ -21,6 +31,11 @@ class CheckinsService(BaseService):
         )
 
     def get_answer(self, *, answer_id: int) -> dict[str, Any]:
+        """Get a single answer by id.
+
+        Args:
+            answer_id: The answer id.
+        """
         return self._request(
             OperationInfo(service="checkins", operation="get_answer", is_mutation=False, resource_id=answer_id),
             "GET",
@@ -29,6 +44,13 @@ class CheckinsService(BaseService):
         )
 
     def update_answer(self, *, answer_id: int, content: str, group_on: str | None = None) -> None:
+        """Update an existing answer.
+
+        Args:
+            answer_id: The answer id.
+            content: The content.
+            group_on: The group on.
+        """
         self._request_void(
             OperationInfo(service="checkins", operation="update_answer", is_mutation=True, resource_id=answer_id),
             "PUT",
@@ -38,6 +60,11 @@ class CheckinsService(BaseService):
         )
 
     def get_questionnaire(self, *, questionnaire_id: int) -> dict[str, Any]:
+        """Get a questionnaire (automatic check-ins container) by id.
+
+        Args:
+            questionnaire_id: The questionnaire id.
+        """
         return self._request(
             OperationInfo(
                 service="checkins", operation="get_questionnaire", is_mutation=False, resource_id=questionnaire_id
@@ -50,6 +77,15 @@ class CheckinsService(BaseService):
     def list_questions(
         self, *, questionnaire_id: int, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List all questions in a questionnaire.
+
+        Args:
+            questionnaire_id: The questionnaire id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(
                 service="checkins", operation="list_questions", is_mutation=False, resource_id=questionnaire_id
@@ -63,6 +99,14 @@ class CheckinsService(BaseService):
     def create_question(
         self, *, questionnaire_id: int, title: str, schedule: dict, visible_to_clients: bool | None = None
     ) -> dict[str, Any]:
+        """Create a new question in a questionnaire.
+
+        Args:
+            questionnaire_id: The questionnaire id.
+            title: The title.
+            schedule: The schedule.
+            visible_to_clients: The visible to clients.
+        """
         return self._request(
             OperationInfo(
                 service="checkins", operation="create_question", is_mutation=True, resource_id=questionnaire_id
@@ -74,6 +118,11 @@ class CheckinsService(BaseService):
         )
 
     def get_question(self, *, question_id: int) -> dict[str, Any]:
+        """Get a single question by id.
+
+        Args:
+            question_id: The question id.
+        """
         return self._request(
             OperationInfo(service="checkins", operation="get_question", is_mutation=False, resource_id=question_id),
             "GET",
@@ -84,6 +133,14 @@ class CheckinsService(BaseService):
     def update_question(
         self, *, question_id: int, title: str | None = None, schedule: dict | None = None, paused: bool | None = None
     ) -> dict[str, Any]:
+        """Update an existing question.
+
+        Args:
+            question_id: The question id.
+            title: The title.
+            schedule: The schedule.
+            paused: The paused.
+        """
         return self._request(
             OperationInfo(service="checkins", operation="update_question", is_mutation=True, resource_id=question_id),
             "PUT",
@@ -93,6 +150,15 @@ class CheckinsService(BaseService):
         )
 
     def list_answers(self, *, question_id: int, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List all answers for a question.
+
+        Args:
+            question_id: The question id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="checkins", operation="list_answers", is_mutation=False, resource_id=question_id),
             f"/questions/{question_id}/answers.json",
@@ -102,6 +168,13 @@ class CheckinsService(BaseService):
         )
 
     def create_answer(self, *, question_id: int, content: str, group_on: str | None = None) -> dict[str, Any]:
+        """Create a new answer for a question.
+
+        Args:
+            question_id: The question id.
+            content: The content.
+            group_on: The group on.
+        """
         return self._request(
             OperationInfo(service="checkins", operation="create_answer", is_mutation=True, resource_id=question_id),
             "POST",
@@ -111,6 +184,13 @@ class CheckinsService(BaseService):
         )
 
     def answerers(self, *, question_id: int, max_items: int | None = None) -> ListResult:
+        """List all people who have answered a question (answerers).
+
+        Args:
+            question_id: The question id.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="checkins", operation="answerers", is_mutation=False, resource_id=question_id),
             f"/questions/{question_id}/answers/by.json",
@@ -121,6 +201,16 @@ class CheckinsService(BaseService):
     def by_person(
         self, *, question_id: int, person_id: int, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """Get all answers from a specific person for a question.
+
+        Args:
+            question_id: The question id.
+            person_id: The person id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="checkins", operation="by_person", is_mutation=False, resource_id=person_id),
             f"/questions/{question_id}/answers/by/{person_id}",
@@ -132,6 +222,13 @@ class CheckinsService(BaseService):
     def update_notification_settings(
         self, *, question_id: int, notify_on_answer: bool | None = None, digest_include_unanswered: bool | None = None
     ) -> dict[str, Any]:
+        """Update notification settings for a check-in question.
+
+        Args:
+            question_id: The question id.
+            notify_on_answer: Notify when someone answers
+            digest_include_unanswered: Include unanswered in digest
+        """
         return self._request(
             OperationInfo(
                 service="checkins", operation="update_notification_settings", is_mutation=True, resource_id=question_id
@@ -145,6 +242,11 @@ class CheckinsService(BaseService):
         )
 
     def pause(self, *, question_id: int) -> dict[str, Any]:
+        """Pause a check-in question (stops sending reminders).
+
+        Args:
+            question_id: The question id.
+        """
         return self._request(
             OperationInfo(service="checkins", operation="pause", is_mutation=True, resource_id=question_id),
             "POST",
@@ -153,6 +255,11 @@ class CheckinsService(BaseService):
         )
 
     def resume(self, *, question_id: int) -> dict[str, Any]:
+        """Resume a paused check-in question (resumes sending reminders).
+
+        Args:
+            question_id: The question id.
+        """
         return self._request(
             OperationInfo(service="checkins", operation="resume", is_mutation=True, resource_id=question_id),
             "DELETE",
@@ -163,6 +270,16 @@ class CheckinsService(BaseService):
 
 class AsyncCheckinsService(AsyncBaseService):
     async def reminders(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """Get pending check-in reminders for the current user.
+
+        Returns questions that are pending a response from the authenticated user.
+
+        Args:
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="checkins", operation="reminders", is_mutation=False),
             "/my/question_reminders.json",
@@ -172,6 +289,11 @@ class AsyncCheckinsService(AsyncBaseService):
         )
 
     async def get_answer(self, *, answer_id: int) -> dict[str, Any]:
+        """Get a single answer by id.
+
+        Args:
+            answer_id: The answer id.
+        """
         return await self._request(
             OperationInfo(service="checkins", operation="get_answer", is_mutation=False, resource_id=answer_id),
             "GET",
@@ -180,6 +302,13 @@ class AsyncCheckinsService(AsyncBaseService):
         )
 
     async def update_answer(self, *, answer_id: int, content: str, group_on: str | None = None) -> None:
+        """Update an existing answer.
+
+        Args:
+            answer_id: The answer id.
+            content: The content.
+            group_on: The group on.
+        """
         await self._request_void(
             OperationInfo(service="checkins", operation="update_answer", is_mutation=True, resource_id=answer_id),
             "PUT",
@@ -189,6 +318,11 @@ class AsyncCheckinsService(AsyncBaseService):
         )
 
     async def get_questionnaire(self, *, questionnaire_id: int) -> dict[str, Any]:
+        """Get a questionnaire (automatic check-ins container) by id.
+
+        Args:
+            questionnaire_id: The questionnaire id.
+        """
         return await self._request(
             OperationInfo(
                 service="checkins", operation="get_questionnaire", is_mutation=False, resource_id=questionnaire_id
@@ -201,6 +335,15 @@ class AsyncCheckinsService(AsyncBaseService):
     async def list_questions(
         self, *, questionnaire_id: int, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List all questions in a questionnaire.
+
+        Args:
+            questionnaire_id: The questionnaire id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(
                 service="checkins", operation="list_questions", is_mutation=False, resource_id=questionnaire_id
@@ -214,6 +357,14 @@ class AsyncCheckinsService(AsyncBaseService):
     async def create_question(
         self, *, questionnaire_id: int, title: str, schedule: dict, visible_to_clients: bool | None = None
     ) -> dict[str, Any]:
+        """Create a new question in a questionnaire.
+
+        Args:
+            questionnaire_id: The questionnaire id.
+            title: The title.
+            schedule: The schedule.
+            visible_to_clients: The visible to clients.
+        """
         return await self._request(
             OperationInfo(
                 service="checkins", operation="create_question", is_mutation=True, resource_id=questionnaire_id
@@ -225,6 +376,11 @@ class AsyncCheckinsService(AsyncBaseService):
         )
 
     async def get_question(self, *, question_id: int) -> dict[str, Any]:
+        """Get a single question by id.
+
+        Args:
+            question_id: The question id.
+        """
         return await self._request(
             OperationInfo(service="checkins", operation="get_question", is_mutation=False, resource_id=question_id),
             "GET",
@@ -235,6 +391,14 @@ class AsyncCheckinsService(AsyncBaseService):
     async def update_question(
         self, *, question_id: int, title: str | None = None, schedule: dict | None = None, paused: bool | None = None
     ) -> dict[str, Any]:
+        """Update an existing question.
+
+        Args:
+            question_id: The question id.
+            title: The title.
+            schedule: The schedule.
+            paused: The paused.
+        """
         return await self._request(
             OperationInfo(service="checkins", operation="update_question", is_mutation=True, resource_id=question_id),
             "PUT",
@@ -246,6 +410,15 @@ class AsyncCheckinsService(AsyncBaseService):
     async def list_answers(
         self, *, question_id: int, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List all answers for a question.
+
+        Args:
+            question_id: The question id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="checkins", operation="list_answers", is_mutation=False, resource_id=question_id),
             f"/questions/{question_id}/answers.json",
@@ -255,6 +428,13 @@ class AsyncCheckinsService(AsyncBaseService):
         )
 
     async def create_answer(self, *, question_id: int, content: str, group_on: str | None = None) -> dict[str, Any]:
+        """Create a new answer for a question.
+
+        Args:
+            question_id: The question id.
+            content: The content.
+            group_on: The group on.
+        """
         return await self._request(
             OperationInfo(service="checkins", operation="create_answer", is_mutation=True, resource_id=question_id),
             "POST",
@@ -264,6 +444,13 @@ class AsyncCheckinsService(AsyncBaseService):
         )
 
     async def answerers(self, *, question_id: int, max_items: int | None = None) -> ListResult:
+        """List all people who have answered a question (answerers).
+
+        Args:
+            question_id: The question id.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="checkins", operation="answerers", is_mutation=False, resource_id=question_id),
             f"/questions/{question_id}/answers/by.json",
@@ -274,6 +461,16 @@ class AsyncCheckinsService(AsyncBaseService):
     async def by_person(
         self, *, question_id: int, person_id: int, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """Get all answers from a specific person for a question.
+
+        Args:
+            question_id: The question id.
+            person_id: The person id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="checkins", operation="by_person", is_mutation=False, resource_id=person_id),
             f"/questions/{question_id}/answers/by/{person_id}",
@@ -285,6 +482,13 @@ class AsyncCheckinsService(AsyncBaseService):
     async def update_notification_settings(
         self, *, question_id: int, notify_on_answer: bool | None = None, digest_include_unanswered: bool | None = None
     ) -> dict[str, Any]:
+        """Update notification settings for a check-in question.
+
+        Args:
+            question_id: The question id.
+            notify_on_answer: Notify when someone answers
+            digest_include_unanswered: Include unanswered in digest
+        """
         return await self._request(
             OperationInfo(
                 service="checkins", operation="update_notification_settings", is_mutation=True, resource_id=question_id
@@ -298,6 +502,11 @@ class AsyncCheckinsService(AsyncBaseService):
         )
 
     async def pause(self, *, question_id: int) -> dict[str, Any]:
+        """Pause a check-in question (stops sending reminders).
+
+        Args:
+            question_id: The question id.
+        """
         return await self._request(
             OperationInfo(service="checkins", operation="pause", is_mutation=True, resource_id=question_id),
             "POST",
@@ -306,6 +515,11 @@ class AsyncCheckinsService(AsyncBaseService):
         )
 
     async def resume(self, *, question_id: int) -> dict[str, Any]:
+        """Resume a paused check-in question (resumes sending reminders).
+
+        Args:
+            question_id: The question id.
+        """
         return await self._request(
             OperationInfo(service="checkins", operation="resume", is_mutation=True, resource_id=question_id),
             "DELETE",

--- a/python/src/basecamp/generated/services/checkins.py
+++ b/python/src/basecamp/generated/services/checkins.py
@@ -19,9 +19,9 @@ class CheckinsService(BaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="checkins", operation="reminders", is_mutation=False),
@@ -84,9 +84,9 @@ class CheckinsService(BaseService):
             questionnaire_id: The questionnaire id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(
@@ -158,9 +158,9 @@ class CheckinsService(BaseService):
             question_id: The question id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="checkins", operation="list_answers", is_mutation=False, resource_id=question_id),
@@ -191,8 +191,9 @@ class CheckinsService(BaseService):
 
         Args:
             question_id: The question id.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages.
         """
         return self._request_paginated(
             OperationInfo(service="checkins", operation="answerers", is_mutation=False, resource_id=question_id),
@@ -211,9 +212,9 @@ class CheckinsService(BaseService):
             person_id: The person id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="checkins", operation="by_person", is_mutation=False, resource_id=person_id),
@@ -281,9 +282,9 @@ class AsyncCheckinsService(AsyncBaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="checkins", operation="reminders", is_mutation=False),
@@ -346,9 +347,9 @@ class AsyncCheckinsService(AsyncBaseService):
             questionnaire_id: The questionnaire id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(
@@ -422,9 +423,9 @@ class AsyncCheckinsService(AsyncBaseService):
             question_id: The question id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="checkins", operation="list_answers", is_mutation=False, resource_id=question_id),
@@ -455,8 +456,9 @@ class AsyncCheckinsService(AsyncBaseService):
 
         Args:
             question_id: The question id.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages.
         """
         return await self._request_paginated(
             OperationInfo(service="checkins", operation="answerers", is_mutation=False, resource_id=question_id),
@@ -475,9 +477,9 @@ class AsyncCheckinsService(AsyncBaseService):
             person_id: The person id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="checkins", operation="by_person", is_mutation=False, resource_id=person_id),

--- a/python/src/basecamp/generated/services/client_approvals.py
+++ b/python/src/basecamp/generated/services/client_approvals.py
@@ -20,6 +20,17 @@ class ClientApprovalsService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """List all client approvals in a project.
+
+        Args:
+            bucket_id: The bucket id.
+            sort: created_at|updated_at
+            direction: asc|desc
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="clientapprovals", operation="list", is_mutation=False, project_id=bucket_id),
             f"/buckets/{bucket_id}/client/approvals.json",
@@ -29,6 +40,11 @@ class ClientApprovalsService(BaseService):
         )
 
     def get(self, *, approval_id: int) -> dict[str, Any]:
+        """Get a single client approval by id.
+
+        Args:
+            approval_id: The approval id.
+        """
         return self._request(
             OperationInfo(service="clientapprovals", operation="get", is_mutation=False, resource_id=approval_id),
             "GET",
@@ -47,6 +63,17 @@ class AsyncClientApprovalsService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """List all client approvals in a project.
+
+        Args:
+            bucket_id: The bucket id.
+            sort: created_at|updated_at
+            direction: asc|desc
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="clientapprovals", operation="list", is_mutation=False, project_id=bucket_id),
             f"/buckets/{bucket_id}/client/approvals.json",
@@ -56,6 +83,11 @@ class AsyncClientApprovalsService(AsyncBaseService):
         )
 
     async def get(self, *, approval_id: int) -> dict[str, Any]:
+        """Get a single client approval by id.
+
+        Args:
+            approval_id: The approval id.
+        """
         return await self._request(
             OperationInfo(service="clientapprovals", operation="get", is_mutation=False, resource_id=approval_id),
             "GET",

--- a/python/src/basecamp/generated/services/client_approvals.py
+++ b/python/src/basecamp/generated/services/client_approvals.py
@@ -28,8 +28,9 @@ class ClientApprovalsService(BaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="clientapprovals", operation="list", is_mutation=False, project_id=bucket_id),
@@ -71,8 +72,9 @@ class AsyncClientApprovalsService(AsyncBaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="clientapprovals", operation="list", is_mutation=False, project_id=bucket_id),

--- a/python/src/basecamp/generated/services/client_approvals.py
+++ b/python/src/basecamp/generated/services/client_approvals.py
@@ -28,9 +28,9 @@ class ClientApprovalsService(BaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="clientapprovals", operation="list", is_mutation=False, project_id=bucket_id),
@@ -72,9 +72,9 @@ class AsyncClientApprovalsService(AsyncBaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="clientapprovals", operation="list", is_mutation=False, project_id=bucket_id),

--- a/python/src/basecamp/generated/services/client_correspondences.py
+++ b/python/src/basecamp/generated/services/client_correspondences.py
@@ -28,9 +28,9 @@ class ClientCorrespondencesService(BaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="clientcorrespondences", operation="list", is_mutation=False, project_id=bucket_id),
@@ -74,9 +74,9 @@ class AsyncClientCorrespondencesService(AsyncBaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="clientcorrespondences", operation="list", is_mutation=False, project_id=bucket_id),

--- a/python/src/basecamp/generated/services/client_correspondences.py
+++ b/python/src/basecamp/generated/services/client_correspondences.py
@@ -28,8 +28,9 @@ class ClientCorrespondencesService(BaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="clientcorrespondences", operation="list", is_mutation=False, project_id=bucket_id),
@@ -73,8 +74,9 @@ class AsyncClientCorrespondencesService(AsyncBaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="clientcorrespondences", operation="list", is_mutation=False, project_id=bucket_id),

--- a/python/src/basecamp/generated/services/client_correspondences.py
+++ b/python/src/basecamp/generated/services/client_correspondences.py
@@ -20,6 +20,17 @@ class ClientCorrespondencesService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """List all client correspondences in a project.
+
+        Args:
+            bucket_id: The bucket id.
+            sort: created_at|updated_at
+            direction: asc|desc
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="clientcorrespondences", operation="list", is_mutation=False, project_id=bucket_id),
             f"/buckets/{bucket_id}/client/correspondences.json",
@@ -29,6 +40,11 @@ class ClientCorrespondencesService(BaseService):
         )
 
     def get(self, *, correspondence_id: int) -> dict[str, Any]:
+        """Get a single client correspondence by id.
+
+        Args:
+            correspondence_id: The correspondence id.
+        """
         return self._request(
             OperationInfo(
                 service="clientcorrespondences", operation="get", is_mutation=False, resource_id=correspondence_id
@@ -49,6 +65,17 @@ class AsyncClientCorrespondencesService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """List all client correspondences in a project.
+
+        Args:
+            bucket_id: The bucket id.
+            sort: created_at|updated_at
+            direction: asc|desc
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="clientcorrespondences", operation="list", is_mutation=False, project_id=bucket_id),
             f"/buckets/{bucket_id}/client/correspondences.json",
@@ -58,6 +85,11 @@ class AsyncClientCorrespondencesService(AsyncBaseService):
         )
 
     async def get(self, *, correspondence_id: int) -> dict[str, Any]:
+        """Get a single client correspondence by id.
+
+        Args:
+            correspondence_id: The correspondence id.
+        """
         return await self._request(
             OperationInfo(
                 service="clientcorrespondences", operation="get", is_mutation=False, resource_id=correspondence_id

--- a/python/src/basecamp/generated/services/client_replies.py
+++ b/python/src/basecamp/generated/services/client_replies.py
@@ -21,9 +21,9 @@ class ClientRepliesService(BaseService):
             recording_id: The recording id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(
@@ -68,9 +68,9 @@ class AsyncClientRepliesService(AsyncBaseService):
             recording_id: The recording id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(

--- a/python/src/basecamp/generated/services/client_replies.py
+++ b/python/src/basecamp/generated/services/client_replies.py
@@ -21,8 +21,9 @@ class ClientRepliesService(BaseService):
             recording_id: The recording id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(
@@ -67,8 +68,9 @@ class AsyncClientRepliesService(AsyncBaseService):
             recording_id: The recording id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(

--- a/python/src/basecamp/generated/services/client_replies.py
+++ b/python/src/basecamp/generated/services/client_replies.py
@@ -14,6 +14,16 @@ class ClientRepliesService(BaseService):
     def list(
         self, *, bucket_id: int, recording_id: int, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List all client replies for a recording (correspondence or approval).
+
+        Args:
+            bucket_id: The bucket id.
+            recording_id: The recording id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(
                 service="clientreplies",
@@ -29,6 +39,13 @@ class ClientRepliesService(BaseService):
         )
 
     def get(self, *, bucket_id: int, recording_id: int, reply_id: int) -> dict[str, Any]:
+        """Get a single client reply by id.
+
+        Args:
+            bucket_id: The bucket id.
+            recording_id: The recording id.
+            reply_id: The reply id.
+        """
         return self._request(
             OperationInfo(
                 service="clientreplies", operation="get", is_mutation=False, project_id=bucket_id, resource_id=reply_id
@@ -43,6 +60,16 @@ class AsyncClientRepliesService(AsyncBaseService):
     async def list(
         self, *, bucket_id: int, recording_id: int, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List all client replies for a recording (correspondence or approval).
+
+        Args:
+            bucket_id: The bucket id.
+            recording_id: The recording id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(
                 service="clientreplies",
@@ -58,6 +85,13 @@ class AsyncClientRepliesService(AsyncBaseService):
         )
 
     async def get(self, *, bucket_id: int, recording_id: int, reply_id: int) -> dict[str, Any]:
+        """Get a single client reply by id.
+
+        Args:
+            bucket_id: The bucket id.
+            recording_id: The recording id.
+            reply_id: The reply id.
+        """
         return await self._request(
             OperationInfo(
                 service="clientreplies", operation="get", is_mutation=False, project_id=bucket_id, resource_id=reply_id

--- a/python/src/basecamp/generated/services/client_visibility.py
+++ b/python/src/basecamp/generated/services/client_visibility.py
@@ -12,6 +12,12 @@ from basecamp.hooks import OperationInfo
 
 class ClientVisibilityService(BaseService):
     def set_visibility(self, *, recording_id: int, visible_to_clients: bool) -> dict[str, Any]:
+        """Set client visibility for a recording.
+
+        Args:
+            recording_id: The recording id.
+            visible_to_clients: The visible to clients.
+        """
         return self._request(
             OperationInfo(
                 service="clientvisibility", operation="set_visibility", is_mutation=True, resource_id=recording_id
@@ -25,6 +31,12 @@ class ClientVisibilityService(BaseService):
 
 class AsyncClientVisibilityService(AsyncBaseService):
     async def set_visibility(self, *, recording_id: int, visible_to_clients: bool) -> dict[str, Any]:
+        """Set client visibility for a recording.
+
+        Args:
+            recording_id: The recording id.
+            visible_to_clients: The visible to clients.
+        """
         return await self._request(
             OperationInfo(
                 service="clientvisibility", operation="set_visibility", is_mutation=True, resource_id=recording_id

--- a/python/src/basecamp/generated/services/cloud_files.py
+++ b/python/src/basecamp/generated/services/cloud_files.py
@@ -23,6 +23,27 @@ class CloudFilesService(BaseService):
         subscriptions: list[int] | None = None,
         visible_to_clients: bool | None = None,
     ) -> dict[str, Any]:
+        """Create a new cloud file in a vault.
+        `url` is validated against the selected service's patterns, so it must be a
+        real link for that service; use service "other" for anything that matches no
+        recognized service. Omitting `title` is allowed and reads back as
+        "Untitled".
+
+        Args:
+            bucket_id: The bucket id.
+            vault_id: The vault id.
+            url: The url.
+            service: Short identifier for the external service — "dropbox", "google_doc", "figma",
+                "other", … Derived from the CloudFile::Service subclass name, so it is always
+                present. `other` accepts any well-formed HTTPS URL.
+            title: The title.
+            description: The description.
+            subscriptions: The subscriptions.
+            visible_to_clients: Whether the cloud file is visible to the project's clients. Applies
+                only when creating directly in the tool's vault — an item created inside a folder
+                inherits the folder's visibility and ignores this. A client caller always creates
+                client-visible records regardless of what is sent.
+        """
         return self._request(
             OperationInfo(
                 service="cloudfiles",
@@ -45,6 +66,11 @@ class CloudFilesService(BaseService):
         )
 
     def get_cloud_file(self, *, cloud_file_id: int) -> dict[str, Any]:
+        """Get a single cloud file by id.
+
+        Args:
+            cloud_file_id: The cloud file id.
+        """
         return self._request(
             OperationInfo(
                 service="cloudfiles", operation="get_cloud_file", is_mutation=False, resource_id=cloud_file_id
@@ -64,6 +90,30 @@ class CloudFilesService(BaseService):
         description: str | None = None,
         subscriptions: list[int] | None = None,
     ) -> dict[str, Any]:
+        """Replace a cloud file with a new complete representation.
+        BC3 builds a brand-new CloudFile from the permitted params and swaps the
+        recordable wholesale, so the request body is the full writable state:
+        omitting `title` clears it (and the cloud file then reads back as
+        "Untitled"), and omitting `description` clears it. `url` and `service` carry
+        presence/format validations, so they are required here rather than
+        clearable — a request without them is a 422, not a silent wipe.
+        Updating a drafted cloud file also publishes it.
+        Subscribers are the exception to omission-clears: a drafted cloud file keeps
+        its current subscribers when the request addresses neither `subscriptions`
+        nor `notify`. The creator is always on the list.
+        The legacy bucket-scoped path PUT /buckets/{bucketId}/cloud_files/{id}.json
+        is also accepted by BC3; this flat spelling is the documented one.
+
+        Args:
+            cloud_file_id: The cloud file id.
+            url: The url.
+            service: Short identifier for the external service — "dropbox", "google_doc", "figma",
+                "other", … Derived from the CloudFile::Service subclass name, so it is always
+                present. `other` accepts any well-formed HTTPS URL.
+            title: The title.
+            description: The description.
+            subscriptions: The subscriptions.
+        """
         return self._request(
             OperationInfo(
                 service="cloudfiles", operation="update_cloud_file", is_mutation=True, resource_id=cloud_file_id
@@ -90,6 +140,27 @@ class AsyncCloudFilesService(AsyncBaseService):
         subscriptions: list[int] | None = None,
         visible_to_clients: bool | None = None,
     ) -> dict[str, Any]:
+        """Create a new cloud file in a vault.
+        `url` is validated against the selected service's patterns, so it must be a
+        real link for that service; use service "other" for anything that matches no
+        recognized service. Omitting `title` is allowed and reads back as
+        "Untitled".
+
+        Args:
+            bucket_id: The bucket id.
+            vault_id: The vault id.
+            url: The url.
+            service: Short identifier for the external service — "dropbox", "google_doc", "figma",
+                "other", … Derived from the CloudFile::Service subclass name, so it is always
+                present. `other` accepts any well-formed HTTPS URL.
+            title: The title.
+            description: The description.
+            subscriptions: The subscriptions.
+            visible_to_clients: Whether the cloud file is visible to the project's clients. Applies
+                only when creating directly in the tool's vault — an item created inside a folder
+                inherits the folder's visibility and ignores this. A client caller always creates
+                client-visible records regardless of what is sent.
+        """
         return await self._request(
             OperationInfo(
                 service="cloudfiles",
@@ -112,6 +183,11 @@ class AsyncCloudFilesService(AsyncBaseService):
         )
 
     async def get_cloud_file(self, *, cloud_file_id: int) -> dict[str, Any]:
+        """Get a single cloud file by id.
+
+        Args:
+            cloud_file_id: The cloud file id.
+        """
         return await self._request(
             OperationInfo(
                 service="cloudfiles", operation="get_cloud_file", is_mutation=False, resource_id=cloud_file_id
@@ -131,6 +207,30 @@ class AsyncCloudFilesService(AsyncBaseService):
         description: str | None = None,
         subscriptions: list[int] | None = None,
     ) -> dict[str, Any]:
+        """Replace a cloud file with a new complete representation.
+        BC3 builds a brand-new CloudFile from the permitted params and swaps the
+        recordable wholesale, so the request body is the full writable state:
+        omitting `title` clears it (and the cloud file then reads back as
+        "Untitled"), and omitting `description` clears it. `url` and `service` carry
+        presence/format validations, so they are required here rather than
+        clearable — a request without them is a 422, not a silent wipe.
+        Updating a drafted cloud file also publishes it.
+        Subscribers are the exception to omission-clears: a drafted cloud file keeps
+        its current subscribers when the request addresses neither `subscriptions`
+        nor `notify`. The creator is always on the list.
+        The legacy bucket-scoped path PUT /buckets/{bucketId}/cloud_files/{id}.json
+        is also accepted by BC3; this flat spelling is the documented one.
+
+        Args:
+            cloud_file_id: The cloud file id.
+            url: The url.
+            service: Short identifier for the external service — "dropbox", "google_doc", "figma",
+                "other", … Derived from the CloudFile::Service subclass name, so it is always
+                present. `other` accepts any well-formed HTTPS URL.
+            title: The title.
+            description: The description.
+            subscriptions: The subscriptions.
+        """
         return await self._request(
             OperationInfo(
                 service="cloudfiles", operation="update_cloud_file", is_mutation=True, resource_id=cloud_file_id

--- a/python/src/basecamp/generated/services/comments.py
+++ b/python/src/basecamp/generated/services/comments.py
@@ -46,8 +46,9 @@ class CommentsService(BaseService):
             recording_id: The recording id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="comments", operation="list", is_mutation=False, resource_id=recording_id),
@@ -109,8 +110,9 @@ class AsyncCommentsService(AsyncBaseService):
             recording_id: The recording id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="comments", operation="list", is_mutation=False, resource_id=recording_id),

--- a/python/src/basecamp/generated/services/comments.py
+++ b/python/src/basecamp/generated/services/comments.py
@@ -12,6 +12,11 @@ from basecamp.hooks import OperationInfo
 
 class CommentsService(BaseService):
     def get(self, *, comment_id: int) -> dict[str, Any]:
+        """Get a single comment by id.
+
+        Args:
+            comment_id: The comment id.
+        """
         return self._request(
             OperationInfo(service="comments", operation="get", is_mutation=False, resource_id=comment_id),
             "GET",
@@ -20,6 +25,12 @@ class CommentsService(BaseService):
         )
 
     def update(self, *, comment_id: int, content: str) -> dict[str, Any]:
+        """Update an existing comment.
+
+        Args:
+            comment_id: The comment id.
+            content: The content.
+        """
         return self._request(
             OperationInfo(service="comments", operation="update", is_mutation=True, resource_id=comment_id),
             "PUT",
@@ -29,6 +40,15 @@ class CommentsService(BaseService):
         )
 
     def list(self, *, recording_id: int, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List comments on a recording.
+
+        Args:
+            recording_id: The recording id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="comments", operation="list", is_mutation=False, resource_id=recording_id),
             f"/recordings/{recording_id}/comments.json",
@@ -38,6 +58,12 @@ class CommentsService(BaseService):
         )
 
     def create(self, *, recording_id: int, content: str) -> dict[str, Any]:
+        """Create a new comment on a recording.
+
+        Args:
+            recording_id: The recording id.
+            content: The content.
+        """
         return self._request(
             OperationInfo(service="comments", operation="create", is_mutation=True, resource_id=recording_id),
             "POST",
@@ -49,6 +75,11 @@ class CommentsService(BaseService):
 
 class AsyncCommentsService(AsyncBaseService):
     async def get(self, *, comment_id: int) -> dict[str, Any]:
+        """Get a single comment by id.
+
+        Args:
+            comment_id: The comment id.
+        """
         return await self._request(
             OperationInfo(service="comments", operation="get", is_mutation=False, resource_id=comment_id),
             "GET",
@@ -57,6 +88,12 @@ class AsyncCommentsService(AsyncBaseService):
         )
 
     async def update(self, *, comment_id: int, content: str) -> dict[str, Any]:
+        """Update an existing comment.
+
+        Args:
+            comment_id: The comment id.
+            content: The content.
+        """
         return await self._request(
             OperationInfo(service="comments", operation="update", is_mutation=True, resource_id=comment_id),
             "PUT",
@@ -66,6 +103,15 @@ class AsyncCommentsService(AsyncBaseService):
         )
 
     async def list(self, *, recording_id: int, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List comments on a recording.
+
+        Args:
+            recording_id: The recording id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="comments", operation="list", is_mutation=False, resource_id=recording_id),
             f"/recordings/{recording_id}/comments.json",
@@ -75,6 +121,12 @@ class AsyncCommentsService(AsyncBaseService):
         )
 
     async def create(self, *, recording_id: int, content: str) -> dict[str, Any]:
+        """Create a new comment on a recording.
+
+        Args:
+            recording_id: The recording id.
+            content: The content.
+        """
         return await self._request(
             OperationInfo(service="comments", operation="create", is_mutation=True, resource_id=recording_id),
             "POST",

--- a/python/src/basecamp/generated/services/comments.py
+++ b/python/src/basecamp/generated/services/comments.py
@@ -46,9 +46,9 @@ class CommentsService(BaseService):
             recording_id: The recording id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="comments", operation="list", is_mutation=False, resource_id=recording_id),
@@ -110,9 +110,9 @@ class AsyncCommentsService(AsyncBaseService):
             recording_id: The recording id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="comments", operation="list", is_mutation=False, resource_id=recording_id),

--- a/python/src/basecamp/generated/services/documents.py
+++ b/python/src/basecamp/generated/services/documents.py
@@ -12,6 +12,11 @@ from basecamp.hooks import OperationInfo
 
 class DocumentsService(BaseService):
     def get(self, *, document_id: int) -> dict[str, Any]:
+        """Get a single document by id.
+
+        Args:
+            document_id: The document id.
+        """
         return self._request(
             OperationInfo(service="documents", operation="get", is_mutation=False, resource_id=document_id),
             "GET",
@@ -20,6 +25,34 @@ class DocumentsService(BaseService):
         )
 
     def replace(self, *, document_id: int, title: str | None = None, content: str | None = None) -> dict[str, Any]:
+        """Replace a document with a new complete representation.
+        The request body is the document's full writable state: any writable field
+        omitted from the request is cleared server-side. Omitting content clears it;
+        omitting title clears it too, and the document then reads back as
+        "Untitled" (Document#title falls back when blank).
+        Neither field is required. BC3 builds a brand-new Document from the
+        permitted params and swaps the recordable wholesale, and neither attribute
+        carries a presence validation — so an omission is a 200 that clears, not a
+        422. What BC3 does require is the wrapping document object, which Rails
+        synthesizes from a flat body, so a request naming neither field is a 400.
+        Publishing a draft (status: "active") is not modeled: the SDK sends only
+        title and content, and BC3 rejects a status-only update for the same
+        reason it 400s an empty body.
+        Subscribers are the one exception to omission-clears. A drafted document
+        keeps its current subscribers when the request addresses neither
+        subscriptions nor notify, so a full-representation PUT that mentions
+        neither is safe on a draft.
+        To set some fields while preserving the rest, use the SDK's merge-safe
+        update or edit methods, which GET the current document and PUT the full
+        representation back. Those read-modify-write helpers are not atomic:
+        a concurrent write between the GET and PUT is overwritten (last write
+        wins for the whole representation; the window is one round-trip).
+
+        Args:
+            document_id: The document id.
+            title: The title.
+            content: The content.
+        """
         return self._request(
             OperationInfo(service="documents", operation="replace", is_mutation=True, resource_id=document_id),
             "PUT",
@@ -29,6 +62,15 @@ class DocumentsService(BaseService):
         )
 
     def list(self, *, vault_id: int, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List documents in a vault.
+
+        Args:
+            vault_id: The vault id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="documents", operation="list", is_mutation=False, resource_id=vault_id),
             f"/vaults/{vault_id}/documents.json",
@@ -47,6 +89,16 @@ class DocumentsService(BaseService):
         subscriptions: list[int] | None = None,
         visible_to_clients: bool | None = None,
     ) -> dict[str, Any]:
+        """Create a new document in a vault.
+
+        Args:
+            vault_id: The vault id.
+            title: The title.
+            content: The content.
+            status: active|drafted
+            subscriptions: The subscriptions.
+            visible_to_clients: The visible to clients.
+        """
         return self._request(
             OperationInfo(service="documents", operation="create", is_mutation=True, resource_id=vault_id),
             "POST",
@@ -64,6 +116,11 @@ class DocumentsService(BaseService):
 
 class AsyncDocumentsService(AsyncBaseService):
     async def get(self, *, document_id: int) -> dict[str, Any]:
+        """Get a single document by id.
+
+        Args:
+            document_id: The document id.
+        """
         return await self._request(
             OperationInfo(service="documents", operation="get", is_mutation=False, resource_id=document_id),
             "GET",
@@ -74,6 +131,34 @@ class AsyncDocumentsService(AsyncBaseService):
     async def replace(
         self, *, document_id: int, title: str | None = None, content: str | None = None
     ) -> dict[str, Any]:
+        """Replace a document with a new complete representation.
+        The request body is the document's full writable state: any writable field
+        omitted from the request is cleared server-side. Omitting content clears it;
+        omitting title clears it too, and the document then reads back as
+        "Untitled" (Document#title falls back when blank).
+        Neither field is required. BC3 builds a brand-new Document from the
+        permitted params and swaps the recordable wholesale, and neither attribute
+        carries a presence validation — so an omission is a 200 that clears, not a
+        422. What BC3 does require is the wrapping document object, which Rails
+        synthesizes from a flat body, so a request naming neither field is a 400.
+        Publishing a draft (status: "active") is not modeled: the SDK sends only
+        title and content, and BC3 rejects a status-only update for the same
+        reason it 400s an empty body.
+        Subscribers are the one exception to omission-clears. A drafted document
+        keeps its current subscribers when the request addresses neither
+        subscriptions nor notify, so a full-representation PUT that mentions
+        neither is safe on a draft.
+        To set some fields while preserving the rest, use the SDK's merge-safe
+        update or edit methods, which GET the current document and PUT the full
+        representation back. Those read-modify-write helpers are not atomic:
+        a concurrent write between the GET and PUT is overwritten (last write
+        wins for the whole representation; the window is one round-trip).
+
+        Args:
+            document_id: The document id.
+            title: The title.
+            content: The content.
+        """
         return await self._request(
             OperationInfo(service="documents", operation="replace", is_mutation=True, resource_id=document_id),
             "PUT",
@@ -83,6 +168,15 @@ class AsyncDocumentsService(AsyncBaseService):
         )
 
     async def list(self, *, vault_id: int, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List documents in a vault.
+
+        Args:
+            vault_id: The vault id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="documents", operation="list", is_mutation=False, resource_id=vault_id),
             f"/vaults/{vault_id}/documents.json",
@@ -101,6 +195,16 @@ class AsyncDocumentsService(AsyncBaseService):
         subscriptions: list[int] | None = None,
         visible_to_clients: bool | None = None,
     ) -> dict[str, Any]:
+        """Create a new document in a vault.
+
+        Args:
+            vault_id: The vault id.
+            title: The title.
+            content: The content.
+            status: active|drafted
+            subscriptions: The subscriptions.
+            visible_to_clients: The visible to clients.
+        """
         return await self._request(
             OperationInfo(service="documents", operation="create", is_mutation=True, resource_id=vault_id),
             "POST",

--- a/python/src/basecamp/generated/services/documents.py
+++ b/python/src/basecamp/generated/services/documents.py
@@ -68,9 +68,9 @@ class DocumentsService(BaseService):
             vault_id: The vault id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="documents", operation="list", is_mutation=False, resource_id=vault_id),
@@ -175,9 +175,9 @@ class AsyncDocumentsService(AsyncBaseService):
             vault_id: The vault id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="documents", operation="list", is_mutation=False, resource_id=vault_id),

--- a/python/src/basecamp/generated/services/documents.py
+++ b/python/src/basecamp/generated/services/documents.py
@@ -68,8 +68,9 @@ class DocumentsService(BaseService):
             vault_id: The vault id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="documents", operation="list", is_mutation=False, resource_id=vault_id),
@@ -174,8 +175,9 @@ class AsyncDocumentsService(AsyncBaseService):
             vault_id: The vault id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="documents", operation="list", is_mutation=False, resource_id=vault_id),

--- a/python/src/basecamp/generated/services/drafts.py
+++ b/python/src/basecamp/generated/services/drafts.py
@@ -21,8 +21,9 @@ class DraftsService(BaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="drafts", operation="list_my_drafts", is_mutation=False),
@@ -44,8 +45,9 @@ class AsyncDraftsService(AsyncBaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="drafts", operation="list_my_drafts", is_mutation=False),

--- a/python/src/basecamp/generated/services/drafts.py
+++ b/python/src/basecamp/generated/services/drafts.py
@@ -12,6 +12,18 @@ from basecamp.hooks import OperationInfo
 
 class DraftsService(BaseService):
     def list_my_drafts(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List the current user's drafts across their active projects, most recently
+        updated first (paginated, capped at 250 like /my/assignments). Five draft
+        kinds are returned: messages, documents, uploads, client approvals, and
+        client correspondences. Drafts under archived or trashed projects are
+        excluded.
+
+        Args:
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="drafts", operation="list_my_drafts", is_mutation=False),
             "/my/drafts.json",
@@ -23,6 +35,18 @@ class DraftsService(BaseService):
 
 class AsyncDraftsService(AsyncBaseService):
     async def list_my_drafts(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List the current user's drafts across their active projects, most recently
+        updated first (paginated, capped at 250 like /my/assignments). Five draft
+        kinds are returned: messages, documents, uploads, client approvals, and
+        client correspondences. Drafts under archived or trashed projects are
+        excluded.
+
+        Args:
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="drafts", operation="list_my_drafts", is_mutation=False),
             "/my/drafts.json",

--- a/python/src/basecamp/generated/services/drafts.py
+++ b/python/src/basecamp/generated/services/drafts.py
@@ -21,9 +21,9 @@ class DraftsService(BaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="drafts", operation="list_my_drafts", is_mutation=False),
@@ -45,9 +45,9 @@ class AsyncDraftsService(AsyncBaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="drafts", operation="list_my_drafts", is_mutation=False),

--- a/python/src/basecamp/generated/services/events.py
+++ b/python/src/basecamp/generated/services/events.py
@@ -18,9 +18,9 @@ class EventsService(BaseService):
             recording_id: The recording id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="events", operation="list", is_mutation=False, resource_id=recording_id),
@@ -39,9 +39,9 @@ class AsyncEventsService(AsyncBaseService):
             recording_id: The recording id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="events", operation="list", is_mutation=False, resource_id=recording_id),

--- a/python/src/basecamp/generated/services/events.py
+++ b/python/src/basecamp/generated/services/events.py
@@ -18,8 +18,9 @@ class EventsService(BaseService):
             recording_id: The recording id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="events", operation="list", is_mutation=False, resource_id=recording_id),
@@ -38,8 +39,9 @@ class AsyncEventsService(AsyncBaseService):
             recording_id: The recording id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="events", operation="list", is_mutation=False, resource_id=recording_id),

--- a/python/src/basecamp/generated/services/events.py
+++ b/python/src/basecamp/generated/services/events.py
@@ -12,6 +12,15 @@ from basecamp.hooks import OperationInfo
 
 class EventsService(BaseService):
     def list(self, *, recording_id: int, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List all events for a recording.
+
+        Args:
+            recording_id: The recording id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="events", operation="list", is_mutation=False, resource_id=recording_id),
             f"/recordings/{recording_id}/events.json",
@@ -23,6 +32,15 @@ class EventsService(BaseService):
 
 class AsyncEventsService(AsyncBaseService):
     async def list(self, *, recording_id: int, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List all events for a recording.
+
+        Args:
+            recording_id: The recording id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="events", operation="list", is_mutation=False, resource_id=recording_id),
             f"/recordings/{recording_id}/events.json",

--- a/python/src/basecamp/generated/services/everything.py
+++ b/python/src/basecamp/generated/services/everything.py
@@ -27,8 +27,9 @@ class EverythingService(BaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_completed_cards", is_mutation=False),
@@ -56,8 +57,9 @@ class EverythingService(BaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_no_due_date_cards", is_mutation=False),
@@ -85,8 +87,9 @@ class EverythingService(BaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_not_now_cards", is_mutation=False),
@@ -115,8 +118,9 @@ class EverythingService(BaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_open_cards", is_mutation=False),
@@ -162,8 +166,9 @@ class EverythingService(BaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_unassigned_cards", is_mutation=False),
@@ -182,8 +187,9 @@ class EverythingService(BaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_checkins", is_mutation=False),
@@ -200,8 +206,9 @@ class EverythingService(BaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_comments", is_mutation=False),
@@ -231,8 +238,9 @@ class EverythingService(BaseService):
             people_ids: Restrict to files created by the given people (repeatable).
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_files", is_mutation=False),
@@ -249,8 +257,9 @@ class EverythingService(BaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_forwards", is_mutation=False),
@@ -267,8 +276,9 @@ class EverythingService(BaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_messages", is_mutation=False),
@@ -294,8 +304,9 @@ class EverythingService(BaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_completed_todos", is_mutation=False),
@@ -323,8 +334,9 @@ class EverythingService(BaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_no_due_date_todos", is_mutation=False),
@@ -353,8 +365,9 @@ class EverythingService(BaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_open_todos", is_mutation=False),
@@ -400,8 +413,9 @@ class EverythingService(BaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_unassigned_todos", is_mutation=False),
@@ -431,8 +445,9 @@ class AsyncEverythingService(AsyncBaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_completed_cards", is_mutation=False),
@@ -460,8 +475,9 @@ class AsyncEverythingService(AsyncBaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_no_due_date_cards", is_mutation=False),
@@ -489,8 +505,9 @@ class AsyncEverythingService(AsyncBaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_not_now_cards", is_mutation=False),
@@ -519,8 +536,9 @@ class AsyncEverythingService(AsyncBaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_open_cards", is_mutation=False),
@@ -566,8 +584,9 @@ class AsyncEverythingService(AsyncBaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_unassigned_cards", is_mutation=False),
@@ -586,8 +605,9 @@ class AsyncEverythingService(AsyncBaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_checkins", is_mutation=False),
@@ -604,8 +624,9 @@ class AsyncEverythingService(AsyncBaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_comments", is_mutation=False),
@@ -635,8 +656,9 @@ class AsyncEverythingService(AsyncBaseService):
             people_ids: Restrict to files created by the given people (repeatable).
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_files", is_mutation=False),
@@ -653,8 +675,9 @@ class AsyncEverythingService(AsyncBaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_forwards", is_mutation=False),
@@ -671,8 +694,9 @@ class AsyncEverythingService(AsyncBaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_messages", is_mutation=False),
@@ -698,8 +722,9 @@ class AsyncEverythingService(AsyncBaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_completed_todos", is_mutation=False),
@@ -727,8 +752,9 @@ class AsyncEverythingService(AsyncBaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_no_due_date_todos", is_mutation=False),
@@ -757,8 +783,9 @@ class AsyncEverythingService(AsyncBaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_open_todos", is_mutation=False),
@@ -804,8 +831,9 @@ class AsyncEverythingService(AsyncBaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_unassigned_todos", is_mutation=False),

--- a/python/src/basecamp/generated/services/everything.py
+++ b/python/src/basecamp/generated/services/everything.py
@@ -27,9 +27,9 @@ class EverythingService(BaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_completed_cards", is_mutation=False),
@@ -57,9 +57,9 @@ class EverythingService(BaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_no_due_date_cards", is_mutation=False),
@@ -87,9 +87,9 @@ class EverythingService(BaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_not_now_cards", is_mutation=False),
@@ -118,9 +118,9 @@ class EverythingService(BaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_open_cards", is_mutation=False),
@@ -166,9 +166,9 @@ class EverythingService(BaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_unassigned_cards", is_mutation=False),
@@ -187,9 +187,9 @@ class EverythingService(BaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_checkins", is_mutation=False),
@@ -206,9 +206,9 @@ class EverythingService(BaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_comments", is_mutation=False),
@@ -238,9 +238,9 @@ class EverythingService(BaseService):
             people_ids: Restrict to files created by the given people (repeatable).
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_files", is_mutation=False),
@@ -257,9 +257,9 @@ class EverythingService(BaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_forwards", is_mutation=False),
@@ -276,9 +276,9 @@ class EverythingService(BaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_messages", is_mutation=False),
@@ -304,9 +304,9 @@ class EverythingService(BaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_completed_todos", is_mutation=False),
@@ -334,9 +334,9 @@ class EverythingService(BaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_no_due_date_todos", is_mutation=False),
@@ -365,9 +365,9 @@ class EverythingService(BaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_open_todos", is_mutation=False),
@@ -413,9 +413,9 @@ class EverythingService(BaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_unassigned_todos", is_mutation=False),
@@ -445,9 +445,9 @@ class AsyncEverythingService(AsyncBaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_completed_cards", is_mutation=False),
@@ -475,9 +475,9 @@ class AsyncEverythingService(AsyncBaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_no_due_date_cards", is_mutation=False),
@@ -505,9 +505,9 @@ class AsyncEverythingService(AsyncBaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_not_now_cards", is_mutation=False),
@@ -536,9 +536,9 @@ class AsyncEverythingService(AsyncBaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_open_cards", is_mutation=False),
@@ -584,9 +584,9 @@ class AsyncEverythingService(AsyncBaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_unassigned_cards", is_mutation=False),
@@ -605,9 +605,9 @@ class AsyncEverythingService(AsyncBaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_checkins", is_mutation=False),
@@ -624,9 +624,9 @@ class AsyncEverythingService(AsyncBaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_comments", is_mutation=False),
@@ -656,9 +656,9 @@ class AsyncEverythingService(AsyncBaseService):
             people_ids: Restrict to files created by the given people (repeatable).
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_files", is_mutation=False),
@@ -675,9 +675,9 @@ class AsyncEverythingService(AsyncBaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_forwards", is_mutation=False),
@@ -694,9 +694,9 @@ class AsyncEverythingService(AsyncBaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_messages", is_mutation=False),
@@ -722,9 +722,9 @@ class AsyncEverythingService(AsyncBaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_completed_todos", is_mutation=False),
@@ -752,9 +752,9 @@ class AsyncEverythingService(AsyncBaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_no_due_date_todos", is_mutation=False),
@@ -783,9 +783,9 @@ class AsyncEverythingService(AsyncBaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_open_todos", is_mutation=False),
@@ -831,9 +831,9 @@ class AsyncEverythingService(AsyncBaseService):
             due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_unassigned_todos", is_mutation=False),

--- a/python/src/basecamp/generated/services/everything.py
+++ b/python/src/basecamp/generated/services/everything.py
@@ -19,6 +19,17 @@ class EverythingService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Completed cards across all accessible projects, grouped by project (paginated).
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_completed_cards", is_mutation=False),
             "/cards/completed.json",
@@ -37,6 +48,17 @@ class EverythingService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Open cards with no due date across all accessible projects, grouped by project (paginated).
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_no_due_date_cards", is_mutation=False),
             "/cards/no_due_date.json",
@@ -55,6 +77,17 @@ class EverythingService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Cards parked in a project's "Not now" column across all accessible projects, grouped by project (paginated).
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_not_now_cards", is_mutation=False),
             "/cards/not_now.json",
@@ -73,6 +106,18 @@ class EverythingService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Incomplete cards in active columns across all accessible projects, grouped by project (paginated).
+        Each bucket entry carries the matching cards and their steps.
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_open_cards", is_mutation=False),
             "/cards/open.json",
@@ -86,6 +131,14 @@ class EverythingService(BaseService):
     def get_everything_overdue_cards(
         self, *, assignee_ids: list[int] | None = None, due: str | None = None
     ) -> ListResult:
+        """Get every overdue card across all accessible projects, oldest-due-date-first.
+        A complete, unpaginated array; each item embeds its `bucket`.
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+        """
         return self._request_list(
             OperationInfo(service="everything", operation="get_everything_overdue_cards", is_mutation=False),
             "/cards/overdue.json",
@@ -101,6 +154,17 @@ class EverythingService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Open, unassigned cards across all accessible projects, grouped by project (paginated).
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_unassigned_cards", is_mutation=False),
             "/cards/unassigned.json",
@@ -112,6 +176,15 @@ class EverythingService(BaseService):
         )
 
     def get_everything_checkins(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """Get every automatic check-in answer across all accessible projects, newest-first.
+        Paginated; each item embeds its `bucket`.
+
+        Args:
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_checkins", is_mutation=False),
             "/checkins.json",
@@ -121,6 +194,15 @@ class EverythingService(BaseService):
         )
 
     def get_everything_comments(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """Get every comment across all accessible projects, newest-first (paginated).
+        Each item embeds its `bucket`.
+
+        Args:
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_comments", is_mutation=False),
             "/comments.json",
@@ -137,6 +219,21 @@ class EverythingService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Get every file recording across all accessible projects, newest-first (paginated).
+        Heterogeneous: uploads and Basecamp documents carry their
+        standard recording shapes, while rich-text attachments are wrapped in a
+        recording envelope plus an `attachable_sgid` and blob metadata. Modeled as
+        an optional-field superset (EverythingFile) so one element type decodes any
+        variant.
+
+        Args:
+            kind: Filter by file kind: all (default), images, pdfs, documents, or videos.
+            people_ids: Restrict to files created by the given people (repeatable).
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_files", is_mutation=False),
             "/files.json",
@@ -146,6 +243,15 @@ class EverythingService(BaseService):
         )
 
     def get_everything_forwards(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """Get every inbox forward across all accessible projects, newest-first (paginated).
+        Each item embeds its `bucket`.
+
+        Args:
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_forwards", is_mutation=False),
             "/forwards.json",
@@ -155,6 +261,15 @@ class EverythingService(BaseService):
         )
 
     def get_everything_messages(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """Get every message across all accessible projects, newest-first (paginated).
+        Each item embeds its `bucket` for project context.
+
+        Args:
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_messages", is_mutation=False),
             "/messages.json",
@@ -171,6 +286,17 @@ class EverythingService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Completed to-dos across all accessible projects, grouped by project (paginated).
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_completed_todos", is_mutation=False),
             "/todos/completed.json",
@@ -189,6 +315,17 @@ class EverythingService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Open to-dos with no due date across all accessible projects, grouped by project (paginated).
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_no_due_date_todos", is_mutation=False),
             "/todos/no_due_date.json",
@@ -207,6 +344,18 @@ class EverythingService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Active, incomplete to-dos across all accessible projects, grouped by project (paginated).
+        Each bucket entry carries the matching to-dos and their steps.
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_open_todos", is_mutation=False),
             "/todos/open.json",
@@ -220,6 +369,14 @@ class EverythingService(BaseService):
     def get_everything_overdue_todos(
         self, *, assignee_ids: list[int] | None = None, due: str | None = None
     ) -> ListResult:
+        """Get every overdue to-do across all accessible projects, oldest-due-date-first.
+        A complete, unpaginated array; each item embeds its `bucket`.
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+        """
         return self._request_list(
             OperationInfo(service="everything", operation="get_everything_overdue_todos", is_mutation=False),
             "/todos/overdue.json",
@@ -235,6 +392,17 @@ class EverythingService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Open, unassigned to-dos across all accessible projects, grouped by project (paginated).
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_unassigned_todos", is_mutation=False),
             "/todos/unassigned.json",
@@ -255,6 +423,17 @@ class AsyncEverythingService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Completed cards across all accessible projects, grouped by project (paginated).
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_completed_cards", is_mutation=False),
             "/cards/completed.json",
@@ -273,6 +452,17 @@ class AsyncEverythingService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Open cards with no due date across all accessible projects, grouped by project (paginated).
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_no_due_date_cards", is_mutation=False),
             "/cards/no_due_date.json",
@@ -291,6 +481,17 @@ class AsyncEverythingService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Cards parked in a project's "Not now" column across all accessible projects, grouped by project (paginated).
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_not_now_cards", is_mutation=False),
             "/cards/not_now.json",
@@ -309,6 +510,18 @@ class AsyncEverythingService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Incomplete cards in active columns across all accessible projects, grouped by project (paginated).
+        Each bucket entry carries the matching cards and their steps.
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_open_cards", is_mutation=False),
             "/cards/open.json",
@@ -322,6 +535,14 @@ class AsyncEverythingService(AsyncBaseService):
     async def get_everything_overdue_cards(
         self, *, assignee_ids: list[int] | None = None, due: str | None = None
     ) -> ListResult:
+        """Get every overdue card across all accessible projects, oldest-due-date-first.
+        A complete, unpaginated array; each item embeds its `bucket`.
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+        """
         return await self._request_list(
             OperationInfo(service="everything", operation="get_everything_overdue_cards", is_mutation=False),
             "/cards/overdue.json",
@@ -337,6 +558,17 @@ class AsyncEverythingService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Open, unassigned cards across all accessible projects, grouped by project (paginated).
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_unassigned_cards", is_mutation=False),
             "/cards/unassigned.json",
@@ -348,6 +580,15 @@ class AsyncEverythingService(AsyncBaseService):
         )
 
     async def get_everything_checkins(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """Get every automatic check-in answer across all accessible projects, newest-first.
+        Paginated; each item embeds its `bucket`.
+
+        Args:
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_checkins", is_mutation=False),
             "/checkins.json",
@@ -357,6 +598,15 @@ class AsyncEverythingService(AsyncBaseService):
         )
 
     async def get_everything_comments(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """Get every comment across all accessible projects, newest-first (paginated).
+        Each item embeds its `bucket`.
+
+        Args:
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_comments", is_mutation=False),
             "/comments.json",
@@ -373,6 +623,21 @@ class AsyncEverythingService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Get every file recording across all accessible projects, newest-first (paginated).
+        Heterogeneous: uploads and Basecamp documents carry their
+        standard recording shapes, while rich-text attachments are wrapped in a
+        recording envelope plus an `attachable_sgid` and blob metadata. Modeled as
+        an optional-field superset (EverythingFile) so one element type decodes any
+        variant.
+
+        Args:
+            kind: Filter by file kind: all (default), images, pdfs, documents, or videos.
+            people_ids: Restrict to files created by the given people (repeatable).
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_files", is_mutation=False),
             "/files.json",
@@ -382,6 +647,15 @@ class AsyncEverythingService(AsyncBaseService):
         )
 
     async def get_everything_forwards(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """Get every inbox forward across all accessible projects, newest-first (paginated).
+        Each item embeds its `bucket`.
+
+        Args:
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_forwards", is_mutation=False),
             "/forwards.json",
@@ -391,6 +665,15 @@ class AsyncEverythingService(AsyncBaseService):
         )
 
     async def get_everything_messages(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """Get every message across all accessible projects, newest-first (paginated).
+        Each item embeds its `bucket` for project context.
+
+        Args:
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_messages", is_mutation=False),
             "/messages.json",
@@ -407,6 +690,17 @@ class AsyncEverythingService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Completed to-dos across all accessible projects, grouped by project (paginated).
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_completed_todos", is_mutation=False),
             "/todos/completed.json",
@@ -425,6 +719,17 @@ class AsyncEverythingService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Open to-dos with no due date across all accessible projects, grouped by project (paginated).
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_no_due_date_todos", is_mutation=False),
             "/todos/no_due_date.json",
@@ -443,6 +748,18 @@ class AsyncEverythingService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Active, incomplete to-dos across all accessible projects, grouped by project (paginated).
+        Each bucket entry carries the matching to-dos and their steps.
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_open_todos", is_mutation=False),
             "/todos/open.json",
@@ -456,6 +773,14 @@ class AsyncEverythingService(AsyncBaseService):
     async def get_everything_overdue_todos(
         self, *, assignee_ids: list[int] | None = None, due: str | None = None
     ) -> ListResult:
+        """Get every overdue to-do across all accessible projects, oldest-due-date-first.
+        A complete, unpaginated array; each item embeds its `bucket`.
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+        """
         return await self._request_list(
             OperationInfo(service="everything", operation="get_everything_overdue_todos", is_mutation=False),
             "/todos/overdue.json",
@@ -471,6 +796,17 @@ class AsyncEverythingService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Open, unassigned to-dos across all accessible projects, grouped by project (paginated).
+
+        Args:
+            assignee_ids: Restrict to tasks assigned to at least one of the given people
+                (repeatable). Assignees on nested steps are not considered.
+            due: Filter by due date: with, without, or overdue. Unrecognized values are ignored.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="everything", operation="get_everything_unassigned_todos", is_mutation=False),
             "/todos/unassigned.json",

--- a/python/src/basecamp/generated/services/folders.py
+++ b/python/src/basecamp/generated/services/folders.py
@@ -12,6 +12,12 @@ from basecamp.hooks import OperationInfo
 
 class FoldersService(BaseService):
     def list_folders(self) -> ListResult:
+        """List the authenticated user's folders in home-screen order.
+
+        Returns a bare array with no pagination envelope. Items are the base folder
+        shape: they carry `bucket_ids` but **not** the expanded `projects`, which
+        only the single-folder operations return.
+        """
         return self._request_list(
             OperationInfo(service="folders", operation="list_folders", is_mutation=False),
             "/stacks.json",
@@ -19,6 +25,20 @@ class FoldersService(BaseService):
         )
 
     def create_folder(self, *, name: str | None = None, project_ids: list[int] | None = None) -> dict[str, Any]:
+        """Create a folder for the authenticated user and file the given projects into it.
+
+        Returns 201 with the new folder and its expanded `projects`, placed at the
+        top of the home screen. Filing an all-access project the user has not joined
+        **grants** them access to it. Every id is preflighted: if any is archived,
+        trashed, or an invitation-only project the user is not on, the whole request
+        fails with 404 and nothing is created — there is no partial success.
+
+        Args:
+            name: The folder's name. Defaults to `New folder` when blank, null, or omitted.
+            project_ids: IDs of the projects to file into the folder — the same ids the folder
+                reports back as `bucket_ids` and expands as `projects`. This does not round-trip
+                under its own name. Omit it, or send null or an empty array, for an empty folder.
+        """
         return self._request(
             OperationInfo(service="folders", operation="create_folder", is_mutation=True),
             "POST",
@@ -28,6 +48,11 @@ class FoldersService(BaseService):
         )
 
     def get_folder(self, *, folder_id: int) -> dict[str, Any]:
+        """Get one folder, with the projects grouped inside it expanded under `projects`.
+
+        Args:
+            folder_id: The folder id.
+        """
         return self._request(
             OperationInfo(service="folders", operation="get_folder", is_mutation=False, resource_id=folder_id),
             "GET",
@@ -36,6 +61,16 @@ class FoldersService(BaseService):
         )
 
     def update_folder(self, *, folder_id: int, name: str) -> dict[str, Any]:
+        """Rename a folder.
+
+        `name` is the only writable attribute; a folder's projects, ordering, and
+        image are managed elsewhere and an image parameter sent here is ignored.
+
+        Args:
+            folder_id: The folder id.
+            name: The folder's new name. Blank is rejected with 422 — unlike create, update does not
+                fall back to a default name.
+        """
         return self._request(
             OperationInfo(service="folders", operation="update_folder", is_mutation=True, resource_id=folder_id),
             "PUT",
@@ -45,6 +80,14 @@ class FoldersService(BaseService):
         )
 
     def delete_folder(self, *, folder_id: int) -> None:
+        """Delete a folder and unpin its projects from the home screen (returns 204 No Content).
+
+        The projects themselves are not deleted and are not moved back out onto the
+        home screen; they simply stop appearing there until pinned again.
+
+        Args:
+            folder_id: The folder id.
+        """
         self._request_void(
             OperationInfo(service="folders", operation="delete_folder", is_mutation=True, resource_id=folder_id),
             "DELETE",
@@ -55,6 +98,12 @@ class FoldersService(BaseService):
 
 class AsyncFoldersService(AsyncBaseService):
     async def list_folders(self) -> ListResult:
+        """List the authenticated user's folders in home-screen order.
+
+        Returns a bare array with no pagination envelope. Items are the base folder
+        shape: they carry `bucket_ids` but **not** the expanded `projects`, which
+        only the single-folder operations return.
+        """
         return await self._request_list(
             OperationInfo(service="folders", operation="list_folders", is_mutation=False),
             "/stacks.json",
@@ -62,6 +111,20 @@ class AsyncFoldersService(AsyncBaseService):
         )
 
     async def create_folder(self, *, name: str | None = None, project_ids: list[int] | None = None) -> dict[str, Any]:
+        """Create a folder for the authenticated user and file the given projects into it.
+
+        Returns 201 with the new folder and its expanded `projects`, placed at the
+        top of the home screen. Filing an all-access project the user has not joined
+        **grants** them access to it. Every id is preflighted: if any is archived,
+        trashed, or an invitation-only project the user is not on, the whole request
+        fails with 404 and nothing is created — there is no partial success.
+
+        Args:
+            name: The folder's name. Defaults to `New folder` when blank, null, or omitted.
+            project_ids: IDs of the projects to file into the folder — the same ids the folder
+                reports back as `bucket_ids` and expands as `projects`. This does not round-trip
+                under its own name. Omit it, or send null or an empty array, for an empty folder.
+        """
         return await self._request(
             OperationInfo(service="folders", operation="create_folder", is_mutation=True),
             "POST",
@@ -71,6 +134,11 @@ class AsyncFoldersService(AsyncBaseService):
         )
 
     async def get_folder(self, *, folder_id: int) -> dict[str, Any]:
+        """Get one folder, with the projects grouped inside it expanded under `projects`.
+
+        Args:
+            folder_id: The folder id.
+        """
         return await self._request(
             OperationInfo(service="folders", operation="get_folder", is_mutation=False, resource_id=folder_id),
             "GET",
@@ -79,6 +147,16 @@ class AsyncFoldersService(AsyncBaseService):
         )
 
     async def update_folder(self, *, folder_id: int, name: str) -> dict[str, Any]:
+        """Rename a folder.
+
+        `name` is the only writable attribute; a folder's projects, ordering, and
+        image are managed elsewhere and an image parameter sent here is ignored.
+
+        Args:
+            folder_id: The folder id.
+            name: The folder's new name. Blank is rejected with 422 — unlike create, update does not
+                fall back to a default name.
+        """
         return await self._request(
             OperationInfo(service="folders", operation="update_folder", is_mutation=True, resource_id=folder_id),
             "PUT",
@@ -88,6 +166,14 @@ class AsyncFoldersService(AsyncBaseService):
         )
 
     async def delete_folder(self, *, folder_id: int) -> None:
+        """Delete a folder and unpin its projects from the home screen (returns 204 No Content).
+
+        The projects themselves are not deleted and are not moved back out onto the
+        home screen; they simply stop appearing there until pinned again.
+
+        Args:
+            folder_id: The folder id.
+        """
         await self._request_void(
             OperationInfo(service="folders", operation="delete_folder", is_mutation=True, resource_id=folder_id),
             "DELETE",

--- a/python/src/basecamp/generated/services/forwards.py
+++ b/python/src/basecamp/generated/services/forwards.py
@@ -31,8 +31,9 @@ class ForwardsService(BaseService):
             forward_id: The forward id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="forwards", operation="list_replies", is_mutation=False, resource_id=forward_id),
@@ -86,8 +87,9 @@ class ForwardsService(BaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="forwards", operation="list", is_mutation=False, resource_id=inbox_id),
@@ -121,8 +123,9 @@ class AsyncForwardsService(AsyncBaseService):
             forward_id: The forward id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="forwards", operation="list_replies", is_mutation=False, resource_id=forward_id),
@@ -176,8 +179,9 @@ class AsyncForwardsService(AsyncBaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="forwards", operation="list", is_mutation=False, resource_id=inbox_id),

--- a/python/src/basecamp/generated/services/forwards.py
+++ b/python/src/basecamp/generated/services/forwards.py
@@ -12,6 +12,11 @@ from basecamp.hooks import OperationInfo
 
 class ForwardsService(BaseService):
     def get(self, *, forward_id: int) -> dict[str, Any]:
+        """Get a forward by ID.
+
+        Args:
+            forward_id: The forward id.
+        """
         return self._request(
             OperationInfo(service="forwards", operation="get", is_mutation=False, resource_id=forward_id),
             "GET",
@@ -20,6 +25,15 @@ class ForwardsService(BaseService):
         )
 
     def list_replies(self, *, forward_id: int, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List all replies to a forward.
+
+        Args:
+            forward_id: The forward id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="forwards", operation="list_replies", is_mutation=False, resource_id=forward_id),
             f"/inbox_forwards/{forward_id}/replies.json",
@@ -29,6 +43,12 @@ class ForwardsService(BaseService):
         )
 
     def get_reply(self, *, forward_id: int, reply_id: int) -> dict[str, Any]:
+        """Get a forward reply by ID.
+
+        Args:
+            forward_id: The forward id.
+            reply_id: The reply id.
+        """
         return self._request(
             OperationInfo(service="forwards", operation="get_reply", is_mutation=False, resource_id=reply_id),
             "GET",
@@ -37,6 +57,11 @@ class ForwardsService(BaseService):
         )
 
     def get_inbox(self, *, inbox_id: int) -> dict[str, Any]:
+        """Get an inbox by ID.
+
+        Args:
+            inbox_id: The inbox id.
+        """
         return self._request(
             OperationInfo(service="forwards", operation="get_inbox", is_mutation=False, resource_id=inbox_id),
             "GET",
@@ -53,6 +78,17 @@ class ForwardsService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """List all forwards in an inbox.
+
+        Args:
+            inbox_id: The inbox id.
+            sort: created_at|updated_at
+            direction: asc|desc
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="forwards", operation="list", is_mutation=False, resource_id=inbox_id),
             f"/inboxes/{inbox_id}/inbox_forwards.json",
@@ -64,6 +100,11 @@ class ForwardsService(BaseService):
 
 class AsyncForwardsService(AsyncBaseService):
     async def get(self, *, forward_id: int) -> dict[str, Any]:
+        """Get a forward by ID.
+
+        Args:
+            forward_id: The forward id.
+        """
         return await self._request(
             OperationInfo(service="forwards", operation="get", is_mutation=False, resource_id=forward_id),
             "GET",
@@ -74,6 +115,15 @@ class AsyncForwardsService(AsyncBaseService):
     async def list_replies(
         self, *, forward_id: int, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List all replies to a forward.
+
+        Args:
+            forward_id: The forward id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="forwards", operation="list_replies", is_mutation=False, resource_id=forward_id),
             f"/inbox_forwards/{forward_id}/replies.json",
@@ -83,6 +133,12 @@ class AsyncForwardsService(AsyncBaseService):
         )
 
     async def get_reply(self, *, forward_id: int, reply_id: int) -> dict[str, Any]:
+        """Get a forward reply by ID.
+
+        Args:
+            forward_id: The forward id.
+            reply_id: The reply id.
+        """
         return await self._request(
             OperationInfo(service="forwards", operation="get_reply", is_mutation=False, resource_id=reply_id),
             "GET",
@@ -91,6 +147,11 @@ class AsyncForwardsService(AsyncBaseService):
         )
 
     async def get_inbox(self, *, inbox_id: int) -> dict[str, Any]:
+        """Get an inbox by ID.
+
+        Args:
+            inbox_id: The inbox id.
+        """
         return await self._request(
             OperationInfo(service="forwards", operation="get_inbox", is_mutation=False, resource_id=inbox_id),
             "GET",
@@ -107,6 +168,17 @@ class AsyncForwardsService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """List all forwards in an inbox.
+
+        Args:
+            inbox_id: The inbox id.
+            sort: created_at|updated_at
+            direction: asc|desc
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="forwards", operation="list", is_mutation=False, resource_id=inbox_id),
             f"/inboxes/{inbox_id}/inbox_forwards.json",

--- a/python/src/basecamp/generated/services/forwards.py
+++ b/python/src/basecamp/generated/services/forwards.py
@@ -31,9 +31,9 @@ class ForwardsService(BaseService):
             forward_id: The forward id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="forwards", operation="list_replies", is_mutation=False, resource_id=forward_id),
@@ -87,9 +87,9 @@ class ForwardsService(BaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="forwards", operation="list", is_mutation=False, resource_id=inbox_id),
@@ -123,9 +123,9 @@ class AsyncForwardsService(AsyncBaseService):
             forward_id: The forward id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="forwards", operation="list_replies", is_mutation=False, resource_id=forward_id),
@@ -179,9 +179,9 @@ class AsyncForwardsService(AsyncBaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="forwards", operation="list", is_mutation=False, resource_id=inbox_id),

--- a/python/src/basecamp/generated/services/gauges.py
+++ b/python/src/basecamp/generated/services/gauges.py
@@ -12,6 +12,11 @@ from basecamp.hooks import OperationInfo
 
 class GaugesService(BaseService):
     def get_gauge_needle(self, *, needle_id: int) -> dict[str, Any]:
+        """Get a gauge needle by ID.
+
+        Args:
+            needle_id: The needle id.
+        """
         return self._request(
             OperationInfo(service="gauges", operation="get_gauge_needle", is_mutation=False, resource_id=needle_id),
             "GET",
@@ -20,6 +25,12 @@ class GaugesService(BaseService):
         )
 
     def update_gauge_needle(self, *, needle_id: int, gauge_needle: dict | None = None) -> dict[str, Any]:
+        """Update a gauge needle's description. Position and color are immutable.
+
+        Args:
+            needle_id: The needle id.
+            gauge_needle: The gauge needle.
+        """
         return self._request(
             OperationInfo(service="gauges", operation="update_gauge_needle", is_mutation=True, resource_id=needle_id),
             "PUT",
@@ -29,6 +40,11 @@ class GaugesService(BaseService):
         )
 
     def destroy_gauge_needle(self, *, needle_id: int) -> None:
+        """Destroy a gauge needle.
+
+        Args:
+            needle_id: The needle id.
+        """
         self._request_void(
             OperationInfo(service="gauges", operation="destroy_gauge_needle", is_mutation=True, resource_id=needle_id),
             "DELETE",
@@ -37,6 +53,12 @@ class GaugesService(BaseService):
         )
 
     def toggle_gauge(self, *, project_id: int, gauge: dict) -> None:
+        """Enable or disable the gauge for a project. Only project admins can toggle gauges.
+
+        Args:
+            project_id: The project id.
+            gauge: The gauge.
+        """
         self._request_void(
             OperationInfo(service="gauges", operation="toggle_gauge", is_mutation=True, project_id=project_id),
             "PUT",
@@ -48,6 +70,15 @@ class GaugesService(BaseService):
     def list_gauge_needles(
         self, *, project_id: int, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List gauge needles for a project, ordered newest first.
+
+        Args:
+            project_id: The project id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="gauges", operation="list_gauge_needles", is_mutation=False, project_id=project_id),
             f"/projects/{project_id}/gauge/needles.json",
@@ -59,6 +90,14 @@ class GaugesService(BaseService):
     def create_gauge_needle(
         self, *, project_id: int, gauge_needle: dict, notify: str | None = None, subscriptions: list[int] | None = None
     ) -> dict[str, Any]:
+        """Create a gauge needle (progress update) for a project.
+
+        Args:
+            project_id: The project id.
+            gauge_needle: The gauge needle.
+            notify: Who to notify: "everyone", "working_on", "custom", or omit for nobody
+            subscriptions: Array of people IDs to notify (only used when notify is "custom")
+        """
         return self._request(
             OperationInfo(service="gauges", operation="create_gauge_needle", is_mutation=True, project_id=project_id),
             "POST",
@@ -70,6 +109,17 @@ class GaugesService(BaseService):
     def list_gauges(
         self, *, bucket_ids: str | None = None, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List gauges across all projects the authenticated user has access to.
+        Gauges are sorted by risk level (red, yellow, green), then alphabetically.
+
+        Args:
+            bucket_ids: Comma-separated list of project IDs. When provided, results are returned in
+                the order specified instead of by risk level.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="gauges", operation="list_gauges", is_mutation=False),
             "/reports/gauges.json",
@@ -81,6 +131,11 @@ class GaugesService(BaseService):
 
 class AsyncGaugesService(AsyncBaseService):
     async def get_gauge_needle(self, *, needle_id: int) -> dict[str, Any]:
+        """Get a gauge needle by ID.
+
+        Args:
+            needle_id: The needle id.
+        """
         return await self._request(
             OperationInfo(service="gauges", operation="get_gauge_needle", is_mutation=False, resource_id=needle_id),
             "GET",
@@ -89,6 +144,12 @@ class AsyncGaugesService(AsyncBaseService):
         )
 
     async def update_gauge_needle(self, *, needle_id: int, gauge_needle: dict | None = None) -> dict[str, Any]:
+        """Update a gauge needle's description. Position and color are immutable.
+
+        Args:
+            needle_id: The needle id.
+            gauge_needle: The gauge needle.
+        """
         return await self._request(
             OperationInfo(service="gauges", operation="update_gauge_needle", is_mutation=True, resource_id=needle_id),
             "PUT",
@@ -98,6 +159,11 @@ class AsyncGaugesService(AsyncBaseService):
         )
 
     async def destroy_gauge_needle(self, *, needle_id: int) -> None:
+        """Destroy a gauge needle.
+
+        Args:
+            needle_id: The needle id.
+        """
         await self._request_void(
             OperationInfo(service="gauges", operation="destroy_gauge_needle", is_mutation=True, resource_id=needle_id),
             "DELETE",
@@ -106,6 +172,12 @@ class AsyncGaugesService(AsyncBaseService):
         )
 
     async def toggle_gauge(self, *, project_id: int, gauge: dict) -> None:
+        """Enable or disable the gauge for a project. Only project admins can toggle gauges.
+
+        Args:
+            project_id: The project id.
+            gauge: The gauge.
+        """
         await self._request_void(
             OperationInfo(service="gauges", operation="toggle_gauge", is_mutation=True, project_id=project_id),
             "PUT",
@@ -117,6 +189,15 @@ class AsyncGaugesService(AsyncBaseService):
     async def list_gauge_needles(
         self, *, project_id: int, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List gauge needles for a project, ordered newest first.
+
+        Args:
+            project_id: The project id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="gauges", operation="list_gauge_needles", is_mutation=False, project_id=project_id),
             f"/projects/{project_id}/gauge/needles.json",
@@ -128,6 +209,14 @@ class AsyncGaugesService(AsyncBaseService):
     async def create_gauge_needle(
         self, *, project_id: int, gauge_needle: dict, notify: str | None = None, subscriptions: list[int] | None = None
     ) -> dict[str, Any]:
+        """Create a gauge needle (progress update) for a project.
+
+        Args:
+            project_id: The project id.
+            gauge_needle: The gauge needle.
+            notify: Who to notify: "everyone", "working_on", "custom", or omit for nobody
+            subscriptions: Array of people IDs to notify (only used when notify is "custom")
+        """
         return await self._request(
             OperationInfo(service="gauges", operation="create_gauge_needle", is_mutation=True, project_id=project_id),
             "POST",
@@ -139,6 +228,17 @@ class AsyncGaugesService(AsyncBaseService):
     async def list_gauges(
         self, *, bucket_ids: str | None = None, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List gauges across all projects the authenticated user has access to.
+        Gauges are sorted by risk level (red, yellow, green), then alphabetically.
+
+        Args:
+            bucket_ids: Comma-separated list of project IDs. When provided, results are returned in
+                the order specified instead of by risk level.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="gauges", operation="list_gauges", is_mutation=False),
             "/reports/gauges.json",

--- a/python/src/basecamp/generated/services/gauges.py
+++ b/python/src/basecamp/generated/services/gauges.py
@@ -76,8 +76,9 @@ class GaugesService(BaseService):
             project_id: The project id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="gauges", operation="list_gauge_needles", is_mutation=False, project_id=project_id),
@@ -117,8 +118,9 @@ class GaugesService(BaseService):
                 the order specified instead of by risk level.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="gauges", operation="list_gauges", is_mutation=False),
@@ -195,8 +197,9 @@ class AsyncGaugesService(AsyncBaseService):
             project_id: The project id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="gauges", operation="list_gauge_needles", is_mutation=False, project_id=project_id),
@@ -236,8 +239,9 @@ class AsyncGaugesService(AsyncBaseService):
                 the order specified instead of by risk level.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="gauges", operation="list_gauges", is_mutation=False),

--- a/python/src/basecamp/generated/services/gauges.py
+++ b/python/src/basecamp/generated/services/gauges.py
@@ -76,9 +76,9 @@ class GaugesService(BaseService):
             project_id: The project id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="gauges", operation="list_gauge_needles", is_mutation=False, project_id=project_id),
@@ -118,9 +118,9 @@ class GaugesService(BaseService):
                 the order specified instead of by risk level.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="gauges", operation="list_gauges", is_mutation=False),
@@ -197,9 +197,9 @@ class AsyncGaugesService(AsyncBaseService):
             project_id: The project id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="gauges", operation="list_gauge_needles", is_mutation=False, project_id=project_id),
@@ -239,9 +239,9 @@ class AsyncGaugesService(AsyncBaseService):
                 the order specified instead of by risk level.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="gauges", operation="list_gauges", is_mutation=False),

--- a/python/src/basecamp/generated/services/google_documents.py
+++ b/python/src/basecamp/generated/services/google_documents.py
@@ -24,6 +24,29 @@ class GoogleDocumentsService(BaseService):
         subscriptions: list[int] | None = None,
         visible_to_clients: bool | None = None,
     ) -> dict[str, Any]:
+        """Create a new Google document in a vault.
+        An unrecognized `document_type` is rejected before validation with the
+        field-keyed 422 {"errors": {"document_type": ["is not a valid document
+        type"]}} — the enum would otherwise raise rather than add an error.
+        Omitting `title` is allowed and reads back as "Untitled".
+
+        Args:
+            bucket_id: The bucket id.
+            vault_id: The vault id.
+            url: The url.
+            document_type: One of "doc", "sheet", "slide", "other". Backed by a Rails enum, so an
+                unrecognized value is rejected up front with a field-keyed 422 ({"errors":
+                {"document_type": ["is not a valid document type"]}}) rather than reaching
+                validation.
+            title: The title.
+            description: The description.
+            status: active|drafted — defaults to drafted
+            subscriptions: The subscriptions.
+            visible_to_clients: Whether the document is visible to the project's clients. Applies
+                only when creating directly in the tool's vault — an item created inside a folder
+                inherits the folder's visibility and ignores this. A client caller always creates
+                client-visible records regardless of what is sent.
+        """
         return self._request(
             OperationInfo(
                 service="googledocuments",
@@ -47,6 +70,11 @@ class GoogleDocumentsService(BaseService):
         )
 
     def get_google_document(self, *, google_document_id: int) -> dict[str, Any]:
+        """Get a single Google document by id.
+
+        Args:
+            google_document_id: The google document id.
+        """
         return self._request(
             OperationInfo(
                 service="googledocuments",
@@ -70,6 +98,32 @@ class GoogleDocumentsService(BaseService):
         status: str | None = None,
         subscriptions: list[int] | None = None,
     ) -> dict[str, Any]:
+        """Replace a Google document with a new complete representation.
+        BC3 builds a brand-new GoogleDocument from the permitted params and swaps
+        the recordable wholesale, so the request body is the full writable state:
+        omitting `title` clears it (and the document then reads back as "Untitled"),
+        and omitting `description` clears it. `url` and `document_type` are required
+        here — `document_type` because an absent or unrecognized value is a 422, and
+        `url` because it carries a presence validation.
+        Subscribers are the exception to omission-clears: a drafted document keeps
+        its current subscribers when the request addresses neither `subscriptions`
+        nor `notify`. The creator is always on the list.
+        The legacy bucket-scoped path
+        PUT /buckets/{bucketId}/google_documents/{id}.json is also accepted by BC3;
+        this flat spelling is the documented one.
+
+        Args:
+            google_document_id: The google document id.
+            url: The url.
+            document_type: One of "doc", "sheet", "slide", "other". Backed by a Rails enum, so an
+                unrecognized value is rejected up front with a field-keyed 422 ({"errors":
+                {"document_type": ["is not a valid document type"]}}) rather than reaching
+                validation.
+            title: The title.
+            description: The description.
+            status: active|drafted
+            subscriptions: The subscriptions.
+        """
         return self._request(
             OperationInfo(
                 service="googledocuments",
@@ -105,6 +159,29 @@ class AsyncGoogleDocumentsService(AsyncBaseService):
         subscriptions: list[int] | None = None,
         visible_to_clients: bool | None = None,
     ) -> dict[str, Any]:
+        """Create a new Google document in a vault.
+        An unrecognized `document_type` is rejected before validation with the
+        field-keyed 422 {"errors": {"document_type": ["is not a valid document
+        type"]}} — the enum would otherwise raise rather than add an error.
+        Omitting `title` is allowed and reads back as "Untitled".
+
+        Args:
+            bucket_id: The bucket id.
+            vault_id: The vault id.
+            url: The url.
+            document_type: One of "doc", "sheet", "slide", "other". Backed by a Rails enum, so an
+                unrecognized value is rejected up front with a field-keyed 422 ({"errors":
+                {"document_type": ["is not a valid document type"]}}) rather than reaching
+                validation.
+            title: The title.
+            description: The description.
+            status: active|drafted — defaults to drafted
+            subscriptions: The subscriptions.
+            visible_to_clients: Whether the document is visible to the project's clients. Applies
+                only when creating directly in the tool's vault — an item created inside a folder
+                inherits the folder's visibility and ignores this. A client caller always creates
+                client-visible records regardless of what is sent.
+        """
         return await self._request(
             OperationInfo(
                 service="googledocuments",
@@ -128,6 +205,11 @@ class AsyncGoogleDocumentsService(AsyncBaseService):
         )
 
     async def get_google_document(self, *, google_document_id: int) -> dict[str, Any]:
+        """Get a single Google document by id.
+
+        Args:
+            google_document_id: The google document id.
+        """
         return await self._request(
             OperationInfo(
                 service="googledocuments",
@@ -151,6 +233,32 @@ class AsyncGoogleDocumentsService(AsyncBaseService):
         status: str | None = None,
         subscriptions: list[int] | None = None,
     ) -> dict[str, Any]:
+        """Replace a Google document with a new complete representation.
+        BC3 builds a brand-new GoogleDocument from the permitted params and swaps
+        the recordable wholesale, so the request body is the full writable state:
+        omitting `title` clears it (and the document then reads back as "Untitled"),
+        and omitting `description` clears it. `url` and `document_type` are required
+        here — `document_type` because an absent or unrecognized value is a 422, and
+        `url` because it carries a presence validation.
+        Subscribers are the exception to omission-clears: a drafted document keeps
+        its current subscribers when the request addresses neither `subscriptions`
+        nor `notify`. The creator is always on the list.
+        The legacy bucket-scoped path
+        PUT /buckets/{bucketId}/google_documents/{id}.json is also accepted by BC3;
+        this flat spelling is the documented one.
+
+        Args:
+            google_document_id: The google document id.
+            url: The url.
+            document_type: One of "doc", "sheet", "slide", "other". Backed by a Rails enum, so an
+                unrecognized value is rejected up front with a field-keyed 422 ({"errors":
+                {"document_type": ["is not a valid document type"]}}) rather than reaching
+                validation.
+            title: The title.
+            description: The description.
+            status: active|drafted
+            subscriptions: The subscriptions.
+        """
         return await self._request(
             OperationInfo(
                 service="googledocuments",

--- a/python/src/basecamp/generated/services/hill_charts.py
+++ b/python/src/basecamp/generated/services/hill_charts.py
@@ -12,6 +12,11 @@ from basecamp.hooks import OperationInfo
 
 class HillChartsService(BaseService):
     def get(self, *, todoset_id: int) -> dict[str, Any]:
+        """Get the hill chart for a todoset.
+
+        Args:
+            todoset_id: The todoset id.
+        """
         return self._request(
             OperationInfo(service="hillcharts", operation="get", is_mutation=False, resource_id=todoset_id),
             "GET",
@@ -22,6 +27,13 @@ class HillChartsService(BaseService):
     def update_settings(
         self, *, todoset_id: int, tracked: list[int] | None = None, untracked: list[int] | None = None
     ) -> dict[str, Any]:
+        """Track or untrack todolists on a hill chart.
+
+        Args:
+            todoset_id: The todoset id.
+            tracked: The tracked.
+            untracked: The untracked.
+        """
         return self._request(
             OperationInfo(service="hillcharts", operation="update_settings", is_mutation=True, resource_id=todoset_id),
             "PUT",
@@ -33,6 +45,11 @@ class HillChartsService(BaseService):
 
 class AsyncHillChartsService(AsyncBaseService):
     async def get(self, *, todoset_id: int) -> dict[str, Any]:
+        """Get the hill chart for a todoset.
+
+        Args:
+            todoset_id: The todoset id.
+        """
         return await self._request(
             OperationInfo(service="hillcharts", operation="get", is_mutation=False, resource_id=todoset_id),
             "GET",
@@ -43,6 +60,13 @@ class AsyncHillChartsService(AsyncBaseService):
     async def update_settings(
         self, *, todoset_id: int, tracked: list[int] | None = None, untracked: list[int] | None = None
     ) -> dict[str, Any]:
+        """Track or untrack todolists on a hill chart.
+
+        Args:
+            todoset_id: The todoset id.
+            tracked: The tracked.
+            untracked: The untracked.
+        """
         return await self._request(
             OperationInfo(service="hillcharts", operation="update_settings", is_mutation=True, resource_id=todoset_id),
             "PUT",

--- a/python/src/basecamp/generated/services/lineup.py
+++ b/python/src/basecamp/generated/services/lineup.py
@@ -12,6 +12,12 @@ from basecamp.hooks import OperationInfo
 
 class LineupService(BaseService):
     def create(self, *, name: str, date: str) -> None:
+        """Create a new lineup marker.
+
+        Args:
+            name: The name.
+            date: The date.
+        """
         self._request_void(
             OperationInfo(service="lineup", operation="create", is_mutation=True),
             "POST",
@@ -21,6 +27,13 @@ class LineupService(BaseService):
         )
 
     def update(self, *, marker_id: int, name: str | None = None, date: str | None = None) -> None:
+        """Update an existing lineup marker.
+
+        Args:
+            marker_id: The marker id.
+            name: The name.
+            date: The date.
+        """
         self._request_void(
             OperationInfo(service="lineup", operation="update", is_mutation=True, resource_id=marker_id),
             "PUT",
@@ -30,6 +43,11 @@ class LineupService(BaseService):
         )
 
     def delete(self, *, marker_id: int) -> None:
+        """Delete a lineup marker.
+
+        Args:
+            marker_id: The marker id.
+        """
         self._request_void(
             OperationInfo(service="lineup", operation="delete", is_mutation=True, resource_id=marker_id),
             "DELETE",
@@ -40,6 +58,12 @@ class LineupService(BaseService):
 
 class AsyncLineupService(AsyncBaseService):
     async def create(self, *, name: str, date: str) -> None:
+        """Create a new lineup marker.
+
+        Args:
+            name: The name.
+            date: The date.
+        """
         await self._request_void(
             OperationInfo(service="lineup", operation="create", is_mutation=True),
             "POST",
@@ -49,6 +73,13 @@ class AsyncLineupService(AsyncBaseService):
         )
 
     async def update(self, *, marker_id: int, name: str | None = None, date: str | None = None) -> None:
+        """Update an existing lineup marker.
+
+        Args:
+            marker_id: The marker id.
+            name: The name.
+            date: The date.
+        """
         await self._request_void(
             OperationInfo(service="lineup", operation="update", is_mutation=True, resource_id=marker_id),
             "PUT",
@@ -58,6 +89,11 @@ class AsyncLineupService(AsyncBaseService):
         )
 
     async def delete(self, *, marker_id: int) -> None:
+        """Delete a lineup marker.
+
+        Args:
+            marker_id: The marker id.
+        """
         await self._request_void(
             OperationInfo(service="lineup", operation="delete", is_mutation=True, resource_id=marker_id),
             "DELETE",

--- a/python/src/basecamp/generated/services/message_boards.py
+++ b/python/src/basecamp/generated/services/message_boards.py
@@ -12,6 +12,11 @@ from basecamp.hooks import OperationInfo
 
 class MessageBoardsService(BaseService):
     def get(self, *, board_id: int) -> dict[str, Any]:
+        """Get a message board.
+
+        Args:
+            board_id: The board id.
+        """
         return self._request(
             OperationInfo(service="messageboards", operation="get", is_mutation=False, resource_id=board_id),
             "GET",
@@ -22,6 +27,11 @@ class MessageBoardsService(BaseService):
 
 class AsyncMessageBoardsService(AsyncBaseService):
     async def get(self, *, board_id: int) -> dict[str, Any]:
+        """Get a message board.
+
+        Args:
+            board_id: The board id.
+        """
         return await self._request(
             OperationInfo(service="messageboards", operation="get", is_mutation=False, resource_id=board_id),
             "GET",

--- a/python/src/basecamp/generated/services/message_types.py
+++ b/python/src/basecamp/generated/services/message_types.py
@@ -16,8 +16,9 @@ class MessageTypesService(BaseService):
 
         Args:
             bucket_id: The bucket id.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages.
         """
         return self._request_paginated(
             OperationInfo(service="messagetypes", operation="list", is_mutation=False, project_id=bucket_id),
@@ -102,8 +103,9 @@ class AsyncMessageTypesService(AsyncBaseService):
 
         Args:
             bucket_id: The bucket id.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages.
         """
         return await self._request_paginated(
             OperationInfo(service="messagetypes", operation="list", is_mutation=False, project_id=bucket_id),

--- a/python/src/basecamp/generated/services/message_types.py
+++ b/python/src/basecamp/generated/services/message_types.py
@@ -16,8 +16,8 @@ class MessageTypesService(BaseService):
 
         Args:
             bucket_id: The bucket id.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages.
         """
         return self._request_paginated(
             OperationInfo(service="messagetypes", operation="list", is_mutation=False, project_id=bucket_id),
@@ -102,8 +102,8 @@ class AsyncMessageTypesService(AsyncBaseService):
 
         Args:
             bucket_id: The bucket id.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages.
         """
         return await self._request_paginated(
             OperationInfo(service="messagetypes", operation="list", is_mutation=False, project_id=bucket_id),

--- a/python/src/basecamp/generated/services/message_types.py
+++ b/python/src/basecamp/generated/services/message_types.py
@@ -12,6 +12,13 @@ from basecamp.hooks import OperationInfo
 
 class MessageTypesService(BaseService):
     def list(self, *, bucket_id: int, max_items: int | None = None) -> ListResult:
+        """List message types in a project.
+
+        Args:
+            bucket_id: The bucket id.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="messagetypes", operation="list", is_mutation=False, project_id=bucket_id),
             f"/buckets/{bucket_id}/categories.json",
@@ -20,6 +27,13 @@ class MessageTypesService(BaseService):
         )
 
     def create(self, *, bucket_id: int, name: str, icon: str) -> dict[str, Any]:
+        """Create a new message type in a project.
+
+        Args:
+            bucket_id: The bucket id.
+            name: The name.
+            icon: The icon.
+        """
         return self._request(
             OperationInfo(service="messagetypes", operation="create", is_mutation=True, project_id=bucket_id),
             "POST",
@@ -29,6 +43,12 @@ class MessageTypesService(BaseService):
         )
 
     def get(self, *, bucket_id: int, type_id: int) -> dict[str, Any]:
+        """Get a single message type by id.
+
+        Args:
+            bucket_id: The bucket id.
+            type_id: The type id.
+        """
         return self._request(
             OperationInfo(
                 service="messagetypes", operation="get", is_mutation=False, project_id=bucket_id, resource_id=type_id
@@ -41,6 +61,14 @@ class MessageTypesService(BaseService):
     def update(
         self, *, bucket_id: int, type_id: int, name: str | None = None, icon: str | None = None
     ) -> dict[str, Any]:
+        """Update an existing message type.
+
+        Args:
+            bucket_id: The bucket id.
+            type_id: The type id.
+            name: The name.
+            icon: The icon.
+        """
         return self._request(
             OperationInfo(
                 service="messagetypes", operation="update", is_mutation=True, project_id=bucket_id, resource_id=type_id
@@ -52,6 +80,12 @@ class MessageTypesService(BaseService):
         )
 
     def delete(self, *, bucket_id: int, type_id: int) -> None:
+        """Delete a message type.
+
+        Args:
+            bucket_id: The bucket id.
+            type_id: The type id.
+        """
         self._request_void(
             OperationInfo(
                 service="messagetypes", operation="delete", is_mutation=True, project_id=bucket_id, resource_id=type_id
@@ -64,6 +98,13 @@ class MessageTypesService(BaseService):
 
 class AsyncMessageTypesService(AsyncBaseService):
     async def list(self, *, bucket_id: int, max_items: int | None = None) -> ListResult:
+        """List message types in a project.
+
+        Args:
+            bucket_id: The bucket id.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="messagetypes", operation="list", is_mutation=False, project_id=bucket_id),
             f"/buckets/{bucket_id}/categories.json",
@@ -72,6 +113,13 @@ class AsyncMessageTypesService(AsyncBaseService):
         )
 
     async def create(self, *, bucket_id: int, name: str, icon: str) -> dict[str, Any]:
+        """Create a new message type in a project.
+
+        Args:
+            bucket_id: The bucket id.
+            name: The name.
+            icon: The icon.
+        """
         return await self._request(
             OperationInfo(service="messagetypes", operation="create", is_mutation=True, project_id=bucket_id),
             "POST",
@@ -81,6 +129,12 @@ class AsyncMessageTypesService(AsyncBaseService):
         )
 
     async def get(self, *, bucket_id: int, type_id: int) -> dict[str, Any]:
+        """Get a single message type by id.
+
+        Args:
+            bucket_id: The bucket id.
+            type_id: The type id.
+        """
         return await self._request(
             OperationInfo(
                 service="messagetypes", operation="get", is_mutation=False, project_id=bucket_id, resource_id=type_id
@@ -93,6 +147,14 @@ class AsyncMessageTypesService(AsyncBaseService):
     async def update(
         self, *, bucket_id: int, type_id: int, name: str | None = None, icon: str | None = None
     ) -> dict[str, Any]:
+        """Update an existing message type.
+
+        Args:
+            bucket_id: The bucket id.
+            type_id: The type id.
+            name: The name.
+            icon: The icon.
+        """
         return await self._request(
             OperationInfo(
                 service="messagetypes", operation="update", is_mutation=True, project_id=bucket_id, resource_id=type_id
@@ -104,6 +166,12 @@ class AsyncMessageTypesService(AsyncBaseService):
         )
 
     async def delete(self, *, bucket_id: int, type_id: int) -> None:
+        """Delete a message type.
+
+        Args:
+            bucket_id: The bucket id.
+            type_id: The type id.
+        """
         await self._request_void(
             OperationInfo(
                 service="messagetypes", operation="delete", is_mutation=True, project_id=bucket_id, resource_id=type_id

--- a/python/src/basecamp/generated/services/messages.py
+++ b/python/src/basecamp/generated/services/messages.py
@@ -20,6 +20,17 @@ class MessagesService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """List messages on a message board.
+
+        Args:
+            board_id: The board id.
+            sort: created_at|updated_at
+            direction: asc|desc
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="messages", operation="list", is_mutation=False, resource_id=board_id),
             f"/message_boards/{board_id}/messages.json",
@@ -39,6 +50,17 @@ class MessagesService(BaseService):
         subscriptions: list[int] | None = None,
         visible_to_clients: bool | None = None,
     ) -> dict[str, Any]:
+        """Create a new message on a message board.
+
+        Args:
+            board_id: The board id.
+            subject: The subject.
+            content: The content.
+            status: active|drafted
+            category_id: The category id.
+            subscriptions: The subscriptions.
+            visible_to_clients: The visible to clients.
+        """
         return self._request(
             OperationInfo(service="messages", operation="create", is_mutation=True, resource_id=board_id),
             "POST",
@@ -55,6 +77,11 @@ class MessagesService(BaseService):
         )
 
     def get(self, *, message_id: int) -> dict[str, Any]:
+        """Get a single message by id.
+
+        Args:
+            message_id: The message id.
+        """
         return self._request(
             OperationInfo(service="messages", operation="get", is_mutation=False, resource_id=message_id),
             "GET",
@@ -71,6 +98,15 @@ class MessagesService(BaseService):
         status: str | None = None,
         category_id: int | None = None,
     ) -> dict[str, Any]:
+        """Update an existing message.
+
+        Args:
+            message_id: The message id.
+            subject: The subject.
+            content: The content.
+            status: active|drafted
+            category_id: The category id.
+        """
         return self._request(
             OperationInfo(service="messages", operation="update", is_mutation=True, resource_id=message_id),
             "PUT",
@@ -80,6 +116,11 @@ class MessagesService(BaseService):
         )
 
     def pin(self, *, message_id: int) -> None:
+        """Pin a message to the top of the message board.
+
+        Args:
+            message_id: The message id.
+        """
         self._request_void(
             OperationInfo(service="messages", operation="pin", is_mutation=True, resource_id=message_id),
             "POST",
@@ -88,6 +129,11 @@ class MessagesService(BaseService):
         )
 
     def unpin(self, *, message_id: int) -> None:
+        """Unpin a message from the message board.
+
+        Args:
+            message_id: The message id.
+        """
         self._request_void(
             OperationInfo(service="messages", operation="unpin", is_mutation=True, resource_id=message_id),
             "DELETE",
@@ -106,6 +152,17 @@ class AsyncMessagesService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """List messages on a message board.
+
+        Args:
+            board_id: The board id.
+            sort: created_at|updated_at
+            direction: asc|desc
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="messages", operation="list", is_mutation=False, resource_id=board_id),
             f"/message_boards/{board_id}/messages.json",
@@ -125,6 +182,17 @@ class AsyncMessagesService(AsyncBaseService):
         subscriptions: list[int] | None = None,
         visible_to_clients: bool | None = None,
     ) -> dict[str, Any]:
+        """Create a new message on a message board.
+
+        Args:
+            board_id: The board id.
+            subject: The subject.
+            content: The content.
+            status: active|drafted
+            category_id: The category id.
+            subscriptions: The subscriptions.
+            visible_to_clients: The visible to clients.
+        """
         return await self._request(
             OperationInfo(service="messages", operation="create", is_mutation=True, resource_id=board_id),
             "POST",
@@ -141,6 +209,11 @@ class AsyncMessagesService(AsyncBaseService):
         )
 
     async def get(self, *, message_id: int) -> dict[str, Any]:
+        """Get a single message by id.
+
+        Args:
+            message_id: The message id.
+        """
         return await self._request(
             OperationInfo(service="messages", operation="get", is_mutation=False, resource_id=message_id),
             "GET",
@@ -157,6 +230,15 @@ class AsyncMessagesService(AsyncBaseService):
         status: str | None = None,
         category_id: int | None = None,
     ) -> dict[str, Any]:
+        """Update an existing message.
+
+        Args:
+            message_id: The message id.
+            subject: The subject.
+            content: The content.
+            status: active|drafted
+            category_id: The category id.
+        """
         return await self._request(
             OperationInfo(service="messages", operation="update", is_mutation=True, resource_id=message_id),
             "PUT",
@@ -166,6 +248,11 @@ class AsyncMessagesService(AsyncBaseService):
         )
 
     async def pin(self, *, message_id: int) -> None:
+        """Pin a message to the top of the message board.
+
+        Args:
+            message_id: The message id.
+        """
         await self._request_void(
             OperationInfo(service="messages", operation="pin", is_mutation=True, resource_id=message_id),
             "POST",
@@ -174,6 +261,11 @@ class AsyncMessagesService(AsyncBaseService):
         )
 
     async def unpin(self, *, message_id: int) -> None:
+        """Unpin a message from the message board.
+
+        Args:
+            message_id: The message id.
+        """
         await self._request_void(
             OperationInfo(service="messages", operation="unpin", is_mutation=True, resource_id=message_id),
             "DELETE",

--- a/python/src/basecamp/generated/services/messages.py
+++ b/python/src/basecamp/generated/services/messages.py
@@ -28,9 +28,9 @@ class MessagesService(BaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="messages", operation="list", is_mutation=False, resource_id=board_id),
@@ -161,9 +161,9 @@ class AsyncMessagesService(AsyncBaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="messages", operation="list", is_mutation=False, resource_id=board_id),

--- a/python/src/basecamp/generated/services/messages.py
+++ b/python/src/basecamp/generated/services/messages.py
@@ -28,8 +28,9 @@ class MessagesService(BaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="messages", operation="list", is_mutation=False, resource_id=board_id),
@@ -160,8 +161,9 @@ class AsyncMessagesService(AsyncBaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="messages", operation="list", is_mutation=False, resource_id=board_id),

--- a/python/src/basecamp/generated/services/my_assignments.py
+++ b/python/src/basecamp/generated/services/my_assignments.py
@@ -12,6 +12,10 @@ from basecamp.hooks import OperationInfo
 
 class MyAssignmentsService(BaseService):
     def get_my_assignments(self) -> dict[str, Any]:
+        """Get the current user's active assignments grouped into priorities and non_priorities.
+        Card table steps are normalized to their parent card with steps as children.
+        This endpoint is not paginated.
+        """
         return self._request(
             OperationInfo(service="myassignments", operation="get_my_assignments", is_mutation=False),
             "GET",
@@ -20,6 +24,9 @@ class MyAssignmentsService(BaseService):
         )
 
     def get_my_completed_assignments(self) -> ListResult:
+        """Get the current user's completed assignments.
+        Archived and trashed recordings are excluded. This endpoint is not paginated.
+        """
         return self._request_list(
             OperationInfo(service="myassignments", operation="get_my_completed_assignments", is_mutation=False),
             "/my/assignments/completed.json",
@@ -27,6 +34,13 @@ class MyAssignmentsService(BaseService):
         )
 
     def get_my_due_assignments(self, *, scope: str | None = None) -> ListResult:
+        """Get the current user's assignments filtered by due date scope.
+        Defaults to overdue when no scope is provided. This endpoint is not paginated.
+
+        Args:
+            scope: Filter by due date range: overdue, due_today, due_tomorrow, due_later_this_week,
+                due_next_week, due_later
+        """
         return self._request_list(
             OperationInfo(service="myassignments", operation="get_my_due_assignments", is_mutation=False),
             "/my/assignments/due.json",
@@ -35,6 +49,15 @@ class MyAssignmentsService(BaseService):
         )
 
     def prioritize_assignment(self, *, id: int) -> None:
+        """Add a recording to Up Next — the current user's ordered list of prioritized
+        assignments (the priorities returned by GetMyAssignments). Identify the item
+        by the recording id that carries the priority; for a card table step
+        surfaced under its parent card, that is the entry's priority_recording_id.
+        Idempotent: re-prioritizing an already-prioritized recording is a no-op.
+
+        Args:
+            id: The recording id to prioritize.
+        """
         self._request_void(
             OperationInfo(service="myassignments", operation="prioritize_assignment", is_mutation=True),
             "POST",
@@ -44,6 +67,15 @@ class MyAssignmentsService(BaseService):
         )
 
     def deprioritize_assignment(self, *, recording_id: int) -> None:
+        """Remove a recording from Up Next (returns 204 No Content). Exact-target:
+        only the priority carried by the identified recording is cleared, and
+        deleting an absent priority is a no-op 204 — so the DELETE is idempotent
+        and safe to retry (BC3 #12483). Address a surfaced card table step by its
+        priority_recording_id, not its parent card's id.
+
+        Args:
+            recording_id: The recording id.
+        """
         self._request_void(
             OperationInfo(
                 service="myassignments", operation="deprioritize_assignment", is_mutation=True, resource_id=recording_id
@@ -54,6 +86,18 @@ class MyAssignmentsService(BaseService):
         )
 
     def reorder_up_next(self, *, source_id: int, position: int) -> None:
+        """Move an already-prioritized recording to a new 1-based position in Up Next
+        (returns 204 No Content). NOT idempotent: a positional move's meaning
+        shifts as the list changes, so a retry can land the item somewhere else —
+        no retry gating is declared. Errors: 400 for a missing or non-integer
+        position, 422 (flat {error} body) for an out-of-range position or an
+        unprioritized recording, and a bare bodyless 404 for an inaccessible
+        recording.
+
+        Args:
+            source_id: The recording id to move, chosen the same way as when prioritizing.
+            position: The 1-based position to move it to.
+        """
         self._request_void(
             OperationInfo(service="myassignments", operation="reorder_up_next", is_mutation=True),
             "POST",
@@ -65,6 +109,10 @@ class MyAssignmentsService(BaseService):
 
 class AsyncMyAssignmentsService(AsyncBaseService):
     async def get_my_assignments(self) -> dict[str, Any]:
+        """Get the current user's active assignments grouped into priorities and non_priorities.
+        Card table steps are normalized to their parent card with steps as children.
+        This endpoint is not paginated.
+        """
         return await self._request(
             OperationInfo(service="myassignments", operation="get_my_assignments", is_mutation=False),
             "GET",
@@ -73,6 +121,9 @@ class AsyncMyAssignmentsService(AsyncBaseService):
         )
 
     async def get_my_completed_assignments(self) -> ListResult:
+        """Get the current user's completed assignments.
+        Archived and trashed recordings are excluded. This endpoint is not paginated.
+        """
         return await self._request_list(
             OperationInfo(service="myassignments", operation="get_my_completed_assignments", is_mutation=False),
             "/my/assignments/completed.json",
@@ -80,6 +131,13 @@ class AsyncMyAssignmentsService(AsyncBaseService):
         )
 
     async def get_my_due_assignments(self, *, scope: str | None = None) -> ListResult:
+        """Get the current user's assignments filtered by due date scope.
+        Defaults to overdue when no scope is provided. This endpoint is not paginated.
+
+        Args:
+            scope: Filter by due date range: overdue, due_today, due_tomorrow, due_later_this_week,
+                due_next_week, due_later
+        """
         return await self._request_list(
             OperationInfo(service="myassignments", operation="get_my_due_assignments", is_mutation=False),
             "/my/assignments/due.json",
@@ -88,6 +146,15 @@ class AsyncMyAssignmentsService(AsyncBaseService):
         )
 
     async def prioritize_assignment(self, *, id: int) -> None:
+        """Add a recording to Up Next — the current user's ordered list of prioritized
+        assignments (the priorities returned by GetMyAssignments). Identify the item
+        by the recording id that carries the priority; for a card table step
+        surfaced under its parent card, that is the entry's priority_recording_id.
+        Idempotent: re-prioritizing an already-prioritized recording is a no-op.
+
+        Args:
+            id: The recording id to prioritize.
+        """
         await self._request_void(
             OperationInfo(service="myassignments", operation="prioritize_assignment", is_mutation=True),
             "POST",
@@ -97,6 +164,15 @@ class AsyncMyAssignmentsService(AsyncBaseService):
         )
 
     async def deprioritize_assignment(self, *, recording_id: int) -> None:
+        """Remove a recording from Up Next (returns 204 No Content). Exact-target:
+        only the priority carried by the identified recording is cleared, and
+        deleting an absent priority is a no-op 204 — so the DELETE is idempotent
+        and safe to retry (BC3 #12483). Address a surfaced card table step by its
+        priority_recording_id, not its parent card's id.
+
+        Args:
+            recording_id: The recording id.
+        """
         await self._request_void(
             OperationInfo(
                 service="myassignments", operation="deprioritize_assignment", is_mutation=True, resource_id=recording_id
@@ -107,6 +183,18 @@ class AsyncMyAssignmentsService(AsyncBaseService):
         )
 
     async def reorder_up_next(self, *, source_id: int, position: int) -> None:
+        """Move an already-prioritized recording to a new 1-based position in Up Next
+        (returns 204 No Content). NOT idempotent: a positional move's meaning
+        shifts as the list changes, so a retry can land the item somewhere else —
+        no retry gating is declared. Errors: 400 for a missing or non-integer
+        position, 422 (flat {error} body) for an out-of-range position or an
+        unprioritized recording, and a bare bodyless 404 for an inaccessible
+        recording.
+
+        Args:
+            source_id: The recording id to move, chosen the same way as when prioritizing.
+            position: The 1-based position to move it to.
+        """
         await self._request_void(
             OperationInfo(service="myassignments", operation="reorder_up_next", is_mutation=True),
             "POST",

--- a/python/src/basecamp/generated/services/my_notes.py
+++ b/python/src/basecamp/generated/services/my_notes.py
@@ -32,7 +32,8 @@ class MyNotesService(BaseService):
         body.
 
         Args:
-            note: The note.
+            note: The writable note payload — the wire body is the nested {note: {content}}
+                envelope, the ProjectConstructionAttributes treatment.
         """
         return self._request(
             OperationInfo(service="mynotes", operation="update_my_note", is_mutation=True),
@@ -65,7 +66,8 @@ class AsyncMyNotesService(AsyncBaseService):
         body.
 
         Args:
-            note: The note.
+            note: The writable note payload — the wire body is the nested {note: {content}}
+                envelope, the ProjectConstructionAttributes treatment.
         """
         return await self._request(
             OperationInfo(service="mynotes", operation="update_my_note", is_mutation=True),

--- a/python/src/basecamp/generated/services/my_notes.py
+++ b/python/src/basecamp/generated/services/my_notes.py
@@ -12,6 +12,11 @@ from basecamp.hooks import OperationInfo
 
 class MyNotesService(BaseService):
     def get_my_note(self) -> dict[str, Any]:
+        """Get the authenticated user's note — a per-person notebook singleton at
+        /my/notes.json. If the user has not yet written anything, the shape is the
+        same with empty content and null id/created_at/updated_at; the record is
+        created on first update.
+        """
         return self._request(
             OperationInfo(service="mynotes", operation="get_my_note", is_mutation=False),
             "GET",
@@ -20,6 +25,15 @@ class MyNotesService(BaseService):
         )
 
     def update_my_note(self, *, note: dict) -> dict[str, Any]:
+        """Replace the note's content, recording a new revision server-side.
+        The first update also creates the underlying notebook if the user did not
+        have one yet. Returns the updated note. Rejections arrive as a field-keyed
+        422 ({"errors": {"content": ["can't be blank"]}}), not the flat {error}
+        body.
+
+        Args:
+            note: The note.
+        """
         return self._request(
             OperationInfo(service="mynotes", operation="update_my_note", is_mutation=True),
             "PUT",
@@ -31,6 +45,11 @@ class MyNotesService(BaseService):
 
 class AsyncMyNotesService(AsyncBaseService):
     async def get_my_note(self) -> dict[str, Any]:
+        """Get the authenticated user's note — a per-person notebook singleton at
+        /my/notes.json. If the user has not yet written anything, the shape is the
+        same with empty content and null id/created_at/updated_at; the record is
+        created on first update.
+        """
         return await self._request(
             OperationInfo(service="mynotes", operation="get_my_note", is_mutation=False),
             "GET",
@@ -39,6 +58,15 @@ class AsyncMyNotesService(AsyncBaseService):
         )
 
     async def update_my_note(self, *, note: dict) -> dict[str, Any]:
+        """Replace the note's content, recording a new revision server-side.
+        The first update also creates the underlying notebook if the user did not
+        have one yet. Returns the updated note. Rejections arrive as a field-keyed
+        422 ({"errors": {"content": ["can't be blank"]}}), not the flat {error}
+        body.
+
+        Args:
+            note: The note.
+        """
         return await self._request(
             OperationInfo(service="mynotes", operation="update_my_note", is_mutation=True),
             "PUT",

--- a/python/src/basecamp/generated/services/my_notifications.py
+++ b/python/src/basecamp/generated/services/my_notifications.py
@@ -43,8 +43,9 @@ class MyNotificationsService(BaseService):
         Args:
             page: Page number. Defaults to 1. A positive value selects exactly that page, not a
                 starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="mynotifications", operation="get_bubble_ups", is_mutation=False),
@@ -104,8 +105,9 @@ class AsyncMyNotificationsService(AsyncBaseService):
         Args:
             page: Page number. Defaults to 1. A positive value selects exactly that page, not a
                 starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="mynotifications", operation="get_bubble_ups", is_mutation=False),

--- a/python/src/basecamp/generated/services/my_notifications.py
+++ b/python/src/basecamp/generated/services/my_notifications.py
@@ -43,9 +43,9 @@ class MyNotificationsService(BaseService):
         Args:
             page: Page number. Defaults to 1. A positive value selects exactly that page, not a
                 starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="mynotifications", operation="get_bubble_ups", is_mutation=False),
@@ -105,9 +105,9 @@ class AsyncMyNotificationsService(AsyncBaseService):
         Args:
             page: Page number. Defaults to 1. A positive value selects exactly that page, not a
                 starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="mynotifications", operation="get_bubble_ups", is_mutation=False),

--- a/python/src/basecamp/generated/services/my_notifications.py
+++ b/python/src/basecamp/generated/services/my_notifications.py
@@ -12,6 +12,20 @@ from basecamp.hooks import OperationInfo
 
 class MyNotificationsService(BaseService):
     def get_my_notifications(self, *, page: int | None = None, limit_bubble_ups: bool | None = None) -> dict[str, Any]:
+        """Get the current user's notification inbox (the "Hey!" menu).
+        Notifications are grouped into unreads, reads, bubble-ups, and
+        scheduled bubble-ups (`memories` remains as an always-empty
+        placeholder on BC5). Reads are paginated (50 per page). Unreads are
+        capped at 100. Bubble-ups are capped per `limit_bubble_ups`.
+
+        Args:
+            page: Page number for paginating through read items. Defaults to 1. This operation is
+                not auto-paginated in any SDK, so a page is returned as asked for and later pages
+                are not followed.
+            limit_bubble_ups: Set to true to cap `bubble_ups` at 2 current bubble-ups and omit the
+                `scheduled_bubble_ups` key entirely. Defaults to false. Use the dedicated bubble-ups
+                endpoint (GetBubbleUps) to page through all current and scheduled bubble-ups.
+        """
         return self._request(
             OperationInfo(service="mynotifications", operation="get_my_notifications", is_mutation=False),
             "GET",
@@ -21,6 +35,17 @@ class MyNotificationsService(BaseService):
         )
 
     def get_bubble_ups(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """Get the current user's current and scheduled bubble-ups (paginated, 50 per page).
+        Current bubble-ups are returned first, ordered by most recently bubbled up;
+        scheduled bubble-ups follow, ordered by scheduled bubble-up time. Each item
+        uses the same notification object shape as GetMyNotifications.
+
+        Args:
+            page: Page number. Defaults to 1. A positive value selects exactly that page, not a
+                starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="mynotifications", operation="get_bubble_ups", is_mutation=False),
             "/my/readings/bubble_ups.json",
@@ -30,6 +55,11 @@ class MyNotificationsService(BaseService):
         )
 
     def mark_as_read(self, *, readables: list[str]) -> None:
+        """Mark specified items as read.
+
+        Args:
+            readables: Array of readable_sgid values identifying the items to mark as read
+        """
         self._request_void(
             OperationInfo(service="mynotifications", operation="mark_as_read", is_mutation=True),
             "PUT",
@@ -43,6 +73,20 @@ class AsyncMyNotificationsService(AsyncBaseService):
     async def get_my_notifications(
         self, *, page: int | None = None, limit_bubble_ups: bool | None = None
     ) -> dict[str, Any]:
+        """Get the current user's notification inbox (the "Hey!" menu).
+        Notifications are grouped into unreads, reads, bubble-ups, and
+        scheduled bubble-ups (`memories` remains as an always-empty
+        placeholder on BC5). Reads are paginated (50 per page). Unreads are
+        capped at 100. Bubble-ups are capped per `limit_bubble_ups`.
+
+        Args:
+            page: Page number for paginating through read items. Defaults to 1. This operation is
+                not auto-paginated in any SDK, so a page is returned as asked for and later pages
+                are not followed.
+            limit_bubble_ups: Set to true to cap `bubble_ups` at 2 current bubble-ups and omit the
+                `scheduled_bubble_ups` key entirely. Defaults to false. Use the dedicated bubble-ups
+                endpoint (GetBubbleUps) to page through all current and scheduled bubble-ups.
+        """
         return await self._request(
             OperationInfo(service="mynotifications", operation="get_my_notifications", is_mutation=False),
             "GET",
@@ -52,6 +96,17 @@ class AsyncMyNotificationsService(AsyncBaseService):
         )
 
     async def get_bubble_ups(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """Get the current user's current and scheduled bubble-ups (paginated, 50 per page).
+        Current bubble-ups are returned first, ordered by most recently bubbled up;
+        scheduled bubble-ups follow, ordered by scheduled bubble-up time. Each item
+        uses the same notification object shape as GetMyNotifications.
+
+        Args:
+            page: Page number. Defaults to 1. A positive value selects exactly that page, not a
+                starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="mynotifications", operation="get_bubble_ups", is_mutation=False),
             "/my/readings/bubble_ups.json",
@@ -61,6 +116,11 @@ class AsyncMyNotificationsService(AsyncBaseService):
         )
 
     async def mark_as_read(self, *, readables: list[str]) -> None:
+        """Mark specified items as read.
+
+        Args:
+            readables: Array of readable_sgid values identifying the items to mark as read
+        """
         await self._request_void(
             OperationInfo(service="mynotifications", operation="mark_as_read", is_mutation=True),
             "PUT",

--- a/python/src/basecamp/generated/services/people.py
+++ b/python/src/basecamp/generated/services/people.py
@@ -15,8 +15,8 @@ class PeopleService(BaseService):
         """List all account users who can be pinged.
 
         Args:
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages.
         """
         return self._request_paginated(
             OperationInfo(service="people", operation="list_pingable", is_mutation=False),
@@ -107,8 +107,9 @@ class PeopleService(BaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="people", operation="list", is_mutation=False),
@@ -181,8 +182,9 @@ class PeopleService(BaseService):
             project_id: The project id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="people", operation="list_for_project", is_mutation=False, project_id=project_id),
@@ -230,8 +232,8 @@ class AsyncPeopleService(AsyncBaseService):
         """List all account users who can be pinged.
 
         Args:
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages.
         """
         return await self._request_paginated(
             OperationInfo(service="people", operation="list_pingable", is_mutation=False),
@@ -322,8 +324,9 @@ class AsyncPeopleService(AsyncBaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="people", operation="list", is_mutation=False),
@@ -398,8 +401,9 @@ class AsyncPeopleService(AsyncBaseService):
             project_id: The project id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="people", operation="list_for_project", is_mutation=False, project_id=project_id),

--- a/python/src/basecamp/generated/services/people.py
+++ b/python/src/basecamp/generated/services/people.py
@@ -15,8 +15,9 @@ class PeopleService(BaseService):
         """List all account users who can be pinged.
 
         Args:
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages.
         """
         return self._request_paginated(
             OperationInfo(service="people", operation="list_pingable", is_mutation=False),
@@ -107,9 +108,9 @@ class PeopleService(BaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="people", operation="list", is_mutation=False),
@@ -182,9 +183,9 @@ class PeopleService(BaseService):
             project_id: The project id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="people", operation="list_for_project", is_mutation=False, project_id=project_id),
@@ -232,8 +233,9 @@ class AsyncPeopleService(AsyncBaseService):
         """List all account users who can be pinged.
 
         Args:
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages.
         """
         return await self._request_paginated(
             OperationInfo(service="people", operation="list_pingable", is_mutation=False),
@@ -324,9 +326,9 @@ class AsyncPeopleService(AsyncBaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="people", operation="list", is_mutation=False),
@@ -401,9 +403,9 @@ class AsyncPeopleService(AsyncBaseService):
             project_id: The project id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="people", operation="list_for_project", is_mutation=False, project_id=project_id),

--- a/python/src/basecamp/generated/services/people.py
+++ b/python/src/basecamp/generated/services/people.py
@@ -12,6 +12,12 @@ from basecamp.hooks import OperationInfo
 
 class PeopleService(BaseService):
     def list_pingable(self, *, max_items: int | None = None) -> ListResult:
+        """List all account users who can be pinged.
+
+        Args:
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="people", operation="list_pingable", is_mutation=False),
             "/circles/people.json",
@@ -20,6 +26,7 @@ class PeopleService(BaseService):
         )
 
     def get_my_preferences(self) -> dict[str, Any]:
+        """Get the current user's preferences."""
         return self._request(
             OperationInfo(service="people", operation="get_my_preferences", is_mutation=False),
             "GET",
@@ -28,6 +35,14 @@ class PeopleService(BaseService):
         )
 
     def update_my_preferences(self, *, person: dict) -> dict[str, Any]:
+        """Update the current user's preferences.
+        Rejections arrive as a field-keyed 422
+        ({"errors": {"time_zone_name": ["is not included in the list"]}}), not the
+        flat {error} body.
+
+        Args:
+            person: The person.
+        """
         return self._request(
             OperationInfo(service="people", operation="update_my_preferences", is_mutation=True),
             "PUT",
@@ -37,6 +52,7 @@ class PeopleService(BaseService):
         )
 
     def my_profile(self) -> dict[str, Any]:
+        """Get the current authenticated user's profile."""
         return self._request(
             OperationInfo(service="people", operation="my_profile", is_mutation=False),
             "GET",
@@ -56,6 +72,18 @@ class PeopleService(BaseService):
         first_week_day: dict | None = None,
         time_format: str | None = None,
     ) -> None:
+        """Update the current authenticated user's profile (returns 204 No Content).
+
+        Args:
+            name: The name.
+            email_address: The email address.
+            title: The title.
+            bio: The bio.
+            location: The location.
+            time_zone_name: The time zone name.
+            first_week_day: The first week day.
+            time_format: The time format.
+        """
         self._request_void(
             OperationInfo(service="people", operation="update_my_profile", is_mutation=True),
             "PUT",
@@ -74,6 +102,14 @@ class PeopleService(BaseService):
         )
 
     def list(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List all people visible to the current user.
+
+        Args:
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="people", operation="list", is_mutation=False),
             "/people.json",
@@ -83,6 +119,11 @@ class PeopleService(BaseService):
         )
 
     def get(self, *, person_id: int) -> dict[str, Any]:
+        """Get a person by ID.
+
+        Args:
+            person_id: The person id.
+        """
         return self._request(
             OperationInfo(service="people", operation="get", is_mutation=False, resource_id=person_id),
             "GET",
@@ -91,6 +132,11 @@ class PeopleService(BaseService):
         )
 
     def get_out_of_office(self, *, person_id: int) -> dict[str, Any]:
+        """Get the out of office status for a person.
+
+        Args:
+            person_id: The person id.
+        """
         return self._request(
             OperationInfo(service="people", operation="get_out_of_office", is_mutation=False, resource_id=person_id),
             "GET",
@@ -99,6 +145,13 @@ class PeopleService(BaseService):
         )
 
     def enable_out_of_office(self, *, person_id: int, out_of_office: dict) -> dict[str, Any]:
+        """Enable or replace out of office for a person.
+        Admins on Pro Pack accounts can manage others; otherwise self only.
+
+        Args:
+            person_id: The person id.
+            out_of_office: The out of office.
+        """
         return self._request(
             OperationInfo(service="people", operation="enable_out_of_office", is_mutation=True, resource_id=person_id),
             "POST",
@@ -108,6 +161,12 @@ class PeopleService(BaseService):
         )
 
     def disable_out_of_office(self, *, person_id: int) -> None:
+        """Disable out of office for a person.
+        Admins on Pro Pack accounts can manage others; otherwise self only.
+
+        Args:
+            person_id: The person id.
+        """
         self._request_void(
             OperationInfo(service="people", operation="disable_out_of_office", is_mutation=True, resource_id=person_id),
             "DELETE",
@@ -116,6 +175,15 @@ class PeopleService(BaseService):
         )
 
     def list_for_project(self, *, project_id: int, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List all active people on a project.
+
+        Args:
+            project_id: The project id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="people", operation="list_for_project", is_mutation=False, project_id=project_id),
             f"/projects/{project_id}/people.json",
@@ -132,6 +200,14 @@ class PeopleService(BaseService):
         revoke: list[int] | None = None,
         create: list[dict] | None = None,
     ) -> dict[str, Any]:
+        """Update project access (grant/revoke/create people).
+
+        Args:
+            project_id: The project id.
+            grant: The grant.
+            revoke: The revoke.
+            create: The create.
+        """
         return self._request(
             OperationInfo(service="people", operation="update_project_access", is_mutation=True, project_id=project_id),
             "PUT",
@@ -141,6 +217,7 @@ class PeopleService(BaseService):
         )
 
     def list_assignable(self) -> ListResult:
+        """List people who can be assigned todos."""
         return self._request_list(
             OperationInfo(service="people", operation="list_assignable", is_mutation=False),
             "/reports/todos/assigned.json",
@@ -150,6 +227,12 @@ class PeopleService(BaseService):
 
 class AsyncPeopleService(AsyncBaseService):
     async def list_pingable(self, *, max_items: int | None = None) -> ListResult:
+        """List all account users who can be pinged.
+
+        Args:
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="people", operation="list_pingable", is_mutation=False),
             "/circles/people.json",
@@ -158,6 +241,7 @@ class AsyncPeopleService(AsyncBaseService):
         )
 
     async def get_my_preferences(self) -> dict[str, Any]:
+        """Get the current user's preferences."""
         return await self._request(
             OperationInfo(service="people", operation="get_my_preferences", is_mutation=False),
             "GET",
@@ -166,6 +250,14 @@ class AsyncPeopleService(AsyncBaseService):
         )
 
     async def update_my_preferences(self, *, person: dict) -> dict[str, Any]:
+        """Update the current user's preferences.
+        Rejections arrive as a field-keyed 422
+        ({"errors": {"time_zone_name": ["is not included in the list"]}}), not the
+        flat {error} body.
+
+        Args:
+            person: The person.
+        """
         return await self._request(
             OperationInfo(service="people", operation="update_my_preferences", is_mutation=True),
             "PUT",
@@ -175,6 +267,7 @@ class AsyncPeopleService(AsyncBaseService):
         )
 
     async def my_profile(self) -> dict[str, Any]:
+        """Get the current authenticated user's profile."""
         return await self._request(
             OperationInfo(service="people", operation="my_profile", is_mutation=False),
             "GET",
@@ -194,6 +287,18 @@ class AsyncPeopleService(AsyncBaseService):
         first_week_day: dict | None = None,
         time_format: str | None = None,
     ) -> None:
+        """Update the current authenticated user's profile (returns 204 No Content).
+
+        Args:
+            name: The name.
+            email_address: The email address.
+            title: The title.
+            bio: The bio.
+            location: The location.
+            time_zone_name: The time zone name.
+            first_week_day: The first week day.
+            time_format: The time format.
+        """
         await self._request_void(
             OperationInfo(service="people", operation="update_my_profile", is_mutation=True),
             "PUT",
@@ -212,6 +317,14 @@ class AsyncPeopleService(AsyncBaseService):
         )
 
     async def list(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List all people visible to the current user.
+
+        Args:
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="people", operation="list", is_mutation=False),
             "/people.json",
@@ -221,6 +334,11 @@ class AsyncPeopleService(AsyncBaseService):
         )
 
     async def get(self, *, person_id: int) -> dict[str, Any]:
+        """Get a person by ID.
+
+        Args:
+            person_id: The person id.
+        """
         return await self._request(
             OperationInfo(service="people", operation="get", is_mutation=False, resource_id=person_id),
             "GET",
@@ -229,6 +347,11 @@ class AsyncPeopleService(AsyncBaseService):
         )
 
     async def get_out_of_office(self, *, person_id: int) -> dict[str, Any]:
+        """Get the out of office status for a person.
+
+        Args:
+            person_id: The person id.
+        """
         return await self._request(
             OperationInfo(service="people", operation="get_out_of_office", is_mutation=False, resource_id=person_id),
             "GET",
@@ -237,6 +360,13 @@ class AsyncPeopleService(AsyncBaseService):
         )
 
     async def enable_out_of_office(self, *, person_id: int, out_of_office: dict) -> dict[str, Any]:
+        """Enable or replace out of office for a person.
+        Admins on Pro Pack accounts can manage others; otherwise self only.
+
+        Args:
+            person_id: The person id.
+            out_of_office: The out of office.
+        """
         return await self._request(
             OperationInfo(service="people", operation="enable_out_of_office", is_mutation=True, resource_id=person_id),
             "POST",
@@ -246,6 +376,12 @@ class AsyncPeopleService(AsyncBaseService):
         )
 
     async def disable_out_of_office(self, *, person_id: int) -> None:
+        """Disable out of office for a person.
+        Admins on Pro Pack accounts can manage others; otherwise self only.
+
+        Args:
+            person_id: The person id.
+        """
         await self._request_void(
             OperationInfo(service="people", operation="disable_out_of_office", is_mutation=True, resource_id=person_id),
             "DELETE",
@@ -256,6 +392,15 @@ class AsyncPeopleService(AsyncBaseService):
     async def list_for_project(
         self, *, project_id: int, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List all active people on a project.
+
+        Args:
+            project_id: The project id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="people", operation="list_for_project", is_mutation=False, project_id=project_id),
             f"/projects/{project_id}/people.json",
@@ -272,6 +417,14 @@ class AsyncPeopleService(AsyncBaseService):
         revoke: list[int] | None = None,
         create: list[dict] | None = None,
     ) -> dict[str, Any]:
+        """Update project access (grant/revoke/create people).
+
+        Args:
+            project_id: The project id.
+            grant: The grant.
+            revoke: The revoke.
+            create: The create.
+        """
         return await self._request(
             OperationInfo(service="people", operation="update_project_access", is_mutation=True, project_id=project_id),
             "PUT",
@@ -281,6 +434,7 @@ class AsyncPeopleService(AsyncBaseService):
         )
 
     async def list_assignable(self) -> ListResult:
+        """List people who can be assigned todos."""
         return await self._request_list(
             OperationInfo(service="people", operation="list_assignable", is_mutation=False),
             "/reports/todos/assigned.json",

--- a/python/src/basecamp/generated/services/projects.py
+++ b/python/src/basecamp/generated/services/projects.py
@@ -18,9 +18,9 @@ class ProjectsService(BaseService):
             status: active|archived|trashed
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="projects", operation="list", is_mutation=False),
@@ -140,9 +140,9 @@ class AsyncProjectsService(AsyncBaseService):
             status: active|archived|trashed
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="projects", operation="list", is_mutation=False),

--- a/python/src/basecamp/generated/services/projects.py
+++ b/python/src/basecamp/generated/services/projects.py
@@ -12,6 +12,15 @@ from basecamp.hooks import OperationInfo
 
 class ProjectsService(BaseService):
     def list(self, *, status: str | None = None, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List projects (active by default; optionally archived/trashed).
+
+        Args:
+            status: active|archived|trashed
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="projects", operation="list", is_mutation=False),
             "/projects.json",
@@ -21,6 +30,12 @@ class ProjectsService(BaseService):
         )
 
     def create(self, *, name: str, description: str | None = None) -> dict[str, Any]:
+        """Create a new project.
+
+        Args:
+            name: The name.
+            description: The description.
+        """
         return self._request(
             OperationInfo(service="projects", operation="create", is_mutation=True),
             "POST",
@@ -30,6 +45,11 @@ class ProjectsService(BaseService):
         )
 
     def get(self, *, project_id: int) -> dict[str, Any]:
+        """Get a single project by id.
+
+        Args:
+            project_id: The project id.
+        """
         return self._request(
             OperationInfo(service="projects", operation="get", is_mutation=False, project_id=project_id),
             "GET",
@@ -46,6 +66,15 @@ class ProjectsService(BaseService):
         admissions: str | None = None,
         schedule_attributes: dict | None = None,
     ) -> dict[str, Any]:
+        """Update an existing project.
+
+        Args:
+            project_id: The project id.
+            name: The name.
+            description: The description.
+            admissions: invite|employee|team
+            schedule_attributes: The schedule attributes.
+        """
         return self._request(
             OperationInfo(service="projects", operation="update", is_mutation=True, project_id=project_id),
             "PUT",
@@ -57,6 +86,11 @@ class ProjectsService(BaseService):
         )
 
     def trash(self, *, project_id: int) -> None:
+        """Trash a project (returns 204 No Content).
+
+        Args:
+            project_id: The project id.
+        """
         self._request_void(
             OperationInfo(service="projects", operation="trash", is_mutation=True, project_id=project_id),
             "DELETE",
@@ -65,6 +99,13 @@ class ProjectsService(BaseService):
         )
 
     def unarchive(self, *, project_id: int) -> None:
+        """Restore a project to active status from trash as well as from the archive (returns 204 No Content).
+        This is the inverse of both ArchiveProject and TrashProject. Restoring counts against
+        the account's project limit, so it answers 507 when that limit is already reached.
+
+        Args:
+            project_id: The project id.
+        """
         self._request_void(
             OperationInfo(service="projects", operation="unarchive", is_mutation=True, project_id=project_id),
             "PUT",
@@ -73,6 +114,13 @@ class ProjectsService(BaseService):
         )
 
     def archive(self, *, project_id: int) -> None:
+        """Archive a project, removing it from the active project list (returns 204 No Content).
+        Accounts on the admin pro pack may restrict archiving to admins and the project's
+        creator, which answers 403.
+
+        Args:
+            project_id: The project id.
+        """
         self._request_void(
             OperationInfo(service="projects", operation="archive", is_mutation=True, project_id=project_id),
             "PUT",
@@ -85,6 +133,15 @@ class AsyncProjectsService(AsyncBaseService):
     async def list(
         self, *, status: str | None = None, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List projects (active by default; optionally archived/trashed).
+
+        Args:
+            status: active|archived|trashed
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="projects", operation="list", is_mutation=False),
             "/projects.json",
@@ -94,6 +151,12 @@ class AsyncProjectsService(AsyncBaseService):
         )
 
     async def create(self, *, name: str, description: str | None = None) -> dict[str, Any]:
+        """Create a new project.
+
+        Args:
+            name: The name.
+            description: The description.
+        """
         return await self._request(
             OperationInfo(service="projects", operation="create", is_mutation=True),
             "POST",
@@ -103,6 +166,11 @@ class AsyncProjectsService(AsyncBaseService):
         )
 
     async def get(self, *, project_id: int) -> dict[str, Any]:
+        """Get a single project by id.
+
+        Args:
+            project_id: The project id.
+        """
         return await self._request(
             OperationInfo(service="projects", operation="get", is_mutation=False, project_id=project_id),
             "GET",
@@ -119,6 +187,15 @@ class AsyncProjectsService(AsyncBaseService):
         admissions: str | None = None,
         schedule_attributes: dict | None = None,
     ) -> dict[str, Any]:
+        """Update an existing project.
+
+        Args:
+            project_id: The project id.
+            name: The name.
+            description: The description.
+            admissions: invite|employee|team
+            schedule_attributes: The schedule attributes.
+        """
         return await self._request(
             OperationInfo(service="projects", operation="update", is_mutation=True, project_id=project_id),
             "PUT",
@@ -130,6 +207,11 @@ class AsyncProjectsService(AsyncBaseService):
         )
 
     async def trash(self, *, project_id: int) -> None:
+        """Trash a project (returns 204 No Content).
+
+        Args:
+            project_id: The project id.
+        """
         await self._request_void(
             OperationInfo(service="projects", operation="trash", is_mutation=True, project_id=project_id),
             "DELETE",
@@ -138,6 +220,13 @@ class AsyncProjectsService(AsyncBaseService):
         )
 
     async def unarchive(self, *, project_id: int) -> None:
+        """Restore a project to active status from trash as well as from the archive (returns 204 No Content).
+        This is the inverse of both ArchiveProject and TrashProject. Restoring counts against
+        the account's project limit, so it answers 507 when that limit is already reached.
+
+        Args:
+            project_id: The project id.
+        """
         await self._request_void(
             OperationInfo(service="projects", operation="unarchive", is_mutation=True, project_id=project_id),
             "PUT",
@@ -146,6 +235,13 @@ class AsyncProjectsService(AsyncBaseService):
         )
 
     async def archive(self, *, project_id: int) -> None:
+        """Archive a project, removing it from the active project list (returns 204 No Content).
+        Accounts on the admin pro pack may restrict archiving to admins and the project's
+        creator, which answers 403.
+
+        Args:
+            project_id: The project id.
+        """
         await self._request_void(
             OperationInfo(service="projects", operation="archive", is_mutation=True, project_id=project_id),
             "PUT",

--- a/python/src/basecamp/generated/services/projects.py
+++ b/python/src/basecamp/generated/services/projects.py
@@ -18,8 +18,9 @@ class ProjectsService(BaseService):
             status: active|archived|trashed
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="projects", operation="list", is_mutation=False),
@@ -139,8 +140,9 @@ class AsyncProjectsService(AsyncBaseService):
             status: active|archived|trashed
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="projects", operation="list", is_mutation=False),

--- a/python/src/basecamp/generated/services/recordings.py
+++ b/python/src/basecamp/generated/services/recordings.py
@@ -22,6 +22,20 @@ class RecordingsService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """List recordings of a given type across projects.
+
+        Args:
+            type: Comment|Document|Door|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule:
+                :Entry|Todo|Todolist|Upload|Vault
+            bucket: The bucket.
+            status: active|archived|trashed
+            sort: created_at|updated_at
+            direction: asc|desc
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="recordings", operation="list", is_mutation=False),
             "/projects/recordings.json",
@@ -31,6 +45,11 @@ class RecordingsService(BaseService):
         )
 
     def unarchive(self, *, recording_id: int) -> None:
+        """Unarchive a recording (restore to active status).
+
+        Args:
+            recording_id: The recording id.
+        """
         self._request_void(
             OperationInfo(service="recordings", operation="unarchive", is_mutation=True, resource_id=recording_id),
             "PUT",
@@ -39,6 +58,11 @@ class RecordingsService(BaseService):
         )
 
     def archive(self, *, recording_id: int) -> None:
+        """Archive a recording.
+
+        Args:
+            recording_id: The recording id.
+        """
         self._request_void(
             OperationInfo(service="recordings", operation="archive", is_mutation=True, resource_id=recording_id),
             "PUT",
@@ -47,6 +71,11 @@ class RecordingsService(BaseService):
         )
 
     def trash(self, *, recording_id: int) -> None:
+        """Trash a recording.
+
+        Args:
+            recording_id: The recording id.
+        """
         self._request_void(
             OperationInfo(service="recordings", operation="trash", is_mutation=True, resource_id=recording_id),
             "PUT",
@@ -67,6 +96,20 @@ class AsyncRecordingsService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """List recordings of a given type across projects.
+
+        Args:
+            type: Comment|Document|Door|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule:
+                :Entry|Todo|Todolist|Upload|Vault
+            bucket: The bucket.
+            status: active|archived|trashed
+            sort: created_at|updated_at
+            direction: asc|desc
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="recordings", operation="list", is_mutation=False),
             "/projects/recordings.json",
@@ -76,6 +119,11 @@ class AsyncRecordingsService(AsyncBaseService):
         )
 
     async def unarchive(self, *, recording_id: int) -> None:
+        """Unarchive a recording (restore to active status).
+
+        Args:
+            recording_id: The recording id.
+        """
         await self._request_void(
             OperationInfo(service="recordings", operation="unarchive", is_mutation=True, resource_id=recording_id),
             "PUT",
@@ -84,6 +132,11 @@ class AsyncRecordingsService(AsyncBaseService):
         )
 
     async def archive(self, *, recording_id: int) -> None:
+        """Archive a recording.
+
+        Args:
+            recording_id: The recording id.
+        """
         await self._request_void(
             OperationInfo(service="recordings", operation="archive", is_mutation=True, resource_id=recording_id),
             "PUT",
@@ -92,6 +145,11 @@ class AsyncRecordingsService(AsyncBaseService):
         )
 
     async def trash(self, *, recording_id: int) -> None:
+        """Trash a recording.
+
+        Args:
+            recording_id: The recording id.
+        """
         await self._request_void(
             OperationInfo(service="recordings", operation="trash", is_mutation=True, resource_id=recording_id),
             "PUT",

--- a/python/src/basecamp/generated/services/recordings.py
+++ b/python/src/basecamp/generated/services/recordings.py
@@ -33,9 +33,9 @@ class RecordingsService(BaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="recordings", operation="list", is_mutation=False),
@@ -108,9 +108,9 @@ class AsyncRecordingsService(AsyncBaseService):
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="recordings", operation="list", is_mutation=False),

--- a/python/src/basecamp/generated/services/recordings.py
+++ b/python/src/basecamp/generated/services/recordings.py
@@ -25,16 +25,17 @@ class RecordingsService(BaseService):
         """List recordings of a given type across projects.
 
         Args:
-            type: Comment|Document|Door|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule:
-                :Entry|Todo|Todolist|Upload|Vault
+            type:
+                Comment|Document|Door|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault
             bucket: The bucket.
             status: active|archived|trashed
             sort: created_at|updated_at
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="recordings", operation="list", is_mutation=False),
@@ -99,16 +100,17 @@ class AsyncRecordingsService(AsyncBaseService):
         """List recordings of a given type across projects.
 
         Args:
-            type: Comment|Document|Door|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule:
-                :Entry|Todo|Todolist|Upload|Vault
+            type:
+                Comment|Document|Door|Kanban::Card|Kanban::Step|Message|Question::Answer|Schedule::Entry|Todo|Todolist|Upload|Vault
             bucket: The bucket.
             status: active|archived|trashed
             sort: created_at|updated_at
             direction: asc|desc
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="recordings", operation="list", is_mutation=False),

--- a/python/src/basecamp/generated/services/reports.py
+++ b/python/src/basecamp/generated/services/reports.py
@@ -12,6 +12,14 @@ from basecamp.hooks import OperationInfo
 
 class ReportsService(BaseService):
     def progress(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """Get account-wide activity feed (progress report).
+
+        Args:
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="reports", operation="progress", is_mutation=False),
             "/reports/progress.json",
@@ -21,6 +29,24 @@ class ReportsService(BaseService):
         )
 
     def upcoming(self, *, window_starts_on: str, window_ends_on: str) -> dict[str, Any]:
+        """Get upcoming schedule entries and assignable items within a date window.
+        This endpoint is preserved as the canonical API path on BC5;
+        the BC5 `/calendar` web view is HTML-only.
+
+        The three arrays carry the report's own reduced projections —
+        UpcomingScheduleEntry and UpcomingAssignable — not the shared ScheduleEntry
+        and Todo/Card shapes. BC3 renders this report through
+        `app/views/api/schedules/calendar/_entry.json.jbuilder` and
+        `_assignable.json.jbuilder`, which emit a narrower key set than the
+        per-resource partials, plus keys those partials never emit. See
+        UpcomingScheduleEntry for the full accounting.
+
+        Args:
+            window_starts_on: Inclusive first day of the window, `YYYY-MM-DD`. Required — BC3
+                answers 400 without it.
+            window_ends_on: Inclusive last day of the window, `YYYY-MM-DD`. Required — BC3 answers
+                400 without it.
+        """
         return self._request(
             OperationInfo(service="reports", operation="upcoming", is_mutation=False),
             "GET",
@@ -30,6 +56,12 @@ class ReportsService(BaseService):
         )
 
     def assigned(self, *, person_id: int, group_by: str | None = None) -> dict[str, Any]:
+        """Get todos assigned to a specific person.
+
+        Args:
+            person_id: The person id.
+            group_by: Group by "bucket" or "date"
+        """
         return self._request(
             OperationInfo(service="reports", operation="assigned", is_mutation=False, resource_id=person_id),
             "GET",
@@ -39,6 +71,7 @@ class ReportsService(BaseService):
         )
 
     def overdue(self) -> dict[str, Any]:
+        """Get overdue todos grouped by lateness."""
         return self._request(
             OperationInfo(service="reports", operation="overdue", is_mutation=False),
             "GET",
@@ -49,6 +82,15 @@ class ReportsService(BaseService):
     def person_progress(
         self, *, person_id: int, page: int | None = None, max_items: int | None = None
     ) -> dict[str, Any]:
+        """Get a person's activity timeline.
+
+        Args:
+            person_id: The person id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated_wrapped(
             OperationInfo(service="reports", operation="person_progress", is_mutation=False, resource_id=person_id),
             f"/reports/users/progress/{person_id}.json",
@@ -61,6 +103,14 @@ class ReportsService(BaseService):
 
 class AsyncReportsService(AsyncBaseService):
     async def progress(self, *, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """Get account-wide activity feed (progress report).
+
+        Args:
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="reports", operation="progress", is_mutation=False),
             "/reports/progress.json",
@@ -70,6 +120,24 @@ class AsyncReportsService(AsyncBaseService):
         )
 
     async def upcoming(self, *, window_starts_on: str, window_ends_on: str) -> dict[str, Any]:
+        """Get upcoming schedule entries and assignable items within a date window.
+        This endpoint is preserved as the canonical API path on BC5;
+        the BC5 `/calendar` web view is HTML-only.
+
+        The three arrays carry the report's own reduced projections —
+        UpcomingScheduleEntry and UpcomingAssignable — not the shared ScheduleEntry
+        and Todo/Card shapes. BC3 renders this report through
+        `app/views/api/schedules/calendar/_entry.json.jbuilder` and
+        `_assignable.json.jbuilder`, which emit a narrower key set than the
+        per-resource partials, plus keys those partials never emit. See
+        UpcomingScheduleEntry for the full accounting.
+
+        Args:
+            window_starts_on: Inclusive first day of the window, `YYYY-MM-DD`. Required — BC3
+                answers 400 without it.
+            window_ends_on: Inclusive last day of the window, `YYYY-MM-DD`. Required — BC3 answers
+                400 without it.
+        """
         return await self._request(
             OperationInfo(service="reports", operation="upcoming", is_mutation=False),
             "GET",
@@ -79,6 +147,12 @@ class AsyncReportsService(AsyncBaseService):
         )
 
     async def assigned(self, *, person_id: int, group_by: str | None = None) -> dict[str, Any]:
+        """Get todos assigned to a specific person.
+
+        Args:
+            person_id: The person id.
+            group_by: Group by "bucket" or "date"
+        """
         return await self._request(
             OperationInfo(service="reports", operation="assigned", is_mutation=False, resource_id=person_id),
             "GET",
@@ -88,6 +162,7 @@ class AsyncReportsService(AsyncBaseService):
         )
 
     async def overdue(self) -> dict[str, Any]:
+        """Get overdue todos grouped by lateness."""
         return await self._request(
             OperationInfo(service="reports", operation="overdue", is_mutation=False),
             "GET",
@@ -98,6 +173,15 @@ class AsyncReportsService(AsyncBaseService):
     async def person_progress(
         self, *, person_id: int, page: int | None = None, max_items: int | None = None
     ) -> dict[str, Any]:
+        """Get a person's activity timeline.
+
+        Args:
+            person_id: The person id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated_wrapped(
             OperationInfo(service="reports", operation="person_progress", is_mutation=False, resource_id=person_id),
             f"/reports/users/progress/{person_id}.json",

--- a/python/src/basecamp/generated/services/reports.py
+++ b/python/src/basecamp/generated/services/reports.py
@@ -17,8 +17,9 @@ class ReportsService(BaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="reports", operation="progress", is_mutation=False),
@@ -88,8 +89,9 @@ class ReportsService(BaseService):
             person_id: The person id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated_wrapped(
             OperationInfo(service="reports", operation="person_progress", is_mutation=False, resource_id=person_id),
@@ -108,8 +110,9 @@ class AsyncReportsService(AsyncBaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="reports", operation="progress", is_mutation=False),
@@ -179,8 +182,9 @@ class AsyncReportsService(AsyncBaseService):
             person_id: The person id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated_wrapped(
             OperationInfo(service="reports", operation="person_progress", is_mutation=False, resource_id=person_id),

--- a/python/src/basecamp/generated/services/reports.py
+++ b/python/src/basecamp/generated/services/reports.py
@@ -17,9 +17,9 @@ class ReportsService(BaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="reports", operation="progress", is_mutation=False),
@@ -89,9 +89,9 @@ class ReportsService(BaseService):
             person_id: The person id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated_wrapped(
             OperationInfo(service="reports", operation="person_progress", is_mutation=False, resource_id=person_id),
@@ -110,9 +110,9 @@ class AsyncReportsService(AsyncBaseService):
         Args:
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="reports", operation="progress", is_mutation=False),
@@ -182,9 +182,9 @@ class AsyncReportsService(AsyncBaseService):
             person_id: The person id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated_wrapped(
             OperationInfo(service="reports", operation="person_progress", is_mutation=False, resource_id=person_id),

--- a/python/src/basecamp/generated/services/schedules.py
+++ b/python/src/basecamp/generated/services/schedules.py
@@ -12,6 +12,13 @@ from basecamp.hooks import OperationInfo
 
 class SchedulesService(BaseService):
     def get_entry(self, *, entry_id: int) -> dict[str, Any]:
+        """Get a single schedule entry by id.
+        Note: Recurring entries will redirect (302) to their recordable URL.
+        Use GetScheduleEntryOccurrence for recurring entries instead.
+
+        Args:
+            entry_id: The entry id.
+        """
         return self._request(
             OperationInfo(service="schedules", operation="get_entry", is_mutation=False, resource_id=entry_id),
             "GET",
@@ -33,6 +40,76 @@ class SchedulesService(BaseService):
         url: str | None = None,
         highlighted: bool | None = None,
     ) -> dict[str, Any]:
+        """Replace a schedule entry with a new complete representation.
+        The request body is the entry's full writable state: a writable field
+        omitted from the request is cleared server-side, because BC3 builds a
+        brand-new Schedule::Entry from the permitted params and swaps the recordable
+        wholesale.
+        Three writable fields are carved out of that swap and preserved when the
+        request does not address them — participant_ids, url and highlighted, as
+        declared by preservedOnOmission. Each is a field a caller could not safely
+        resend from a read-back, which is why the guard is server-side: the response
+        carries participants (objects, not ids) and join_url (the entry's own url
+        key is its Basecamp API URL, a different value under a colliding name).
+        Addressing one applies it normally, so participant_ids: [] clears the
+        participants, url: "" clears the join link and highlighted: false removes
+        the highlight.
+        starts_at and ends_at are required: Schedule::Entry validates their presence
+        and Recording validates the associated recordable on update, so omitting
+        either is a 422 rather than a clear. summary carries no validation — omit it
+        and the entry reads back as "Untitled" (Schedule::Entry#summary falls back
+        when blank).
+        Recurring entries are unreachable here. ensure_non_recurring_event redirects
+        both show and update to the entry's occurrence, so this operation serves
+        non-recurring entries only; read a recurring entry through
+        GetScheduleEntryOccurrence.
+        time_zone_name, recurs_until and recurrence_schedule are not modeled: BC3
+        forces all three to nil for a non-recurring entry, which is the only kind
+        this route serves.
+        Subscribers follow the same carve-out logic one level up. A drafted entry
+        keeps its current subscribers when the request addresses neither
+        subscriptions, notify, nor the participant parameters.
+        To set some fields while preserving the rest, use the SDK's merge-safe
+        update or edit methods, which GET the current entry and PUT the full
+        representation back. Those read-modify-write helpers are not atomic:
+        a concurrent write between the GET and PUT is overwritten (last write
+        wins for the whole representation; the window is one round-trip).
+
+        Args:
+            entry_id: The entry id.
+            starts_at: The entry's start, as a bare date ("2026-06-01") for an all-day entry or a
+                full timestamp otherwise. Same rule as CreateScheduleEntry: send it verbatim, never
+                parsed and re-rendered.
+            ends_at: The entry's end. See starts_at for the date-vs-timestamp rule.
+            summary: The summary.
+            description: The description.
+            participant_ids: Replaces the entry's participants. Omitting this member preserves the
+                current participants; sending an empty array clears them. That guarantee is BC3-side
+                and recent: until basecamp/bc3#12425, `Schedules::EntriesController#update` called
+                `replace_participants` unconditionally, so any update omitting the key — including
+                the shape in BC3's own "Update a schedule entry" doc example — silently removed
+                every participant and notified each one. The controller now guards on the request
+                actually addressing participants.
+            all_day: Whether the entry occupies whole days rather than a time range. Not carved out,
+                and the carve-out list is what makes that dangerous to forget:
+                `schedule_entries.all_day` is NOT NULL with a `false` default, so omitting this
+                member on a replace resets it — silently converting an all-day entry into a
+                midnight-to-midnight timed one. The SDK's merge-safe update and edit resend it from
+                the read-back for exactly this reason. Sending an explicit null is worse than
+                omitting it: the column rejects NULL, so BC3 raises rather than falling back to the
+                default. The same is true of highlighted.
+            notify: The notify.
+            url: The entry's join link — a video-call URL or similar, up to 2500 characters,
+                validated as a URL when present. Omitting this member preserves the current join
+                link; sending an empty string clears it. Read it back as `join_url`, never as `url`:
+                the entry's `url` is its own Basecamp API URL, written by a partial that renders
+                before this one, so BC3 emits the join link under a non-colliding key. Echoing the
+                response's `url` into this member would write the API URL into the join link.
+            highlighted: Whether the entry is highlighted on the schedule. Omitting this member
+                preserves the current highlight; sending false removes it. Preserved on omission
+                because until basecamp/bc3#12502 the field was writable but never returned, so no
+                caller could resend it.
+        """
         return self._request(
             OperationInfo(service="schedules", operation="replace_entry", is_mutation=True, resource_id=entry_id),
             "PUT",
@@ -52,6 +129,12 @@ class SchedulesService(BaseService):
         )
 
     def get_entry_occurrence(self, *, entry_id: int, date: str) -> dict[str, Any]:
+        """Get a specific occurrence of a recurring schedule entry.
+
+        Args:
+            entry_id: The entry id.
+            date: The date.
+        """
         return self._request(
             OperationInfo(
                 service="schedules", operation="get_entry_occurrence", is_mutation=False, resource_id=entry_id
@@ -62,6 +145,11 @@ class SchedulesService(BaseService):
         )
 
     def get(self, *, schedule_id: int) -> dict[str, Any]:
+        """Get a schedule.
+
+        Args:
+            schedule_id: The schedule id.
+        """
         return self._request(
             OperationInfo(service="schedules", operation="get", is_mutation=False, resource_id=schedule_id),
             "GET",
@@ -70,6 +158,12 @@ class SchedulesService(BaseService):
         )
 
     def update_settings(self, *, schedule_id: int, include_due_assignments: bool) -> dict[str, Any]:
+        """Update schedule settings.
+
+        Args:
+            schedule_id: The schedule id.
+            include_due_assignments: The include due assignments.
+        """
         return self._request(
             OperationInfo(service="schedules", operation="update_settings", is_mutation=True, resource_id=schedule_id),
             "PUT",
@@ -81,6 +175,16 @@ class SchedulesService(BaseService):
     def list_entries(
         self, *, schedule_id: int, status: str | None = None, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List entries on a schedule.
+
+        Args:
+            schedule_id: The schedule id.
+            status: active|archived|trashed
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="schedules", operation="list_entries", is_mutation=False, resource_id=schedule_id),
             f"/schedules/{schedule_id}/entries.json",
@@ -106,6 +210,52 @@ class SchedulesService(BaseService):
         subscriptions: list[int] | None = None,
         visible_to_clients: bool | None = None,
     ) -> dict[str, Any]:
+        """Create a new schedule entry.
+
+        Args:
+            schedule_id: The schedule id.
+            summary: The summary.
+            starts_at: The entry's start, as a bare date ("2026-06-01") for an all-day entry or a
+                full timestamp ("2026-06-01T09:00:00Z") otherwise — the same two forms the response
+                renders, and the same two ReplaceScheduleEntry accepts. Create and replace share one
+                permit list: `Schedules::Entries::BaseController#base_schedule_entry_params` is what
+                both `new_schedule_entry_params` and `update_schedule_entry_params` call, and
+                Schedule::Entry does no format-specific parsing of either bound, so whatever one
+                operation takes the other takes too. Treat the value as opaque and send it verbatim.
+                Parsing it into a date-time type and re-rendering rewrites an all-day entry's bounds
+                into midnight timestamps, which is why every SDK models it as a string.
+            ends_at: The entry's end. See starts_at for the date-vs-timestamp rule.
+            description: The description.
+            participant_ids: The participant ids.
+            all_day: The all day.
+            notify: The notify.
+            url: The entry's join link — a video-call URL or similar, up to 2500 characters,
+                validated as a URL when present. A scheme-less value is normalized to `https://`.
+                Spell it `url` on the way in and read it back as `join_url`: the response key `url`
+                is the entry's own Basecamp API URL, written by a partial that renders before this
+                field, so BC3 emits the join link under a non-colliding name. Sending `join_url`
+                instead is silently dropped by strong parameters — the create succeeds with no join
+                link. Accepted on create since long before it was documented:
+                `Schedules::Entries::BaseController#base_schedule_entry_params` permits it and
+                `new_schedule_entry_params` passes it through unchanged for API requests. Modeling
+                it only on ReplaceScheduleEntry forced callers into a three-request read-modify-
+                write for a field the create already took — and create is the notifying write, so
+                participants learned about a video call before its link existed.
+            highlighted: Whether the entry is highlighted on the schedule. Defaults to false. Do not
+                send an explicit null: `schedule_entries.highlighted` is NOT NULL, so BC3 raises
+                rather than falling back to the default. Omit it instead — every SDK's request
+                compactor already drops unset members.
+            status: Publication state at creation — `active|drafted`, defaulting to `active` for an
+                API create. A top-level parameter, not part of the entry's attributes: `status` is a
+                Recording column, so `wrap_parameters` leaves it outside the `schedule_entry`
+                envelope and `Recording::StatusParam#status_param` reads it directly. On create it
+                accepts `drafted`, `active`, `archived` or `trashed` and raises
+                `ActionController::BadRequest` — a 400, not a 422 — for anything else; the two
+                documented values are the two worth sending. Unlike messages and documents,
+                schedule-entry drafts are not listed by GetMyDrafts.
+            subscriptions: The subscriptions.
+            visible_to_clients: The visible to clients.
+        """
         return self._request(
             OperationInfo(service="schedules", operation="create_entry", is_mutation=True, resource_id=schedule_id),
             "POST",
@@ -130,6 +280,13 @@ class SchedulesService(BaseService):
 
 class AsyncSchedulesService(AsyncBaseService):
     async def get_entry(self, *, entry_id: int) -> dict[str, Any]:
+        """Get a single schedule entry by id.
+        Note: Recurring entries will redirect (302) to their recordable URL.
+        Use GetScheduleEntryOccurrence for recurring entries instead.
+
+        Args:
+            entry_id: The entry id.
+        """
         return await self._request(
             OperationInfo(service="schedules", operation="get_entry", is_mutation=False, resource_id=entry_id),
             "GET",
@@ -151,6 +308,76 @@ class AsyncSchedulesService(AsyncBaseService):
         url: str | None = None,
         highlighted: bool | None = None,
     ) -> dict[str, Any]:
+        """Replace a schedule entry with a new complete representation.
+        The request body is the entry's full writable state: a writable field
+        omitted from the request is cleared server-side, because BC3 builds a
+        brand-new Schedule::Entry from the permitted params and swaps the recordable
+        wholesale.
+        Three writable fields are carved out of that swap and preserved when the
+        request does not address them — participant_ids, url and highlighted, as
+        declared by preservedOnOmission. Each is a field a caller could not safely
+        resend from a read-back, which is why the guard is server-side: the response
+        carries participants (objects, not ids) and join_url (the entry's own url
+        key is its Basecamp API URL, a different value under a colliding name).
+        Addressing one applies it normally, so participant_ids: [] clears the
+        participants, url: "" clears the join link and highlighted: false removes
+        the highlight.
+        starts_at and ends_at are required: Schedule::Entry validates their presence
+        and Recording validates the associated recordable on update, so omitting
+        either is a 422 rather than a clear. summary carries no validation — omit it
+        and the entry reads back as "Untitled" (Schedule::Entry#summary falls back
+        when blank).
+        Recurring entries are unreachable here. ensure_non_recurring_event redirects
+        both show and update to the entry's occurrence, so this operation serves
+        non-recurring entries only; read a recurring entry through
+        GetScheduleEntryOccurrence.
+        time_zone_name, recurs_until and recurrence_schedule are not modeled: BC3
+        forces all three to nil for a non-recurring entry, which is the only kind
+        this route serves.
+        Subscribers follow the same carve-out logic one level up. A drafted entry
+        keeps its current subscribers when the request addresses neither
+        subscriptions, notify, nor the participant parameters.
+        To set some fields while preserving the rest, use the SDK's merge-safe
+        update or edit methods, which GET the current entry and PUT the full
+        representation back. Those read-modify-write helpers are not atomic:
+        a concurrent write between the GET and PUT is overwritten (last write
+        wins for the whole representation; the window is one round-trip).
+
+        Args:
+            entry_id: The entry id.
+            starts_at: The entry's start, as a bare date ("2026-06-01") for an all-day entry or a
+                full timestamp otherwise. Same rule as CreateScheduleEntry: send it verbatim, never
+                parsed and re-rendered.
+            ends_at: The entry's end. See starts_at for the date-vs-timestamp rule.
+            summary: The summary.
+            description: The description.
+            participant_ids: Replaces the entry's participants. Omitting this member preserves the
+                current participants; sending an empty array clears them. That guarantee is BC3-side
+                and recent: until basecamp/bc3#12425, `Schedules::EntriesController#update` called
+                `replace_participants` unconditionally, so any update omitting the key — including
+                the shape in BC3's own "Update a schedule entry" doc example — silently removed
+                every participant and notified each one. The controller now guards on the request
+                actually addressing participants.
+            all_day: Whether the entry occupies whole days rather than a time range. Not carved out,
+                and the carve-out list is what makes that dangerous to forget:
+                `schedule_entries.all_day` is NOT NULL with a `false` default, so omitting this
+                member on a replace resets it — silently converting an all-day entry into a
+                midnight-to-midnight timed one. The SDK's merge-safe update and edit resend it from
+                the read-back for exactly this reason. Sending an explicit null is worse than
+                omitting it: the column rejects NULL, so BC3 raises rather than falling back to the
+                default. The same is true of highlighted.
+            notify: The notify.
+            url: The entry's join link — a video-call URL or similar, up to 2500 characters,
+                validated as a URL when present. Omitting this member preserves the current join
+                link; sending an empty string clears it. Read it back as `join_url`, never as `url`:
+                the entry's `url` is its own Basecamp API URL, written by a partial that renders
+                before this one, so BC3 emits the join link under a non-colliding key. Echoing the
+                response's `url` into this member would write the API URL into the join link.
+            highlighted: Whether the entry is highlighted on the schedule. Omitting this member
+                preserves the current highlight; sending false removes it. Preserved on omission
+                because until basecamp/bc3#12502 the field was writable but never returned, so no
+                caller could resend it.
+        """
         return await self._request(
             OperationInfo(service="schedules", operation="replace_entry", is_mutation=True, resource_id=entry_id),
             "PUT",
@@ -170,6 +397,12 @@ class AsyncSchedulesService(AsyncBaseService):
         )
 
     async def get_entry_occurrence(self, *, entry_id: int, date: str) -> dict[str, Any]:
+        """Get a specific occurrence of a recurring schedule entry.
+
+        Args:
+            entry_id: The entry id.
+            date: The date.
+        """
         return await self._request(
             OperationInfo(
                 service="schedules", operation="get_entry_occurrence", is_mutation=False, resource_id=entry_id
@@ -180,6 +413,11 @@ class AsyncSchedulesService(AsyncBaseService):
         )
 
     async def get(self, *, schedule_id: int) -> dict[str, Any]:
+        """Get a schedule.
+
+        Args:
+            schedule_id: The schedule id.
+        """
         return await self._request(
             OperationInfo(service="schedules", operation="get", is_mutation=False, resource_id=schedule_id),
             "GET",
@@ -188,6 +426,12 @@ class AsyncSchedulesService(AsyncBaseService):
         )
 
     async def update_settings(self, *, schedule_id: int, include_due_assignments: bool) -> dict[str, Any]:
+        """Update schedule settings.
+
+        Args:
+            schedule_id: The schedule id.
+            include_due_assignments: The include due assignments.
+        """
         return await self._request(
             OperationInfo(service="schedules", operation="update_settings", is_mutation=True, resource_id=schedule_id),
             "PUT",
@@ -199,6 +443,16 @@ class AsyncSchedulesService(AsyncBaseService):
     async def list_entries(
         self, *, schedule_id: int, status: str | None = None, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List entries on a schedule.
+
+        Args:
+            schedule_id: The schedule id.
+            status: active|archived|trashed
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="schedules", operation="list_entries", is_mutation=False, resource_id=schedule_id),
             f"/schedules/{schedule_id}/entries.json",
@@ -224,6 +478,52 @@ class AsyncSchedulesService(AsyncBaseService):
         subscriptions: list[int] | None = None,
         visible_to_clients: bool | None = None,
     ) -> dict[str, Any]:
+        """Create a new schedule entry.
+
+        Args:
+            schedule_id: The schedule id.
+            summary: The summary.
+            starts_at: The entry's start, as a bare date ("2026-06-01") for an all-day entry or a
+                full timestamp ("2026-06-01T09:00:00Z") otherwise — the same two forms the response
+                renders, and the same two ReplaceScheduleEntry accepts. Create and replace share one
+                permit list: `Schedules::Entries::BaseController#base_schedule_entry_params` is what
+                both `new_schedule_entry_params` and `update_schedule_entry_params` call, and
+                Schedule::Entry does no format-specific parsing of either bound, so whatever one
+                operation takes the other takes too. Treat the value as opaque and send it verbatim.
+                Parsing it into a date-time type and re-rendering rewrites an all-day entry's bounds
+                into midnight timestamps, which is why every SDK models it as a string.
+            ends_at: The entry's end. See starts_at for the date-vs-timestamp rule.
+            description: The description.
+            participant_ids: The participant ids.
+            all_day: The all day.
+            notify: The notify.
+            url: The entry's join link — a video-call URL or similar, up to 2500 characters,
+                validated as a URL when present. A scheme-less value is normalized to `https://`.
+                Spell it `url` on the way in and read it back as `join_url`: the response key `url`
+                is the entry's own Basecamp API URL, written by a partial that renders before this
+                field, so BC3 emits the join link under a non-colliding name. Sending `join_url`
+                instead is silently dropped by strong parameters — the create succeeds with no join
+                link. Accepted on create since long before it was documented:
+                `Schedules::Entries::BaseController#base_schedule_entry_params` permits it and
+                `new_schedule_entry_params` passes it through unchanged for API requests. Modeling
+                it only on ReplaceScheduleEntry forced callers into a three-request read-modify-
+                write for a field the create already took — and create is the notifying write, so
+                participants learned about a video call before its link existed.
+            highlighted: Whether the entry is highlighted on the schedule. Defaults to false. Do not
+                send an explicit null: `schedule_entries.highlighted` is NOT NULL, so BC3 raises
+                rather than falling back to the default. Omit it instead — every SDK's request
+                compactor already drops unset members.
+            status: Publication state at creation — `active|drafted`, defaulting to `active` for an
+                API create. A top-level parameter, not part of the entry's attributes: `status` is a
+                Recording column, so `wrap_parameters` leaves it outside the `schedule_entry`
+                envelope and `Recording::StatusParam#status_param` reads it directly. On create it
+                accepts `drafted`, `active`, `archived` or `trashed` and raises
+                `ActionController::BadRequest` — a 400, not a 422 — for anything else; the two
+                documented values are the two worth sending. Unlike messages and documents,
+                schedule-entry drafts are not listed by GetMyDrafts.
+            subscriptions: The subscriptions.
+            visible_to_clients: The visible to clients.
+        """
         return await self._request(
             OperationInfo(service="schedules", operation="create_entry", is_mutation=True, resource_id=schedule_id),
             "POST",

--- a/python/src/basecamp/generated/services/schedules.py
+++ b/python/src/basecamp/generated/services/schedules.py
@@ -182,8 +182,9 @@ class SchedulesService(BaseService):
             status: active|archived|trashed
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="schedules", operation="list_entries", is_mutation=False, resource_id=schedule_id),
@@ -238,9 +239,9 @@ class SchedulesService(BaseService):
                 link. Accepted on create since long before it was documented:
                 `Schedules::Entries::BaseController#base_schedule_entry_params` permits it and
                 `new_schedule_entry_params` passes it through unchanged for API requests. Modeling
-                it only on ReplaceScheduleEntry forced callers into a three-request read-modify-
-                write for a field the create already took — and create is the notifying write, so
-                participants learned about a video call before its link existed.
+                it only on ReplaceScheduleEntry forced callers into a three-request
+                read-modify-write for a field the create already took — and create is the notifying
+                write, so participants learned about a video call before its link existed.
             highlighted: Whether the entry is highlighted on the schedule. Defaults to false. Do not
                 send an explicit null: `schedule_entries.highlighted` is NOT NULL, so BC3 raises
                 rather than falling back to the default. Omit it instead — every SDK's request
@@ -450,8 +451,9 @@ class AsyncSchedulesService(AsyncBaseService):
             status: active|archived|trashed
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="schedules", operation="list_entries", is_mutation=False, resource_id=schedule_id),
@@ -506,9 +508,9 @@ class AsyncSchedulesService(AsyncBaseService):
                 link. Accepted on create since long before it was documented:
                 `Schedules::Entries::BaseController#base_schedule_entry_params` permits it and
                 `new_schedule_entry_params` passes it through unchanged for API requests. Modeling
-                it only on ReplaceScheduleEntry forced callers into a three-request read-modify-
-                write for a field the create already took — and create is the notifying write, so
-                participants learned about a video call before its link existed.
+                it only on ReplaceScheduleEntry forced callers into a three-request
+                read-modify-write for a field the create already took — and create is the notifying
+                write, so participants learned about a video call before its link existed.
             highlighted: Whether the entry is highlighted on the schedule. Defaults to false. Do not
                 send an explicit null: `schedule_entries.highlighted` is NOT NULL, so BC3 raises
                 rather than falling back to the default. Omit it instead — every SDK's request

--- a/python/src/basecamp/generated/services/schedules.py
+++ b/python/src/basecamp/generated/services/schedules.py
@@ -182,9 +182,9 @@ class SchedulesService(BaseService):
             status: active|archived|trashed
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="schedules", operation="list_entries", is_mutation=False, resource_id=schedule_id),
@@ -451,9 +451,9 @@ class AsyncSchedulesService(AsyncBaseService):
             status: active|archived|trashed
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="schedules", operation="list_entries", is_mutation=False, resource_id=schedule_id),

--- a/python/src/basecamp/generated/services/search.py
+++ b/python/src/basecamp/generated/services/search.py
@@ -28,11 +28,32 @@ class SearchService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
-        """Deprecated parameters (prefer the replacement):
+        """Search for content across the account.
+
+        Deprecated parameters (prefer the replacement):
 
         - type: prefer type_names[].
         - bucket_id: prefer bucket_ids[].
         - creator_id: prefer creator_ids[].
+
+        Args:
+            q: The q.
+            type_names: Recording types to include. Use `key` values from the metadata endpoint's
+                `recording_search_types`. Available since Basecamp 5.
+            bucket_ids: Project IDs to filter by. Available since Basecamp 5.
+            creator_ids: Creator person IDs to filter by. Available since Basecamp 5.
+            file_type: Filter attachments by type. Use `key` values from the metadata endpoint's
+                `file_search_types`.
+            exclude_chat: Set to true to exclude chat results.
+            since: last_7_days|last_30_days|last_90_days|last_12_months|forever
+            sort: best_match|recency
+            type: Deprecated: prefer type_names[].
+            bucket_id: Deprecated: prefer bucket_ids[].
+            creator_id: Deprecated: prefer creator_ids[].
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
         """
         return self._request_paginated(
             OperationInfo(service="search", operation="search", is_mutation=False),
@@ -60,6 +81,7 @@ class SearchService(BaseService):
         )
 
     def metadata(self) -> dict[str, Any]:
+        """Get search metadata (available filter options)."""
         return self._request(
             OperationInfo(service="search", operation="metadata", is_mutation=False),
             "GET",
@@ -86,11 +108,32 @@ class AsyncSearchService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
-        """Deprecated parameters (prefer the replacement):
+        """Search for content across the account.
+
+        Deprecated parameters (prefer the replacement):
 
         - type: prefer type_names[].
         - bucket_id: prefer bucket_ids[].
         - creator_id: prefer creator_ids[].
+
+        Args:
+            q: The q.
+            type_names: Recording types to include. Use `key` values from the metadata endpoint's
+                `recording_search_types`. Available since Basecamp 5.
+            bucket_ids: Project IDs to filter by. Available since Basecamp 5.
+            creator_ids: Creator person IDs to filter by. Available since Basecamp 5.
+            file_type: Filter attachments by type. Use `key` values from the metadata endpoint's
+                `file_search_types`.
+            exclude_chat: Set to true to exclude chat results.
+            since: last_7_days|last_30_days|last_90_days|last_12_months|forever
+            sort: best_match|recency
+            type: Deprecated: prefer type_names[].
+            bucket_id: Deprecated: prefer bucket_ids[].
+            creator_id: Deprecated: prefer creator_ids[].
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
         """
         return await self._request_paginated(
             OperationInfo(service="search", operation="search", is_mutation=False),
@@ -118,6 +161,7 @@ class AsyncSearchService(AsyncBaseService):
         )
 
     async def metadata(self) -> dict[str, Any]:
+        """Get search metadata (available filter options)."""
         return await self._request(
             OperationInfo(service="search", operation="metadata", is_mutation=False),
             "GET",

--- a/python/src/basecamp/generated/services/search.py
+++ b/python/src/basecamp/generated/services/search.py
@@ -52,9 +52,9 @@ class SearchService(BaseService):
             creator_id: Deprecated: prefer creator_ids[].
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="search", operation="search", is_mutation=False),
@@ -133,9 +133,9 @@ class AsyncSearchService(AsyncBaseService):
             creator_id: Deprecated: prefer creator_ids[].
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="search", operation="search", is_mutation=False),

--- a/python/src/basecamp/generated/services/search.py
+++ b/python/src/basecamp/generated/services/search.py
@@ -52,8 +52,9 @@ class SearchService(BaseService):
             creator_id: Deprecated: prefer creator_ids[].
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="search", operation="search", is_mutation=False),
@@ -132,8 +133,9 @@ class AsyncSearchService(AsyncBaseService):
             creator_id: Deprecated: prefer creator_ids[].
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="search", operation="search", is_mutation=False),

--- a/python/src/basecamp/generated/services/subscriptions.py
+++ b/python/src/basecamp/generated/services/subscriptions.py
@@ -12,6 +12,11 @@ from basecamp.hooks import OperationInfo
 
 class SubscriptionsService(BaseService):
     def get(self, *, recording_id: int) -> dict[str, Any]:
+        """Get subscription information for a recording.
+
+        Args:
+            recording_id: The recording id.
+        """
         return self._request(
             OperationInfo(service="subscriptions", operation="get", is_mutation=False, resource_id=recording_id),
             "GET",
@@ -20,6 +25,11 @@ class SubscriptionsService(BaseService):
         )
 
     def subscribe(self, *, recording_id: int) -> dict[str, Any]:
+        """Subscribe the current user to a recording.
+
+        Args:
+            recording_id: The recording id.
+        """
         return self._request(
             OperationInfo(service="subscriptions", operation="subscribe", is_mutation=True, resource_id=recording_id),
             "POST",
@@ -30,6 +40,13 @@ class SubscriptionsService(BaseService):
     def update(
         self, *, recording_id: int, subscriptions: list[int] | None = None, unsubscriptions: list[int] | None = None
     ) -> dict[str, Any]:
+        """Update subscriptions by adding or removing specific users.
+
+        Args:
+            recording_id: The recording id.
+            subscriptions: The subscriptions.
+            unsubscriptions: The unsubscriptions.
+        """
         return self._request(
             OperationInfo(service="subscriptions", operation="update", is_mutation=True, resource_id=recording_id),
             "PUT",
@@ -39,6 +56,11 @@ class SubscriptionsService(BaseService):
         )
 
     def unsubscribe(self, *, recording_id: int) -> None:
+        """Unsubscribe the current user from a recording.
+
+        Args:
+            recording_id: The recording id.
+        """
         self._request_void(
             OperationInfo(service="subscriptions", operation="unsubscribe", is_mutation=True, resource_id=recording_id),
             "DELETE",
@@ -49,6 +71,11 @@ class SubscriptionsService(BaseService):
 
 class AsyncSubscriptionsService(AsyncBaseService):
     async def get(self, *, recording_id: int) -> dict[str, Any]:
+        """Get subscription information for a recording.
+
+        Args:
+            recording_id: The recording id.
+        """
         return await self._request(
             OperationInfo(service="subscriptions", operation="get", is_mutation=False, resource_id=recording_id),
             "GET",
@@ -57,6 +84,11 @@ class AsyncSubscriptionsService(AsyncBaseService):
         )
 
     async def subscribe(self, *, recording_id: int) -> dict[str, Any]:
+        """Subscribe the current user to a recording.
+
+        Args:
+            recording_id: The recording id.
+        """
         return await self._request(
             OperationInfo(service="subscriptions", operation="subscribe", is_mutation=True, resource_id=recording_id),
             "POST",
@@ -67,6 +99,13 @@ class AsyncSubscriptionsService(AsyncBaseService):
     async def update(
         self, *, recording_id: int, subscriptions: list[int] | None = None, unsubscriptions: list[int] | None = None
     ) -> dict[str, Any]:
+        """Update subscriptions by adding or removing specific users.
+
+        Args:
+            recording_id: The recording id.
+            subscriptions: The subscriptions.
+            unsubscriptions: The unsubscriptions.
+        """
         return await self._request(
             OperationInfo(service="subscriptions", operation="update", is_mutation=True, resource_id=recording_id),
             "PUT",
@@ -76,6 +115,11 @@ class AsyncSubscriptionsService(AsyncBaseService):
         )
 
     async def unsubscribe(self, *, recording_id: int) -> None:
+        """Unsubscribe the current user from a recording.
+
+        Args:
+            recording_id: The recording id.
+        """
         await self._request_void(
             OperationInfo(service="subscriptions", operation="unsubscribe", is_mutation=True, resource_id=recording_id),
             "DELETE",

--- a/python/src/basecamp/generated/services/templates.py
+++ b/python/src/basecamp/generated/services/templates.py
@@ -18,8 +18,9 @@ class TemplatesService(BaseService):
             status: active|archived|trashed
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="templates", operation="list", is_mutation=False),
@@ -128,8 +129,9 @@ class AsyncTemplatesService(AsyncBaseService):
             status: active|archived|trashed
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="templates", operation="list", is_mutation=False),

--- a/python/src/basecamp/generated/services/templates.py
+++ b/python/src/basecamp/generated/services/templates.py
@@ -18,9 +18,9 @@ class TemplatesService(BaseService):
             status: active|archived|trashed
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="templates", operation="list", is_mutation=False),
@@ -129,9 +129,9 @@ class AsyncTemplatesService(AsyncBaseService):
             status: active|archived|trashed
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="templates", operation="list", is_mutation=False),

--- a/python/src/basecamp/generated/services/templates.py
+++ b/python/src/basecamp/generated/services/templates.py
@@ -12,6 +12,15 @@ from basecamp.hooks import OperationInfo
 
 class TemplatesService(BaseService):
     def list(self, *, status: str | None = None, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List all templates visible to the current user.
+
+        Args:
+            status: active|archived|trashed
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="templates", operation="list", is_mutation=False),
             "/templates.json",
@@ -21,6 +30,12 @@ class TemplatesService(BaseService):
         )
 
     def create(self, *, name: str, description: str | None = None) -> dict[str, Any]:
+        """Create a new template.
+
+        Args:
+            name: The name.
+            description: The description.
+        """
         return self._request(
             OperationInfo(service="templates", operation="create", is_mutation=True),
             "POST",
@@ -30,6 +45,11 @@ class TemplatesService(BaseService):
         )
 
     def get(self, *, template_id: int) -> dict[str, Any]:
+        """Get a single template by id.
+
+        Args:
+            template_id: The template id.
+        """
         return self._request(
             OperationInfo(service="templates", operation="get", is_mutation=False, resource_id=template_id),
             "GET",
@@ -38,6 +58,13 @@ class TemplatesService(BaseService):
         )
 
     def update(self, *, template_id: int, name: str | None = None, description: str | None = None) -> dict[str, Any]:
+        """Update an existing template.
+
+        Args:
+            template_id: The template id.
+            name: The name.
+            description: The description.
+        """
         return self._request(
             OperationInfo(service="templates", operation="update", is_mutation=True, resource_id=template_id),
             "PUT",
@@ -47,6 +74,11 @@ class TemplatesService(BaseService):
         )
 
     def delete(self, *, template_id: int) -> None:
+        """Delete a template (trash it).
+
+        Args:
+            template_id: The template id.
+        """
         self._request_void(
             OperationInfo(service="templates", operation="delete", is_mutation=True, resource_id=template_id),
             "DELETE",
@@ -55,6 +87,12 @@ class TemplatesService(BaseService):
         )
 
     def create_project(self, *, template_id: int, project: dict) -> dict[str, Any]:
+        """Create a project from a template (asynchronous).
+
+        Args:
+            template_id: The template id.
+            project: The project.
+        """
         return self._request(
             OperationInfo(service="templates", operation="create_project", is_mutation=True, resource_id=template_id),
             "POST",
@@ -64,6 +102,12 @@ class TemplatesService(BaseService):
         )
 
     def get_construction(self, *, template_id: int, construction_id: int) -> dict[str, Any]:
+        """Get the status of a project construction.
+
+        Args:
+            template_id: The template id.
+            construction_id: The construction id.
+        """
         return self._request(
             OperationInfo(
                 service="templates", operation="get_construction", is_mutation=False, resource_id=construction_id
@@ -78,6 +122,15 @@ class AsyncTemplatesService(AsyncBaseService):
     async def list(
         self, *, status: str | None = None, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List all templates visible to the current user.
+
+        Args:
+            status: active|archived|trashed
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="templates", operation="list", is_mutation=False),
             "/templates.json",
@@ -87,6 +140,12 @@ class AsyncTemplatesService(AsyncBaseService):
         )
 
     async def create(self, *, name: str, description: str | None = None) -> dict[str, Any]:
+        """Create a new template.
+
+        Args:
+            name: The name.
+            description: The description.
+        """
         return await self._request(
             OperationInfo(service="templates", operation="create", is_mutation=True),
             "POST",
@@ -96,6 +155,11 @@ class AsyncTemplatesService(AsyncBaseService):
         )
 
     async def get(self, *, template_id: int) -> dict[str, Any]:
+        """Get a single template by id.
+
+        Args:
+            template_id: The template id.
+        """
         return await self._request(
             OperationInfo(service="templates", operation="get", is_mutation=False, resource_id=template_id),
             "GET",
@@ -106,6 +170,13 @@ class AsyncTemplatesService(AsyncBaseService):
     async def update(
         self, *, template_id: int, name: str | None = None, description: str | None = None
     ) -> dict[str, Any]:
+        """Update an existing template.
+
+        Args:
+            template_id: The template id.
+            name: The name.
+            description: The description.
+        """
         return await self._request(
             OperationInfo(service="templates", operation="update", is_mutation=True, resource_id=template_id),
             "PUT",
@@ -115,6 +186,11 @@ class AsyncTemplatesService(AsyncBaseService):
         )
 
     async def delete(self, *, template_id: int) -> None:
+        """Delete a template (trash it).
+
+        Args:
+            template_id: The template id.
+        """
         await self._request_void(
             OperationInfo(service="templates", operation="delete", is_mutation=True, resource_id=template_id),
             "DELETE",
@@ -123,6 +199,12 @@ class AsyncTemplatesService(AsyncBaseService):
         )
 
     async def create_project(self, *, template_id: int, project: dict) -> dict[str, Any]:
+        """Create a project from a template (asynchronous).
+
+        Args:
+            template_id: The template id.
+            project: The project.
+        """
         return await self._request(
             OperationInfo(service="templates", operation="create_project", is_mutation=True, resource_id=template_id),
             "POST",
@@ -132,6 +214,12 @@ class AsyncTemplatesService(AsyncBaseService):
         )
 
     async def get_construction(self, *, template_id: int, construction_id: int) -> dict[str, Any]:
+        """Get the status of a project construction.
+
+        Args:
+            template_id: The template id.
+            construction_id: The construction id.
+        """
         return await self._request(
             OperationInfo(
                 service="templates", operation="get_construction", is_mutation=False, resource_id=construction_id

--- a/python/src/basecamp/generated/services/timeline.py
+++ b/python/src/basecamp/generated/services/timeline.py
@@ -14,6 +14,15 @@ class TimelineService(BaseService):
     def get_project_timeline(
         self, *, project_id: int, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """Get project timeline.
+
+        Args:
+            project_id: The project id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(
                 service="timeline", operation="get_project_timeline", is_mutation=False, project_id=project_id
@@ -29,6 +38,15 @@ class AsyncTimelineService(AsyncBaseService):
     async def get_project_timeline(
         self, *, project_id: int, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """Get project timeline.
+
+        Args:
+            project_id: The project id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(
                 service="timeline", operation="get_project_timeline", is_mutation=False, project_id=project_id

--- a/python/src/basecamp/generated/services/timeline.py
+++ b/python/src/basecamp/generated/services/timeline.py
@@ -20,9 +20,9 @@ class TimelineService(BaseService):
             project_id: The project id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(
@@ -45,9 +45,9 @@ class AsyncTimelineService(AsyncBaseService):
             project_id: The project id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(

--- a/python/src/basecamp/generated/services/timeline.py
+++ b/python/src/basecamp/generated/services/timeline.py
@@ -20,8 +20,9 @@ class TimelineService(BaseService):
             project_id: The project id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(
@@ -44,8 +45,9 @@ class AsyncTimelineService(AsyncBaseService):
             project_id: The project id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(

--- a/python/src/basecamp/generated/services/timesheets.py
+++ b/python/src/basecamp/generated/services/timesheets.py
@@ -21,6 +21,18 @@ class TimesheetsService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Get timesheet for a specific project.
+
+        Args:
+            project_id: The project id.
+            from_: The from .
+            to: The to.
+            person_id: The person id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="timesheets", operation="for_project", is_mutation=False, project_id=project_id),
             f"/projects/{project_id}/timesheet.json",
@@ -43,6 +55,18 @@ class TimesheetsService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Get timesheet for a specific recording.
+
+        Args:
+            recording_id: The recording id.
+            from_: The from .
+            to: The to.
+            person_id: The person id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="timesheets", operation="for_recording", is_mutation=False, resource_id=recording_id),
             f"/recordings/{recording_id}/timesheet.json",
@@ -58,6 +82,15 @@ class TimesheetsService(BaseService):
     def create(
         self, *, recording_id: int, date: str, hours: str, description: str | None = None, person_id: int | None = None
     ) -> dict[str, Any]:
+        """Create a timesheet entry on a recording.
+
+        Args:
+            recording_id: The recording id.
+            date: The date.
+            hours: The hours.
+            description: The description.
+            person_id: The person id.
+        """
         return self._request(
             OperationInfo(service="timesheets", operation="create", is_mutation=True, resource_id=recording_id),
             "POST",
@@ -67,6 +100,13 @@ class TimesheetsService(BaseService):
         )
 
     def report(self, *, from_: str | None = None, to: str | None = None, person_id: int | None = None) -> ListResult:
+        """Get account-wide timesheet report.
+
+        Args:
+            from_: The from .
+            to: The to.
+            person_id: The person id.
+        """
         return self._request_list(
             OperationInfo(service="timesheets", operation="report", is_mutation=False),
             "/reports/timesheet.json",
@@ -75,6 +115,11 @@ class TimesheetsService(BaseService):
         )
 
     def get(self, *, entry_id: int) -> dict[str, Any]:
+        """Get a single timesheet entry.
+
+        Args:
+            entry_id: The entry id.
+        """
         return self._request(
             OperationInfo(service="timesheets", operation="get", is_mutation=False, resource_id=entry_id),
             "GET",
@@ -91,6 +136,15 @@ class TimesheetsService(BaseService):
         description: str | None = None,
         person_id: int | None = None,
     ) -> dict[str, Any]:
+        """Update a timesheet entry.
+
+        Args:
+            entry_id: The entry id.
+            date: The date.
+            hours: The hours.
+            description: The description.
+            person_id: The person id.
+        """
         return self._request(
             OperationInfo(service="timesheets", operation="update", is_mutation=True, resource_id=entry_id),
             "PUT",
@@ -100,6 +154,11 @@ class TimesheetsService(BaseService):
         )
 
     def destroy(self, *, entry_id: int) -> None:
+        """Permanently delete a timesheet entry; answers 403 when the caller may not archive or trash it.
+
+        Args:
+            entry_id: The entry id.
+        """
         self._request_void(
             OperationInfo(service="timesheets", operation="destroy", is_mutation=True, resource_id=entry_id),
             "DELETE",
@@ -119,6 +178,18 @@ class AsyncTimesheetsService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Get timesheet for a specific project.
+
+        Args:
+            project_id: The project id.
+            from_: The from .
+            to: The to.
+            person_id: The person id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="timesheets", operation="for_project", is_mutation=False, project_id=project_id),
             f"/projects/{project_id}/timesheet.json",
@@ -141,6 +212,18 @@ class AsyncTimesheetsService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """Get timesheet for a specific recording.
+
+        Args:
+            recording_id: The recording id.
+            from_: The from .
+            to: The to.
+            person_id: The person id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="timesheets", operation="for_recording", is_mutation=False, resource_id=recording_id),
             f"/recordings/{recording_id}/timesheet.json",
@@ -156,6 +239,15 @@ class AsyncTimesheetsService(AsyncBaseService):
     async def create(
         self, *, recording_id: int, date: str, hours: str, description: str | None = None, person_id: int | None = None
     ) -> dict[str, Any]:
+        """Create a timesheet entry on a recording.
+
+        Args:
+            recording_id: The recording id.
+            date: The date.
+            hours: The hours.
+            description: The description.
+            person_id: The person id.
+        """
         return await self._request(
             OperationInfo(service="timesheets", operation="create", is_mutation=True, resource_id=recording_id),
             "POST",
@@ -167,6 +259,13 @@ class AsyncTimesheetsService(AsyncBaseService):
     async def report(
         self, *, from_: str | None = None, to: str | None = None, person_id: int | None = None
     ) -> ListResult:
+        """Get account-wide timesheet report.
+
+        Args:
+            from_: The from .
+            to: The to.
+            person_id: The person id.
+        """
         return await self._request_list(
             OperationInfo(service="timesheets", operation="report", is_mutation=False),
             "/reports/timesheet.json",
@@ -175,6 +274,11 @@ class AsyncTimesheetsService(AsyncBaseService):
         )
 
     async def get(self, *, entry_id: int) -> dict[str, Any]:
+        """Get a single timesheet entry.
+
+        Args:
+            entry_id: The entry id.
+        """
         return await self._request(
             OperationInfo(service="timesheets", operation="get", is_mutation=False, resource_id=entry_id),
             "GET",
@@ -191,6 +295,15 @@ class AsyncTimesheetsService(AsyncBaseService):
         description: str | None = None,
         person_id: int | None = None,
     ) -> dict[str, Any]:
+        """Update a timesheet entry.
+
+        Args:
+            entry_id: The entry id.
+            date: The date.
+            hours: The hours.
+            description: The description.
+            person_id: The person id.
+        """
         return await self._request(
             OperationInfo(service="timesheets", operation="update", is_mutation=True, resource_id=entry_id),
             "PUT",
@@ -200,6 +313,11 @@ class AsyncTimesheetsService(AsyncBaseService):
         )
 
     async def destroy(self, *, entry_id: int) -> None:
+        """Permanently delete a timesheet entry; answers 403 when the caller may not archive or trash it.
+
+        Args:
+            entry_id: The entry id.
+        """
         await self._request_void(
             OperationInfo(service="timesheets", operation="destroy", is_mutation=True, resource_id=entry_id),
             "DELETE",

--- a/python/src/basecamp/generated/services/timesheets.py
+++ b/python/src/basecamp/generated/services/timesheets.py
@@ -30,9 +30,9 @@ class TimesheetsService(BaseService):
             person_id: The person id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="timesheets", operation="for_project", is_mutation=False, project_id=project_id),
@@ -65,9 +65,9 @@ class TimesheetsService(BaseService):
             person_id: The person id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="timesheets", operation="for_recording", is_mutation=False, resource_id=recording_id),
@@ -189,9 +189,9 @@ class AsyncTimesheetsService(AsyncBaseService):
             person_id: The person id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="timesheets", operation="for_project", is_mutation=False, project_id=project_id),
@@ -224,9 +224,9 @@ class AsyncTimesheetsService(AsyncBaseService):
             person_id: The person id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="timesheets", operation="for_recording", is_mutation=False, resource_id=recording_id),

--- a/python/src/basecamp/generated/services/timesheets.py
+++ b/python/src/basecamp/generated/services/timesheets.py
@@ -25,13 +25,14 @@ class TimesheetsService(BaseService):
 
         Args:
             project_id: The project id.
-            from_: The from .
+            from_: The from.
             to: The to.
             person_id: The person id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="timesheets", operation="for_project", is_mutation=False, project_id=project_id),
@@ -59,13 +60,14 @@ class TimesheetsService(BaseService):
 
         Args:
             recording_id: The recording id.
-            from_: The from .
+            from_: The from.
             to: The to.
             person_id: The person id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="timesheets", operation="for_recording", is_mutation=False, resource_id=recording_id),
@@ -103,7 +105,7 @@ class TimesheetsService(BaseService):
         """Get account-wide timesheet report.
 
         Args:
-            from_: The from .
+            from_: The from.
             to: The to.
             person_id: The person id.
         """
@@ -182,13 +184,14 @@ class AsyncTimesheetsService(AsyncBaseService):
 
         Args:
             project_id: The project id.
-            from_: The from .
+            from_: The from.
             to: The to.
             person_id: The person id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="timesheets", operation="for_project", is_mutation=False, project_id=project_id),
@@ -216,13 +219,14 @@ class AsyncTimesheetsService(AsyncBaseService):
 
         Args:
             recording_id: The recording id.
-            from_: The from .
+            from_: The from.
             to: The to.
             person_id: The person id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="timesheets", operation="for_recording", is_mutation=False, resource_id=recording_id),
@@ -262,7 +266,7 @@ class AsyncTimesheetsService(AsyncBaseService):
         """Get account-wide timesheet report.
 
         Args:
-            from_: The from .
+            from_: The from.
             to: The to.
             person_id: The person id.
         """

--- a/python/src/basecamp/generated/services/todolist_groups.py
+++ b/python/src/basecamp/generated/services/todolist_groups.py
@@ -12,6 +12,12 @@ from basecamp.hooks import OperationInfo
 
 class TodolistGroupsService(BaseService):
     def reposition(self, *, group_id: int, position: int) -> None:
+        """Reposition a todolist group.
+
+        Args:
+            group_id: The group id.
+            position: The position.
+        """
         self._request_void(
             OperationInfo(service="todolistgroups", operation="reposition", is_mutation=True, resource_id=group_id),
             "PUT",
@@ -21,6 +27,15 @@ class TodolistGroupsService(BaseService):
         )
 
     def list(self, *, todolist_id: int, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List groups in a todolist.
+
+        Args:
+            todolist_id: The todolist id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="todolistgroups", operation="list", is_mutation=False, resource_id=todolist_id),
             f"/todolists/{todolist_id}/groups.json",
@@ -30,6 +45,12 @@ class TodolistGroupsService(BaseService):
         )
 
     def create(self, *, todolist_id: int, name: str) -> dict[str, Any]:
+        """Create a new group in a todolist.
+
+        Args:
+            todolist_id: The todolist id.
+            name: The name.
+        """
         return self._request(
             OperationInfo(service="todolistgroups", operation="create", is_mutation=True, resource_id=todolist_id),
             "POST",
@@ -41,6 +62,12 @@ class TodolistGroupsService(BaseService):
 
 class AsyncTodolistGroupsService(AsyncBaseService):
     async def reposition(self, *, group_id: int, position: int) -> None:
+        """Reposition a todolist group.
+
+        Args:
+            group_id: The group id.
+            position: The position.
+        """
         await self._request_void(
             OperationInfo(service="todolistgroups", operation="reposition", is_mutation=True, resource_id=group_id),
             "PUT",
@@ -50,6 +77,15 @@ class AsyncTodolistGroupsService(AsyncBaseService):
         )
 
     async def list(self, *, todolist_id: int, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List groups in a todolist.
+
+        Args:
+            todolist_id: The todolist id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="todolistgroups", operation="list", is_mutation=False, resource_id=todolist_id),
             f"/todolists/{todolist_id}/groups.json",
@@ -59,6 +95,12 @@ class AsyncTodolistGroupsService(AsyncBaseService):
         )
 
     async def create(self, *, todolist_id: int, name: str) -> dict[str, Any]:
+        """Create a new group in a todolist.
+
+        Args:
+            todolist_id: The todolist id.
+            name: The name.
+        """
         return await self._request(
             OperationInfo(service="todolistgroups", operation="create", is_mutation=True, resource_id=todolist_id),
             "POST",

--- a/python/src/basecamp/generated/services/todolist_groups.py
+++ b/python/src/basecamp/generated/services/todolist_groups.py
@@ -33,8 +33,9 @@ class TodolistGroupsService(BaseService):
             todolist_id: The todolist id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="todolistgroups", operation="list", is_mutation=False, resource_id=todolist_id),
@@ -83,8 +84,9 @@ class AsyncTodolistGroupsService(AsyncBaseService):
             todolist_id: The todolist id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="todolistgroups", operation="list", is_mutation=False, resource_id=todolist_id),

--- a/python/src/basecamp/generated/services/todolist_groups.py
+++ b/python/src/basecamp/generated/services/todolist_groups.py
@@ -33,9 +33,9 @@ class TodolistGroupsService(BaseService):
             todolist_id: The todolist id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="todolistgroups", operation="list", is_mutation=False, resource_id=todolist_id),
@@ -84,9 +84,9 @@ class AsyncTodolistGroupsService(AsyncBaseService):
             todolist_id: The todolist id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="todolistgroups", operation="list", is_mutation=False, resource_id=todolist_id),

--- a/python/src/basecamp/generated/services/todolists.py
+++ b/python/src/basecamp/generated/services/todolists.py
@@ -12,6 +12,13 @@ from basecamp.hooks import OperationInfo
 
 class TodolistsService(BaseService):
     def get(self, *, id: int) -> dict[str, Any]:
+        """Get a single todolist or todolist group by id
+        The endpoint is polymorphic, but it answers with one shape: BC3 has no group
+        model, so both variants come back as a flat Todolist (see the Todolist shape).
+
+        Args:
+            id: The id.
+        """
         return self._request(
             OperationInfo(service="todolists", operation="get", is_mutation=False, resource_id=id),
             "GET",
@@ -20,6 +27,27 @@ class TodolistsService(BaseService):
         )
 
     def replace(self, *, id: int, name: str, description: str | None = None) -> dict[str, Any]:
+        """Replace a todolist (or todolist group) with a new complete representation.
+        The endpoint is polymorphic - it addresses a to-do list or a group, and answers
+        with the same flat Todolist shape either way.
+        The request body is the recordable's full writable state: TodolistsController#update
+        builds a brand-new Todolist from the permitted params and swaps it in, so any
+        writable field omitted from the request is cleared server-side (a request that
+        omits description erases the description). name is required - it is
+        presence-validated on the model, so a request without it is rejected.
+        To set some fields while preserving the rest, use the SDK's merge-safe
+        update or edit methods, which GET the current list and PUT the full
+        representation back. Those read-modify-write helpers are not atomic:
+        a concurrent write between the GET and PUT is overwritten (last write
+        wins for the whole representation; the window is one round-trip).
+
+        Args:
+            id: The id.
+            name: Name (required for a to-do list and for a group alike) - presence-validated
+                server-side, so omitting it is a 422, not a preserve
+            description: Description (rich text HTML) - writable for a todolist group as well as a
+                todolist, and omitting it clears it either way
+        """
         return self._request(
             OperationInfo(service="todolists", operation="replace", is_mutation=True, resource_id=id),
             "PUT",
@@ -29,6 +57,14 @@ class TodolistsService(BaseService):
         )
 
     def reposition(self, *, todolist_id: int, position: int) -> None:
+        """Reposition a to-do list within its to-do set.
+        position is the 1-based index among the to-do lists the caller can see; the server
+        translates it relative to loose to-dos and hidden completed lists. Shifts siblings.
+
+        Args:
+            todolist_id: The todolist id.
+            position: The position.
+        """
         self._request_void(
             OperationInfo(service="todolists", operation="reposition", is_mutation=True, resource_id=todolist_id),
             "PUT",
@@ -40,6 +76,16 @@ class TodolistsService(BaseService):
     def list(
         self, *, todoset_id: int, status: str | None = None, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List todolists in a todoset.
+
+        Args:
+            todoset_id: The todoset id.
+            status: active|archived|trashed
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="todolists", operation="list", is_mutation=False, resource_id=todoset_id),
             f"/todosets/{todoset_id}/todolists.json",
@@ -51,6 +97,14 @@ class TodolistsService(BaseService):
     def create(
         self, *, todoset_id: int, name: str, description: str | None = None, visible_to_clients: bool | None = None
     ) -> dict[str, Any]:
+        """Create a new todolist in a todoset.
+
+        Args:
+            todoset_id: The todoset id.
+            name: The name.
+            description: The description.
+            visible_to_clients: The visible to clients.
+        """
         return self._request(
             OperationInfo(service="todolists", operation="create", is_mutation=True, resource_id=todoset_id),
             "POST",
@@ -62,6 +116,13 @@ class TodolistsService(BaseService):
 
 class AsyncTodolistsService(AsyncBaseService):
     async def get(self, *, id: int) -> dict[str, Any]:
+        """Get a single todolist or todolist group by id
+        The endpoint is polymorphic, but it answers with one shape: BC3 has no group
+        model, so both variants come back as a flat Todolist (see the Todolist shape).
+
+        Args:
+            id: The id.
+        """
         return await self._request(
             OperationInfo(service="todolists", operation="get", is_mutation=False, resource_id=id),
             "GET",
@@ -70,6 +131,27 @@ class AsyncTodolistsService(AsyncBaseService):
         )
 
     async def replace(self, *, id: int, name: str, description: str | None = None) -> dict[str, Any]:
+        """Replace a todolist (or todolist group) with a new complete representation.
+        The endpoint is polymorphic - it addresses a to-do list or a group, and answers
+        with the same flat Todolist shape either way.
+        The request body is the recordable's full writable state: TodolistsController#update
+        builds a brand-new Todolist from the permitted params and swaps it in, so any
+        writable field omitted from the request is cleared server-side (a request that
+        omits description erases the description). name is required - it is
+        presence-validated on the model, so a request without it is rejected.
+        To set some fields while preserving the rest, use the SDK's merge-safe
+        update or edit methods, which GET the current list and PUT the full
+        representation back. Those read-modify-write helpers are not atomic:
+        a concurrent write between the GET and PUT is overwritten (last write
+        wins for the whole representation; the window is one round-trip).
+
+        Args:
+            id: The id.
+            name: Name (required for a to-do list and for a group alike) - presence-validated
+                server-side, so omitting it is a 422, not a preserve
+            description: Description (rich text HTML) - writable for a todolist group as well as a
+                todolist, and omitting it clears it either way
+        """
         return await self._request(
             OperationInfo(service="todolists", operation="replace", is_mutation=True, resource_id=id),
             "PUT",
@@ -79,6 +161,14 @@ class AsyncTodolistsService(AsyncBaseService):
         )
 
     async def reposition(self, *, todolist_id: int, position: int) -> None:
+        """Reposition a to-do list within its to-do set.
+        position is the 1-based index among the to-do lists the caller can see; the server
+        translates it relative to loose to-dos and hidden completed lists. Shifts siblings.
+
+        Args:
+            todolist_id: The todolist id.
+            position: The position.
+        """
         await self._request_void(
             OperationInfo(service="todolists", operation="reposition", is_mutation=True, resource_id=todolist_id),
             "PUT",
@@ -90,6 +180,16 @@ class AsyncTodolistsService(AsyncBaseService):
     async def list(
         self, *, todoset_id: int, status: str | None = None, page: int | None = None, max_items: int | None = None
     ) -> ListResult:
+        """List todolists in a todoset.
+
+        Args:
+            todoset_id: The todoset id.
+            status: active|archived|trashed
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="todolists", operation="list", is_mutation=False, resource_id=todoset_id),
             f"/todosets/{todoset_id}/todolists.json",
@@ -101,6 +201,14 @@ class AsyncTodolistsService(AsyncBaseService):
     async def create(
         self, *, todoset_id: int, name: str, description: str | None = None, visible_to_clients: bool | None = None
     ) -> dict[str, Any]:
+        """Create a new todolist in a todoset.
+
+        Args:
+            todoset_id: The todoset id.
+            name: The name.
+            description: The description.
+            visible_to_clients: The visible to clients.
+        """
         return await self._request(
             OperationInfo(service="todolists", operation="create", is_mutation=True, resource_id=todoset_id),
             "POST",

--- a/python/src/basecamp/generated/services/todolists.py
+++ b/python/src/basecamp/generated/services/todolists.py
@@ -83,8 +83,9 @@ class TodolistsService(BaseService):
             status: active|archived|trashed
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="todolists", operation="list", is_mutation=False, resource_id=todoset_id),
@@ -187,8 +188,9 @@ class AsyncTodolistsService(AsyncBaseService):
             status: active|archived|trashed
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="todolists", operation="list", is_mutation=False, resource_id=todoset_id),

--- a/python/src/basecamp/generated/services/todolists.py
+++ b/python/src/basecamp/generated/services/todolists.py
@@ -83,9 +83,9 @@ class TodolistsService(BaseService):
             status: active|archived|trashed
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="todolists", operation="list", is_mutation=False, resource_id=todoset_id),
@@ -188,9 +188,9 @@ class AsyncTodolistsService(AsyncBaseService):
             status: active|archived|trashed
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="todolists", operation="list", is_mutation=False, resource_id=todoset_id),

--- a/python/src/basecamp/generated/services/todos.py
+++ b/python/src/basecamp/generated/services/todos.py
@@ -24,6 +24,22 @@ class TodosService(BaseService):
         due_on: str | None = None,
         starts_on: str | None = None,
     ) -> dict[str, Any]:
+        """Create a to-do directly under a project's to-do set, outside any to-do list.
+        This form exists only project-scoped (no account-scoped variant); parameters
+        and response match the to-do-list create. Find a project's to-do set id via
+        GetTodoset.
+
+        Args:
+            bucket_id: The bucket id.
+            todoset_id: The todoset id.
+            content: The content.
+            description: The description.
+            assignee_ids: The assignee ids.
+            completion_subscriber_ids: The completion subscriber ids.
+            notify: The notify.
+            due_on: The due on.
+            starts_on: The starts on.
+        """
         return self._request(
             OperationInfo(
                 service="todos",
@@ -55,6 +71,17 @@ class TodosService(BaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """List todos in a todolist.
+
+        Args:
+            todolist_id: The todolist id.
+            status: active|archived|trashed
+            completed: The completed.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="todos", operation="list", is_mutation=False, resource_id=todolist_id),
             f"/todolists/{todolist_id}/todos.json",
@@ -75,6 +102,18 @@ class TodosService(BaseService):
         due_on: str | None = None,
         starts_on: str | None = None,
     ) -> dict[str, Any]:
+        """Create a new todo in a todolist.
+
+        Args:
+            todolist_id: The todolist id.
+            content: The content.
+            description: The description.
+            assignee_ids: The assignee ids.
+            completion_subscriber_ids: The completion subscriber ids.
+            notify: The notify.
+            due_on: The due on.
+            starts_on: The starts on.
+        """
         return self._request(
             OperationInfo(service="todos", operation="create", is_mutation=True, resource_id=todolist_id),
             "POST",
@@ -92,6 +131,11 @@ class TodosService(BaseService):
         )
 
     def get(self, *, todo_id: int) -> dict[str, Any]:
+        """Get a single todo by id.
+
+        Args:
+            todo_id: The todo id.
+        """
         return self._request(
             OperationInfo(service="todos", operation="get", is_mutation=False, resource_id=todo_id),
             "GET",
@@ -111,6 +155,27 @@ class TodosService(BaseService):
         due_on: str | None = None,
         starts_on: str | None = None,
     ) -> dict[str, Any]:
+        """Replace a todo with a new complete representation.
+        The request body is the todo's full writable state: any writable field
+        omitted from the request is cleared server-side (empty/missing
+        assignee_ids clears assignees, missing description clears it, and so
+        on). content is required — a request without it is rejected.
+        To set some fields while preserving the rest, use the SDK's merge-safe
+        update or edit methods, which GET the current todo and PUT the full
+        representation back. Those read-modify-write helpers are not atomic:
+        a concurrent write between the GET and PUT is overwritten (last write
+        wins for the whole representation; the window is one round-trip).
+
+        Args:
+            todo_id: The todo id.
+            content: The content.
+            description: The description.
+            assignee_ids: The assignee ids.
+            completion_subscriber_ids: The completion subscriber ids.
+            notify: The notify.
+            due_on: The due on.
+            starts_on: The starts on.
+        """
         return self._request(
             OperationInfo(service="todos", operation="replace", is_mutation=True, resource_id=todo_id),
             "PUT",
@@ -128,6 +193,11 @@ class TodosService(BaseService):
         )
 
     def complete(self, *, todo_id: int) -> None:
+        """Mark a todo as complete.
+
+        Args:
+            todo_id: The todo id.
+        """
         self._request_void(
             OperationInfo(service="todos", operation="complete", is_mutation=True, resource_id=todo_id),
             "POST",
@@ -136,6 +206,11 @@ class TodosService(BaseService):
         )
 
     def uncomplete(self, *, todo_id: int) -> None:
+        """Mark a todo as incomplete.
+
+        Args:
+            todo_id: The todo id.
+        """
         self._request_void(
             OperationInfo(service="todos", operation="uncomplete", is_mutation=True, resource_id=todo_id),
             "DELETE",
@@ -144,6 +219,13 @@ class TodosService(BaseService):
         )
 
     def reposition(self, *, todo_id: int, position: int, parent_id: int | None = None) -> None:
+        """Reposition a todo within its todolist.
+
+        Args:
+            todo_id: The todo id.
+            position: The position.
+            parent_id: Optional todolist ID to move the todo to a different parent
+        """
         self._request_void(
             OperationInfo(service="todos", operation="reposition", is_mutation=True, resource_id=todo_id),
             "PUT",
@@ -167,6 +249,22 @@ class AsyncTodosService(AsyncBaseService):
         due_on: str | None = None,
         starts_on: str | None = None,
     ) -> dict[str, Any]:
+        """Create a to-do directly under a project's to-do set, outside any to-do list.
+        This form exists only project-scoped (no account-scoped variant); parameters
+        and response match the to-do-list create. Find a project's to-do set id via
+        GetTodoset.
+
+        Args:
+            bucket_id: The bucket id.
+            todoset_id: The todoset id.
+            content: The content.
+            description: The description.
+            assignee_ids: The assignee ids.
+            completion_subscriber_ids: The completion subscriber ids.
+            notify: The notify.
+            due_on: The due on.
+            starts_on: The starts on.
+        """
         return await self._request(
             OperationInfo(
                 service="todos",
@@ -198,6 +296,17 @@ class AsyncTodosService(AsyncBaseService):
         page: int | None = None,
         max_items: int | None = None,
     ) -> ListResult:
+        """List todos in a todolist.
+
+        Args:
+            todolist_id: The todolist id.
+            status: active|archived|trashed
+            completed: The completed.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="todos", operation="list", is_mutation=False, resource_id=todolist_id),
             f"/todolists/{todolist_id}/todos.json",
@@ -218,6 +327,18 @@ class AsyncTodosService(AsyncBaseService):
         due_on: str | None = None,
         starts_on: str | None = None,
     ) -> dict[str, Any]:
+        """Create a new todo in a todolist.
+
+        Args:
+            todolist_id: The todolist id.
+            content: The content.
+            description: The description.
+            assignee_ids: The assignee ids.
+            completion_subscriber_ids: The completion subscriber ids.
+            notify: The notify.
+            due_on: The due on.
+            starts_on: The starts on.
+        """
         return await self._request(
             OperationInfo(service="todos", operation="create", is_mutation=True, resource_id=todolist_id),
             "POST",
@@ -235,6 +356,11 @@ class AsyncTodosService(AsyncBaseService):
         )
 
     async def get(self, *, todo_id: int) -> dict[str, Any]:
+        """Get a single todo by id.
+
+        Args:
+            todo_id: The todo id.
+        """
         return await self._request(
             OperationInfo(service="todos", operation="get", is_mutation=False, resource_id=todo_id),
             "GET",
@@ -254,6 +380,27 @@ class AsyncTodosService(AsyncBaseService):
         due_on: str | None = None,
         starts_on: str | None = None,
     ) -> dict[str, Any]:
+        """Replace a todo with a new complete representation.
+        The request body is the todo's full writable state: any writable field
+        omitted from the request is cleared server-side (empty/missing
+        assignee_ids clears assignees, missing description clears it, and so
+        on). content is required — a request without it is rejected.
+        To set some fields while preserving the rest, use the SDK's merge-safe
+        update or edit methods, which GET the current todo and PUT the full
+        representation back. Those read-modify-write helpers are not atomic:
+        a concurrent write between the GET and PUT is overwritten (last write
+        wins for the whole representation; the window is one round-trip).
+
+        Args:
+            todo_id: The todo id.
+            content: The content.
+            description: The description.
+            assignee_ids: The assignee ids.
+            completion_subscriber_ids: The completion subscriber ids.
+            notify: The notify.
+            due_on: The due on.
+            starts_on: The starts on.
+        """
         return await self._request(
             OperationInfo(service="todos", operation="replace", is_mutation=True, resource_id=todo_id),
             "PUT",
@@ -271,6 +418,11 @@ class AsyncTodosService(AsyncBaseService):
         )
 
     async def complete(self, *, todo_id: int) -> None:
+        """Mark a todo as complete.
+
+        Args:
+            todo_id: The todo id.
+        """
         await self._request_void(
             OperationInfo(service="todos", operation="complete", is_mutation=True, resource_id=todo_id),
             "POST",
@@ -279,6 +431,11 @@ class AsyncTodosService(AsyncBaseService):
         )
 
     async def uncomplete(self, *, todo_id: int) -> None:
+        """Mark a todo as incomplete.
+
+        Args:
+            todo_id: The todo id.
+        """
         await self._request_void(
             OperationInfo(service="todos", operation="uncomplete", is_mutation=True, resource_id=todo_id),
             "DELETE",
@@ -287,6 +444,13 @@ class AsyncTodosService(AsyncBaseService):
         )
 
     async def reposition(self, *, todo_id: int, position: int, parent_id: int | None = None) -> None:
+        """Reposition a todo within its todolist.
+
+        Args:
+            todo_id: The todo id.
+            position: The position.
+            parent_id: Optional todolist ID to move the todo to a different parent
+        """
         await self._request_void(
             OperationInfo(service="todos", operation="reposition", is_mutation=True, resource_id=todo_id),
             "PUT",

--- a/python/src/basecamp/generated/services/todos.py
+++ b/python/src/basecamp/generated/services/todos.py
@@ -79,9 +79,9 @@ class TodosService(BaseService):
             completed: The completed.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="todos", operation="list", is_mutation=False, resource_id=todolist_id),
@@ -305,9 +305,9 @@ class AsyncTodosService(AsyncBaseService):
             completed: The completed.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="todos", operation="list", is_mutation=False, resource_id=todolist_id),

--- a/python/src/basecamp/generated/services/todos.py
+++ b/python/src/basecamp/generated/services/todos.py
@@ -79,8 +79,9 @@ class TodosService(BaseService):
             completed: The completed.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="todos", operation="list", is_mutation=False, resource_id=todolist_id),
@@ -304,8 +305,9 @@ class AsyncTodosService(AsyncBaseService):
             completed: The completed.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="todos", operation="list", is_mutation=False, resource_id=todolist_id),

--- a/python/src/basecamp/generated/services/todosets.py
+++ b/python/src/basecamp/generated/services/todosets.py
@@ -12,6 +12,11 @@ from basecamp.hooks import OperationInfo
 
 class TodosetsService(BaseService):
     def get(self, *, todoset_id: int) -> dict[str, Any]:
+        """Get a todoset (container for todolists in a project).
+
+        Args:
+            todoset_id: The todoset id.
+        """
         return self._request(
             OperationInfo(service="todosets", operation="get", is_mutation=False, resource_id=todoset_id),
             "GET",
@@ -22,6 +27,11 @@ class TodosetsService(BaseService):
 
 class AsyncTodosetsService(AsyncBaseService):
     async def get(self, *, todoset_id: int) -> dict[str, Any]:
+        """Get a todoset (container for todolists in a project).
+
+        Args:
+            todoset_id: The todoset id.
+        """
         return await self._request(
             OperationInfo(service="todosets", operation="get", is_mutation=False, resource_id=todoset_id),
             "GET",

--- a/python/src/basecamp/generated/services/tools.py
+++ b/python/src/basecamp/generated/services/tools.py
@@ -14,6 +14,19 @@ class ToolsService(BaseService):
     def create(
         self, *, bucket_id: int, tool_type: str, title: str | None = None, visible_to_clients: bool | None = None
     ) -> dict[str, Any]:
+        """Create a tool in a project dock.
+
+        Args:
+            bucket_id: The bucket id.
+            tool_type: Tool type to add to the project dock. Values: Chat::Transcript|Inbox|Kanban::
+                Board|Message::Board|Questionnaire|Schedule|Todoset|Vault.
+            title: Title for the new tool. When omitted, Basecamp assigns the next available default
+                title for the tool type.
+            visible_to_clients: Create the tool already visible to clients. Honored only for tool
+                types that manage their own client visibility (Chat::Transcript, Kanban::Board),
+                which otherwise start hidden; every other tool type ignores it and inherits the
+                project default.
+        """
         return self._request(
             OperationInfo(service="tools", operation="create", is_mutation=True, project_id=bucket_id),
             "POST",
@@ -23,6 +36,11 @@ class ToolsService(BaseService):
         )
 
     def get(self, *, tool_id: int) -> dict[str, Any]:
+        """Get a dock tool by id.
+
+        Args:
+            tool_id: The tool id.
+        """
         return self._request(
             OperationInfo(service="tools", operation="get", is_mutation=False, resource_id=tool_id),
             "GET",
@@ -31,6 +49,12 @@ class ToolsService(BaseService):
         )
 
     def update(self, *, tool_id: int, title: str) -> dict[str, Any]:
+        """Update (rename) an existing tool.
+
+        Args:
+            tool_id: The tool id.
+            title: The title.
+        """
         return self._request(
             OperationInfo(service="tools", operation="update", is_mutation=True, resource_id=tool_id),
             "PUT",
@@ -40,6 +64,11 @@ class ToolsService(BaseService):
         )
 
     def delete(self, *, tool_id: int) -> None:
+        """Delete a tool (trash it).
+
+        Args:
+            tool_id: The tool id.
+        """
         self._request_void(
             OperationInfo(service="tools", operation="delete", is_mutation=True, resource_id=tool_id),
             "DELETE",
@@ -48,6 +77,11 @@ class ToolsService(BaseService):
         )
 
     def enable(self, *, tool_id: int) -> None:
+        """Enable a tool (show it on the project dock).
+
+        Args:
+            tool_id: The tool id.
+        """
         self._request_void(
             OperationInfo(service="tools", operation="enable", is_mutation=True, resource_id=tool_id),
             "POST",
@@ -56,6 +90,12 @@ class ToolsService(BaseService):
         )
 
     def reposition(self, *, tool_id: int, position: int) -> None:
+        """Reposition a tool on the project dock.
+
+        Args:
+            tool_id: The tool id.
+            position: The position.
+        """
         self._request_void(
             OperationInfo(service="tools", operation="reposition", is_mutation=True, resource_id=tool_id),
             "PUT",
@@ -65,6 +105,11 @@ class ToolsService(BaseService):
         )
 
     def disable(self, *, tool_id: int) -> None:
+        """Disable a tool (hide it from the project dock).
+
+        Args:
+            tool_id: The tool id.
+        """
         self._request_void(
             OperationInfo(service="tools", operation="disable", is_mutation=True, resource_id=tool_id),
             "DELETE",
@@ -77,6 +122,19 @@ class AsyncToolsService(AsyncBaseService):
     async def create(
         self, *, bucket_id: int, tool_type: str, title: str | None = None, visible_to_clients: bool | None = None
     ) -> dict[str, Any]:
+        """Create a tool in a project dock.
+
+        Args:
+            bucket_id: The bucket id.
+            tool_type: Tool type to add to the project dock. Values: Chat::Transcript|Inbox|Kanban::
+                Board|Message::Board|Questionnaire|Schedule|Todoset|Vault.
+            title: Title for the new tool. When omitted, Basecamp assigns the next available default
+                title for the tool type.
+            visible_to_clients: Create the tool already visible to clients. Honored only for tool
+                types that manage their own client visibility (Chat::Transcript, Kanban::Board),
+                which otherwise start hidden; every other tool type ignores it and inherits the
+                project default.
+        """
         return await self._request(
             OperationInfo(service="tools", operation="create", is_mutation=True, project_id=bucket_id),
             "POST",
@@ -86,6 +144,11 @@ class AsyncToolsService(AsyncBaseService):
         )
 
     async def get(self, *, tool_id: int) -> dict[str, Any]:
+        """Get a dock tool by id.
+
+        Args:
+            tool_id: The tool id.
+        """
         return await self._request(
             OperationInfo(service="tools", operation="get", is_mutation=False, resource_id=tool_id),
             "GET",
@@ -94,6 +157,12 @@ class AsyncToolsService(AsyncBaseService):
         )
 
     async def update(self, *, tool_id: int, title: str) -> dict[str, Any]:
+        """Update (rename) an existing tool.
+
+        Args:
+            tool_id: The tool id.
+            title: The title.
+        """
         return await self._request(
             OperationInfo(service="tools", operation="update", is_mutation=True, resource_id=tool_id),
             "PUT",
@@ -103,6 +172,11 @@ class AsyncToolsService(AsyncBaseService):
         )
 
     async def delete(self, *, tool_id: int) -> None:
+        """Delete a tool (trash it).
+
+        Args:
+            tool_id: The tool id.
+        """
         await self._request_void(
             OperationInfo(service="tools", operation="delete", is_mutation=True, resource_id=tool_id),
             "DELETE",
@@ -111,6 +185,11 @@ class AsyncToolsService(AsyncBaseService):
         )
 
     async def enable(self, *, tool_id: int) -> None:
+        """Enable a tool (show it on the project dock).
+
+        Args:
+            tool_id: The tool id.
+        """
         await self._request_void(
             OperationInfo(service="tools", operation="enable", is_mutation=True, resource_id=tool_id),
             "POST",
@@ -119,6 +198,12 @@ class AsyncToolsService(AsyncBaseService):
         )
 
     async def reposition(self, *, tool_id: int, position: int) -> None:
+        """Reposition a tool on the project dock.
+
+        Args:
+            tool_id: The tool id.
+            position: The position.
+        """
         await self._request_void(
             OperationInfo(service="tools", operation="reposition", is_mutation=True, resource_id=tool_id),
             "PUT",
@@ -128,6 +213,11 @@ class AsyncToolsService(AsyncBaseService):
         )
 
     async def disable(self, *, tool_id: int) -> None:
+        """Disable a tool (hide it from the project dock).
+
+        Args:
+            tool_id: The tool id.
+        """
         await self._request_void(
             OperationInfo(service="tools", operation="disable", is_mutation=True, resource_id=tool_id),
             "DELETE",

--- a/python/src/basecamp/generated/services/tools.py
+++ b/python/src/basecamp/generated/services/tools.py
@@ -18,8 +18,8 @@ class ToolsService(BaseService):
 
         Args:
             bucket_id: The bucket id.
-            tool_type: Tool type to add to the project dock. Values: Chat::Transcript|Inbox|Kanban::
-                Board|Message::Board|Questionnaire|Schedule|Todoset|Vault.
+            tool_type: Tool type to add to the project dock. Values:
+                Chat::Transcript|Inbox|Kanban::Board|Message::Board|Questionnaire|Schedule|Todoset|Vault.
             title: Title for the new tool. When omitted, Basecamp assigns the next available default
                 title for the tool type.
             visible_to_clients: Create the tool already visible to clients. Honored only for tool
@@ -126,8 +126,8 @@ class AsyncToolsService(AsyncBaseService):
 
         Args:
             bucket_id: The bucket id.
-            tool_type: Tool type to add to the project dock. Values: Chat::Transcript|Inbox|Kanban::
-                Board|Message::Board|Questionnaire|Schedule|Todoset|Vault.
+            tool_type: Tool type to add to the project dock. Values:
+                Chat::Transcript|Inbox|Kanban::Board|Message::Board|Questionnaire|Schedule|Todoset|Vault.
             title: Title for the new tool. When omitted, Basecamp assigns the next available default
                 title for the tool type.
             visible_to_clients: Create the tool already visible to clients. Honored only for tool

--- a/python/src/basecamp/generated/services/uploads.py
+++ b/python/src/basecamp/generated/services/uploads.py
@@ -45,8 +45,8 @@ class UploadsService(BaseService):
 
         Args:
             upload_id: The upload id.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages.
         """
         return self._request_paginated(
             OperationInfo(service="uploads", operation="list_versions", is_mutation=False, resource_id=upload_id),
@@ -103,8 +103,9 @@ class UploadsService(BaseService):
             vault_id: The vault id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="uploads", operation="list", is_mutation=False, resource_id=vault_id),
@@ -186,8 +187,8 @@ class AsyncUploadsService(AsyncBaseService):
 
         Args:
             upload_id: The upload id.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages.
         """
         return await self._request_paginated(
             OperationInfo(service="uploads", operation="list_versions", is_mutation=False, resource_id=upload_id),
@@ -244,8 +245,9 @@ class AsyncUploadsService(AsyncBaseService):
             vault_id: The vault id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="uploads", operation="list", is_mutation=False, resource_id=vault_id),

--- a/python/src/basecamp/generated/services/uploads.py
+++ b/python/src/basecamp/generated/services/uploads.py
@@ -12,6 +12,11 @@ from basecamp.hooks import OperationInfo
 
 class UploadsService(BaseService):
     def get(self, *, upload_id: int) -> dict[str, Any]:
+        """Get a single upload by id.
+
+        Args:
+            upload_id: The upload id.
+        """
         return self._request(
             OperationInfo(service="uploads", operation="get", is_mutation=False, resource_id=upload_id),
             "GET",
@@ -20,6 +25,13 @@ class UploadsService(BaseService):
         )
 
     def update(self, *, upload_id: int, description: str | None = None, base_name: str | None = None) -> dict[str, Any]:
+        """Update an existing upload.
+
+        Args:
+            upload_id: The upload id.
+            description: The description.
+            base_name: The base name.
+        """
         return self._request(
             OperationInfo(service="uploads", operation="update", is_mutation=True, resource_id=upload_id),
             "PUT",
@@ -29,6 +41,13 @@ class UploadsService(BaseService):
         )
 
     def list_versions(self, *, upload_id: int, max_items: int | None = None) -> ListResult:
+        """List versions of an upload.
+
+        Args:
+            upload_id: The upload id.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="uploads", operation="list_versions", is_mutation=False, resource_id=upload_id),
             f"/uploads/{upload_id}/versions.json",
@@ -46,6 +65,23 @@ class UploadsService(BaseService):
         notify: str | None = None,
         subscriptions: list[int] | None = None,
     ) -> dict[str, Any]:
+        """Replace an upload's file with a new version.
+
+        The recording keeps its id, its URL and its comments; the previous file becomes a
+        past version. Use this instead of CreateUpload when publishing a new release of the
+        same file, so its published link keeps working.
+
+        Args:
+            upload_id: The upload id.
+            attachable_sgid: The attachable sgid.
+            base_name: Omit to keep the uploaded file's own name. Sending "" also keeps it.
+            description: Presence-aware: omit to carry the previous version's description forward,
+                send "" to clear it, send a value to set it.
+            notify: Who to notify: "default", "everyone", or "custom" (the people in subscriptions).
+                Omit both this and subscriptions to notify nobody. A subscriptions array sent
+                without notify is read as "custom".
+            subscriptions: People to notify about the replacement and subscribe to the upload.
+        """
         return self._request(
             OperationInfo(service="uploads", operation="create_version", is_mutation=True, resource_id=upload_id),
             "POST",
@@ -61,6 +97,15 @@ class UploadsService(BaseService):
         )
 
     def list(self, *, vault_id: int, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List uploads in a vault.
+
+        Args:
+            vault_id: The vault id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="uploads", operation="list", is_mutation=False, resource_id=vault_id),
             f"/vaults/{vault_id}/uploads.json",
@@ -79,6 +124,16 @@ class UploadsService(BaseService):
         subscriptions: list[int] | None = None,
         visible_to_clients: bool | None = None,
     ) -> dict[str, Any]:
+        """Create a new upload in a vault.
+
+        Args:
+            vault_id: The vault id.
+            attachable_sgid: The attachable sgid.
+            description: The description.
+            base_name: The base name.
+            subscriptions: The subscriptions.
+            visible_to_clients: The visible to clients.
+        """
         return self._request(
             OperationInfo(service="uploads", operation="create", is_mutation=True, resource_id=vault_id),
             "POST",
@@ -96,6 +151,11 @@ class UploadsService(BaseService):
 
 class AsyncUploadsService(AsyncBaseService):
     async def get(self, *, upload_id: int) -> dict[str, Any]:
+        """Get a single upload by id.
+
+        Args:
+            upload_id: The upload id.
+        """
         return await self._request(
             OperationInfo(service="uploads", operation="get", is_mutation=False, resource_id=upload_id),
             "GET",
@@ -106,6 +166,13 @@ class AsyncUploadsService(AsyncBaseService):
     async def update(
         self, *, upload_id: int, description: str | None = None, base_name: str | None = None
     ) -> dict[str, Any]:
+        """Update an existing upload.
+
+        Args:
+            upload_id: The upload id.
+            description: The description.
+            base_name: The base name.
+        """
         return await self._request(
             OperationInfo(service="uploads", operation="update", is_mutation=True, resource_id=upload_id),
             "PUT",
@@ -115,6 +182,13 @@ class AsyncUploadsService(AsyncBaseService):
         )
 
     async def list_versions(self, *, upload_id: int, max_items: int | None = None) -> ListResult:
+        """List versions of an upload.
+
+        Args:
+            upload_id: The upload id.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="uploads", operation="list_versions", is_mutation=False, resource_id=upload_id),
             f"/uploads/{upload_id}/versions.json",
@@ -132,6 +206,23 @@ class AsyncUploadsService(AsyncBaseService):
         notify: str | None = None,
         subscriptions: list[int] | None = None,
     ) -> dict[str, Any]:
+        """Replace an upload's file with a new version.
+
+        The recording keeps its id, its URL and its comments; the previous file becomes a
+        past version. Use this instead of CreateUpload when publishing a new release of the
+        same file, so its published link keeps working.
+
+        Args:
+            upload_id: The upload id.
+            attachable_sgid: The attachable sgid.
+            base_name: Omit to keep the uploaded file's own name. Sending "" also keeps it.
+            description: Presence-aware: omit to carry the previous version's description forward,
+                send "" to clear it, send a value to set it.
+            notify: Who to notify: "default", "everyone", or "custom" (the people in subscriptions).
+                Omit both this and subscriptions to notify nobody. A subscriptions array sent
+                without notify is read as "custom".
+            subscriptions: People to notify about the replacement and subscribe to the upload.
+        """
         return await self._request(
             OperationInfo(service="uploads", operation="create_version", is_mutation=True, resource_id=upload_id),
             "POST",
@@ -147,6 +238,15 @@ class AsyncUploadsService(AsyncBaseService):
         )
 
     async def list(self, *, vault_id: int, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List uploads in a vault.
+
+        Args:
+            vault_id: The vault id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="uploads", operation="list", is_mutation=False, resource_id=vault_id),
             f"/vaults/{vault_id}/uploads.json",
@@ -165,6 +265,16 @@ class AsyncUploadsService(AsyncBaseService):
         subscriptions: list[int] | None = None,
         visible_to_clients: bool | None = None,
     ) -> dict[str, Any]:
+        """Create a new upload in a vault.
+
+        Args:
+            vault_id: The vault id.
+            attachable_sgid: The attachable sgid.
+            description: The description.
+            base_name: The base name.
+            subscriptions: The subscriptions.
+            visible_to_clients: The visible to clients.
+        """
         return await self._request(
             OperationInfo(service="uploads", operation="create", is_mutation=True, resource_id=vault_id),
             "POST",

--- a/python/src/basecamp/generated/services/uploads.py
+++ b/python/src/basecamp/generated/services/uploads.py
@@ -45,8 +45,9 @@ class UploadsService(BaseService):
 
         Args:
             upload_id: The upload id.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages.
         """
         return self._request_paginated(
             OperationInfo(service="uploads", operation="list_versions", is_mutation=False, resource_id=upload_id),
@@ -103,9 +104,9 @@ class UploadsService(BaseService):
             vault_id: The vault id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="uploads", operation="list", is_mutation=False, resource_id=vault_id),
@@ -187,8 +188,9 @@ class AsyncUploadsService(AsyncBaseService):
 
         Args:
             upload_id: The upload id.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages.
         """
         return await self._request_paginated(
             OperationInfo(service="uploads", operation="list_versions", is_mutation=False, resource_id=upload_id),
@@ -245,9 +247,9 @@ class AsyncUploadsService(AsyncBaseService):
             vault_id: The vault id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="uploads", operation="list", is_mutation=False, resource_id=vault_id),

--- a/python/src/basecamp/generated/services/vaults.py
+++ b/python/src/basecamp/generated/services/vaults.py
@@ -12,6 +12,11 @@ from basecamp.hooks import OperationInfo
 
 class VaultsService(BaseService):
     def get(self, *, vault_id: int) -> dict[str, Any]:
+        """Get a single vault by id.
+
+        Args:
+            vault_id: The vault id.
+        """
         return self._request(
             OperationInfo(service="vaults", operation="get", is_mutation=False, resource_id=vault_id),
             "GET",
@@ -20,6 +25,12 @@ class VaultsService(BaseService):
         )
 
     def update(self, *, vault_id: int, title: str | None = None) -> dict[str, Any]:
+        """Update an existing vault.
+
+        Args:
+            vault_id: The vault id.
+            title: The title.
+        """
         return self._request(
             OperationInfo(service="vaults", operation="update", is_mutation=True, resource_id=vault_id),
             "PUT",
@@ -29,6 +40,15 @@ class VaultsService(BaseService):
         )
 
     def list(self, *, vault_id: int, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List vaults (subfolders) in a vault.
+
+        Args:
+            vault_id: The vault id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="vaults", operation="list", is_mutation=False, resource_id=vault_id),
             f"/vaults/{vault_id}/vaults.json",
@@ -38,6 +58,12 @@ class VaultsService(BaseService):
         )
 
     def create(self, *, vault_id: int, title: str) -> dict[str, Any]:
+        """Create a new vault (subfolder) in a vault.
+
+        Args:
+            vault_id: The vault id.
+            title: The title.
+        """
         return self._request(
             OperationInfo(service="vaults", operation="create", is_mutation=True, resource_id=vault_id),
             "POST",
@@ -49,6 +75,11 @@ class VaultsService(BaseService):
 
 class AsyncVaultsService(AsyncBaseService):
     async def get(self, *, vault_id: int) -> dict[str, Any]:
+        """Get a single vault by id.
+
+        Args:
+            vault_id: The vault id.
+        """
         return await self._request(
             OperationInfo(service="vaults", operation="get", is_mutation=False, resource_id=vault_id),
             "GET",
@@ -57,6 +88,12 @@ class AsyncVaultsService(AsyncBaseService):
         )
 
     async def update(self, *, vault_id: int, title: str | None = None) -> dict[str, Any]:
+        """Update an existing vault.
+
+        Args:
+            vault_id: The vault id.
+            title: The title.
+        """
         return await self._request(
             OperationInfo(service="vaults", operation="update", is_mutation=True, resource_id=vault_id),
             "PUT",
@@ -66,6 +103,15 @@ class AsyncVaultsService(AsyncBaseService):
         )
 
     async def list(self, *, vault_id: int, page: int | None = None, max_items: int | None = None) -> ListResult:
+        """List vaults (subfolders) in a vault.
+
+        Args:
+            vault_id: The vault id.
+            page: Page number for paginating through results. Defaults to 1. A positive value
+                selects exactly that page, not a starting offset; see SPEC section 8.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="vaults", operation="list", is_mutation=False, resource_id=vault_id),
             f"/vaults/{vault_id}/vaults.json",
@@ -75,6 +121,12 @@ class AsyncVaultsService(AsyncBaseService):
         )
 
     async def create(self, *, vault_id: int, title: str) -> dict[str, Any]:
+        """Create a new vault (subfolder) in a vault.
+
+        Args:
+            vault_id: The vault id.
+            title: The title.
+        """
         return await self._request(
             OperationInfo(service="vaults", operation="create", is_mutation=True, resource_id=vault_id),
             "POST",

--- a/python/src/basecamp/generated/services/vaults.py
+++ b/python/src/basecamp/generated/services/vaults.py
@@ -46,9 +46,9 @@ class VaultsService(BaseService):
             vault_id: The vault id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="vaults", operation="list", is_mutation=False, resource_id=vault_id),
@@ -110,9 +110,9 @@ class AsyncVaultsService(AsyncBaseService):
             vault_id: The vault id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages. A positive page argument
-                fetches exactly that one page.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages. A positive page argument fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="vaults", operation="list", is_mutation=False, resource_id=vault_id),

--- a/python/src/basecamp/generated/services/vaults.py
+++ b/python/src/basecamp/generated/services/vaults.py
@@ -46,8 +46,9 @@ class VaultsService(BaseService):
             vault_id: The vault id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return self._request_paginated(
             OperationInfo(service="vaults", operation="list", is_mutation=False, resource_id=vault_id),
@@ -109,8 +110,9 @@ class AsyncVaultsService(AsyncBaseService):
             vault_id: The vault id.
             page: Page number for paginating through results. Defaults to 1. A positive value
                 selects exactly that page, not a starting offset; see SPEC section 8.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages. A positive page argument
+                fetches exactly that one page.
         """
         return await self._request_paginated(
             OperationInfo(service="vaults", operation="list", is_mutation=False, resource_id=vault_id),

--- a/python/src/basecamp/generated/services/webhooks_service.py
+++ b/python/src/basecamp/generated/services/webhooks_service.py
@@ -12,6 +12,13 @@ from basecamp.hooks import OperationInfo
 
 class WebhooksService(BaseService):
     def list(self, *, bucket_id: int, max_items: int | None = None) -> ListResult:
+        """List all webhooks for a project.
+
+        Args:
+            bucket_id: The bucket id.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return self._request_paginated(
             OperationInfo(service="webhooks", operation="list", is_mutation=False, project_id=bucket_id),
             f"/buckets/{bucket_id}/webhooks.json",
@@ -22,6 +29,14 @@ class WebhooksService(BaseService):
     def create(
         self, *, bucket_id: int, payload_url: str, types: list[str], active: bool | None = None
     ) -> dict[str, Any]:
+        """Create a new webhook for a project.
+
+        Args:
+            bucket_id: The bucket id.
+            payload_url: The payload url.
+            types: The types.
+            active: The active.
+        """
         return self._request(
             OperationInfo(service="webhooks", operation="create", is_mutation=True, project_id=bucket_id),
             "POST",
@@ -31,6 +46,11 @@ class WebhooksService(BaseService):
         )
 
     def get(self, *, webhook_id: int) -> dict[str, Any]:
+        """Get a single webhook by id.
+
+        Args:
+            webhook_id: The webhook id.
+        """
         return self._request(
             OperationInfo(service="webhooks", operation="get", is_mutation=False, resource_id=webhook_id),
             "GET",
@@ -46,6 +66,14 @@ class WebhooksService(BaseService):
         types: list[str] | None = None,
         active: bool | None = None,
     ) -> dict[str, Any]:
+        """Update an existing webhook.
+
+        Args:
+            webhook_id: The webhook id.
+            payload_url: The payload url.
+            types: The types.
+            active: The active.
+        """
         return self._request(
             OperationInfo(service="webhooks", operation="update", is_mutation=True, resource_id=webhook_id),
             "PUT",
@@ -55,6 +83,11 @@ class WebhooksService(BaseService):
         )
 
     def delete(self, *, webhook_id: int) -> None:
+        """Delete a webhook.
+
+        Args:
+            webhook_id: The webhook id.
+        """
         self._request_void(
             OperationInfo(service="webhooks", operation="delete", is_mutation=True, resource_id=webhook_id),
             "DELETE",
@@ -65,6 +98,13 @@ class WebhooksService(BaseService):
 
 class AsyncWebhooksService(AsyncBaseService):
     async def list(self, *, bucket_id: int, max_items: int | None = None) -> ListResult:
+        """List all webhooks for a project.
+
+        Args:
+            bucket_id: The bucket id.
+            max_items: Client-side cap on the total number of items collected across pages; None
+                collects every page.
+        """
         return await self._request_paginated(
             OperationInfo(service="webhooks", operation="list", is_mutation=False, project_id=bucket_id),
             f"/buckets/{bucket_id}/webhooks.json",
@@ -75,6 +115,14 @@ class AsyncWebhooksService(AsyncBaseService):
     async def create(
         self, *, bucket_id: int, payload_url: str, types: list[str], active: bool | None = None
     ) -> dict[str, Any]:
+        """Create a new webhook for a project.
+
+        Args:
+            bucket_id: The bucket id.
+            payload_url: The payload url.
+            types: The types.
+            active: The active.
+        """
         return await self._request(
             OperationInfo(service="webhooks", operation="create", is_mutation=True, project_id=bucket_id),
             "POST",
@@ -84,6 +132,11 @@ class AsyncWebhooksService(AsyncBaseService):
         )
 
     async def get(self, *, webhook_id: int) -> dict[str, Any]:
+        """Get a single webhook by id.
+
+        Args:
+            webhook_id: The webhook id.
+        """
         return await self._request(
             OperationInfo(service="webhooks", operation="get", is_mutation=False, resource_id=webhook_id),
             "GET",
@@ -99,6 +152,14 @@ class AsyncWebhooksService(AsyncBaseService):
         types: list[str] | None = None,
         active: bool | None = None,
     ) -> dict[str, Any]:
+        """Update an existing webhook.
+
+        Args:
+            webhook_id: The webhook id.
+            payload_url: The payload url.
+            types: The types.
+            active: The active.
+        """
         return await self._request(
             OperationInfo(service="webhooks", operation="update", is_mutation=True, resource_id=webhook_id),
             "PUT",
@@ -108,6 +169,11 @@ class AsyncWebhooksService(AsyncBaseService):
         )
 
     async def delete(self, *, webhook_id: int) -> None:
+        """Delete a webhook.
+
+        Args:
+            webhook_id: The webhook id.
+        """
         await self._request_void(
             OperationInfo(service="webhooks", operation="delete", is_mutation=True, resource_id=webhook_id),
             "DELETE",

--- a/python/src/basecamp/generated/services/webhooks_service.py
+++ b/python/src/basecamp/generated/services/webhooks_service.py
@@ -16,8 +16,8 @@ class WebhooksService(BaseService):
 
         Args:
             bucket_id: The bucket id.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages.
         """
         return self._request_paginated(
             OperationInfo(service="webhooks", operation="list", is_mutation=False, project_id=bucket_id),
@@ -102,8 +102,8 @@ class AsyncWebhooksService(AsyncBaseService):
 
         Args:
             bucket_id: The bucket id.
-            max_items: Client-side cap on the total number of items collected across pages; None
-                collects every page.
+            max_items: Client-side cap on the number of items collected across pages; None means no
+                item cap. Collection is always bounded by config.max_pages.
         """
         return await self._request_paginated(
             OperationInfo(service="webhooks", operation="list", is_mutation=False, project_id=bucket_id),

--- a/python/src/basecamp/generated/services/webhooks_service.py
+++ b/python/src/basecamp/generated/services/webhooks_service.py
@@ -16,8 +16,9 @@ class WebhooksService(BaseService):
 
         Args:
             bucket_id: The bucket id.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages.
         """
         return self._request_paginated(
             OperationInfo(service="webhooks", operation="list", is_mutation=False, project_id=bucket_id),
@@ -102,8 +103,9 @@ class AsyncWebhooksService(AsyncBaseService):
 
         Args:
             bucket_id: The bucket id.
-            max_items: Client-side cap on the number of items collected across pages; None means no
-                item cap. Collection is always bounded by config.max_pages.
+            max_items: Client-side cap on the number of items collected across pages; None or a
+                non-positive value means no item cap. Collection is always bounded by
+                config.max_pages.
         """
         return await self._request_paginated(
             OperationInfo(service="webhooks", operation="list", is_mutation=False, project_id=bucket_id),

--- a/python/src/basecamp/generated/services/wormholes.py
+++ b/python/src/basecamp/generated/services/wormholes.py
@@ -12,6 +12,14 @@ from basecamp.hooks import OperationInfo
 
 class WormholesService(BaseService):
     def update(self, *, bucket_id: int, wormhole_id: int, destination_recording_id: int) -> dict[str, Any]:
+        """Update a wormhole's destination column.
+
+        Args:
+            bucket_id: The bucket id.
+            wormhole_id: The wormhole id.
+            destination_recording_id: Id of the new destination column (on another accessible card
+                table).
+        """
         return self._request(
             OperationInfo(
                 service="wormholes", operation="update", is_mutation=True, project_id=bucket_id, resource_id=wormhole_id
@@ -23,6 +31,12 @@ class WormholesService(BaseService):
         )
 
     def delete(self, *, bucket_id: int, wormhole_id: int) -> None:
+        """Delete a wormhole.
+
+        Args:
+            bucket_id: The bucket id.
+            wormhole_id: The wormhole id.
+        """
         self._request_void(
             OperationInfo(
                 service="wormholes", operation="delete", is_mutation=True, project_id=bucket_id, resource_id=wormhole_id
@@ -33,6 +47,18 @@ class WormholesService(BaseService):
         )
 
     def create(self, *, bucket_id: int, card_table_id: int, destination_recording_id: int) -> dict[str, Any]:
+        """Create a wormhole linking this card table to a column on another card table.
+
+        A wormhole is the only mechanism for moving a card to a different project: its
+        id is a valid `column_id` for MoveCard, teleporting the card across projects.
+        `destinationRecordingId` is the id of a column on another accessible card table.
+
+        Args:
+            bucket_id: The bucket id.
+            card_table_id: The card table id.
+            destination_recording_id: Id of the destination column (on another accessible card
+                table) to link to.
+        """
         return self._request(
             OperationInfo(
                 service="wormholes",
@@ -50,6 +76,14 @@ class WormholesService(BaseService):
 
 class AsyncWormholesService(AsyncBaseService):
     async def update(self, *, bucket_id: int, wormhole_id: int, destination_recording_id: int) -> dict[str, Any]:
+        """Update a wormhole's destination column.
+
+        Args:
+            bucket_id: The bucket id.
+            wormhole_id: The wormhole id.
+            destination_recording_id: Id of the new destination column (on another accessible card
+                table).
+        """
         return await self._request(
             OperationInfo(
                 service="wormholes", operation="update", is_mutation=True, project_id=bucket_id, resource_id=wormhole_id
@@ -61,6 +95,12 @@ class AsyncWormholesService(AsyncBaseService):
         )
 
     async def delete(self, *, bucket_id: int, wormhole_id: int) -> None:
+        """Delete a wormhole.
+
+        Args:
+            bucket_id: The bucket id.
+            wormhole_id: The wormhole id.
+        """
         await self._request_void(
             OperationInfo(
                 service="wormholes", operation="delete", is_mutation=True, project_id=bucket_id, resource_id=wormhole_id
@@ -71,6 +111,18 @@ class AsyncWormholesService(AsyncBaseService):
         )
 
     async def create(self, *, bucket_id: int, card_table_id: int, destination_recording_id: int) -> dict[str, Any]:
+        """Create a wormhole linking this card table to a column on another card table.
+
+        A wormhole is the only mechanism for moving a card to a different project: its
+        id is a valid `column_id` for MoveCard, teleporting the card across projects.
+        `destinationRecordingId` is the id of a column on another accessible card table.
+
+        Args:
+            bucket_id: The bucket id.
+            card_table_id: The card table id.
+            destination_recording_id: Id of the destination column (on another accessible card
+                table) to link to.
+        """
         return await self._request(
             OperationInfo(
                 service="wormholes",

--- a/python/tests/test_generate_docstrings.py
+++ b/python/tests/test_generate_docstrings.py
@@ -1,0 +1,109 @@
+"""Fixture for the generated-service method docstrings (#663). A description
+can, in principle, contain triple quotes (which would close the docstring
+early), backslashes (which would form stray escape sequences), and embedded
+newlines; escape_docstring_text must keep such text valid when the generator
+interpolates it into a method's triple-quoted docstring.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+from generate_services import build_params, method_docstring  # noqa: E402
+
+# Triple quotes (would close the docstring), a backslash + `u` (would be an
+# invalid unicode escape), an embedded newline, and a trailing double-quote
+# (would fuse with the closing delimiter if it ever ended a docstring).
+NASTY = 'has """ triple, back\\slash \\u not-unicode, and\na newline, ends with quote "'
+
+
+def _hostile_op() -> dict:
+    return {
+        "operation_id": "NastyOp",
+        "description": NASTY + "\n\n**Pagination**: manual\n\nsecond paragraph",
+        "path_params": [
+            {"name": "projectId", "python_name": "project_id", "type": "int", "description": NASTY},
+        ],
+        "query_params": [
+            {
+                "name": "type",
+                "python_name": "type",
+                "type": "str",
+                "required": False,
+                "deprecated": True,
+                "deprecation_reason": NASTY,
+                "description": None,
+            },
+        ],
+        "body_params": [
+            {"name": "note", "python_name": "note", "type": "str", "required": True, "description": NASTY},
+        ],
+        "has_body": True,
+        "has_binary_body": False,
+        "has_multipart_body": False,
+        "has_pagination": True,
+        "pagination_key": None,
+    }
+
+
+def _emit(op: dict) -> tuple[str, str]:
+    """Render the docstring at class-method depth, compile it, and return
+    (emitted source, runtime docstring)."""
+    params = build_params(op)
+    doc = "\n".join(method_docstring(op, params))
+    src = f"class C:\n    def f(self):\n{doc}\n        return 1\n"
+    namespace: dict = {}
+    exec(compile(src, op["operation_id"], "exec"), namespace)  # noqa: S102
+    return doc, namespace["C"].f.__doc__
+
+
+def test_hostile_description_stays_valid_and_composes_deprecation():
+    doc, runtime = _emit(_hostile_op())
+    # The hostile text survives escaping intact at runtime...
+    assert '"""' in runtime
+    # ...and every docstring section is present: summary, deprecation note
+    # (composed, not clobbered), and Args covering path/body/query/max_items.
+    assert "Deprecated parameters (prefer the replacement):" in runtime
+    for arg in ("project_id:", "note:", "type:", "max_items:"):
+        assert arg in runtime
+
+
+def test_raw_description_would_break_without_escaping():
+    # Guard: the fixture input really is hostile — the unescaped form does not
+    # compile, so the escaping above is doing real work.
+    src = f'x = """{NASTY}"""\n'
+    try:
+        compile(src, "<raw>", "exec")
+    except (SyntaxError, ValueError):
+        return
+    raise AssertionError("expected the raw description to break compilation")
+
+
+def test_degenerate_operation_shapes_compile():
+    base = {
+        "path_params": [],
+        "query_params": [],
+        "body_params": [],
+        "has_body": False,
+        "has_binary_body": False,
+        "has_multipart_body": False,
+        "has_pagination": False,
+        "pagination_key": None,
+    }
+    no_params = {**base, "operation_id": "X", "description": ""}
+    pagination_only = {
+        **base,
+        "operation_id": "P",
+        "description": "**Pagination**: Uses Link header.",
+        "has_pagination": True,
+        "pagination_key": "events",
+    }
+    doc, runtime = _emit(no_params)
+    assert doc.strip() == '"""X operation."""'
+    _, runtime = _emit(pagination_only)
+    # The manual Link-following boilerplate is dropped (the method paginates
+    # itself); max_items documents the collected-pages behavior instead.
+    assert "Link header" not in runtime
+    assert "max_items:" in runtime

--- a/python/tests/test_generate_docstrings.py
+++ b/python/tests/test_generate_docstrings.py
@@ -14,9 +14,11 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 from generate_services import build_params, method_docstring  # noqa: E402
 
 # Triple quotes (would close the docstring), a backslash + `u` (would be an
-# invalid unicode escape), an embedded newline, and a trailing double-quote
-# (would fuse with the closing delimiter if it ever ended a docstring).
-NASTY = 'has """ triple, back\\slash \\u not-unicode, and\na newline, ends with quote "'
+# invalid unicode escape), an embedded newline, a literal NUL (JSON `\\u0000`
+# — "source code string cannot contain null bytes"), and a trailing
+# double-quote (would fuse with the closing delimiter if it ever ended a
+# docstring).
+NASTY = 'has """ triple, back\\slash \\u not-unicode, a \x00 NUL, and\na newline, ends with quote "'
 
 
 def _hostile_op() -> dict:
@@ -63,6 +65,8 @@ def test_hostile_description_stays_valid_and_composes_deprecation():
     doc, runtime = _emit(_hostile_op())
     # The hostile text survives escaping intact at runtime...
     assert '"""' in runtime
+    # ...minus the source-breaking NUL, which is dropped, not smuggled through.
+    assert "\x00" not in doc and "\x00" not in runtime
     # ...and every docstring section is present: summary, deprecation note
     # (composed, not clobbered), and Args covering path/body/query/max_items.
     assert "Deprecated parameters (prefer the replacement):" in runtime
@@ -102,6 +106,15 @@ def test_degenerate_operation_shapes_compile():
     }
     doc, runtime = _emit(no_params)
     assert doc.strip() == '"""X operation."""'
+    # A no-param op whose description ends in a double-quote must not emit
+    # `"""text""""`: the summary-period rule treats a trailing quote as
+    # non-terminal punctuation, so every one-line docstring ends in `.!?`,
+    # never adjacent to the closing delimiter.
+    trailing_quote = {**base, "operation_id": "T", "description": 'Group by "bucket" or "date"'}
+    doc, runtime = _emit(trailing_quote)
+    assert '""""' not in doc
+    assert doc.strip().endswith('"."""')
+    assert runtime == 'Group by "bucket" or "date".'
     _, runtime = _emit(pagination_only)
     # The manual Link-following boilerplate is dropped (the method paginates
     # itself); max_items documents the collected-pages behavior instead.

--- a/python/tests/test_generate_docstrings.py
+++ b/python/tests/test_generate_docstrings.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
-from generate_services import build_params, method_docstring  # noqa: E402
+from generate_services import build_params, extract_body_params, method_docstring  # noqa: E402
 
 # Triple quotes (would close the docstring), a backslash + `u` (would be an
 # invalid unicode escape), an embedded newline, a literal NUL (JSON `\\u0000`
@@ -72,6 +72,27 @@ def test_hostile_description_stays_valid_and_composes_deprecation():
     assert "Deprecated parameters (prefer the replacement):" in runtime
     for arg in ("project_id:", "note:", "type:", "max_items:"):
         assert arg in runtime
+
+
+def test_ref_body_property_reads_target_schema_description():
+    schemas = {
+        "Body": {
+            "properties": {
+                "calendar": {"$ref": "#/components/schemas/Attrs"},
+                "labeled": {"$ref": "#/components/schemas/Attrs", "description": "Sibling wins."},
+                "bare": {"$ref": "#/components/schemas/Undescribed"},
+            },
+        },
+        "Attrs": {"type": "object", "description": "The writable payload."},
+        "Undescribed": {"type": "object"},
+    }
+    by_name = {p["name"]: p for p in extract_body_params({"$ref": "#/components/schemas/Body"}, schemas)}
+    # A bare $ref property has no description of its own — the referenced
+    # schema's description documents it; a sibling description still wins; an
+    # undescribed target leaves None for the humanized fallback.
+    assert by_name["calendar"]["description"] == "The writable payload."
+    assert by_name["labeled"]["description"] == "Sibling wins."
+    assert by_name["bare"]["description"] is None
 
 
 def test_raw_description_would_break_without_escaping():


### PR DESCRIPTION
Python was the only SDK whose generated services carried no method documentation at all — only the #406 deprecation note, and only on Search. Every generated method, sync and async, now gets a docstring (AST-verified 250/250 on both variants).

Closes #663.

## Shape

- **Summary** — the operation description's whole first paragraph, not Ruby's first-line truncation: 191/250 first lines are unterminated phrases, so the paragraph keeps whole sentences (a period is appended when terminal punctuation is missing). Remaining paragraphs verbatim.
- **Google-style `Args:`** — path, body, and query params plus the synthetic `max_items` on paginated ops. Per-param descriptions come from the OpenAPI spec (the generator now parses them); a description-less param gets a humanized fallback (`bucket_id:` → "The bucket id.") rather than being omitted — path params have zero spec descriptions, so the fallback is what documents them. Enriching spec descriptions is the durable fix where fallbacks read thin; no hand-kept hints table (the TS approach) was cloned.
- **Deprecation notes compose** — `deprecation_docstring` became a section between description and Args, so Search keeps both its docstring and its #406 note.
- **One deliberate text change**: the spec's `**Pagination**` boilerplate paragraph is dropped on paginated ops — it instructs manual Link-header following that these methods do automatically; the `max_items` line documents the actual behavior. No non-paginated op carries that paragraph.
- **Escaping hardened** — embedded `"""`, backslashes, and stray quotes are neutralized; the closing delimiter always lands safely. Guarded by a committed generator test (`python/tests/test_generate_docstrings.py`, mirroring `test_generate_deprecation.py`) whose hostile fixture was red-proved: neutering the escaper makes the emitted file fail to compile.

## Churn and verification

55 files, +4,387/−36 — 53 of them regenerated service files via `make py-generate` only. `make py-check`, `make py-check-drift` (deterministic regen, no drift), and full `make check` all green. Adversarial shapes exercised: no-params, body-only, query-only, binary upload, multipart, deprecated+paginated, wrapped-paginated.

Deferred (will note on the issue): a docstring-presence parity gate across SDKs — net-new gate, separate decision.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generate real docstrings for all Python SDK service methods (sync and async), improving editor help and readability with safe escaping. Deprecation notes now compose into the docstring, and pagination boilerplate is removed in favor of accurate behavior docs; wrapping and pagination text are tightened.

- **New Features**
  - Google-style Args built from the spec across path/body/query params, plus synthetic `max_items`; humanized fallbacks when descriptions are missing.
  - Summaries use the operation description’s full first paragraph; remaining paragraphs are kept, and a period is added if missing.
  - Robust escaping for quotes/backslashes/control characters with a generator test; services regenerated only, no runtime behavior changes.

- **Bug Fixes**
  - Token-safe wrapping (no mid-token splits) via `textwrap` with `break_long_words=False`, `break_on_hyphens=False`.
  - Precise `max_items` docs: None or a non-positive value means no item cap; collection is bounded by `config.max_pages`; a positive `page` selects a single page. The page sentence is emitted only when a `page` param exists.
  - Body `$ref` properties now inherit descriptions from the referenced schema when the property has none.
  - Fallback humanization strips keyword-collision underscores (e.g. `from_` → “The from.”).
  - NUL-proof escaping: remaining C0 controls and DEL (including NUL) are dropped in both docstring and string escapers; pinned by a new regression test.

<sup>Written for commit 45e18eee9afd0e7336ef686227e4874d71c2f392. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

