### PR TITLE
Deflake wall-clock timing assertions: assert the mechanism, not elapsed time

### DIFF
--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -801,9 +801,11 @@ class OAuthTransportTest < Minitest::Test
     # find_proxy resolves the target hostname (IPSocket.getaddress) to
     # evaluate its loopback rule — a stalled resolver must be cut by the
     # advertised bound, not hold the request open before any deadline exists.
+    resolver_finished = false
     real = IPSocket.method(:getaddress)
     IPSocket.define_singleton_method(:getaddress) do |host|
       sleep(5)
+      resolver_finished = true
       real.call(host)
     end
 
@@ -812,12 +814,23 @@ class OAuthTransportTest < Minitest::Test
     proxy_env.each { |k| ENV.delete(k) }
     ENV["https_proxy"] = "http://127.0.0.1:9"
     begin
-      started = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      assert_raises(Faraday::TimeoutError) do
-        Basecamp::Oauth::Fetcher.stream_http(:get, "https://dns-stall.test/token", timeout: 0.5)
+      took = elapsed do
+        assert_raises(Faraday::TimeoutError) do
+          Basecamp::Oauth::Fetcher.stream_http(:get, "https://dns-stall.test/token", timeout: 0.5)
+        end
       end
-      took = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
-      assert_operator took, :<, 2.0, "proxy-resolution DNS must be cut by the deadline, took #{took.round(2)}s"
+      # Assert the MECHANISM, not wall clock (#708): the find_proxy bound's
+      # asynchronous raise interrupts the resolver stub MID-SLEEP, so its
+      # completion flag never flips. Without the bound the call sits out the
+      # full 5s stall, the flag flips, and the ECONNREFUSED that follows still
+      # maps to Faraday::TimeoutError (past-deadline classification) — this
+      # assertion, not the error class, is what discriminates.
+      assert_not resolver_finished, \
+        "stream_http returned only after the stalled resolver ran to completion — the find_proxy bound did not cut it"
+      # Hang guard ONLY — generous on purpose: it protects the suite from a
+      # wedged resolution phase and asserts nothing about timing tightness.
+      assert_operator took, :<, 15, \
+        "hang guard, not a timing bound: the stalled resolver should be cut in ~0.5s; #{took.round(2)}s means nothing cut it"
     ensure
       proxy_env.each { |k| ENV.delete(k) }
       saved.each { |k, v| ENV[k] = v }
@@ -892,6 +905,16 @@ class OAuthTransportTest < Minitest::Test
     # the per-read timeout resets on every dripped byte. A proxy dripping the
     # CONNECT response below read_timeout must be cut by the whole-phase
     # deadline bound, not left to per-read timeouts that never fire.
+    #
+    # The drip is ENDLESS: the terminating blank line never arrives, and every
+    # 0.2s gap sits well under the 0.5s per-read timeout — so no per-read
+    # timeout can ever fire and the call can NEVER return on its own. The only
+    # way out is the whole-phase connect bound's asynchronous cut closing the
+    # socket MID-DRIP, which the proxy observes as a write error and reports
+    # on the queue. (The drip does stop after ~20s — far past every assertion
+    # horizon — solely so a broken bound fails the hang guard below instead of
+    # wedging the suite.)
+    cut = Queue.new
     proxy = TCPServer.new("127.0.0.1", 0)
     @servers << proxy
     @server_threads << Thread.new do
@@ -899,14 +922,22 @@ class OAuthTransportTest < Minitest::Test
         conn = proxy.accept
         @conns << conn
         while (line = conn.gets) && line != "\r\n"; end
-        # Drip the CONNECT response one byte at a time, each gap well below
-        # the 0.5s per-read timeout, for ~7.6s — far past the 0.5s deadline.
-        "HTTP/1.1 200 Connection Established\r\n\r\n".each_char do |ch|
-          conn.write(ch)
-          sleep(0.2)
+        begin
+          conn.write("HTTP/1.1 200 Connection Established\r\n")
+          100.times do
+            conn.write("a")
+            sleep(0.2)
+          end
+          conn.close
+        rescue IOError, SystemCallError
+          # The rescue must wrap the WHOLE drip loop, not a single write: the
+          # first write after the client closes can still land in the socket
+          # buffer, and only a later write raises. Reaching here means the
+          # client cut the socket mid-drip.
+          cut << true
         end
       rescue IOError, SystemCallError
-        break
+        break # listener closed in teardown
       end
     end
 
@@ -920,12 +951,26 @@ class OAuthTransportTest < Minitest::Test
     ENV["https_proxy"] = "http://127.0.0.1:#{proxy.addr[1]}"
     begin
       took = elapsed do
+        # Discriminating on its own now that the drip is endless: without the
+        # whole-phase connect bound the call cannot return before the drip's
+        # ~20s cap (per-read timeouts never fire between 0.2s gaps, and the
+        # watchdog cannot reach a pre-started? session).
         assert_raises(Faraday::TimeoutError) do
           Basecamp::Oauth::Fetcher.stream_http(:get, "https://proxy-drip.test/token", timeout: 0.5)
         end
       end
-      assert_operator took, :<, 2.0, \
-        "CONNECT parsing must be cut at the ~0.5s deadline; per-read timeouts alone let the drip run ~8s"
+      # Assert the MECHANISM, not wall clock (#708): the proxy observed the
+      # CLIENT cutting the socket mid-drip. Only the whole-phase
+      # Timeout.timeout(connect_remaining) bound closes this socket — the
+      # watchdog's finish raises IOError until the session is started, and no
+      # per-read timeout can fire. A drip that ran out on the proxy's side
+      # instead leaves the queue empty.
+      assert cut.pop(timeout: 5), \
+        "the proxy never saw the client cut the CONNECT drip — the whole-phase connect bound did not fire"
+      # Hang guard ONLY — generous on purpose: it protects the suite from a
+      # wedged connect phase and asserts nothing about timing tightness.
+      assert_operator took, :<, 15, \
+        "hang guard, not a timing bound: the endless drip should be cut in ~0.5s; #{took.round(2)}s means nothing cut it"
     ensure
       proxy_env.each { |k| ENV.delete(k) }
       saved.each { |k, v| ENV[k] = v }

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -964,8 +964,10 @@ class OAuthTransportTest < Minitest::Test
       # Timeout.timeout(connect_remaining) bound closes this socket — the
       # watchdog's finish raises IOError until the session is started, and no
       # per-read timeout can fire. A drip that ran out on the proxy's side
-      # instead leaves the queue empty.
-      assert cut.pop(timeout: 5), \
+      # instead leaves the queue empty. The pop timeout is a WAIT bound, not a
+      # timing assertion — as generous as the hang guard, so a loaded runner
+      # cannot fail it spuriously (#708's whole class).
+      assert cut.pop(timeout: 15), \
         "the proxy never saw the client cut the CONNECT drip — the whole-phase connect bound did not fire"
       # Hang guard ONLY — generous on purpose: it protects the suite from a
       # wedged connect phase and asserts nothing about timing tightness.

--- a/typescript/tests/client.test.ts
+++ b/typescript/tests/client.test.ts
@@ -567,8 +567,14 @@ describe("BasecampClient", () => {
     });
 
     it("propagates a caller-supplied signal through the combined signal", async () => {
+      const controller = new AbortController();
       server.use(
         http.get(`${BASE_URL}/projects.json`, async () => {
+          // Abort from INSIDE the handler: the request is provably in flight,
+          // so no timer races machine load (#655). The delayed response stays
+          // as the fallback — if the abort failed to propagate, the request
+          // would resolve normally and the rejection assertion below fails.
+          controller.abort();
           await new Promise(resolve => setTimeout(resolve, 1000));
           return HttpResponse.json([]);
         })
@@ -582,24 +588,14 @@ describe("BasecampClient", () => {
         requestTimeoutMs: 30000,
       });
 
-      const controller = new AbortController();
-      const abortTimer = setTimeout(() => controller.abort(), 50);
-
-      try {
-        const startedAt = Date.now();
-        // A caller abort surfaces as AbortError, distinct from the timeout's
-        // TimeoutError — so this also proves it was the caller's signal, not
-        // the (30s) timeout, that won.
-        await expect(
-          client.GET("/projects.json", { signal: controller.signal })
-        ).rejects.toMatchObject({ name: "AbortError" });
-
-        // Aborting promptly proves the caller's signal reached the request; the
-        // 30s timeout signal could not have fired.
-        expect(Date.now() - startedAt).toBeLessThan(900);
-      } finally {
-        clearTimeout(abortTimer);
-      }
+      // A caller abort surfaces as AbortError, distinct from the timeout's
+      // TimeoutError — so this also proves it was the caller's signal, not
+      // the (30s) timeout, that won. That identity check is the whole
+      // assertion: a wall-clock ceiling adds no discriminating power here,
+      // only load sensitivity (#655).
+      await expect(
+        client.GET("/projects.json", { signal: controller.signal })
+      ).rejects.toMatchObject({ name: "AbortError" });
     });
   });
 


### PR DESCRIPTION
Two CI flakes, one class: a wall-clock ceiling racing scheduler latency on a loaded shared runner. Both tests measured *how fast* a bound fired when the property they exist to prove is *which* bound fired. This PR makes each test assert the mechanism and keeps elapsed time only as a generous hang guard (or drops it where it was fully redundant).

## Ruby: `test_proxy_connect_drip_is_bounded_by_the_deadline` (#708)

The old test dripped a *finite* CONNECT response over ~7.6s and asserted `took < 2.0`. That ceiling was the **only** discriminating assertion — `Faraday::TimeoutError` fired either way (the fail-open just took ~8s), and a slow runner blew through it (5.0s observed on docs-only #707).

Now the drip is **endless**: the terminating blank line never arrives, and every 0.2s gap sits under the 0.5s per-read timeout, so no per-read timeout can ever fire and the call can never return on its own. Two mechanism assertions replace the ceiling:

- `assert_raises(Faraday::TimeoutError)` is now genuinely discriminating — the only way out is the whole-phase connect bound (the watchdog's `finish` raises `IOError` against a pre-`started?` session).
- The proxy reports on a `Queue` that it observed the **client cutting the socket mid-drip** — only `Timeout.timeout(connect_remaining) { http.start }` closes that socket. The rescue wraps the whole drip loop because the first write after the client closes can still land in the socket buffer.

Elapsed survives only as `assert_operator took, :<, 15` labeled a hang guard; the drip caps at ~20s solely so a broken bound fails that guard instead of wedging the suite.

## Ruby: `test_proxy_resolution_dns_is_inside_the_deadline` (same class, pre-empted)

The next flake waiting to happen: `took < 2.0` against a `sleep(5)` resolver stub — its fail-open profile is ~5.04s, the exact shape CI observed. The stub now flips a flag after its sleep completes, and the test asserts (`assert_not`) it never flipped: the `find_proxy` bound's asynchronous raise interrupts the stub **mid-sleep**, while the fail-open sits out the full stall (and still maps to `Faraday::TimeoutError` past the deadline, so the error class alone cannot discriminate). Same 15s hang guard demotion.

## TypeScript: caller-signal abort test (#655)

Opposite treatment, per the issue's option 1: the discriminating assertion **already existed** (`AbortError` vs the 30s timeout's `TimeoutError`), so the redundant `Date.now() - startedAt < 900` ceiling is deleted, and the 50ms-timer-vs-1000ms-response race is removed by firing `controller.abort()` from **inside the MSW handler**, once the request is provably in flight. The delayed response stays as the fallback that fails the rejection assertion if the abort ever stops propagating. The sibling timeout-direction test keeps its 900ms ceiling — there promptness *is* the property under test.

## Red proof

Ran the rewritten Ruby tests against a bound-disabled fetcher (`Timeout.timeout(connect_remaining, ...) { http.start }` → bare `http.start`, `find_proxy` bound removed). Both fail on the new mechanism assertions:

```
FF..
Finished in 31.679926s ...

  2) Failure:
OAuthTransportTest#test_proxy_connect_drip_is_bounded_by_the_deadline [test/basecamp/oauth_transport_test.rb:967]:
the proxy never saw the client cut the CONNECT drip — the whole-phase connect bound did not fire

4 runs, 12 assertions, 2 failures, 0 errors, 0 skips
REAL_EXIT=1
```

(The endless drip drove the un-bounded fetcher out to its ~20s cap instead of passing; the DNS test in that run failed on `assert_raises` — the unbounded stall leaks a raw `ReadDeadlineExceeded`.)

A second variant reproduced the exact historical fail-open (bound removed *and* pre-connect deadline check disabled, so the post-stall `ECONNREFUSED` classifies as `Faraday::TimeoutError` at 5.02s — the 5.038s CI shape). The new mechanism assertion catches it:

```
  1) Failure:
OAuthTransportTest#test_proxy_resolution_dns_is_inside_the_deadline [test/basecamp/oauth_transport_test.rb:828]:
stream_http returned only after the stalled resolver ran to completion — the find_proxy bound did not cut it

1 runs, 2 assertions, 1 failures, 0 errors, 0 skips
REAL_EXIT=1
```

Fetcher restored from a `cp` backup and verified byte-identical to `git show HEAD:` before committing; the diff touches only the two test files.

## Verification

- `ruby/test/basecamp/oauth_transport_test.rb`: green against the restored fetcher (44 runs, 0 failures locally)
- Full Ruby suite: green locally (0 failures, 0 errors); `bundle exec rubocop`: no offenses
- Full TypeScript suite: green locally (all files passing)
- Full `make`: green locally on everything except a since-fixed `Rails/RefuteMethods` offense on the new assertion (`refute` → `assert_not`); rubocop re-verified clean after the fix. (A first fresh-worktree run hit the known conformance-runner lockfile residual; the re-run's lockfile gate reported all 7 lockfiles byte-identical.)

Closes #708
Closes #655

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deflakes timing-based tests by asserting the timeout mechanism instead of wall-clock ceilings, removing load-sensitive CI flakes. Previously we checked “took < 2s”; now we assert which bound fired and keep only generous hang guards.

- Ruby CONNECT drip: the drip is now endless, so only the whole-phase connect bound can end the call. Assert `Faraday::TimeoutError` and that the proxy saw the client cut the socket via a `Queue`; widen the queue wait to 15s to match the hang guard; replace the <2s ceiling with a 15s hang guard.
- Ruby DNS stall: a 5s resolver stub flips a flag when it completes. Assert `Faraday::TimeoutError` and `assert_not` that the flag flipped (the `find_proxy` bound interrupted mid-sleep); replace the <2s ceiling with a 15s hang guard.
- TypeScript caller-signal abort: abort from inside the MSW handler to remove the timer-vs-response race; drop the wall-clock check and assert `AbortError` (distinct from the 30s `TimeoutError`). Sibling timeout-direction test remains unchanged.

**Review notes**
- Only tests changed: `ruby/test/basecamp/oauth_transport_test.rb` and `typescript/tests/client.test.ts`.
- Hang guards and the queue wait are intentionally loose (15s) and only catch wedged phases, not enforce promptness.

<sup>Written for commit 30f556017f2b4711f295438e0dbb092eae90ea96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

