### PR TITLE
Model the special-cased search branches and person_minimal's guaranteed keys

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -11,6 +11,55 @@ what wrong behaviour you get if you ignore one. This file is that half.
 
 ---
 
+# Unreleased
+
+### `SearchResult` lost five required members and gained the special-branch keys (#651)
+
+BC3's search projection special-cases four result branches — chat lines,
+kanban (card table) lists, file attachments and gauge needles — and the
+file-attachment branch writes its own projection with **none of the top-level
+`id`/`title`/`type`/`url`/`app_url` keys**. Those five are now optional, and
+the branches' keys are modeled: the attachment branch's ten file keys
+(`filename` … `app_download_url`), the kanban list's (`subscribers`, `color`,
+`cards_count`, `comment_count`, `cards_url`, `on_hold`), the gauge needle's
+(`color`, `position`, `comment_count`), the chat line kinds' (`language`,
+`image_url`, `sound_url`), the shared envelope's (`subscription_url`,
+`position`, `comments_count`/`_url`, `boosts_count`/`_url`), and a typed
+`attachments` array. Derive the member delta from the spec rather than
+trusting this prose:
+
+```bash
+git show v0.14.0:openapi.json | jq '.components.schemas.SearchResult | {required, props: (.properties|keys|length)}'
+jq '.components.schemas.SearchResult | {required, props: (.properties|keys|length)}' openapi.json
+```
+
+`content` and `description` stay required-and-nullable — the show template
+nil-overwrites them on every branch, attachment hits included.
+
+| SDK | was | now |
+|---|---|---|
+| Go `pkg/generated` | `Id int64`; `Title`, `Type`, `Url`, `AppUrl string` | `*int64` / `*string` — value use is a compile error |
+| Go `pkg/basecamp` | value fields on the wrapper | unchanged types, zero-valued on a file-attachment hit; new fields + `SearchResultAttachment` |
+| Swift | `let id: Int`; `let title/type/url/appUrl: String` | optionals — non-optional use is a compile error |
+| TypeScript | `id: number`, `title/type/url/app_url: string` | `id?: number`, … — compile error under `strictNullChecks` |
+| Python | `id`/`title`/`type`/`url`/`app_url` required in the `TypedDict` | `NotRequired[...]` — type-checker-visible only, nothing changes at runtime |
+| Ruby | `Types::SearchResult.required_fields` returned all seven | returns `[:content, :description]`; readers for every new key |
+| Kotlin | untyped (`JsonElement`) | unchanged |
+
+**Wrong behaviour you get if you ignore it:** code that renders search hits by
+`id`/`title`/`type` shows a file-attachment hit as a blank row (Go wrapper,
+Ruby, Python — nothing raises), or crashes on a nil unwrap (Swift force-unwraps,
+Go `pkg/generated` derefs). Recognize a file-attachment hit by the absence of
+`type` and the presence of `filename`.
+
+**The `attachments` key was previously documented away as redundant — that was
+wrong for chat upload lines.** A chat *upload* line's `attachments` is a bespoke
+six-key aggregate (`title`, `url`, `filename`, `content_type`, `byte_size`,
+`download_url`) that does **not** match `RichTextAttachment` — no `id`, no
+`sgid`, no preview fields. The new `SearchResultAttachment` element type is the
+optional-field superset of both wire variants, with only the four keys both
+always emit required.
+
 # v0.14.0
 
 Breaking in Go and in the shape every SDK decodes from

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -60,6 +60,27 @@ six-key aggregate (`title`, `url`, `filename`, `content_type`, `byte_size`,
 optional-field superset of both wire variants, with only the four keys both
 always emit required.
 
+### `MyAssignmentAssignee` / `OutOfOfficePerson`: `name` and `avatar_url` became required (#659)
+
+Both shapes model bc3's `people/_person_minimal.json.jbuilder`, which renders
+`id`, `name` and `avatar_url` unconditionally — the same partial
+`UpcomingSchedulePerson` already models with all three required. Only `id` was
+required here; now all three are.
+
+| SDK | was | now |
+|---|---|---|
+| Go `pkg/generated` | `Name`, `AvatarUrl *string` | `string` — pointer use (`*a.Name`, nil-checks) is a compile error |
+| Go `pkg/basecamp` | own decode structs | unchanged |
+| Swift | `var name: String?`, `var avatarUrl: String?` | `let name: String`, `let avatarUrl: String` — optional-chaining and the old memberwise `init(id:avatarUrl:name:)` with defaulted nils are compile errors; decode of a payload missing either key now throws |
+| TypeScript | `name?: string`, `avatar_url?: string` | `name: string`, `avatar_url: string` — removes the need for `!`/guards; only breaks code *constructing* the type |
+| Python | `NotRequired[str]` | `str` (required in the `TypedDict`) — type-checker-visible only |
+| Ruby | `required_fields` returned `[:id]` | returns `[:avatar_url, :id, :name]` |
+| Kotlin | untyped (`JsonElement`) | unchanged |
+
+The Swift decode-throw is the only runtime face, and it needs a response bc3
+cannot produce (the partial has no conditional keys) — class B by this
+document's rule.
+
 # v0.14.0
 
 Breaking in Go and in the shape every SDK decodes from

--- a/go/pkg/basecamp/my_assignments_test.go
+++ b/go/pkg/basecamp/my_assignments_test.go
@@ -30,7 +30,9 @@ func TestMyAssignmentsService_Get(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
-		w.Write([]byte(`{"priorities":[{"id":1,"content":"Priority task"}],"non_priorities":[{"id":2,"content":"Regular task"}]}`))
+		// assignees carry the full three-key person_minimal projection — bc3
+		// renders id, name and avatar_url unconditionally (#659).
+		w.Write([]byte(`{"priorities":[{"id":1,"content":"Priority task","assignees":[{"id":1049715914,"name":"Victor Cooper","avatar_url":"https://example.com/avatar"}]}],"non_priorities":[{"id":2,"content":"Regular task"}]}`))
 	})
 
 	result, err := svc.Get(context.Background())
@@ -45,6 +47,19 @@ func TestMyAssignmentsService_Get(t *testing.T) {
 	}
 	if result.Priorities[0].Content != "Priority task" {
 		t.Errorf("expected 'Priority task', got %q", result.Priorities[0].Content)
+	}
+	if len(result.Priorities[0].Assignees) != 1 {
+		t.Fatalf("expected 1 assignee, got %d", len(result.Priorities[0].Assignees))
+	}
+	assignee := result.Priorities[0].Assignees[0]
+	if assignee.ID != 1049715914 {
+		t.Errorf("expected assignee id 1049715914, got %d", assignee.ID)
+	}
+	if assignee.Name != "Victor Cooper" {
+		t.Errorf("expected assignee name to flow through, got %q", assignee.Name)
+	}
+	if assignee.AvatarURL != "https://example.com/avatar" {
+		t.Errorf("expected assignee avatar_url to flow through, got %q", assignee.AvatarURL)
 	}
 }
 

--- a/go/pkg/basecamp/people_test.go
+++ b/go/pkg/basecamp/people_test.go
@@ -476,7 +476,10 @@ func TestOutOfOffice_Unmarshal(t *testing.T) {
 }
 
 func TestOutOfOffice_UnmarshalDisabled(t *testing.T) {
-	data := []byte(`{"person":{"id":1049715913,"name":"Victor Cooper"},"enabled":false,"ongoing":false}`)
+	// person_minimal always renders all three keys — id, name, avatar_url —
+	// even when out of office is disabled (#659). A stub without avatar_url
+	// is a payload the API cannot produce.
+	data := []byte(`{"person":{"id":1049715913,"name":"Victor Cooper","avatar_url":"https://example.com/avatar"},"enabled":false,"ongoing":false}`)
 
 	var ooo OutOfOffice
 	if err := json.Unmarshal(data, &ooo); err != nil {
@@ -485,6 +488,9 @@ func TestOutOfOffice_UnmarshalDisabled(t *testing.T) {
 
 	if ooo.Enabled {
 		t.Error("expected enabled to be false")
+	}
+	if ooo.Person.AvatarURL != "https://example.com/avatar" {
+		t.Errorf("expected avatar_url to flow through to the wrapper, got %q", ooo.Person.AvatarURL)
 	}
 	if ooo.Ongoing {
 		t.Error("expected ongoing to be false")

--- a/go/pkg/basecamp/search.go
+++ b/go/pkg/basecamp/search.go
@@ -10,6 +10,14 @@ import (
 )
 
 // SearchResult represents a single search result from the Basecamp API.
+//
+// It is a polymorphic projection: most result types render the common
+// recording envelope plus their own partial, but BC3 special-cases four
+// branches — chat lines, kanban (card table) lists, file attachments and
+// gauge needles — each contributing branch-specific fields below. A
+// file-attachment hit omits the top-level ID/Title/Type/URL/AppURL envelope
+// keys entirely (they stay zero-valued) and carries the file fields
+// (Filename through AppDownloadURL) instead.
 type SearchResult struct {
 	ID               int64  `json:"id"`
 	Status           string `json:"status"`
@@ -66,7 +74,120 @@ type SearchResult struct {
 	// the list. See Recording for the same contract and RichTextAttachment.
 	ContentAttachments     *[]RichTextAttachment `json:"content_attachments,omitempty"`
 	DescriptionAttachments *[]RichTextAttachment `json:"description_attachments,omitempty"`
-	Subject                string                `json:"subject,omitempty"`
+	// Attachments carries the result's file attachments, in either of two wire
+	// shapes — see SearchResultAttachment. For a result whose recordable has
+	// downloadable rich-text attachments it repeats the companion array above;
+	// for a chat upload line it is the bespoke six-key aggregate the line
+	// builds inline.
+	Attachments []SearchResultAttachment `json:"attachments,omitempty"`
+	Subject     string                   `json:"subject,omitempty"`
+
+	// SubscriptionURL is emitted by the recording envelope for any
+	// subscribable result — kanban lists and gauge needles among the special
+	// branches, plus subscribable generic types (messages, todos, …).
+	SubscriptionURL string `json:"subscription_url,omitempty"`
+	// Position is shared by two emitters: the envelope's list position for
+	// positioned recordings (kanban lists among the special branches), and the
+	// gauge-needle branch's own 0–100 gauge position.
+	Position int `json:"position,omitempty"`
+	// CommentsCount/CommentsURL ride the envelope's commentable flag — gauge
+	// needles among the special branches, plus commentable generic types.
+	CommentsCount int    `json:"comments_count,omitempty"`
+	CommentsURL   string `json:"comments_url,omitempty"`
+	// BoostsCount/BoostsURL ride the envelope's boostable flag — chat lines
+	// and gauge needles.
+	BoostsCount int    `json:"boosts_count,omitempty"`
+	BoostsURL   string `json:"boosts_url,omitempty"`
+
+	// Language is the language of a code chat line.
+	Language string `json:"language,omitempty"`
+	// ImageURL is set on a play-kind chat line whose sound carries an image.
+	ImageURL string `json:"image_url,omitempty"`
+	// SoundURL is always set on a play-kind chat line.
+	SoundURL string `json:"sound_url,omitempty"`
+
+	// Subscribers lists everyone subscribed to a kanban list, as full Person
+	// projections.
+	Subscribers []Person `json:"subscribers,omitempty"`
+	// Color of a kanban list or gauge needle; both branches emit the key
+	// unconditionally with a null value when unset, which collapses to "".
+	Color        string            `json:"color,omitempty"`
+	CardsCount   int               `json:"cards_count,omitempty"`
+	CommentCount int               `json:"comment_count,omitempty"`
+	CardsURL     string            `json:"cards_url,omitempty"`
+	OnHold       *CardColumnOnHold `json:"on_hold,omitempty"`
+
+	// Filename through AppDownloadURL are the file-attachment branch's keys —
+	// the one branch that omits the ID/Title/Type/URL/AppURL envelope keys.
+	Filename    string `json:"filename,omitempty"`
+	ContentType string `json:"content_type,omitempty"`
+	ByteSize    int64  `json:"byte_size,omitempty"`
+	Previewable bool   `json:"previewable,omitempty"`
+	// Width and Height are emitted only for previewable files, may be
+	// float-spelled (1024.0) on the wire, and are nullable — hence *int32,
+	// like RichTextAttachment's dimensions.
+	Width          *int32 `json:"width,omitempty"`
+	Height         *int32 `json:"height,omitempty"`
+	PreviewURL     string `json:"preview_url,omitempty"`
+	ThumbnailURL   string `json:"thumbnail_url,omitempty"`
+	DownloadURL    string `json:"download_url,omitempty"`
+	AppDownloadURL string `json:"app_download_url,omitempty"`
+}
+
+// SearchResultAttachment is a file attached to a search result, in either of
+// two wire shapes: the rich-text attachment/blob shape (the same emitters
+// behind RichTextAttachment) re-emitted under the result's generic
+// `attachments` key, or the bespoke six-key aggregate a chat upload line
+// builds inline. Only the four fields both variants always emit are
+// guaranteed; the rest identify their variant and stay zero-valued on the
+// other.
+type SearchResultAttachment struct {
+	Filename    string `json:"filename"`
+	ContentType string `json:"content_type"`
+	ByteSize    int64  `json:"byte_size"`
+	DownloadURL string `json:"download_url"`
+
+	// Rich-text attachment/blob variant.
+	ID           int64  `json:"id,omitempty"`
+	SGID         string `json:"sgid,omitempty"`
+	Previewable  bool   `json:"previewable,omitempty"`
+	PreviewURL   string `json:"preview_url,omitempty"`
+	ThumbnailURL string `json:"thumbnail_url,omitempty"`
+	// Width and Height may be float-spelled (1024.0) on the wire and are null
+	// for non-image blobs — hence *int32, like RichTextAttachment's.
+	Width  *int32 `json:"width,omitempty"`
+	Height *int32 `json:"height,omitempty"`
+
+	// Chat upload-line variant.
+	Title string `json:"title,omitempty"`
+	URL   string `json:"url,omitempty"`
+}
+
+// UnmarshalJSON decodes a SearchResult from JSON, handling the BC3 API's
+// float-encoded integer dimensions (e.g. "width": 1920.0) on a
+// file-attachment hit. Delegates through the generated type (which uses
+// FlexInt) so the public struct can keep *int32 dimensions while remaining
+// directly decodable from the API wire format. Mirrors Upload.UnmarshalJSON.
+func (sr *SearchResult) UnmarshalJSON(data []byte) error {
+	var gsr generated.SearchResult
+	if err := json.Unmarshal(data, &gsr); err != nil {
+		return err
+	}
+	*sr = searchResultFromGenerated(gsr)
+	return nil
+}
+
+// UnmarshalJSON decodes a SearchResultAttachment from JSON — the rich-text
+// variant's dimensions arrive float-spelled (1024.0), exactly like
+// RichTextAttachment's. Delegates through the generated type (FlexInt), so
+// the elements of a directly-decoded SearchResult.Attachments handle them.
+func (a *SearchResultAttachment) UnmarshalJSON(data []byte) error {
+	var ga generated.SearchResultAttachment
+	if err := json.Unmarshal(data, &ga); err != nil {
+		return err
+	}
+	*a = searchResultAttachmentFromGenerated(ga)
+	return nil
 }
 
 // SearchMetadata represents the available search filter options returned by
@@ -356,11 +477,11 @@ func searchResultFromGenerated(gsr generated.SearchResult) SearchResult {
 		VisibleToClients:     deref(gsr.VisibleToClients),
 		CreatedAt:            gsr.CreatedAt,
 		UpdatedAt:            gsr.UpdatedAt,
-		Title:                gsr.Title,
+		Title:                deref(gsr.Title),
 		InheritsStatus:       deref(gsr.InheritsStatus),
-		Type:                 gsr.Type,
-		URL:                  gsr.Url,
-		AppURL:               gsr.AppUrl,
+		Type:                 deref(gsr.Type),
+		URL:                  deref(gsr.Url),
+		AppURL:               deref(gsr.AppUrl),
 		BookmarkURL:          deref(gsr.BookmarkUrl),
 		BubbleUpURL:          deref(gsr.BubbleUpUrl),
 		Content:              gsr.Content,
@@ -368,10 +489,70 @@ func searchResultFromGenerated(gsr generated.SearchResult) SearchResult {
 		PlainTextContent:     deref(gsr.PlainTextContent),
 		PlainTextDescription: deref(gsr.PlainTextDescription),
 		Subject:              deref(gsr.Subject),
+		SubscriptionURL:      deref(gsr.SubscriptionUrl),
+		Position:             int(deref(gsr.Position)),
+		CommentsCount:        int(deref(gsr.CommentsCount)),
+		CommentsURL:          deref(gsr.CommentsUrl),
+		BoostsCount:          int(deref(gsr.BoostsCount)),
+		BoostsURL:            deref(gsr.BoostsUrl),
+		Language:             deref(gsr.Language),
+		ImageURL:             deref(gsr.ImageUrl),
+		SoundURL:             deref(gsr.SoundUrl),
+		Color:                deref(gsr.Color),
+		CardsCount:           int(deref(gsr.CardsCount)),
+		CommentCount:         int(deref(gsr.CommentCount)),
+		CardsURL:             deref(gsr.CardsUrl),
+		Filename:             deref(gsr.Filename),
+		ContentType:          deref(gsr.ContentType),
+		ByteSize:             deref(gsr.ByteSize),
+		Previewable:          deref(gsr.Previewable),
+		PreviewURL:           deref(gsr.PreviewUrl),
+		ThumbnailURL:         deref(gsr.ThumbnailUrl),
+		DownloadURL:          deref(gsr.DownloadUrl),
+		AppDownloadURL:       deref(gsr.AppDownloadUrl),
 	}
 
-	if gsr.Id != 0 {
-		sr.ID = gsr.Id
+	if gsr.Id != nil {
+		sr.ID = *gsr.Id
+	}
+
+	// Width/Height arrive as optional/nullable *types.FlexInt (the wire may
+	// float-spell them); narrow a present value to the public *int32 and leave
+	// absent-or-null nil, exactly like richTextAttachmentFromGenerated.
+	if gsr.Width != nil {
+		w := int32(*gsr.Width)
+		sr.Width = &w
+	}
+	if gsr.Height != nil {
+		h := int32(*gsr.Height)
+		sr.Height = &h
+	}
+
+	if gsr.OnHold != nil {
+		sr.OnHold = &CardColumnOnHold{
+			ID:             gsr.OnHold.Id,
+			Status:         gsr.OnHold.Status,
+			InheritsStatus: gsr.OnHold.InheritsStatus,
+			Title:          gsr.OnHold.Title,
+			CreatedAt:      gsr.OnHold.CreatedAt,
+			UpdatedAt:      gsr.OnHold.UpdatedAt,
+			CardsCount:     int(gsr.OnHold.CardsCount),
+			CardsURL:       gsr.OnHold.CardsUrl,
+		}
+	}
+
+	if len(gsr.Subscribers) > 0 {
+		sr.Subscribers = make([]Person, 0, len(gsr.Subscribers))
+		for _, gs := range gsr.Subscribers {
+			sr.Subscribers = append(sr.Subscribers, personFromGenerated(gs))
+		}
+	}
+
+	if len(gsr.Attachments) > 0 {
+		sr.Attachments = make([]SearchResultAttachment, 0, len(gsr.Attachments))
+		for _, ga := range gsr.Attachments {
+			sr.Attachments = append(sr.Attachments, searchResultAttachmentFromGenerated(ga))
+		}
 	}
 
 	// Convert nested types
@@ -402,4 +583,34 @@ func searchResultFromGenerated(gsr generated.SearchResult) SearchResult {
 	sr.DescriptionAttachments = richTextAttachmentsPtrFromGenerated(gsr.DescriptionAttachments)
 
 	return sr
+}
+
+// searchResultAttachmentFromGenerated converts a generated
+// SearchResultAttachment to our clean type. The four both-variant fields are
+// @required in the schema and copied directly; the rest deref to their zero
+// values when the other variant omits them. Width and Height narrow a present
+// *types.FlexInt to *int32, like richTextAttachmentFromGenerated.
+func searchResultAttachmentFromGenerated(ga generated.SearchResultAttachment) SearchResultAttachment {
+	a := SearchResultAttachment{
+		Filename:     ga.Filename,
+		ContentType:  ga.ContentType,
+		ByteSize:     ga.ByteSize,
+		DownloadURL:  ga.DownloadUrl,
+		ID:           deref(ga.Id),
+		SGID:         deref(ga.Sgid),
+		Previewable:  deref(ga.Previewable),
+		PreviewURL:   deref(ga.PreviewUrl),
+		ThumbnailURL: deref(ga.ThumbnailUrl),
+		Title:        deref(ga.Title),
+		URL:          deref(ga.Url),
+	}
+	if ga.Width != nil {
+		w := int32(*ga.Width)
+		a.Width = &w
+	}
+	if ga.Height != nil {
+		h := int32(*ga.Height)
+		a.Height = &h
+	}
+	return a
 }

--- a/go/pkg/basecamp/search.go
+++ b/go/pkg/basecamp/search.go
@@ -19,7 +19,12 @@ import (
 // keys entirely (they stay zero-valued) and carries the file fields
 // (Filename through AppDownloadURL) instead.
 type SearchResult struct {
-	ID               int64  `json:"id"`
+	// ID, Title, Type, URL and AppURL stay value-typed for compatibility, but
+	// carry omitempty: a file-attachment hit never receives them, and the
+	// absence of these keys is the branch discriminator, so a re-marshal must
+	// not fabricate `"id":0` and empty strings — the same absence-round-trips-
+	// as-absence discipline as CreatedAt/UpdatedAt/BubbleUpURL below.
+	ID               int64  `json:"id,omitempty"`
 	Status           string `json:"status"`
 	VisibleToClients bool   `json:"visible_to_clients"`
 	// CreatedAt and UpdatedAt are optional on this polymorphic projection —
@@ -31,11 +36,11 @@ type SearchResult struct {
 	// value-typed field would always emit).
 	CreatedAt      *time.Time `json:"created_at,omitempty"`
 	UpdatedAt      *time.Time `json:"updated_at,omitempty"`
-	Title          string     `json:"title"`
+	Title          string     `json:"title,omitempty"`
 	InheritsStatus bool       `json:"inherits_status"`
-	Type           string     `json:"type"`
-	URL            string     `json:"url"`
-	AppURL         string     `json:"app_url"`
+	Type           string     `json:"type,omitempty"`
+	URL            string     `json:"url,omitempty"`
+	AppURL         string     `json:"app_url,omitempty"`
 	BookmarkURL    string     `json:"bookmark_url"`
 	// BubbleUpURL is the URL of the Bubble Up record for this recording. Optional
 	// on this polymorphic projection: recordings/_recording.json.jbuilder emits

--- a/go/pkg/basecamp/search_test.go
+++ b/go/pkg/basecamp/search_test.go
@@ -302,6 +302,62 @@ func TestSearchResult_UnmarshalResults(t *testing.T) {
 	}
 }
 
+// TestSearchResult_AttachmentHitRoundTrip pins the branch discriminator
+// through a re-marshal: a file-attachment hit is recognizable by the ABSENCE
+// of the five envelope keys (id, title, type, url, app_url), so decoding one
+// and re-encoding it must not fabricate `"id":0` and empty strings for keys
+// the wire never carried. The five are value-typed for compatibility; their
+// omitempty tags are what this test guards.
+func TestSearchResult_AttachmentHitRoundTrip(t *testing.T) {
+	data := loadSearchFixture(t, "results.json")
+
+	var results []SearchResult
+	if err := json.Unmarshal(data, &results); err != nil {
+		t.Fatalf("failed to unmarshal results.json: %v", err)
+	}
+
+	out, err := json.Marshal(results[4]) // the file-attachment hit
+	if err != nil {
+		t.Fatalf("failed to re-marshal attachment hit: %v", err)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal(out, &obj); err != nil {
+		t.Fatalf("failed to parse re-marshaled attachment hit: %v", err)
+	}
+
+	for _, key := range []string{"id", "title", "type", "url", "app_url"} {
+		if _, ok := obj[key]; ok {
+			t.Errorf("re-marshaled attachment hit fabricates %q — absence of this key is the branch discriminator", key)
+		}
+	}
+	// The keys the wire did carry survive the round trip.
+	if obj["filename"] != "leto-hero.jpg" {
+		t.Errorf("expected filename to round-trip, got %v", obj["filename"])
+	}
+	// content/description stay present-and-null (required, no omitempty).
+	for _, key := range []string{"content", "description"} {
+		if v, ok := obj[key]; !ok || v != nil {
+			t.Errorf("expected %s to round-trip as present-and-null, got %v (present=%v)", key, v, ok)
+		}
+	}
+
+	// A generic hit keeps all five on re-marshal — omitempty must not eat
+	// real values.
+	out0, err := json.Marshal(results[0])
+	if err != nil {
+		t.Fatalf("failed to re-marshal message hit: %v", err)
+	}
+	var obj0 map[string]any
+	if err := json.Unmarshal(out0, &obj0); err != nil {
+		t.Fatalf("failed to parse re-marshaled message hit: %v", err)
+	}
+	for _, key := range []string{"id", "title", "type", "url", "app_url"} {
+		if _, ok := obj0[key]; !ok {
+			t.Errorf("re-marshaled message hit lost %q", key)
+		}
+	}
+}
+
 func TestSearchMetadata_Unmarshal(t *testing.T) {
 	data := loadSearchFixture(t, "metadata.json")
 

--- a/go/pkg/basecamp/search_test.go
+++ b/go/pkg/basecamp/search_test.go
@@ -36,8 +36,8 @@ func TestSearchResult_UnmarshalResults(t *testing.T) {
 		t.Fatalf("failed to unmarshal results.json: %v", err)
 	}
 
-	if len(results) != 4 {
-		t.Errorf("expected 4 results, got %d", len(results))
+	if len(results) != 8 {
+		t.Errorf("expected 8 results, got %d", len(results))
 	}
 
 	// bubble_up_url rides the polymorphic search projection: Todolists are
@@ -184,6 +184,108 @@ func TestSearchResult_UnmarshalResults(t *testing.T) {
 	}
 	if !strings.Contains(r3.PlainTextContent, `<mark class="circled-text">`) {
 		t.Errorf("expected a highlighted excerpt in PlainTextContent, got %q", r3.PlainTextContent)
+	}
+
+	// Verify the four special-branch hits (issue #651).
+
+	// /4 — file-attachment branch: no envelope id/title/type/url/app_url (they
+	// stay zero-valued), file keys instead. Width is float-spelled (1920.0) on
+	// the wire and must narrow to 1920.
+	r5 := results[4]
+	if r5.ID != 0 || r5.Title != "" || r5.Type != "" || r5.URL != "" || r5.AppURL != "" {
+		t.Errorf("attachment hit: expected zero-valued envelope keys, got id=%d title=%q type=%q url=%q app_url=%q",
+			r5.ID, r5.Title, r5.Type, r5.URL, r5.AppURL)
+	}
+	if r5.Filename != "leto-hero.jpg" || r5.ContentType != "image/jpeg" || r5.ByteSize != 512000 {
+		t.Errorf("attachment hit: unexpected file keys: %q %q %d", r5.Filename, r5.ContentType, r5.ByteSize)
+	}
+	if !r5.Previewable {
+		t.Error("attachment hit: expected Previewable true")
+	}
+	if r5.Width == nil || *r5.Width != 1920 {
+		t.Errorf("attachment hit: expected Width 1920 (float-spelled on the wire), got %v", r5.Width)
+	}
+	if r5.Height == nil || *r5.Height != 1080 {
+		t.Errorf("attachment hit: expected Height 1080, got %v", r5.Height)
+	}
+	if r5.DownloadURL == "" || r5.AppDownloadURL == "" || r5.PreviewURL == "" || r5.ThumbnailURL == "" {
+		t.Error("attachment hit: expected all four URLs to be set")
+	}
+	if r5.Content != nil || r5.Description != nil {
+		t.Error("attachment hit: content/description must still be present-and-null")
+	}
+	if r5.Parent == nil || r5.Parent.Type != "Message" {
+		t.Errorf("attachment hit: expected Message parent, got %+v", r5.Parent)
+	}
+
+	// /5 — chat upload line: bespoke six-key attachments aggregate that does
+	// NOT match RichTextAttachment (no id/sgid/previewable), plus boostable
+	// envelope keys.
+	r6 := results[5]
+	if r6.Type != "Chat::Lines::Upload" {
+		t.Errorf("upload-line hit: expected type Chat::Lines::Upload, got %q", r6.Type)
+	}
+	if r6.BoostsCount != 1 || r6.BoostsURL == "" {
+		t.Errorf("upload-line hit: expected boosts envelope keys, got %d %q", r6.BoostsCount, r6.BoostsURL)
+	}
+	if len(r6.Attachments) != 1 {
+		t.Fatalf("upload-line hit: expected 1 attachment, got %d", len(r6.Attachments))
+	}
+	ua := r6.Attachments[0]
+	if ua.Title != "leto-benchmarks.pdf" || ua.URL == "" {
+		t.Errorf("upload-line attachment: expected bespoke title/url keys, got %q %q", ua.Title, ua.URL)
+	}
+	if ua.Filename != "leto-benchmarks.pdf" || ua.ContentType != "application/pdf" || ua.ByteSize != 1048576 || ua.DownloadURL == "" {
+		t.Errorf("upload-line attachment: unexpected common keys: %+v", ua)
+	}
+	if ua.ID != 0 || ua.SGID != "" || ua.Previewable || ua.Width != nil {
+		t.Errorf("upload-line attachment: rich-text-variant keys must stay zero-valued, got %+v", ua)
+	}
+
+	// /6 — kanban list: list-partial keys over the envelope; color emitted
+	// null (collapses to ""), on_hold present.
+	r7 := results[6]
+	if r7.Type != "Kanban::Column" {
+		t.Errorf("kanban hit: expected type Kanban::Column, got %q", r7.Type)
+	}
+	if r7.SubscriptionURL == "" || r7.Position != 2 {
+		t.Errorf("kanban hit: expected envelope subscription_url/position, got %q %d", r7.SubscriptionURL, r7.Position)
+	}
+	if r7.Color != "" {
+		t.Errorf("kanban hit: expected null color to collapse to \"\", got %q", r7.Color)
+	}
+	if r7.CardsCount != 4 || r7.CommentCount != 1 || r7.CardsURL == "" {
+		t.Errorf("kanban hit: unexpected list keys: %d %d %q", r7.CardsCount, r7.CommentCount, r7.CardsURL)
+	}
+	if len(r7.Subscribers) != 1 || r7.Subscribers[0].Name != "Victor Cooper" {
+		t.Errorf("kanban hit: expected 1 subscriber, got %+v", r7.Subscribers)
+	}
+	if r7.OnHold == nil || r7.OnHold.CardsCount != 0 || r7.OnHold.CardsURL == "" {
+		t.Errorf("kanban hit: expected populated on_hold, got %+v", r7.OnHold)
+	}
+
+	// /7 — gauge needle: commentable+boostable envelope, needle keys, and the
+	// rich-text description companion array surviving the nil-overwrite.
+	r8 := results[7]
+	if r8.Type != "Gauge::Needle" {
+		t.Errorf("needle hit: expected type Gauge::Needle, got %q", r8.Type)
+	}
+	if r8.CommentsCount != 2 || r8.BoostsCount != 3 || r8.CommentCount != 2 {
+		t.Errorf("needle hit: unexpected counts: %d %d %d", r8.CommentsCount, r8.BoostsCount, r8.CommentCount)
+	}
+	if r8.Color != "green" || r8.Position != 72 {
+		t.Errorf("needle hit: expected color green / position 72, got %q %d", r8.Color, r8.Position)
+	}
+	if r8.Description != nil {
+		t.Error("needle hit: description must be nil-overwritten")
+	}
+	if r8.DescriptionAttachments == nil || len(*r8.DescriptionAttachments) != 1 {
+		t.Error("needle hit: expected the description companion array to survive")
+	}
+	// The generic attachments key repeats the companion array through the
+	// same partial, so the rich-text-variant fields are populated.
+	if len(r8.Attachments) != 1 || r8.Attachments[0].ID == 0 || r8.Attachments[0].SGID == "" {
+		t.Errorf("needle hit: expected rich-text-variant attachments element, got %+v", r8.Attachments)
 	}
 
 	// Verify timestamps are parsed. Both are optional (*time.Time), so
@@ -534,8 +636,8 @@ func TestSearchService_Search_BestMatchSort(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(result.Results) != 4 {
-		t.Errorf("expected 4 results, got %d", len(result.Results))
+	if len(result.Results) != 8 {
+		t.Errorf("expected 8 results, got %d", len(result.Results))
 	}
 
 	// End-to-end projection proof: the polymorphic search projection carries a

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -2883,10 +2883,44 @@ type SearchMetadata struct {
 // SearchResponseContent defines model for SearchResponseContent.
 type SearchResponseContent = []SearchResult
 
-// SearchResult defines model for SearchResult.
+// SearchResult One hit from account-wide search — a polymorphic projection over every
+// searchable recording type.
+//
+// Most result types render the common recording envelope
+// (`recordings/_recording.json.jbuilder`) plus their own recordable partial,
+// but `api_search_result_template_path` special-cases four branches — chat
+// lines, kanban (card table) lists, file attachments and gauge needles — and
+// the file-attachment branch writes its own projection from scratch instead
+// of the envelope. Members are therefore optional unless every branch emits
+// them; the doc comments name the branches that carry each optional member.
 type SearchResult struct {
-	AppUrl      string  `json:"app_url"`
-	BookmarkUrl *string `json:"bookmark_url,omitempty"`
+	// AppDownloadUrl Web (app-host) download URL of a file-attachment hit.
+	AppDownloadUrl *string `json:"app_download_url,omitempty"`
+
+	// AppUrl See `id` — omitted by the file-attachment branch, emitted by every other
+	// branch.
+	AppUrl *string `json:"app_url,omitempty"`
+
+	// Attachments File attachments on the result, in either of two wire shapes — see
+	// `SearchResultAttachment`.
+	//
+	// For a result whose recordable carries downloadable rich-text
+	// attachments, `searches/show.json.jbuilder` emits this key through the
+	// same `attachments/_attachment` partial that builds the rich-text
+	// companion array above, so it repeats that array's elements. For a chat
+	// *upload* line, `chats/lines/_upload.json.jbuilder` instead builds a
+	// bespoke six-key aggregate inline — and because upload lines have no
+	// rich-text attribute, the show template never overwrites it, so that
+	// distinct shape survives to the wire.
+	Attachments []SearchResultAttachment `json:"attachments,omitempty"`
+	BookmarkUrl *string                  `json:"bookmark_url,omitempty"`
+
+	// BoostsCount Boost count, emitted by the recording envelope when the branch passes
+	// `boostable` — chat lines and gauge needles.
+	BoostsCount *int32 `json:"boosts_count,omitempty"`
+
+	// BoostsUrl See `boosts_count` — the companion URL.
+	BoostsUrl *string `json:"boosts_url,omitempty"`
 
 	// BubbleUpUrl URL of the Bubble Up record for this recording (BC5 addition). Optional
 	// here because this is a polymorphic projection:
@@ -2896,6 +2930,33 @@ type SearchResult struct {
 	// other recording types do not.
 	BubbleUpUrl *string          `json:"bubble_up_url,omitempty"`
 	Bucket      *RecordingBucket `json:"bucket,omitempty"`
+
+	// ByteSize Size in bytes of a file-attachment hit.
+	ByteSize *int64 `json:"byte_size,omitempty"`
+
+	// CardsCount Number of cards in the kanban list.
+	CardsCount *int32 `json:"cards_count,omitempty"`
+
+	// CardsUrl API URL of the kanban list's cards.
+	CardsUrl *string `json:"cards_url,omitempty"`
+
+	// Color Color of a kanban list or gauge needle. Emitted unconditionally by both
+	// branches with a null value when unset, so it is nullable (the enhance
+	// pass layers `nullable: true` onto the OpenAPI).
+	Color *string `json:"color,omitempty"`
+
+	// CommentCount Comment count of a kanban list or gauge needle (branch-partial key,
+	// singular `comment_count` — distinct from the envelope's
+	// `comments_count`, which a needle also carries).
+	CommentCount *int32 `json:"comment_count,omitempty"`
+
+	// CommentsCount Comment count, emitted by the recording envelope when the branch passes
+	// `commentable` — gauge needles among the special branches, plus
+	// commentable generic-branch types.
+	CommentsCount *int32 `json:"comments_count,omitempty"`
+
+	// CommentsUrl See `comments_count` — the companion URL.
+	CommentsUrl *string `json:"comments_url,omitempty"`
 
 	// Content Always present, always null. `api/searches/show.json.jbuilder` renders the
 	// recording's own partial and then unconditionally overwrites `content` with
@@ -2909,20 +2970,12 @@ type SearchResult struct {
 	// the array matching its rich-text attribute (`content_attachments` for a
 	// Comment/Message, `description_attachments` for a Todo); a webhook-sourced
 	// result carries neither. Optional (no `@required`), non-nullable.
-	//
-	// Search results additionally repeat this same array under a generic
-	// `attachments` key. It is a redundant projection, not a distinct
-	// aggregate: `searches/show.json.jbuilder` emits
-	// `recording.downloadable_attachments`, which delegates to the recordable's
-	// sole `rich_text_content`, through the same `attachments/_attachment`
-	// partial that `recordings/_rich_text.json.jbuilder` uses to build the
-	// companion array. `RichText.rich_text_attribute` permits exactly one
-	// rich-text attribute per model, so the two keys always carry identical
-	// elements. Modeling `attachments` would duplicate the field, so it is
-	// deliberately not modeled.
 	ContentAttachments []RichTextAttachment `json:"content_attachments,omitempty"`
-	CreatedAt          *time.Time           `json:"created_at,omitempty"`
-	Creator            *Person              `json:"creator,omitempty"`
+
+	// ContentType MIME type of a file-attachment hit.
+	ContentType *string    `json:"content_type,omitempty"`
+	CreatedAt   *time.Time `json:"created_at,omitempty"`
+	Creator     *Person    `json:"creator,omitempty"`
 
 	// Description Always present, always null — the description-attribute counterpart to
 	// `content`. Read `plain_text_description` instead.
@@ -2930,9 +2983,35 @@ type SearchResult struct {
 
 	// DescriptionAttachments See `content_attachments` — the description-attribute companion array.
 	DescriptionAttachments []RichTextAttachment `json:"description_attachments,omitempty"`
-	Id                     int64                `json:"id"`
-	InheritsStatus         *bool                `json:"inherits_status,omitempty"`
-	Parent                 *RecordingParent     `json:"parent,omitempty"`
+
+	// DownloadUrl Authenticated download URL of a file-attachment hit.
+	DownloadUrl *string `json:"download_url,omitempty"`
+
+	// Filename Filename of a file-attachment hit. This and the following file keys are
+	// emitted only by the file-attachment branch — the one branch that omits
+	// the id/title/type/url/app_url envelope keys.
+	Filename *string `json:"filename,omitempty"`
+
+	// Height See `width` — same conditional emission and nullable/float-spelled
+	// behavior.
+	Height *types.FlexInt `json:"height,omitempty"`
+
+	// Id The recording id. Optional only because the file-attachment branch
+	// (`searches/_attachment.json.jbuilder`) skips the recording envelope and
+	// emits none of the top-level id/title/type/url/app_url keys; every other
+	// branch emits all five.
+	Id *int64 `json:"id,omitempty"`
+
+	// ImageUrl Image URL of a soundtracked (play-kind) chat line whose sound carries an
+	// image; such a line emits `image_url` in place of `content`.
+	ImageUrl       *string `json:"image_url,omitempty"`
+	InheritsStatus *bool   `json:"inherits_status,omitempty"`
+
+	// Language Language of a code chat line (`chats/lines/_code.json.jbuilder`);
+	// validated present on the model, so never null when the key is emitted.
+	Language *string           `json:"language,omitempty"`
+	OnHold   *CardColumnOnHold `json:"on_hold,omitempty"`
+	Parent   *RecordingParent  `json:"parent,omitempty"`
 
 	// PlainTextContent A highlighted, truncated excerpt of the recording's content — **not** plain
 	// text despite the name. `excerpt_and_highlight_matches` converts the rich
@@ -2948,14 +3027,107 @@ type SearchResult struct {
 	// PlainTextDescription The description-attribute counterpart to `plain_text_content`, with the
 	// same highlighting, escaping, and 300-character truncation. Optional and
 	// non-nullable — omitted when the recordable has no description attribute.
-	PlainTextDescription *string    `json:"plain_text_description,omitempty"`
-	Status               *string    `json:"status,omitempty"`
-	Subject              *string    `json:"subject,omitempty"`
-	Title                string     `json:"title"`
-	Type                 string     `json:"type"`
-	UpdatedAt            *time.Time `json:"updated_at,omitempty"`
-	Url                  string     `json:"url"`
-	VisibleToClients     *bool      `json:"visible_to_clients,omitempty"`
+	PlainTextDescription *string `json:"plain_text_description,omitempty"`
+
+	// Position Position of the result. Two emitters share the key: the recording
+	// envelope emits list position for positioned recordings (kanban lists
+	// among the special branches), and the gauge-needle branch overwrites it
+	// with the needle's own 0–100 gauge position.
+	Position *int32 `json:"position,omitempty"`
+
+	// PreviewUrl Full-size preview URL of a file-attachment hit.
+	PreviewUrl *string `json:"preview_url,omitempty"`
+
+	// Previewable Whether the file can be previewed.
+	Previewable *bool `json:"previewable,omitempty"`
+
+	// SoundUrl Sound URL of a play-kind chat line; always emitted for that kind.
+	SoundUrl *string `json:"sound_url,omitempty"`
+	Status   *string `json:"status,omitempty"`
+	Subject  *string `json:"subject,omitempty"`
+
+	// Subscribers Everyone subscribed to the kanban list, as full Person projections.
+	Subscribers []Person `json:"subscribers,omitempty"`
+
+	// SubscriptionUrl Subscription URL, emitted by the common recording envelope for any
+	// subscribable result — kanban lists and gauge needles among the special
+	// branches, plus subscribable generic-branch types (messages, todos, …).
+	SubscriptionUrl *string `json:"subscription_url,omitempty"`
+
+	// ThumbnailUrl Thumbnail URL of a file-attachment hit.
+	ThumbnailUrl *string `json:"thumbnail_url,omitempty"`
+
+	// Title See `id` — omitted by the file-attachment branch, emitted by every other
+	// branch.
+	Title *string `json:"title,omitempty"`
+
+	// Type See `id` — omitted by the file-attachment branch, emitted by every other
+	// branch. A file-attachment hit is therefore recognizable by the absence
+	// of this key (its file keys, `filename` through `app_download_url`, are
+	// the positive signal).
+	Type      *string    `json:"type,omitempty"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+
+	// Url See `id` — omitted by the file-attachment branch, emitted by every other
+	// branch.
+	Url              *string `json:"url,omitempty"`
+	VisibleToClients *bool   `json:"visible_to_clients,omitempty"`
+
+	// Width Pixel width, emitted only when the file is previewable. May be
+	// float-spelled (`1024.0`) and nullable, like every other blob dimension —
+	// see `RichTextAttachment.width` for the cross-SDK typing note.
+	Width *types.FlexInt `json:"width,omitempty"`
+}
+
+// SearchResultAttachment A file attached to a search result, in either of two wire shapes.
+//
+// This is an optional-field superset over the two variants the search
+// projection emits (the TimelineAttachment approach): the rich-text
+// attachment/blob shape rendered through `attachments/_attachment` +
+// `blobs/_blob` — the same emitters `RichTextAttachment` models — and the
+// bespoke six-key aggregate a chat upload line builds inline in
+// `chats/lines/_upload.json.jbuilder`. Only the four keys both variants
+// always emit are `@required`; the rest identify their variant.
+type SearchResultAttachment struct {
+	// ByteSize Size of the file in bytes (both variants).
+	ByteSize int64 `json:"byte_size"`
+
+	// ContentType MIME type of the file (both variants).
+	ContentType string `json:"content_type"`
+
+	// DownloadUrl Authenticated download URL for the file (both variants).
+	DownloadUrl string `json:"download_url"`
+
+	// Filename Original filename (both variants).
+	Filename string `json:"filename"`
+
+	// Height See `width` (rich-text variant).
+	Height *types.FlexInt `json:"height,omitempty"`
+
+	// Id Attachment id (rich-text variant).
+	Id *int64 `json:"id,omitempty"`
+
+	// PreviewUrl Full-size preview URL (rich-text variant).
+	PreviewUrl *string `json:"preview_url,omitempty"`
+
+	// Previewable Whether the blob can be previewed (rich-text variant).
+	Previewable *bool `json:"previewable,omitempty"`
+
+	// Sgid Signed global id of the attachment (rich-text variant).
+	Sgid *string `json:"sgid,omitempty"`
+
+	// ThumbnailUrl Thumbnail URL (rich-text variant).
+	ThumbnailUrl *string `json:"thumbnail_url,omitempty"`
+
+	// Title Title of the attachment recording (chat upload-line variant).
+	Title *string `json:"title,omitempty"`
+
+	// Url Browser preview URL of the blob (chat upload-line variant).
+	Url *string `json:"url,omitempty"`
+
+	// Width Pixel width (rich-text variant) — null for non-image blobs and may be
+	// float-spelled (`1024.0`); see `RichTextAttachment.width`.
+	Width *types.FlexInt `json:"width,omitempty"`
 }
 
 // SearchType A selectable search filter option. `key` is the value passed back as a

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -2114,11 +2114,14 @@ type MyAssignment struct {
 	Type                *string     `json:"type,omitempty"`
 }
 
-// MyAssignmentAssignee defines model for MyAssignmentAssignee.
+// MyAssignmentAssignee A person as bc3's `people/_person_minimal.json.jbuilder` renders them —
+// the same three-key partial behind UpcomingSchedulePerson and
+// OutOfOfficePerson. All three keys are emitted unconditionally, so all
+// three are required.
 type MyAssignmentAssignee struct {
-	AvatarUrl *string `json:"avatar_url,omitempty"`
-	Id        int64   `json:"id"`
-	Name      *string `json:"name,omitempty"`
+	AvatarUrl string `json:"avatar_url"`
+	Id        int64  `json:"id"`
+	Name      string `json:"name"`
 }
 
 // MyAssignmentBucket defines model for MyAssignmentBucket.
@@ -2218,12 +2221,17 @@ type Notification struct {
 type OutOfOffice struct {
 	// BackOnDate First working day after the out-of-office window ends.
 	// Omitted when out of office is not enabled.
-	BackOnDate *string            `json:"back_on_date,omitempty"`
-	Enabled    *bool              `json:"enabled,omitempty"`
-	EndDate    *string            `json:"end_date,omitempty"`
-	Ongoing    *bool              `json:"ongoing,omitempty"`
-	Person     *OutOfOfficePerson `json:"person,omitempty"`
-	StartDate  *string            `json:"start_date,omitempty"`
+	BackOnDate *string `json:"back_on_date,omitempty"`
+	Enabled    *bool   `json:"enabled,omitempty"`
+	EndDate    *string `json:"end_date,omitempty"`
+	Ongoing    *bool   `json:"ongoing,omitempty"`
+
+	// Person A person as bc3's `people/_person_minimal.json.jbuilder` renders them —
+	// the same three-key partial behind UpcomingSchedulePerson and
+	// MyAssignmentAssignee. All three keys are emitted unconditionally, so all
+	// three are required.
+	Person    *OutOfOfficePerson `json:"person,omitempty"`
+	StartDate *string            `json:"start_date,omitempty"`
 }
 
 // OutOfOfficePayload defines model for OutOfOfficePayload.
@@ -2235,11 +2243,14 @@ type OutOfOfficePayload struct {
 	StartDate string `json:"start_date"`
 }
 
-// OutOfOfficePerson defines model for OutOfOfficePerson.
+// OutOfOfficePerson A person as bc3's `people/_person_minimal.json.jbuilder` renders them —
+// the same three-key partial behind UpcomingSchedulePerson and
+// MyAssignmentAssignee. All three keys are emitted unconditionally, so all
+// three are required.
 type OutOfOfficePerson struct {
-	AvatarUrl *string `json:"avatar_url,omitempty"`
-	Id        int64   `json:"id"`
-	Name      *string `json:"name,omitempty"`
+	AvatarUrl string `json:"avatar_url"`
+	Id        int64  `json:"id"`
+	Name      string `json:"name"`
 }
 
 // PauseQuestionResponseContent defines model for PauseQuestionResponseContent.

--- a/openapi.json
+++ b/openapi.json
@@ -33637,9 +33637,11 @@
       },
       "SearchResult": {
         "type": "object",
+        "description": "One hit from account-wide search — a polymorphic projection over every\nsearchable recording type.\n\nMost result types render the common recording envelope\n(`recordings/_recording.json.jbuilder`) plus their own recordable partial,\nbut `api_search_result_template_path` special-cases four branches — chat\nlines, kanban (card table) lists, file attachments and gauge needles — and\nthe file-attachment branch writes its own projection from scratch instead\nof the envelope. Members are therefore optional unless every branch emits\nthem; the doc comments name the branches that carry each optional member.",
         "properties": {
           "id": {
             "type": "integer",
+            "description": "The recording id. Optional only because the file-attachment branch\n(`searches/_attachment.json.jbuilder`) skips the recording envelope and\nemits none of the top-level id/title/type/url/app_url keys; every other\nbranch emits all five.",
             "format": "int64"
           },
           "status": {
@@ -33663,22 +33665,30 @@
             }
           },
           "title": {
-            "type": "string"
+            "type": "string",
+            "description": "See `id` — omitted by the file-attachment branch, emitted by every other\nbranch."
           },
           "inherits_status": {
             "type": "boolean"
           },
           "type": {
-            "type": "string"
+            "type": "string",
+            "description": "See `id` — omitted by the file-attachment branch, emitted by every other\nbranch. A file-attachment hit is therefore recognizable by the absence\nof this key (its file keys, `filename` through `app_download_url`, are\nthe positive signal)."
           },
           "url": {
-            "type": "string"
+            "type": "string",
+            "description": "See `id` — omitted by the file-attachment branch, emitted by every other\nbranch."
           },
           "app_url": {
-            "type": "string"
+            "type": "string",
+            "description": "See `id` — omitted by the file-attachment branch, emitted by every other\nbranch."
           },
           "bookmark_url": {
             "type": "string"
+          },
+          "subscription_url": {
+            "type": "string",
+            "description": "Subscription URL, emitted by the common recording envelope for any\nsubscribable result — kanban lists and gauge needles among the special\nbranches, plus subscribable generic-branch types (messages, todos, …)."
           },
           "bubble_up_url": {
             "type": "string",
@@ -33722,7 +33732,7 @@
             "items": {
               "$ref": "#/components/schemas/RichTextAttachment"
             },
-            "description": "Rich-text companion arrays carried through the polymorphic search\nprojection. A given result is one recording type, so it carries only\nthe array matching its rich-text attribute (`content_attachments` for a\nComment/Message, `description_attachments` for a Todo); a webhook-sourced\nresult carries neither. Optional (no `@required`), non-nullable.\n\nSearch results additionally repeat this same array under a generic\n`attachments` key. It is a redundant projection, not a distinct\naggregate: `searches/show.json.jbuilder` emits\n`recording.downloadable_attachments`, which delegates to the recordable's\nsole `rich_text_content`, through the same `attachments/_attachment`\npartial that `recordings/_rich_text.json.jbuilder` uses to build the\ncompanion array. `RichText.rich_text_attribute` permits exactly one\nrich-text attribute per model, so the two keys always carry identical\nelements. Modeling `attachments` would duplicate the field, so it is\ndeliberately not modeled.",
+            "description": "Rich-text companion arrays carried through the polymorphic search\nprojection. A given result is one recording type, so it carries only\nthe array matching its rich-text attribute (`content_attachments` for a\nComment/Message, `description_attachments` for a Todo); a webhook-sourced\nresult carries neither. Optional (no `@required`), non-nullable.",
             "x-go-type-skip-optional-pointer": true
           },
           "description_attachments": {
@@ -33733,18 +33743,219 @@
             "description": "See `content_attachments` — the description-attribute companion array.",
             "x-go-type-skip-optional-pointer": true
           },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchResultAttachment"
+            },
+            "description": "File attachments on the result, in either of two wire shapes — see\n`SearchResultAttachment`.\n\nFor a result whose recordable carries downloadable rich-text\nattachments, `searches/show.json.jbuilder` emits this key through the\nsame `attachments/_attachment` partial that builds the rich-text\ncompanion array above, so it repeats that array's elements. For a chat\n*upload* line, `chats/lines/_upload.json.jbuilder` instead builds a\nbespoke six-key aggregate inline — and because upload lines have no\nrich-text attribute, the show template never overwrites it, so that\ndistinct shape survives to the wire.",
+            "x-go-type-skip-optional-pointer": true
+          },
           "subject": {
             "type": "string"
+          },
+          "boosts_count": {
+            "type": "integer",
+            "description": "Boost count, emitted by the recording envelope when the branch passes\n`boostable` — chat lines and gauge needles.",
+            "format": "int32"
+          },
+          "boosts_url": {
+            "type": "string",
+            "description": "See `boosts_count` — the companion URL."
+          },
+          "language": {
+            "type": "string",
+            "description": "Language of a code chat line (`chats/lines/_code.json.jbuilder`);\nvalidated present on the model, so never null when the key is emitted."
+          },
+          "image_url": {
+            "type": "string",
+            "description": "Image URL of a soundtracked (play-kind) chat line whose sound carries an\nimage; such a line emits `image_url` in place of `content`."
+          },
+          "sound_url": {
+            "type": "string",
+            "description": "Sound URL of a play-kind chat line; always emitted for that kind."
+          },
+          "subscribers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Person"
+            },
+            "description": "Everyone subscribed to the kanban list, as full Person projections.",
+            "x-go-type-skip-optional-pointer": true
+          },
+          "color": {
+            "type": "string",
+            "description": "Color of a kanban list or gauge needle. Emitted unconditionally by both\nbranches with a null value when unset, so it is nullable (the enhance\npass layers `nullable: true` onto the OpenAPI).",
+            "nullable": true
+          },
+          "cards_count": {
+            "type": "integer",
+            "description": "Number of cards in the kanban list.",
+            "format": "int32"
+          },
+          "comment_count": {
+            "type": "integer",
+            "description": "Comment count of a kanban list or gauge needle (branch-partial key,\nsingular `comment_count` — distinct from the envelope's\n`comments_count`, which a needle also carries).",
+            "format": "int32"
+          },
+          "cards_url": {
+            "type": "string",
+            "description": "API URL of the kanban list's cards."
+          },
+          "on_hold": {
+            "$ref": "#/components/schemas/CardColumnOnHold"
+          },
+          "comments_count": {
+            "type": "integer",
+            "description": "Comment count, emitted by the recording envelope when the branch passes\n`commentable` — gauge needles among the special branches, plus\ncommentable generic-branch types.",
+            "format": "int32"
+          },
+          "comments_url": {
+            "type": "string",
+            "description": "See `comments_count` — the companion URL."
+          },
+          "position": {
+            "type": "integer",
+            "description": "Position of the result. Two emitters share the key: the recording\nenvelope emits list position for positioned recordings (kanban lists\namong the special branches), and the gauge-needle branch overwrites it\nwith the needle's own 0–100 gauge position.",
+            "format": "int32"
+          },
+          "filename": {
+            "type": "string",
+            "description": "Filename of a file-attachment hit. This and the following file keys are\nemitted only by the file-attachment branch — the one branch that omits\nthe id/title/type/url/app_url envelope keys."
+          },
+          "content_type": {
+            "type": "string",
+            "description": "MIME type of a file-attachment hit."
+          },
+          "byte_size": {
+            "type": "integer",
+            "description": "Size in bytes of a file-attachment hit.",
+            "format": "int64"
+          },
+          "previewable": {
+            "type": "boolean",
+            "description": "Whether the file can be previewed."
+          },
+          "width": {
+            "type": "integer",
+            "description": "Pixel width, emitted only when the file is previewable. May be\nfloat-spelled (`1024.0`) and nullable, like every other blob dimension —\nsee `RichTextAttachment.width` for the cross-SDK typing note.",
+            "format": "int32",
+            "nullable": true,
+            "x-go-type": "types.FlexInt",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            }
+          },
+          "height": {
+            "type": "integer",
+            "description": "See `width` — same conditional emission and nullable/float-spelled\nbehavior.",
+            "format": "int32",
+            "nullable": true,
+            "x-go-type": "types.FlexInt",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            }
+          },
+          "preview_url": {
+            "type": "string",
+            "description": "Full-size preview URL of a file-attachment hit."
+          },
+          "thumbnail_url": {
+            "type": "string",
+            "description": "Thumbnail URL of a file-attachment hit."
+          },
+          "download_url": {
+            "type": "string",
+            "description": "Authenticated download URL of a file-attachment hit.",
+            "x-basecamp-auth-routable-url": {}
+          },
+          "app_download_url": {
+            "type": "string",
+            "description": "Web (app-host) download URL of a file-attachment hit."
           }
         },
         "required": [
-          "app_url",
           "content",
-          "description",
-          "id",
-          "title",
-          "type",
-          "url"
+          "description"
+        ]
+      },
+      "SearchResultAttachment": {
+        "type": "object",
+        "description": "A file attached to a search result, in either of two wire shapes.\n\nThis is an optional-field superset over the two variants the search\nprojection emits (the TimelineAttachment approach): the rich-text\nattachment/blob shape rendered through `attachments/_attachment` +\n`blobs/_blob` — the same emitters `RichTextAttachment` models — and the\nbespoke six-key aggregate a chat upload line builds inline in\n`chats/lines/_upload.json.jbuilder`. Only the four keys both variants\nalways emit are `@required`; the rest identify their variant.",
+        "properties": {
+          "filename": {
+            "type": "string",
+            "description": "Original filename (both variants)."
+          },
+          "content_type": {
+            "type": "string",
+            "description": "MIME type of the file (both variants)."
+          },
+          "byte_size": {
+            "type": "integer",
+            "description": "Size of the file in bytes (both variants).",
+            "format": "int64"
+          },
+          "download_url": {
+            "type": "string",
+            "description": "Authenticated download URL for the file (both variants).",
+            "x-basecamp-auth-routable-url": {}
+          },
+          "id": {
+            "type": "integer",
+            "description": "Attachment id (rich-text variant).",
+            "format": "int64"
+          },
+          "sgid": {
+            "type": "string",
+            "description": "Signed global id of the attachment (rich-text variant)."
+          },
+          "previewable": {
+            "type": "boolean",
+            "description": "Whether the blob can be previewed (rich-text variant)."
+          },
+          "preview_url": {
+            "type": "string",
+            "description": "Full-size preview URL (rich-text variant)."
+          },
+          "thumbnail_url": {
+            "type": "string",
+            "description": "Thumbnail URL (rich-text variant)."
+          },
+          "width": {
+            "type": "integer",
+            "description": "Pixel width (rich-text variant) — null for non-image blobs and may be\nfloat-spelled (`1024.0`); see `RichTextAttachment.width`.",
+            "format": "int32",
+            "nullable": true,
+            "x-go-type": "types.FlexInt",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            }
+          },
+          "height": {
+            "type": "integer",
+            "description": "See `width` (rich-text variant).",
+            "format": "int32",
+            "nullable": true,
+            "x-go-type": "types.FlexInt",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            }
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the attachment recording (chat upload-line variant)."
+          },
+          "url": {
+            "type": "string",
+            "description": "Browser preview URL of the blob (chat upload-line variant)."
+          }
+        },
+        "required": [
+          "byte_size",
+          "content_type",
+          "download_url",
+          "filename"
         ]
       },
       "SearchType": {

--- a/openapi.json
+++ b/openapi.json
@@ -31753,6 +31753,7 @@
       },
       "MyAssignmentAssignee": {
         "type": "object",
+        "description": "A person as bc3's `people/_person_minimal.json.jbuilder` renders them —\nthe same three-key partial behind UpcomingSchedulePerson and\nOutOfOfficePerson. All three keys are emitted unconditionally, so all\nthree are required.",
         "properties": {
           "id": {
             "type": "integer",
@@ -31768,7 +31769,9 @@
           }
         },
         "required": [
-          "id"
+          "avatar_url",
+          "id",
+          "name"
         ]
       },
       "MyAssignmentBucket": {
@@ -32061,6 +32064,7 @@
       },
       "OutOfOfficePerson": {
         "type": "object",
+        "description": "A person as bc3's `people/_person_minimal.json.jbuilder` renders them —\nthe same three-key partial behind UpcomingSchedulePerson and\nMyAssignmentAssignee. All three keys are emitted unconditionally, so all\nthree are required.",
         "properties": {
           "id": {
             "type": "integer",
@@ -32076,7 +32080,9 @@
           }
         },
         "required": [
-          "id"
+          "avatar_url",
+          "id",
+          "name"
         ]
       },
       "PauseQuestionResponseContent": {

--- a/python/src/basecamp/generated/types.py
+++ b/python/src/basecamp/generated/types.py
@@ -1621,28 +1621,70 @@ class SearchMetadata(TypedDict):
 
 
 class SearchResult(TypedDict):
-    app_url: str
+    app_download_url: NotRequired[str]
+    app_url: NotRequired[str]
+    attachments: NotRequired[list[SearchResultAttachment]]
     bookmark_url: NotRequired[str]
+    boosts_count: NotRequired[int]
+    boosts_url: NotRequired[str]
     bubble_up_url: NotRequired[str]
     bucket: NotRequired[RecordingBucket]
+    byte_size: NotRequired[int]
+    cards_count: NotRequired[int]
+    cards_url: NotRequired[str]
+    color: NotRequired[Optional[str]]
+    comment_count: NotRequired[int]
+    comments_count: NotRequired[int]
+    comments_url: NotRequired[str]
     content: str | None
     content_attachments: NotRequired[list[RichTextAttachment]]
+    content_type: NotRequired[str]
     created_at: NotRequired[str]
     creator: NotRequired[Person]
     description: str | None
     description_attachments: NotRequired[list[RichTextAttachment]]
-    id: int
+    download_url: NotRequired[str]
+    filename: NotRequired[str]
+    height: NotRequired[Optional[int | float]]
+    id: NotRequired[int]
+    image_url: NotRequired[str]
     inherits_status: NotRequired[bool]
+    language: NotRequired[str]
+    on_hold: NotRequired[CardColumnOnHold]
     parent: NotRequired[RecordingParent]
     plain_text_content: NotRequired[str]
     plain_text_description: NotRequired[str]
+    position: NotRequired[int]
+    preview_url: NotRequired[str]
+    previewable: NotRequired[bool]
+    sound_url: NotRequired[str]
     status: NotRequired[str]
     subject: NotRequired[str]
-    title: str
-    type: str
+    subscribers: NotRequired[list[Person]]
+    subscription_url: NotRequired[str]
+    thumbnail_url: NotRequired[str]
+    title: NotRequired[str]
+    type: NotRequired[str]
     updated_at: NotRequired[str]
-    url: str
+    url: NotRequired[str]
     visible_to_clients: NotRequired[bool]
+    width: NotRequired[Optional[int | float]]
+
+
+class SearchResultAttachment(TypedDict):
+    byte_size: int
+    content_type: str
+    download_url: str
+    filename: str
+    height: NotRequired[Optional[int | float]]
+    id: NotRequired[int]
+    preview_url: NotRequired[str]
+    previewable: NotRequired[bool]
+    sgid: NotRequired[str]
+    thumbnail_url: NotRequired[str]
+    title: NotRequired[str]
+    url: NotRequired[str]
+    width: NotRequired[Optional[int | float]]
 
 
 class SearchType(TypedDict):

--- a/python/src/basecamp/generated/types.py
+++ b/python/src/basecamp/generated/types.py
@@ -1127,9 +1127,9 @@ class MyAssignment(TypedDict):
 
 
 class MyAssignmentAssignee(TypedDict):
-    avatar_url: NotRequired[str]
+    avatar_url: str
     id: int
-    name: NotRequired[str]
+    name: str
 
 
 class MyAssignmentBucket(TypedDict):
@@ -1208,9 +1208,9 @@ class OutOfOfficePayload(TypedDict):
 
 
 class OutOfOfficePerson(TypedDict):
-    avatar_url: NotRequired[str]
+    avatar_url: str
     id: int
-    name: NotRequired[str]
+    name: str
 
 
 class PauseQuestionResponseContent(TypedDict):

--- a/python/tests/services/test_my_assignments_service.py
+++ b/python/tests/services/test_my_assignments_service.py
@@ -18,6 +18,41 @@ def _my_assignments():
     return Client(access_token="test-token").for_account("12345").my_assignments
 
 
+class TestGetMyAssignments:
+    @respx.mock
+    def test_decodes_assignees_with_full_person_minimal_projection(self):
+        # bc3's people/_person_minimal partial renders id, name and avatar_url
+        # unconditionally, so an assignee always carries all three keys (#659).
+        respx.get(f"{BASE}/my/assignments.json").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "priorities": [
+                        {
+                            "id": 1,
+                            "content": "Priority task",
+                            "assignees": [
+                                {
+                                    "id": 1049715914,
+                                    "name": "Victor Cooper",
+                                    "avatar_url": "https://example.com/avatar",
+                                }
+                            ],
+                        }
+                    ],
+                    "non_priorities": [],
+                },
+            )
+        )
+
+        result = _my_assignments().get_my_assignments()
+
+        assignee = result["priorities"][0]["assignees"][0]
+        assert assignee["id"] == 1049715914
+        assert assignee["name"] == "Victor Cooper"
+        assert assignee["avatar_url"] == "https://example.com/avatar"
+
+
 class TestPrioritizeAssignment:
     @respx.mock
     def test_posts_the_recording_id(self):

--- a/python/tests/services/test_search.py
+++ b/python/tests/services/test_search.py
@@ -11,6 +11,56 @@ from basecamp import AsyncClient, Client
 SEARCH_URL = "https://3.basecampapi.com/12345/search.json"
 METADATA_URL = "https://3.basecampapi.com/12345/searches/metadata.json"
 
+# A file-attachment hit (searches/_attachment.json.jbuilder): the one branch
+# that omits the id/title/type/url/app_url envelope keys and carries the ten
+# file keys instead. width/height ride only on previewable files and may
+# arrive float-spelled (1920.0). content/description are still present-and-
+# null — the show template nil-overwrites them on every branch.
+_ATTACHMENT_HIT = {
+    "parent": {
+        "id": 10,
+        "title": "Message Board",
+        "type": "Message",
+        "url": "https://3.basecampapi.com/12345/buckets/1/messages/11.json",
+        "app_url": "https://3.basecamp.com/12345/buckets/1/messages/11",
+    },
+    "bucket": {"id": 1, "name": "Leto", "type": "Project"},
+    "created_at": "2022-10-28T15:25:00.000Z",
+    "filename": "leto-hero.jpg",
+    "content_type": "image/jpeg",
+    "byte_size": 512000,
+    "previewable": True,
+    "width": 1920.0,
+    "height": 1080,
+    "preview_url": "https://3.basecampapi.com/12345/blobs/hero/previews/leto-hero.jpg",
+    "thumbnail_url": "https://3.basecampapi.com/12345/blobs/hero/thumbnails/leto-hero.jpg",
+    "download_url": "https://3.basecampapi.com/12345/blobs/hero/download/leto-hero.jpg",
+    "app_download_url": "https://3.basecamp.com/12345/blobs/hero/download/leto-hero.jpg",
+    "content": None,
+    "description": None,
+}
+
+
+def _assert_attachment_hit(results: list) -> None:
+    assert len(results) == 1
+    hit = results[0]
+    for key in ("id", "title", "type", "url", "app_url"):
+        assert key not in hit
+    assert hit["filename"] == "leto-hero.jpg"
+    assert hit["content_type"] == "image/jpeg"
+    assert hit["byte_size"] == 512000
+    assert hit["previewable"] is True
+    # Float-spelled dimensions survive the untyped decode as-is.
+    assert hit["width"] == 1920
+    assert hit["height"] == 1080
+    assert "/previews/" in hit["preview_url"]
+    assert "/thumbnails/" in hit["thumbnail_url"]
+    assert "/download/" in hit["download_url"]
+    assert "/download/" in hit["app_download_url"]
+    assert hit["content"] is None and hit["description"] is None
+    assert hit["parent"]["type"] == "Message"
+
+
 _METADATA = {
     "recording_search_types": [
         {"key": None, "value": "Everything"},
@@ -101,6 +151,15 @@ class TestSyncSearch:
         _assert_full_surface_wire(route.calls[0].request)
 
     @respx.mock
+    def test_attachment_branch_hit_decodes(self):
+        respx.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=[_ATTACHMENT_HIT]))
+
+        account = Client(access_token="test-token").for_account("12345")
+        results = account.search.search(q="leto hero")
+
+        _assert_attachment_hit(list(results))
+
+    @respx.mock
     def test_metadata_decodes_filter_options(self):
         respx.get(METADATA_URL).mock(return_value=httpx.Response(200, json=_METADATA))
 
@@ -143,6 +202,16 @@ class TestAsyncSearch:
 
         assert route.called
         _assert_full_surface_wire(route.calls[0].request)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_attachment_branch_hit_decodes(self):
+        respx.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=[_ATTACHMENT_HIT]))
+
+        account = AsyncClient(access_token="test-token").for_account("12345")
+        results = await account.search.search(q="leto hero")
+
+        _assert_attachment_hit(list(results))
 
     @pytest.mark.asyncio
     @respx.mock

--- a/ruby/lib/basecamp/generated/metadata.json
+++ b/ruby/lib/basecamp/generated/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-08-12T15:28:10Z",
+  "generated": "2026-08-12T15:52:56Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/ruby/lib/basecamp/generated/metadata.json
+++ b/ruby/lib/basecamp/generated/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-08-12T04:40:54Z",
+  "generated": "2026-08-12T15:28:10Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Auto-generated from OpenAPI spec. Do not edit manually.
-# Generated: 2026-08-12T15:28:10Z
+# Generated: 2026-08-12T15:52:56Z
 
 require "json"
 require "time"
@@ -2672,23 +2672,23 @@ module Basecamp
     # MyAssignmentAssignee
     class MyAssignmentAssignee
       include TypeHelpers
-      attr_accessor :id, :avatar_url, :name
+      attr_accessor :avatar_url, :id, :name
 
       # @return [Array<Symbol>]
       def self.required_fields
-        %i[id].freeze
+        %i[avatar_url id name].freeze
       end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
         @avatar_url = data["avatar_url"]
+        @id = parse_integer(data["id"])
         @name = data["name"]
       end
 
       def to_h
         {
-          "id" => @id,
           "avatar_url" => @avatar_url,
+          "id" => @id,
           "name" => @name,
         }.compact
       end
@@ -2955,23 +2955,23 @@ module Basecamp
     # OutOfOfficePerson
     class OutOfOfficePerson
       include TypeHelpers
-      attr_accessor :id, :avatar_url, :name
+      attr_accessor :avatar_url, :id, :name
 
       # @return [Array<Symbol>]
       def self.required_fields
-        %i[id].freeze
+        %i[avatar_url id name].freeze
       end
 
       def initialize(data = {})
-        @id = parse_integer(data["id"])
         @avatar_url = data["avatar_url"]
+        @id = parse_integer(data["id"])
         @name = data["name"]
       end
 
       def to_h
         {
-          "id" => @id,
           "avatar_url" => @avatar_url,
+          "id" => @id,
           "name" => @name,
         }.compact
       end

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Auto-generated from OpenAPI spec. Do not edit manually.
-# Generated: 2026-08-12T04:40:54Z
+# Generated: 2026-08-12T15:28:10Z
 
 require "json"
 require "time"
@@ -4025,63 +4025,164 @@ module Basecamp
     # SearchResult
     class SearchResult
       include TypeHelpers
-      attr_accessor :app_url, :content, :description, :id, :title, :type, :url, :bookmark_url, :bubble_up_url, :bucket, :content_attachments, :created_at, :creator, :description_attachments, :inherits_status, :parent, :plain_text_content, :plain_text_description, :status, :subject, :updated_at, :visible_to_clients
+      attr_accessor :content, :description, :app_download_url, :app_url, :attachments, :bookmark_url, :boosts_count, :boosts_url, :bubble_up_url, :bucket, :byte_size, :cards_count, :cards_url, :color, :comment_count, :comments_count, :comments_url, :content_attachments, :content_type, :created_at, :creator, :description_attachments, :download_url, :filename, :height, :id, :image_url, :inherits_status, :language, :on_hold, :parent, :plain_text_content, :plain_text_description, :position, :preview_url, :previewable, :sound_url, :status, :subject, :subscribers, :subscription_url, :thumbnail_url, :title, :type, :updated_at, :url, :visible_to_clients, :width
 
       # @return [Array<Symbol>]
       def self.required_fields
-        %i[app_url content description id title type url].freeze
+        %i[content description].freeze
       end
 
       def initialize(data = {})
-        @app_url = data["app_url"]
         @content = data["content"]
         @description = data["description"]
-        @id = parse_integer(data["id"])
-        @title = data["title"]
-        @type = data["type"]
-        @url = data["url"]
+        @app_download_url = data["app_download_url"]
+        @app_url = data["app_url"]
+        @attachments = parse_array(data["attachments"], "SearchResultAttachment")
         @bookmark_url = data["bookmark_url"]
+        @boosts_count = parse_integer(data["boosts_count"])
+        @boosts_url = data["boosts_url"]
         @bubble_up_url = data["bubble_up_url"]
         @bucket = parse_type(data["bucket"], "RecordingBucket")
+        @byte_size = parse_integer(data["byte_size"])
+        @cards_count = parse_integer(data["cards_count"])
+        @cards_url = data["cards_url"]
+        @color = data["color"]
+        @comment_count = parse_integer(data["comment_count"])
+        @comments_count = parse_integer(data["comments_count"])
+        @comments_url = data["comments_url"]
         @content_attachments = parse_array(data["content_attachments"], "RichTextAttachment")
+        @content_type = data["content_type"]
         @created_at = parse_datetime(data["created_at"])
         @creator = parse_type(data["creator"], "Person")
         @description_attachments = parse_array(data["description_attachments"], "RichTextAttachment")
+        @download_url = data["download_url"]
+        @filename = data["filename"]
+        @height = parse_integer(data["height"])
+        @id = parse_integer(data["id"])
+        @image_url = data["image_url"]
         @inherits_status = parse_boolean(data["inherits_status"])
+        @language = data["language"]
+        @on_hold = parse_type(data["on_hold"], "CardColumnOnHold")
         @parent = parse_type(data["parent"], "RecordingParent")
         @plain_text_content = data["plain_text_content"]
         @plain_text_description = data["plain_text_description"]
+        @position = parse_integer(data["position"])
+        @preview_url = data["preview_url"]
+        @previewable = parse_boolean(data["previewable"])
+        @sound_url = data["sound_url"]
         @status = data["status"]
         @subject = data["subject"]
+        @subscribers = parse_array(data["subscribers"], "Person")
+        @subscription_url = data["subscription_url"]
+        @thumbnail_url = data["thumbnail_url"]
+        @title = data["title"]
+        @type = data["type"]
         @updated_at = parse_datetime(data["updated_at"])
+        @url = data["url"]
         @visible_to_clients = parse_boolean(data["visible_to_clients"])
+        @width = parse_integer(data["width"])
       end
 
       def to_h
         {
-          "app_url" => @app_url,
           "content" => @content,
           "description" => @description,
-          "id" => @id,
-          "title" => @title,
-          "type" => @type,
-          "url" => @url,
+          "app_download_url" => @app_download_url,
+          "app_url" => @app_url,
+          "attachments" => @attachments,
           "bookmark_url" => @bookmark_url,
+          "boosts_count" => @boosts_count,
+          "boosts_url" => @boosts_url,
           "bubble_up_url" => @bubble_up_url,
           "bucket" => @bucket,
+          "byte_size" => @byte_size,
+          "cards_count" => @cards_count,
+          "cards_url" => @cards_url,
+          "color" => @color,
+          "comment_count" => @comment_count,
+          "comments_count" => @comments_count,
+          "comments_url" => @comments_url,
           "content_attachments" => @content_attachments,
+          "content_type" => @content_type,
           "created_at" => @created_at,
           "creator" => @creator,
           "description_attachments" => @description_attachments,
+          "download_url" => @download_url,
+          "filename" => @filename,
+          "height" => @height,
+          "id" => @id,
+          "image_url" => @image_url,
           "inherits_status" => @inherits_status,
+          "language" => @language,
+          "on_hold" => @on_hold,
           "parent" => @parent,
           "plain_text_content" => @plain_text_content,
           "plain_text_description" => @plain_text_description,
+          "position" => @position,
+          "preview_url" => @preview_url,
+          "previewable" => @previewable,
+          "sound_url" => @sound_url,
           "status" => @status,
           "subject" => @subject,
+          "subscribers" => @subscribers,
+          "subscription_url" => @subscription_url,
+          "thumbnail_url" => @thumbnail_url,
+          "title" => @title,
+          "type" => @type,
           "updated_at" => @updated_at,
+          "url" => @url,
           "visible_to_clients" => @visible_to_clients,
+          "width" => @width,
         }.reject { |k, v| v.nil? && !["content", "description"].include?(k) }
+      end
+
+      def to_json(*args)
+        to_h.to_json(*args)
+      end
+    end
+
+    # SearchResultAttachment
+    class SearchResultAttachment
+      include TypeHelpers
+      attr_accessor :byte_size, :content_type, :download_url, :filename, :height, :id, :preview_url, :previewable, :sgid, :thumbnail_url, :title, :url, :width
+
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[byte_size content_type download_url filename].freeze
+      end
+
+      def initialize(data = {})
+        @byte_size = parse_integer(data["byte_size"])
+        @content_type = data["content_type"]
+        @download_url = data["download_url"]
+        @filename = data["filename"]
+        @height = parse_integer(data["height"])
+        @id = parse_integer(data["id"])
+        @preview_url = data["preview_url"]
+        @previewable = parse_boolean(data["previewable"])
+        @sgid = data["sgid"]
+        @thumbnail_url = data["thumbnail_url"]
+        @title = data["title"]
+        @url = data["url"]
+        @width = parse_integer(data["width"])
+      end
+
+      def to_h
+        {
+          "byte_size" => @byte_size,
+          "content_type" => @content_type,
+          "download_url" => @download_url,
+          "filename" => @filename,
+          "height" => @height,
+          "id" => @id,
+          "preview_url" => @preview_url,
+          "previewable" => @previewable,
+          "sgid" => @sgid,
+          "thumbnail_url" => @thumbnail_url,
+          "title" => @title,
+          "url" => @url,
+          "width" => @width,
+        }.compact
       end
 
       def to_json(*args)

--- a/ruby/test/basecamp/generated_types_test.rb
+++ b/ruby/test/basecamp/generated_types_test.rb
@@ -149,7 +149,10 @@ class GeneratedTypesTest < Minitest::Test
     assert_nil hash["description"]
     # The excerpt is the opposite contract: optional and non-nullable.
     assert_includes hash["plain_text_content"], "circled-text"
-    assert_equal %i[app_url content description id title type url],
+    # content/description are the ONLY required members: the file-attachment
+    # branch omits id/title/type/url/app_url entirely (#651), while the
+    # show-template nil-overwrite guarantees these two on every branch.
+    assert_equal %i[content description],
                  Basecamp::Types::SearchResult.required_fields
   end
 

--- a/ruby/test/basecamp/services/my_assignments_service_test.rb
+++ b/ruby/test/basecamp/services/my_assignments_service_test.rb
@@ -9,6 +9,26 @@ class MyAssignmentsServiceTest < Minitest::Test
     @account = create_account_client(account_id: "12345")
   end
 
+  def test_get_my_assignments_decodes_assignees
+    # bc3's people/_person_minimal partial renders id, name and avatar_url
+    # unconditionally, so an assignee always carries all three keys (#659).
+    stub_get("/12345/my/assignments.json", response_body: {
+      "priorities" => [
+        { "id" => 1, "content" => "Priority task",
+          "assignees" => [ { "id" => 1049715914, "name" => "Victor Cooper",
+                             "avatar_url" => "https://example.com/avatar" } ] }
+      ],
+      "non_priorities" => []
+    })
+
+    result = @account.my_assignments.get_my_assignments
+
+    assignee = result["priorities"][0]["assignees"][0]
+    assert_equal 1049715914, assignee["id"]
+    assert_equal "Victor Cooper", assignee["name"]
+    assert_equal "https://example.com/avatar", assignee["avatar_url"]
+  end
+
   def test_prioritize_assignment_posts_the_recording_id
     stub_request(:post, "https://3.basecampapi.com/12345/my/priorities.json")
       .with(body: { "id" => 1069479801 }.to_json)

--- a/ruby/test/basecamp/services/people_service_test.rb
+++ b/ruby/test/basecamp/services/people_service_test.rb
@@ -124,8 +124,11 @@ class PeopleServiceTest < Minitest::Test
   end
 
   def test_get_out_of_office_disabled_omits_dates
+    # person_minimal always renders all three keys, even when out of office is
+    # disabled (#659).
     stub_get("/12345/people/1/out_of_office.json", response_body: {
-      "person" => { "id" => 1049715913, "name" => "Victor Cooper" },
+      "person" => { "id" => 1049715913, "name" => "Victor Cooper",
+                    "avatar_url" => "https://example.com/avatar" },
       "enabled" => false,
       "ongoing" => false
     })

--- a/ruby/test/basecamp/services/search_service_test.rb
+++ b/ruby/test/basecamp/services/search_service_test.rb
@@ -24,6 +24,23 @@ class SearchServiceTest < Minitest::Test
       { "id" => 2, "title" => "Q1 Report Draft", "type" => "Document", "content_attachments" => [],
         "url" => "https://3.basecampapi.com/12345/buckets/1/documents/2.json",
         "app_url" => "https://3.basecamp.com/12345/buckets/1/documents/2",
+        "content" => nil, "description" => nil },
+      # A file-attachment hit (searches/_attachment.json.jbuilder): the one
+      # branch that omits the id/title/type/url/app_url envelope keys and
+      # carries the ten file keys instead. width/height ride only on
+      # previewable files and may arrive float-spelled (1920.0).
+      { "parent" => { "id" => 10, "title" => "Message Board", "type" => "Message",
+                      "url" => "https://3.basecampapi.com/12345/buckets/1/messages/11.json",
+                      "app_url" => "https://3.basecamp.com/12345/buckets/1/messages/11" },
+        "bucket" => { "id" => 1, "name" => "Leto", "type" => "Project" },
+        "created_at" => "2022-10-28T15:25:00.000Z",
+        "filename" => "leto-hero.jpg", "content_type" => "image/jpeg",
+        "byte_size" => 512000, "previewable" => true,
+        "width" => 1920.0, "height" => 1080,
+        "preview_url" => "https://3.basecampapi.com/12345/blobs/hero/previews/leto-hero.jpg",
+        "thumbnail_url" => "https://3.basecampapi.com/12345/blobs/hero/thumbnails/leto-hero.jpg",
+        "download_url" => "https://3.basecampapi.com/12345/blobs/hero/download/leto-hero.jpg",
+        "app_download_url" => "https://3.basecamp.com/12345/blobs/hero/download/leto-hero.jpg",
         "content" => nil, "description" => nil }
     ]
     stub_request(:get, "https://3.basecampapi.com/12345/search.json")
@@ -32,7 +49,7 @@ class SearchServiceTest < Minitest::Test
 
     result = @account.search.search(q: "quarterly report").to_a
 
-    assert_equal 2, result.length
+    assert_equal 3, result.length
     assert_equal "Quarterly Report", result[0]["title"]
     # The optional projection array surfaces on each matching-type result.
     assert_equal [], result[0]["content_attachments"]
@@ -47,6 +64,23 @@ class SearchServiceTest < Minitest::Test
     end
     assert_includes result[0]["plain_text_content"], "circled-text"
     assert_nil result[1]["plain_text_content"]
+
+    # The file-attachment hit: no envelope keys, file keys instead.
+    hit = result[2]
+    %w[id title type url app_url].each do |key|
+      assert_not hit.key?(key), "attachment hit must omit #{key}"
+    end
+    assert_equal "leto-hero.jpg", hit["filename"]
+    assert_equal "image/jpeg", hit["content_type"]
+    assert_equal 512000, hit["byte_size"]
+    assert hit["previewable"]
+    assert_equal 1920, hit["width"]
+    assert_equal 1080, hit["height"]
+    assert_includes hit["preview_url"], "/previews/"
+    assert_includes hit["thumbnail_url"], "/thumbnails/"
+    assert_includes hit["download_url"], "/download/"
+    assert_includes hit["app_download_url"], "/download/"
+    assert_equal "Message", hit.dig("parent", "type")
   end
 
   def test_search_with_sort

--- a/scripts/enhance-openapi-go-types.sh
+++ b/scripts/enhance-openapi-go-types.sh
@@ -241,6 +241,46 @@ walk(
   }
 )
 |
+# Fourth-c pass: SearchResult / SearchResultAttachment width/height → nullable
+# *types.FlexInt. The search file-attachment branch emits blob pixel dimensions
+# at the top level of the hit, and the `attachments` elements of a search
+# result come through the same attachments/_attachment + blobs/_blob partials
+# that RichTextAttachment models — float-spelled (1024.0) and null for
+# non-image blobs either way. Same treatment as Fourth-b.
+.components.schemas.SearchResult.properties |= (
+  (.width // empty) += {
+    "nullable": true,
+    "x-go-type": "types.FlexInt",
+    "x-go-type-import": {"path": "github.com/basecamp/basecamp-sdk/go/pkg/types"}
+  } |
+  (.height // empty) += {
+    "nullable": true,
+    "x-go-type": "types.FlexInt",
+    "x-go-type-import": {"path": "github.com/basecamp/basecamp-sdk/go/pkg/types"}
+  }
+)
+|
+.components.schemas.SearchResultAttachment.properties |= (
+  (.width // empty) += {
+    "nullable": true,
+    "x-go-type": "types.FlexInt",
+    "x-go-type-import": {"path": "github.com/basecamp/basecamp-sdk/go/pkg/types"}
+  } |
+  (.height // empty) += {
+    "nullable": true,
+    "x-go-type": "types.FlexInt",
+    "x-go-type-import": {"path": "github.com/basecamp/basecamp-sdk/go/pkg/types"}
+  }
+)
+|
+# Fourth-d pass: SearchResult.color is nullable-when-present. The kanban-list
+# and gauge-needle search branches emit `json.color recording.color`
+# unconditionally, and the recording color enum is null when unset (the same
+# wire behavior Wormhole.color documents). The member is optional — only those
+# two branches carry it — so plain `nullable: true` suffices, the same
+# optional-and-nullable treatment as the Fifth-g date passes below.
+.components.schemas.SearchResult.properties.color += { "nullable": true }
+|
 # Fifth pass: override starts_at/ends_at on ScheduleEntry response to use types.FlexibleTime
 # The API returns date-only strings ("2006-01-02") for all-day schedule entries,
 # which time.Time cannot parse. FlexibleTime handles RFC3339, RFC3339Nano, and date-only.

--- a/spec/api-gaps/rich-text-attachments-coverage.md
+++ b/spec/api-gaps/rich-text-attachments-coverage.md
@@ -27,6 +27,8 @@ smithy_refs:
   - "QuestionAnswer$content_attachments (spec/basecamp.smithy)"
   - "SearchResult$content_attachments (spec/basecamp.smithy)"
   - "SearchResult$description_attachments (spec/basecamp.smithy)"
+  - "SearchResult$attachments (spec/basecamp.smithy)"
+  - "SearchResultAttachment (spec/basecamp.smithy)"
   - "Gauge$description_attachments (spec/basecamp.smithy)"
   - "GaugeNeedle$description_attachments (spec/basecamp.smithy)"
 bc3_refs:
@@ -88,25 +90,31 @@ SDK decodes now carries its companion array, reusing `RichTextAttachment` +
   `to_recordable_partial_path`). A given item carries only the array matching its
   type; a webhook-sourced item carries neither.
 
-**Explicitly out of scope (not "absorbed" — accurate status per item):**
+**Also absorbed — the generic `attachments` key on SearchResult (#716,
+`SearchResult$attachments` / `SearchResultAttachment`):** this entry
+previously listed the key as explicitly out of scope, "a redundant projection
+of the companion array, not a distinct aggregate". (That was this item's
+*second* correction: an earlier version called it "the recording's aggregate
+downloadable files, a *different* projection concern", and #428 — filed on
+that premise — is closed as a result.) The redundancy analysis, verified
+against bc3 `c308693171`, was sound for its path — `searches/show.json.jbuilder`
+emits `recording.downloadable_attachments` through the same
+`attachments/_attachment` partial that builds the companion array, and
+`RichText.rich_text_attribute` registers exactly one rich-text attribute per
+model, so on THAT path the two keys always carry identical elements — but it
+missed a second emitter: for chat *upload* lines,
+`chats/lines/_upload.json.jbuilder` builds a bespoke six-key `attachments`
+aggregate (`title`, `url`, `filename`, `content_type`, `byte_size`,
+`download_url`) inline, and because upload lines have no `rich_text_content`,
+`has_downloadable_attachments?` is false and the show template never
+overwrites it — the bespoke shape reaches the wire. That shape lacks
+`RichTextAttachment`'s required `id`/`sgid`/`previewable`/`preview_url`/
+`thumbnail_url`, so #716 models the key as its own element type,
+`SearchResultAttachment`: an optional-field superset of both wire variants
+with only the four keys both always emit required (re-verified against the
+revision `spec/api-provenance.json` currently pins).
 
-- **Generic `attachments` key on SearchResult** (`searches/show:25`):
-  **deliberately not modeled — it is a redundant projection of the companion
-  array, not a distinct aggregate.** (Corrected: an earlier version of this
-  entry called it "the recording's aggregate downloadable files, a *different*
-  projection concern". That was wrong, and #428 — filed on that premise — is
-  closed as a result.) Verified against bc3 `c308693171`:
-  `searches/show.json.jbuilder:25` emits
-  `recording.downloadable_attachments` through the `attachments/_attachment`
-  partial; `Recording::Attachables` delegates `downloadable_attachments` to
-  `attachable_rich_text_content`, i.e. `recordable.rich_text_content`; and
-  `recordings/_rich_text.json.jbuilder:3` builds the companion array from
-  `rich_text&.downloadable_attachments` through that *same* partial. Since
-  `RichText.rich_text_attribute` registers exactly one attribute per model
-  (`RichText::ATTRIBUTES[model_name.name] = attribute_name`, and a second call
-  raises `NotImplementedError`), the two keys always carry identical elements.
-  Modeling `attachments` would duplicate `content_attachments` /
-  `description_attachments` under a second name.
+**Explicitly out of scope (not "absorbed" — accurate status per item):**
 - **everything/aggregates endpoints** (`everything/*`, which also render full
   partials): **unmodeled in the SDK** — no decode path exists to carry an array
   into. Covered by the separate `everything-aggregates.md` gap

--- a/spec/basecamp.smithy
+++ b/spec/basecamp.smithy
@@ -10962,10 +10962,16 @@ structure MyAssignmentParent {
   app_url: String
 }
 
+/// A person as bc3's `people/_person_minimal.json.jbuilder` renders them —
+/// the same three-key partial behind UpcomingSchedulePerson and
+/// OutOfOfficePerson. All three keys are emitted unconditionally, so all
+/// three are required.
 structure MyAssignmentAssignee {
   @required
   id: PersonId
+  @required
   name: PersonName
+  @required
   avatar_url: AvatarUrl
 }
 
@@ -11661,10 +11667,16 @@ structure OutOfOffice {
   back_on_date: ISO8601Date
 }
 
+/// A person as bc3's `people/_person_minimal.json.jbuilder` renders them —
+/// the same three-key partial behind UpcomingSchedulePerson and
+/// MyAssignmentAssignee. All three keys are emitted unconditionally, so all
+/// three are required.
 structure OutOfOfficePerson {
   @required
   id: PersonId
+  @required
   name: PersonName
+  @required
   avatar_url: AvatarUrl
 }
 

--- a/spec/basecamp.smithy
+++ b/spec/basecamp.smithy
@@ -9315,23 +9315,46 @@ list SearchResultList {
   member: SearchResult
 }
 
+/// One hit from account-wide search — a polymorphic projection over every
+/// searchable recording type.
+///
+/// Most result types render the common recording envelope
+/// (`recordings/_recording.json.jbuilder`) plus their own recordable partial,
+/// but `api_search_result_template_path` special-cases four branches — chat
+/// lines, kanban (card table) lists, file attachments and gauge needles — and
+/// the file-attachment branch writes its own projection from scratch instead
+/// of the envelope. Members are therefore optional unless every branch emits
+/// them; the doc comments name the branches that carry each optional member.
 structure SearchResult {
-  @required
+  /// The recording id. Optional only because the file-attachment branch
+  /// (`searches/_attachment.json.jbuilder`) skips the recording envelope and
+  /// emits none of the top-level id/title/type/url/app_url keys; every other
+  /// branch emits all five.
   id: Long
   status: String
   visible_to_clients: Boolean
   created_at: ISO8601Timestamp
   updated_at: ISO8601Timestamp
-  @required
+  /// See `id` — omitted by the file-attachment branch, emitted by every other
+  /// branch.
   title: String
   inherits_status: Boolean
-  @required
+  /// See `id` — omitted by the file-attachment branch, emitted by every other
+  /// branch. A file-attachment hit is therefore recognizable by the absence
+  /// of this key (its file keys, `filename` through `app_download_url`, are
+  /// the positive signal).
   type: String
-  @required
+  /// See `id` — omitted by the file-attachment branch, emitted by every other
+  /// branch.
   url: String
-  @required
+  /// See `id` — omitted by the file-attachment branch, emitted by every other
+  /// branch.
   app_url: String
   bookmark_url: String
+  /// Subscription URL, emitted by the common recording envelope for any
+  /// subscribable result — kanban lists and gauge needles among the special
+  /// branches, plus subscribable generic-branch types (messages, todos, …).
+  subscription_url: String
 
   /// URL of the Bubble Up record for this recording (BC5 addition). Optional
   /// here because this is a polymorphic projection:
@@ -9373,21 +9396,155 @@ structure SearchResult {
   /// the array matching its rich-text attribute (`content_attachments` for a
   /// Comment/Message, `description_attachments` for a Todo); a webhook-sourced
   /// result carries neither. Optional (no `@required`), non-nullable.
-  ///
-  /// Search results additionally repeat this same array under a generic
-  /// `attachments` key. It is a redundant projection, not a distinct
-  /// aggregate: `searches/show.json.jbuilder` emits
-  /// `recording.downloadable_attachments`, which delegates to the recordable's
-  /// sole `rich_text_content`, through the same `attachments/_attachment`
-  /// partial that `recordings/_rich_text.json.jbuilder` uses to build the
-  /// companion array. `RichText.rich_text_attribute` permits exactly one
-  /// rich-text attribute per model, so the two keys always carry identical
-  /// elements. Modeling `attachments` would duplicate the field, so it is
-  /// deliberately not modeled.
   content_attachments: RichTextAttachmentList
   /// See `content_attachments` — the description-attribute companion array.
   description_attachments: RichTextAttachmentList
+  /// File attachments on the result, in either of two wire shapes — see
+  /// `SearchResultAttachment`.
+  ///
+  /// For a result whose recordable carries downloadable rich-text
+  /// attachments, `searches/show.json.jbuilder` emits this key through the
+  /// same `attachments/_attachment` partial that builds the rich-text
+  /// companion array above, so it repeats that array's elements. For a chat
+  /// *upload* line, `chats/lines/_upload.json.jbuilder` instead builds a
+  /// bespoke six-key aggregate inline — and because upload lines have no
+  /// rich-text attribute, the show template never overwrites it, so that
+  /// distinct shape survives to the wire.
+  attachments: SearchResultAttachmentList
   subject: String
+
+  // ----- chat-line branch (chats/lines/_line + per-kind partials) -----
+
+  /// Boost count, emitted by the recording envelope when the branch passes
+  /// `boostable` — chat lines and gauge needles.
+  boosts_count: Integer
+  /// See `boosts_count` — the companion URL.
+  boosts_url: String
+  /// Language of a code chat line (`chats/lines/_code.json.jbuilder`);
+  /// validated present on the model, so never null when the key is emitted.
+  language: String
+  /// Image URL of a soundtracked (play-kind) chat line whose sound carries an
+  /// image; such a line emits `image_url` in place of `content`.
+  image_url: String
+  /// Sound URL of a play-kind chat line; always emitted for that kind.
+  sound_url: String
+
+  // ----- kanban-list branch (kanban/lists/_list.json.jbuilder) -----
+
+  /// Everyone subscribed to the kanban list, as full Person projections.
+  subscribers: PersonList
+  /// Color of a kanban list or gauge needle. Emitted unconditionally by both
+  /// branches with a null value when unset, so it is nullable (the enhance
+  /// pass layers `nullable: true` onto the OpenAPI).
+  color: String
+  /// Number of cards in the kanban list.
+  cards_count: Integer
+  /// Comment count of a kanban list or gauge needle (branch-partial key,
+  /// singular `comment_count` — distinct from the envelope's
+  /// `comments_count`, which a needle also carries).
+  comment_count: Integer
+  /// API URL of the kanban list's cards.
+  cards_url: String
+  /// The kanban list's on-hold section, when present — the same shape the
+  /// card-table column endpoints return.
+  on_hold: CardColumnOnHold
+
+  // ----- gauge-needle branch (gauges/needles/_needle.json.jbuilder) -----
+
+  /// Comment count, emitted by the recording envelope when the branch passes
+  /// `commentable` — gauge needles among the special branches, plus
+  /// commentable generic-branch types.
+  comments_count: Integer
+  /// See `comments_count` — the companion URL.
+  comments_url: String
+  /// Position of the result. Two emitters share the key: the recording
+  /// envelope emits list position for positioned recordings (kanban lists
+  /// among the special branches), and the gauge-needle branch overwrites it
+  /// with the needle's own 0–100 gauge position.
+  position: Integer
+
+  // ----- file-attachment branch (searches/_attachment.json.jbuilder) -----
+
+  /// Filename of a file-attachment hit. This and the following file keys are
+  /// emitted only by the file-attachment branch — the one branch that omits
+  /// the id/title/type/url/app_url envelope keys.
+  filename: String
+  /// MIME type of a file-attachment hit.
+  content_type: String
+  /// Size in bytes of a file-attachment hit.
+  byte_size: Long
+  /// Whether the file can be previewed.
+  previewable: Boolean
+  /// Pixel width, emitted only when the file is previewable. May be
+  /// float-spelled (`1024.0`) and nullable, like every other blob dimension —
+  /// see `RichTextAttachment.width` for the cross-SDK typing note.
+  width: Integer
+  /// See `width` — same conditional emission and nullable/float-spelled
+  /// behavior.
+  height: Integer
+  /// Full-size preview URL of a file-attachment hit.
+  preview_url: String
+  /// Thumbnail URL of a file-attachment hit.
+  thumbnail_url: String
+  /// Authenticated download URL of a file-attachment hit.
+  @basecampAuthRoutableUrl
+  download_url: String
+  /// Web (app-host) download URL of a file-attachment hit.
+  app_download_url: String
+}
+
+list SearchResultAttachmentList {
+  member: SearchResultAttachment
+}
+
+/// A file attached to a search result, in either of two wire shapes.
+///
+/// This is an optional-field superset over the two variants the search
+/// projection emits (the TimelineAttachment approach): the rich-text
+/// attachment/blob shape rendered through `attachments/_attachment` +
+/// `blobs/_blob` — the same emitters `RichTextAttachment` models — and the
+/// bespoke six-key aggregate a chat upload line builds inline in
+/// `chats/lines/_upload.json.jbuilder`. Only the four keys both variants
+/// always emit are `@required`; the rest identify their variant.
+structure SearchResultAttachment {
+  /// Original filename (both variants).
+  @required
+  filename: String
+  /// MIME type of the file (both variants).
+  @required
+  content_type: String
+  /// Size of the file in bytes (both variants).
+  @required
+  byte_size: Long
+  /// Authenticated download URL for the file (both variants).
+  @required
+  @basecampAuthRoutableUrl
+  download_url: String
+
+  // ----- rich-text attachment/blob variant -----
+
+  /// Attachment id (rich-text variant).
+  id: Long
+  /// Signed global id of the attachment (rich-text variant).
+  sgid: String
+  /// Whether the blob can be previewed (rich-text variant).
+  previewable: Boolean
+  /// Full-size preview URL (rich-text variant).
+  preview_url: String
+  /// Thumbnail URL (rich-text variant).
+  thumbnail_url: String
+  /// Pixel width (rich-text variant) — null for non-image blobs and may be
+  /// float-spelled (`1024.0`); see `RichTextAttachment.width`.
+  width: Integer
+  /// See `width` (rich-text variant).
+  height: Integer
+
+  // ----- chat upload-line variant -----
+
+  /// Title of the attachment recording (chat upload-line variant).
+  title: String
+  /// Browser preview URL of the blob (chat upload-line variant).
+  url: String
 }
 
 structure SearchMetadata {

--- a/spec/fixtures/manifest.yaml
+++ b/spec/fixtures/manifest.yaml
@@ -259,6 +259,39 @@ targets:
     fixture: search/results.json
     pointer: "/3"
     schema: SearchResult
+  # The four special-cased search branches (api_search_result_template_path):
+  # a file-attachment hit omits the id/title/type/url/app_url envelope keys
+  # and carries the ten file keys instead; a chat upload line carries the
+  # bespoke six-key attachments aggregate; a kanban list carries the list
+  # partial's keys (color exercised as null); a gauge needle carries the
+  # needle partial's keys over the commentable+boostable envelope.
+  - id: search-result-attachment
+    fixture: search/results.json
+    pointer: "/4"
+    schema: SearchResult
+  - id: search-result-chat-upload
+    fixture: search/results.json
+    pointer: "/5"
+    schema: SearchResult
+  - id: search-result-kanban-list
+    fixture: search/results.json
+    pointer: "/6"
+    schema: SearchResult
+  - id: search-result-needle
+    fixture: search/results.json
+    pointer: "/7"
+    schema: SearchResult
+  # Both SearchResultAttachment wire variants: the rich-text attachment/blob
+  # shape a generic result re-emits under `attachments`, and the bespoke
+  # six-key aggregate a chat upload line builds inline.
+  - id: search-result-attachments-richtext
+    fixture: search/results.json
+    pointer: "/0/attachments/0"
+    schema: SearchResultAttachment
+  - id: search-result-attachments-upload
+    fixture: search/results.json
+    pointer: "/5/attachments/0"
+    schema: SearchResultAttachment
 
   # Two concrete RichTextAttachment instances (populated elements, not empty
   # arrays) — the only way to cover RichTextAttachment per the concrete-instance
@@ -331,7 +364,9 @@ covered_schemas:
   QuestionAnswer: [question-answer-get]
   Recording: [recording-get, recording-list-todolist]
   Todo: [todo-get]
-  SearchResult: [search-result-0, search-result-todolist]
+  SearchResult: [search-result-0, search-result-todolist, search-result-attachment,
+                 search-result-chat-upload, search-result-kanban-list, search-result-needle]
+  SearchResultAttachment: [search-result-attachments-richtext, search-result-attachments-upload]
   RichTextAttachment: [richtext-comment-0, richtext-upload-0]
   Gauge: [gauge-get]
   GaugeNeedle: [gauge-needle-get]

--- a/spec/fixtures/search/results.json
+++ b/spec/fixtures/search/results.json
@@ -61,6 +61,21 @@
         "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA30--pr0j0030/previews/diagram-30.png",
         "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA30--pr0j0030/thumbnails/diagram-30.png"
       }
+    ],
+    "attachments": [
+      {
+        "id": 1069481030,
+        "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA30--pr0j0030",
+        "filename": "diagram-30.png",
+        "content_type": "image/png",
+        "byte_size": 204800,
+        "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA30--pr0j0030/download/diagram-30.png",
+        "width": 1024.0,
+        "height": 768,
+        "previewable": true,
+        "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA30--pr0j0030/previews/diagram-30.png",
+        "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA30--pr0j0030/thumbnails/diagram-30.png"
+      }
     ]
   },
   {
@@ -237,5 +252,285 @@
       "can_manage_projects": true,
       "can_manage_people": true
     }
+  },
+  {
+    "parent": {
+      "id": 1069479338,
+      "title": "Message Board",
+      "type": "Message",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/messages/1069479351.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/messages/1069479351"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715914,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+      "name": "Victor Cooper",
+      "email_address": "victor@honchodesign.com",
+      "personable_type": "User",
+      "title": "Chief Strategist",
+      "bio": null,
+      "location": null,
+      "created_at": "2022-11-22T08:23:21.732Z",
+      "updated_at": "2022-11-22T08:23:21.732Z",
+      "admin": true,
+      "owner": true,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+      "can_manage_projects": true,
+      "can_manage_people": true
+    },
+    "created_at": "2022-10-28T15:25:00.000Z",
+    "filename": "leto-hero.jpg",
+    "content_type": "image/jpeg",
+    "byte_size": 512000,
+    "previewable": true,
+    "width": 1920.0,
+    "height": 1080,
+    "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA35--srch0035/previews/leto-hero.jpg",
+    "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA35--srch0035/thumbnails/leto-hero.jpg",
+    "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA35--srch0035/download/leto-hero.jpg",
+    "app_download_url": "https://3.basecamp.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA35--srch0035/download/leto-hero.jpg",
+    "content": null,
+    "description": null
+  },
+  {
+    "id": 1069479610,
+    "status": "active",
+    "visible_to_clients": false,
+    "created_at": "2022-10-28T15:30:00.000Z",
+    "updated_at": "2022-10-28T15:30:00.000Z",
+    "title": "leto-benchmarks.pdf",
+    "inherits_status": true,
+    "type": "Chat::Lines::Upload",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/chats/1069479345/lines/1069479610.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/chats/1069479345#__recording_1069479610",
+    "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5NjEwP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--mmnnoopp.json",
+    "boosts_count": 1,
+    "boosts_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479610/boosts.json",
+    "parent": {
+      "id": 1069479345,
+      "title": "Campfire",
+      "type": "Chat::Transcript",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/chats/1069479345.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/chats/1069479345"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715914,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+      "name": "Victor Cooper",
+      "email_address": "victor@honchodesign.com",
+      "personable_type": "User",
+      "title": "Chief Strategist",
+      "bio": null,
+      "location": null,
+      "created_at": "2022-11-22T08:23:21.732Z",
+      "updated_at": "2022-11-22T08:23:21.732Z",
+      "admin": true,
+      "owner": true,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+      "can_manage_projects": true,
+      "can_manage_people": true
+    },
+    "attachments": [
+      {
+        "title": "leto-benchmarks.pdf",
+        "url": "https://3.basecampapi.com/195539477/buckets/2085958499/uploads/1069479611.json",
+        "filename": "leto-benchmarks.pdf",
+        "content_type": "application/pdf",
+        "byte_size": 1048576,
+        "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/uploads/1069479611/download/leto-benchmarks.pdf"
+      }
+    ],
+    "content": null,
+    "description": null
+  },
+  {
+    "id": 1069479620,
+    "status": "active",
+    "visible_to_clients": false,
+    "created_at": "2024-01-15T09:31:00.000-06:00",
+    "updated_at": "2024-01-20T14:45:00.000-06:00",
+    "title": "Leto in progress",
+    "inherits_status": true,
+    "type": "Kanban::Column",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/columns/1069479620.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/columns/1069479620",
+    "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5NjIwP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--qqrrsstt.json",
+    "subscription_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479620/subscription.json",
+    "position": 2,
+    "parent": {
+      "id": 1069479345,
+      "title": "Development Board",
+      "type": "Kanban::Board",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/1069479345.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/1069479345"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715914,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+      "name": "Victor Cooper",
+      "email_address": "victor@honchodesign.com",
+      "personable_type": "User",
+      "title": "Chief Strategist",
+      "bio": null,
+      "location": null,
+      "created_at": "2022-11-22T08:23:21.732Z",
+      "updated_at": "2022-11-22T08:23:21.732Z",
+      "admin": true,
+      "owner": true,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+      "can_manage_projects": true,
+      "can_manage_people": true
+    },
+    "subscribers": [
+      {
+        "id": 1049715914,
+        "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+        "name": "Victor Cooper",
+        "email_address": "victor@honchodesign.com",
+        "personable_type": "User",
+        "title": "Chief Strategist",
+        "bio": null,
+        "location": null,
+        "created_at": "2022-11-22T08:23:21.732Z",
+        "updated_at": "2022-11-22T08:23:21.732Z",
+        "admin": true,
+        "owner": true,
+        "client": false,
+        "employee": true,
+        "time_zone": "America/Chicago",
+        "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+        "can_manage_projects": true,
+        "can_manage_people": true
+      }
+    ],
+    "color": null,
+    "cards_count": 4,
+    "comment_count": 1,
+    "cards_url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/lists/1069479620/cards.json",
+    "on_hold": {
+      "id": 1069479621,
+      "status": "active",
+      "inherits_status": true,
+      "title": "On hold",
+      "created_at": "2024-01-15T09:31:00.000-06:00",
+      "updated_at": "2024-01-20T14:45:00.000-06:00",
+      "cards_count": 0,
+      "cards_url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/lists/1069479621/cards.json"
+    },
+    "content": null,
+    "description": null,
+    "plain_text_content": "Cards for the <mark class=\"circled-text\"><span></span>Leto</mark> build currently in flight.",
+    "plain_text_description": "Cards for the <mark class=\"circled-text\"><span></span>Leto</mark> build currently in flight."
+  },
+  {
+    "id": 1069479630,
+    "status": "active",
+    "visible_to_clients": false,
+    "created_at": "2022-11-28T14:12:00.000Z",
+    "updated_at": "2022-11-28T14:12:00.000Z",
+    "title": "Progress update",
+    "inherits_status": true,
+    "type": "Gauge::Needle",
+    "url": "https://3.basecampapi.com/195539477/buckets/2085958499/gauge_needles/1069479630.json",
+    "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/gauge_needles/1069479630",
+    "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5NjMwP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--uuvvwwxx.json",
+    "subscription_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479630/subscription.json",
+    "comments_count": 2,
+    "comments_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479630/comments.json",
+    "boosts_count": 3,
+    "boosts_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479630/boosts.json",
+    "parent": {
+      "id": 1069479800,
+      "title": "Gauge",
+      "type": "Gauge",
+      "url": "https://3.basecampapi.com/195539477/buckets/2085958499/gauges/1069479800.json",
+      "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/gauges/1069479800"
+    },
+    "bucket": {
+      "id": 2085958499,
+      "name": "The Leto Laptop",
+      "type": "Project"
+    },
+    "creator": {
+      "id": 1049715914,
+      "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+      "name": "Victor Cooper",
+      "email_address": "victor@honchodesign.com",
+      "personable_type": "User",
+      "title": "Chief Strategist",
+      "bio": null,
+      "location": null,
+      "created_at": "2022-11-22T08:23:21.732Z",
+      "updated_at": "2022-11-22T08:23:21.732Z",
+      "admin": true,
+      "owner": true,
+      "client": false,
+      "employee": true,
+      "time_zone": "America/Chicago",
+      "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+      "can_manage_projects": true,
+      "can_manage_people": true
+    },
+    "description_attachments": [
+      {
+        "id": 1069479631,
+        "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--srchndl1",
+        "filename": "leto-burndown.png",
+        "content_type": "image/png",
+        "byte_size": 40960,
+        "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--srchndl1/download/leto-burndown.png",
+        "width": 1024.0,
+        "height": 768,
+        "previewable": true,
+        "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--srchndl1/previews/leto-burndown.png",
+        "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--srchndl1/thumbnails/leto-burndown.png"
+      }
+    ],
+    "color": "green",
+    "position": 72,
+    "comment_count": 2,
+    "content": null,
+    "description": null,
+    "plain_text_content": "<mark class=\"circled-text\"><span></span>Leto</mark> hardware is on track for the launch window.",
+    "plain_text_description": "<mark class=\"circled-text\"><span></span>Leto</mark> hardware is on track for the launch window.",
+    "attachments": [
+      {
+        "id": 1069479631,
+        "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--srchndl1",
+        "filename": "leto-burndown.png",
+        "content_type": "image/png",
+        "byte_size": 40960,
+        "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--srchndl1/download/leto-burndown.png",
+        "width": 1024.0,
+        "height": 768,
+        "previewable": true,
+        "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--srchndl1/previews/leto-burndown.png",
+        "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--srchndl1/thumbnails/leto-burndown.png"
+      }
+    ]
   }
 ]

--- a/swift/Sources/Basecamp/Generated/Models/MyAssignmentAssignee.swift
+++ b/swift/Sources/Basecamp/Generated/Models/MyAssignmentAssignee.swift
@@ -2,13 +2,13 @@
 import Foundation
 
 public struct MyAssignmentAssignee: Codable, Sendable {
+    public let avatarUrl: String
     public let id: Int
-    public var avatarUrl: String?
-    public var name: String?
+    public let name: String
 
-    public init(id: Int, avatarUrl: String? = nil, name: String? = nil) {
-        self.id = id
+    public init(avatarUrl: String, id: Int, name: String) {
         self.avatarUrl = avatarUrl
+        self.id = id
         self.name = name
     }
 }

--- a/swift/Sources/Basecamp/Generated/Models/OutOfOfficePerson.swift
+++ b/swift/Sources/Basecamp/Generated/Models/OutOfOfficePerson.swift
@@ -2,13 +2,13 @@
 import Foundation
 
 public struct OutOfOfficePerson: Codable, Sendable {
+    public let avatarUrl: String
     public let id: Int
-    public var avatarUrl: String?
-    public var name: String?
+    public let name: String
 
-    public init(id: Int, avatarUrl: String? = nil, name: String? = nil) {
-        self.id = id
+    public init(avatarUrl: String, id: Int, name: String) {
         self.avatarUrl = avatarUrl
+        self.id = id
         self.name = name
     }
 }

--- a/swift/Sources/Basecamp/Generated/Models/SearchResult.swift
+++ b/swift/Sources/Basecamp/Generated/Models/SearchResult.swift
@@ -2,151 +2,307 @@
 import Foundation
 
 public struct SearchResult: Codable, Sendable {
-    public let appUrl: String
     public let content: String?
     public let description: String?
-    public let id: Int
-    public let title: String
-    public let type: String
-    public let url: String
+    public var appDownloadUrl: String?
+    public var appUrl: String?
+    public var attachments: [SearchResultAttachment]?
     public var bookmarkUrl: String?
+    public var boostsCount: Int32?
+    public var boostsUrl: String?
     public var bubbleUpUrl: String?
     public var bucket: RecordingBucket?
+    public var byteSize: Int?
+    public var cardsCount: Int32?
+    public var cardsUrl: String?
+    public var color: String?
+    public var commentCount: Int32?
+    public var commentsCount: Int32?
+    public var commentsUrl: String?
     public var contentAttachments: [RichTextAttachment]?
+    public var contentType: String?
     public var createdAt: String?
     public var creator: Person?
     public var descriptionAttachments: [RichTextAttachment]?
+    public var downloadUrl: String?
+    public var filename: String?
+    public var height: Int32?
+    public var id: Int?
+    public var imageUrl: String?
     public var inheritsStatus: Bool?
+    public var language: String?
+    public var onHold: CardColumnOnHold?
     public var parent: RecordingParent?
     public var plainTextContent: String?
     public var plainTextDescription: String?
+    public var position: Int32?
+    public var previewUrl: String?
+    public var previewable: Bool?
+    public var soundUrl: String?
     public var status: String?
     public var subject: String?
+    public var subscribers: [Person]?
+    public var subscriptionUrl: String?
+    public var thumbnailUrl: String?
+    public var title: String?
+    public var type: String?
     public var updatedAt: String?
+    public var url: String?
     public var visibleToClients: Bool?
+    public var width: Int32?
 
     public init(
-        appUrl: String,
         content: String?,
         description: String?,
-        id: Int,
-        title: String,
-        type: String,
-        url: String,
+        appDownloadUrl: String? = nil,
+        appUrl: String? = nil,
+        attachments: [SearchResultAttachment]? = nil,
         bookmarkUrl: String? = nil,
+        boostsCount: Int32? = nil,
+        boostsUrl: String? = nil,
         bubbleUpUrl: String? = nil,
         bucket: RecordingBucket? = nil,
+        byteSize: Int? = nil,
+        cardsCount: Int32? = nil,
+        cardsUrl: String? = nil,
+        color: String? = nil,
+        commentCount: Int32? = nil,
+        commentsCount: Int32? = nil,
+        commentsUrl: String? = nil,
         contentAttachments: [RichTextAttachment]? = nil,
+        contentType: String? = nil,
         createdAt: String? = nil,
         creator: Person? = nil,
         descriptionAttachments: [RichTextAttachment]? = nil,
+        downloadUrl: String? = nil,
+        filename: String? = nil,
+        height: Int32? = nil,
+        id: Int? = nil,
+        imageUrl: String? = nil,
         inheritsStatus: Bool? = nil,
+        language: String? = nil,
+        onHold: CardColumnOnHold? = nil,
         parent: RecordingParent? = nil,
         plainTextContent: String? = nil,
         plainTextDescription: String? = nil,
+        position: Int32? = nil,
+        previewUrl: String? = nil,
+        previewable: Bool? = nil,
+        soundUrl: String? = nil,
         status: String? = nil,
         subject: String? = nil,
+        subscribers: [Person]? = nil,
+        subscriptionUrl: String? = nil,
+        thumbnailUrl: String? = nil,
+        title: String? = nil,
+        type: String? = nil,
         updatedAt: String? = nil,
-        visibleToClients: Bool? = nil
+        url: String? = nil,
+        visibleToClients: Bool? = nil,
+        width: Int32? = nil
     ) {
-        self.appUrl = appUrl
         self.content = content
         self.description = description
-        self.id = id
-        self.title = title
-        self.type = type
-        self.url = url
+        self.appDownloadUrl = appDownloadUrl
+        self.appUrl = appUrl
+        self.attachments = attachments
         self.bookmarkUrl = bookmarkUrl
+        self.boostsCount = boostsCount
+        self.boostsUrl = boostsUrl
         self.bubbleUpUrl = bubbleUpUrl
         self.bucket = bucket
+        self.byteSize = byteSize
+        self.cardsCount = cardsCount
+        self.cardsUrl = cardsUrl
+        self.color = color
+        self.commentCount = commentCount
+        self.commentsCount = commentsCount
+        self.commentsUrl = commentsUrl
         self.contentAttachments = contentAttachments
+        self.contentType = contentType
         self.createdAt = createdAt
         self.creator = creator
         self.descriptionAttachments = descriptionAttachments
+        self.downloadUrl = downloadUrl
+        self.filename = filename
+        self.height = height
+        self.id = id
+        self.imageUrl = imageUrl
         self.inheritsStatus = inheritsStatus
+        self.language = language
+        self.onHold = onHold
         self.parent = parent
         self.plainTextContent = plainTextContent
         self.plainTextDescription = plainTextDescription
+        self.position = position
+        self.previewUrl = previewUrl
+        self.previewable = previewable
+        self.soundUrl = soundUrl
         self.status = status
         self.subject = subject
+        self.subscribers = subscribers
+        self.subscriptionUrl = subscriptionUrl
+        self.thumbnailUrl = thumbnailUrl
+        self.title = title
+        self.type = type
         self.updatedAt = updatedAt
+        self.url = url
         self.visibleToClients = visibleToClients
+        self.width = width
     }
 
     enum CodingKeys: String, CodingKey {
-        case appUrl
         case content
         case description
-        case id
-        case title
-        case type
-        case url
+        case appDownloadUrl
+        case appUrl
+        case attachments
         case bookmarkUrl
+        case boostsCount
+        case boostsUrl
         case bubbleUpUrl
         case bucket
+        case byteSize
+        case cardsCount
+        case cardsUrl
+        case color
+        case commentCount
+        case commentsCount
+        case commentsUrl
         case contentAttachments
+        case contentType
         case createdAt
         case creator
         case descriptionAttachments
+        case downloadUrl
+        case filename
+        case height
+        case id
+        case imageUrl
         case inheritsStatus
+        case language
+        case onHold
         case parent
         case plainTextContent
         case plainTextDescription
+        case position
+        case previewUrl
+        case previewable
+        case soundUrl
         case status
         case subject
+        case subscribers
+        case subscriptionUrl
+        case thumbnailUrl
+        case title
+        case type
         case updatedAt
+        case url
         case visibleToClients
+        case width
     }
 
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.appUrl = try container.decode(String.self, forKey: .appUrl)
         self.content = try container.decode(String?.self, forKey: .content)
         self.description = try container.decode(String?.self, forKey: .description)
-        self.id = try container.decode(Int.self, forKey: .id)
-        self.title = try container.decode(String.self, forKey: .title)
-        self.type = try container.decode(String.self, forKey: .type)
-        self.url = try container.decode(String.self, forKey: .url)
+        self.appDownloadUrl = try container.decodeIfPresent(String.self, forKey: .appDownloadUrl)
+        self.appUrl = try container.decodeIfPresent(String.self, forKey: .appUrl)
+        self.attachments = try container.decodeIfPresent([SearchResultAttachment].self, forKey: .attachments)
         self.bookmarkUrl = try container.decodeIfPresent(String.self, forKey: .bookmarkUrl)
+        self.boostsCount = try container.decodeIfPresent(Int32.self, forKey: .boostsCount)
+        self.boostsUrl = try container.decodeIfPresent(String.self, forKey: .boostsUrl)
         self.bubbleUpUrl = try container.decodeIfPresent(String.self, forKey: .bubbleUpUrl)
         self.bucket = try container.decodeIfPresent(RecordingBucket.self, forKey: .bucket)
+        self.byteSize = try container.decodeIfPresent(Int.self, forKey: .byteSize)
+        self.cardsCount = try container.decodeIfPresent(Int32.self, forKey: .cardsCount)
+        self.cardsUrl = try container.decodeIfPresent(String.self, forKey: .cardsUrl)
+        self.color = try container.decodeIfPresent(String.self, forKey: .color)
+        self.commentCount = try container.decodeIfPresent(Int32.self, forKey: .commentCount)
+        self.commentsCount = try container.decodeIfPresent(Int32.self, forKey: .commentsCount)
+        self.commentsUrl = try container.decodeIfPresent(String.self, forKey: .commentsUrl)
         self.contentAttachments = try container.decodeIfPresent([RichTextAttachment].self, forKey: .contentAttachments)
+        self.contentType = try container.decodeIfPresent(String.self, forKey: .contentType)
         self.createdAt = try container.decodeIfPresent(String.self, forKey: .createdAt)
         self.creator = try container.decodeIfPresent(Person.self, forKey: .creator)
         self.descriptionAttachments = try container.decodeIfPresent([RichTextAttachment].self, forKey: .descriptionAttachments)
+        self.downloadUrl = try container.decodeIfPresent(String.self, forKey: .downloadUrl)
+        self.filename = try container.decodeIfPresent(String.self, forKey: .filename)
+        self.height = try container.decodeIfPresent(Int32.self, forKey: .height)
+        self.id = try container.decodeIfPresent(Int.self, forKey: .id)
+        self.imageUrl = try container.decodeIfPresent(String.self, forKey: .imageUrl)
         self.inheritsStatus = try container.decodeIfPresent(Bool.self, forKey: .inheritsStatus)
+        self.language = try container.decodeIfPresent(String.self, forKey: .language)
+        self.onHold = try container.decodeIfPresent(CardColumnOnHold.self, forKey: .onHold)
         self.parent = try container.decodeIfPresent(RecordingParent.self, forKey: .parent)
         self.plainTextContent = try container.decodeIfPresent(String.self, forKey: .plainTextContent)
         self.plainTextDescription = try container.decodeIfPresent(String.self, forKey: .plainTextDescription)
+        self.position = try container.decodeIfPresent(Int32.self, forKey: .position)
+        self.previewUrl = try container.decodeIfPresent(String.self, forKey: .previewUrl)
+        self.previewable = try container.decodeIfPresent(Bool.self, forKey: .previewable)
+        self.soundUrl = try container.decodeIfPresent(String.self, forKey: .soundUrl)
         self.status = try container.decodeIfPresent(String.self, forKey: .status)
         self.subject = try container.decodeIfPresent(String.self, forKey: .subject)
+        self.subscribers = try container.decodeIfPresent([Person].self, forKey: .subscribers)
+        self.subscriptionUrl = try container.decodeIfPresent(String.self, forKey: .subscriptionUrl)
+        self.thumbnailUrl = try container.decodeIfPresent(String.self, forKey: .thumbnailUrl)
+        self.title = try container.decodeIfPresent(String.self, forKey: .title)
+        self.type = try container.decodeIfPresent(String.self, forKey: .type)
         self.updatedAt = try container.decodeIfPresent(String.self, forKey: .updatedAt)
+        self.url = try container.decodeIfPresent(String.self, forKey: .url)
         self.visibleToClients = try container.decodeIfPresent(Bool.self, forKey: .visibleToClients)
+        self.width = try container.decodeIfPresent(Int32.self, forKey: .width)
     }
 
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(self.appUrl, forKey: .appUrl)
         try container.encode(self.content, forKey: .content)
         try container.encode(self.description, forKey: .description)
-        try container.encode(self.id, forKey: .id)
-        try container.encode(self.title, forKey: .title)
-        try container.encode(self.type, forKey: .type)
-        try container.encode(self.url, forKey: .url)
+        try container.encodeIfPresent(self.appDownloadUrl, forKey: .appDownloadUrl)
+        try container.encodeIfPresent(self.appUrl, forKey: .appUrl)
+        try container.encodeIfPresent(self.attachments, forKey: .attachments)
         try container.encodeIfPresent(self.bookmarkUrl, forKey: .bookmarkUrl)
+        try container.encodeIfPresent(self.boostsCount, forKey: .boostsCount)
+        try container.encodeIfPresent(self.boostsUrl, forKey: .boostsUrl)
         try container.encodeIfPresent(self.bubbleUpUrl, forKey: .bubbleUpUrl)
         try container.encodeIfPresent(self.bucket, forKey: .bucket)
+        try container.encodeIfPresent(self.byteSize, forKey: .byteSize)
+        try container.encodeIfPresent(self.cardsCount, forKey: .cardsCount)
+        try container.encodeIfPresent(self.cardsUrl, forKey: .cardsUrl)
+        try container.encodeIfPresent(self.color, forKey: .color)
+        try container.encodeIfPresent(self.commentCount, forKey: .commentCount)
+        try container.encodeIfPresent(self.commentsCount, forKey: .commentsCount)
+        try container.encodeIfPresent(self.commentsUrl, forKey: .commentsUrl)
         try container.encodeIfPresent(self.contentAttachments, forKey: .contentAttachments)
+        try container.encodeIfPresent(self.contentType, forKey: .contentType)
         try container.encodeIfPresent(self.createdAt, forKey: .createdAt)
         try container.encodeIfPresent(self.creator, forKey: .creator)
         try container.encodeIfPresent(self.descriptionAttachments, forKey: .descriptionAttachments)
+        try container.encodeIfPresent(self.downloadUrl, forKey: .downloadUrl)
+        try container.encodeIfPresent(self.filename, forKey: .filename)
+        try container.encodeIfPresent(self.height, forKey: .height)
+        try container.encodeIfPresent(self.id, forKey: .id)
+        try container.encodeIfPresent(self.imageUrl, forKey: .imageUrl)
         try container.encodeIfPresent(self.inheritsStatus, forKey: .inheritsStatus)
+        try container.encodeIfPresent(self.language, forKey: .language)
+        try container.encodeIfPresent(self.onHold, forKey: .onHold)
         try container.encodeIfPresent(self.parent, forKey: .parent)
         try container.encodeIfPresent(self.plainTextContent, forKey: .plainTextContent)
         try container.encodeIfPresent(self.plainTextDescription, forKey: .plainTextDescription)
+        try container.encodeIfPresent(self.position, forKey: .position)
+        try container.encodeIfPresent(self.previewUrl, forKey: .previewUrl)
+        try container.encodeIfPresent(self.previewable, forKey: .previewable)
+        try container.encodeIfPresent(self.soundUrl, forKey: .soundUrl)
         try container.encodeIfPresent(self.status, forKey: .status)
         try container.encodeIfPresent(self.subject, forKey: .subject)
+        try container.encodeIfPresent(self.subscribers, forKey: .subscribers)
+        try container.encodeIfPresent(self.subscriptionUrl, forKey: .subscriptionUrl)
+        try container.encodeIfPresent(self.thumbnailUrl, forKey: .thumbnailUrl)
+        try container.encodeIfPresent(self.title, forKey: .title)
+        try container.encodeIfPresent(self.type, forKey: .type)
         try container.encodeIfPresent(self.updatedAt, forKey: .updatedAt)
+        try container.encodeIfPresent(self.url, forKey: .url)
         try container.encodeIfPresent(self.visibleToClients, forKey: .visibleToClients)
+        try container.encodeIfPresent(self.width, forKey: .width)
     }
 }

--- a/swift/Sources/Basecamp/Generated/Models/SearchResultAttachment.swift
+++ b/swift/Sources/Basecamp/Generated/Models/SearchResultAttachment.swift
@@ -1,0 +1,48 @@
+// @generated from OpenAPI spec — do not edit directly
+import Foundation
+
+public struct SearchResultAttachment: Codable, Sendable {
+    public let byteSize: Int
+    public let contentType: String
+    public let downloadUrl: String
+    public let filename: String
+    public var height: Int32?
+    public var id: Int?
+    public var previewUrl: String?
+    public var previewable: Bool?
+    public var sgid: String?
+    public var thumbnailUrl: String?
+    public var title: String?
+    public var url: String?
+    public var width: Int32?
+
+    public init(
+        byteSize: Int,
+        contentType: String,
+        downloadUrl: String,
+        filename: String,
+        height: Int32? = nil,
+        id: Int? = nil,
+        previewUrl: String? = nil,
+        previewable: Bool? = nil,
+        sgid: String? = nil,
+        thumbnailUrl: String? = nil,
+        title: String? = nil,
+        url: String? = nil,
+        width: Int32? = nil
+    ) {
+        self.byteSize = byteSize
+        self.contentType = contentType
+        self.downloadUrl = downloadUrl
+        self.filename = filename
+        self.height = height
+        self.id = id
+        self.previewUrl = previewUrl
+        self.previewable = previewable
+        self.sgid = sgid
+        self.thumbnailUrl = thumbnailUrl
+        self.title = title
+        self.url = url
+        self.width = width
+    }
+}

--- a/typescript/src/generated/metadata.ts
+++ b/typescript/src/generated/metadata.ts
@@ -37,7 +37,7 @@ export interface MetadataOutput {
 const metadata: MetadataOutput = {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-08-12T15:28:09.913Z",
+  "generated": "2026-08-12T15:52:54.826Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/typescript/src/generated/metadata.ts
+++ b/typescript/src/generated/metadata.ts
@@ -37,7 +37,7 @@ export interface MetadataOutput {
 const metadata: MetadataOutput = {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-08-12T04:40:53.269Z",
+  "generated": "2026-08-12T15:28:09.913Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/typescript/src/generated/openapi-stripped.json
+++ b/typescript/src/generated/openapi-stripped.json
@@ -30797,9 +30797,11 @@
       },
       "SearchResult": {
         "type": "object",
+        "description": "One hit from account-wide search — a polymorphic projection over every\nsearchable recording type.\n\nMost result types render the common recording envelope\n(`recordings/_recording.json.jbuilder`) plus their own recordable partial,\nbut `api_search_result_template_path` special-cases four branches — chat\nlines, kanban (card table) lists, file attachments and gauge needles — and\nthe file-attachment branch writes its own projection from scratch instead\nof the envelope. Members are therefore optional unless every branch emits\nthem; the doc comments name the branches that carry each optional member.",
         "properties": {
           "id": {
             "type": "integer",
+            "description": "The recording id. Optional only because the file-attachment branch\n(`searches/_attachment.json.jbuilder`) skips the recording envelope and\nemits none of the top-level id/title/type/url/app_url keys; every other\nbranch emits all five.",
             "format": "int64"
           },
           "status": {
@@ -30823,22 +30825,30 @@
             }
           },
           "title": {
-            "type": "string"
+            "type": "string",
+            "description": "See `id` — omitted by the file-attachment branch, emitted by every other\nbranch."
           },
           "inherits_status": {
             "type": "boolean"
           },
           "type": {
-            "type": "string"
+            "type": "string",
+            "description": "See `id` — omitted by the file-attachment branch, emitted by every other\nbranch. A file-attachment hit is therefore recognizable by the absence\nof this key (its file keys, `filename` through `app_download_url`, are\nthe positive signal)."
           },
           "url": {
-            "type": "string"
+            "type": "string",
+            "description": "See `id` — omitted by the file-attachment branch, emitted by every other\nbranch."
           },
           "app_url": {
-            "type": "string"
+            "type": "string",
+            "description": "See `id` — omitted by the file-attachment branch, emitted by every other\nbranch."
           },
           "bookmark_url": {
             "type": "string"
+          },
+          "subscription_url": {
+            "type": "string",
+            "description": "Subscription URL, emitted by the common recording envelope for any\nsubscribable result — kanban lists and gauge needles among the special\nbranches, plus subscribable generic-branch types (messages, todos, …)."
           },
           "bubble_up_url": {
             "type": "string",
@@ -30882,7 +30892,7 @@
             "items": {
               "$ref": "#/components/schemas/RichTextAttachment"
             },
-            "description": "Rich-text companion arrays carried through the polymorphic search\nprojection. A given result is one recording type, so it carries only\nthe array matching its rich-text attribute (`content_attachments` for a\nComment/Message, `description_attachments` for a Todo); a webhook-sourced\nresult carries neither. Optional (no `@required`), non-nullable.\n\nSearch results additionally repeat this same array under a generic\n`attachments` key. It is a redundant projection, not a distinct\naggregate: `searches/show.json.jbuilder` emits\n`recording.downloadable_attachments`, which delegates to the recordable's\nsole `rich_text_content`, through the same `attachments/_attachment`\npartial that `recordings/_rich_text.json.jbuilder` uses to build the\ncompanion array. `RichText.rich_text_attribute` permits exactly one\nrich-text attribute per model, so the two keys always carry identical\nelements. Modeling `attachments` would duplicate the field, so it is\ndeliberately not modeled.",
+            "description": "Rich-text companion arrays carried through the polymorphic search\nprojection. A given result is one recording type, so it carries only\nthe array matching its rich-text attribute (`content_attachments` for a\nComment/Message, `description_attachments` for a Todo); a webhook-sourced\nresult carries neither. Optional (no `@required`), non-nullable.",
             "x-go-type-skip-optional-pointer": true
           },
           "description_attachments": {
@@ -30893,18 +30903,219 @@
             "description": "See `content_attachments` — the description-attribute companion array.",
             "x-go-type-skip-optional-pointer": true
           },
+          "attachments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchResultAttachment"
+            },
+            "description": "File attachments on the result, in either of two wire shapes — see\n`SearchResultAttachment`.\n\nFor a result whose recordable carries downloadable rich-text\nattachments, `searches/show.json.jbuilder` emits this key through the\nsame `attachments/_attachment` partial that builds the rich-text\ncompanion array above, so it repeats that array's elements. For a chat\n*upload* line, `chats/lines/_upload.json.jbuilder` instead builds a\nbespoke six-key aggregate inline — and because upload lines have no\nrich-text attribute, the show template never overwrites it, so that\ndistinct shape survives to the wire.",
+            "x-go-type-skip-optional-pointer": true
+          },
           "subject": {
             "type": "string"
+          },
+          "boosts_count": {
+            "type": "integer",
+            "description": "Boost count, emitted by the recording envelope when the branch passes\n`boostable` — chat lines and gauge needles.",
+            "format": "int32"
+          },
+          "boosts_url": {
+            "type": "string",
+            "description": "See `boosts_count` — the companion URL."
+          },
+          "language": {
+            "type": "string",
+            "description": "Language of a code chat line (`chats/lines/_code.json.jbuilder`);\nvalidated present on the model, so never null when the key is emitted."
+          },
+          "image_url": {
+            "type": "string",
+            "description": "Image URL of a soundtracked (play-kind) chat line whose sound carries an\nimage; such a line emits `image_url` in place of `content`."
+          },
+          "sound_url": {
+            "type": "string",
+            "description": "Sound URL of a play-kind chat line; always emitted for that kind."
+          },
+          "subscribers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Person"
+            },
+            "description": "Everyone subscribed to the kanban list, as full Person projections.",
+            "x-go-type-skip-optional-pointer": true
+          },
+          "color": {
+            "type": "string",
+            "description": "Color of a kanban list or gauge needle. Emitted unconditionally by both\nbranches with a null value when unset, so it is nullable (the enhance\npass layers `nullable: true` onto the OpenAPI).",
+            "nullable": true
+          },
+          "cards_count": {
+            "type": "integer",
+            "description": "Number of cards in the kanban list.",
+            "format": "int32"
+          },
+          "comment_count": {
+            "type": "integer",
+            "description": "Comment count of a kanban list or gauge needle (branch-partial key,\nsingular `comment_count` — distinct from the envelope's\n`comments_count`, which a needle also carries).",
+            "format": "int32"
+          },
+          "cards_url": {
+            "type": "string",
+            "description": "API URL of the kanban list's cards."
+          },
+          "on_hold": {
+            "$ref": "#/components/schemas/CardColumnOnHold"
+          },
+          "comments_count": {
+            "type": "integer",
+            "description": "Comment count, emitted by the recording envelope when the branch passes\n`commentable` — gauge needles among the special branches, plus\ncommentable generic-branch types.",
+            "format": "int32"
+          },
+          "comments_url": {
+            "type": "string",
+            "description": "See `comments_count` — the companion URL."
+          },
+          "position": {
+            "type": "integer",
+            "description": "Position of the result. Two emitters share the key: the recording\nenvelope emits list position for positioned recordings (kanban lists\namong the special branches), and the gauge-needle branch overwrites it\nwith the needle's own 0–100 gauge position.",
+            "format": "int32"
+          },
+          "filename": {
+            "type": "string",
+            "description": "Filename of a file-attachment hit. This and the following file keys are\nemitted only by the file-attachment branch — the one branch that omits\nthe id/title/type/url/app_url envelope keys."
+          },
+          "content_type": {
+            "type": "string",
+            "description": "MIME type of a file-attachment hit."
+          },
+          "byte_size": {
+            "type": "integer",
+            "description": "Size in bytes of a file-attachment hit.",
+            "format": "int64"
+          },
+          "previewable": {
+            "type": "boolean",
+            "description": "Whether the file can be previewed."
+          },
+          "width": {
+            "type": "integer",
+            "description": "Pixel width, emitted only when the file is previewable. May be\nfloat-spelled (`1024.0`) and nullable, like every other blob dimension —\nsee `RichTextAttachment.width` for the cross-SDK typing note.",
+            "format": "int32",
+            "nullable": true,
+            "x-go-type": "types.FlexInt",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            }
+          },
+          "height": {
+            "type": "integer",
+            "description": "See `width` — same conditional emission and nullable/float-spelled\nbehavior.",
+            "format": "int32",
+            "nullable": true,
+            "x-go-type": "types.FlexInt",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            }
+          },
+          "preview_url": {
+            "type": "string",
+            "description": "Full-size preview URL of a file-attachment hit."
+          },
+          "thumbnail_url": {
+            "type": "string",
+            "description": "Thumbnail URL of a file-attachment hit."
+          },
+          "download_url": {
+            "type": "string",
+            "description": "Authenticated download URL of a file-attachment hit.",
+            "x-basecamp-auth-routable-url": {}
+          },
+          "app_download_url": {
+            "type": "string",
+            "description": "Web (app-host) download URL of a file-attachment hit."
           }
         },
         "required": [
-          "app_url",
           "content",
-          "description",
-          "id",
-          "title",
-          "type",
-          "url"
+          "description"
+        ]
+      },
+      "SearchResultAttachment": {
+        "type": "object",
+        "description": "A file attached to a search result, in either of two wire shapes.\n\nThis is an optional-field superset over the two variants the search\nprojection emits (the TimelineAttachment approach): the rich-text\nattachment/blob shape rendered through `attachments/_attachment` +\n`blobs/_blob` — the same emitters `RichTextAttachment` models — and the\nbespoke six-key aggregate a chat upload line builds inline in\n`chats/lines/_upload.json.jbuilder`. Only the four keys both variants\nalways emit are `@required`; the rest identify their variant.",
+        "properties": {
+          "filename": {
+            "type": "string",
+            "description": "Original filename (both variants)."
+          },
+          "content_type": {
+            "type": "string",
+            "description": "MIME type of the file (both variants)."
+          },
+          "byte_size": {
+            "type": "integer",
+            "description": "Size of the file in bytes (both variants).",
+            "format": "int64"
+          },
+          "download_url": {
+            "type": "string",
+            "description": "Authenticated download URL for the file (both variants).",
+            "x-basecamp-auth-routable-url": {}
+          },
+          "id": {
+            "type": "integer",
+            "description": "Attachment id (rich-text variant).",
+            "format": "int64"
+          },
+          "sgid": {
+            "type": "string",
+            "description": "Signed global id of the attachment (rich-text variant)."
+          },
+          "previewable": {
+            "type": "boolean",
+            "description": "Whether the blob can be previewed (rich-text variant)."
+          },
+          "preview_url": {
+            "type": "string",
+            "description": "Full-size preview URL (rich-text variant)."
+          },
+          "thumbnail_url": {
+            "type": "string",
+            "description": "Thumbnail URL (rich-text variant)."
+          },
+          "width": {
+            "type": "integer",
+            "description": "Pixel width (rich-text variant) — null for non-image blobs and may be\nfloat-spelled (`1024.0`); see `RichTextAttachment.width`.",
+            "format": "int32",
+            "nullable": true,
+            "x-go-type": "types.FlexInt",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            }
+          },
+          "height": {
+            "type": "integer",
+            "description": "See `width` (rich-text variant).",
+            "format": "int32",
+            "nullable": true,
+            "x-go-type": "types.FlexInt",
+            "x-go-type-import": {
+              "path": "github.com/basecamp/basecamp-sdk/go/pkg/types"
+            }
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the attachment recording (chat upload-line variant)."
+          },
+          "url": {
+            "type": "string",
+            "description": "Browser preview URL of the blob (chat upload-line variant)."
+          }
+        },
+        "required": [
+          "byte_size",
+          "content_type",
+          "download_url",
+          "filename"
         ]
       },
       "SearchType": {

--- a/typescript/src/generated/openapi-stripped.json
+++ b/typescript/src/generated/openapi-stripped.json
@@ -28913,6 +28913,7 @@
       },
       "MyAssignmentAssignee": {
         "type": "object",
+        "description": "A person as bc3's `people/_person_minimal.json.jbuilder` renders them —\nthe same three-key partial behind UpcomingSchedulePerson and\nOutOfOfficePerson. All three keys are emitted unconditionally, so all\nthree are required.",
         "properties": {
           "id": {
             "type": "integer",
@@ -28928,7 +28929,9 @@
           }
         },
         "required": [
-          "id"
+          "avatar_url",
+          "id",
+          "name"
         ]
       },
       "MyAssignmentBucket": {
@@ -29221,6 +29224,7 @@
       },
       "OutOfOfficePerson": {
         "type": "object",
+        "description": "A person as bc3's `people/_person_minimal.json.jbuilder` renders them —\nthe same three-key partial behind UpcomingSchedulePerson and\nMyAssignmentAssignee. All three keys are emitted unconditionally, so all\nthree are required.",
         "properties": {
           "id": {
             "type": "integer",
@@ -29236,7 +29240,9 @@
           }
         },
         "required": [
-          "id"
+          "avatar_url",
+          "id",
+          "name"
         ]
       },
       "PauseQuestionResponseContent": {

--- a/typescript/src/generated/schema.d.ts
+++ b/typescript/src/generated/schema.d.ts
@@ -5049,13 +5049,19 @@ export interface components {
             parent?: components["schemas"]["MyAssignmentParent"];
             children?: components["schemas"]["MyAssignment"][];
         };
+        /**
+         * @description A person as bc3's `people/_person_minimal.json.jbuilder` renders them —
+         *     the same three-key partial behind UpcomingSchedulePerson and
+         *     OutOfOfficePerson. All three keys are emitted unconditionally, so all
+         *     three are required.
+         */
         MyAssignmentAssignee: {
             /** Format: int64 */
             id: number;
             /** Format: password */
-            name?: string;
+            name: string;
             /** Format: password */
-            avatar_url?: string;
+            avatar_url: string;
         };
         MyAssignmentBucket: {
             /** Format: int64 */
@@ -5169,13 +5175,19 @@ export interface components {
             /** @description End date in ISO 8601 format (YYYY-MM-DD) */
             end_date: string;
         };
+        /**
+         * @description A person as bc3's `people/_person_minimal.json.jbuilder` renders them —
+         *     the same three-key partial behind UpcomingSchedulePerson and
+         *     MyAssignmentAssignee. All three keys are emitted unconditionally, so all
+         *     three are required.
+         */
         OutOfOfficePerson: {
             /** Format: int64 */
             id: number;
             /** Format: password */
-            name?: string;
+            name: string;
             /** Format: password */
-            avatar_url?: string;
+            avatar_url: string;
         };
         PauseQuestionResponseContent: {
             paused?: boolean;

--- a/typescript/src/generated/schema.d.ts
+++ b/typescript/src/generated/schema.d.ts
@@ -5817,19 +5817,61 @@ export interface components {
             default_type_label: string;
         };
         SearchResponseContent: components["schemas"]["SearchResult"][];
+        /**
+         * @description One hit from account-wide search — a polymorphic projection over every
+         *     searchable recording type.
+         *
+         *     Most result types render the common recording envelope
+         *     (`recordings/_recording.json.jbuilder`) plus their own recordable partial,
+         *     but `api_search_result_template_path` special-cases four branches — chat
+         *     lines, kanban (card table) lists, file attachments and gauge needles — and
+         *     the file-attachment branch writes its own projection from scratch instead
+         *     of the envelope. Members are therefore optional unless every branch emits
+         *     them; the doc comments name the branches that carry each optional member.
+         */
         SearchResult: {
-            /** Format: int64 */
-            id: number;
+            /**
+             * Format: int64
+             * @description The recording id. Optional only because the file-attachment branch
+             *     (`searches/_attachment.json.jbuilder`) skips the recording envelope and
+             *     emits none of the top-level id/title/type/url/app_url keys; every other
+             *     branch emits all five.
+             */
+            id?: number;
             status?: string;
             visible_to_clients?: boolean;
             created_at?: string;
             updated_at?: string;
-            title: string;
+            /**
+             * @description See `id` — omitted by the file-attachment branch, emitted by every other
+             *     branch.
+             */
+            title?: string;
             inherits_status?: boolean;
-            type: string;
-            url: string;
-            app_url: string;
+            /**
+             * @description See `id` — omitted by the file-attachment branch, emitted by every other
+             *     branch. A file-attachment hit is therefore recognizable by the absence
+             *     of this key (its file keys, `filename` through `app_download_url`, are
+             *     the positive signal).
+             */
+            type?: string;
+            /**
+             * @description See `id` — omitted by the file-attachment branch, emitted by every other
+             *     branch.
+             */
+            url?: string;
+            /**
+             * @description See `id` — omitted by the file-attachment branch, emitted by every other
+             *     branch.
+             */
+            app_url?: string;
             bookmark_url?: string;
+            /**
+             * @description Subscription URL, emitted by the common recording envelope for any
+             *     subscribable result — kanban lists and gauge needles among the special
+             *     branches, plus subscribable generic-branch types (messages, todos, …).
+             */
+            subscription_url?: string;
             /**
              * @description URL of the Bubble Up record for this recording (BC5 addition). Optional
              *     here because this is a polymorphic projection:
@@ -5879,22 +5921,173 @@ export interface components {
              *     the array matching its rich-text attribute (`content_attachments` for a
              *     Comment/Message, `description_attachments` for a Todo); a webhook-sourced
              *     result carries neither. Optional (no `@required`), non-nullable.
-             *
-             *     Search results additionally repeat this same array under a generic
-             *     `attachments` key. It is a redundant projection, not a distinct
-             *     aggregate: `searches/show.json.jbuilder` emits
-             *     `recording.downloadable_attachments`, which delegates to the recordable's
-             *     sole `rich_text_content`, through the same `attachments/_attachment`
-             *     partial that `recordings/_rich_text.json.jbuilder` uses to build the
-             *     companion array. `RichText.rich_text_attribute` permits exactly one
-             *     rich-text attribute per model, so the two keys always carry identical
-             *     elements. Modeling `attachments` would duplicate the field, so it is
-             *     deliberately not modeled.
              */
             content_attachments?: components["schemas"]["RichTextAttachment"][];
             /** @description See `content_attachments` — the description-attribute companion array. */
             description_attachments?: components["schemas"]["RichTextAttachment"][];
+            /**
+             * @description File attachments on the result, in either of two wire shapes — see
+             *     `SearchResultAttachment`.
+             *
+             *     For a result whose recordable carries downloadable rich-text
+             *     attachments, `searches/show.json.jbuilder` emits this key through the
+             *     same `attachments/_attachment` partial that builds the rich-text
+             *     companion array above, so it repeats that array's elements. For a chat
+             *     *upload* line, `chats/lines/_upload.json.jbuilder` instead builds a
+             *     bespoke six-key aggregate inline — and because upload lines have no
+             *     rich-text attribute, the show template never overwrites it, so that
+             *     distinct shape survives to the wire.
+             */
+            attachments?: components["schemas"]["SearchResultAttachment"][];
             subject?: string;
+            /**
+             * Format: int32
+             * @description Boost count, emitted by the recording envelope when the branch passes
+             *     `boostable` — chat lines and gauge needles.
+             */
+            boosts_count?: number;
+            /** @description See `boosts_count` — the companion URL. */
+            boosts_url?: string;
+            /**
+             * @description Language of a code chat line (`chats/lines/_code.json.jbuilder`);
+             *     validated present on the model, so never null when the key is emitted.
+             */
+            language?: string;
+            /**
+             * @description Image URL of a soundtracked (play-kind) chat line whose sound carries an
+             *     image; such a line emits `image_url` in place of `content`.
+             */
+            image_url?: string;
+            /** @description Sound URL of a play-kind chat line; always emitted for that kind. */
+            sound_url?: string;
+            /** @description Everyone subscribed to the kanban list, as full Person projections. */
+            subscribers?: components["schemas"]["Person"][];
+            /**
+             * @description Color of a kanban list or gauge needle. Emitted unconditionally by both
+             *     branches with a null value when unset, so it is nullable (the enhance
+             *     pass layers `nullable: true` onto the OpenAPI).
+             */
+            color?: string | null;
+            /**
+             * Format: int32
+             * @description Number of cards in the kanban list.
+             */
+            cards_count?: number;
+            /**
+             * Format: int32
+             * @description Comment count of a kanban list or gauge needle (branch-partial key,
+             *     singular `comment_count` — distinct from the envelope's
+             *     `comments_count`, which a needle also carries).
+             */
+            comment_count?: number;
+            /** @description API URL of the kanban list's cards. */
+            cards_url?: string;
+            on_hold?: components["schemas"]["CardColumnOnHold"];
+            /**
+             * Format: int32
+             * @description Comment count, emitted by the recording envelope when the branch passes
+             *     `commentable` — gauge needles among the special branches, plus
+             *     commentable generic-branch types.
+             */
+            comments_count?: number;
+            /** @description See `comments_count` — the companion URL. */
+            comments_url?: string;
+            /**
+             * Format: int32
+             * @description Position of the result. Two emitters share the key: the recording
+             *     envelope emits list position for positioned recordings (kanban lists
+             *     among the special branches), and the gauge-needle branch overwrites it
+             *     with the needle's own 0–100 gauge position.
+             */
+            position?: number;
+            /**
+             * @description Filename of a file-attachment hit. This and the following file keys are
+             *     emitted only by the file-attachment branch — the one branch that omits
+             *     the id/title/type/url/app_url envelope keys.
+             */
+            filename?: string;
+            /** @description MIME type of a file-attachment hit. */
+            content_type?: string;
+            /**
+             * Format: int64
+             * @description Size in bytes of a file-attachment hit.
+             */
+            byte_size?: number;
+            /** @description Whether the file can be previewed. */
+            previewable?: boolean;
+            /**
+             * Format: int32
+             * @description Pixel width, emitted only when the file is previewable. May be
+             *     float-spelled (`1024.0`) and nullable, like every other blob dimension —
+             *     see `RichTextAttachment.width` for the cross-SDK typing note.
+             */
+            width?: number | null;
+            /**
+             * Format: int32
+             * @description See `width` — same conditional emission and nullable/float-spelled
+             *     behavior.
+             */
+            height?: number | null;
+            /** @description Full-size preview URL of a file-attachment hit. */
+            preview_url?: string;
+            /** @description Thumbnail URL of a file-attachment hit. */
+            thumbnail_url?: string;
+            /** @description Authenticated download URL of a file-attachment hit. */
+            download_url?: string;
+            /** @description Web (app-host) download URL of a file-attachment hit. */
+            app_download_url?: string;
+        };
+        /**
+         * @description A file attached to a search result, in either of two wire shapes.
+         *
+         *     This is an optional-field superset over the two variants the search
+         *     projection emits (the TimelineAttachment approach): the rich-text
+         *     attachment/blob shape rendered through `attachments/_attachment` +
+         *     `blobs/_blob` — the same emitters `RichTextAttachment` models — and the
+         *     bespoke six-key aggregate a chat upload line builds inline in
+         *     `chats/lines/_upload.json.jbuilder`. Only the four keys both variants
+         *     always emit are `@required`; the rest identify their variant.
+         */
+        SearchResultAttachment: {
+            /** @description Original filename (both variants). */
+            filename: string;
+            /** @description MIME type of the file (both variants). */
+            content_type: string;
+            /**
+             * Format: int64
+             * @description Size of the file in bytes (both variants).
+             */
+            byte_size: number;
+            /** @description Authenticated download URL for the file (both variants). */
+            download_url: string;
+            /**
+             * Format: int64
+             * @description Attachment id (rich-text variant).
+             */
+            id?: number;
+            /** @description Signed global id of the attachment (rich-text variant). */
+            sgid?: string;
+            /** @description Whether the blob can be previewed (rich-text variant). */
+            previewable?: boolean;
+            /** @description Full-size preview URL (rich-text variant). */
+            preview_url?: string;
+            /** @description Thumbnail URL (rich-text variant). */
+            thumbnail_url?: string;
+            /**
+             * Format: int32
+             * @description Pixel width (rich-text variant) — null for non-image blobs and may be
+             *     float-spelled (`1024.0`); see `RichTextAttachment.width`.
+             */
+            width?: number | null;
+            /**
+             * Format: int32
+             * @description See `width` (rich-text variant).
+             */
+            height?: number | null;
+            /** @description Title of the attachment recording (chat upload-line variant). */
+            title?: string;
+            /** @description Browser preview URL of the blob (chat upload-line variant). */
+            url?: string;
         };
         /**
          * @description A selectable search filter option. `key` is the value passed back as a

--- a/typescript/tests/services/my-assignments.test.ts
+++ b/typescript/tests/services/my-assignments.test.ts
@@ -18,6 +18,38 @@ describe("MyAssignmentsService — Up Next writes", () => {
     });
   });
 
+  describe("myAssignments", () => {
+    it("decodes assignees with the full three-key person_minimal projection (#659)", async () => {
+      server.use(
+        http.get(`${BASE_URL}/my/assignments.json`, () =>
+          HttpResponse.json({
+            priorities: [
+              {
+                id: 1,
+                content: "Priority task",
+                // bc3 renders id, name and avatar_url unconditionally.
+                assignees: [
+                  {
+                    id: 1049715914,
+                    name: "Victor Cooper",
+                    avatar_url: "https://example.com/avatar",
+                  },
+                ],
+              },
+            ],
+            non_priorities: [],
+          })
+        )
+      );
+
+      const result = await client.myAssignments.myAssignments();
+      const assignee = result.priorities![0]!.assignees![0]!;
+      expect(assignee.id).toBe(1049715914);
+      expect(assignee.name).toBe("Victor Cooper");
+      expect(assignee.avatar_url).toBe("https://example.com/avatar");
+    });
+  });
+
   describe("prioritizeAssignment", () => {
     it("POSTs the recording id and accepts 204", async () => {
       server.use(

--- a/typescript/tests/services/people.test.ts
+++ b/typescript/tests/services/people.test.ts
@@ -172,7 +172,13 @@ describe("PeopleService", () => {
       server.use(
         http.get(`${BASE_URL}/people/1/out_of_office.json`, () => {
           return HttpResponse.json({
-            person: { id: 1049715913, name: "Victor Cooper" },
+            // person_minimal always renders all three keys, even when out of
+            // office is disabled (#659).
+            person: {
+              id: 1049715913,
+              name: "Victor Cooper",
+              avatar_url: "https://example.com/avatar",
+            },
             enabled: false,
             ongoing: false,
           });

--- a/typescript/tests/services/search.test.ts
+++ b/typescript/tests/services/search.test.ts
@@ -74,6 +74,35 @@ describe("SearchService", () => {
             },
           ],
         },
+        {
+          // A file-attachment hit (searches/_attachment.json.jbuilder): the
+          // one branch that omits the id/title/type/url/app_url envelope keys
+          // and carries the ten file keys instead. width/height ride only on
+          // previewable files and may arrive float-spelled (1920.0).
+          parent: {
+            id: 10,
+            title: "Message Board",
+            type: "Message",
+            url: "https://example.com/buckets/1/messages/11.json",
+            app_url: "https://basecamp.com/buckets/1/messages/11",
+          },
+          bucket: { id: 1, name: "Leto", type: "Project" },
+          created_at: "2022-10-28T15:25:00.000Z",
+          filename: "leto-hero.jpg",
+          content_type: "image/jpeg",
+          byte_size: 512000,
+          previewable: true,
+          width: 1920.0,
+          height: 1080,
+          preview_url: "https://example.com/blobs/hero/previews/leto-hero.jpg",
+          thumbnail_url:
+            "https://example.com/blobs/hero/thumbnails/leto-hero.jpg",
+          download_url: "https://example.com/blobs/hero/download/leto-hero.jpg",
+          app_download_url:
+            "https://basecamp.com/blobs/hero/download/leto-hero.jpg",
+          content: null,
+          description: null,
+        },
       ];
 
       server.use(
@@ -85,7 +114,7 @@ describe("SearchService", () => {
       );
 
       const results = await client.search.search("project");
-      expect(results).toHaveLength(2);
+      expect(results).toHaveLength(3);
       // The optional projection array surfaces on the matching-type result.
       expect(results[1]!.content_attachments).toHaveLength(1);
 
@@ -101,6 +130,24 @@ describe("SearchService", () => {
       expect(results[1]!.content_attachments![0]!.width).toBe(1024);
       expect(results[0]!.title).toBe("Project Plan");
       expect(results[1]!.type).toBe("Message");
+
+      // The file-attachment hit: no envelope keys, file keys instead.
+      const hit = results[2]!;
+      expect(hit.id).toBeUndefined();
+      expect(hit.title).toBeUndefined();
+      expect(hit.type).toBeUndefined();
+      expect(hit.url).toBeUndefined();
+      expect(hit.app_url).toBeUndefined();
+      expect(hit.filename).toBe("leto-hero.jpg");
+      expect(hit.content_type).toBe("image/jpeg");
+      expect(hit.byte_size).toBe(512000);
+      expect(hit.previewable).toBe(true);
+      expect(hit.width).toBe(1920);
+      expect(hit.height).toBe(1080);
+      expect(hit.preview_url).toContain("/previews/");
+      expect(hit.thumbnail_url).toContain("/thumbnails/");
+      expect(hit.download_url).toContain("/download/");
+      expect(hit.app_download_url).toContain("/download/");
     });
 
     it("should support sort option", async () => {


### PR DESCRIPTION
Two spec-shape corrections, one commit per issue, each carrying its own full regeneration across all six SDKs. Both were audited against bc3 at exactly the provenance pin (all four special-cased search branches read from the object store at the pinned revision, every fact re-verified before encoding).

Closes #651. Closes #659.

## SearchResult models what the four special branches actually emit (#651)

bc3's search rendering special-cases four result types (`searches/attachment`, `chats/lines/line`, `kanban/lists/list`, `gauges/needles/needle` — exhaustively enumerated from the dispatch helper; there is no fifth). Only the attachment branch violates the old `@required` set; the others contribute optional keys.

- **Demoted** `id`, `title`, `type`, `url`, `app_url` from `@required` — the attachment branch emits none of them. `content`/`description` **stay required**: the show template nil-overwrites them after every branch partial.
- **Added 26 optional members**: the attachment branch's 10 file keys (width/height are float-spelled ints upstream → the existing `*types.FlexInt` nullable pattern), kanban list keys (`on_hold` reuses `CardColumnOnHold`, whose 8 subkeys match the branch emission exactly), gauge-needle keys, chat-line keys, and common-envelope `subscription_url`.
- **`attachments` got its own element shape.** The old doc comment claimed top-level `attachments` always duplicates the rich-text companion array — falsified by chat *upload* lines, which build a bespoke inline `{title, url, filename, content_type, byte_size, download_url}` aggregate and have no `rich_text_content`, so the overwrite never fires and the bespoke shape reaches the wire. It misses `RichTextAttachment`'s required `id/sgid/previewable/preview_url/thumbnail_url`, so `SearchResultAttachment` is an optional-field superset of both variants (the TimelineAttachment idiom) with only the 4 both-variant keys required. `RichTextAttachment` itself is untouched — its other emitters do guarantee those fields.

openapi diff is exactly the intended change: required `[app_url,content,description,id,title,type,url]` → `[content,description]`, 26 properties added, 0 removed, one new schema, paths identical, no projection side effects.

Fixtures: `spec/fixtures/search/results.json` grew from 4 to 8 hits — one per special branch, including a float-spelled `1920.0` width, a chat-upload bespoke aggregate, `color: null`, and `on_hold` — with the coverage guard red-proved against the old schema (fails on exactly the five demotions + the unknown shape) and green after. Go/TS/Ruby/Python search tests each assert an attachment-branch hit end-to-end; the Go wrapper carries the 26 fields under the wrapper-drift gate (92 pairs, 1245 fields).

## person_minimal's guaranteed keys become @required (#659)

`people/_person_minimal.json.jbuilder` unconditionally emits `id`, `name`, `avatar_url` (`avatar_url` is a route helper, never nil); of its three consuming shapes, `UpcomingSchedulePerson` already marked all three `@required`. `MyAssignmentAssignee` and `OutOfOfficePerson` now match. No projection patch needed — proven by build+diff: exactly the two schemas' `required` arrays change and nothing else.

Generated flips: Go `*string` → `string`; Swift `var String?` → `let String` (decode now throws on a missing key — noted as class B in MIGRATING); TS `name?:` → `name:`; Python `NotRequired[str]` → `str`; Ruby required_fields. Kotlin is a no-op for both commits (no typed Kotlin model exists for these shapes; services return `JsonElement`).

## MIGRATING

New Unreleased section with per-SDK was/now tables for both changes, counts derived per the document's stated-derivation rule.

## Verification

Full serial `make check` green at HEAD ("All checks passed"), including go/kt/py drift, `check-go-optional-pointers`, `check-kotlin-optional-arrays-and-scalars`, fixture coverage, wrapper drift, and doc-constants. Per-suite: Go 0 failures, Ruby 1412 runs/0 failures, TS 1485 passed, Python 1215 passed, Swift 375 passed.

Deliberately out of scope (declared in the commit message): the attachment branch's grandparent parent-id/title quirk (semantic, not structural) and chat lines' dead `subscription_url`/`position`. Follow-up to be filed on close: a six-runner Search conformance fixture (no runner has a mock Search fixture today; Swift doesn't dispatch Search at all).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Models the four special-cased search result branches and makes `person_minimal`’s three keys required. Previously `SearchResult` required `id/title/type/url/app_url`; attachment hits omitted them and the Go wrapper fabricated zeros. Now only `content` and `description` are required, and the Go wrapper uses `omitempty` to preserve key absence.

- Adds optional fields for attachments, kanban lists, gauge needles, chat lines, and shared envelope; width/height accept float-spelled values. Top-level `attachments` is now a typed `SearchResultAttachment` that covers both rich-text and chat-upload shapes.
- Requires `avatar_url` and `name` on `MyAssignmentAssignee` and `OutOfOfficePerson`, matching `person_minimal`. Adds per-SDK tests asserting all three keys on My Assignments reads; updates the out-of-office disabled stub to include `avatar_url`.
- Retires the “attachments” gap in docs by marking it absorbed; the spec references `SearchResult$attachments`/`SearchResultAttachment`.

**Migration**
- Do not assume `id`, `title`, `type`, `url`, or `app_url` exist on every `SearchResult`. Continue to expect `content` and `description` as present (nullable).
- Treat `attachments` elements as `SearchResultAttachment`; do not assume the rich‑text attachment shape.
- Update callers to require `avatar_url` and `name` on `MyAssignmentAssignee` and `OutOfOfficePerson` (e.g., non-optional in Swift/TS, non-pointer in Go, required in Python/Ruby).

<sup>Written for commit d95d470b80d693107d66b7dcc515b78e196ab074. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

