### PR TITLE
Resolve embedded structs in the wrapper-drift field walk

### DIFF
--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -389,9 +389,23 @@ type structFields struct {
 	embeds []embedRef
 	// tagPath maps a PROMOTED tag to the embedded field names traversed to
 	// reach it (`{"Base", "Audit"}` for a field promoted through Base's
-	// embedded Audit). Own tags are absent. populationTargets expands it into
-	// the assignment spellings that count as populating the field.
+	// embedded Audit). Own tags are absent.
 	tagPath map[string][]string
+	// tagTargets holds the assignment spellings that count as populating a
+	// PROMOTED tag, computed during flattening because the legal spellings
+	// depend on Go-name shadowing across the whole promotion tree. Own tags
+	// are absent; see populationTargets.
+	tagTargets map[string][]string
+	// fieldNames lists every field name declared directly on this struct —
+	// tagged or not, exported or not, including the embedded fields' own
+	// names. Go resolves a selector by NAME with the same shallowest-wins
+	// rule, independently of json tags, so this is what decides whether a
+	// promoted field can be written by its bare name.
+	fieldNames []string
+	// taggedEmbeds lists anonymous fields that carry a json tag. They are not
+	// promotion sources, but an unexported one is only on the wire if its type
+	// is a struct — which needs the universe, so flattenEmbedded settles it.
+	taggedEmbeds []taggedEmbed
 	// unresolved lists embedded types the checker could not resolve, as
 	// human-readable paths ("Task.Meta -> time.Time"). Reported as drift when
 	// a pair reaches this struct; see run.
@@ -422,22 +436,60 @@ func (sf *structFields) populationTargets(tag string) []string {
 	if goField == "" {
 		return nil
 	}
-	path := sf.tagPath[tag]
-	if len(path) == 0 {
-		return []string{goField}
+	if targets, ok := sf.tagTargets[tag]; ok {
+		return targets
 	}
-	out := make([]string, 0, len(path)+1+len(path)*(len(path)+1)/2)
+	return []string{goField}
+}
+
+// promotedTargets enumerates the spellings that populate a promoted field,
+// given the depth at which each Go name resolves on the embedding struct
+// (nameDepth, with nameConflict marking names that are ambiguous and therefore
+// unwritable). path is the chain of embedded field names and goField the
+// promoted field.
+//
+// Every suffix of the path is a candidate spelling, because each embed name is
+// itself promoted — but only while the FIRST component of that spelling still
+// resolves to this chain. If a shallower field shares that Go name it wins the
+// selector, and crediting the spelling would attribute a write that lands on a
+// different field: `w.ID = …` on a struct that declares its own ID writes the
+// outer one and leaves the promoted `id` zero, with BOTH keys on the wire.
+func promotedTargets(path []string, goField string, nameDepth map[string]int, nameConflict map[string]bool) []string {
+	resolves := func(name string, depth int) bool {
+		d, ok := nameDepth[name]
+		return ok && d == depth && !nameConflict[name]
+	}
+	var out []string
+	// The field itself, spelled from each suffix of its path. path[i] is
+	// declared at depth i; the field itself at depth len(path).
 	for i := 0; i <= len(path); i++ {
+		first, firstDepth := goField, len(path)
+		if i < len(path) {
+			first, firstDepth = path[i], i
+		}
+		if !resolves(first, firstDepth) {
+			continue
+		}
 		out = append(out, strings.Join(append(append([]string{}, path[i:]...), goField), "."))
 	}
-	// Ancestors: every contiguous sub-path path[i:j] names the embed at
-	// depth j, so an opaque assignment to it covers everything below.
+	// Ancestors: an opaque assignment to any embed on the path covers
+	// everything below it, and each is spelled from any suffix that reaches it.
 	for j := 1; j <= len(path); j++ {
 		for i := 0; i < j; i++ {
+			if !resolves(path[i], i) {
+				continue
+			}
 			out = append(out, strings.Join(path[i:j], ".")+".*")
 		}
 	}
 	return out
+}
+
+// taggedEmbed is an anonymous field carrying its own json tag: an ordinary
+// field under that tag rather than a promotion source.
+type taggedEmbed struct {
+	tag string
+	ref embedRef
 }
 
 // taggedField is one JSON-tagged field declared directly on a struct.
@@ -753,9 +805,21 @@ func collectStructsAndMarkers(fset *token.FileSet, f *ast.File) map[string]*stru
 				omitted:      map[string]bool{},
 				tagToGoField: map[string]string{},
 				tagPath:      map[string][]string{},
+				tagTargets:   map[string][]string{},
 				declaration:  ts.Pos(),
 			}
 			for _, field := range st.Fields.List {
+				// Go resolves selectors by field NAME regardless of tags, so
+				// every name counts for shadowing — including untagged and
+				// unexported ones, and the embedded fields' own names.
+				if len(field.Names) == 0 {
+					if n := embedRefFromExpr(field.Type).name; n != "" {
+						sf.fieldNames = append(sf.fieldNames, n)
+					}
+				}
+				for _, fn := range field.Names {
+					sf.fieldNames = append(sf.fieldNames, fn.Name)
+				}
 				tag := ""
 				if field.Tag != nil {
 					tag = extractJSONTag(field.Tag.Value)
@@ -792,8 +856,12 @@ func collectStructsAndMarkers(fset *token.FileSet, f *ast.File) map[string]*stru
 				if goField == "" {
 					// A TAGGED anonymous field is not promoted — encoding/json
 					// treats it as an ordinary field under its tag, whose Go
-					// field name is the embedded type's name.
-					goField = embedRefFromExpr(field.Type).name
+					// field name is the embedded type's name. Whether it is on
+					// the wire at all depends on the type when the type name is
+					// unexported, which only flattenEmbedded can settle.
+					ref := embedRefFromExpr(field.Type)
+					goField = ref.name
+					sf.taggedEmbeds = append(sf.taggedEmbeds, taggedEmbed{tag: tag, ref: ref})
 				}
 				if goField != "" {
 					sf.tagToGoField[tag] = goField
@@ -923,11 +991,58 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 	}
 
 	// Tags declared directly on the root are claimed at depth 0 and shadow
-	// anything promoted from below.
+	// anything promoted from below — EXCEPT where the root declares one tag
+	// twice, which encoding/json annihilates exactly like a same-depth
+	// promotion conflict. The tag is then on no field's wire output, so it
+	// stays claimed (blocking deeper promotion) but is not present.
 	claimed := map[string]bool{}
+	ownCount := map[string]int{}
+	for _, f := range root.ownFields {
+		ownCount[f.tag]++
+	}
 	for _, f := range root.ownFields {
 		claimed[f.tag] = true
+		if ownCount[f.tag] > 1 {
+			delete(root.tags, f.tag)
+			delete(root.tagToGoField, f.tag)
+		}
 	}
+
+	// A tagged anonymous field of an UNEXPORTED type is only on the wire when
+	// that type is a struct; encoding/json drops the others whatever the tag
+	// says. This needs the universe, so it is settled here rather than at
+	// collection.
+	for _, te := range root.taggedEmbeds {
+		if te.ref.name == "" || ast.IsExported(te.ref.name) {
+			continue
+		}
+		if child, _, err := resolveEmbed(te.ref, structs, decls); err == "" && child != nil {
+			continue
+		}
+		delete(root.tags, te.tag)
+		delete(root.tagToGoField, te.tag)
+	}
+
+	// Go-name resolution, tracked alongside the tag walk: nameDepth records the
+	// shallowest depth at which each field NAME appears and nameConflict the
+	// names two same-depth structs both declare, which makes the selector
+	// ambiguous. promotedTargets needs both to know which spellings of a
+	// promoted field actually reach it.
+	nameDepth := map[string]int{}
+	nameConflict := map[string]bool{}
+	recordNames := func(names []string, depth int, seenThisDepth map[string]bool) {
+		for _, n := range names {
+			if d, ok := nameDepth[n]; ok {
+				if d == depth && seenThisDepth[n] {
+					nameConflict[n] = true
+				}
+				continue
+			}
+			nameDepth[n] = depth
+			seenThisDepth[n] = true
+		}
+	}
+	recordNames(root.fieldNames, 0, map[string]bool{})
 
 	visited := map[string]bool{rootName: true}
 	level := []reached{{name: rootName, sf: root}}
@@ -974,6 +1089,13 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 			visited[r.name] = true
 		}
 
+		// Names first: a spelling's validity depends on what resolves at this
+		// depth and shallower, all of which is known once this level is built.
+		seenThisDepth := map[string]bool{}
+		for _, r := range next {
+			recordNames(r.sf.fieldNames, depth, seenThisDepth)
+		}
+
 		// Gather this depth's contributions before claiming any of them, so
 		// same-depth conflicts can be detected.
 		type candidate struct {
@@ -1014,6 +1136,7 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 				root.tagToGoField[tag] = c.field.goField
 			}
 			root.tagPath[tag] = c.path
+			root.tagTargets[tag] = promotedTargets(c.path, c.field.goField, nameDepth, nameConflict)
 		}
 
 		level = next

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -387,6 +387,12 @@ type structFields struct {
 	// embeds lists this struct's anonymous, untagged fields — the ones whose
 	// tagged fields are promoted onto this struct by encoding/json.
 	embeds []embedRef
+	// ignoredOwn marks ownFields slots encoding/json never sees — a tagged
+	// anonymous field of an unexported non-struct type. Computed once per
+	// struct by flattenEmbedded, and skipped at EVERY promotion depth: a field
+	// the encoder ignores cannot be promoted onto an embedding struct, nor
+	// annihilate or shadow a field the encoder does see.
+	ignoredOwn map[int]bool
 	// tagPath maps a PROMOTED tag to the embedded field names traversed to
 	// reach it (`{"Base", "Audit"}` for a field promoted through Base's
 	// embedded Audit). Own tags are absent.
@@ -917,12 +923,13 @@ func collectStructsAndMarkers(fset *token.FileSet, f *ast.File) map[string]*stru
 // of promoted tags describes the wire shape any more.
 func collectJSONMethodTypes(f *ast.File) map[string]bool {
 	out := map[string]bool{}
+	// Methods declared with a receiver.
 	for _, decl := range f.Decls {
 		fd, ok := decl.(*ast.FuncDecl)
 		if !ok || fd.Recv == nil || len(fd.Recv.List) != 1 {
 			continue
 		}
-		if fd.Name.Name != "MarshalJSON" && fd.Name.Name != "UnmarshalJSON" {
+		if !isJSONMethodName(fd.Name.Name) {
 			continue
 		}
 		recv := fd.Recv.List[0].Type
@@ -933,7 +940,56 @@ func collectJSONMethodTypes(f *ast.File) map[string]bool {
 			out[id.Name] = true
 		}
 	}
+	// Interfaces carrying the method in their method set. Embedding one
+	// promotes it just as embedding a struct with the method does, and the
+	// interface itself has no field to give the walk a second chance.
+	ifaceEmbeds := map[string][]string{}
+	for name, rhs := range collectTypeDecls(f) {
+		it, ok := rhs.(*ast.InterfaceType)
+		if !ok {
+			continue
+		}
+		for _, m := range it.Methods.List {
+			if len(m.Names) == 0 {
+				// An embedded interface: it contributes its whole method set.
+				if id, ok := m.Type.(*ast.Ident); ok {
+					ifaceEmbeds[name] = append(ifaceEmbeds[name], id.Name)
+				}
+				continue
+			}
+			for _, n := range m.Names {
+				if isJSONMethodName(n.Name) {
+					out[name] = true
+				}
+			}
+		}
+	}
+	// Propagate through interface embedding until stable. The universe is
+	// small and the loop is bounded by its size, so a cycle cannot spin.
+	for range ifaceEmbeds {
+		changed := false
+		for name, embedded := range ifaceEmbeds {
+			if out[name] {
+				continue
+			}
+			for _, e := range embedded {
+				if out[e] {
+					out[name] = true
+					changed = true
+				}
+			}
+		}
+		if !changed {
+			break
+		}
+	}
 	return out
+}
+
+// isJSONMethodName reports whether a method name is one whose promotion
+// redirects encoding/json away from a struct's fields.
+func isJSONMethodName(name string) bool {
+	return name == "MarshalJSON" || name == "UnmarshalJSON"
 }
 
 // collectTypeDecls returns every top-level `type X <expr>` declaration in the
@@ -1021,6 +1077,22 @@ const maxEmbedDepth = 16
 // unresolved list — never skipped — and reported by run when a pair reaches
 // them.
 func flattenEmbedded(structs map[string]*structFields, decls map[string]ast.Expr, jsonMethods map[string]bool) {
+	// Settle which fields the encoder ignores before any promotion runs, for
+	// every struct rather than just the roots: the walk reads a descendant's
+	// ownFields directly, so filtering only at depth 0 would promote a tag out
+	// of a field encoding/json never emits.
+	for _, sf := range structs {
+		sf.ignoredOwn = map[int]bool{}
+		for _, te := range sf.taggedEmbeds {
+			if te.ref.name == "" || ast.IsExported(te.ref.name) {
+				continue
+			}
+			if child, _, err := resolveEmbed(te.ref, structs, decls); err == "" && child != nil {
+				continue
+			}
+			sf.ignoredOwn[te.ownIndex] = true
+		}
+	}
 	for name, sf := range structs {
 		flattenOne(name, sf, structs, decls, jsonMethods)
 	}
@@ -1042,22 +1114,6 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 	// twice, which encoding/json annihilates exactly like a same-depth
 	// promotion conflict. The tag is then on no field's wire output, so it
 	// stays claimed (blocking deeper promotion) but is not present.
-	// A tagged anonymous field of an UNEXPORTED type is only on the wire when
-	// that type is a struct; encoding/json drops the others whatever the tag
-	// says. This needs the universe, so it is settled here rather than at
-	// collection — and it has to happen BEFORE dominance, because a field
-	// encoding/json never sees cannot annihilate or shadow one it does.
-	ignoredOwn := map[int]bool{}
-	for _, te := range root.taggedEmbeds {
-		if te.ref.name == "" || ast.IsExported(te.ref.name) {
-			continue
-		}
-		if child, _, err := resolveEmbed(te.ref, structs, decls); err == "" && child != nil {
-			continue
-		}
-		ignoredOwn[te.ownIndex] = true
-	}
-
 	// Rebuild the own-tag view from the surviving fields — deleting the ignored
 	// field's tag outright would take a REAL field's tag with it when the two
 	// collide, which is the phantom drift this ordering exists to avoid. A tag
@@ -1068,7 +1124,7 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 	root.tags = map[string]bool{}
 	root.tagToGoField = map[string]string{}
 	for i, f := range root.ownFields {
-		if ignoredOwn[i] {
+		if root.ignoredOwn[i] {
 			continue
 		}
 		ownCount[f.tag]++
@@ -1087,6 +1143,24 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 			delete(root.tags, tag)
 			delete(root.tagToGoField, tag)
 		}
+	}
+
+	// The own-only view, kept so a discovery that invalidates promotion (a
+	// promoted custom marshaller) can drop every promoted tag and leave the
+	// struct judged on its own declarations alone.
+	ownTags := make(map[string]bool, len(root.tags))
+	for t := range root.tags {
+		ownTags[t] = true
+	}
+	ownTagToGoField := make(map[string]string, len(root.tagToGoField))
+	for t, f := range root.tagToGoField {
+		ownTagToGoField[t] = f
+	}
+	discardPromotions := func() {
+		root.tags = ownTags
+		root.tagToGoField = ownTagToGoField
+		root.tagPath = map[string][]string{}
+		root.tagTargets = map[string][]string{}
 	}
 
 	// Go-name resolution, tracked alongside the tag walk: nameDepth records the
@@ -1130,15 +1204,23 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 						fmt.Sprintf("%s -> %s (%s)", strings.Join(append([]string{rootName}, parent.path...), "."), e.display, err))
 					continue
 				}
-				if jsonMethods[childName] {
+				// Checked on the embed's own name as well as the resolved
+				// struct: an embedded INTERFACE carries the method in its
+				// method set and resolves to no struct at all, so keying only
+				// on the resolution would miss it entirely.
+				if jsonMethods[e.name] || (childName != "" && jsonMethods[childName]) {
 					// Promoting a custom marshaller changes how the WHOLE
-					// embedding struct is encoded, so its tag set no longer
-					// describes the wire at all. Refuse to judge rather than
-					// certify keys the method may never emit.
+					// embedding struct is encoded, so NO promoted tag on this
+					// struct describes the wire any more — not just this
+					// embed's. Method promotion is transitive, so this holds
+					// wherever in the tree the method appears. Report, discard
+					// every promotion made so far, and stop: refusing to judge
+					// beats certifying keys the method may never emit.
 					root.unresolved = append(root.unresolved,
-						fmt.Sprintf("%s -> %s (embedded type declares MarshalJSON/UnmarshalJSON, which the embedding struct promotes; encoding/json then calls it instead of walking these fields)",
+						fmt.Sprintf("%s -> %s (embedded type declares MarshalJSON/UnmarshalJSON, which the embedding struct promotes; encoding/json then calls it instead of walking these fields, so no promoted tag here is trustworthy)",
 							strings.Join(append([]string{rootName}, parent.path...), "."), e.display))
-					continue
+					discardPromotions()
+					return
 				}
 				if child == nil || visited[childName] {
 					// Either the embedded type promotes no JSON-tagged fields
@@ -1181,7 +1263,10 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 		byTag := map[string][]candidate{}
 		var order []string
 		for _, r := range next {
-			for _, f := range r.sf.ownFields {
+			for i, f := range r.sf.ownFields {
+				if r.sf.ignoredOwn[i] {
+					continue
+				}
 				if _, seen := byTag[f.tag]; !seen {
 					order = append(order, f.tag)
 				}

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -123,6 +123,17 @@
 //     each other out — encoding/json emits neither — so the tag counts as
 //     absent, and deeper occurrences stay shadowed (matching
 //     encoding/json's dominantField).
+//   - The same applies to one type reached by two paths at the same depth (the
+//     diamond: Outer embeds Left and Right, both embedding Common). Such a
+//     type is walked once but its arrival count is remembered, and its fields
+//     are entered twice so the rule above annihilates them — mirroring the
+//     nextCount/count pair in encoding/json's typeFields, which duplicates the
+//     field for exactly this reason. Deduplicating without counting would
+//     claim a tag that is not on the wire.
+//   - Unexported fields are ignored, whatever their tag says, because
+//     encoding/json ignores unexported non-anonymous fields; one cannot
+//     satisfy a generated tag. An embedded unexported STRUCT TYPE is the
+//     opposite case — its exported fields promote normally.
 //   - An anonymous field that carries its own json:"…" tag is NOT promoted:
 //     encoding/json treats it as an ordinary named field under that tag, and so
 //     does this check — the tag is recorded, with the embedded type's name as
@@ -145,6 +156,31 @@
 // map, a slice — today: generated.ClientWithResponses embedding ClientInterface)
 // promotes no JSON-tagged fields and contributes nothing. A defined type whose
 // underlying type is another name (`type Alias Base`) is followed to that name.
+//
+// # Population of promoted fields
+//
+// A promoted field can be assigned by several spellings, and the population
+// check accepts each (see populationTargets): the promoted field itself
+// (`w.CreatedAt`), any partially or fully qualified path to it
+// (`w.Audit.CreatedAt`, `w.Base.Audit.CreatedAt`), or an assignment of any
+// embed on the path. That last one is only total coverage when the assigned
+// value is OPAQUE — a call or a variable the walker cannot see inside. When it
+// is a visible struct literal the walker enumerates its keys instead, so
+// `w.Base = Base{ID: g.Id}` populates `id` and nothing else: the fields the
+// literal omits stay zero-valued on the wire, and crediting them would let the
+// next generated field through in silence.
+//
+// What this deliberately does NOT check is whether a pointer embed on the path
+// was initialized before a promoted write. `w.CreatedAt = …` across a nil
+// `*Audit` panics — but that is a loud, immediate crash on the first execution
+// of the path, not the silent zero-valued wire data this guard exists to
+// catch, and the guard is a reachability check by design (it counts a
+// conditional assignment as populated, and does not model statement order).
+// Demanding initialization means recognizing every spelling that provides it,
+// and a walk that misses one manufactures drift — which is the failure #599
+// itself was: it trains people to work around the guard rather than read it.
+// Nil-capability analysis is #621's subject; this walk is the input it needs,
+// not the place to do it.
 //
 // `intentionally-omitted` markers are NOT inherited through an embed: a marker
 // declares that one wrapper deliberately drops a tag of ITS generated
@@ -351,30 +387,57 @@ type structFields struct {
 	// embeds lists this struct's anonymous, untagged fields — the ones whose
 	// tagged fields are promoted onto this struct by encoding/json.
 	embeds []embedRef
-	// tagPopNames maps a PROMOTED tag to the Go field names whose assignment
-	// counts as populating it: the promoted field's own name plus every
-	// embedded field name on the path to it, since assigning the embedded
-	// struct wholesale (`w.Base = Base{...}`) populates everything under it.
-	// Own (non-promoted) tags are absent here; see populationTargets.
-	tagPopNames map[string][]string
+	// tagPath maps a PROMOTED tag to the embedded field names traversed to
+	// reach it (`{"Base", "Audit"}` for a field promoted through Base's
+	// embedded Audit). Own tags are absent. populationTargets expands it into
+	// the assignment spellings that count as populating the field.
+	tagPath map[string][]string
 	// unresolved lists embedded types the checker could not resolve, as
 	// human-readable paths ("Task.Meta -> time.Time"). Reported as drift when
 	// a pair reaches this struct; see run.
 	unresolved []string
 }
 
-// populationTargets returns the Go field names whose assignment counts as
-// populating tag on this struct. For a field declared directly on the struct
-// that is the field itself; for a promoted field it is the field plus the
-// embedded fields on the path to it.
+// populationTargets returns the assignment spellings that count as populating
+// tag on this struct, in the dotted-path vocabulary collectAssignedFields
+// records (see recordAssignedValue).
+//
+// A field declared directly on the struct has exactly one spelling: itself.
+//
+// A PROMOTED field has several, because every embedded field name on its path
+// is itself promoted, so each suffix of that path is legal Go:
+//
+//	w.CreatedAt            — the promoted field
+//	w.Audit.CreatedAt      — through the inner embed, itself promoted
+//	w.Base.Audit.CreatedAt — fully qualified
+//
+// and so is assigning any ancestor OPAQUELY — `w.Base = baseFromGenerated(g)`,
+// which the walker records as the total marker `Base.*` because it cannot see
+// inside the value. Each such ancestor is spelled by any suffix of the path
+// that reaches it. An ancestor assigned from a composite literal produces no
+// total marker: the walker enumerates that literal's keys instead, so a
+// partial literal populates only the fields it names.
 func (sf *structFields) populationTargets(tag string) []string {
-	if names := sf.tagPopNames[tag]; len(names) > 0 {
-		return names
+	goField := sf.tagToGoField[tag]
+	if goField == "" {
+		return nil
 	}
-	if f := sf.tagToGoField[tag]; f != "" {
-		return []string{f}
+	path := sf.tagPath[tag]
+	if len(path) == 0 {
+		return []string{goField}
 	}
-	return nil
+	out := make([]string, 0, len(path)+1+len(path)*(len(path)+1)/2)
+	for i := 0; i <= len(path); i++ {
+		out = append(out, strings.Join(append(append([]string{}, path[i:]...), goField), "."))
+	}
+	// Ancestors: every contiguous sub-path path[i:j] names the embed at
+	// depth j, so an opaque assignment to it covers everything below.
+	for j := 1; j <= len(path); j++ {
+		for i := 0; i < j; i++ {
+			out = append(out, strings.Join(path[i:j], ".")+".*")
+		}
+	}
+	return out
 }
 
 // taggedField is one JSON-tagged field declared directly on a struct.
@@ -689,7 +752,7 @@ func collectStructsAndMarkers(fset *token.FileSet, f *ast.File) map[string]*stru
 				tags:         map[string]bool{},
 				omitted:      map[string]bool{},
 				tagToGoField: map[string]string{},
-				tagPopNames:  map[string][]string{},
+				tagPath:      map[string][]string{},
 				declaration:  ts.Pos(),
 			}
 			for _, field := range st.Fields.List {
@@ -708,7 +771,6 @@ func collectStructsAndMarkers(fset *token.FileSet, f *ast.File) map[string]*stru
 					}
 					continue
 				}
-				sf.tags[tag] = true
 				// Record the Go field identifier for this tag. Tagged
 				// fields in these structs always have exactly one name;
 				// if a field ever had multiple names sharing a tag, the
@@ -717,6 +779,16 @@ func collectStructsAndMarkers(fset *token.FileSet, f *ast.File) map[string]*stru
 				for _, fn := range field.Names {
 					goField = fn.Name
 				}
+				if goField != "" && !ast.IsExported(goField) {
+					// encoding/json ignores unexported non-anonymous fields
+					// whatever their tag says, so this one is not on the wire
+					// and must not satisfy a generated tag. (Embedded
+					// unexported STRUCT TYPES are a different case: their
+					// exported fields do promote, and resolveEmbed handles
+					// them.)
+					continue
+				}
+				sf.tags[tag] = true
 				if goField == "" {
 					// A TAGGED anonymous field is not promoted — encoding/json
 					// treats it as an ordinary field under its tag, whose Go
@@ -862,6 +934,13 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 
 	for depth := 1; depth <= maxEmbedDepth && len(level) > 0; depth++ {
 		var next []reached
+		// reaches counts how many distinct paths arrive at each type AT THIS
+		// DEPTH. encoding/json queues such a type once but remembers the count
+		// and then duplicates its fields so the annihilation rule sees the
+		// conflict (see the nextCount/count pair in encoding/json's
+		// typeFields). Deduplicating without counting would promote a tag that
+		// two equal-depth paths actually annihilate.
+		reaches := map[string]int{}
 		for _, parent := range level {
 			for _, e := range parent.sf.embeds {
 				child, childName, err := resolveEmbed(e, structs, decls)
@@ -872,18 +951,27 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 				}
 				if child == nil || visited[childName] {
 					// Either the embedded type promotes no JSON-tagged fields
-					// (an interface, a map, a slice), or it has already been
-					// visited at this or a shallower depth — encoding/json
-					// likewise visits each type once, which also terminates
-					// embedding cycles.
+					// (an interface, a map, a slice), or it was already reached
+					// at a SHALLOWER depth — encoding/json likewise visits each
+					// type once, which also terminates embedding cycles.
 					continue
 				}
-				visited[childName] = true
+				reaches[childName]++
+				if reaches[childName] > 1 {
+					// Same type, same depth, second path: counted above, queued
+					// once.
+					continue
+				}
 				path := make([]string, 0, len(parent.path)+1)
 				path = append(path, parent.path...)
 				path = append(path, e.name)
 				next = append(next, reached{name: childName, sf: child, path: path})
 			}
+		}
+		// Marking visited only once the whole level is gathered is what keeps
+		// the second same-depth path visible to the count above.
+		for _, r := range next {
+			visited[r.name] = true
 		}
 
 		// Gather this depth's contributions before claiming any of them, so
@@ -900,6 +988,12 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 					order = append(order, f.tag)
 				}
 				byTag[f.tag] = append(byTag[f.tag], candidate{field: f, path: r.path})
+				if reaches[r.name] > 1 {
+					// Reached by more than one path at this depth: every field
+					// it contributes is ambiguous with itself, which the
+					// same-depth rule below turns into an annihilation.
+					byTag[f.tag] = append(byTag[f.tag], candidate{field: f, path: r.path})
+				}
 			}
 		}
 		for _, tag := range order {
@@ -919,14 +1013,7 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 			if c.field.goField != "" {
 				root.tagToGoField[tag] = c.field.goField
 			}
-			// Assigning any embedded struct on the path populates everything
-			// promoted through it, as does assigning the promoted field itself.
-			targets := make([]string, 0, len(c.path)+1)
-			targets = append(targets, c.path...)
-			if c.field.goField != "" {
-				targets = append(targets, c.field.goField)
-			}
-			root.tagPopNames[tag] = targets
+			root.tagPath[tag] = c.path
 		}
 
 		level = next
@@ -1097,18 +1184,24 @@ func collectAssignedFields(f *ast.File) map[string]map[string]bool {
 						continue
 					}
 					if key, ok := kv.Key.(*ast.Ident); ok {
-						assigned[key.Name] = true
+						recordAssignedValue(assigned, key.Name, kv.Value)
 					}
 				}
 			case *ast.AssignStmt:
-				for _, lhs := range node.Lhs {
-					if base, name := selectorBaseAndField(lhs); name != "" && wrapperVars[base] {
-						assigned[name] = true
+				for i, lhs := range node.Lhs {
+					base, path := selectorRootAndPath(lhs)
+					if path == "" || !wrapperVars[base] {
+						continue
 					}
+					var value ast.Expr
+					if len(node.Lhs) == len(node.Rhs) {
+						value = node.Rhs[i]
+					}
+					recordAssignedValue(assigned, path, value)
 				}
 			case *ast.IncDecStmt:
-				if base, name := selectorBaseAndField(node.X); name != "" && wrapperVars[base] {
-					assigned[name] = true
+				if base, path := selectorRootAndPath(node.X); path != "" && wrapperVars[base] {
+					recordAssignedValue(assigned, path, nil)
 				}
 			}
 			return true
@@ -1201,21 +1294,79 @@ func litTypeName(expr ast.Expr) string {
 	return ""
 }
 
-// selectorBaseAndField decomposes an `x.Field` selector rooted in a bare
-// identifier into its base identifier and field name (`c.Creator` -> "c",
-// "Creator"). Returns "", "" for anything else (index expressions, deeper
-// chains like `a.b.c`, non-selector expressions). The base lets callers scope
-// the write to a known wrapper variable.
-func selectorBaseAndField(expr ast.Expr) (base, field string) {
-	sel, ok := expr.(*ast.SelectorExpr)
-	if !ok {
+// recordAssignedValue records every population fact implied by assigning value
+// to path (a dotted field path relative to the wrapper instance, e.g. "Base" or
+// "Base.Audit"). It is the single vocabulary the population check reads through
+// populationTargets.
+//
+// The path itself is always recorded. What the assignment covers BELOW that
+// path depends on whether the walker can see inside the value:
+//
+//   - A struct composite literal (`Base{ID: g.Id}`, `&Base{...}`) is
+//     enumerated: each key becomes `path.Key`, recursively. A partial literal
+//     therefore covers only the fields it names — assigning an embedded struct
+//     with two of its five fields set leaves the other three unpopulated, which
+//     is the true wire outcome and must not read as full coverage.
+//   - Anything else — a function call, a variable, a slice or map literal — is
+//     opaque, and gets the total marker `path.*`: the walker cannot enumerate
+//     it, and crediting the whole subtree matches the one-level-nesting
+//     doctrine the check already applies to nested wrappers (`c.Creator =
+//     &creator` counts, and Person's own fields are verified through Person's
+//     own pair).
+//
+// A nil value means the write had no readable right-hand side (`x.F++`), which
+// is treated as opaque.
+func recordAssignedValue(assigned map[string]bool, path string, value ast.Expr) {
+	if path == "" {
+		return
+	}
+	assigned[path] = true
+	if lit := structLiteral(value); lit != nil {
+		for _, elt := range lit.Elts {
+			kv, ok := elt.(*ast.KeyValueExpr)
+			if !ok {
+				continue
+			}
+			if key, ok := kv.Key.(*ast.Ident); ok {
+				recordAssignedValue(assigned, path+"."+key.Name, kv.Value)
+			}
+		}
+		return
+	}
+	assigned[path+".*"] = true
+}
+
+// structLiteral returns the composite literal behind expr when it is a
+// bare-identifier-typed struct literal (`Base{...}` or `&Base{...}`), and nil
+// otherwise — including for slice, map and qualified-type literals, whose
+// contents say nothing about a wrapper's fields.
+func structLiteral(expr ast.Expr) *ast.CompositeLit {
+	if u, ok := expr.(*ast.UnaryExpr); ok && u.Op == token.AND {
+		expr = u.X
+	}
+	cl, ok := expr.(*ast.CompositeLit)
+	if !ok || litTypeName(cl.Type) == "" {
+		return nil
+	}
+	return cl
+}
+
+// selectorRootAndPath decomposes an identifier-rooted selector chain into its
+// root identifier and the dotted path below it: `t.Base.ID` -> ("t",
+// "Base.ID"), `c.Creator` -> ("c", "Creator"). Returns "", "" for anything not
+// rooted in a bare identifier, or for a bare identifier with no field selected.
+// Keeping the full path (rather than only the final field) is what lets the
+// population check recognize a fully-qualified write to a promoted field.
+func selectorRootAndPath(expr ast.Expr) (root, path string) {
+	full := exprToPath(expr)
+	if full == "" {
 		return "", ""
 	}
-	ident, ok := sel.X.(*ast.Ident)
-	if !ok {
+	dot := strings.IndexByte(full, '.')
+	if dot == -1 {
 		return "", ""
 	}
-	return ident.Name, sel.Sel.Name
+	return full[:dot], full[dot+1:]
 }
 
 // exprToPath converts an identifier-rooted selector chain into a dotted path
@@ -1235,24 +1386,6 @@ func exprToPath(expr ast.Expr) string {
 		return base + "." + e.Sel.Name
 	}
 	return ""
-}
-
-// pathPrefixAndField decomposes any identifier-rooted selector expression into
-// its prefix-path string and final field name. `q.Schedule.WeekInstance` ->
-// ("q.Schedule", "WeekInstance"); `resp.ID` -> ("resp", "ID"). Returns "", ""
-// for non-selector or non-identifier-rooted expressions. The prefix lets
-// callers look up a previously-recorded composite-literal binding to determine
-// which wrapper this write targets.
-func pathPrefixAndField(expr ast.Expr) (prefix, field string) {
-	sel, ok := expr.(*ast.SelectorExpr)
-	if !ok {
-		return "", ""
-	}
-	prefix = exprToPath(sel.X)
-	if prefix == "" {
-		return "", ""
-	}
-	return prefix, sel.Sel.Name
 }
 
 // collectCompositeLiteralFields walks every function body in f and, for each
@@ -1286,7 +1419,7 @@ func collectCompositeLiteralFields(f *ast.File, tier3 map[string]bool) map[strin
 	if len(tier3) == 0 {
 		return out
 	}
-	addField := func(wrapper, field string) {
+	addValue := func(wrapper, path string, value ast.Expr) {
 		if !tier3[wrapper] {
 			return
 		}
@@ -1295,7 +1428,7 @@ func collectCompositeLiteralFields(f *ast.File, tier3 map[string]bool) map[strin
 			set = map[string]bool{}
 			out[wrapper] = set
 		}
-		set[field] = true
+		recordAssignedValue(set, path, value)
 	}
 	for _, decl := range f.Decls {
 		fd, ok := decl.(*ast.FuncDecl)
@@ -1313,7 +1446,7 @@ func collectCompositeLiteralFields(f *ast.File, tier3 map[string]bool) map[strin
 							continue
 						}
 						if key, ok := kv.Key.(*ast.Ident); ok {
-							addField(t, key.Name)
+							addValue(t, key.Name, kv.Value)
 						}
 					}
 				}
@@ -1330,24 +1463,50 @@ func collectCompositeLiteralFields(f *ast.File, tier3 map[string]bool) map[strin
 					}
 				}
 				// Attribute selector-target writes to any bound path.
-				for _, lhs := range node.Lhs {
-					if prefix, field := pathPrefixAndField(lhs); field != "" {
-						if wrapper, ok := bindings[prefix]; ok {
-							addField(wrapper, field)
-						}
+				for i, lhs := range node.Lhs {
+					wrapper, rest := boundWrapperAndPath(bindings, lhs)
+					if rest == "" {
+						continue
 					}
+					var value ast.Expr
+					if len(node.Lhs) == len(node.Rhs) {
+						value = node.Rhs[i]
+					}
+					addValue(wrapper, rest, value)
 				}
 			case *ast.IncDecStmt:
-				if prefix, field := pathPrefixAndField(node.X); field != "" {
-					if wrapper, ok := bindings[prefix]; ok {
-						addField(wrapper, field)
-					}
+				if wrapper, rest := boundWrapperAndPath(bindings, node.X); rest != "" {
+					addValue(wrapper, rest, nil)
 				}
 			}
 			return true
 		})
 	}
 	return out
+}
+
+// boundWrapperAndPath matches a write target against the composite-literal
+// bindings recorded in one function body, returning the tier-3 wrapper it
+// belongs to and the dotted path of the write RELATIVE to that binding:
+// with `resp := Wrapper{...}` bound at "resp", `resp.Base.ID = …` yields
+// ("Wrapper", "Base.ID"). The longest matching binding wins, so a nested
+// binding is preferred over an enclosing one. Returns "", "" for a write
+// against an unbound path.
+func boundWrapperAndPath(bindings map[string]string, lhs ast.Expr) (wrapper, path string) {
+	full := exprToPath(lhs)
+	if full == "" {
+		return "", ""
+	}
+	best := ""
+	for prefix := range bindings {
+		if strings.HasPrefix(full, prefix+".") && len(prefix) > len(best) {
+			best = prefix
+		}
+	}
+	if best == "" {
+		return "", ""
+	}
+	return bindings[best], full[len(best)+1:]
 }
 
 // extractGeneratedTypeName recognizes `generated.X` (SelectorExpr) and returns

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -490,6 +490,10 @@ func promotedTargets(path []string, goField string, nameDepth map[string]int, na
 type taggedEmbed struct {
 	tag string
 	ref embedRef
+	// ownIndex is this field's slot in ownFields, so flattenEmbedded can take
+	// it out of the depth-0 dominance candidates when encoding/json ignores
+	// the field outright.
+	ownIndex int
 }
 
 // taggedField is one JSON-tagged field declared directly on a struct.
@@ -569,7 +573,7 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 		return fmt.Errorf("parse generated: %w", err)
 	}
 	genStructs := collectStructsAndMarkers(fset, genFile)
-	flattenEmbedded(genStructs, collectTypeDecls(genFile))
+	flattenEmbedded(genStructs, collectTypeDecls(genFile), collectJSONMethodTypes(genFile))
 
 	// Parse all wrapper files.
 	entries, err := os.ReadDir(wrapperDir)
@@ -578,6 +582,7 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 	}
 	wrapperStructs := map[string]*structFields{}
 	wrapperTypeDecls := map[string]ast.Expr{}      // every top-level type decl in the wrapper package, for embed resolution
+	wrapperJSONMethods := map[string]bool{}        // types declaring MarshalJSON/UnmarshalJSON, whose promotion invalidates flattening
 	fromGenPairs := map[string]string{}            // wrapper name -> generated name (derived from *FromGenerated signatures)
 	assignedFields := map[string]map[string]bool{} // wrapper name -> set of Go fields written at the wrapper's construction site (tier 1 + tier 3)
 	// Tier-3 names sourced from the production tier3Wrappers set. Tests can
@@ -599,6 +604,9 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 		}
 		for k, v := range collectTypeDecls(f) {
 			wrapperTypeDecls[k] = v
+		}
+		for k := range collectJSONMethodTypes(f) {
+			wrapperJSONMethods[k] = true
 		}
 		// collectFromGeneratedPairs already drops excluded functions by their
 		// function name (see excludedFromGenerated check inside it), so no
@@ -637,7 +645,7 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 
 	// Every wrapper file is parsed, so embedded types can now be resolved
 	// across the package: an embed may name a struct declared in another file.
-	flattenEmbedded(wrapperStructs, wrapperTypeDecls)
+	flattenEmbedded(wrapperStructs, wrapperTypeDecls, wrapperJSONMethods)
 
 	// Build the final pair list: union of fromGen + directDecode.
 	pairs := map[string]string{}
@@ -835,10 +843,22 @@ func collectStructsAndMarkers(fset *token.FileSet, f *ast.File) map[string]*stru
 					}
 					continue
 				}
-				// Record the Go field identifier for this tag. Tagged
-				// fields in these structs always have exactly one name;
-				// if a field ever had multiple names sharing a tag, the
-				// last wins (still correct for membership lookups).
+				// A grouped declaration (`A, B string ` + "`json:\"x\"`" + `) is TWO
+				// fields to encoding/json, which then annihilates them for
+				// sharing a tag at one depth. Record one candidate per name so
+				// the dominance rules see the conflict.
+				if len(field.Names) > 1 {
+					for _, fn := range field.Names {
+						if !ast.IsExported(fn.Name) {
+							continue
+						}
+						sf.tags[tag] = true
+						sf.tagToGoField[tag] = fn.Name
+						sf.ownFields = append(sf.ownFields, taggedField{tag: tag, goField: fn.Name})
+					}
+					continue
+				}
+				// Record the Go field identifier for this tag.
 				goField := ""
 				for _, fn := range field.Names {
 					goField = fn.Name
@@ -861,7 +881,7 @@ func collectStructsAndMarkers(fset *token.FileSet, f *ast.File) map[string]*stru
 					// unexported, which only flattenEmbedded can settle.
 					ref := embedRefFromExpr(field.Type)
 					goField = ref.name
-					sf.taggedEmbeds = append(sf.taggedEmbeds, taggedEmbed{tag: tag, ref: ref})
+					sf.taggedEmbeds = append(sf.taggedEmbeds, taggedEmbed{tag: tag, ref: ref, ownIndex: len(sf.ownFields)})
 				}
 				if goField != "" {
 					sf.tagToGoField[tag] = goField
@@ -884,6 +904,33 @@ func collectStructsAndMarkers(fset *token.FileSet, f *ast.File) map[string]*stru
 				}
 			}
 			out[ts.Name.Name] = sf
+		}
+	}
+	return out
+}
+
+// collectJSONMethodTypes returns the names of types in this file that declare
+// MarshalJSON or UnmarshalJSON, on either a value or a pointer receiver.
+// Embedding such a type promotes the method, which makes the EMBEDDING type
+// implement json.Marshaler / json.Unmarshaler too — so encoding/json calls that
+// method for the whole struct instead of walking its fields, and no comparison
+// of promoted tags describes the wire shape any more.
+func collectJSONMethodTypes(f *ast.File) map[string]bool {
+	out := map[string]bool{}
+	for _, decl := range f.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok || fd.Recv == nil || len(fd.Recv.List) != 1 {
+			continue
+		}
+		if fd.Name.Name != "MarshalJSON" && fd.Name.Name != "UnmarshalJSON" {
+			continue
+		}
+		recv := fd.Recv.List[0].Type
+		if star, ok := recv.(*ast.StarExpr); ok {
+			recv = star.X
+		}
+		if id, ok := recv.(*ast.Ident); ok {
+			out[id.Name] = true
 		}
 	}
 	return out
@@ -973,14 +1020,14 @@ const maxEmbedDepth = 16
 // full rule list. Unresolvable embeds are recorded on the embedding struct's
 // unresolved list — never skipped — and reported by run when a pair reaches
 // them.
-func flattenEmbedded(structs map[string]*structFields, decls map[string]ast.Expr) {
+func flattenEmbedded(structs map[string]*structFields, decls map[string]ast.Expr, jsonMethods map[string]bool) {
 	for name, sf := range structs {
-		flattenOne(name, sf, structs, decls)
+		flattenOne(name, sf, structs, decls, jsonMethods)
 	}
 }
 
 // flattenOne performs the breadth-first promotion walk for a single struct.
-func flattenOne(rootName string, root *structFields, structs map[string]*structFields, decls map[string]ast.Expr) {
+func flattenOne(rootName string, root *structFields, structs map[string]*structFields, decls map[string]ast.Expr, jsonMethods map[string]bool) {
 	// A struct reached at depth d contributes its own tagged fields at depth d;
 	// path records the embedded field names traversed to reach it, both for
 	// population targets and for unresolvable-embed messages.
@@ -995,23 +1042,12 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 	// twice, which encoding/json annihilates exactly like a same-depth
 	// promotion conflict. The tag is then on no field's wire output, so it
 	// stays claimed (blocking deeper promotion) but is not present.
-	claimed := map[string]bool{}
-	ownCount := map[string]int{}
-	for _, f := range root.ownFields {
-		ownCount[f.tag]++
-	}
-	for _, f := range root.ownFields {
-		claimed[f.tag] = true
-		if ownCount[f.tag] > 1 {
-			delete(root.tags, f.tag)
-			delete(root.tagToGoField, f.tag)
-		}
-	}
-
 	// A tagged anonymous field of an UNEXPORTED type is only on the wire when
 	// that type is a struct; encoding/json drops the others whatever the tag
 	// says. This needs the universe, so it is settled here rather than at
-	// collection.
+	// collection — and it has to happen BEFORE dominance, because a field
+	// encoding/json never sees cannot annihilate or shadow one it does.
+	ignoredOwn := map[int]bool{}
 	for _, te := range root.taggedEmbeds {
 		if te.ref.name == "" || ast.IsExported(te.ref.name) {
 			continue
@@ -1019,8 +1055,38 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 		if child, _, err := resolveEmbed(te.ref, structs, decls); err == "" && child != nil {
 			continue
 		}
-		delete(root.tags, te.tag)
-		delete(root.tagToGoField, te.tag)
+		ignoredOwn[te.ownIndex] = true
+	}
+
+	// Rebuild the own-tag view from the surviving fields — deleting the ignored
+	// field's tag outright would take a REAL field's tag with it when the two
+	// collide, which is the phantom drift this ordering exists to avoid. A tag
+	// whose only carrier was an ignored field is simply absent, and stays
+	// unclaimed so a promotion can still supply it.
+	claimed := map[string]bool{}
+	ownCount := map[string]int{}
+	root.tags = map[string]bool{}
+	root.tagToGoField = map[string]string{}
+	for i, f := range root.ownFields {
+		if ignoredOwn[i] {
+			continue
+		}
+		ownCount[f.tag]++
+		claimed[f.tag] = true
+		root.tags[f.tag] = true
+		if f.goField != "" {
+			root.tagToGoField[f.tag] = f.goField
+		}
+	}
+	// Two surviving fields sharing a tag annihilate: encoding/json emits
+	// neither, so the tag is not on the wire — but it stays claimed, which
+	// blocks a deeper promotion from filling the vacancy, as dominantField
+	// gives up on the tie rather than falling through.
+	for tag, n := range ownCount {
+		if n > 1 {
+			delete(root.tags, tag)
+			delete(root.tagToGoField, tag)
+		}
 	}
 
 	// Go-name resolution, tracked alongside the tag walk: nameDepth records the
@@ -1062,6 +1128,16 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 				if err != "" {
 					root.unresolved = append(root.unresolved,
 						fmt.Sprintf("%s -> %s (%s)", strings.Join(append([]string{rootName}, parent.path...), "."), e.display, err))
+					continue
+				}
+				if jsonMethods[childName] {
+					// Promoting a custom marshaller changes how the WHOLE
+					// embedding struct is encoded, so its tag set no longer
+					// describes the wire at all. Refuse to judge rather than
+					// certify keys the method may never emit.
+					root.unresolved = append(root.unresolved,
+						fmt.Sprintf("%s -> %s (embedded type declares MarshalJSON/UnmarshalJSON, which the embedding struct promotes; encoding/json then calls it instead of walking these fields)",
+							strings.Join(append([]string{rootName}, parent.path...), "."), e.display))
 					continue
 				}
 				if child == nil || visited[childName] {
@@ -1453,19 +1529,46 @@ func recordAssignedValue(assigned map[string]bool, path string, value ast.Expr) 
 		return
 	}
 	assigned[path] = true
+	if id, ok := unparen(value).(*ast.Ident); ok && id.Name == "nil" {
+		// Assigning nil to a pointer embed populates nothing — encoding/json
+		// emits none of its promoted fields — so the write is recorded without
+		// any subtree coverage.
+		return
+	}
 	if lit := structLiteral(value); lit != nil {
+		keyed := false
 		for _, elt := range lit.Elts {
 			kv, ok := elt.(*ast.KeyValueExpr)
 			if !ok {
 				continue
 			}
+			keyed = true
 			if key, ok := kv.Key.(*ast.Ident); ok {
 				recordAssignedValue(assigned, path+"."+key.Name, kv.Value)
 			}
 		}
-		return
+		if keyed || len(lit.Elts) == 0 {
+			// A keyed literal covers exactly the keys enumerated above. An
+			// empty literal covers nothing.
+			return
+		}
+		// A positional literal must list every field of the struct, so it
+		// covers the whole subtree.
 	}
 	assigned[path+".*"] = true
+}
+
+// unparen strips redundant parentheses: `(Base{...})` is the same value as
+// `Base{...}`, and classifying the parenthesized form as opaque would credit a
+// subtree the literal only partly fills.
+func unparen(expr ast.Expr) ast.Expr {
+	for {
+		p, ok := expr.(*ast.ParenExpr)
+		if !ok {
+			return expr
+		}
+		expr = p.X
+	}
 }
 
 // structLiteral returns the composite literal behind expr when it is a
@@ -1473,8 +1576,9 @@ func recordAssignedValue(assigned map[string]bool, path string, value ast.Expr) 
 // otherwise — including for slice, map and qualified-type literals, whose
 // contents say nothing about a wrapper's fields.
 func structLiteral(expr ast.Expr) *ast.CompositeLit {
+	expr = unparen(expr)
 	if u, ok := expr.(*ast.UnaryExpr); ok && u.Op == token.AND {
-		expr = u.X
+		expr = unparen(u.X)
 	}
 	cl, ok := expr.(*ast.CompositeLit)
 	if !ok || litTypeName(cl.Type) == "" {

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -579,7 +579,9 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 		return fmt.Errorf("parse generated: %w", err)
 	}
 	genStructs := collectStructsAndMarkers(fset, genFile)
-	flattenEmbedded(genStructs, collectTypeDecls(genFile), collectJSONMethodTypes(genFile))
+	genJSONMethods, genIfaceEmbeds := collectJSONMethodTypes(genFile)
+	closeJSONMethodTypes(genJSONMethods, genIfaceEmbeds)
+	flattenEmbedded(genStructs, collectTypeDecls(genFile), genJSONMethods)
 
 	// Parse all wrapper files.
 	entries, err := os.ReadDir(wrapperDir)
@@ -587,8 +589,9 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 		return fmt.Errorf("read wrapper dir: %w", err)
 	}
 	wrapperStructs := map[string]*structFields{}
-	wrapperTypeDecls := map[string]ast.Expr{}      // every top-level type decl in the wrapper package, for embed resolution
+	wrapperTypeDecls := map[string]typeDecl{}      // every top-level type decl in the wrapper package, for embed resolution
 	wrapperJSONMethods := map[string]bool{}        // types declaring MarshalJSON/UnmarshalJSON, whose promotion invalidates flattening
+	wrapperIfaceEmbeds := map[string][]string{}    // interface -> embedded interfaces, closed once every file is in
 	fromGenPairs := map[string]string{}            // wrapper name -> generated name (derived from *FromGenerated signatures)
 	assignedFields := map[string]map[string]bool{} // wrapper name -> set of Go fields written at the wrapper's construction site (tier 1 + tier 3)
 	// Tier-3 names sourced from the production tier3Wrappers set. Tests can
@@ -611,8 +614,12 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 		for k, v := range collectTypeDecls(f) {
 			wrapperTypeDecls[k] = v
 		}
-		for k := range collectJSONMethodTypes(f) {
+		fileJSONMethods, fileIfaceEmbeds := collectJSONMethodTypes(f)
+		for k := range fileJSONMethods {
 			wrapperJSONMethods[k] = true
+		}
+		for k, v := range fileIfaceEmbeds {
+			wrapperIfaceEmbeds[k] = append(wrapperIfaceEmbeds[k], v...)
 		}
 		// collectFromGeneratedPairs already drops excluded functions by their
 		// function name (see excludedFromGenerated check inside it), so no
@@ -651,6 +658,9 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 
 	// Every wrapper file is parsed, so embedded types can now be resolved
 	// across the package: an embed may name a struct declared in another file.
+	// Closed across the whole package: an interface may embed one declared in
+	// another file, and the promotion is just as real.
+	closeJSONMethodTypes(wrapperJSONMethods, wrapperIfaceEmbeds)
 	flattenEmbedded(wrapperStructs, wrapperTypeDecls, wrapperJSONMethods)
 
 	// Build the final pair list: union of fromGen + directDecode.
@@ -921,7 +931,7 @@ func collectStructsAndMarkers(fset *token.FileSet, f *ast.File) map[string]*stru
 // implement json.Marshaler / json.Unmarshaler too — so encoding/json calls that
 // method for the whole struct instead of walking its fields, and no comparison
 // of promoted tags describes the wire shape any more.
-func collectJSONMethodTypes(f *ast.File) map[string]bool {
+func collectJSONMethodTypes(f *ast.File) (map[string]bool, map[string][]string) {
 	out := map[string]bool{}
 	// Methods declared with a receiver.
 	for _, decl := range f.Decls {
@@ -944,8 +954,8 @@ func collectJSONMethodTypes(f *ast.File) map[string]bool {
 	// promotes it just as embedding a struct with the method does, and the
 	// interface itself has no field to give the walk a second chance.
 	ifaceEmbeds := map[string][]string{}
-	for name, rhs := range collectTypeDecls(f) {
-		it, ok := rhs.(*ast.InterfaceType)
+	for name, decl := range collectTypeDecls(f) {
+		it, ok := decl.expr.(*ast.InterfaceType)
 		if !ok {
 			continue
 		}
@@ -964,26 +974,44 @@ func collectJSONMethodTypes(f *ast.File) map[string]bool {
 			}
 		}
 	}
-	// Propagate through interface embedding until stable. The universe is
-	// small and the loop is bounded by its size, so a cycle cannot spin.
+	return out, ifaceEmbeds
+}
+
+// closeJSONMethodTypes propagates the method sets through interface embedding
+// until stable. It runs over the MERGED package, not one file: the interface
+// declaring MarshalJSON and the interface embedding it routinely live in
+// different files, and a per-file closure would mark the first and never the
+// second. The loop is bounded by the graph size, so a cycle cannot spin.
+func closeJSONMethodTypes(direct map[string]bool, ifaceEmbeds map[string][]string) {
 	for range ifaceEmbeds {
 		changed := false
 		for name, embedded := range ifaceEmbeds {
-			if out[name] {
+			if direct[name] {
 				continue
 			}
 			for _, e := range embedded {
-				if out[e] {
-					out[name] = true
+				if direct[e] {
+					direct[name] = true
 					changed = true
 				}
 			}
 		}
 		if !changed {
-			break
+			return
 		}
 	}
-	return out
+}
+
+// promotesJSONMethod reports whether embedding e makes the embedding struct
+// implement json.Marshaler / json.Unmarshaler. The embed's own name always
+// counts (it is the type written at the embed site, and an interface resolves
+// to no struct at all); a name reached through type-declaration hops counts
+// only when the method set travelled with it — see resolveEmbedFull.
+func promotesJSONMethod(e embedRef, childName string, methodsTravel bool, jsonMethods map[string]bool) bool {
+	if jsonMethods[e.name] {
+		return true
+	}
+	return methodsTravel && childName != "" && jsonMethods[childName]
 }
 
 // isJSONMethodName reports whether a method name is one whose promotion
@@ -999,8 +1027,8 @@ func isJSONMethodName(name string) bool {
 // from it is unresolvable (declared elsewhere, or in another package), while an
 // embedded name present but non-struct (an interface, a map, a slice) simply
 // promotes no JSON-tagged fields.
-func collectTypeDecls(f *ast.File) map[string]ast.Expr {
-	out := map[string]ast.Expr{}
+func collectTypeDecls(f *ast.File) map[string]typeDecl {
+	out := map[string]typeDecl{}
 	for _, decl := range f.Decls {
 		gd, ok := decl.(*ast.GenDecl)
 		if !ok || gd.Tok != token.TYPE {
@@ -1008,11 +1036,20 @@ func collectTypeDecls(f *ast.File) map[string]ast.Expr {
 		}
 		for _, spec := range gd.Specs {
 			if ts, ok := spec.(*ast.TypeSpec); ok {
-				out[ts.Name.Name] = ts.Type
+				out[ts.Name.Name] = typeDecl{expr: ts.Type, alias: ts.Assign.IsValid()}
 			}
 		}
 	}
 	return out
+}
+
+// typeDecl is one `type X …` declaration. alias distinguishes `type X = Y`,
+// which is the same type as Y and therefore has its methods, from `type X Y`,
+// which takes Y's underlying structure but starts with an EMPTY method set.
+// That distinction decides whether embedding X promotes Y's MarshalJSON.
+type typeDecl struct {
+	expr  ast.Expr
+	alias bool
 }
 
 // embedRefFromExpr decomposes an anonymous field's type expression into an
@@ -1076,7 +1113,7 @@ const maxEmbedDepth = 16
 // full rule list. Unresolvable embeds are recorded on the embedding struct's
 // unresolved list — never skipped — and reported by run when a pair reaches
 // them.
-func flattenEmbedded(structs map[string]*structFields, decls map[string]ast.Expr, jsonMethods map[string]bool) {
+func flattenEmbedded(structs map[string]*structFields, decls map[string]typeDecl, jsonMethods map[string]bool) {
 	// Settle which fields the encoder ignores before any promotion runs, for
 	// every struct rather than just the roots: the walk reads a descendant's
 	// ownFields directly, so filtering only at depth 0 would promote a tag out
@@ -1099,7 +1136,7 @@ func flattenEmbedded(structs map[string]*structFields, decls map[string]ast.Expr
 }
 
 // flattenOne performs the breadth-first promotion walk for a single struct.
-func flattenOne(rootName string, root *structFields, structs map[string]*structFields, decls map[string]ast.Expr, jsonMethods map[string]bool) {
+func flattenOne(rootName string, root *structFields, structs map[string]*structFields, decls map[string]typeDecl, jsonMethods map[string]bool) {
 	// A struct reached at depth d contributes its own tagged fields at depth d;
 	// path records the embedded field names traversed to reach it, both for
 	// population targets and for unresolvable-embed messages.
@@ -1163,6 +1200,21 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 		root.tagTargets = map[string][]string{}
 	}
 
+	// A json tag stops an anonymous field from promoting its FIELDS. It does
+	// nothing to method promotion, so a tagged embed of a marshaller redirects
+	// the encoder exactly as an untagged one does.
+	for _, te := range root.taggedEmbeds {
+		_, childName, methodsTravel, err := resolveEmbedFull(te.ref, structs, decls)
+		if err != "" || !promotesJSONMethod(te.ref, childName, methodsTravel, jsonMethods) {
+			continue
+		}
+		root.unresolved = append(root.unresolved,
+			fmt.Sprintf("%s -> %s (tagged embedded type declares MarshalJSON/UnmarshalJSON; the tag stops its FIELDS being promoted but not its methods, so encoding/json calls it for the whole struct)",
+				rootName, te.ref.display))
+		discardPromotions()
+		return
+	}
+
 	// Go-name resolution, tracked alongside the tag walk: nameDepth records the
 	// shallowest depth at which each field NAME appears and nameConflict the
 	// names two same-depth structs both declare, which makes the selector
@@ -1198,7 +1250,7 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 		reaches := map[string]int{}
 		for _, parent := range level {
 			for _, e := range parent.sf.embeds {
-				child, childName, err := resolveEmbed(e, structs, decls)
+				child, childName, methodsTravel, err := resolveEmbedFull(e, structs, decls)
 				if err != "" {
 					root.unresolved = append(root.unresolved,
 						fmt.Sprintf("%s -> %s (%s)", strings.Join(append([]string{rootName}, parent.path...), "."), e.display, err))
@@ -1208,7 +1260,7 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 				// struct: an embedded INTERFACE carries the method in its
 				// method set and resolves to no struct at all, so keying only
 				// on the resolution would miss it entirely.
-				if jsonMethods[e.name] || (childName != "" && jsonMethods[childName]) {
+				if promotesJSONMethod(e, childName, methodsTravel, jsonMethods) {
 					// Promoting a custom marshaller changes how the WHOLE
 					// embedding struct is encoded, so NO promoted tag on this
 					// struct describes the wire any more — not just this
@@ -1320,35 +1372,52 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 // non-empty reason string when the type cannot be resolved at all. A nil struct
 // with an empty reason means "resolved, but promotes no JSON-tagged fields"
 // (an interface, map, slice, func or channel type).
-func resolveEmbed(e embedRef, structs map[string]*structFields, decls map[string]ast.Expr) (*structFields, string, string) {
+func resolveEmbed(e embedRef, structs map[string]*structFields, decls map[string]typeDecl) (sf *structFields, name string, reason string) {
+	sf, name, _, reason = resolveEmbedFull(e, structs, decls)
+	return sf, name, reason
+}
+
+// resolveEmbedFull is resolveEmbed plus methodsTravel: whether the resolved
+// type's METHOD SET reaches the embedding struct. Every hop must be an alias
+// for that to hold — `type Safe Stamp` has Stamp's fields but none of its
+// methods, so embedding Safe does not make the outer type a json.Marshaler
+// even when Stamp is one.
+func resolveEmbedFull(e embedRef, structs map[string]*structFields, decls map[string]typeDecl) (*structFields, string, bool, string) {
 	switch {
 	case e.name == "":
-		return nil, "", "unsupported embedded type expression"
+		return nil, "", false, "unsupported embedded type expression"
 	case e.qualifier != "":
-		return nil, "", "declared in another package, which this check does not parse"
+		return nil, "", false, "declared in another package, which this check does not parse"
 	}
 	// Follow `type Alias Base` hops. maxEmbedDepth also bounds this chain, so a
 	// self-referential declaration cannot spin.
 	name := e.name
+	methodsTravel := true
 	seen := map[string]bool{}
 	for hop := 0; hop <= maxEmbedDepth; hop++ {
 		if sf, ok := structs[name]; ok {
-			return sf, name, ""
+			return sf, name, methodsTravel, ""
 		}
-		rhs, ok := decls[name]
+		decl, ok := decls[name]
 		if !ok {
-			return nil, "", "not declared in the parsed sources"
+			return nil, "", methodsTravel, "not declared in the parsed sources"
 		}
 		if seen[name] {
-			return nil, "", "self-referential type declaration"
+			return nil, "", methodsTravel, "self-referential type declaration"
 		}
 		seen[name] = true
-		switch t := rhs.(type) {
+		switch t := decl.expr.(type) {
 		case *ast.Ident:
-			name = t.Name // `type Alias Base` — follow it.
+			// `type Alias = Base` keeps Base's method set; `type Alias Base`
+			// starts empty.
+			if !decl.alias {
+				methodsTravel = false
+			}
+			name = t.Name
 		case *ast.SelectorExpr:
-			return nil, "", "defined in terms of another package's type, which this check does not parse"
+			return nil, "", methodsTravel, "defined in terms of another package's type, which this check does not parse"
 		default:
+			// (fallthrough comment below applies to the default branch)
 			// An interface, map, slice, func, chan or generic type. It is a
 			// valid embed and it is NOT absent from the wire — encoding/json
 			// treats it as an ordinary field keyed by the Go field name
@@ -1360,10 +1429,10 @@ func resolveEmbed(e embedRef, structs map[string]*structFields, decls map[string
 			// can drift past it: generated structs are oapi-codegen output,
 			// where every field carries a tag, so no generated wire key is
 			// ever spelled this way for a wrapper to miss.
-			return nil, "", ""
+			return nil, "", methodsTravel, ""
 		}
 	}
-	return nil, "", "type declaration chain is too deep to resolve"
+	return nil, "", methodsTravel, "type declaration chain is too deep to resolve"
 }
 
 // collectFromGeneratedPairs walks the AST for function declarations of the form
@@ -1637,8 +1706,18 @@ func recordAssignedValue(assigned map[string]bool, path string, value ast.Expr) 
 			// empty literal covers nothing.
 			return
 		}
-		// A positional literal must list every field of the struct, so it
-		// covers the whole subtree.
+		// A positional literal must list every DIRECT field of the struct, so
+		// it covers the subtree — unless one of those fields is an embedded
+		// pointer given nil, which puts none of ITS promoted fields on the
+		// wire. The walker cannot tell which element is which field without
+		// the full declaration order, so a nil element withdraws the claim
+		// rather than guessing: the author writes keys, and the report is the
+		// safe direction.
+		for _, elt := range lit.Elts {
+			if id, ok := unparen(elt).(*ast.Ident); ok && id.Name == "nil" {
+				return
+			}
+		}
 	}
 	assigned[path+".*"] = true
 }

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -433,6 +433,13 @@ type structFields struct {
 	// promotion sources, but an unexported one is only on the wire if its type
 	// is a struct — which needs the universe, so flattenEmbedded settles it.
 	taggedEmbeds []taggedEmbed
+	// decodeUnsafe lists embeds that break DECODING only: an embedded pointer
+	// to an unexported type, which encoding/json refuses to allocate ("cannot
+	// set embedded pointer to unexported struct"). Marshalling and in-Go
+	// construction are unaffected, so this is reported for tier-2 pairs — the
+	// ones whose whole premise is that the decoder populates the tags — and not
+	// for wrappers built by a *FromGenerated or a composite literal.
+	decodeUnsafe []string
 	// unresolved lists embedded types the checker could not resolve, as
 	// human-readable paths ("Task.Meta -> time.Time"). Reported as drift when
 	// a pair reaches this struct; see run.
@@ -720,6 +727,14 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 			continue
 		}
 
+		// Tiering first: it decides which reports apply. Tier 2 is the only
+		// path that skips the population check — its wrappers have no
+		// in-package literal; the JSON decoder writes straight onto struct
+		// tags, so tag presence IS population.
+		_, isDirectDecode := directDecode[wrapName]
+		isTier2 := isDirectDecode && !tier3[wrapName]
+		assigned := assignedFields[wrapName]
+
 		// An embedded type the checker could not resolve hides an unknown
 		// number of promoted fields from both the tag and population checks.
 		// Report it instead of comparing against a knowingly-partial tag set —
@@ -728,19 +743,14 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 		for _, u := range wrap.unresolved {
 			drift = append(drift, fmt.Sprintf("%s ↔ generated.%s: unresolvable embedded type in the wrapper: %s. Promoted fields from it are invisible to this check; teach the resolver about it or replace the embed with named fields.", wrapName, genName, u))
 		}
+		if isTier2 {
+			for _, u := range wrap.decodeUnsafe {
+				drift = append(drift, fmt.Sprintf("%s ↔ generated.%s: %s. This pair is direct-decode, where tag presence IS population, so those fields are silently absent.", wrapName, genName, u))
+			}
+		}
 		for _, u := range gen.unresolved {
 			drift = append(drift, fmt.Sprintf("%s ↔ generated.%s: unresolvable embedded type in the generated struct: %s. Promoted fields from it are invisible to this check; teach the resolver about it.", wrapName, genName, u))
 		}
-
-		// The population check runs for tier 1 (assignedFields sourced from
-		// the *FromGenerated body) and tier 3 (assignedFields sourced from the
-		// inline composite literal walker). Tier 2 is the only path that skips
-		// the population check — its wrappers have no in-package literal; the
-		// JSON decoder writes straight onto struct tags, so tag presence IS
-		// population.
-		_, isDirectDecode := directDecode[wrapName]
-		isTier2 := isDirectDecode && !tier3[wrapName]
-		assigned := assignedFields[wrapName]
 
 		// Walk every JSON tag declared on the generated struct.
 		tags := make([]string, 0, len(gen.tags))
@@ -964,7 +974,7 @@ func collectJSONMethodTypes(f *ast.File) (map[string]bool, map[string][]string) 
 		if !ok || fd.Recv == nil || len(fd.Recv.List) != 1 {
 			continue
 		}
-		if !isJSONMethodName(fd.Name.Name) {
+		if !isJSONMethod(fd.Name.Name, fd.Type) {
 			continue
 		}
 		recv := fd.Recv.List[0].Type
@@ -999,8 +1009,9 @@ func collectJSONMethodTypes(f *ast.File) (map[string]bool, map[string][]string) 
 				out[name] = true
 				continue
 			}
+			ft, _ := m.Type.(*ast.FuncType)
 			for _, n := range m.Names {
-				if isJSONMethodName(n.Name) {
+				if isJSONMethod(n.Name, ft) {
 					out[name] = true
 				}
 			}
@@ -1058,13 +1069,6 @@ func vouch(e embedRef, childName string, methodsTravel bool, resolveErr string, 
 	if jsonMethods[e.name] || (methodsTravel && childName != "" && jsonMethods[childName]) {
 		return "the embedded type's method set carries MarshalJSON/UnmarshalJSON, which the embedding struct promotes; encoding/json then calls it instead of walking any of these fields, so no promoted tag here is trustworthy"
 	}
-	if e.pointer && e.name != "" && !ast.IsExported(e.name) {
-		// encoding/json refuses to allocate an embedded pointer to an
-		// unexported type ("cannot set embedded pointer to unexported
-		// struct"), so a direct-decode wrapper never gets these fields
-		// populated even though their tags are present.
-		return "an embedded pointer to an unexported type cannot be allocated by encoding/json, so its promoted fields are never decoded"
-	}
 	if resolveErr != "" {
 		// An unresolvable type may also be a marshaller — time.Time is one —
 		// so this cannot be treated as merely "fields we cannot see".
@@ -1073,10 +1077,60 @@ func vouch(e embedRef, childName string, methodsTravel bool, resolveErr string, 
 	return ""
 }
 
-// isJSONMethodName reports whether a method name is one whose promotion
-// redirects encoding/json away from a struct's fields.
-func isJSONMethodName(name string) bool {
-	return name == "MarshalJSON" || name == "UnmarshalJSON"
+// isJSONMethod reports whether a method is one whose promotion redirects
+// encoding/json away from a struct's fields — which takes the right NAME and
+// the right SIGNATURE, since only a method that satisfies json.Marshaler or
+// json.Unmarshaler is ever called. A `MarshalJSON(int) []byte` implements
+// neither, and refusing to judge a struct that embeds its type would
+// manufacture drift on a wrapper the encoder walks normally.
+//
+// Signatures are compared by rendered type expression, which is exact for the
+// shapes these two interfaces require:
+//
+//	MarshalJSON() ([]byte, error)
+//	UnmarshalJSON([]byte) error
+func isJSONMethod(name string, ft *ast.FuncType) bool {
+	if ft == nil {
+		return false
+	}
+	switch name {
+	case "MarshalJSON":
+		return signatureIs(ft, nil, []string{"[]byte", "error"})
+	case "UnmarshalJSON":
+		return signatureIs(ft, []string{"[]byte"}, []string{"error"})
+	}
+	return false
+}
+
+// signatureIs compares a function type's parameter and result types against
+// rendered type expressions, treating each declared name in a grouped
+// parameter as its own entry.
+func signatureIs(ft *ast.FuncType, params, results []string) bool {
+	return fieldListIs(ft.Params, params) && fieldListIs(ft.Results, results)
+}
+
+func fieldListIs(fl *ast.FieldList, want []string) bool {
+	var got []string
+	if fl != nil {
+		for _, f := range fl.List {
+			n := 1
+			if len(f.Names) > 0 {
+				n = len(f.Names)
+			}
+			for i := 0; i < n; i++ {
+				got = append(got, exprDisplay(f.Type))
+			}
+		}
+	}
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // collectTypeDecls returns every top-level `type X <expr>` declaration in the
@@ -1152,6 +1206,10 @@ func exprDisplay(expr ast.Expr) string {
 		return exprDisplay(e.X) + "[…]"
 	case *ast.IndexListExpr: // generic instantiation: Base[T, U]
 		return exprDisplay(e.X) + "[…]"
+	case *ast.ArrayType:
+		if e.Len == nil {
+			return "[]" + exprDisplay(e.Elt)
+		}
 	}
 	return "<unsupported type expression>"
 }
@@ -1357,6 +1415,11 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 						fmt.Sprintf("%s -> %s (%s)", strings.Join(append([]string{rootName}, parent.path...), "."), e.display, reason))
 					discardPromotions()
 					return
+				}
+				if e.pointer && e.name != "" && !ast.IsExported(e.name) {
+					root.decodeUnsafe = append(root.decodeUnsafe,
+						fmt.Sprintf("%s -> %s (encoding/json cannot allocate an embedded pointer to an unexported type, so a decoder never populates its promoted fields)",
+							strings.Join(append([]string{rootName}, parent.path...), "."), e.display))
 				}
 				if child == nil || visited[childName] {
 					// Either the embedded type promotes no JSON-tagged fields

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -174,6 +174,20 @@
 //   - An embedded pointer to an unexported type, for direct-decode pairs only:
 //     encoding/json cannot allocate it, so the decoder never populates it.
 //
+// Known to OVER-report, and deliberately left that way, because each fails
+// loudly and naming the shape is cheaper than modelling it:
+//
+//   - A promoted field written through the second path of a diamond
+//     (`w.Right.Common.Field` where the walk retained the Left path, which is
+//     also the one encoding/json indexes) reads as unpopulated.
+//   - A defined type whose name chain reaches a marshaller is refused even
+//     where Go would walk its fields, because the closure does not model
+//     which declaration form carries a method set.
+//   - The decode-allocation report fires for an embed whose fields would
+//     have annihilated anyway.
+//   - A skipped-segment selector (`w.Base.Field` where an embed sits between)
+//     is not among the recognised spellings.
+//
 // The invariant: ANYTHING UNRECOGNISED IS REPORTED. Never credited, never
 // skipped. Both failure modes this walk has actually had — the original #599
 // bug and every regression found while fixing it — were a silent assumption

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -218,6 +218,23 @@
 // bug and every regression found while fixing it — were a silent assumption
 // about something the walker did not understand.
 //
+// # This analysis is best-effort, and the gaps are inventoried
+//
+// Issue #741 lists every shape where the promotion analysis is known to be
+// wrong — separated into the ones that can SILENTLY pass a wrapper dropping a
+// generated field and the ones that merely over-report — plus the two that are
+// verified impossible. The gate prints a pointer to it on every run, because a
+// clean run is not proof that this part is sound.
+//
+// Read that issue before extending this code. In particular: the conservative
+// default above cannot reach those defects. A default only helps where the
+// walker recognises its own ignorance, and in every case listed there the
+// walker is not unsure — it resolves a name or classifies a shape and returns a
+// definite answer that differs from Go's. Closing them means enumerating type
+// identity and conversion rules, which does not end in an AST-only walk.
+// Restricting what may be embedded, or moving to go/types, are the two real
+// options.
+//
 // # An honest tally, for whoever adds the next rule
 //
 // This support was reviewed over a long run of rounds — the PR discussion has
@@ -1018,6 +1035,7 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 		fmt.Printf("  Embedded-field promotion: %d of %d pairs embed a struct, %d of them contributing %d promoted fields to the checks above.\n", pairsWithEmbeds, len(pairNames), pairsWithPromotions, promotedFieldsChecked)
 	}
 	fmt.Println("  Scope: shapes this walker resolves. Unrecognised embeds and assignment shapes are reported as drift, never assumed away — see the CAN/CANNOT list in this file's header.")
+	fmt.Println("  Limitation: certifying promoted fields through embeds is BEST-EFFORT. Known shapes where it is confidently wrong — including ones that can pass a wrapper dropping a generated field — are enumerated in issue #741. A clean run is not proof that the promotion analysis is sound.")
 
 	if len(drift) > 0 {
 		fmt.Fprintln(os.Stderr)

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -525,6 +525,12 @@ type structFields struct {
 	// depend on Go-name shadowing across the whole promotion tree. Own tags
 	// are absent; see populationTargets.
 	tagTargets map[string][]string
+	// declaresJSONMethodDirectly is set from the PRE-CLOSURE method set: this
+	// type's own receiver declarations, not what it inherits or what an
+	// unknown name might carry. The root gate below needs "declares one
+	// itself" to actually mean that; inherited and unknown cases belong to
+	// vouch, which reports them per embed with the right explanation.
+	declaresJSONMethodDirectly bool
 	// promotesFromStruct is true when at least one UNTAGGED embed of this
 	// struct resolves to a struct — the only shape that promotes fields at
 	// all. It is what the scope line means by "embeds a struct", and it is
@@ -730,8 +736,9 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 	}
 	genStructs := collectStructsAndMarkers(fset, genFile)
 	genJSONMethods, genIfaceEmbeds := collectJSONMethodTypes(genFile)
+	genJSONMethodsDirect := copySet(genJSONMethods) // before the closure widens it
 	closeJSONMethodTypes(genJSONMethods, genIfaceEmbeds)
-	flattenEmbedded(genStructs, collectTypeDecls(genFile), genJSONMethods)
+	flattenEmbedded(genStructs, collectTypeDecls(genFile), genJSONMethods, genJSONMethodsDirect)
 
 	// Parse all wrapper files.
 	entries, err := os.ReadDir(wrapperDir)
@@ -810,8 +817,9 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 	// across the package: an embed may name a struct declared in another file.
 	// Closed across the whole package: an interface may embed one declared in
 	// another file, and the promotion is just as real.
+	wrapperJSONMethodsDirect := copySet(wrapperJSONMethods) // before the closure widens it
 	closeJSONMethodTypes(wrapperJSONMethods, wrapperIfaceEmbeds)
-	flattenEmbedded(wrapperStructs, wrapperTypeDecls, wrapperJSONMethods)
+	flattenEmbedded(wrapperStructs, wrapperTypeDecls, wrapperJSONMethods, wrapperJSONMethodsDirect)
 
 	// Build the final pair list: union of fromGen + directDecode.
 	pairs := map[string]string{}
@@ -928,7 +936,10 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 		// promoted tag that a GENERATED tag actually asked for, counted at the
 		// check itself below, not merely a promoted tag the wrapper happens to
 		// carry.
-		if wrap.promotesFromStruct {
+		// EITHER side embedding counts: this check flattens both universes, and
+		// a flat wrapper paired with a generated struct that embeds is still a
+		// pair whose verdict came through the promotion machinery.
+		if wrap.promotesFromStruct || gen.promotesFromStruct {
 			pairsWithEmbeds++
 		}
 		pairPromotedFields := 0
@@ -943,7 +954,7 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 				missing = append(missing, tag)
 				continue
 			}
-			if len(wrap.tagPath[tag]) > 0 {
+			if len(wrap.tagPath[tag]) > 0 || len(gen.tagPath[tag]) > 0 {
 				promotedFieldsChecked++
 				pairPromotedFields++
 			}
@@ -1239,6 +1250,17 @@ func collectJSONMethodTypes(f *ast.File) (map[string]bool, map[string][]string) 
 		}
 	}
 	return out, ifaceEmbeds
+}
+
+// copySet snapshots a set so a later closure over it cannot change what the
+// snapshot means. The root gate needs the method sets a type DECLARES, which
+// only exists before the transitive closure runs.
+func copySet(in map[string]bool) map[string]bool {
+	out := make(map[string]bool, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 // closeJSONMethodTypes propagates the method sets through interface embedding
@@ -1557,7 +1579,7 @@ const maxEmbedDepth = 16
 // full rule list. Unresolvable embeds are recorded on the embedding struct's
 // unresolved list — never skipped — and reported by run when a pair reaches
 // them.
-func flattenEmbedded(structs map[string]*structFields, decls map[string]typeDecl, jsonMethods map[string]bool) {
+func flattenEmbedded(structs map[string]*structFields, decls map[string]typeDecl, jsonMethods, directJSONMethods map[string]bool) {
 	// Settle which fields the encoder ignores before any promotion runs, for
 	// every struct rather than just the roots: the walk reads a descendant's
 	// ownFields directly, so filtering only at depth 0 would promote a tag out
@@ -1621,7 +1643,8 @@ func flattenEmbedded(structs map[string]*structFields, decls map[string]typeDecl
 		}
 	}
 
-	for _, sf := range structs {
+	for name, sf := range structs {
+		sf.declaresJSONMethodDirectly = directJSONMethods[name]
 		for _, ref := range sf.embeds {
 			if child, _, _, err := resolveEmbedFull(ref, structs, decls); err == "" && child != nil {
 				sf.promotesFromStruct = true
@@ -1741,9 +1764,9 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 	// being certified against an encoder that bypasses them, and that is the
 	// silent case. None of today's adapters embed anything, so this fires on
 	// none of them.
-	if jsonMethods[rootName] && len(root.embeds)+len(root.taggedEmbeds) > 0 {
+	if root.declaresJSONMethodDirectly && root.promotesFromStruct {
 		root.unresolved = append(root.unresolved,
-			fmt.Sprintf("%s declares MarshalJSON/UnmarshalJSON itself and also embeds a struct; encoding/json calls that method rather than walking the promoted fields, so promotion is not certified here (its own declared tags still are)", rootName))
+			fmt.Sprintf("%s declares a custom JSON or text marshaller itself and also promotes fields through an embedded struct; encoding/json calls that method rather than walking the promoted fields, so promotion is not certified here (its own declared tags still are)", rootName))
 		discardPromotions()
 		return
 	}
@@ -2366,8 +2389,19 @@ func literalToEnumerate(expr ast.Expr) *ast.CompositeLit {
 	if u, ok := expr.(*ast.UnaryExpr); ok && u.Op == token.AND {
 		expr = unparen(u.X)
 	}
-	if cl, ok := expr.(*ast.CompositeLit); ok && cl.Type == nil {
-		return cl
+	if cl, ok := expr.(*ast.CompositeLit); ok {
+		// Type == nil is the ELIDED form inside another literal. A StructType
+		// is an ANONYMOUS struct, which Go lets you assign to a named struct
+		// with the same underlying type — so `n.Base = struct{ID int;
+		// Content string}{ID: g.Id}` sets one field and leaves the other
+		// zero. Both are enumerable, and crediting either as a whole value
+		// would certify fields nobody assigned.
+		if cl.Type == nil {
+			return cl
+		}
+		if _, anon := cl.Type.(*ast.StructType); anon {
+			return cl
+		}
 	}
 	return nil
 }
@@ -2383,8 +2417,10 @@ func deliversWholeValue(expr ast.Expr) bool {
 		*ast.IndexListExpr, *ast.TypeAssertExpr, *ast.StarExpr:
 		return true
 	case *ast.CompositeLit:
-		// A slice or map literal: not a struct, nothing to enumerate as
-		// fields, and a complete value of its own type.
+		// Struct literals — named, elided or anonymous — are enumerated by
+		// literalToEnumerate before this point, so what reaches here is a
+		// slice, array or map literal: nothing to enumerate as fields, and a
+		// complete value of its own type.
 		return true
 	case *ast.UnaryExpr:
 		// &x delivers a pointer to whatever x delivers; <-ch delivers a whole

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -190,11 +190,16 @@
 //
 // The invariant: ANYTHING UNRECOGNISED IS REPORTED. Never credited, never
 // skipped. It holds at all THREE places this file makes a coverage judgement,
-// and a new one must join them:
+// and each is now a single chokepoint rather than a property re-established at
+// every call site — because the same bug kept coming back in a path the last
+// fix had not reached:
 //
 //   - the embed walk (an embed it cannot vouch for is reported),
-//   - the assignment walk (a value shape it cannot classify credits nothing
-//     and is reported),
+//   - the assignment walk (classifyValue: ONE exhaustive switch whose default
+//     arm is valueUnrecognized, so a Go shape nobody thought about lands on
+//     "report" instead of on whichever branch happened to be permissive —
+//     three separate tests with three separate defaults is how an anonymous
+//     struct literal got credited as a whole value),
 //   - the method graph (a type whose method set it cannot evaluate — a
 //     qualified alias, a generic instantiation — counts as carrying, which
 //     makes every embed of it refused).
@@ -203,7 +208,13 @@
 // reviewer produced `type A = json.Marshaler; type B interface { A }`: field
 // promotion and assignment population were already flipped, so the bug had
 // nowhere to show except through the method set. Fixing one instance of this
-// class rather than the class is how that happens. Both failure modes this walk has actually had — the original #599
+// class rather than the class is how that happens.
+//
+// The gate's own coverage statement follows the same rule for the same reason:
+// embeddingScope DERIVES it from the flattened structs instead of counting at
+// the check sites, after three rounds of that sentence being false in three
+// different ways. A claim maintained alongside the code it describes will
+// eventually disagree with it. Both failure modes this walk has actually had — the original #599
 // bug and every regression found while fixing it — were a silent assumption
 // about something the walker did not understand.
 //
@@ -840,9 +851,6 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 	var drift []string
 	totalFieldsChecked := 0
 	totalFieldsPopChecked := 0
-	pairsWithEmbeds := 0       // pairs whose wrapper DECLARES an embed, whatever came of it
-	pairsWithPromotions := 0   // pairs where a promoted tag actually survived to be checked
-	promotedFieldsChecked := 0 // generated tags satisfied by a promoted (not directly declared) field
 	for _, wrapName := range pairNames {
 		genName := pairs[wrapName]
 		gen := genStructs[genName]
@@ -936,13 +944,6 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 		// promoted tag that a GENERATED tag actually asked for, counted at the
 		// check itself below, not merely a promoted tag the wrapper happens to
 		// carry.
-		// EITHER side embedding counts: this check flattens both universes, and
-		// a flat wrapper paired with a generated struct that embeds is still a
-		// pair whose verdict came through the promotion machinery.
-		if wrap.promotesFromStruct || gen.promotesFromStruct {
-			pairsWithEmbeds++
-		}
-		pairPromotedFields := 0
 		var missing []string
 		var unpopulated []string
 		for _, tag := range tags {
@@ -953,10 +954,6 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 			if !wrap.tags[tag] {
 				missing = append(missing, tag)
 				continue
-			}
-			if len(wrap.tagPath[tag]) > 0 || len(gen.tagPath[tag]) > 0 {
-				promotedFieldsChecked++
-				pairPromotedFields++
 			}
 			// Tag is declared on the wrapper. For tier-1 and tier-3 pairs,
 			// also confirm the construction site actually assigns the field —
@@ -973,9 +970,6 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 					unpopulated = append(unpopulated, fmt.Sprintf("%s (field %s)", tag, goField))
 				}
 			}
-		}
-		if pairPromotedFields > 0 {
-			pairsWithPromotions++
 		}
 		if len(missing) > 0 {
 			drift = append(drift, fmt.Sprintf("%s ↔ generated.%s: missing JSON tags %v (add to wrapper struct or mark with `// intentionally-omitted: <tag> - <reason>`)", wrapName, genName, missing))
@@ -1012,6 +1006,9 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 	// this walker resolves", and when no pair embeds anything at all — which
 	// is the case in this repo today — the embedded-field machinery verified
 	// nothing and the line should not let a reader think otherwise.
+	// Derived from the flattened structs, not accumulated as the walk goes —
+	// see embeddingScope for why.
+	pairsWithEmbeds, pairsWithPromotions, promotedFieldsChecked := embeddingScope(pairs, wrapperStructs, genStructs)
 	switch {
 	case pairsWithEmbeds == 0:
 		fmt.Println("  Embedded-field promotion: no pair embeds a struct, so nothing above was verified through it.")
@@ -1035,6 +1032,52 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 	}
 
 	return nil
+}
+
+// embeddingScope answers how much of this run the embedded-field machinery
+// actually decided: how many pairs embed a struct on either side, how many of
+// those contributed a promoted tag the check consumed, and how many such tags
+// there were.
+//
+// It is DERIVED from the flattened structs rather than accumulated as the pair
+// walk goes, and that is the point. This sentence has been wrong three times —
+// once counting surviving promotions while claiming to count embedding, once
+// counting any anonymous field as an embed, once ignoring the generated side
+// entirely — because counters maintained at the check sites drift from the
+// sentence they feed, and every new branch is another chance to forget one.
+// Reading the answer back out of the same state the checks read means the
+// statement cannot fall behind the code that produced it.
+func embeddingScope(pairs map[string]string, wrapperStructs, genStructs map[string]*structFields) (embedded, contributing, promotedFields int) {
+	for wrapName, genName := range pairs {
+		wrap, gen := wrapperStructs[wrapName], genStructs[genName]
+		if wrap == nil || gen == nil {
+			continue
+		}
+		// "Embeds a struct" is an untagged embed that RESOLVES to one, on
+		// either side — a tagged embed is an ordinary field, an embedded
+		// interface or map promotes nothing, and this check flattens both
+		// universes.
+		if wrap.promotesFromStruct || gen.promotesFromStruct {
+			embedded++
+		}
+		// "Contributed" is a generated tag the check actually consumed —
+		// declared by the generated struct, not intentionally omitted, present
+		// on the wrapper — that got there by promotion on either side.
+		pairFields := 0
+		for tag := range gen.tags {
+			if wrap.omitted[tag] || !wrap.tags[tag] {
+				continue
+			}
+			if len(wrap.tagPath[tag]) > 0 || len(gen.tagPath[tag]) > 0 {
+				pairFields++
+			}
+		}
+		promotedFields += pairFields
+		if pairFields > 0 {
+			contributing++
+		}
+	}
+	return embedded, contributing, promotedFields
 }
 
 // collectStructsAndMarkers walks the AST and returns a map of struct name
@@ -2243,124 +2286,6 @@ func litTypeName(expr ast.Expr) string {
 // spelling. run() turns each into drift for the pair that reaches it.
 const unrecognizedPrefix = "?"
 
-// recordAssignedValue records every population fact implied by assigning value
-// to path (a dotted field path relative to the wrapper instance, e.g. "Base" or
-// "Base.Audit"). It is the single vocabulary the population check reads through
-// populationTargets.
-//
-// The path itself is always recorded. What the assignment covers BELOW it is
-// decided by an EXHAUSTIVE classification of the value, because the default for
-// an unrecognized shape is the thing this whole check exists to prevent:
-// silently crediting fields nobody assigned. The classification is therefore a
-// whitelist, and its last branch reports rather than assumes.
-//
-//   - Statically zero — `nil`, `new(T)`, `(*T)(nil)`, an empty literal —
-//     covers NOTHING. None of them carry a value in.
-//   - A struct literal with keys, written with its type (`Base{ID: g.Id}`) or
-//     with the type elided inside another literal (`Base{Audit: {At: g.At}}`),
-//     is ENUMERATED key by key, recursively. A partial literal covers only the
-//     fields it names.
-//   - A positional struct literal lists every direct field, so it covers the
-//     subtree — unless an element is statically zero, which withdraws the
-//     claim, since the walker cannot tell which field that element lands on.
-//   - A call, a variable, a field selector, a dereference, an index or a type
-//     assertion delivers a whole value of the field's type, so it covers the
-//     subtree. This is the one-level-nesting doctrine the check has always
-//     applied (`c.Creator = &creator` counts, and Person's own fields are
-//     verified through Person's own pair).
-//   - ANYTHING ELSE is recorded as unrecognized and covers nothing. The pair
-//     that reaches it reports, and the shape gets read by a person instead of
-//     being credited by a walker that did not understand it.
-//
-// A nil value means the write had no readable right-hand side (`x.F++`), which
-// covers the subtree: the field was written, and there is nothing to look into.
-func recordAssignedValue(assigned map[string]bool, path string, value ast.Expr) {
-	if path == "" {
-		return
-	}
-	assigned[path] = true
-	if value == nil {
-		assigned[path+".*"] = true
-		return
-	}
-	if zeroValued(value) {
-		return
-	}
-	if lit := literalToEnumerate(value); lit != nil {
-		keyed := false
-		for _, elt := range lit.Elts {
-			kv, ok := elt.(*ast.KeyValueExpr)
-			if !ok {
-				continue
-			}
-			keyed = true
-			key, ok := kv.Key.(*ast.Ident)
-			if !ok {
-				// A struct literal's keys are field names; anything else is a
-				// shape this walker does not model.
-				assigned[unrecognizedPrefix+path] = true
-				continue
-			}
-			recordAssignedValue(assigned, path+"."+key.Name, kv.Value)
-		}
-		if keyed || len(lit.Elts) == 0 {
-			return
-		}
-		// Positional: every direct field is listed, so the subtree is covered
-		// — unless an element is statically zero, or is itself a literal whose
-		// contents the walker can see but cannot ATTRIBUTE to a field without
-		// the declaration order. `Base{Audit{At: x}, g.ID}` fills one field of
-		// Audit and leaves the rest zero; claiming the subtree would credit
-		// them. Seeing content it cannot place is a reason to stop claiming,
-		// not to assume.
-		for _, elt := range lit.Elts {
-			if zeroValued(elt) || literalToEnumerate(elt) != nil {
-				return
-			}
-		}
-		assigned[path+".*"] = true
-		return
-	}
-	if deliversWholeValue(value) {
-		assigned[path+".*"] = true
-		return
-	}
-	assigned[unrecognizedPrefix+path] = true
-}
-
-// zeroValued reports whether an assigned value is statically known to carry no
-// data: the nil identifier, `new(T)`, a conversion of nil such as
-// `(*Base)(nil)`, or an empty composite literal. Crediting any of them with
-// subtree coverage would pass a converter that emits none of the fields it
-// claims.
-func zeroValued(expr ast.Expr) bool {
-	switch e := unparen(expr).(type) {
-	case *ast.Ident:
-		return e.Name == "nil"
-	case *ast.CompositeLit:
-		// An empty literal — `Audit{}`, or `{}` elided inside another —
-		// contributes nothing.
-		return len(e.Elts) == 0
-	case *ast.UnaryExpr:
-		return e.Op == token.AND && zeroValued(e.X)
-	case *ast.CallExpr:
-		// new(T) — the builtin, not a method named new.
-		if id, ok := unparen(e.Fun).(*ast.Ident); ok && id.Name == "new" {
-			return true
-		}
-		// A pointer conversion of nil: (*Base)(nil). The parenthesized star is
-		// what makes this unambiguous — `baseFrom(nil)` is an ordinary call
-		// that may well populate everything, and only the type checker could
-		// tell `Base(nil)` from it, so neither is claimed here.
-		if _, isStar := unparenOnce(e.Fun).(*ast.StarExpr); isStar && len(e.Args) == 1 {
-			if id, ok := unparen(e.Args[0]).(*ast.Ident); ok && id.Name == "nil" {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 // unparen strips redundant parentheses: `(Base{...})` is the same value as
 // `Base{...}`, and classifying the parenthesized form differently would credit
 // or refuse a subtree on punctuation alone.
@@ -2374,63 +2299,168 @@ func unparen(expr ast.Expr) ast.Expr {
 	}
 }
 
-// literalToEnumerate returns the composite literal to walk key-by-key for a
-// value, or nil. It accepts the typed forms (`Base{…}`, `&Base{…}`) and the
-// ELIDED form Go permits for a nested literal (`Base{Audit: {At: g.At}}`),
-// whose type is implied by the field it initializes. Treating an elided
-// literal as opaque would credit every field under it while only the keys
-// written are set. Slice and map literals are not struct literals and are
-// handled elsewhere.
-func literalToEnumerate(expr ast.Expr) *ast.CompositeLit {
-	if lit := structLiteral(expr); lit != nil {
-		return lit
+// valueKind is how a value was classified for coverage purposes. Every
+// coverage decision in this file routes through classifyValue, and this is the
+// complete set of answers it can give.
+type valueKind int
+
+const (
+	// valueUnrecognized is the DEFAULT, and it is the point of the type: a
+	// shape the walker cannot place credits nothing and gets reported. Every
+	// silent failure this check has had — #599 itself, and each regression
+	// found while fixing it — was an unrecognised shape being assumed away, so
+	// the zero value of this enum is the safe one.
+	valueUnrecognized valueKind = iota
+	// valueZero carries no data: nil, new(T), (*T)(nil), an empty literal.
+	valueZero
+	// valueEnumerable is a struct literal whose keys can be walked — named,
+	// elided inside another literal, or anonymous.
+	valueEnumerable
+	// valueWhole is a complete value of the field's type whose contents the
+	// walker cannot see: a call, a variable, a selector, an index, a
+	// dereference, a type assertion, a channel receive, or a slice/array/map
+	// literal.
+	valueWhole
+)
+
+// classifyValue is the single chokepoint every coverage decision routes
+// through. It exists because the same bug kept recurring in different shapes:
+// a value the walker did not understand was credited anyway, once per code
+// path that made its own judgement (a separate zero test, a separate literal
+// test, a separate whole-value test, each with its own default). One
+// exhaustive switch with ONE default arm means a Go shape nobody thought about
+// lands on valueUnrecognized instead of on whichever branch happened to be
+// permissive.
+//
+// A nil expression means the write had no readable right-hand side (`x.F++`):
+// the field was written and there is nothing to look into.
+func classifyValue(expr ast.Expr) (valueKind, *ast.CompositeLit) {
+	if expr == nil {
+		return valueWhole, nil
 	}
-	expr = unparen(expr)
-	if u, ok := expr.(*ast.UnaryExpr); ok && u.Op == token.AND {
-		expr = unparen(u.X)
-	}
-	if cl, ok := expr.(*ast.CompositeLit); ok {
-		// Type == nil is the ELIDED form inside another literal. A StructType
-		// is an ANONYMOUS struct, which Go lets you assign to a named struct
-		// with the same underlying type — so `n.Base = struct{ID int;
-		// Content string}{ID: g.Id}` sets one field and leaves the other
-		// zero. Both are enumerable, and crediting either as a whole value
-		// would certify fields nobody assigned.
-		if cl.Type == nil {
-			return cl
+	switch e := unparen(expr).(type) {
+	case *ast.Ident:
+		if e.Name == "nil" {
+			return valueZero, nil
 		}
-		if _, anon := cl.Type.(*ast.StructType); anon {
-			return cl
+		return valueWhole, nil
+
+	case *ast.CompositeLit:
+		if len(e.Elts) == 0 {
+			return valueZero, nil
 		}
+		switch e.Type.(type) {
+		case nil, *ast.StructType:
+			// Elided inside another literal, or an anonymous struct — Go lets
+			// the latter be assigned to a named struct with the same
+			// underlying type, so it fills only what it names.
+			return valueEnumerable, e
+		case *ast.Ident:
+			return valueEnumerable, e
+		}
+		// A slice, array or map literal: nothing to enumerate as fields.
+		return valueWhole, nil
+
+	case *ast.UnaryExpr:
+		switch e.Op {
+		case token.ARROW:
+			// <-ch delivers a whole value of the element type.
+			return valueWhole, nil
+		case token.AND:
+			// &x is whatever x is: &Base{...} enumerates, &v is whole, and
+			// &Base{} carries nothing.
+			return classifyValue(e.X)
+		}
+		return valueUnrecognized, nil
+
+	case *ast.CallExpr:
+		// new(T) allocates a zero value; (*T)(nil) is a nil in a conversion's
+		// clothing. The parenthesized star is what makes the second
+		// unambiguous — `baseFrom(nil)` is an ordinary call that may populate
+		// everything, and only the type checker could tell `Base(nil)` from
+		// it, so neither is claimed as zero.
+		if id, ok := unparen(e.Fun).(*ast.Ident); ok && id.Name == "new" {
+			return valueZero, nil
+		}
+		if _, isStar := unparenOnce(e.Fun).(*ast.StarExpr); isStar && len(e.Args) == 1 {
+			if id, ok := unparen(e.Args[0]).(*ast.Ident); ok && id.Name == "nil" {
+				return valueZero, nil
+			}
+		}
+		return valueWhole, nil
+
+	case *ast.SelectorExpr, *ast.IndexExpr, *ast.IndexListExpr,
+		*ast.TypeAssertExpr, *ast.StarExpr:
+		return valueWhole, nil
 	}
-	return nil
+	return valueUnrecognized, nil
 }
 
-// deliversWholeValue reports whether an expression yields a complete value of
-// the assigned field's type — the shapes whose contents the walker cannot see
-// but whose result is a whole value, so crediting the subtree is sound under
-// the one-level-nesting doctrine. Anything outside this list is reported
-// rather than assumed.
-func deliversWholeValue(expr ast.Expr) bool {
-	switch e := unparen(expr).(type) {
-	case *ast.CallExpr, *ast.Ident, *ast.SelectorExpr, *ast.IndexExpr,
-		*ast.IndexListExpr, *ast.TypeAssertExpr, *ast.StarExpr:
-		return true
-	case *ast.CompositeLit:
-		// Struct literals — named, elided or anonymous — are enumerated by
-		// literalToEnumerate before this point, so what reaches here is a
-		// slice, array or map literal: nothing to enumerate as fields, and a
-		// complete value of its own type.
-		return true
-	case *ast.UnaryExpr:
-		// &x delivers a pointer to whatever x delivers; <-ch delivers a whole
-		// value of the channel's element type, exactly as a call does.
-		if e.Op == token.ARROW {
-			return true
-		}
-		return e.Op == token.AND && deliversWholeValue(e.X)
+// recordAssignedValue records every population fact implied by assigning value
+// to path (a dotted field path relative to the wrapper instance, e.g. "Base" or
+// "Base.Audit"). It is the single vocabulary the population check reads through
+// populationTargets.
+//
+// The path itself is always recorded. What the assignment covers BELOW it
+// follows from classifyValue, and nothing here re-derives that judgement:
+//
+//   - valueZero covers NOTHING. None of those shapes carry a value in.
+//   - valueEnumerable is walked key by key, recursively, so a partial literal
+//     covers only the fields it names.
+//   - valueWhole covers the subtree — the one-level-nesting doctrine the check
+//     has always applied (`c.Creator = &creator` counts, and Person's own
+//     fields are verified through Person's own pair).
+//   - valueUnrecognized covers nothing and is REPORTED, so the shape is read
+//     by a person instead of credited by a walker that did not understand it.
+//
+// A positional literal is the one place this adds a rule: it lists every direct
+// field, so it covers the subtree — unless an element is zero, or is itself a
+// literal whose contents the walker can see but cannot ATTRIBUTE to a field
+// without the declaration order. Seeing content it cannot place is a reason to
+// stop claiming, not to assume.
+func recordAssignedValue(assigned map[string]bool, path string, value ast.Expr) {
+	if path == "" {
+		return
 	}
-	return false
+	assigned[path] = true
+
+	kind, lit := classifyValue(value)
+	switch kind {
+	case valueZero:
+		return
+	case valueWhole:
+		assigned[path+".*"] = true
+		return
+	case valueUnrecognized:
+		assigned[unrecognizedPrefix+path] = true
+		return
+	}
+
+	keyed := false
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		keyed = true
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			// A struct literal's keys are field names; anything else is a
+			// shape this walker does not model.
+			assigned[unrecognizedPrefix+path] = true
+			continue
+		}
+		recordAssignedValue(assigned, path+"."+key.Name, kv.Value)
+	}
+	if keyed {
+		return
+	}
+	for _, elt := range lit.Elts {
+		if kind, _ := classifyValue(elt); kind != valueWhole {
+			return
+		}
+	}
+	assigned[path+".*"] = true
 }
 
 // unparenOnce strips one layer of parentheses, distinguishing `(*T)(nil)` —

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -1299,6 +1299,23 @@ func signatureIs(ft *ast.FuncType, params, results []string) bool {
 	return fieldListIs(ft.Params, params) && fieldListIs(ft.Results, results)
 }
 
+// normalizeTypeSpelling collapses spellings Go treats as identical. `byte` is
+// an alias for `uint8`, so `MarshalJSON() ([]uint8, error)` implements
+// json.Marshaler exactly as the usual spelling does — and missing that is a
+// SILENT miss, since the promoted method still redirects the encoder.
+func normalizeTypeSpelling(s string) string {
+	switch s {
+	case "[]uint8":
+		return "[]byte"
+	case "uint8":
+		return "byte"
+	case "int32":
+		// rune, likewise, for any signature that ever spells one.
+		return "rune"
+	}
+	return s
+}
+
 func fieldListIs(fl *ast.FieldList, want []string) bool {
 	var got []string
 	if fl != nil {
@@ -1308,7 +1325,7 @@ func fieldListIs(fl *ast.FieldList, want []string) bool {
 				n = len(f.Names)
 			}
 			for i := 0; i < n; i++ {
-				got = append(got, exprDisplay(f.Type))
+				got = append(got, normalizeTypeSpelling(exprDisplay(f.Type)))
 			}
 		}
 	}
@@ -1316,7 +1333,7 @@ func fieldListIs(fl *ast.FieldList, want []string) bool {
 		return false
 	}
 	for i := range got {
-		if got[i] != want[i] {
+		if got[i] != normalizeTypeSpelling(want[i]) {
 			return false
 		}
 	}
@@ -1473,6 +1490,33 @@ func flattenEmbedded(structs map[string]*structFields, decls map[string]typeDecl
 		}
 	}
 
+	// Each struct's OWN decode-unsafe records, computed before any root is
+	// flattened so a parent can inherit them whatever order the map iterates.
+	// encoding/json cannot allocate an embedded pointer to an unexported type,
+	// and that is just as true when the field arrives by promotion as when the
+	// struct holding it is the one being judged.
+	for name, sf := range structs {
+		sf.decodeUnsafe = nil
+		refs := make([]embedRef, 0, len(sf.embeds)+len(sf.taggedEmbeds))
+		refs = append(refs, sf.embeds...)
+		for _, te := range sf.taggedEmbeds {
+			refs = append(refs, te.ref)
+		}
+		for _, ref := range refs {
+			if !ref.pointer || ref.name == "" || ast.IsExported(ref.name) {
+				continue
+			}
+			// A struct only: an anonymous pointer to an unexported NON-struct
+			// is ignored by encoding/json rather than allocated, so there is no
+			// field it failed to populate.
+			if child, _, _, err := resolveEmbedFull(ref, structs, decls); err != "" || child == nil {
+				continue
+			}
+			sf.decodeUnsafe = append(sf.decodeUnsafe,
+				fmt.Sprintf("%s -> %s (encoding/json cannot allocate an embedded pointer to an unexported type, so a decoder never populates its promoted fields)", name, ref.display))
+		}
+	}
+
 	for _, sf := range structs {
 		sf.ignoredOwn = map[int]bool{}
 		for _, te := range sf.taggedEmbeds {
@@ -1619,13 +1663,16 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 					discardPromotions()
 					return
 				}
-				if child != nil && e.pointer && !ast.IsExported(e.name) {
-					// A struct only: an anonymous pointer to an unexported
-					// NON-struct is ignored by encoding/json rather than
-					// allocated, so there is no field it failed to populate.
-					root.decodeUnsafe = append(root.decodeUnsafe,
-						fmt.Sprintf("%s -> %s (encoding/json cannot allocate an embedded pointer to an unexported type, so a decoder never populates its promoted fields)",
-							strings.Join(append([]string{rootName}, parent.path...), "."), e.display))
+				// A struct reached here brings its OWN decode-unsafe records
+				// with it: a tagged or untagged unexported pointer inside it is
+				// promoted onto this root and is just as unallocatable there.
+				// Those records are computed for every struct before any root
+				// is walked, so this does not depend on iteration order.
+				if child != nil && childName != rootName {
+					for _, du := range child.decodeUnsafe {
+						root.decodeUnsafe = append(root.decodeUnsafe,
+							fmt.Sprintf("%s (reached through %s)", du, strings.Join(append([]string{rootName}, parent.path...), ".")))
+					}
 				}
 				if child == nil || visited[childName] {
 					// Either the embedded type promotes no JSON-tagged fields

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -209,7 +209,9 @@
 //
 // # An honest tally, for whoever adds the next rule
 //
-// This support was reviewed in ten rounds and grew a rule in almost every one:
+// This support was reviewed over a long run of rounds — the PR discussion has
+// the count, and it kept climbing after this paragraph was written — growing a
+// rule in almost every one:
 // promotion, annihilation, same-depth multiplicity, export visibility, literal
 // enumeration, qualified assignment paths, Go-name shadowing, depth-0
 // conflicts, method promotion (declared, inherited, interface, aliased, text),
@@ -523,6 +525,15 @@ type structFields struct {
 	// depend on Go-name shadowing across the whole promotion tree. Own tags
 	// are absent; see populationTargets.
 	tagTargets map[string][]string
+	// promotesFromStruct is true when at least one UNTAGGED embed of this
+	// struct resolves to a struct — the only shape that promotes fields at
+	// all. It is what the scope line means by "embeds a struct", and it is
+	// deliberately not "has an anonymous field": a tagged embed is an ordinary
+	// field, and an embedded interface or map promotes nothing. Set in the
+	// pre-pass, so a promotion later REFUSED (method-bearing) still counts as
+	// embedding — which is the case the scope line most needs to be honest
+	// about.
+	promotesFromStruct bool
 	// fieldNames lists every field name declared directly on this struct —
 	// tagged or not, exported or not, including the embedded fields' own
 	// names. Go resolves a selector by NAME with the same shallowest-wins
@@ -910,17 +921,17 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 		}
 		sort.Strings(tags)
 
-		// Two different facts, and conflating them lets the scope line below
-		// claim nothing embeds a struct while something does: a wrapper whose
-		// promotion was REFUSED (method-bearing), whose embedded struct has no
-		// tagged fields, or whose tags annihilated in a diamond declares an
-		// embed and contributes no tagPath.
-		if len(wrap.embeds)+len(wrap.taggedEmbeds) > 0 {
+		// Each counter must mean exactly what its sentence says. "Embeds a
+		// struct" is an untagged embed that RESOLVES to one — not any
+		// anonymous field, since a tagged embed is an ordinary field and an
+		// embedded interface or map promotes nothing. "Contributed" is a
+		// promoted tag that a GENERATED tag actually asked for, counted at the
+		// check itself below, not merely a promoted tag the wrapper happens to
+		// carry.
+		if wrap.promotesFromStruct {
 			pairsWithEmbeds++
 		}
-		if len(wrap.tagPath) > 0 {
-			pairsWithPromotions++
-		}
+		pairPromotedFields := 0
 		var missing []string
 		var unpopulated []string
 		for _, tag := range tags {
@@ -934,6 +945,7 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 			}
 			if len(wrap.tagPath[tag]) > 0 {
 				promotedFieldsChecked++
+				pairPromotedFields++
 			}
 			// Tag is declared on the wrapper. For tier-1 and tier-3 pairs,
 			// also confirm the construction site actually assigns the field —
@@ -950,6 +962,9 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 					unpopulated = append(unpopulated, fmt.Sprintf("%s (field %s)", tag, goField))
 				}
 			}
+		}
+		if pairPromotedFields > 0 {
+			pairsWithPromotions++
 		}
 		if len(missing) > 0 {
 			drift = append(drift, fmt.Sprintf("%s ↔ generated.%s: missing JSON tags %v (add to wrapper struct or mark with `// intentionally-omitted: <tag> - <reason>`)", wrapName, genName, missing))
@@ -1343,56 +1358,57 @@ func isJSONMethod(name string, ft *ast.FuncType) bool {
 	return false
 }
 
-// signatureMatches is signatureIs plus a deliberate bias: a component this
-// check cannot resolve to a builtin spelling — a local name like
-// `type Bytes = []byte`, or any imported type — counts as a MATCH rather than
-// a miss. The alternative is to certify a wrapper whose promoted marshaller
-// was spelled through an alias, which is the silent direction. A signature
-// built entirely from resolvable spellings is compared exactly, so
-// `MarshalJSON(int) []byte` is still correctly not a marshaller.
+// signatureMatches compares a method signature against the one an interface
+// requires, slot by slot.
+//
+// ARITY IS COMPARED FIRST, and a mismatch is decisive: `MarshalJSON(Custom)
+// error` cannot implement json.Marshaler however unfamiliar `Custom` is, and
+// refusing to judge a struct that embeds its type would manufacture drift over
+// an ordinary same-named method.
+//
+// Within a matching arity, a type this check cannot evaluate — a local name
+// like `type Bytes = []byte`, or any imported type — is a wildcard in ITS OWN
+// slot only. That bias is deliberate and one-directional: a false match costs
+// an over-report that names the type, while a false miss silently certifies a
+// wrapper whose promoted marshaller was spelled through an alias.
 func signatureMatches(ft *ast.FuncType, params, results []string) bool {
-	if signatureIs(ft, params, results) {
-		return true
-	}
-	return signatureHasUnresolvableComponent(ft)
+	return fieldListMatches(ft.Params, params) && fieldListMatches(ft.Results, results)
 }
 
-// signatureHasUnresolvableComponent reports whether any parameter or result
-// type is spelled with a name this check cannot evaluate — anything that is
-// not a builtin, a slice of one, or an error.
-func signatureHasUnresolvableComponent(ft *ast.FuncType) bool {
-	resolvable := func(expr ast.Expr) bool {
-		switch e := expr.(type) {
-		case *ast.Ident:
-			return predeclaredTypes[e.Name]
-		case *ast.ArrayType:
-			if e.Len != nil {
-				return false
+// fieldListMatches compares one parameter or result list against the required
+// spellings, treating each declared name in a grouped field as its own slot.
+func fieldListMatches(fl *ast.FieldList, want []string) bool {
+	var got []ast.Expr
+	if fl != nil {
+		for _, f := range fl.List {
+			n := 1
+			if len(f.Names) > 0 {
+				n = len(f.Names)
 			}
-			if id, ok := e.Elt.(*ast.Ident); ok {
-				return predeclaredTypes[id.Name]
+			for i := 0; i < n; i++ {
+				got = append(got, f.Type)
 			}
 		}
+	}
+	if len(got) != len(want) {
 		return false
 	}
-	for _, fl := range []*ast.FieldList{ft.Params, ft.Results} {
-		if fl == nil {
-			continue
-		}
-		for _, f := range fl.List {
-			if !resolvable(f.Type) {
-				return true
-			}
+	for i, expr := range got {
+		if !typeSlotMatches(expr, want[i]) {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
-// signatureIs compares a function type's parameter and result types against
-// rendered type expressions, treating each declared name in a grouped
-// parameter as its own entry.
-func signatureIs(ft *ast.FuncType, params, results []string) bool {
-	return fieldListIs(ft.Params, params) && fieldListIs(ft.Results, results)
+// typeSlotMatches reports whether one parameter or result type satisfies the
+// required spelling. A type spelled entirely in terms this check can evaluate
+// is compared exactly; anything else is a wildcard for that slot alone.
+func typeSlotMatches(expr ast.Expr, want string) bool {
+	if !resolvableTypeSpelling(expr) {
+		return true
+	}
+	return normalizeTypeSpelling(exprDisplay(expr)) == normalizeTypeSpelling(want)
 }
 
 // normalizeTypeSpelling collapses spellings Go treats as identical. `byte` is
@@ -1406,34 +1422,26 @@ func normalizeTypeSpelling(s string) string {
 	case "uint8":
 		return "byte"
 	case "int32":
-		// rune, likewise, for any signature that ever spells one.
 		return "rune"
 	}
 	return s
 }
 
-func fieldListIs(fl *ast.FieldList, want []string) bool {
-	var got []string
-	if fl != nil {
-		for _, f := range fl.List {
-			n := 1
-			if len(f.Names) > 0 {
-				n = len(f.Names)
-			}
-			for i := 0; i < n; i++ {
-				got = append(got, normalizeTypeSpelling(exprDisplay(f.Type)))
-			}
-		}
-	}
-	if len(got) != len(want) {
-		return false
-	}
-	for i := range got {
-		if got[i] != normalizeTypeSpelling(want[i]) {
+// resolvableTypeSpelling reports whether a type expression is spelled entirely
+// in builtins — the only names this check can compare without a type checker.
+func resolvableTypeSpelling(expr ast.Expr) bool {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return predeclaredTypes[e.Name]
+	case *ast.ArrayType:
+		if e.Len != nil {
 			return false
 		}
+		if id, ok := e.Elt.(*ast.Ident); ok {
+			return predeclaredTypes[id.Name]
+		}
 	}
-	return true
+	return false
 }
 
 // collectTypeDecls returns every top-level `type X <expr>` declaration in the
@@ -1610,6 +1618,15 @@ func flattenEmbedded(structs map[string]*structFields, decls map[string]typeDecl
 			}
 			sf.decodeUnsafeOwn = append(sf.decodeUnsafeOwn,
 				fmt.Sprintf("%s -> %s (encoding/json cannot allocate an embedded pointer to an unexported type, so a decoder never populates its promoted fields)", name, ref.display))
+		}
+	}
+
+	for _, sf := range structs {
+		for _, ref := range sf.embeds {
+			if child, _, _, err := resolveEmbedFull(ref, structs, decls); err == "" && child != nil {
+				sf.promotesFromStruct = true
+				break
+			}
 		}
 	}
 

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -304,6 +304,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -1775,6 +1776,13 @@ func resolveEmbedFull(e embedRef, structs map[string]*structFields, decls map[st
 			name = t.Name
 		case *ast.SelectorExpr:
 			return nil, "", methodsTravel, "defined in terms of another package's type, which this check does not parse"
+		case *ast.IndexExpr, *ast.IndexListExpr:
+			// `type A G[int]` keeps G's fields, and an alias to one keeps its
+			// method set too. Modelling instantiation is type-checker work;
+			// under this file's invariant the answer is to report, not to
+			// treat it as fieldless — which would drop its tags from the
+			// GENERATED side as well and let a wrapper omit them silently.
+			return nil, "", methodsTravel, "declared over an instantiated generic type, whose fields and method set this check does not model"
 		default:
 			// (fallthrough comment below applies to the default branch)
 			// An interface, map, slice, func, chan or generic type. It is a
@@ -2427,44 +2435,20 @@ func extractJSONTag(tagLiteral string) string {
 	default:
 		return ""
 	}
-	// Use reflect-style key-value parsing. Tags look like `json:"foo,omitempty" xml:"bar"`.
-	for inner != "" {
-		// Skip leading spaces.
-		i := 0
-		for i < len(inner) && inner[i] == ' ' {
-			i++
-		}
-		inner = inner[i:]
-		if inner == "" {
-			break
-		}
-		// Find key (up to ':').
-		colon := strings.IndexByte(inner, ':')
-		if colon == -1 {
-			break
-		}
-		key := inner[:colon]
-		// Value must start with a quote.
-		if colon+1 >= len(inner) || inner[colon+1] != '"' {
-			break
-		}
-		// Find closing quote (Go struct tags don't escape quotes in values).
-		end := strings.IndexByte(inner[colon+2:], '"')
-		if end == -1 {
-			break
-		}
-		val := inner[colon+2 : colon+2+end]
-		if key == "json" {
-			// Take everything before the first comma.
-			comma := strings.IndexByte(val, ',')
-			if comma == -1 {
-				return val
-			}
-			return val[:comma]
-		}
-		inner = inner[colon+3+end:]
+	// The tag body is parsed by reflect, not by hand. A hand-rolled scanner
+	// has to re-derive Go's quoted-string rules, and the one that lived here
+	// stopped at an escaped quote inside an unrelated tag — reading a TAGGED
+	// anonymous field as untagged, which promotes members that are not on the
+	// wire. reflect.StructTag is the same parser encoding/json consults, so
+	// the two cannot disagree.
+	val, ok := reflect.StructTag(inner).Lookup("json")
+	if !ok {
+		return ""
 	}
-	return ""
+	if comma := strings.IndexByte(val, ','); comma != -1 {
+		return val[:comma]
+	}
+	return val
 }
 
 // assignedAny reports whether the construction site assigned any of the given

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -851,18 +851,36 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 			}
 		}
 		// A value shape the walker could not interpret was recorded rather
-		// than credited. Report it: an uninterpreted assignment is exactly
-		// where a silently-credited field would hide.
+		// than credited. Report it — but only where the SUBTREE mattered.
+		//
+		// Every expression yields a value of its field's type, so an
+		// unclassifiable one is only interesting when this walker would
+		// otherwise have credited what is UNDER it: an assignment to an embed
+		// on some promoted field's path. On an ordinary field there is nothing
+		// underneath to get wrong, and `w.ID = 1` or `w.Name = first + last`
+		// are perfectly good assignments the check has always accepted.
 		if !isTier2 {
+			subtreeMatters := map[string]bool{}
+			for tag := range wrap.tagPath {
+				for _, target := range wrap.populationTargets(tag) {
+					if strings.HasSuffix(target, ".*") {
+						subtreeMatters[strings.TrimSuffix(target, ".*")] = true
+					}
+				}
+			}
 			var unrecognized []string
 			for spelling := range assigned {
-				if strings.HasPrefix(spelling, unrecognizedPrefix) {
-					unrecognized = append(unrecognized, strings.TrimPrefix(spelling, unrecognizedPrefix))
+				if !strings.HasPrefix(spelling, unrecognizedPrefix) {
+					continue
+				}
+				path := strings.TrimPrefix(spelling, unrecognizedPrefix)
+				if subtreeMatters[path] {
+					unrecognized = append(unrecognized, path)
 				}
 			}
 			sort.Strings(unrecognized)
 			for _, u := range unrecognized {
-				drift = append(drift, fmt.Sprintf("%s ↔ generated.%s: the value assigned to %s is a shape this walker does not interpret, so it credits nothing. Assign the field with a composite literal, a call or a variable, or mark the tags with `// intentionally-omitted: <tag> - <reason>`.", wrapName, genName, u))
+				drift = append(drift, fmt.Sprintf("%s ↔ generated.%s: %s is an embed on a promoted field's path, and the value assigned to it is a shape this walker does not interpret — so it credits none of the fields under it rather than guessing. Assign it with a composite literal, a call or a variable, or mark the affected tags with `// intentionally-omitted: <tag> - <reason>`.", wrapName, genName, u))
 			}
 		}
 		for _, u := range gen.unresolved {
@@ -2222,9 +2240,14 @@ func recordAssignedValue(assigned map[string]bool, path string, value ast.Expr) 
 			return
 		}
 		// Positional: every direct field is listed, so the subtree is covered
-		// unless one of the elements is itself statically zero.
+		// — unless an element is statically zero, or is itself a literal whose
+		// contents the walker can see but cannot ATTRIBUTE to a field without
+		// the declaration order. `Base{Audit{At: x}, g.ID}` fills one field of
+		// Audit and leaves the rest zero; claiming the subtree would credit
+		// them. Seeing content it cannot place is a reason to stop claiming,
+		// not to assume.
 		for _, elt := range lit.Elts {
-			if zeroValued(elt) {
+			if zeroValued(elt) || literalToEnumerate(elt) != nil {
 				return
 			}
 		}

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -98,6 +98,61 @@
 // tag on the parent, while a partial nested copy (where the nested wrapper
 // itself drifts) would surface only if that nested wrapper has its own pair
 // in the map.
+//
+// # Embedded (anonymous) fields
+//
+// An anonymous field has no tag and no name, so the field walk cannot read a
+// JSON tag off it — but its own tagged fields ARE on the wire, promoted into
+// the embedding struct. Both sides of every pair are therefore flattened
+// before comparison (see flattenEmbedded): each struct's tag set is its own
+// tagged fields plus the tagged fields promoted through its embedded types,
+// resolved recursively. Without this, a wrapper that embeds a struct reads as
+// having none of the promoted fields and every one of them is reported as
+// missing (issue #599).
+//
+// The flattening follows encoding/json's promotion rules, since the wire shape
+// is what this check is about:
+//
+//   - Embedded pointers (`*Base`) promote exactly like value embeds.
+//   - Promotion is transitive: a struct embedding a struct that embeds a struct
+//     contributes all three levels, breadth-first by depth.
+//   - Shallower wins. A JSON tag declared directly on the embedding struct
+//     shadows the same tag promoted from an embedded type; a depth-1 promotion
+//     shadows the same tag at depth 2.
+//   - Two embedded types contributing the SAME tag at the SAME depth cancel
+//     each other out — encoding/json emits neither — so the tag counts as
+//     absent, and deeper occurrences stay shadowed (matching
+//     encoding/json's dominantField).
+//   - An anonymous field that carries its own json:"…" tag is NOT promoted:
+//     encoding/json treats it as an ordinary named field under that tag, and so
+//     does this check — the tag is recorded, with the embedded type's name as
+//     its Go field name for the population check. (`json:"-"` is recorded as
+//     the literal tag "-", matching how the check already handles a named
+//     field spelled that way; see TestExtractJSONTag_DashSentinel.)
+//   - Cycles (A embeds B embeds A, or a self-embedding pointer) terminate: each
+//     type name is visited once per flattening.
+//
+// An embedded type the checker cannot resolve — a qualified one from another
+// package (`time.Time`), or a name not declared in the parsed sources — is
+// reported as drift for any pair that reaches it, rather than skipped. Skipping
+// silently is what produced #599 in the first place; the check parses only
+// go/pkg/basecamp/*.go and client.gen.go, so it cannot see another package's
+// fields and must not pretend they are absent. The report is deferred to the
+// pair walk, so an unresolvable embed on a struct outside every pair (today:
+// FlexTime embedding time.Time) costs nothing.
+//
+// An embedded name that resolves to a declared NON-struct type (an interface, a
+// map, a slice — today: generated.ClientWithResponses embedding ClientInterface)
+// promotes no JSON-tagged fields and contributes nothing. A defined type whose
+// underlying type is another name (`type Alias Base`) is followed to that name.
+//
+// `intentionally-omitted` markers are NOT inherited through an embed: a marker
+// declares that one wrapper deliberately drops a tag of ITS generated
+// counterpart, and each marker is validated against that counterpart, so
+// inheriting one would suppress a check in an unrelated pair and would report
+// marker/generated mismatches for tags the embedded struct's own pair owns. An
+// embedding wrapper that means to drop a tag carries its own marker; the
+// failure mode of getting this wrong is a loud missing-tag report, not silence.
 package main
 
 import (
@@ -279,11 +334,66 @@ var markerRe = regexp.MustCompile(`intentionally-omitted:\s*([a-zA-Z0-9_]+)\s*-\
 // "tagline" -> "Tagline"). The population check (see run) uses it to translate
 // the set of assigned Go fields collected from a *FromGenerated body into the
 // JSON-tag space the rest of the check operates in.
+//
+// tags and tagToGoField hold the FLATTENED view: the struct's own tagged fields
+// after collectStructsAndMarkers, plus the fields promoted through embedded
+// types after flattenEmbedded has run over the whole universe. ownFields and
+// embeds are the unflattened inputs flattenEmbedded walks; it never reads tags,
+// so flattening is order-independent across structs.
 type structFields struct {
 	tags         map[string]bool
 	omitted      map[string]bool
 	tagToGoField map[string]string
 	declaration  token.Pos
+
+	// ownFields lists this struct's own tagged fields in declaration order.
+	ownFields []taggedField
+	// embeds lists this struct's anonymous, untagged fields — the ones whose
+	// tagged fields are promoted onto this struct by encoding/json.
+	embeds []embedRef
+	// tagPopNames maps a PROMOTED tag to the Go field names whose assignment
+	// counts as populating it: the promoted field's own name plus every
+	// embedded field name on the path to it, since assigning the embedded
+	// struct wholesale (`w.Base = Base{...}`) populates everything under it.
+	// Own (non-promoted) tags are absent here; see populationTargets.
+	tagPopNames map[string][]string
+	// unresolved lists embedded types the checker could not resolve, as
+	// human-readable paths ("Task.Meta -> time.Time"). Reported as drift when
+	// a pair reaches this struct; see run.
+	unresolved []string
+}
+
+// populationTargets returns the Go field names whose assignment counts as
+// populating tag on this struct. For a field declared directly on the struct
+// that is the field itself; for a promoted field it is the field plus the
+// embedded fields on the path to it.
+func (sf *structFields) populationTargets(tag string) []string {
+	if names := sf.tagPopNames[tag]; len(names) > 0 {
+		return names
+	}
+	if f := sf.tagToGoField[tag]; f != "" {
+		return []string{f}
+	}
+	return nil
+}
+
+// taggedField is one JSON-tagged field declared directly on a struct.
+type taggedField struct {
+	tag     string
+	goField string
+}
+
+// embedRef is one anonymous, untagged field — an embedded type whose tagged
+// fields are promoted onto the embedding struct.
+type embedRef struct {
+	// name is the embedded type's own name: "Base" for `Base` and `*Base`,
+	// "Time" for `time.Time`.
+	name string
+	// qualifier is the package qualifier for a cross-package embed ("time" for
+	// `time.Time`), empty for a same-package embed.
+	qualifier string
+	// display is the source spelling, used in messages ("*Base", "time.Time").
+	display string
 }
 
 func main() {
@@ -344,6 +454,7 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 		return fmt.Errorf("parse generated: %w", err)
 	}
 	genStructs := collectStructsAndMarkers(fset, genFile)
+	flattenEmbedded(genStructs, collectTypeDecls(genFile))
 
 	// Parse all wrapper files.
 	entries, err := os.ReadDir(wrapperDir)
@@ -351,6 +462,7 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 		return fmt.Errorf("read wrapper dir: %w", err)
 	}
 	wrapperStructs := map[string]*structFields{}
+	wrapperTypeDecls := map[string]ast.Expr{}      // every top-level type decl in the wrapper package, for embed resolution
 	fromGenPairs := map[string]string{}            // wrapper name -> generated name (derived from *FromGenerated signatures)
 	assignedFields := map[string]map[string]bool{} // wrapper name -> set of Go fields written at the wrapper's construction site (tier 1 + tier 3)
 	// Tier-3 names sourced from the production tier3Wrappers set. Tests can
@@ -369,6 +481,9 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 		}
 		for k, v := range collectStructsAndMarkers(fset, f) {
 			wrapperStructs[k] = v
+		}
+		for k, v := range collectTypeDecls(f) {
+			wrapperTypeDecls[k] = v
 		}
 		// collectFromGeneratedPairs already drops excluded functions by their
 		// function name (see excludedFromGenerated check inside it), so no
@@ -405,6 +520,10 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 		}
 	}
 
+	// Every wrapper file is parsed, so embedded types can now be resolved
+	// across the package: an embed may name a struct declared in another file.
+	flattenEmbedded(wrapperStructs, wrapperTypeDecls)
+
 	// Build the final pair list: union of fromGen + directDecode.
 	pairs := map[string]string{}
 	for k, v := range fromGenPairs {
@@ -435,6 +554,18 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 		if wrap == nil {
 			drift = append(drift, fmt.Sprintf("PAIR ERROR: wrapper %s referenced in %sFromGenerated or directDecodePairs but the wrapper struct was not found in go/pkg/basecamp/", wrapName, lowercaseFirst(wrapName)))
 			continue
+		}
+
+		// An embedded type the checker could not resolve hides an unknown
+		// number of promoted fields from both the tag and population checks.
+		// Report it instead of comparing against a knowingly-partial tag set —
+		// silently dropping embedded fields is the bug this reporting exists
+		// to prevent (#599).
+		for _, u := range wrap.unresolved {
+			drift = append(drift, fmt.Sprintf("%s ↔ generated.%s: unresolvable embedded type in the wrapper: %s. Promoted fields from it are invisible to this check; teach the resolver about it or replace the embed with named fields.", wrapName, genName, u))
+		}
+		for _, u := range gen.unresolved {
+			drift = append(drift, fmt.Sprintf("%s ↔ generated.%s: unresolvable embedded type in the generated struct: %s. Promoted fields from it are invisible to this check; teach the resolver about it.", wrapName, genName, u))
 		}
 
 		// The population check runs for tier 1 (assignedFields sourced from
@@ -472,7 +603,11 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 			if !isTier2 {
 				totalFieldsPopChecked++
 				goField := wrap.tagToGoField[tag]
-				if goField != "" && (assigned == nil || !assigned[goField]) {
+				// A promoted field accepts more than one spelling at the
+				// construction site: the field itself (`w.Name = ...`, legal
+				// through promotion) or any embedded struct on the path to it
+				// (`w.Base = Base{...}`), which populates everything under it.
+				if goField != "" && !assignedAny(assigned, wrap.populationTargets(tag)) {
 					unpopulated = append(unpopulated, fmt.Sprintf("%s (field %s)", tag, goField))
 				}
 			}
@@ -529,6 +664,11 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 // that fall within the struct's source range (between the opening { and
 // closing }), so markers don't need to be attached to a specific field —
 // they can sit on their own line inside the struct body.
+//
+// The returned tag sets cover the struct's OWN tagged fields. Anonymous
+// (embedded) fields are recorded in embeds for flattenEmbedded to resolve once
+// every file has been parsed — an embedded type may be declared in a different
+// file of the same package, so it cannot be resolved here.
 func collectStructsAndMarkers(fset *token.FileSet, f *ast.File) map[string]*structFields {
 	out := map[string]*structFields{}
 	for _, decl := range f.Decls {
@@ -549,23 +689,44 @@ func collectStructsAndMarkers(fset *token.FileSet, f *ast.File) map[string]*stru
 				tags:         map[string]bool{},
 				omitted:      map[string]bool{},
 				tagToGoField: map[string]string{},
+				tagPopNames:  map[string][]string{},
 				declaration:  ts.Pos(),
 			}
 			for _, field := range st.Fields.List {
-				if field.Tag == nil {
+				tag := ""
+				if field.Tag != nil {
+					tag = extractJSONTag(field.Tag.Value)
+				}
+				if tag == "" {
+					// An anonymous field with no json tag is an embedded type:
+					// its own tagged fields are promoted onto this struct by
+					// encoding/json. Record it for flattenEmbedded. (A NAMED
+					// field with no json tag is invisible on the wire and to
+					// this check, as before.)
+					if len(field.Names) == 0 {
+						sf.embeds = append(sf.embeds, embedRefFromExpr(field.Type))
+					}
 					continue
 				}
-				tagVal := field.Tag.Value
-				if tag := extractJSONTag(tagVal); tag != "" {
-					sf.tags[tag] = true
-					// Record the Go field identifier for this tag. Tagged
-					// fields in these structs always have exactly one name;
-					// if a field ever had multiple names sharing a tag, the
-					// last wins (still correct for membership lookups).
-					for _, fn := range field.Names {
-						sf.tagToGoField[tag] = fn.Name
-					}
+				sf.tags[tag] = true
+				// Record the Go field identifier for this tag. Tagged
+				// fields in these structs always have exactly one name;
+				// if a field ever had multiple names sharing a tag, the
+				// last wins (still correct for membership lookups).
+				goField := ""
+				for _, fn := range field.Names {
+					goField = fn.Name
 				}
+				if goField == "" {
+					// A TAGGED anonymous field is not promoted — encoding/json
+					// treats it as an ordinary field under its tag, whose Go
+					// field name is the embedded type's name.
+					goField = embedRefFromExpr(field.Type).name
+				}
+				if goField != "" {
+					sf.tagToGoField[tag] = goField
+				}
+				sf.ownFields = append(sf.ownFields, taggedField{tag: tag, goField: goField})
 			}
 			// Scan every comment inside the struct body for opt-out markers.
 			// (Field-attached comments are duplicates of these for our purposes;
@@ -586,6 +747,243 @@ func collectStructsAndMarkers(fset *token.FileSet, f *ast.File) map[string]*stru
 		}
 	}
 	return out
+}
+
+// collectTypeDecls returns every top-level `type X <expr>` declaration in the
+// file, mapping the type name to its right-hand-side type expression. Struct
+// types are included, so the map doubles as the "is this name declared in the
+// parsed sources at all?" oracle flattenEmbedded needs: an embedded name absent
+// from it is unresolvable (declared elsewhere, or in another package), while an
+// embedded name present but non-struct (an interface, a map, a slice) simply
+// promotes no JSON-tagged fields.
+func collectTypeDecls(f *ast.File) map[string]ast.Expr {
+	out := map[string]ast.Expr{}
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			if ts, ok := spec.(*ast.TypeSpec); ok {
+				out[ts.Name.Name] = ts.Type
+			}
+		}
+	}
+	return out
+}
+
+// embedRefFromExpr decomposes an anonymous field's type expression into an
+// embedRef. `Base` -> {name: "Base"}; `*Base` -> {name: "Base", display:
+// "*Base"}; `time.Time` -> {name: "Time", qualifier: "time"}. Anything else
+// (a generic instantiation, an inline struct type) yields an empty name, which
+// flattenEmbedded reports as unresolvable rather than skipping.
+func embedRefFromExpr(expr ast.Expr) embedRef {
+	ref := embedRef{display: exprDisplay(expr)}
+	if star, ok := expr.(*ast.StarExpr); ok {
+		expr = star.X
+	}
+	switch e := expr.(type) {
+	case *ast.Ident:
+		ref.name = e.Name
+	case *ast.SelectorExpr:
+		if pkg, ok := e.X.(*ast.Ident); ok {
+			ref.qualifier = pkg.Name
+			ref.name = e.Sel.Name
+		}
+	}
+	return ref
+}
+
+// exprDisplay renders a type expression for error messages. It handles the
+// shapes an embedded field can take and falls back to a placeholder for
+// anything exotic, so messages never come out blank.
+func exprDisplay(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.StarExpr:
+		return "*" + exprDisplay(e.X)
+	case *ast.SelectorExpr:
+		if pkg := exprDisplay(e.X); pkg != "" {
+			return pkg + "." + e.Sel.Name
+		}
+		return e.Sel.Name
+	case *ast.IndexExpr: // generic instantiation: Base[T]
+		return exprDisplay(e.X) + "[…]"
+	case *ast.IndexListExpr: // generic instantiation: Base[T, U]
+		return exprDisplay(e.X) + "[…]"
+	}
+	return "<unsupported type expression>"
+}
+
+// maxEmbedDepth bounds the promotion walk. The visited-set already terminates
+// cycles; this is a second, independent stop so a pathological chain can never
+// spin. Real embedding chains in this repo are one level deep.
+const maxEmbedDepth = 16
+
+// flattenEmbedded resolves embedded (anonymous) fields for every struct in a
+// universe, merging each embedded type's promoted JSON tags into the embedding
+// struct's tag set. structs is the struct universe (all structs parsed from one
+// package's files, or from client.gen.go); decls is every top-level type
+// declaration from the same sources.
+//
+// The walk is breadth-first by promotion depth so encoding/json's "shallowest
+// declaration wins" rule falls out naturally, and two same-depth contributors
+// of one tag cancel (encoding/json emits neither). See the package doc for the
+// full rule list. Unresolvable embeds are recorded on the embedding struct's
+// unresolved list — never skipped — and reported by run when a pair reaches
+// them.
+func flattenEmbedded(structs map[string]*structFields, decls map[string]ast.Expr) {
+	for name, sf := range structs {
+		flattenOne(name, sf, structs, decls)
+	}
+}
+
+// flattenOne performs the breadth-first promotion walk for a single struct.
+func flattenOne(rootName string, root *structFields, structs map[string]*structFields, decls map[string]ast.Expr) {
+	// A struct reached at depth d contributes its own tagged fields at depth d;
+	// path records the embedded field names traversed to reach it, both for
+	// population targets and for unresolvable-embed messages.
+	type reached struct {
+		name string
+		sf   *structFields
+		path []string
+	}
+
+	// Tags declared directly on the root are claimed at depth 0 and shadow
+	// anything promoted from below.
+	claimed := map[string]bool{}
+	for _, f := range root.ownFields {
+		claimed[f.tag] = true
+	}
+
+	visited := map[string]bool{rootName: true}
+	level := []reached{{name: rootName, sf: root}}
+
+	for depth := 1; depth <= maxEmbedDepth && len(level) > 0; depth++ {
+		var next []reached
+		for _, parent := range level {
+			for _, e := range parent.sf.embeds {
+				child, childName, err := resolveEmbed(e, structs, decls)
+				if err != "" {
+					root.unresolved = append(root.unresolved,
+						fmt.Sprintf("%s -> %s (%s)", strings.Join(append([]string{rootName}, parent.path...), "."), e.display, err))
+					continue
+				}
+				if child == nil || visited[childName] {
+					// Either the embedded type promotes no JSON-tagged fields
+					// (an interface, a map, a slice), or it has already been
+					// visited at this or a shallower depth — encoding/json
+					// likewise visits each type once, which also terminates
+					// embedding cycles.
+					continue
+				}
+				visited[childName] = true
+				path := make([]string, 0, len(parent.path)+1)
+				path = append(path, parent.path...)
+				path = append(path, e.name)
+				next = append(next, reached{name: childName, sf: child, path: path})
+			}
+		}
+
+		// Gather this depth's contributions before claiming any of them, so
+		// same-depth conflicts can be detected.
+		type candidate struct {
+			field taggedField
+			path  []string
+		}
+		byTag := map[string][]candidate{}
+		var order []string
+		for _, r := range next {
+			for _, f := range r.sf.ownFields {
+				if _, seen := byTag[f.tag]; !seen {
+					order = append(order, f.tag)
+				}
+				byTag[f.tag] = append(byTag[f.tag], candidate{field: f, path: r.path})
+			}
+		}
+		for _, tag := range order {
+			if claimed[tag] {
+				continue // a shallower declaration wins (or blocked the tag).
+			}
+			// Claim the tag either way: a same-depth conflict means
+			// encoding/json emits nothing for it, and it also stops any
+			// deeper occurrence from being promoted.
+			claimed[tag] = true
+			cands := byTag[tag]
+			if len(cands) != 1 {
+				continue
+			}
+			c := cands[0]
+			root.tags[tag] = true
+			if c.field.goField != "" {
+				root.tagToGoField[tag] = c.field.goField
+			}
+			// Assigning any embedded struct on the path populates everything
+			// promoted through it, as does assigning the promoted field itself.
+			targets := make([]string, 0, len(c.path)+1)
+			targets = append(targets, c.path...)
+			if c.field.goField != "" {
+				targets = append(targets, c.field.goField)
+			}
+			root.tagPopNames[tag] = targets
+		}
+
+		level = next
+	}
+
+	// Exhausting the depth budget with embeds still unfollowed would hide
+	// fields exactly the way #599 did. Report it rather than stopping quietly.
+	for _, r := range level {
+		if len(r.sf.embeds) > 0 {
+			root.unresolved = append(root.unresolved,
+				fmt.Sprintf("%s -> %s (embedding chain deeper than %d levels; promotion beyond that was not followed)",
+					strings.Join(append([]string{rootName}, r.path...), "."), r.name, maxEmbedDepth))
+			break
+		}
+	}
+}
+
+// resolveEmbed resolves one embedded type reference against the parsed
+// universe. It returns the embedded struct and the name it resolved to, or a
+// non-empty reason string when the type cannot be resolved at all. A nil struct
+// with an empty reason means "resolved, but promotes no JSON-tagged fields"
+// (an interface, map, slice, func or channel type).
+func resolveEmbed(e embedRef, structs map[string]*structFields, decls map[string]ast.Expr) (*structFields, string, string) {
+	switch {
+	case e.name == "":
+		return nil, "", "unsupported embedded type expression"
+	case e.qualifier != "":
+		return nil, "", "declared in another package, which this check does not parse"
+	}
+	// Follow `type Alias Base` hops. maxEmbedDepth also bounds this chain, so a
+	// self-referential declaration cannot spin.
+	name := e.name
+	seen := map[string]bool{}
+	for hop := 0; hop <= maxEmbedDepth; hop++ {
+		if sf, ok := structs[name]; ok {
+			return sf, name, ""
+		}
+		rhs, ok := decls[name]
+		if !ok {
+			return nil, "", "not declared in the parsed sources"
+		}
+		if seen[name] {
+			return nil, "", "self-referential type declaration"
+		}
+		seen[name] = true
+		switch t := rhs.(type) {
+		case *ast.Ident:
+			name = t.Name // `type Alias Base` — follow it.
+		case *ast.SelectorExpr:
+			return nil, "", "defined in terms of another package's type, which this check does not parse"
+		default:
+			// An interface, map, slice, func, chan or generic type: a valid
+			// embed that promotes no JSON-tagged fields.
+			return nil, "", ""
+		}
+	}
+	return nil, "", "type declaration chain is too deep to resolve"
 }
 
 // collectFromGeneratedPairs walks the AST for function declarations of the form
@@ -1022,6 +1420,18 @@ func extractJSONTag(tagLiteral string) string {
 		inner = inner[colon+3+end:]
 	}
 	return ""
+}
+
+// assignedAny reports whether the construction site assigned any of the given
+// Go field names. The population check in run only consults it for tags whose
+// Go field name is known, so an empty target list means unassigned.
+func assignedAny(assigned map[string]bool, names []string) bool {
+	for _, n := range names {
+		if assigned[n] {
+			return true
+		}
+	}
+	return false
 }
 
 func lowercaseFirst(s string) string {

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -1231,7 +1231,11 @@ func collectTypeDecls(f *ast.File) map[string]typeDecl {
 		}
 		for _, spec := range gd.Specs {
 			if ts, ok := spec.(*ast.TypeSpec); ok {
-				out[ts.Name.Name] = typeDecl{expr: ts.Type, alias: ts.Assign.IsValid()}
+				// `type Alias = (Base)` is legal, and the parentheses are not
+				// part of the type. Unwrapping here means every consumer —
+				// the name-edge closure, embed resolution, the interface scan
+				// — sees the same shape without each having to remember.
+				out[ts.Name.Name] = typeDecl{expr: unparen(ts.Type), alias: ts.Assign.IsValid()}
 			}
 		}
 	}

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -1452,14 +1452,16 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 	// consults tags — so a tagged embed is vouched for on exactly the same
 	// terms as an untagged one.
 	for _, te := range root.taggedEmbeds {
-		if te.ref.pointer && te.ref.name != "" && !ast.IsExported(te.ref.name) {
+		child, childName, methodsTravel, err := resolveEmbedFull(te.ref, structs, decls)
+		if child != nil && te.ref.pointer && !ast.IsExported(te.ref.name) {
 			// Same allocation problem as an untagged one: the tag changes which
 			// KEY the field appears under, not whether the decoder can create
-			// it.
+			// it. Only for a STRUCT, though — encoding/json ignores an
+			// anonymous unexported non-struct field outright, so there is
+			// nothing it failed to allocate.
 			root.decodeUnsafe = append(root.decodeUnsafe,
 				fmt.Sprintf("%s -> %s (encoding/json cannot allocate an embedded pointer to an unexported type, so a decoder never populates it)", rootName, te.ref.display))
 		}
-		_, childName, methodsTravel, err := resolveEmbedFull(te.ref, structs, decls)
 		if reason := vouch(te.ref, childName, methodsTravel, err, jsonMethods); reason != "" {
 			root.unresolved = append(root.unresolved, fmt.Sprintf("%s -> %s (%s)", rootName, te.ref.display, reason))
 			discardPromotions()
@@ -1509,7 +1511,10 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 					discardPromotions()
 					return
 				}
-				if e.pointer && e.name != "" && !ast.IsExported(e.name) {
+				if child != nil && e.pointer && !ast.IsExported(e.name) {
+					// A struct only: an anonymous pointer to an unexported
+					// NON-struct is ignored by encoding/json rather than
+					// allocated, so there is no field it failed to populate.
 					root.decodeUnsafe = append(root.decodeUnsafe,
 						fmt.Sprintf("%s -> %s (encoding/json cannot allocate an embedded pointer to an unexported type, so a decoder never populates its promoted fields)",
 							strings.Join(append([]string{rootName}, parent.path...), "."), e.display))
@@ -1974,7 +1979,7 @@ func recordAssignedValue(assigned map[string]bool, path string, value ast.Expr) 
 		// rather than guessing: the author writes keys, and the report is the
 		// safe direction.
 		for _, elt := range lit.Elts {
-			if id, ok := unparen(elt).(*ast.Ident); ok && id.Name == "nil" {
+			if zeroValued(elt) {
 				return
 			}
 		}
@@ -1993,6 +1998,11 @@ func zeroValued(expr ast.Expr) bool {
 	switch e := expr.(type) {
 	case *ast.Ident:
 		return e.Name == "nil"
+	case *ast.CompositeLit:
+		// An empty struct literal — `Audit{}` as a positional element —
+		// contributes nothing, so a literal containing one cannot claim to
+		// have populated what is under it.
+		return len(e.Elts) == 0 && litTypeName(e.Type) != ""
 	case *ast.CallExpr:
 		// new(T) — the builtin, not a method named new.
 		if id, ok := unparen(e.Fun).(*ast.Ident); ok && id.Name == "new" {

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -143,6 +143,60 @@
 //   - Cycles (A embeds B embeds A, or a self-embedding pointer) terminate: each
 //     type name is visited once per flattening.
 //
+// # CAN / CANNOT
+//
+// The honest boundary of the embedded-field support, and the invariant that
+// makes the boundary safe. Read this before adding a rule to either list.
+//
+// CAN resolve and judge:
+//
+//   - An embed of a locally-declared struct, by value or pointer, from any
+//     file of the same package, at any depth, including through a chain of
+//     `type A B` / `type A = B` declarations.
+//   - Promotion under encoding/json's rules: shallowest declaration wins,
+//     same-depth conflicts annihilate (including a type reached twice at one
+//     depth), unexported fields are ignored, a tagged anonymous field is an
+//     ordinary field rather than a promotion source.
+//   - Population of a promoted field through any legal spelling of it —
+//     `w.Field`, `w.Embed.Field`, or an assignment of any embed on its path —
+//     with the value classified exhaustively: literals are enumerated key by
+//     key, statically zero values credit nothing.
+//
+// CANNOT, and therefore REPORTS rather than assumes:
+//
+//   - A type from another package, or a name not declared in the parsed
+//     sources. Its fields and its method set are both invisible.
+//   - A type whose method set carries MarshalJSON/UnmarshalJSON/MarshalText/
+//     UnmarshalText by any route. Promotion redirects the encoder away from
+//     every field, so no tag on the struct is trustworthy.
+//   - An assignment whose right-hand side is a shape not in the classification
+//     above.
+//   - An embedded pointer to an unexported type, for direct-decode pairs only:
+//     encoding/json cannot allocate it, so the decoder never populates it.
+//
+// The invariant: ANYTHING UNRECOGNISED IS REPORTED. Never credited, never
+// skipped. Both failure modes this walk has actually had — the original #599
+// bug and every regression found while fixing it — were a silent assumption
+// about something the walker did not understand.
+//
+// # An honest tally, for whoever adds the next rule
+//
+// This support was reviewed in ten rounds and grew a rule in almost every one:
+// promotion, annihilation, same-depth multiplicity, export visibility, literal
+// enumeration, qualified assignment paths, Go-name shadowing, depth-0
+// conflicts, method promotion (declared, inherited, interface, aliased, text),
+// decode allocation, value classification. The call sites that support covers
+// grew exactly once — at the original fix — and remain at ZERO: no wrapper in
+// a checked pair embeds a struct, and the gate's output on the real corpus has
+// been byte-identical throughout.
+//
+// The rules that earned their place are the ones that turn a silent assumption
+// into a report. A rule that only makes an already-loud report more precise, on
+// a shape with no call site, is the kind this file has enough of. Prefer
+// widening the reported set over modelling another corner of encoding/json or
+// of Go's type identity — those are the type checker's job, and every attempt
+// here to do a piece of it produced the next round's finding about itself.
+//
 // # What the walk will and will not judge
 //
 // Flattening happens only through embeds the walk can fully vouch for (see
@@ -238,6 +292,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -730,6 +785,8 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 	var drift []string
 	totalFieldsChecked := 0
 	totalFieldsPopChecked := 0
+	embeddedPairs := 0         // pairs whose wrapper actually promotes fields through an embed
+	promotedFieldsChecked := 0 // generated tags satisfied by a promoted (not directly declared) field
 	for _, wrapName := range pairNames {
 		genName := pairs[wrapName]
 		gen := genStructs[genName]
@@ -764,6 +821,21 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 				drift = append(drift, fmt.Sprintf("%s ↔ generated.%s: %s. This pair is direct-decode, where tag presence IS population, so those fields are silently absent.", wrapName, genName, u))
 			}
 		}
+		// A value shape the walker could not interpret was recorded rather
+		// than credited. Report it: an uninterpreted assignment is exactly
+		// where a silently-credited field would hide.
+		if !isTier2 {
+			var unrecognized []string
+			for spelling := range assigned {
+				if strings.HasPrefix(spelling, unrecognizedPrefix) {
+					unrecognized = append(unrecognized, strings.TrimPrefix(spelling, unrecognizedPrefix))
+				}
+			}
+			sort.Strings(unrecognized)
+			for _, u := range unrecognized {
+				drift = append(drift, fmt.Sprintf("%s ↔ generated.%s: the value assigned to %s is a shape this walker does not interpret, so it credits nothing. Assign the field with a composite literal, a call or a variable, or mark the tags with `// intentionally-omitted: <tag> - <reason>`.", wrapName, genName, u))
+			}
+		}
 		for _, u := range gen.unresolved {
 			drift = append(drift, fmt.Sprintf("%s ↔ generated.%s: unresolvable embedded type in the generated struct: %s. Promoted fields from it are invisible to this check; teach the resolver about it.", wrapName, genName, u))
 		}
@@ -775,6 +847,9 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 		}
 		sort.Strings(tags)
 
+		if len(wrap.tagPath) > 0 {
+			embeddedPairs++
+		}
 		var missing []string
 		var unpopulated []string
 		for _, tag := range tags {
@@ -785,6 +860,9 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 			if !wrap.tags[tag] {
 				missing = append(missing, tag)
 				continue
+			}
+			if len(wrap.tagPath[tag]) > 0 {
+				promotedFieldsChecked++
 			}
 			// Tag is declared on the wrapper. For tier-1 and tier-3 pairs,
 			// also confirm the construction site actually assigns the field —
@@ -832,6 +910,18 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 	}
 
 	fmt.Printf("Wrapper drift check: %d pairs walked, %d generated fields verified (%d field assignments verified at tier-1 *FromGenerated bodies + tier-3 composite literals)\n", len(pairNames), totalFieldsChecked, totalFieldsPopChecked)
+
+	// Say what the verdict covers. A clean run means "no drift in the shapes
+	// this walker resolves", and when no pair embeds anything at all — which
+	// is the case in this repo today — the embedded-field machinery verified
+	// nothing and the line should not let a reader think otherwise.
+	switch {
+	case embeddedPairs == 0:
+		fmt.Println("  Embedded-field promotion: no pair embeds a struct, so nothing above was verified through it.")
+	default:
+		fmt.Printf("  Embedded-field promotion: %d of %d pairs embed a struct; %d promoted fields verified through it.\n", embeddedPairs, len(pairNames), promotedFieldsChecked)
+	}
+	fmt.Println("  Scope: shapes this walker resolves. Unrecognised embeds and assignment shapes are reported as drift, never assumed away — see the CAN/CANNOT list in this file's header.")
 
 	if len(drift) > 0 {
 		fmt.Fprintln(os.Stderr)
@@ -993,9 +1083,12 @@ func collectJSONMethodTypes(f *ast.File) (map[string]bool, map[string][]string) 
 		if !isJSONMethod(fd.Name.Name, fd.Type) {
 			continue
 		}
-		recv := fd.Recv.List[0].Type
+		// `func (m (M)) MarshalJSON()` is legal, and reading the receiver as
+		// unrecognized would leave M out of the method set — a silent miss, so
+		// the parentheses come off even though nobody writes them.
+		recv := unparen(fd.Recv.List[0].Type)
 		if star, ok := recv.(*ast.StarExpr); ok {
-			recv = star.X
+			recv = unparen(star.X)
 		}
 		if id, ok := recv.(*ast.Ident); ok {
 			out[id.Name] = true
@@ -1920,41 +2013,56 @@ func litTypeName(expr ast.Expr) string {
 	return ""
 }
 
+// unrecognizedPrefix marks a value shape the walker could not interpret. It is
+// stored in the same set as the dotted assignment paths, prefixed with a byte
+// that cannot begin a Go identifier, so it can never collide with a real
+// spelling. run() turns each into drift for the pair that reaches it.
+const unrecognizedPrefix = "?"
+
 // recordAssignedValue records every population fact implied by assigning value
 // to path (a dotted field path relative to the wrapper instance, e.g. "Base" or
 // "Base.Audit"). It is the single vocabulary the population check reads through
 // populationTargets.
 //
-// The path itself is always recorded. What the assignment covers BELOW that
-// path depends on whether the walker can see inside the value:
+// The path itself is always recorded. What the assignment covers BELOW it is
+// decided by an EXHAUSTIVE classification of the value, because the default for
+// an unrecognized shape is the thing this whole check exists to prevent:
+// silently crediting fields nobody assigned. The classification is therefore a
+// whitelist, and its last branch reports rather than assumes.
 //
-//   - A struct composite literal (`Base{ID: g.Id}`, `&Base{...}`) is
-//     enumerated: each key becomes `path.Key`, recursively. A partial literal
-//     therefore covers only the fields it names — assigning an embedded struct
-//     with two of its five fields set leaves the other three unpopulated, which
-//     is the true wire outcome and must not read as full coverage.
-//   - Anything else — a function call, a variable, a slice or map literal — is
-//     opaque, and gets the total marker `path.*`: the walker cannot enumerate
-//     it, and crediting the whole subtree matches the one-level-nesting
-//     doctrine the check already applies to nested wrappers (`c.Creator =
-//     &creator` counts, and Person's own fields are verified through Person's
-//     own pair).
+//   - Statically zero — `nil`, `new(T)`, `(*T)(nil)`, an empty literal —
+//     covers NOTHING. None of them carry a value in.
+//   - A struct literal with keys, written with its type (`Base{ID: g.Id}`) or
+//     with the type elided inside another literal (`Base{Audit: {At: g.At}}`),
+//     is ENUMERATED key by key, recursively. A partial literal covers only the
+//     fields it names.
+//   - A positional struct literal lists every direct field, so it covers the
+//     subtree — unless an element is statically zero, which withdraws the
+//     claim, since the walker cannot tell which field that element lands on.
+//   - A call, a variable, a field selector, a dereference, an index or a type
+//     assertion delivers a whole value of the field's type, so it covers the
+//     subtree. This is the one-level-nesting doctrine the check has always
+//     applied (`c.Creator = &creator` counts, and Person's own fields are
+//     verified through Person's own pair).
+//   - ANYTHING ELSE is recorded as unrecognized and covers nothing. The pair
+//     that reaches it reports, and the shape gets read by a person instead of
+//     being credited by a walker that did not understand it.
 //
 // A nil value means the write had no readable right-hand side (`x.F++`), which
-// is treated as opaque.
+// covers the subtree: the field was written, and there is nothing to look into.
 func recordAssignedValue(assigned map[string]bool, path string, value ast.Expr) {
 	if path == "" {
 		return
 	}
 	assigned[path] = true
-	if zeroValued(value) {
-		// nil, new(T) and a typed nil conversion all populate nothing:
-		// encoding/json emits none of a nil embed's promoted fields, and
-		// new(T) copies no value in. The write is recorded without any
-		// subtree coverage.
+	if value == nil {
+		assigned[path+".*"] = true
 		return
 	}
-	if lit := structLiteral(value); lit != nil {
+	if zeroValued(value) {
+		return
+	}
+	if lit := literalToEnumerate(value); lit != nil {
 		keyed := false
 		for _, elt := range lit.Elts {
 			kv, ok := elt.(*ast.KeyValueExpr)
@@ -1962,47 +2070,50 @@ func recordAssignedValue(assigned map[string]bool, path string, value ast.Expr) 
 				continue
 			}
 			keyed = true
-			if key, ok := kv.Key.(*ast.Ident); ok {
-				recordAssignedValue(assigned, path+"."+key.Name, kv.Value)
+			key, ok := kv.Key.(*ast.Ident)
+			if !ok {
+				// A struct literal's keys are field names; anything else is a
+				// shape this walker does not model.
+				assigned[unrecognizedPrefix+path] = true
+				continue
 			}
+			recordAssignedValue(assigned, path+"."+key.Name, kv.Value)
 		}
 		if keyed || len(lit.Elts) == 0 {
-			// A keyed literal covers exactly the keys enumerated above. An
-			// empty literal covers nothing.
 			return
 		}
-		// A positional literal must list every DIRECT field of the struct, so
-		// it covers the subtree — unless one of those fields is an embedded
-		// pointer given nil, which puts none of ITS promoted fields on the
-		// wire. The walker cannot tell which element is which field without
-		// the full declaration order, so a nil element withdraws the claim
-		// rather than guessing: the author writes keys, and the report is the
-		// safe direction.
+		// Positional: every direct field is listed, so the subtree is covered
+		// unless one of the elements is itself statically zero.
 		for _, elt := range lit.Elts {
 			if zeroValued(elt) {
 				return
 			}
 		}
+		assigned[path+".*"] = true
+		return
 	}
-	assigned[path+".*"] = true
+	if deliversWholeValue(value) {
+		assigned[path+".*"] = true
+		return
+	}
+	assigned[unrecognizedPrefix+path] = true
 }
 
 // zeroValued reports whether an assigned value is statically known to carry no
-// data: the nil identifier, `new(T)`, or a conversion of nil such as
-// `(*Base)(nil)`. Crediting any of them with subtree coverage would pass a
-// converter that emits none of the fields it claims. Anything else is opaque —
-// the walker cannot see inside it and credits the subtree, which is the
-// one-level-nesting doctrine the check has always applied.
+// data: the nil identifier, `new(T)`, a conversion of nil such as
+// `(*Base)(nil)`, or an empty composite literal. Crediting any of them with
+// subtree coverage would pass a converter that emits none of the fields it
+// claims.
 func zeroValued(expr ast.Expr) bool {
-	expr = unparen(expr)
-	switch e := expr.(type) {
+	switch e := unparen(expr).(type) {
 	case *ast.Ident:
 		return e.Name == "nil"
 	case *ast.CompositeLit:
-		// An empty struct literal — `Audit{}` as a positional element —
-		// contributes nothing, so a literal containing one cannot claim to
-		// have populated what is under it.
-		return len(e.Elts) == 0 && litTypeName(e.Type) != ""
+		// An empty literal — `Audit{}`, or `{}` elided inside another —
+		// contributes nothing.
+		return len(e.Elts) == 0
+	case *ast.UnaryExpr:
+		return e.Op == token.AND && zeroValued(e.X)
 	case *ast.CallExpr:
 		// new(T) — the builtin, not a method named new.
 		if id, ok := unparen(e.Fun).(*ast.Ident); ok && id.Name == "new" {
@@ -2021,18 +2132,9 @@ func zeroValued(expr ast.Expr) bool {
 	return false
 }
 
-// unparenOnce strips one layer of parentheses, distinguishing `(*T)(nil)` —
-// where the parens are part of the conversion syntax — from a bare call.
-func unparenOnce(expr ast.Expr) ast.Expr {
-	if p, ok := expr.(*ast.ParenExpr); ok {
-		return p.X
-	}
-	return expr
-}
-
 // unparen strips redundant parentheses: `(Base{...})` is the same value as
-// `Base{...}`, and classifying the parenthesized form as opaque would credit a
-// subtree the literal only partly fills.
+// `Base{...}`, and classifying the parenthesized form differently would credit
+// or refuse a subtree on punctuation alone.
 func unparen(expr ast.Expr) ast.Expr {
 	for {
 		p, ok := expr.(*ast.ParenExpr)
@@ -2041,6 +2143,56 @@ func unparen(expr ast.Expr) ast.Expr {
 		}
 		expr = p.X
 	}
+}
+
+// literalToEnumerate returns the composite literal to walk key-by-key for a
+// value, or nil. It accepts the typed forms (`Base{…}`, `&Base{…}`) and the
+// ELIDED form Go permits for a nested literal (`Base{Audit: {At: g.At}}`),
+// whose type is implied by the field it initializes. Treating an elided
+// literal as opaque would credit every field under it while only the keys
+// written are set. Slice and map literals are not struct literals and are
+// handled elsewhere.
+func literalToEnumerate(expr ast.Expr) *ast.CompositeLit {
+	if lit := structLiteral(expr); lit != nil {
+		return lit
+	}
+	expr = unparen(expr)
+	if u, ok := expr.(*ast.UnaryExpr); ok && u.Op == token.AND {
+		expr = unparen(u.X)
+	}
+	if cl, ok := expr.(*ast.CompositeLit); ok && cl.Type == nil {
+		return cl
+	}
+	return nil
+}
+
+// deliversWholeValue reports whether an expression yields a complete value of
+// the assigned field's type — the shapes whose contents the walker cannot see
+// but whose result is a whole value, so crediting the subtree is sound under
+// the one-level-nesting doctrine. Anything outside this list is reported
+// rather than assumed.
+func deliversWholeValue(expr ast.Expr) bool {
+	switch e := unparen(expr).(type) {
+	case *ast.CallExpr, *ast.Ident, *ast.SelectorExpr, *ast.IndexExpr,
+		*ast.IndexListExpr, *ast.TypeAssertExpr, *ast.StarExpr:
+		return true
+	case *ast.CompositeLit:
+		// A slice or map literal: not a struct, nothing to enumerate as
+		// fields, and a complete value of its own type.
+		return true
+	case *ast.UnaryExpr:
+		return e.Op == token.AND && deliversWholeValue(e.X)
+	}
+	return false
+}
+
+// unparenOnce strips one layer of parentheses, distinguishing `(*T)(nil)` —
+// where the parens are part of the conversion syntax — from a bare call.
+func unparenOnce(expr ast.Expr) ast.Expr {
+	if p, ok := expr.(*ast.ParenExpr); ok {
+		return p.X
+	}
+	return expr
 }
 
 // structLiteral returns the composite literal behind expr when it is a
@@ -2244,11 +2396,23 @@ func extractLocalTypeName(expr ast.Expr) string {
 // extractJSONTag pulls the tag name from a struct tag literal like
 // "`json:\"foo,omitempty\"`". Returns "" if no json tag is present.
 func extractJSONTag(tagLiteral string) string {
-	// Strip the surrounding backticks.
-	if len(tagLiteral) < 2 || tagLiteral[0] != '`' || tagLiteral[len(tagLiteral)-1] != '`' {
+	// Go accepts either a raw literal (the universal convention here) or an
+	// interpreted one: `Base "json:\"base\""` is a TAGGED field, and reading
+	// it as untagged would treat an ordinary field as an embed and promote
+	// members that are not on the wire.
+	inner := ""
+	switch {
+	case len(tagLiteral) >= 2 && tagLiteral[0] == '`' && tagLiteral[len(tagLiteral)-1] == '`':
+		inner = tagLiteral[1 : len(tagLiteral)-1]
+	case len(tagLiteral) >= 2 && tagLiteral[0] == '"' && tagLiteral[len(tagLiteral)-1] == '"':
+		unquoted, err := strconv.Unquote(tagLiteral)
+		if err != nil {
+			return ""
+		}
+		inner = unquoted
+	default:
 		return ""
 	}
-	inner := tagLiteral[1 : len(tagLiteral)-1]
 	// Use reflect-style key-value parsing. Tags look like `json:"foo,omitempty" xml:"bar"`.
 	for inner != "" {
 		// Skip leading spaces.

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -143,14 +143,35 @@
 //   - Cycles (A embeds B embeds A, or a self-embedding pointer) terminate: each
 //     type name is visited once per flattening.
 //
-// An embedded type the checker cannot resolve — a qualified one from another
-// package (`time.Time`), or a name not declared in the parsed sources — is
-// reported as drift for any pair that reaches it, rather than skipped. Skipping
-// silently is what produced #599 in the first place; the check parses only
-// go/pkg/basecamp/*.go and client.gen.go, so it cannot see another package's
-// fields and must not pretend they are absent. The report is deferred to the
-// pair walk, so an unresolvable embed on a struct outside every pair (today:
-// FlexTime embedding time.Time) costs nothing.
+// # What the walk will and will not judge
+//
+// Flattening happens only through embeds the walk can fully vouch for (see
+// vouch). Anything else is REPORTED — the struct is then judged on its own
+// declarations alone, and any pair that reaches it fails loudly. Two things
+// fail to vouch:
+//
+//   - A type this check does not parse: qualified from another package
+//     (`time.Time`), or a name not declared in the parsed sources. It cannot
+//     be assumed field-less, and it cannot be assumed method-less either.
+//   - A type whose method set carries MarshalJSON/UnmarshalJSON by any route —
+//     its own declaration, an interface it embeds, an alias. Promoting such a
+//     method makes the EMBEDDING struct implement json.Marshaler, so
+//     encoding/json calls it and never walks any of these fields; every
+//     promoted tag on the struct is then meaningless, not just that embed's.
+//     A json tag on the embed does not change this: a tag governs field
+//     selection, while method promotion is a language rule that never consults
+//     tags.
+//
+// This is a whitelist on purpose, and it is where the design stops mirroring
+// encoding/json. Field promotion is a bounded, syntactic problem this walk can
+// model faithfully. Method promotion and cross-package types are not: they are
+// decided by the type checker, travel through interfaces, aliases and other
+// packages, and every rule that models one spelling of them invites the next.
+// Reporting is the bound. A new shape in that class belongs here as a refusal,
+// not as another mirror of the standard library.
+//
+// The report is deferred to the pair walk, so an unvouched embed on a struct
+// outside every pair (today: FlexTime embedding time.Time) costs nothing.
 //
 // An embedded name that resolves to a declared NON-struct type (an interface, a
 // map, a slice — today: generated.ClientWithResponses embedding ClientInterface)
@@ -1002,16 +1023,36 @@ func closeJSONMethodTypes(direct map[string]bool, ifaceEmbeds map[string][]strin
 	}
 }
 
-// promotesJSONMethod reports whether embedding e makes the embedding struct
-// implement json.Marshaler / json.Unmarshaler. The embed's own name always
-// counts (it is the type written at the embed site, and an interface resolves
-// to no struct at all); a name reached through type-declaration hops counts
-// only when the method set travelled with it — see resolveEmbedFull.
-func promotesJSONMethod(e embedRef, childName string, methodsTravel bool, jsonMethods map[string]bool) bool {
-	if jsonMethods[e.name] {
-		return true
+// vouch is the single gate on whether the walk may flatten through an embed. It
+// returns "" when the embed is safe to walk, or the reason it is not.
+//
+// This is deliberately a WHITELIST, and it is where the design stops chasing
+// encoding/json's tail. Two mechanisms decide an embedding struct's wire shape
+// that source text cannot settle: promoted METHODS (a promoted MarshalJSON
+// redirects the encoder away from every field, and method sets travel through
+// interfaces, aliases and other packages) and types this check never parses.
+// Each is an unbounded surface for a static walk, and each new rule modelling
+// one spelling of it invites the next. So anything not plainly vouched for —
+// a type from another package, a name not declared in the parsed sources, a
+// type whose method set carries MarshalJSON/UnmarshalJSON by any route — is
+// REPORTED rather than modelled, and the struct is judged on its own
+// declarations alone.
+//
+// The method check keys on the embed's own name as well as the resolved
+// struct: an embedded interface carries the method in its method set and
+// resolves to no struct at all. A name reached through declaration hops counts
+// only when the method set travelled with it (every hop an alias), since a
+// defined type starts with an empty method set.
+func vouch(e embedRef, childName string, methodsTravel bool, resolveErr string, jsonMethods map[string]bool) string {
+	if jsonMethods[e.name] || (methodsTravel && childName != "" && jsonMethods[childName]) {
+		return "the embedded type's method set carries MarshalJSON/UnmarshalJSON, which the embedding struct promotes; encoding/json then calls it instead of walking any of these fields, so no promoted tag here is trustworthy"
 	}
-	return methodsTravel && childName != "" && jsonMethods[childName]
+	if resolveErr != "" {
+		// An unresolvable type may also be a marshaller — time.Time is one —
+		// so this cannot be treated as merely "fields we cannot see".
+		return resolveErr + "; its fields AND any custom JSON methods it would promote are invisible here"
+	}
+	return ""
 }
 
 // isJSONMethodName reports whether a method name is one whose promotion
@@ -1201,18 +1242,16 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 	}
 
 	// A json tag stops an anonymous field from promoting its FIELDS. It does
-	// nothing to method promotion, so a tagged embed of a marshaller redirects
-	// the encoder exactly as an untagged one does.
+	// nothing to method promotion — that is a language rule which never
+	// consults tags — so a tagged embed is vouched for on exactly the same
+	// terms as an untagged one.
 	for _, te := range root.taggedEmbeds {
 		_, childName, methodsTravel, err := resolveEmbedFull(te.ref, structs, decls)
-		if err != "" || !promotesJSONMethod(te.ref, childName, methodsTravel, jsonMethods) {
-			continue
+		if reason := vouch(te.ref, childName, methodsTravel, err, jsonMethods); reason != "" {
+			root.unresolved = append(root.unresolved, fmt.Sprintf("%s -> %s (%s)", rootName, te.ref.display, reason))
+			discardPromotions()
+			return
 		}
-		root.unresolved = append(root.unresolved,
-			fmt.Sprintf("%s -> %s (tagged embedded type declares MarshalJSON/UnmarshalJSON; the tag stops its FIELDS being promoted but not its methods, so encoding/json calls it for the whole struct)",
-				rootName, te.ref.display))
-		discardPromotions()
-		return
 	}
 
 	// Go-name resolution, tracked alongside the tag walk: nameDepth records the
@@ -1251,26 +1290,9 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 		for _, parent := range level {
 			for _, e := range parent.sf.embeds {
 				child, childName, methodsTravel, err := resolveEmbedFull(e, structs, decls)
-				if err != "" {
+				if reason := vouch(e, childName, methodsTravel, err, jsonMethods); reason != "" {
 					root.unresolved = append(root.unresolved,
-						fmt.Sprintf("%s -> %s (%s)", strings.Join(append([]string{rootName}, parent.path...), "."), e.display, err))
-					continue
-				}
-				// Checked on the embed's own name as well as the resolved
-				// struct: an embedded INTERFACE carries the method in its
-				// method set and resolves to no struct at all, so keying only
-				// on the resolution would miss it entirely.
-				if promotesJSONMethod(e, childName, methodsTravel, jsonMethods) {
-					// Promoting a custom marshaller changes how the WHOLE
-					// embedding struct is encoded, so NO promoted tag on this
-					// struct describes the wire any more — not just this
-					// embed's. Method promotion is transitive, so this holds
-					// wherever in the tree the method appears. Report, discard
-					// every promotion made so far, and stop: refusing to judge
-					// beats certifying keys the method may never emit.
-					root.unresolved = append(root.unresolved,
-						fmt.Sprintf("%s -> %s (embedded type declares MarshalJSON/UnmarshalJSON, which the embedding struct promotes; encoding/json then calls it instead of walking these fields, so no promoted tag here is trustworthy)",
-							strings.Join(append([]string{rootName}, parent.path...), "."), e.display))
+						fmt.Sprintf("%s -> %s (%s)", strings.Join(append([]string{rootName}, parent.path...), "."), e.display, reason))
 					discardPromotions()
 					return
 				}
@@ -1429,7 +1451,11 @@ func resolveEmbedFull(e embedRef, structs map[string]*structFields, decls map[st
 			// can drift past it: generated structs are oapi-codegen output,
 			// where every field carries a tag, so no generated wire key is
 			// ever spelled this way for a wrapper to miss.
-			return nil, "", methodsTravel, ""
+			//
+			// The NAME is still returned even though there is no struct: an
+			// embedded interface promotes its method set, and vouch has to be
+			// able to look that name up.
+			return nil, name, methodsTravel, ""
 		}
 	}
 	return nil, "", methodsTravel, "type declaration chain is too deep to resolve"
@@ -1683,10 +1709,11 @@ func recordAssignedValue(assigned map[string]bool, path string, value ast.Expr) 
 		return
 	}
 	assigned[path] = true
-	if id, ok := unparen(value).(*ast.Ident); ok && id.Name == "nil" {
-		// Assigning nil to a pointer embed populates nothing — encoding/json
-		// emits none of its promoted fields — so the write is recorded without
-		// any subtree coverage.
+	if zeroValued(value) {
+		// nil, new(T) and a typed nil conversion all populate nothing:
+		// encoding/json emits none of a nil embed's promoted fields, and
+		// new(T) copies no value in. The write is recorded without any
+		// subtree coverage.
 		return
 	}
 	if lit := structLiteral(value); lit != nil {
@@ -1720,6 +1747,32 @@ func recordAssignedValue(assigned map[string]bool, path string, value ast.Expr) 
 		}
 	}
 	assigned[path+".*"] = true
+}
+
+// zeroValued reports whether an assigned value is statically known to carry no
+// data: the nil identifier, `new(T)`, or a conversion of nil such as
+// `(*Base)(nil)`. Crediting any of them with subtree coverage would pass a
+// converter that emits none of the fields it claims. Anything else is opaque —
+// the walker cannot see inside it and credits the subtree, which is the
+// one-level-nesting doctrine the check has always applied.
+func zeroValued(expr ast.Expr) bool {
+	expr = unparen(expr)
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name == "nil"
+	case *ast.CallExpr:
+		// new(T) — the builtin, not a method named new.
+		if id, ok := unparen(e.Fun).(*ast.Ident); ok && id.Name == "new" {
+			return true
+		}
+		// A conversion whose single argument is nil: (*Base)(nil), Base(nil).
+		if len(e.Args) == 1 {
+			if id, ok := unparen(e.Args[0]).(*ast.Ident); ok && id.Name == "nil" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // unparen strips redundant parentheses: `(Base{...})` is the same value as

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -1065,8 +1065,17 @@ func resolveEmbed(e embedRef, structs map[string]*structFields, decls map[string
 		case *ast.SelectorExpr:
 			return nil, "", "defined in terms of another package's type, which this check does not parse"
 		default:
-			// An interface, map, slice, func, chan or generic type: a valid
-			// embed that promotes no JSON-tagged fields.
+			// An interface, map, slice, func, chan or generic type. It is a
+			// valid embed and it is NOT absent from the wire — encoding/json
+			// treats it as an ordinary field keyed by the Go field name
+			// (`struct{ Payload }` emits "Payload") — but it promotes no
+			// JSON-TAGGED fields, and tags are this check's entire vocabulary.
+			// An untagged field is invisible here whether it is embedded or
+			// named (`Plain string` emits "Plain" and is likewise not
+			// tracked), so the treatment is uniform and neither side of a pair
+			// can drift past it: generated structs are oapi-codegen output,
+			// where every field carries a tag, so no generated wire key is
+			// ever spelled this way for a wrapper to miss.
 			return nil, "", ""
 		}
 	}

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -153,14 +153,30 @@
 //   - A type this check does not parse: qualified from another package
 //     (`time.Time`), or a name not declared in the parsed sources. It cannot
 //     be assumed field-less, and it cannot be assumed method-less either.
-//   - A type whose method set carries MarshalJSON/UnmarshalJSON by any route —
-//     its own declaration, an interface it embeds, an alias. Promoting such a
-//     method makes the EMBEDDING struct implement json.Marshaler, so
-//     encoding/json calls it and never walks any of these fields; every
-//     promoted tag on the struct is then meaningless, not just that embed's.
-//     A json tag on the embed does not change this: a tag governs field
-//     selection, while method promotion is a language rule that never consults
-//     tags.
+//
+//   - A type whose method set carries MarshalJSON/UnmarshalJSON — or
+//     MarshalText/UnmarshalText, which encoding/json falls back to — by any
+//     route: its own declaration, a type it embeds, an interface, a name
+//     chain. Promoting such a method makes the EMBEDDING struct implement the
+//     interface, so encoding/json calls it and never walks any of these
+//     fields; every promoted tag on the struct is then meaningless, not just
+//     that embed's. A json tag on the embed does not change this: a tag
+//     governs field selection, while method promotion is a language rule that
+//     never consults tags.
+//
+//     "By any route" is computed as one closure over name edges — every
+//     `type A B` and `type A = B`, every embedded type, every interface
+//     method set — rather than by modelling which routes carry a method set
+//     and which do not. Go distinguishes them (a defined type over a struct
+//     starts empty; an alias does not), and this walk deliberately does not:
+//     that distinction was the source of four consecutive rounds of review
+//     findings, each about the previous round's rule. The closure
+//     over-approximates, refusing a name chain that reaches a marshaller even
+//     where Go would walk the fields, and in exchange the class is closed.
+//     Signatures ARE checked, so an unrelated method that merely shares a
+//     name does not trigger it — but a signature spelled through a name this
+//     check cannot evaluate counts as a match, since the alternative is to
+//     certify a wrapper whose marshaller was hidden behind an alias.
 //
 // This is a whitelist on purpose, and it is where the design stops mirroring
 // encoding/json. Field promotion is a bounded, syntactic problem this walk can
@@ -990,6 +1006,18 @@ func collectJSONMethodTypes(f *ast.File) (map[string]bool, map[string][]string) 
 	// interface itself has no field to give the walk a second chance.
 	ifaceEmbeds := map[string][]string{}
 	for name, decl := range collectTypeDecls(f) {
+		// `type A = M` and `type A M` both make A a name for M's shape, and
+		// the first also for its method set. Both become edges: the closure is
+		// deliberately conservative here, because distinguishing them means
+		// tracking which declaration form each hop used, and every rule of
+		// that kind has produced the next round's finding about itself. A
+		// defined type over a method-bearing struct is therefore refused
+		// though Go would walk it — one over-report, in exchange for closing
+		// the alias/defined surface entirely.
+		if id, ok := decl.expr.(*ast.Ident); ok {
+			ifaceEmbeds[name] = append(ifaceEmbeds[name], id.Name)
+			continue
+		}
 		it, ok := decl.expr.(*ast.InterfaceType)
 		if !ok {
 			continue
@@ -1095,9 +1123,63 @@ func isJSONMethod(name string, ft *ast.FuncType) bool {
 	}
 	switch name {
 	case "MarshalJSON":
-		return signatureIs(ft, nil, []string{"[]byte", "error"})
+		return signatureMatches(ft, nil, []string{"[]byte", "error"})
 	case "UnmarshalJSON":
-		return signatureIs(ft, []string{"[]byte"}, []string{"error"})
+		return signatureMatches(ft, []string{"[]byte"}, []string{"error"})
+	case "MarshalText", "UnmarshalText":
+		// encoding/json falls back to encoding.TextMarshaler when a type does
+		// not implement json.Marshaler, encoding the value as a JSON string —
+		// so promoting one redirects the encoder away from the fields just as
+		// surely.
+		if name == "MarshalText" {
+			return signatureMatches(ft, nil, []string{"[]byte", "error"})
+		}
+		return signatureMatches(ft, []string{"[]byte"}, []string{"error"})
+	}
+	return false
+}
+
+// signatureMatches is signatureIs plus a deliberate bias: a component this
+// check cannot resolve to a builtin spelling — a local name like
+// `type Bytes = []byte`, or any imported type — counts as a MATCH rather than
+// a miss. The alternative is to certify a wrapper whose promoted marshaller
+// was spelled through an alias, which is the silent direction. A signature
+// built entirely from resolvable spellings is compared exactly, so
+// `MarshalJSON(int) []byte` is still correctly not a marshaller.
+func signatureMatches(ft *ast.FuncType, params, results []string) bool {
+	if signatureIs(ft, params, results) {
+		return true
+	}
+	return signatureHasUnresolvableComponent(ft)
+}
+
+// signatureHasUnresolvableComponent reports whether any parameter or result
+// type is spelled with a name this check cannot evaluate — anything that is
+// not a builtin, a slice of one, or an error.
+func signatureHasUnresolvableComponent(ft *ast.FuncType) bool {
+	resolvable := func(expr ast.Expr) bool {
+		switch e := expr.(type) {
+		case *ast.Ident:
+			return predeclaredTypes[e.Name]
+		case *ast.ArrayType:
+			if e.Len != nil {
+				return false
+			}
+			if id, ok := e.Elt.(*ast.Ident); ok {
+				return predeclaredTypes[id.Name]
+			}
+		}
+		return false
+	}
+	for _, fl := range []*ast.FieldList{ft.Params, ft.Results} {
+		if fl == nil {
+			continue
+		}
+		for _, f := range fl.List {
+			if !resolvable(f.Type) {
+				return true
+			}
+		}
 	}
 	return false
 }
@@ -1366,6 +1448,13 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 	// consults tags — so a tagged embed is vouched for on exactly the same
 	// terms as an untagged one.
 	for _, te := range root.taggedEmbeds {
+		if te.ref.pointer && te.ref.name != "" && !ast.IsExported(te.ref.name) {
+			// Same allocation problem as an untagged one: the tag changes which
+			// KEY the field appears under, not whether the decoder can create
+			// it.
+			root.decodeUnsafe = append(root.decodeUnsafe,
+				fmt.Sprintf("%s -> %s (encoding/json cannot allocate an embedded pointer to an unexported type, so a decoder never populates it)", rootName, te.ref.display))
+		}
 		_, childName, methodsTravel, err := resolveEmbedFull(te.ref, structs, decls)
 		if reason := vouch(te.ref, childName, methodsTravel, err, jsonMethods); reason != "" {
 			root.unresolved = append(root.unresolved, fmt.Sprintf("%s -> %s (%s)", rootName, te.ref.display, reason))

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -189,7 +189,21 @@
 //     is not among the recognised spellings.
 //
 // The invariant: ANYTHING UNRECOGNISED IS REPORTED. Never credited, never
-// skipped. Both failure modes this walk has actually had — the original #599
+// skipped. It holds at all THREE places this file makes a coverage judgement,
+// and a new one must join them:
+//
+//   - the embed walk (an embed it cannot vouch for is reported),
+//   - the assignment walk (a value shape it cannot classify credits nothing
+//     and is reported),
+//   - the method graph (a type whose method set it cannot evaluate — a
+//     qualified alias, a generic instantiation — counts as carrying, which
+//     makes every embed of it refused).
+//
+// The third was the last to get it, and its absence was invisible until a
+// reviewer produced `type A = json.Marshaler; type B interface { A }`: field
+// promotion and assignment population were already flipped, so the bug had
+// nowhere to show except through the method set. Fixing one instance of this
+// class rather than the class is how that happens. Both failure modes this walk has actually had — the original #599
 // bug and every regression found while fixing it — were a silent assumption
 // about something the walker did not understand.
 //
@@ -1101,12 +1115,8 @@ func collectJSONMethodTypes(f *ast.File) (map[string]bool, map[string][]string) 
 		// `func (m (M)) MarshalJSON()` is legal, and reading the receiver as
 		// unrecognized would leave M out of the method set — a silent miss, so
 		// the parentheses come off even though nobody writes them.
-		recv := unparen(fd.Recv.List[0].Type)
-		if star, ok := recv.(*ast.StarExpr); ok {
-			recv = unparen(star.X)
-		}
-		if id, ok := recv.(*ast.Ident); ok {
-			out[id.Name] = true
+		if name := receiverTypeName(fd.Recv.List[0].Type); name != "" {
+			out[name] = true
 		}
 	}
 	// Interfaces carrying the method in their method set. Embedding one
@@ -1122,14 +1132,30 @@ func collectJSONMethodTypes(f *ast.File) (map[string]bool, map[string][]string) 
 		// defined type over a method-bearing struct is therefore refused
 		// though Go would walk it — one over-report, in exchange for closing
 		// the alias/defined surface entirely.
-		if id, ok := decl.expr.(*ast.Ident); ok {
-			ifaceEmbeds[name] = append(ifaceEmbeds[name], id.Name)
+		switch decl.expr.(type) {
+		case *ast.Ident:
+			ifaceEmbeds[name] = append(ifaceEmbeds[name], decl.expr.(*ast.Ident).Name)
+			continue
+		case *ast.InterfaceType:
+			// Handled below.
+		case *ast.StructType, *ast.MapType, *ast.ArrayType, *ast.FuncType,
+			*ast.ChanType:
+			// A type literal has no method set of its own; methods declared on
+			// THIS name are already collected from their receivers above.
+			continue
+		default:
+			// A qualified name (`type A = json.Marshaler`), a generic
+			// instantiation (`type A = G[int]`), or anything else this check
+			// does not parse. The method set is unknown, and unknown counts as
+			// carrying — the same answer the interface scan below gives a
+			// qualified embed, and the same answer the field walk gives an
+			// unresolvable embed. Skipping here would let a struct embedding
+			// A be certified while a promoted MarshalJSON redirects the
+			// encoder, which is the silent case this invariant exists for.
+			out[name] = true
 			continue
 		}
-		it, ok := decl.expr.(*ast.InterfaceType)
-		if !ok {
-			continue
-		}
+		it := decl.expr.(*ast.InterfaceType)
 		for _, m := range it.Methods.List {
 			if len(m.Names) == 0 {
 				// An embedded interface contributes its whole method set.
@@ -1209,6 +1235,32 @@ func vouch(e embedRef, childName string, methodsTravel bool, resolveErr string, 
 		// An unresolvable type may also be a marshaller — time.Time is one —
 		// so this cannot be treated as merely "fields we cannot see".
 		return resolveErr + "; its fields AND any custom JSON methods it would promote are invisible here"
+	}
+	return ""
+}
+
+// receiverTypeName returns the defined type a method is declared on, or "" if
+// the receiver is not a shape Go allows. A receiver base is always a type NAME,
+// optionally parenthesized, pointer-taken, or generic-instantiated
+// (`func (b Base[T]) …`), so this classification is complete rather than a
+// best effort — there is no legal receiver it silently drops.
+func receiverTypeName(expr ast.Expr) string {
+	expr = unparen(expr)
+	if star, ok := expr.(*ast.StarExpr); ok {
+		expr = unparen(star.X)
+	}
+	switch e := expr.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.IndexExpr:
+		// A generic receiver: the method belongs to the base type.
+		if id, ok := unparen(e.X).(*ast.Ident); ok {
+			return id.Name
+		}
+	case *ast.IndexListExpr:
+		if id, ok := unparen(e.X).(*ast.Ident); ok {
+			return id.Name
+		}
 	}
 	return ""
 }

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -533,6 +533,13 @@ type structFields struct {
 	// promotion sources, but an unexported one is only on the wire if its type
 	// is a struct — which needs the universe, so flattenEmbedded settles it.
 	taggedEmbeds []taggedEmbed
+	// decodeUnsafeOwn lists this struct's OWN decode-breaking embeds, computed
+	// once by flattenEmbedded and never appended to afterwards. Keeping it
+	// separate from decodeUnsafe is what makes the walk's output deterministic:
+	// a root accumulates into decodeUnsafe, and if that were the same slice a
+	// parent read from, whether it saw a child's inherited records would depend
+	// on map iteration order — and the same record could be copied twice.
+	decodeUnsafeOwn []string
 	// decodeUnsafe lists embeds that break DECODING only: an embedded pointer
 	// to an unexported type, which encoding/json refuses to allocate ("cannot
 	// set embedded pointer to unexported struct"). Marshalling and in-Go
@@ -814,7 +821,8 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 	var drift []string
 	totalFieldsChecked := 0
 	totalFieldsPopChecked := 0
-	embeddedPairs := 0         // pairs whose wrapper actually promotes fields through an embed
+	pairsWithEmbeds := 0       // pairs whose wrapper DECLARES an embed, whatever came of it
+	pairsWithPromotions := 0   // pairs where a promoted tag actually survived to be checked
 	promotedFieldsChecked := 0 // generated tags satisfied by a promoted (not directly declared) field
 	for _, wrapName := range pairNames {
 		genName := pairs[wrapName]
@@ -860,8 +868,16 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 		// underneath to get wrong, and `w.ID = 1` or `w.Name = first + last`
 		// are perfectly good assignments the check has always accepted.
 		if !isTier2 {
+			// Only tags that are actually being CHECKED count: a tag the
+			// generated struct does not declare is not this pair's business,
+			// and one the wrapper intentionally omits has been answered
+			// already. Without that filter the report survives the marker its
+			// own message recommends, which makes the instruction a dead end.
 			subtreeMatters := map[string]bool{}
 			for tag := range wrap.tagPath {
+				if !gen.tags[tag] || wrap.omitted[tag] {
+					continue
+				}
 				for _, target := range wrap.populationTargets(tag) {
 					if strings.HasSuffix(target, ".*") {
 						subtreeMatters[strings.TrimSuffix(target, ".*")] = true
@@ -894,8 +910,16 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 		}
 		sort.Strings(tags)
 
+		// Two different facts, and conflating them lets the scope line below
+		// claim nothing embeds a struct while something does: a wrapper whose
+		// promotion was REFUSED (method-bearing), whose embedded struct has no
+		// tagged fields, or whose tags annihilated in a diamond declares an
+		// embed and contributes no tagPath.
+		if len(wrap.embeds)+len(wrap.taggedEmbeds) > 0 {
+			pairsWithEmbeds++
+		}
 		if len(wrap.tagPath) > 0 {
-			embeddedPairs++
+			pairsWithPromotions++
 		}
 		var missing []string
 		var unpopulated []string
@@ -963,10 +987,12 @@ func run(wrapperDir, generatedFile string, directDecode map[string]string, tier3
 	// is the case in this repo today — the embedded-field machinery verified
 	// nothing and the line should not let a reader think otherwise.
 	switch {
-	case embeddedPairs == 0:
+	case pairsWithEmbeds == 0:
 		fmt.Println("  Embedded-field promotion: no pair embeds a struct, so nothing above was verified through it.")
+	case promotedFieldsChecked == 0:
+		fmt.Printf("  Embedded-field promotion: %d of %d pairs embed a struct, but no promoted tag reached the check — annihilated, untagged, or refused (any refusal is reported above).\n", pairsWithEmbeds, len(pairNames))
 	default:
-		fmt.Printf("  Embedded-field promotion: %d of %d pairs embed a struct; %d promoted fields verified through it.\n", embeddedPairs, len(pairNames), promotedFieldsChecked)
+		fmt.Printf("  Embedded-field promotion: %d of %d pairs embed a struct, %d of them contributing %d promoted fields to the checks above.\n", pairsWithEmbeds, len(pairNames), pairsWithPromotions, promotedFieldsChecked)
 	}
 	fmt.Println("  Scope: shapes this walker resolves. Unrecognised embeds and assignment shapes are reported as drift, never assumed away — see the CAN/CANNOT list in this file's header.")
 
@@ -1247,7 +1273,7 @@ func closeJSONMethodTypes(direct map[string]bool, ifaceEmbeds map[string][]strin
 // defined type starts with an empty method set.
 func vouch(e embedRef, childName string, methodsTravel bool, resolveErr string, jsonMethods map[string]bool) string {
 	if jsonMethods[e.name] || (methodsTravel && childName != "" && jsonMethods[childName]) {
-		return "the embedded type's method set carries MarshalJSON/UnmarshalJSON, which the embedding struct promotes; encoding/json then calls it instead of walking any of these fields, so no promoted tag here is trustworthy"
+		return "the embedded type's method set carries a custom JSON or text marshaller (MarshalJSON/UnmarshalJSON/MarshalText/UnmarshalText), which the embedding struct promotes; encoding/json then calls it instead of walking any of these fields, so no promoted tag here is trustworthy"
 	}
 	if resolveErr != "" {
 		// An unresolvable type may also be a marshaller — time.Time is one —
@@ -1566,7 +1592,7 @@ func flattenEmbedded(structs map[string]*structFields, decls map[string]typeDecl
 	// and that is just as true when the field arrives by promotion as when the
 	// struct holding it is the one being judged.
 	for name, sf := range structs {
-		sf.decodeUnsafe = nil
+		sf.decodeUnsafeOwn = nil
 		refs := make([]embedRef, 0, len(sf.embeds)+len(sf.taggedEmbeds))
 		refs = append(refs, sf.embeds...)
 		for _, te := range sf.taggedEmbeds {
@@ -1582,7 +1608,7 @@ func flattenEmbedded(structs map[string]*structFields, decls map[string]typeDecl
 			if child, _, _, err := resolveEmbedFull(ref, structs, decls); err != "" || child == nil {
 				continue
 			}
-			sf.decodeUnsafe = append(sf.decodeUnsafe,
+			sf.decodeUnsafeOwn = append(sf.decodeUnsafeOwn,
 				fmt.Sprintf("%s -> %s (encoding/json cannot allocate an embedded pointer to an unexported type, so a decoder never populates its promoted fields)", name, ref.display))
 		}
 	}
@@ -1669,21 +1695,17 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 		root.tagTargets = map[string][]string{}
 	}
 
+	// This struct's own decode-breaking embeds — tagged and untagged alike —
+	// were settled by the pre-pass. Seed the accumulated list from them; the
+	// walk adds what it inherits from the structs it reaches.
+	root.decodeUnsafe = append([]string(nil), root.decodeUnsafeOwn...)
+
 	// A json tag stops an anonymous field from promoting its FIELDS. It does
 	// nothing to method promotion — that is a language rule which never
 	// consults tags — so a tagged embed is vouched for on exactly the same
 	// terms as an untagged one.
 	for _, te := range root.taggedEmbeds {
-		child, childName, methodsTravel, err := resolveEmbedFull(te.ref, structs, decls)
-		if child != nil && te.ref.pointer && !ast.IsExported(te.ref.name) {
-			// Same allocation problem as an untagged one: the tag changes which
-			// KEY the field appears under, not whether the decoder can create
-			// it. Only for a STRUCT, though — encoding/json ignores an
-			// anonymous unexported non-struct field outright, so there is
-			// nothing it failed to allocate.
-			root.decodeUnsafe = append(root.decodeUnsafe,
-				fmt.Sprintf("%s -> %s (encoding/json cannot allocate an embedded pointer to an unexported type, so a decoder never populates it)", rootName, te.ref.display))
-		}
+		_, childName, methodsTravel, err := resolveEmbedFull(te.ref, structs, decls)
 		if reason := vouch(te.ref, childName, methodsTravel, err, jsonMethods); reason != "" {
 			root.unresolved = append(root.unresolved, fmt.Sprintf("%s -> %s (%s)", rootName, te.ref.display, reason))
 			discardPromotions()
@@ -1757,7 +1779,12 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 				// Those records are computed for every struct before any root
 				// is walked, so this does not depend on iteration order.
 				if child != nil && childName != rootName {
-					for _, du := range child.decodeUnsafe {
+					// Only the child's OWN records: its accumulated list may
+					// already hold what IT inherited, and copying that would
+					// duplicate entries and make the output depend on which
+					// struct flattenEmbedded happened to walk first. This walk
+					// reaches every descendant itself.
+					for _, du := range child.decodeUnsafeOwn {
 						root.decodeUnsafe = append(root.decodeUnsafe,
 							fmt.Sprintf("%s (reached through %s)", du, strings.Join(append([]string{rootName}, parent.path...), ".")))
 					}
@@ -2343,6 +2370,11 @@ func deliversWholeValue(expr ast.Expr) bool {
 		// fields, and a complete value of its own type.
 		return true
 	case *ast.UnaryExpr:
+		// &x delivers a pointer to whatever x delivers; <-ch delivers a whole
+		// value of the channel's element type, exactly as a call does.
+		if e.Op == token.ARROW {
+			return true
+		}
 		return e.Op == token.AND && deliversWholeValue(e.X)
 	}
 	return false

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -540,6 +540,10 @@ type embedRef struct {
 	qualifier string
 	// display is the source spelling, used in messages ("*Base", "time.Time").
 	display string
+	// pointer is true for `*Base`. It matters for decoding: encoding/json
+	// cannot allocate an embedded pointer to an UNEXPORTED type, so a
+	// direct-decode wrapper with one never gets those fields populated.
+	pointer bool
 }
 
 func main() {
@@ -982,10 +986,17 @@ func collectJSONMethodTypes(f *ast.File) (map[string]bool, map[string][]string) 
 		}
 		for _, m := range it.Methods.List {
 			if len(m.Names) == 0 {
-				// An embedded interface: it contributes its whole method set.
+				// An embedded interface contributes its whole method set.
 				if id, ok := m.Type.(*ast.Ident); ok {
 					ifaceEmbeds[name] = append(ifaceEmbeds[name], id.Name)
+					continue
 				}
+				// Qualified (`json.Marshaler`) or otherwise unreadable: this
+				// check does not parse the other package, so the method set is
+				// unknown. Unknown counts as carrying — the whole point of the
+				// vouching rule is that "cannot tell" is answered with a
+				// refusal, not an assumption.
+				out[name] = true
 				continue
 			}
 			for _, n := range m.Names {
@@ -1047,6 +1058,13 @@ func vouch(e embedRef, childName string, methodsTravel bool, resolveErr string, 
 	if jsonMethods[e.name] || (methodsTravel && childName != "" && jsonMethods[childName]) {
 		return "the embedded type's method set carries MarshalJSON/UnmarshalJSON, which the embedding struct promotes; encoding/json then calls it instead of walking any of these fields, so no promoted tag here is trustworthy"
 	}
+	if e.pointer && e.name != "" && !ast.IsExported(e.name) {
+		// encoding/json refuses to allocate an embedded pointer to an
+		// unexported type ("cannot set embedded pointer to unexported
+		// struct"), so a direct-decode wrapper never gets these fields
+		// populated even though their tags are present.
+		return "an embedded pointer to an unexported type cannot be allocated by encoding/json, so its promoted fields are never decoded"
+	}
 	if resolveErr != "" {
 		// An unresolvable type may also be a marshaller — time.Time is one —
 		// so this cannot be treated as merely "fields we cannot see".
@@ -1101,6 +1119,7 @@ type typeDecl struct {
 func embedRefFromExpr(expr ast.Expr) embedRef {
 	ref := embedRef{display: exprDisplay(expr)}
 	if star, ok := expr.(*ast.StarExpr); ok {
+		ref.pointer = true
 		expr = star.X
 	}
 	switch e := expr.(type) {
@@ -1137,6 +1156,17 @@ func exprDisplay(expr ast.Expr) string {
 	return "<unsupported type expression>"
 }
 
+// predeclaredTypes are Go's builtin type names. A declaration chain ending in
+// one is resolved, not unresolvable: it contributes no fields and no method set
+// of its own, so it needs neither a refusal nor a walk.
+var predeclaredTypes = map[string]bool{
+	"any": true, "bool": true, "byte": true, "comparable": true,
+	"complex64": true, "complex128": true, "error": true, "float32": true,
+	"float64": true, "int": true, "int8": true, "int16": true, "int32": true,
+	"int64": true, "rune": true, "string": true, "uint": true, "uint8": true,
+	"uint16": true, "uint32": true, "uint64": true, "uintptr": true,
+}
+
 // maxEmbedDepth bounds the promotion walk. The visited-set already terminates
 // cycles; this is a second, independent stop so a pathological chain can never
 // spin. Real embedding chains in this repo are one level deep.
@@ -1159,6 +1189,38 @@ func flattenEmbedded(structs map[string]*structFields, decls map[string]typeDecl
 	// every struct rather than just the roots: the walk reads a descendant's
 	// ownFields directly, so filtering only at depth 0 would promote a tag out
 	// of a field encoding/json never emits.
+	// A struct promotes the methods of everything it embeds, so "carries a
+	// custom JSON method" is transitive through struct embedding just as it is
+	// through interface embedding — and a json TAG on the embed does not stop
+	// it. Close over that before any flattening, so an embed of a struct that
+	// merely inherits a marshaller is refused as readily as one that declares
+	// it. Unresolvable embeds count as carrying: an unparsed type can be a
+	// marshaller (time.Time is), and "cannot tell" is answered with a refusal.
+	for {
+		changed := false
+		for name, sf := range structs {
+			if jsonMethods[name] {
+				continue
+			}
+			refs := make([]embedRef, 0, len(sf.embeds)+len(sf.taggedEmbeds))
+			refs = append(refs, sf.embeds...)
+			for _, te := range sf.taggedEmbeds {
+				refs = append(refs, te.ref)
+			}
+			for _, ref := range refs {
+				_, childName, methodsTravel, err := resolveEmbedFull(ref, structs, decls)
+				if err != "" || jsonMethods[ref.name] || (methodsTravel && childName != "" && jsonMethods[childName]) {
+					jsonMethods[name] = true
+					changed = true
+					break
+				}
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+
 	for _, sf := range structs {
 		sf.ignoredOwn = map[int]bool{}
 		for _, te := range sf.taggedEmbeds {
@@ -1422,6 +1484,13 @@ func resolveEmbedFull(e embedRef, structs map[string]*structFields, decls map[st
 		}
 		decl, ok := decls[name]
 		if !ok {
+			if predeclaredTypes[name] {
+				// A defined type over a builtin (`type hidden string`). It is
+				// fully accounted for: no fields to promote, and no method set
+				// of its own — any methods would be declared locally and are
+				// already in jsonMethods under the defining name.
+				return nil, name, methodsTravel, ""
+			}
 			return nil, "", methodsTravel, "not declared in the parsed sources"
 		}
 		if seen[name] {
@@ -1455,6 +1524,14 @@ func resolveEmbedFull(e embedRef, structs map[string]*structFields, decls map[st
 			// The NAME is still returned even though there is no struct: an
 			// embedded interface promotes its method set, and vouch has to be
 			// able to look that name up.
+			//
+			// An interface is also the one target where the defined-type rule
+			// does NOT apply: `type Safe Marshaler` is still an interface with
+			// Marshaler's methods, unlike `type Safe SomeStruct`, which starts
+			// with an empty method set.
+			if _, isIface := decl.expr.(*ast.InterfaceType); isIface {
+				methodsTravel = true
+			}
 			return nil, name, methodsTravel, ""
 		}
 	}
@@ -1765,14 +1842,26 @@ func zeroValued(expr ast.Expr) bool {
 		if id, ok := unparen(e.Fun).(*ast.Ident); ok && id.Name == "new" {
 			return true
 		}
-		// A conversion whose single argument is nil: (*Base)(nil), Base(nil).
-		if len(e.Args) == 1 {
+		// A pointer conversion of nil: (*Base)(nil). The parenthesized star is
+		// what makes this unambiguous — `baseFrom(nil)` is an ordinary call
+		// that may well populate everything, and only the type checker could
+		// tell `Base(nil)` from it, so neither is claimed here.
+		if _, isStar := unparenOnce(e.Fun).(*ast.StarExpr); isStar && len(e.Args) == 1 {
 			if id, ok := unparen(e.Args[0]).(*ast.Ident); ok && id.Name == "nil" {
 				return true
 			}
 		}
 	}
 	return false
+}
+
+// unparenOnce strips one layer of parentheses, distinguishing `(*T)(nil)` —
+// where the parens are part of the conversion syntax — from a bare call.
+func unparenOnce(expr ast.Expr) ast.Expr {
+	if p, ok := expr.(*ast.ParenExpr); ok {
+		return p.X
+	}
+	return expr
 }
 
 // unparen strips redundant parentheses: `(Base{...})` is the same value as

--- a/scripts/check-wrapper-drift/main.go
+++ b/scripts/check-wrapper-drift/main.go
@@ -1621,6 +1621,24 @@ func flattenOne(rootName string, root *structFields, structs map[string]*structF
 		}
 	}
 
+	// A root that declares its own MarshalJSON/UnmarshalJSON AND promotes
+	// fields through an embed is refused — for the promotion only.
+	//
+	// The root method alone is not disqualifying, and deliberately so: every
+	// wrapper in this repo that declares one is a decode adapter that
+	// unmarshals into the GENERATED type and hands off to the *FromGenerated
+	// conversion this check verifies, so the pairing is what they are built
+	// on. But once such a root also PROMOTES fields, the promoted tags are
+	// being certified against an encoder that bypasses them, and that is the
+	// silent case. None of today's adapters embed anything, so this fires on
+	// none of them.
+	if jsonMethods[rootName] && len(root.embeds)+len(root.taggedEmbeds) > 0 {
+		root.unresolved = append(root.unresolved,
+			fmt.Sprintf("%s declares MarshalJSON/UnmarshalJSON itself and also embeds a struct; encoding/json calls that method rather than walking the promoted fields, so promotion is not certified here (its own declared tags still are)", rootName))
+		discardPromotions()
+		return
+	}
+
 	// Go-name resolution, tracked alongside the tag walk: nameDepth records the
 	// shallowest depth at which each field NAME appears and nameConflict the
 	// names two same-depth structs both declare, which makes the selector

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -3517,3 +3517,61 @@ type UsesAlias struct {
 		}
 	}
 }
+
+// TestFlattenEmbedded_DecodeUnsafeTravelsToTheEmbeddingStruct is the promotion
+// half of the allocation rule. `Base` holds a tagged anonymous `*hidden`; a
+// wrapper embedding `Base` promotes that field under the same key, and the
+// decoder can no more allocate it there than it could in Base. Recording it
+// only while Base is the struct being judged would leave every wrapper that
+// embeds Base silently unpopulated — and for a tier-2 pair, tag presence IS
+// the population claim.
+func TestFlattenEmbedded_DecodeUnsafeTravelsToTheEmbeddingStruct(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type hidden struct {
+	ID int64 ~json:"id"~
+}
+
+type Base struct {
+	*hidden ~json:"hidden"~
+	Name    string ~json:"name"~
+}
+
+type Outer struct {
+	Base
+}
+`))
+	if b := structs["Base"]; b == nil || len(b.decodeUnsafe) == 0 {
+		t.Fatalf("Base itself must record it, got %+v", structs["Base"])
+	}
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	if len(outer.decodeUnsafe) == 0 {
+		t.Error("the record must travel to the struct that promotes the field")
+	}
+	if !outer.tags["name"] {
+		t.Errorf("the rest of Base still promotes normally, got %v", outer.tags)
+	}
+}
+
+// TestIsJSONMethod_ByteAliasSpelling covers `[]uint8`. byte IS uint8, so
+// `MarshalJSON() ([]uint8, error)` implements json.Marshaler and its promotion
+// redirects the encoder — missing it is a silent certification, not a cosmetic
+// mismatch.
+func TestIsJSONMethod_ByteAliasSpelling(t *testing.T) {
+	for _, decl := range []string{
+		"func (s Stamp) MarshalJSON() ([]uint8, error) { return nil, nil }",
+		"func (s *Stamp) UnmarshalJSON(b []uint8) error { return nil }",
+	} {
+		f, err := parser.ParseFile(token.NewFileSet(), "f.go", "package fixture\n\ntype Stamp struct{}\n\n"+decl+"\n", parser.ParseComments)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		got, _ := collectJSONMethodTypes(f)
+		if !got["Stamp"] {
+			t.Errorf("%s: []uint8 is []byte and must be recognized", decl)
+		}
+	}
+}

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -3181,3 +3181,49 @@ type W struct {
 		t.Error("a TAGGED unexported pointer embed is just as undecodable as an untagged one")
 	}
 }
+
+// TestFlattenEmbedded_ParenthesizedDeclarationsFollowed covers legal but
+// unusual `type Alias = (Base)` syntax. The parentheses are not part of the
+// type, and dropping the declaration on the floor because of them is the
+// silent-skip pattern this whole check exists to remove — here it would lose a
+// name edge and certify a wrapper whose promoted marshaller sat behind it.
+func TestFlattenEmbedded_ParenthesizedDeclarationsFollowed(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Stamp struct {
+	At string ~json:"at"~
+}
+
+func (s Stamp) MarshalJSON() ([]byte, error) { return nil, nil }
+
+type Alias = (Stamp)
+
+type Plain struct {
+	ID int64 ~json:"id"~
+}
+
+type PlainAlias = (Plain)
+
+type Outer struct {
+	Alias
+}
+
+type Harmless struct {
+	PlainAlias
+}
+`))
+	if o := structs["Outer"]; o == nil || len(o.unresolved) == 0 {
+		t.Errorf("a parenthesized alias to a marshaller is still an edge to it, got %+v", structs["Outer"])
+	}
+	// And the paired positive: parentheses alone must not cause a refusal.
+	h := structs["Harmless"]
+	if h == nil {
+		t.Fatal("Harmless not collected")
+	}
+	if len(h.unresolved) != 0 {
+		t.Errorf("a parenthesized alias to an ordinary struct is vouched, got %v", h.unresolved)
+	}
+	if !h.tags["id"] {
+		t.Errorf("and its fields promote, got %v", h.tags)
+	}
+}

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -2277,6 +2277,10 @@ func TestRecordAssignedValue_ValueShapes(t *testing.T) {
 		{"positional literal with a nil element", "Base{nil, g.Name}", nil, false, []string{"Base.*"}},
 		{"empty literal", "Base{}", nil, false, []string{"Base.*"}},
 		{"opaque call", "baseFrom(g)", nil, true, nil},
+		// Statically zero-producing values carry nothing in, so they cannot
+		// populate what they claim.
+		{"new(T)", "new(Base)", nil, false, []string{"Base.*"}},
+		{"typed nil conversion", "(*Base)(nil)", nil, false, []string{"Base.*"}},
 		// nil populates nothing: a nil embedded pointer emits none of its fields.
 		{"nil", "nil", nil, false, []string{"Base.*"}},
 	}
@@ -2721,5 +2725,77 @@ type Fancy interface {
 	closeJSONMethodTypes(merged, graph)
 	if !merged["Fancy"] {
 		t.Error("an interface embedding a marshaler from ANOTHER file carries the method too")
+	}
+}
+
+// TestRun_UnresolvableTaggedEmbedIsReported closes the tagged half of the
+// vouching rule. A tag stops FIELD promotion and nothing else, so an
+// unresolvable tagged embed can still promote a custom marshaller —
+// `time.Time` is exactly such a type — and the walk cannot see either its
+// fields or its methods. It reports instead of certifying the tags around it.
+func TestRun_UnresolvableTaggedEmbedIsReported(t *testing.T) {
+	genSrc := src(`package generated
+
+type Note struct {
+	Id int64 ~json:"id"~
+}
+`)
+	wrapperSrc := src(`package basecamp
+
+import (
+	"time"
+
+	"github.com/basecamp/basecamp-sdk/go/pkg/generated"
+)
+
+type Note struct {
+	time.Time ~json:"at"~
+	ID        int64 ~json:"id"~
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.ID = g.Id
+	return n
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": wrapperSrc})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err == nil {
+		t.Error("run: an unresolvable TAGGED embed can promote a marshaller and must be reported")
+	}
+}
+
+// TestFlattenEmbedded_AliasToMethodBearingInterfaceIsRejected covers a method
+// set reached through an alias to an interface — the embed's own name is the
+// alias, and the interface resolves to no struct, so neither key alone finds
+// it. The vouching rule catches it because an alias carries the method set and
+// resolution reports that it travelled.
+func TestFlattenEmbedded_AliasToMethodBearingInterfaceIsRejected(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Marshaler interface {
+	MarshalJSON() ([]byte, error)
+}
+
+type Alias = Marshaler
+
+type Base struct {
+	ID int64 ~json:"id"~
+}
+
+type Outer struct {
+	Alias
+	Base
+}
+`))
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	if len(outer.unresolved) == 0 {
+		t.Error("an alias to a method-bearing interface promotes the method and must be reported")
+	}
+	if outer.tags["id"] {
+		t.Error("a sibling embed's tags are just as meaningless once the encoder is redirected")
 	}
 }

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -1624,6 +1624,25 @@ type Outer struct {
 	if !outer.tags["name"] || len(outer.tags) != 2 {
 		t.Errorf("expected exactly name+id, got %v", outer.tags)
 	}
+	// The interface and map embeds are not absent from the wire —
+	// encoding/json emits them under their Go field names ("Doer",
+	// "Payload"). They carry no json TAG, which is this check's whole
+	// vocabulary, so they are invisible here in exactly the way an untagged
+	// NAMED field is. Asserting the parallel pins that the treatment is
+	// uniform rather than an embed-specific hole.
+	if outer.tags["Doer"] || outer.tags["Payload"] {
+		t.Errorf("untagged fields are outside this check's tag vocabulary, got %v", outer.tags)
+	}
+	plain := flattenFixture(t, src(`package fixture
+
+type Outer struct {
+	Plain string
+	Name  string ~json:"name"~
+}
+`))["Outer"]
+	if plain.tags["Plain"] || len(plain.tags) != 1 {
+		t.Errorf("an untagged NAMED field is equally invisible; got %v", plain.tags)
+	}
 }
 
 // TestCollectStructs_TaggedAnonymousFieldNotPromoted pins the encoding/json

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -2614,13 +2614,22 @@ type Outer struct {
 	}
 }
 
-// TestFlattenEmbedded_DefinedTypeDoesNotInheritMethods separates the two
-// declaration forms. `type Safe Stamp` takes Stamp's fields with an EMPTY
-// method set, so embedding Safe promotes no marshaller and the fields are
-// judged normally; `type Same = Stamp` is the same type and does carry the
-// method, so embedding it must be rejected. Getting this wrong in the strict
-// direction manufactures drift on a wrapper that is fine.
-func TestFlattenEmbedded_DefinedTypeDoesNotInheritMethods(t *testing.T) {
+// TestFlattenEmbedded_NameChainToMarshallerIsRefused records a deliberate
+// over-approximation, and the reasoning belongs with it.
+//
+// Go distinguishes the two declaration forms: `type Same = Stamp` IS Stamp,
+// methods included, while `type Safe Stamp` takes its fields with an empty
+// method set — so Go would walk a struct embedding Safe. The walk refuses both.
+//
+// Telling them apart means tracking which declaration form each hop used and
+// keeping that straight through interfaces, chains of hops and re-aliasing —
+// the surface that produced four consecutive rounds of review findings, each
+// about the previous round's rule. Both forms are name edges in one closure
+// instead, which costs an over-report on a shape Go would accept and closes
+// the class. The over-report names the embed and says what it will not vouch
+// for; the failure it prevents is certifying tags a promoted marshaller never
+// emits.
+func TestFlattenEmbedded_NameChainToMarshallerIsRefused(t *testing.T) {
 	structs := flattenFixture(t, src(`package fixture
 
 type Stamp struct {
@@ -2640,22 +2649,45 @@ type UsesAlias struct {
 	Same
 }
 `))
-	defined := structs["UsesDefined"]
-	if defined == nil {
-		t.Fatal("UsesDefined not collected")
+	for _, name := range []string{"UsesDefined", "UsesAlias"} {
+		sf := structs[name]
+		if sf == nil {
+			t.Fatalf("%s not collected", name)
+		}
+		if len(sf.unresolved) == 0 {
+			t.Errorf("%s: a name chain reaching a marshaller is refused, whichever declaration form it uses", name)
+		}
 	}
-	if len(defined.unresolved) != 0 {
-		t.Errorf("a defined type has an empty method set; embedding it promotes no marshaller, got %v", defined.unresolved)
-	}
-	if !defined.tags["at"] {
-		t.Errorf("its fields promote normally, got %v", defined.tags)
-	}
-	alias := structs["UsesAlias"]
-	if alias == nil {
-		t.Fatal("UsesAlias not collected")
-	}
-	if len(alias.unresolved) == 0 {
-		t.Error("an alias IS the type, methods included; embedding it must be rejected")
+}
+
+// TestFlattenEmbedded_NameChainToOrdinaryTypeIsFine is the paired positive that
+// keeps the rule above from becoming "refuse every name chain": a chain to an
+// ordinary struct still flattens, so the over-approximation is scoped to
+// chains that actually reach a method.
+func TestFlattenEmbedded_NameChainToOrdinaryTypeIsFine(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Base struct {
+	ID int64 ~json:"id"~
+}
+
+type Defined Base
+type Aliased = Base
+
+type UsesDefined struct{ Defined }
+type UsesAlias struct{ Aliased }
+`))
+	for _, name := range []string{"UsesDefined", "UsesAlias"} {
+		sf := structs[name]
+		if sf == nil {
+			t.Fatalf("%s not collected", name)
+		}
+		if len(sf.unresolved) != 0 {
+			t.Errorf("%s: a chain to an ordinary struct is vouched, got %v", name, sf.unresolved)
+		}
+		if !sf.tags["id"] {
+			t.Errorf("%s: its fields promote, got %v", name, sf.tags)
+		}
 	}
 }
 
@@ -2957,7 +2989,16 @@ func TestIsJSONMethod_SignatureMatters(t *testing.T) {
 		{"func (s Stamp) MarshalJSON() []byte { return nil }", false},
 		{"func (s *Stamp) UnmarshalJSON(b string) error { return nil }", false},
 		{"func (s *Stamp) UnmarshalJSON(b []byte) (int, error) { return 0, nil }", false},
-		{"func (s Stamp) MarshalText() ([]byte, error) { return nil, nil }", false},
+		// encoding/json falls back to encoding.TextMarshaler, so a promoted
+		// MarshalText redirects the encoder too.
+		{"func (s Stamp) MarshalText() ([]byte, error) { return nil, nil }", true},
+		{"func (s *Stamp) UnmarshalText(b []byte) error { return nil }", true},
+		{"func (s Stamp) MarshalText() string { return \"\" }", false},
+		{"func (s Stamp) String() string { return \"\" }", false},
+		// A signature spelled through a local alias cannot be evaluated here,
+		// and the conservative reading is the one that does not certify a
+		// wrapper whose marshaller was hidden behind a name.
+		{"func (s Stamp) MarshalJSON() (Bytes, error) { return nil, nil }", true},
 	}
 	for _, c := range cases {
 		source := "package fixture" + "\n\n" + c.decl + "\n"
@@ -3054,5 +3095,89 @@ type Outer struct {
 	}
 	if !outer.tags["name"] {
 		t.Errorf("its sibling fields must be judged normally, got %v", outer.tags)
+	}
+}
+
+// TestFlattenEmbedded_AliasedInterfaceInGraph covers a method set reached
+// through an aliased interface name inside the interface graph itself
+// (`type M interface{ MarshalJSON() … }; type A = M; type B interface { A }`).
+// Since every single-identifier declaration is an edge, the closure marks A and
+// then B, and a struct embedding B is refused.
+func TestFlattenEmbedded_AliasedInterfaceInGraph(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type M interface {
+	MarshalJSON() ([]byte, error)
+}
+
+type A = M
+
+type B interface {
+	A
+	Other()
+}
+
+type Base struct {
+	ID int64 ~json:"id"~
+}
+
+type Outer struct {
+	B
+	Base
+}
+`))
+	if o := structs["Outer"]; o == nil || len(o.unresolved) == 0 {
+		t.Errorf("an interface embedding an ALIASED marshaler still promotes the method, got %+v", structs["Outer"])
+	}
+}
+
+// TestFlattenEmbedded_MethodOnIntermediateNameIsRefused covers the other order:
+// the method is declared on a name in the middle of the chain rather than at
+// either end (`type Custom Wire; func (Custom) MarshalJSON(); type Alias =
+// Custom`). Closing over name edges catches it wherever in the chain it sits,
+// which is the point of doing this with a closure rather than by inspecting
+// the two endpoints.
+func TestFlattenEmbedded_MethodOnIntermediateNameIsRefused(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Wire struct {
+	Raw string ~json:"raw"~
+}
+
+type Custom Wire
+
+func (c Custom) MarshalJSON() ([]byte, error) { return nil, nil }
+
+type Alias = Custom
+
+type Outer struct {
+	Alias
+}
+`))
+	if o := structs["Outer"]; o == nil || len(o.unresolved) == 0 {
+		t.Errorf("a method declared mid-chain is still promoted and must be refused, got %+v", structs["Outer"])
+	}
+}
+
+// TestFlattenEmbedded_TaggedUnexportedPointerIsDecodeUnsafe pairs with the
+// untagged case: a json tag changes which KEY the field appears under, not
+// whether the decoder can allocate it.
+func TestFlattenEmbedded_TaggedUnexportedPointerIsDecodeUnsafe(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type hidden struct {
+	ID int64 ~json:"id"~
+}
+
+type W struct {
+	*hidden ~json:"hidden"~
+}
+`))
+	w := structs["W"]
+	if w == nil {
+		t.Fatal("W not collected")
+	}
+	if len(w.decodeUnsafe) == 0 {
+		t.Error("a TAGGED unexported pointer embed is just as undecodable as an untagged one")
 	}
 }

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -3776,3 +3776,206 @@ func noteFromGenerated(g generated.Note) Note {
 		t.Error("run: an uninterpretable value assigned to an embed must still be reported")
 	}
 }
+
+// TestRun_ScopeLineDoesNotUnderstateEmbedding guards the gate's statement about
+// its OWN coverage. Counting "pairs that embed a struct" by whether a promoted
+// tag survived made the line claim nothing embeds a struct while something did:
+// a refused (method-bearing) promotion, an embedded struct with no tagged
+// fields, and a diamond whose tags annihilate all leave tagPath empty.
+//
+// A gate that overstates its reach is the failure this PR exists to fix; one
+// that misreports its own coverage is the same failure with the opposite sign.
+func TestRun_ScopeLineDoesNotUnderstateEmbedding(t *testing.T) {
+	genSrc := src(`package generated
+
+type Note struct {
+	Id int64 ~json:"id"~
+}
+`)
+	// The wrapper embeds a struct whose promotion is REFUSED, so no promoted
+	// tag survives — but it plainly embeds one.
+	wrapperSrc := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Stamp struct {
+	At string ~json:"at"~
+}
+
+func (s Stamp) MarshalJSON() ([]byte, error) { return nil, nil }
+
+type Note struct {
+	Stamp
+	ID int64 ~json:"id"~
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.ID = g.Id
+	return n
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": wrapperSrc})
+	var stdout string
+	stderr := captureStderr(t, func() {
+		stdout = captureStdout(t, func() {
+			// The refusal itself is drift; the assertion here is about what the
+			// scope line SAYS, not about the verdict.
+			_ = run(wrapperDir, generatedFile, nil, nil, false)
+		})
+	})
+	_ = stderr
+	if strings.Contains(stdout, "no pair embeds a struct") {
+		t.Errorf("the scope line must not claim nothing embeds a struct when a pair does:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "1 of 1 pairs embed a struct") {
+		t.Errorf("expected the embed count to be reported, got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "no promoted tag reached the check") {
+		t.Errorf("and to say that nothing was verified through it, got:\n%s", stdout)
+	}
+}
+
+// captureStdout is captureStderr's twin: the scope and summary lines go to
+// stdout, and they make claims worth asserting on.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	saved := os.Stdout
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var buf strings.Builder
+		io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+	fn()
+	os.Stdout = saved
+	w.Close()
+	out := <-done
+	r.Close()
+	return out
+}
+
+// TestFlattenEmbedded_DecodeUnsafeIsNotDoubleCounted pins the determinism fix.
+// Each struct's own records are computed once and never appended to; a root
+// accumulates separately. Sharing one slice made a parent's output depend on
+// whether its child had been flattened first — randomized map order — and
+// could copy the same record twice.
+func TestFlattenEmbedded_DecodeUnsafeIsNotDoubleCounted(t *testing.T) {
+	source := src(`package fixture
+
+type hidden struct {
+	ID int64 ~json:"id"~
+}
+
+type Inner struct {
+	*hidden
+	Name string ~json:"name"~
+}
+
+type Middle struct {
+	Inner
+}
+
+type Outer struct {
+	Middle
+}
+`)
+	// Flatten repeatedly: each run gets a fresh universe, and map iteration
+	// order differs between them. Every run must produce the same counts.
+	want := -1
+	for i := 0; i < 25; i++ {
+		structs := flattenFixture(t, source)
+		outer := structs["Outer"]
+		if outer == nil {
+			t.Fatal("Outer not collected")
+		}
+		if want == -1 {
+			want = len(outer.decodeUnsafe)
+		}
+		if len(outer.decodeUnsafe) != want {
+			t.Fatalf("run %d: got %d decode-unsafe records, first run got %d — output depends on map order: %v",
+				i, len(outer.decodeUnsafe), want, outer.decodeUnsafe)
+		}
+		seen := map[string]bool{}
+		for _, du := range outer.decodeUnsafe {
+			if seen[du] {
+				t.Fatalf("duplicate record: %q in %v", du, outer.decodeUnsafe)
+			}
+			seen[du] = true
+		}
+	}
+	if want != 1 {
+		t.Errorf("expected exactly one record for the single undecodable embed, got %d", want)
+	}
+}
+
+// TestRun_OmittedTagClearsUnrecognizedValueReport holds the report to its own
+// advice. It tells the reader to mark the affected tags
+// `intentionally-omitted`; before this, omitted tags still counted toward the
+// subtree, so the marker could not clear the drift it was recommended for. An
+// instruction that does not resolve the error is worse than none.
+func TestRun_OmittedTagClearsUnrecognizedValueReport(t *testing.T) {
+	genSrc := src(`package generated
+
+type Note struct {
+	Id      int64  ~json:"id"~
+	Content string ~json:"content"~
+}
+`)
+	wrapperSrc := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Base struct {
+	ID      int64  ~json:"id"~
+	Content string ~json:"content"~
+}
+
+type Note struct {
+	Base
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.Base = *baseOf(g) + *baseOf(g)
+	return n
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": wrapperSrc})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err == nil {
+		t.Fatal("fixture setup: the uninterpretable value must report before the markers are added")
+	}
+
+	marked := strings.Replace(wrapperSrc, "type Note struct {\n\tBase\n}",
+		"type Note struct {\n\t// intentionally-omitted: id - answered by the marker, not the walker\n\t// intentionally-omitted: content - same\n\tBase\n}", 1)
+	if !strings.Contains(marked, "intentionally-omitted: id") {
+		t.Fatal("fixture setup: markers were not added")
+	}
+	wrapperDir, generatedFile = writeDriftFixtures(t, genSrc, map[string]string{"note.go": marked})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err != nil {
+		t.Errorf("the marker the message recommends must clear the report it is recommended for, got %v", err)
+	}
+}
+
+// TestRecordAssignedValue_ChannelReceive covers `w.Base = <-ch`, which delivers
+// a whole value of the field's type exactly as a call does. Treating it as
+// uninterpretable is the over-report class this walk shipped once already.
+func TestRecordAssignedValue_ChannelReceive(t *testing.T) {
+	expr, err := parser.ParseExpr("<-ch")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	assigned := map[string]bool{}
+	recordAssignedValue(assigned, "Base", expr)
+	if !assigned["Base.*"] {
+		t.Errorf("a channel receive delivers a whole value and covers the subtree, got %v", assigned)
+	}
+	if assigned[unrecognizedPrefix+"Base"] {
+		t.Errorf("and must not be recorded as unrecognised, got %v", assigned)
+	}
+}

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -3455,3 +3455,65 @@ func (m (M)) MarshalJSON() ([]byte, error) { return nil, nil }
 		t.Error("a parenthesized receiver still declares the method")
 	}
 }
+
+// TestExtractJSONTag_EscapedQuoteInAnotherTag covers a tag body whose EARLIER
+// value contains an escaped quote. The hand-rolled scanner that used to live
+// here stopped at it and reported no json tag, which on an anonymous field
+// silently turns a tagged member into a promotion source. Parsing is now
+// reflect's job — the same parser encoding/json consults — so the two cannot
+// disagree.
+func TestExtractJSONTag_EscapedQuoteInAnotherTag(t *testing.T) {
+	// `xml:"a\"b" json:"base"` as it appears in source, inside a raw literal.
+	literal := "`" + `xml:"a\"b" json:"base"` + "`"
+	if got := extractJSONTag(literal); got != "base" {
+		t.Errorf("escaped quote in a preceding tag: got %q, want \"base\"", got)
+	}
+	// And the consequence at the walk level: such a field is NOT a promotion
+	// source, so the embedded type's tags must not appear on the outer struct.
+	structs := flattenFixture(t, "package fixture\n\ntype Base struct {\n\tID int64 `json:\"id\"`\n}\n\ntype Outer struct {\n\tBase "+literal+"\n}\n")
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	if outer.tags["id"] {
+		t.Error("a tagged anonymous field is not a promotion source, whatever the earlier tags contain")
+	}
+	if !outer.tags["base"] {
+		t.Errorf("it registers under its own json tag, got %v", outer.tags)
+	}
+}
+
+// TestFlattenEmbedded_GenericInstantiationIsReported covers a name declared
+// over an instantiated generic (`type A G[int]`). Such a type keeps G's fields
+// — and an alias to one keeps its method set — so treating it as fieldless
+// would drop those tags from BOTH sides of a pair and let a wrapper omit them
+// with no report at all. Modelling instantiation is the type checker's job, so
+// the walk reports instead.
+func TestFlattenEmbedded_GenericInstantiationIsReported(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type G[T any] struct {
+	Value T ~json:"value"~
+}
+
+type Defined G[int]
+type Aliased = G[int]
+
+type UsesDefined struct {
+	Defined
+}
+
+type UsesAlias struct {
+	Aliased
+}
+`))
+	for _, name := range []string{"UsesDefined", "UsesAlias"} {
+		sf := structs[name]
+		if sf == nil {
+			t.Fatalf("%s not collected", name)
+		}
+		if len(sf.unresolved) == 0 {
+			t.Errorf("%s: an instantiated generic is not modelled and must be reported, not treated as fieldless", name)
+		}
+	}
+}

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -1473,10 +1473,13 @@ type Outer struct {
 	// spelling, or by an opaque assignment of the embed — and by nothing else.
 	assertTargets(t, outer, "kind", []string{"Kind", "Mid.Kind", "Mid.*"})
 	// A depth-2 promotion adds the intermediate spellings, since `Deep` is
-	// itself promoted onto Outer. The promoted field here is also named Deep,
-	// which is why "Deep.Deep" and a bare "Deep" both appear.
+	// itself promoted onto Outer. The promoted field here is ALSO named Deep,
+	// and that collision is instructive: `outer.Deep` resolves to the embedded
+	// Deep struct at depth 1, not to the string field at depth 2, so the bare
+	// spelling is absent from the target set — crediting it would attribute a
+	// write that lands somewhere else entirely.
 	assertTargets(t, outer, "deep_only", []string{
-		"Deep", "Deep.Deep", "Mid.Deep.Deep", "Mid.*", "Deep.*", "Mid.Deep.*",
+		"Deep.Deep", "Mid.Deep.Deep", "Mid.*", "Deep.*", "Mid.Deep.*",
 	})
 }
 
@@ -2085,5 +2088,129 @@ func wrapFromGenerated(g generated.Wrap) Wrap {
 	// rather than being enumerated as if its elements were field keys.
 	if assigned["Items.0"] {
 		t.Error("a slice literal must not be enumerated as struct keys")
+	}
+}
+
+// TestRun_OuterGoNameShadowsPromotedField is the second-round shadowing case,
+// and it is subtle enough to be worth spelling out. The wrapper embeds Base
+// (`ID` tagged `id`) and declares its OWN `ID` tagged `other_id`. Both keys are
+// on the wire — the Go names collide but the JSON names do not — while
+// `n.ID = …` writes the outer field only:
+//
+//	json.Marshal(b) where b.ID = 7  =>  {"id":0,"other_id":7}
+//
+// So crediting the bare `ID` spelling to the promoted `id` would pass a wrapper
+// that ships `"id": 0` on every response. The qualified spelling still counts,
+// which is the paired positive.
+func TestRun_OuterGoNameShadowsPromotedField(t *testing.T) {
+	genSrc := src(`package generated
+
+type Note struct {
+	Id      int64 ~json:"id"~
+	OtherId int64 ~json:"other_id"~
+}
+`)
+	wrapperSrc := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Base struct {
+	ID int64 ~json:"id"~
+}
+
+type Note struct {
+	Base
+	ID int64 ~json:"other_id"~
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.ID = g.OtherId
+	return n
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": wrapperSrc})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err == nil {
+		t.Error("run: `n.ID` writes the outer field, so the promoted `id` is unpopulated and must be reported")
+	}
+
+	qualified := strings.Replace(wrapperSrc, "\tn.ID = g.OtherId\n", "\tn.ID = g.OtherId\n\tn.Base.ID = g.Id\n", 1)
+	if !strings.Contains(qualified, "n.Base.ID") {
+		t.Fatal("fixture setup: the qualified write was not added")
+	}
+	wrapperDir, generatedFile = writeDriftFixtures(t, genSrc, map[string]string{"note.go": qualified})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err != nil {
+		t.Errorf("run: the qualified write reaches the promoted field and must count, got %v", err)
+	}
+}
+
+// TestFlattenEmbedded_DuplicateOwnTagAnnihilates covers the depth-0 case of the
+// conflict rule that already governed promotions: two fields on ONE struct
+// sharing a json tag are both dropped by encoding/json —
+// `json.Marshal(struct{A,B string "same"; C string "c"}{...})` emits only "c" —
+// so the tag is not on the wire and cannot satisfy a generated field. The
+// conflict also blocks a deeper promotion of the same tag, matching
+// dominantField, which gives up as soon as its two shallowest entries tie.
+func TestFlattenEmbedded_DuplicateOwnTagAnnihilates(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Base struct {
+	FromEmbed string ~json:"same"~
+}
+
+type Outer struct {
+	Base
+	A string ~json:"same"~
+	B string ~json:"same"~
+	C string ~json:"c"~
+}
+`))
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	if outer.tags["same"] {
+		t.Error("one tag on two fields of the same struct is annihilated; it must not count as present")
+	}
+	if !outer.tags["c"] {
+		t.Errorf("the unambiguous tag must survive, got %v", outer.tags)
+	}
+}
+
+// TestFlattenEmbedded_TaggedUnexportedNonStructEmbedIgnored covers the last of
+// encoding/json's embed carve-outs: an anonymous field of an unexported
+// NON-STRUCT type is dropped even when tagged (`struct{ hidden "json:secret" }`
+// marshals without "secret"), while an unexported STRUCT type keeps its tag,
+// because typeFields only skips the non-struct case.
+func TestFlattenEmbedded_TaggedUnexportedNonStructEmbedIgnored(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type hidden string
+
+type hiddenStruct struct {
+	Inner string ~json:"inner"~
+}
+
+type Outer struct {
+	hidden       ~json:"secret"~
+	hiddenStruct ~json:"nested"~
+	Name         string ~json:"name"~
+}
+`))
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	if outer.tags["secret"] {
+		t.Error("an anonymous unexported non-struct field is dropped by encoding/json even when tagged")
+	}
+	if !outer.tags["nested"] {
+		t.Errorf("an anonymous unexported STRUCT type keeps its tag, got %v", outer.tags)
+	}
+	if outer.tags["inner"] {
+		t.Error("a tagged anonymous field is not a promotion source")
+	}
+	if !outer.tags["name"] {
+		t.Errorf("expected the plain field to survive, got %v", outer.tags)
 	}
 }

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -3631,3 +3631,78 @@ func (a *Adapter) UnmarshalJSON(b []byte) error { return nil }
 		t.Errorf("its tags are judged normally, got %v", ad.tags)
 	}
 }
+
+// TestCollectJSONMethodTypes_UnknownRHSCounts covers the method graph's half of
+// the "unrecognised is never credited" invariant. A type declaration whose
+// right-hand side this check cannot evaluate — a qualified name, a generic
+// instantiation — has an UNKNOWN method set, and unknown counts as carrying.
+// Skipping it silently is how a struct embedding the alias gets its sibling
+// tags certified while a promoted MarshalJSON redirects the encoder.
+//
+// The paired negatives matter as much: a type literal has no method set of its
+// own, so `type A = struct{…}` and friends must NOT be marked, or the rule
+// degenerates into refusing every declaration.
+func TestCollectJSONMethodTypes_UnknownRHSCounts(t *testing.T) {
+	f, err := parser.ParseFile(token.NewFileSet(), "f.go", `package fixture
+
+import "encoding/json"
+
+type QualifiedAlias = json.Marshaler
+type Generic[T any] struct{ V T }
+type GenericAlias = Generic[int]
+
+type ViaInterface interface {
+	QualifiedAlias
+}
+
+type PlainStruct = struct{ ID int64 }
+type PlainMap map[string]string
+type PlainFunc func() error
+`, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	direct, graph := collectJSONMethodTypes(f)
+	closeJSONMethodTypes(direct, graph)
+	for _, name := range []string{"QualifiedAlias", "GenericAlias"} {
+		if !direct[name] {
+			t.Errorf("%s: an unevaluable right-hand side has an unknown method set and must count as carrying", name)
+		}
+	}
+	// And it propagates: an interface embedding the unknown alias carries too.
+	if !direct["ViaInterface"] {
+		t.Error("an interface embedding a name with an unknown method set carries it as well")
+	}
+	for _, name := range []string{"PlainStruct", "PlainMap", "PlainFunc"} {
+		if direct[name] {
+			t.Errorf("%s: a type literal has no method set of its own and must not be marked", name)
+		}
+	}
+}
+
+// TestCollectJSONMethodTypes_GenericReceiver covers the other silent skip in
+// the method graph: `func (b Base[T]) MarshalJSON()` declares the method on
+// Base, and reading the receiver as unrecognized left Base unmarked — so a
+// wrapper embedding it would be certified while the encoder is redirected.
+func TestCollectJSONMethodTypes_GenericReceiver(t *testing.T) {
+	f, err := parser.ParseFile(token.NewFileSet(), "f.go", `package fixture
+
+type Base[T any] struct{ V T }
+
+func (b Base[T]) MarshalJSON() ([]byte, error) { return nil, nil }
+
+type Two[A any, B any] struct{}
+
+func (t *Two[A, B]) UnmarshalJSON(b []byte) error { return nil }
+`, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got, _ := collectJSONMethodTypes(f)
+	if !got["Base"] {
+		t.Error("a generic receiver declares the method on its base type")
+	}
+	if !got["Two"] {
+		t.Error("the multi-parameter receiver form counts too")
+	}
+}

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -4,6 +4,7 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -165,6 +166,31 @@ func writeDriftFixtures(t *testing.T, genSrc string, wrapperSrcByName map[string
 		}
 	}
 	return wrapperDir, generatedFile
+}
+
+// captureStderr runs fn with os.Stderr redirected and returns what it wrote.
+// run() reports drift to stderr, so this is how a test asserts on the
+// DIAGNOSIS rather than only on the exit path.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	saved := os.Stderr
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		var buf strings.Builder
+		io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+	fn()
+	os.Stderr = saved
+	w.Close()
+	out := <-done
+	r.Close()
+	return out
 }
 
 // TestRun_InSync drives the real run() over a tree where every generated tag is
@@ -3275,5 +3301,157 @@ type Struct struct {
 	}
 	if sf := structs["Struct"]; sf == nil || len(sf.decodeUnsafe) == 0 {
 		t.Errorf("the struct form is the real allocation failure and must still be reported, got %+v", structs["Struct"])
+	}
+}
+
+// TestRun_UnrecognizedAssignmentShapeIsReported is the flipped default, which
+// is the same correction as the original #599 bug one layer down: the first
+// walker met an anonymous field it did not understand and dropped it; this one
+// met a value shape it did not understand and CREDITED it. Both are silent
+// assumptions, and both are now reports.
+//
+// The paired positive is the shape the walker does understand — the same
+// wrapper with a literal — so "report the unknown" cannot be satisfied by
+// reporting everything.
+func TestRun_UnrecognizedAssignmentShapeIsReported(t *testing.T) {
+	genSrc := src(`package generated
+
+type Note struct {
+	Id      int64  ~json:"id"~
+	Content string ~json:"content"~
+}
+`)
+	// A binary expression is not a shape the classifier models.
+	oddSrc := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Base struct {
+	ID      int64  ~json:"id"~
+	Content string ~json:"content"~
+}
+
+type Note struct {
+	Base
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.Base = *baseOf(g) + *baseOf(g)
+	return n
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": oddSrc})
+	stderr := captureStderr(t, func() {
+		if err := run(wrapperDir, generatedFile, nil, nil, false); err == nil {
+			t.Error("run: a value shape the walker cannot interpret must be reported, not credited")
+		}
+	})
+	// The diagnosis matters as much as the failure: "unpopulated" would send
+	// the reader looking for a missing assignment that is right there.
+	if !strings.Contains(stderr, "shape this walker does not interpret") {
+		t.Errorf("expected the report to name the uninterpreted shape, got:\n%s", stderr)
+	}
+
+	knownSrc := strings.Replace(oddSrc, "*baseOf(g) + *baseOf(g)", "Base{ID: g.Id, Content: g.Content}", 1)
+
+	wrapperDir, generatedFile = writeDriftFixtures(t, genSrc, map[string]string{"note.go": knownSrc})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err != nil {
+		t.Errorf("run: a shape the walker DOES interpret must still pass, got %v", err)
+	}
+}
+
+// TestRecordAssignedValue_ElidedNestedLiteral covers the elided form Go permits
+// for a nested literal. `Base{Audit: {At: g.At}}` sets exactly one field of
+// Audit; treating the inner literal as opaque would credit every field under
+// it — the silent direction — so it is enumerated like any other keyed literal.
+func TestRecordAssignedValue_ElidedNestedLiteral(t *testing.T) {
+	expr, err := parser.ParseExpr("Base{Audit: {At: g.At}, ID: g.Id}")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	assigned := map[string]bool{}
+	recordAssignedValue(assigned, "Base", expr)
+	for _, want := range []string{"Base", "Base.ID", "Base.Audit", "Base.Audit.At"} {
+		if !assigned[want] {
+			t.Errorf("expected %q, got %v", want, assigned)
+		}
+	}
+	for _, absent := range []string{"Base.*", "Base.Audit.*"} {
+		if assigned[absent] {
+			t.Errorf("an enumerated literal must not grant %q, got %v", absent, assigned)
+		}
+	}
+	// An elided EMPTY literal contributes nothing, exactly like a typed one.
+	expr2, err := parser.ParseExpr("Base{Audit: {}}")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	assigned2 := map[string]bool{}
+	recordAssignedValue(assigned2, "Base", expr2)
+	if assigned2["Base.Audit.*"] {
+		t.Errorf("an empty elided literal populates nothing, got %v", assigned2)
+	}
+}
+
+// TestExtractJSONTag_InterpretedLiteral covers the interpreted (double-quoted)
+// struct tag Go also accepts. Reading it as untagged is not a cosmetic miss: on
+// an ANONYMOUS field it flips the field from an ordinary member into a
+// promotion source, certifying members that are not on the wire.
+func TestExtractJSONTag_InterpretedLiteral(t *testing.T) {
+	if got := extractJSONTag(`"json:\"base\""`); got != "base" {
+		t.Errorf("interpreted tag literal: got %q, want \"base\"", got)
+	}
+	if got := extractJSONTag("`json:\"base\"`"); got != "base" {
+		t.Errorf("raw tag literal: got %q, want \"base\"", got)
+	}
+	if got := extractJSONTag(`"not a tag`); got != "" {
+		t.Errorf("malformed literal must yield no tag, got %q", got)
+	}
+}
+
+// TestFlattenEmbedded_InterpretedTagStopsPromotion is the consequence of the
+// above at the walk level: a tagged anonymous field is an ordinary field
+// whichever literal form its tag uses.
+func TestFlattenEmbedded_InterpretedTagStopsPromotion(t *testing.T) {
+	structs := flattenFixture(t, `package fixture
+
+type Base struct {
+	ID int64 `+"`json:\"id\"`"+`
+}
+
+type Outer struct {
+	Base "json:\"base\""
+}
+`)
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	if outer.tags["id"] {
+		t.Error("a field tagged with an interpreted literal is not a promotion source")
+	}
+	if !outer.tags["base"] {
+		t.Errorf("it registers under its own tag, got %v", outer.tags)
+	}
+}
+
+// TestCollectJSONMethodTypes_ParenthesizedReceiver covers `func (m (M)) …`.
+// Legal, essentially unwritten — but missing it drops M from the method set,
+// which is a SILENT miss: a wrapper embedding M would be certified while the
+// encoder is redirected. One unwrap, because the failure is in the silent class.
+func TestCollectJSONMethodTypes_ParenthesizedReceiver(t *testing.T) {
+	f, err := parser.ParseFile(token.NewFileSet(), "f.go", `package fixture
+
+type M struct{}
+
+func (m (M)) MarshalJSON() ([]byte, error) { return nil, nil }
+`, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got, _ := collectJSONMethodTypes(f)
+	if !got["M"] {
+		t.Error("a parenthesized receiver still declares the method")
 	}
 }

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -2460,3 +2460,94 @@ type Outer struct {
 		t.Error("assigning the embed with an empty literal must not populate the leaf")
 	}
 }
+
+// TestFlattenEmbedded_IgnoredFieldNotPromotedFromDescendant is the depth-N half
+// of the ignored-field rule: a tagged anonymous field of an unexported
+// non-struct type is invisible to encoding/json wherever it is declared, so
+// embedding the struct that declares it must not promote its tag either.
+// Filtering only the root would have promoted a key that is on no wire.
+func TestFlattenEmbedded_IgnoredFieldNotPromotedFromDescendant(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type hidden string
+
+type Mid struct {
+	hidden ~json:"ghost"~
+	Real   string ~json:"real"~
+}
+
+type Outer struct {
+	Mid
+}
+`))
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	if outer.tags["ghost"] {
+		t.Error("a field encoding/json ignores cannot be promoted onto an embedding struct")
+	}
+	if !outer.tags["real"] {
+		t.Errorf("the visible field must still promote, got %v", outer.tags)
+	}
+}
+
+// TestFlattenEmbedded_MethodBearingInterfaceEmbedIsRejected covers the other
+// way a custom marshaller reaches the embedding type: an embedded INTERFACE
+// carrying MarshalJSON in its method set promotes it exactly as a struct's
+// method would, and the interface has no fields for the walk to notice. Also
+// covers an interface that gets the method by embedding another interface,
+// since a method set is transitive.
+func TestFlattenEmbedded_MethodBearingInterfaceEmbedIsRejected(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Marshaler interface {
+	MarshalJSON() ([]byte, error)
+}
+
+type Fancy interface {
+	Marshaler
+	Extra()
+}
+
+type Plain interface {
+	Do()
+}
+
+type Base struct {
+	ID int64 ~json:"id"~
+}
+
+type Direct struct {
+	Marshaler
+	Base
+}
+
+type Transitive struct {
+	Fancy
+	Base
+}
+
+type Harmless struct {
+	Plain
+	Base
+}
+`))
+	for _, name := range []string{"Direct", "Transitive"} {
+		sf := structs[name]
+		if sf == nil {
+			t.Fatalf("%s not collected", name)
+		}
+		if len(sf.unresolved) == 0 {
+			t.Errorf("%s: embedding an interface whose method set carries MarshalJSON must be reported", name)
+		}
+		if sf.tags["id"] {
+			t.Errorf("%s: no tag may be certified once a custom marshaller is promoted", name)
+		}
+	}
+	// An ordinary interface embed promotes no method that redirects the
+	// encoder, so it stays the harmless no-op it always was.
+	if h := structs["Harmless"]; h == nil || len(h.unresolved) != 0 || !h.tags["id"] {
+		t.Errorf("a plain interface embed must not be rejected, got %+v", structs["Harmless"])
+	}
+}

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -4239,3 +4239,59 @@ func noteFromGenerated(g generated.Note) Note {
 		t.Errorf("expected the generated-side embed to count, got:\n%s", stdout)
 	}
 }
+
+// TestRun_ScopeCountsOnlyTagsTheCheckConsumed pins the other half of the
+// derivation: "contributed" means a generated tag the check actually consumed.
+// A promoted tag the wrapper intentionally omits was answered by the marker,
+// and a tag promoted on the GENERATED side that the wrapper does not declare is
+// reported as missing — neither was verified through promotion, and counting
+// them would overstate what the run exercised.
+func TestRun_ScopeCountsOnlyTagsTheCheckConsumed(t *testing.T) {
+	genSrc := src(`package generated
+
+type Timestamps struct {
+	CreatedAt string ~json:"created_at"~
+	UpdatedAt string ~json:"updated_at"~
+}
+
+type Note struct {
+	Timestamps
+	Id int64 ~json:"id"~
+}
+`)
+	// created_at is omitted by marker; updated_at is simply absent from the
+	// wrapper. Both are promoted on the generated side; neither is consumed.
+	wrapperSrc := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Note struct {
+	// intentionally-omitted: created_at - answered here, not through promotion
+	// intentionally-omitted: updated_at - same
+	ID int64 ~json:"id"~
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.ID = g.Id
+	return n
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": wrapperSrc})
+	var stdout string
+	_ = captureStderr(t, func() {
+		stdout = captureStdout(t, func() {
+			if err := run(wrapperDir, generatedFile, nil, nil, false); err != nil {
+				t.Errorf("fixture setup: the markers answer both promoted tags, got %v", err)
+			}
+		})
+	})
+	// The generated side embeds, so the pair counts as embedding...
+	if !strings.Contains(stdout, "1 of 1 pairs embed a struct") {
+		t.Errorf("the generated-side embed must still count, got:\n%s", stdout)
+	}
+	// ...but no promoted tag was consumed by a check.
+	if !strings.Contains(stdout, "no promoted tag reached the check") {
+		t.Errorf("an omitted or absent tag was not verified through promotion; the line must not claim it was:\n%s", stdout)
+	}
+}

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -4295,3 +4295,48 @@ func noteFromGenerated(g generated.Note) Note {
 		t.Errorf("an omitted or absent tag was not verified through promotion; the line must not claim it was:\n%s", stdout)
 	}
 }
+
+// TestRun_OutputCarriesTheBestEffortLimitation pins the honesty requirement one
+// step further than the scope line. The scope line says which SHAPES this
+// walker resolves; this one says that where it does resolve a promotion, the
+// certification is best-effort — there are enumerated shapes where it is
+// confidently wrong, including some that can pass a wrapper dropping a
+// generated field. A reader must not take a clean run as proof of soundness,
+// and the pointer to the inventory has to survive refactors of this output.
+func TestRun_OutputCarriesTheBestEffortLimitation(t *testing.T) {
+	genSrc := src(`package generated
+
+type Note struct {
+	Id int64 ~json:"id"~
+}
+`)
+	wrapperSrc := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Note struct {
+	ID int64 ~json:"id"~
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.ID = g.Id
+	return n
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": wrapperSrc})
+	var stdout string
+	_ = captureStderr(t, func() {
+		stdout = captureStdout(t, func() {
+			if err := run(wrapperDir, generatedFile, nil, nil, false); err != nil {
+				t.Fatalf("fixture setup: this pair is in sync, got %v", err)
+			}
+		})
+	})
+	// A CLEAN run is exactly when the disclaimer matters.
+	for _, want := range []string{"BEST-EFFORT", "#741", "not proof"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("a clean run must still carry %q:\n%s", want, stdout)
+		}
+	}
+}

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -2852,12 +2852,14 @@ type UntaggedParent struct {
 	}
 }
 
-// TestFlattenEmbedded_UnexportedPointerEmbedIsRejected covers the decode side:
-// encoding/json cannot allocate an embedded pointer to an unexported type
-// ("cannot set embedded pointer to unexported struct"), so a direct-decode
-// wrapper's tags are present but never populated — the exact assumption tier 2
-// rests on. The value form has no such problem and must keep working.
-func TestFlattenEmbedded_UnexportedPointerEmbedIsRejected(t *testing.T) {
+// TestFlattenEmbedded_UnexportedPointerEmbedIsDecodeUnsafe covers a failure
+// that is real for ONE direction only: encoding/json cannot allocate an
+// embedded pointer to an unexported type ("cannot set embedded pointer to
+// unexported struct"), so a decoder never populates its promoted fields —
+// while marshalling and in-Go construction are unaffected. It is therefore
+// recorded separately from the refusals, and run() reports it for tier-2 pairs
+// alone, whose whole premise is that the decoder does the populating.
+func TestFlattenEmbedded_UnexportedPointerEmbedIsDecodeUnsafe(t *testing.T) {
 	structs := flattenFixture(t, src(`package fixture
 
 type hidden struct {
@@ -2872,11 +2874,101 @@ type ByValue struct {
 	hidden
 }
 `))
-	if p := structs["ByPointer"]; p == nil || len(p.unresolved) == 0 {
-		t.Errorf("an unexported pointer embed cannot be decoded and must be reported, got %+v", structs["ByPointer"])
+	p := structs["ByPointer"]
+	if p == nil {
+		t.Fatal("ByPointer not collected")
 	}
-	if v := structs["ByValue"]; v == nil || len(v.unresolved) != 0 || !v.tags["id"] {
-		t.Errorf("the value form promotes normally, got %+v", structs["ByValue"])
+	if len(p.decodeUnsafe) == 0 {
+		t.Error("an unexported pointer embed must be recorded as decode-unsafe")
+	}
+	if len(p.unresolved) != 0 {
+		t.Errorf("it is not a refusal: marshalling and construction work, got %v", p.unresolved)
+	}
+	if !p.tags["id"] {
+		t.Error("the fields still promote — the problem is decoding, not the shape")
+	}
+	if v := structs["ByValue"]; v == nil || len(v.decodeUnsafe) != 0 || !v.tags["id"] {
+		t.Errorf("the value form has no decode problem at all, got %+v", structs["ByValue"])
+	}
+}
+
+// TestRun_UnexportedPointerEmbedReportedForDirectDecodeOnly is the pairing that
+// makes the scoping meaningful: the SAME wrapper shape is reported when the
+// pair is direct-decode and accepted when it is built by a *FromGenerated.
+func TestRun_UnexportedPointerEmbedReportedForDirectDecodeOnly(t *testing.T) {
+	genSrc := src(`package generated
+
+type Note struct {
+	Id int64 ~json:"id"~
+}
+`)
+	tier2Src := src(`package basecamp
+
+type hidden struct {
+	ID int64 ~json:"id"~
+}
+
+type Note struct {
+	*hidden
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": tier2Src})
+	if err := run(wrapperDir, generatedFile, map[string]string{"Note": "Note"}, nil, false); err == nil {
+		t.Error("run: a direct-decode pair relies on the decoder, which cannot allocate this embed")
+	}
+
+	tier1Src := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type hidden struct {
+	ID int64 ~json:"id"~
+}
+
+type Note struct {
+	*hidden
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.hidden = &hidden{}
+	n.ID = g.Id
+	return n
+}
+`)
+	wrapperDir, generatedFile = writeDriftFixtures(t, genSrc, map[string]string{"note.go": tier1Src})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err != nil {
+		t.Errorf("run: a constructed wrapper initializes the embed itself and is unaffected, got %v", err)
+	}
+}
+
+// TestIsJSONMethod_SignatureMatters guards the guard: only a method that
+// actually satisfies json.Marshaler / json.Unmarshaler redirects the encoder,
+// so a same-named method with a different signature must not make the walk
+// refuse a struct encoding/json walks normally.
+func TestIsJSONMethod_SignatureMatters(t *testing.T) {
+	cases := []struct {
+		decl string
+		want bool
+	}{
+		{"func (s Stamp) MarshalJSON() ([]byte, error) { return nil, nil }", true},
+		{"func (s *Stamp) UnmarshalJSON(b []byte) error { return nil }", true},
+		{"func (s Stamp) MarshalJSON(n int) []byte { return nil }", false},
+		{"func (s Stamp) MarshalJSON() []byte { return nil }", false},
+		{"func (s *Stamp) UnmarshalJSON(b string) error { return nil }", false},
+		{"func (s *Stamp) UnmarshalJSON(b []byte) (int, error) { return 0, nil }", false},
+		{"func (s Stamp) MarshalText() ([]byte, error) { return nil, nil }", false},
+	}
+	for _, c := range cases {
+		source := "package fixture" + "\n\n" + c.decl + "\n"
+		f, err := parser.ParseFile(token.NewFileSet(), "f.go", source, parser.ParseComments)
+		if err != nil {
+			t.Fatalf("parse %q: %v", c.decl, err)
+		}
+		got, _ := collectJSONMethodTypes(f)
+		if got["Stamp"] != c.want {
+			t.Errorf("%s: recognized = %v, want %v", c.decl, got["Stamp"], c.want)
+		}
 	}
 }
 

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -5,8 +5,10 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestExtractJSONTag(t *testing.T) {
@@ -1067,5 +1069,607 @@ func TestPathPrefixAndField(t *testing.T) {
 			t.Errorf("pathPrefixAndField(%q) = (%q, %q), want (%q, %q)",
 				c.src, prefix, field, c.wantPrefix, c.wantField)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Embedded (anonymous) field promotion — issue #599.
+//
+// Before the promotion walk existed, an anonymous field was dropped on the
+// floor (no tag, no name), so a wrapper that embedded a struct read as having
+// none of its promoted fields and every one of them was reported missing. The
+// cases below come in pairs: an embedding wrapper that must PASS, and a
+// genuinely-drifted sibling built on the same shape that must still FAIL — a
+// fix that simply stopped checking embedding wrappers would pass the first and
+// fail the second.
+// ---------------------------------------------------------------------------
+
+// src rewrites ~ to a backtick so struct-tag fixtures can be written as raw
+// string literals (Go raw strings cannot contain a backtick, and these
+// embedding fixtures carry too many tags for the escaped-concatenation style
+// used by the older fixtures above).
+func src(s string) string { return strings.ReplaceAll(s, "~", "`") }
+
+// flattenFixture parses one source file, collects its structs and resolves
+// their embedded types, returning the flattened universe.
+func flattenFixture(t *testing.T, source string) map[string]*structFields {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "fixture.go", source, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	structs := collectStructsAndMarkers(fset, f)
+	flattenEmbedded(structs, collectTypeDecls(f))
+	return structs
+}
+
+// embeddingGenSrc is the generated side shared by the embedding pair below: 14
+// tags, 12 of which the wrapper can only satisfy through promotion.
+const embeddingGenSrc = `package generated
+
+type Task struct {
+	Id               int64  ~json:"id"~
+	Status           string ~json:"status"~
+	Title            string ~json:"title"~
+	Content          string ~json:"content"~
+	Type             string ~json:"type"~
+	Position         int64  ~json:"position"~
+	VisibleToClients bool   ~json:"visible_to_clients"~
+	CreatorName      string ~json:"creator_name"~
+	CreatorId        int64  ~json:"creator_id"~
+	CreatedAt        string ~json:"created_at"~
+	UpdatedAt        string ~json:"updated_at"~
+	Url              string ~json:"url"~
+	AppUrl           string ~json:"app_url"~
+	BookmarkUrl      string ~json:"bookmark_url"~
+}
+`
+
+// embeddingWrapperSrc declares two tags directly and inherits the other twelve
+// through a two-level embedding chain (Task embeds Meta by value, Meta embeds
+// *Audit by pointer). Meta and Audit live in a SECOND wrapper file, so the
+// resolution has to happen after every file is parsed, not per file.
+const embeddingWrapperSrc = `package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Task struct {
+	Meta
+	Status string ~json:"status"~
+	Title  string ~json:"title"~
+}
+
+func taskFromGenerated(g generated.Task) Task {
+	t := Task{Status: g.Status}
+	t.Title = g.Title
+	t.ID = g.Id
+	t.Content = g.Content
+	t.Type = g.Type
+	t.Position = g.Position
+	t.VisibleToClients = g.VisibleToClients
+	t.CreatorName = g.CreatorName
+	t.CreatorID = g.CreatorId
+	t.CreatedAt = g.CreatedAt
+	t.UpdatedAt = g.UpdatedAt
+	t.URL = g.Url
+	t.AppURL = g.AppUrl
+	t.BookmarkURL = g.BookmarkUrl
+	return t
+}
+`
+
+const embeddingBaseSrc = `package basecamp
+
+type Meta struct {
+	*Audit
+	ID               int64  ~json:"id"~
+	Content          string ~json:"content"~
+	Type             string ~json:"type"~
+	Position         int64  ~json:"position"~
+	VisibleToClients bool   ~json:"visible_to_clients"~
+	CreatorName      string ~json:"creator_name"~
+	CreatorID        int64  ~json:"creator_id"~
+}
+
+type Audit struct {
+	CreatedAt   string ~json:"created_at"~
+	UpdatedAt   string ~json:"updated_at"~
+	URL         string ~json:"url"~
+	AppURL      string ~json:"app_url"~
+	BookmarkURL string ~json:"bookmark_url"~
+}
+`
+
+// TestRun_EmbeddedWrapperInSync is the #599 regression. Every generated tag is
+// present on the wrapper — two declared directly, twelve promoted through the
+// embedding chain — and every one is assigned. Before the promotion walk, this
+// reported all twelve promoted tags as missing.
+func TestRun_EmbeddedWrapperInSync(t *testing.T) {
+	wrapperDir, generatedFile := writeDriftFixtures(t, src(embeddingGenSrc), map[string]string{
+		"task.go": src(embeddingWrapperSrc),
+		"meta.go": src(embeddingBaseSrc),
+	})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err != nil {
+		t.Errorf("run: expected no drift for an embedding wrapper, got %v", err)
+	}
+}
+
+// TestRun_EmbeddedWrapperGenuinelyMissingTag is the paired negative: the same
+// embedding shape, plus one generated tag that neither the wrapper nor
+// anything it embeds declares. Resolving embedded fields must not blunt the
+// check — this must still be reported.
+func TestRun_EmbeddedWrapperGenuinelyMissingTag(t *testing.T) {
+	genSrc := strings.Replace(embeddingGenSrc,
+		"\tBookmarkUrl      string ~json:\"bookmark_url\"~\n",
+		"\tBookmarkUrl      string ~json:\"bookmark_url\"~\n\tSubscriptionUrl  string ~json:\"subscription_url\"~\n", 1)
+	if !strings.Contains(genSrc, "subscription_url") {
+		t.Fatal("fixture setup: subscription_url was not added to the generated struct")
+	}
+	wrapperDir, generatedFile := writeDriftFixtures(t, src(genSrc), map[string]string{
+		"task.go": src(embeddingWrapperSrc),
+		"meta.go": src(embeddingBaseSrc),
+	})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err == nil {
+		t.Error("run: expected drift on subscription_url, which no embedded struct declares, got nil")
+	}
+}
+
+// TestRun_EmbeddedPromotedFieldUnassigned proves the population check reaches
+// through promotion too: the tag is declared (on the embedded struct) but the
+// *FromGenerated body never assigns it, in any spelling.
+func TestRun_EmbeddedPromotedFieldUnassigned(t *testing.T) {
+	genSrc := src(`package generated
+
+type Note struct {
+	Id      int64  ~json:"id"~
+	Content string ~json:"content"~
+}
+`)
+	wrapperSrc := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Base struct {
+	ID      int64  ~json:"id"~
+	Content string ~json:"content"~
+}
+
+type Note struct {
+	Base
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.ID = g.Id
+	return n
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": wrapperSrc})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err == nil {
+		t.Error("run: expected population drift on the promoted-but-unassigned Content field, got nil")
+	}
+}
+
+// TestRun_EmbeddedStructAssignedWholesale covers the other legal spelling:
+// assigning the embedded struct itself populates every field promoted through
+// it, including fields promoted from a deeper embed.
+func TestRun_EmbeddedStructAssignedWholesale(t *testing.T) {
+	genSrc := src(`package generated
+
+type Note struct {
+	Id        int64  ~json:"id"~
+	Content   string ~json:"content"~
+	CreatedAt string ~json:"created_at"~
+}
+`)
+	wrapperSrc := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Stamp struct {
+	CreatedAt string ~json:"created_at"~
+}
+
+type Base struct {
+	Stamp
+	ID      int64  ~json:"id"~
+	Content string ~json:"content"~
+}
+
+type Note struct {
+	Base
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.Base = Base{ID: g.Id, Content: g.Content, Stamp: Stamp{CreatedAt: g.CreatedAt}}
+	return n
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": wrapperSrc})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err != nil {
+		t.Errorf("run: assigning the embedded struct wholesale must populate its promoted fields, got %v", err)
+	}
+}
+
+// TestRun_GeneratedStructEmbeds covers the other side of the pair: the
+// GENERATED struct embeds a struct, so its promoted tags are part of the
+// contract the wrapper must satisfy. Dropping them would make the check
+// silently under-report.
+func TestRun_GeneratedStructEmbeds(t *testing.T) {
+	genSrc := src(`package generated
+
+type Timestamps struct {
+	CreatedAt string ~json:"created_at"~
+	UpdatedAt string ~json:"updated_at"~
+}
+
+type Note struct {
+	Timestamps
+	Id int64 ~json:"id"~
+}
+`)
+	wrapperMissing := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Note struct {
+	ID        int64  ~json:"id"~
+	CreatedAt string ~json:"created_at"~
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.ID = g.Id
+	n.CreatedAt = g.CreatedAt
+	return n
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": wrapperMissing})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err == nil {
+		t.Error("run: expected drift on updated_at, promoted onto the generated struct, got nil")
+	}
+
+	wrapperComplete := strings.Replace(wrapperMissing,
+		"\tn.CreatedAt = g.CreatedAt\n",
+		"\tn.CreatedAt = g.CreatedAt\n\tn.UpdatedAt = g.UpdatedAt\n", 1)
+	wrapperComplete = strings.Replace(wrapperComplete,
+		src("\tCreatedAt string ~json:\"created_at\"~\n"),
+		src("\tCreatedAt string ~json:\"created_at\"~\n\tUpdatedAt string ~json:\"updated_at\"~\n"), 1)
+	wrapperDir, generatedFile = writeDriftFixtures(t, genSrc, map[string]string{"note.go": wrapperComplete})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err != nil {
+		t.Errorf("run: wrapper covering both promoted generated tags must pass, got %v", err)
+	}
+}
+
+// TestRun_UnresolvableEmbedIsReportedNotSkipped pins the deliberate choice for
+// an embed the checker cannot resolve: report it for any pair that reaches it,
+// because the promoted fields are invisible and pretending they are absent (or
+// that there are none) is the silent-drop failure mode of #599. Structs
+// OUTSIDE every pair keep their unresolvable embeds for free — go/pkg/basecamp
+// has one today (FlexTime embeds time.Time).
+func TestRun_UnresolvableEmbedIsReportedNotSkipped(t *testing.T) {
+	genSrc := src(`package generated
+
+type Note struct {
+	Id int64 ~json:"id"~
+}
+`)
+	wrapperSrc := src(`package basecamp
+
+import (
+	"time"
+
+	"github.com/basecamp/basecamp-sdk/go/pkg/generated"
+)
+
+// FlexTime is outside every pair: its unresolvable embed must NOT fail the run.
+type FlexTime struct {
+	time.Time
+}
+
+type Note struct {
+	ID int64 ~json:"id"~
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.ID = g.Id
+	return n
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": wrapperSrc})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err != nil {
+		t.Errorf("run: an unresolvable embed on a struct outside every pair must not fail, got %v", err)
+	}
+
+	// Now put the unresolvable embed ON the paired wrapper.
+	paired := strings.Replace(wrapperSrc, src("type Note struct {\n\tID int64 ~json:\"id\"~\n}"),
+		src("type Note struct {\n\ttime.Time\n\tID int64 ~json:\"id\"~\n}"), 1)
+	if !strings.Contains(paired, "\ttime.Time\n\tID") {
+		t.Fatal("fixture setup: the embed was not added to the paired wrapper")
+	}
+	wrapperDir, generatedFile = writeDriftFixtures(t, genSrc, map[string]string{"note.go": paired})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err == nil {
+		t.Error("run: an unresolvable embed on a paired wrapper must be reported, got nil")
+	}
+}
+
+// TestFlattenEmbedded_Shadowing pins encoding/json's promotion rules: a tag
+// declared directly on the struct wins over the same tag promoted from an
+// embed, and a depth-1 promotion wins over depth 2.
+func TestFlattenEmbedded_Shadowing(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Deep struct {
+	Name string ~json:"name"~
+	Deep string ~json:"deep_only"~
+}
+
+type Mid struct {
+	Deep
+	Name string ~json:"name"~
+	Kind string ~json:"kind"~
+}
+
+type Outer struct {
+	Mid
+	Name string ~json:"name"~
+}
+`))
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	for _, tag := range []string{"name", "kind", "deep_only"} {
+		if !outer.tags[tag] {
+			t.Errorf("expected Outer to carry tag %q, got %v", tag, outer.tags)
+		}
+	}
+	if got := outer.tagToGoField["name"]; got != "Name" {
+		t.Errorf("name should resolve to Outer's own Name field, got %q", got)
+	}
+	// The own field wins, so its population target is itself alone — not the
+	// embedded path that would also have carried a "name".
+	if got := outer.populationTargets("name"); len(got) != 1 || got[0] != "Name" {
+		t.Errorf("expected population target [Name] for the shadowing own field, got %v", got)
+	}
+	if got := outer.populationTargets("kind"); len(got) != 2 || got[0] != "Mid" || got[1] != "Kind" {
+		t.Errorf("expected population targets [Mid Kind] for the depth-1 promotion, got %v", got)
+	}
+	if got := outer.populationTargets("deep_only"); len(got) != 3 || got[0] != "Mid" || got[1] != "Deep" || got[2] != "Deep" {
+		t.Errorf("expected population targets [Mid Deep Deep] for the depth-2 promotion, got %v", got)
+	}
+}
+
+// TestFlattenEmbedded_SameDepthConflictCancels pins the other half of
+// encoding/json's rule: two embeds contributing the same tag at the same depth
+// cancel out, so the tag is NOT on the wire and must not be reported as
+// present. Non-conflicting tags from the same two embeds still promote.
+func TestFlattenEmbedded_SameDepthConflictCancels(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Left struct {
+	Name string ~json:"name"~
+	Only string ~json:"left_only"~
+}
+
+type Right struct {
+	Name string ~json:"name"~
+	Only string ~json:"right_only"~
+}
+
+type Outer struct {
+	Left
+	Right
+}
+`))
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	if outer.tags["name"] {
+		t.Error("a tag contributed twice at the same depth is dropped by encoding/json; it must not count as present")
+	}
+	if !outer.tags["left_only"] || !outer.tags["right_only"] {
+		t.Errorf("non-conflicting tags from both embeds must still promote, got %v", outer.tags)
+	}
+}
+
+// TestFlattenEmbedded_CyclesTerminate covers mutual and self embedding. The
+// assertion that matters is that this returns at all; the tag expectations
+// pin the fields it still finds on the way round.
+func TestFlattenEmbedded_CyclesTerminate(t *testing.T) {
+	source := src(`package fixture
+
+type A struct {
+	*B
+	AField string ~json:"a_field"~
+}
+
+type B struct {
+	*A
+	BField string ~json:"b_field"~
+}
+
+type Selfish struct {
+	*Selfish
+	SelfField string ~json:"self_field"~
+}
+`)
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "fixture.go", source, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	structs := collectStructsAndMarkers(fset, f)
+	decls := collectTypeDecls(f)
+	// flattenEmbedded runs on its own goroutine so a walk that fails to
+	// terminate fails the test instead of hanging the whole package.
+	done := make(chan struct{})
+	go func() {
+		flattenEmbedded(structs, decls)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("flattenEmbedded did not terminate on an embedding cycle")
+	}
+	if a := structs["A"]; a == nil || !a.tags["a_field"] || !a.tags["b_field"] {
+		t.Errorf("expected A to carry a_field and b_field, got %v", structs["A"])
+	}
+	if s := structs["Selfish"]; s == nil || !s.tags["self_field"] || len(s.tags) != 1 {
+		t.Errorf("expected Selfish to carry exactly self_field, got %v", structs["Selfish"])
+	}
+}
+
+// TestFlattenEmbedded_NonStructAndAliasEmbeds covers the two resolvable
+// non-struct shapes: an embedded interface or map promotes no JSON fields
+// (generated.ClientWithResponses embeds ClientInterface today), while a defined
+// type standing for a struct is followed to it.
+func TestFlattenEmbedded_NonStructAndAliasEmbeds(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Doer interface{ Do() }
+
+type Payload map[string]string
+
+type Base struct {
+	ID int64 ~json:"id"~
+}
+
+type Alias Base
+
+type Outer struct {
+	Doer
+	Payload
+	Alias
+	Name string ~json:"name"~
+}
+`))
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	if len(outer.unresolved) != 0 {
+		t.Errorf("interface/map/alias embeds all resolve; got unresolved %v", outer.unresolved)
+	}
+	if !outer.tags["id"] {
+		t.Errorf("expected the alias embed to promote id, got %v", outer.tags)
+	}
+	if !outer.tags["name"] || len(outer.tags) != 2 {
+		t.Errorf("expected exactly name+id, got %v", outer.tags)
+	}
+}
+
+// TestCollectStructs_TaggedAnonymousFieldNotPromoted pins the encoding/json
+// carve-out: an anonymous field that carries its own json tag is an ordinary
+// field under that tag, not a promotion source.
+func TestCollectStructs_TaggedAnonymousFieldNotPromoted(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Base struct {
+	ID int64 ~json:"id"~
+}
+
+type Outer struct {
+	Base ~json:"base"~
+	Name string ~json:"name"~
+}
+`))
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	if outer.tags["id"] {
+		t.Error("a tagged anonymous field must not promote its fields")
+	}
+	if !outer.tags["base"] {
+		t.Errorf("expected the tagged anonymous field to register under its own tag, got %v", outer.tags)
+	}
+	if got := outer.tagToGoField["base"]; got != "Base" {
+		t.Errorf("expected the embedded type name as the Go field name, got %q", got)
+	}
+}
+
+// TestRun_OmitMarkerNotInheritedThroughEmbed pins the deliberate non-inheritance
+// of intentionally-omitted markers. A marker inside an embedded struct belongs
+// to that struct's own pair; the embedding wrapper must declare its own, and
+// until it does the tag is reported. The failure mode of this choice is a loud
+// missing-tag report, never a silent pass.
+func TestRun_OmitMarkerNotInheritedThroughEmbed(t *testing.T) {
+	genSrc := src(`package generated
+
+type Note struct {
+	Id     int64  ~json:"id"~
+	Secret string ~json:"secret"~
+}
+`)
+	wrapperSrc := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Base struct {
+	// intentionally-omitted: secret - Base's own decision, not Note's
+	ID int64 ~json:"id"~
+}
+
+type Note struct {
+	Base
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.ID = g.Id
+	return n
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": wrapperSrc})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err == nil {
+		t.Error("run: an embedded struct's intentionally-omitted marker must not suppress the embedding wrapper's check")
+	}
+
+	// The embedding wrapper carrying its own marker resolves it.
+	withOwn := strings.Replace(wrapperSrc, "type Note struct {\n\tBase\n}",
+		"type Note struct {\n\t// intentionally-omitted: secret - Note's own decision\n\tBase\n}", 1)
+	if !strings.Contains(withOwn, "Note's own decision") {
+		t.Fatal("fixture setup: the marker was not added to the embedding wrapper")
+	}
+	wrapperDir, generatedFile = writeDriftFixtures(t, genSrc, map[string]string{"note.go": withOwn})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err != nil {
+		t.Errorf("run: the embedding wrapper's own marker must suppress the tag, got %v", err)
+	}
+}
+
+// TestFlattenEmbedded_DepthCapIsReportedNotSilent pins the behaviour at the
+// depth budget: a chain longer than maxEmbedDepth is truncated (the walk must
+// terminate), but the truncation is REPORTED on the root, because a quietly
+// truncated chain hides fields exactly the way #599 did.
+func TestFlattenEmbedded_DepthCapIsReportedNotSilent(t *testing.T) {
+	deepest := maxEmbedDepth + 2
+	var b strings.Builder
+	b.WriteString("package fixture\n")
+	for i := 0; i <= deepest; i++ {
+		b.WriteString("\ntype T" + strconv.Itoa(i) + " struct {\n")
+		if i < deepest {
+			b.WriteString("\tT" + strconv.Itoa(i+1) + "\n")
+		}
+		b.WriteString("\tF" + strconv.Itoa(i) + " string ~json:\"f" + strconv.Itoa(i) + "\"~\n}\n")
+	}
+	structs := flattenFixture(t, src(b.String()))
+	root := structs["T0"]
+	if root == nil {
+		t.Fatal("T0 not collected")
+	}
+	if len(root.unresolved) == 0 {
+		t.Error("a chain truncated at the depth cap must be reported, not dropped silently")
+	}
+	if !root.tags["f"+strconv.Itoa(maxEmbedDepth)] {
+		t.Errorf("expected everything within the cap to promote, got %v", root.tags)
+	}
+	if root.tags["f"+strconv.Itoa(deepest)] {
+		t.Error("fixture is not actually exceeding the cap; the test would prove nothing")
 	}
 }

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -1157,8 +1157,9 @@ func flattenFixture(t *testing.T, source string) map[string]*structFields {
 	}
 	structs := collectStructsAndMarkers(fset, f)
 	jsonMethods, ifaceEmbeds := collectJSONMethodTypes(f)
+	direct := copySet(jsonMethods)
 	closeJSONMethodTypes(jsonMethods, ifaceEmbeds)
-	flattenEmbedded(structs, collectTypeDecls(f), jsonMethods)
+	flattenEmbedded(structs, collectTypeDecls(f), jsonMethods, direct)
 	return structs
 }
 
@@ -1605,7 +1606,7 @@ type Selfish struct {
 	// terminate fails the test instead of hanging the whole package.
 	done := make(chan struct{})
 	go func() {
-		flattenEmbedded(structs, decls, jsonMethods)
+		flattenEmbedded(structs, decls, jsonMethods, copySet(jsonMethods))
 		close(done)
 	}()
 	select {
@@ -4112,5 +4113,129 @@ func noteFromGenerated(g generated.Note) Note {
 	})
 	if !strings.Contains(stdout, "no pair embeds a struct") {
 		t.Errorf("a tagged embed and an interface embed are not struct promotion; the scope line must say so:\n%s", stdout)
+	}
+}
+
+// TestRecordAssignedValue_AnonymousStructLiteral covers the assignment Go
+// permits between an unnamed struct and a named one with the same underlying
+// type. `n.Base = struct{ID int64; Content string}{ID: g.Id}` sets one field
+// and leaves the other zero; crediting it as a whole value certified a field
+// nobody assigned.
+func TestRecordAssignedValue_AnonymousStructLiteral(t *testing.T) {
+	expr, err := parser.ParseExpr("struct{ ID int64; Content string }{ID: g.Id}")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	assigned := map[string]bool{}
+	recordAssignedValue(assigned, "Base", expr)
+	if !assigned["Base.ID"] {
+		t.Errorf("an anonymous struct literal is enumerated like any other, got %v", assigned)
+	}
+	if assigned["Base.*"] {
+		t.Errorf("and must not be credited as a whole value, got %v", assigned)
+	}
+	if assigned["Base.Content"] {
+		t.Errorf("the field it omits stays uncovered, got %v", assigned)
+	}
+}
+
+// TestFlattenEmbedded_RootGateNeedsRealPromotionAndOwnMethod tightens the root
+// marshaller gate three ways it was wrong: it consulted the CLOSED method set,
+// so an inherited or unknown method read as "declares one itself"; it counted
+// any anonymous field as promotion, so a decode adapter with only a tagged
+// embed was rejected though it promotes nothing; and it named only the JSON
+// pair though the check also matches Text.
+//
+// Inherited cases are not dropped — they belong to vouch, which reports them
+// per embed with the right explanation.
+func TestFlattenEmbedded_RootGateNeedsRealPromotionAndOwnMethod(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Extra struct {
+	Unasked string ~json:"unasked"~
+}
+
+type Base struct {
+	ID int64 ~json:"id"~
+}
+
+// Declares its own method AND promotes: the case the gate is for.
+type RealCase struct {
+	Base
+	Name string ~json:"name"~
+}
+
+func (r RealCase) MarshalJSON() ([]byte, error) { return nil, nil }
+
+// Declares its own method but promotes nothing — a tagged embed is an
+// ordinary field. This is the repo's decode-adapter shape and must pass.
+type AdapterWithTaggedEmbed struct {
+	Extra ~json:"extra"~
+	ID    int64 ~json:"id"~
+}
+
+func (a *AdapterWithTaggedEmbed) UnmarshalJSON(b []byte) error { return nil }
+`))
+	if rc := structs["RealCase"]; rc == nil || len(rc.unresolved) == 0 {
+		t.Errorf("a root that declares a marshaller AND promotes must be reported, got %+v", structs["RealCase"])
+	}
+	ad := structs["AdapterWithTaggedEmbed"]
+	if ad == nil {
+		t.Fatal("AdapterWithTaggedEmbed not collected")
+	}
+	if len(ad.unresolved) != 0 {
+		t.Errorf("a tagged embed promotes nothing; the adapter shape must not be rejected, got %v", ad.unresolved)
+	}
+	if !ad.tags["id"] || !ad.tags["extra"] {
+		t.Errorf("its own tags are judged normally, got %v", ad.tags)
+	}
+}
+
+// TestRun_ScopeLineCountsTheGeneratedSide closes the last gap in the coverage
+// statement: this check flattens BOTH universes, so a flat wrapper paired with
+// a generated struct that embeds still had its verdict produced by the
+// promotion machinery — and printing "no pair embeds a struct" there is false.
+func TestRun_ScopeLineCountsTheGeneratedSide(t *testing.T) {
+	genSrc := src(`package generated
+
+type Timestamps struct {
+	CreatedAt string ~json:"created_at"~
+}
+
+type Note struct {
+	Timestamps
+	Id int64 ~json:"id"~
+}
+`)
+	wrapperSrc := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Note struct {
+	ID        int64  ~json:"id"~
+	CreatedAt string ~json:"created_at"~
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.ID = g.Id
+	n.CreatedAt = g.CreatedAt
+	return n
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": wrapperSrc})
+	var stdout string
+	_ = captureStderr(t, func() {
+		stdout = captureStdout(t, func() {
+			if err := run(wrapperDir, generatedFile, nil, nil, false); err != nil {
+				t.Errorf("fixture setup: the wrapper covers both generated tags, got %v", err)
+			}
+		})
+	})
+	if strings.Contains(stdout, "no pair embeds a struct") {
+		t.Errorf("the generated side embeds, and its promoted tag was verified; the scope line must say so:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "1 of 1 pairs embed a struct") {
+		t.Errorf("expected the generated-side embed to count, got:\n%s", stdout)
 	}
 }

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -3979,3 +3979,138 @@ func TestRecordAssignedValue_ChannelReceive(t *testing.T) {
 		t.Errorf("and must not be recorded as unrecognised, got %v", assigned)
 	}
 }
+
+// TestIsJSONMethod_ArityBeatsUnknownTypes pins that arity is decisive. A method
+// whose parameter or result COUNT is wrong cannot implement the interface
+// however unfamiliar its types are; treating an unknown type as a wildcard for
+// the whole signature made `MarshalJSON(Custom) error` a marshaller and would
+// have refused any struct embedding its type over an ordinary same-named
+// method. The wildcard applies to its own slot only.
+func TestIsJSONMethod_ArityBeatsUnknownTypes(t *testing.T) {
+	cases := []struct {
+		decl string
+		want bool
+	}{
+		// Right arity, unknown type in one slot: still a match, because a
+		// marshaller spelled through an alias must not slip past.
+		{"func (s Stamp) MarshalJSON() (Bytes, error) { return nil, nil }", true},
+		{"func (s *Stamp) UnmarshalJSON(b Bytes) error { return nil }", true},
+		// Wrong arity: decisive, whatever the types are called.
+		{"func (s Stamp) MarshalJSON(c Custom) error { return nil }", false},
+		{"func (s Stamp) MarshalJSON() (Custom, int, error) { return nil, 0, nil }", false},
+		{"func (s *Stamp) UnmarshalJSON() error { return nil }", false},
+		// Right arity, a KNOWN type that is wrong: also decisive.
+		{"func (s Stamp) MarshalJSON() (string, error) { return \"\", nil }", false},
+		{"func (s *Stamp) UnmarshalJSON(b string) error { return nil }", false},
+		// Right arity, known-wrong in one slot and unknown in the other: the
+		// known mismatch still decides it.
+		{"func (s Stamp) MarshalJSON() (Custom, int) { return nil, 0 }", false},
+	}
+	for _, c := range cases {
+		f, err := parser.ParseFile(token.NewFileSet(), "f.go", "package fixture\n\ntype Stamp struct{}\n\n"+c.decl+"\n", parser.ParseComments)
+		if err != nil {
+			t.Fatalf("parse %q: %v", c.decl, err)
+		}
+		got, _ := collectJSONMethodTypes(f)
+		if got["Stamp"] != c.want {
+			t.Errorf("%s: recognized = %v, want %v", c.decl, got["Stamp"], c.want)
+		}
+	}
+}
+
+// TestRun_ScopeCountersMeanWhatTheySay is the second pass on the scope line.
+// Counting "any anonymous field" as embedding a struct claims embedding for a
+// TAGGED embed (an ordinary field) and for an embedded interface (which
+// promotes nothing); counting "any promoted tag" as contributing claims a
+// contribution for a promoted tag no GENERATED tag ever asked for. Both make
+// the gate overstate what it exercised.
+func TestRun_ScopeCountersMeanWhatTheySay(t *testing.T) {
+	genSrc := src(`package generated
+
+type Note struct {
+	Id int64 ~json:"id"~
+}
+`)
+	// Tagged embed (an ordinary field), an interface embed (promotes nothing),
+	// and a promoted tag no generated tag asks for. Nothing here is an
+	// exercised struct promotion.
+	wrapperSrc := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Doer interface{ Do() }
+
+type Extra struct {
+	Unasked string ~json:"unasked"~
+}
+
+type Tagged struct {
+	Extra ~json:"tagged"~
+	Doer
+	ID int64 ~json:"id"~
+}
+
+type Note struct {
+	Tagged
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.ID = g.Id
+	return n
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": wrapperSrc})
+	var stdout string
+	_ = captureStderr(t, func() {
+		stdout = captureStdout(t, func() { _ = run(wrapperDir, generatedFile, nil, nil, false) })
+	})
+	// Note DOES embed Tagged, a struct, and `id` IS promoted through it and
+	// asked for by the generated struct — so this pair legitimately counts.
+	if !strings.Contains(stdout, "1 of 1 pairs embed a struct") {
+		t.Errorf("expected the resolved struct embed to count, got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "1 promoted fields") {
+		t.Errorf("expected exactly the asked-for promoted field to count, got:\n%s", stdout)
+	}
+	// The Tagged struct itself embeds only a tagged field and an interface, so
+	// it must NOT read as promoting from a struct.
+	structs := flattenFixture(t, wrapperSrc)
+	if tg := structs["Tagged"]; tg == nil || tg.promotesFromStruct {
+		t.Errorf("a tagged embed and an interface embed are not struct promotion, got %+v", structs["Tagged"])
+	}
+
+	// And the discriminating case at the RUN level: a paired wrapper whose only
+	// anonymous fields are a tagged embed and an interface. Counting "any
+	// anonymous field" would claim it embeds a struct; nothing here promotes.
+	onlyNonPromoting := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Doer interface{ Do() }
+
+type Extra struct {
+	Unasked string ~json:"unasked"~
+}
+
+type Note struct {
+	Extra ~json:"tagged"~
+	Doer
+	ID int64 ~json:"id"~
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.ID = g.Id
+	n.Extra = Extra{}
+	return n
+}
+`)
+	wrapperDir, generatedFile = writeDriftFixtures(t, genSrc, map[string]string{"note.go": onlyNonPromoting})
+	_ = captureStderr(t, func() {
+		stdout = captureStdout(t, func() { _ = run(wrapperDir, generatedFile, nil, nil, false) })
+	})
+	if !strings.Contains(stdout, "no pair embeds a struct") {
+		t.Errorf("a tagged embed and an interface embed are not struct promotion; the scope line must say so:\n%s", stdout)
+	}
+}

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -2281,6 +2281,10 @@ func TestRecordAssignedValue_ValueShapes(t *testing.T) {
 		// populate what they claim.
 		{"new(T)", "new(Base)", nil, false, []string{"Base.*"}},
 		{"typed nil conversion", "(*Base)(nil)", nil, false, []string{"Base.*"}},
+		// An ordinary call that happens to take nil is NOT a conversion; only
+		// the type checker could tell `Base(nil)` from a call, so neither is
+		// claimed and both stay opaque.
+		{"call with a nil argument", "baseFrom(nil)", nil, true, nil},
 		// nil populates nothing: a nil embedded pointer emits none of its fields.
 		{"nil", "nil", nil, false, []string{"Base.*"}},
 	}
@@ -2797,5 +2801,166 @@ type Outer struct {
 	}
 	if outer.tags["id"] {
 		t.Error("a sibling embed's tags are just as meaningless once the encoder is redirected")
+	}
+}
+
+// TestFlattenEmbedded_InheritedMarshallerIsRejected covers method promotion
+// arriving through a chain rather than a declaration. Mid does not declare
+// MarshalJSON — it embeds Wire, which does — so Mid promotes it and anything
+// embedding Mid promotes it in turn. A json tag on that embed changes nothing,
+// since tags govern field selection and not method sets, and the tag is
+// precisely what stops the field walk from ever reaching Wire.
+func TestFlattenEmbedded_InheritedMarshallerIsRejected(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Wire struct {
+	Raw string ~json:"raw"~
+}
+
+func (w Wire) MarshalJSON() ([]byte, error) { return nil, nil }
+
+type Mid struct {
+	Wire
+	Extra string ~json:"extra"~
+}
+
+type Base struct {
+	ID int64 ~json:"id"~
+}
+
+type TaggedParent struct {
+	Mid ~json:"mid"~
+	Base
+}
+
+type UntaggedParent struct {
+	Mid
+	Base
+}
+`))
+	for _, name := range []string{"TaggedParent", "UntaggedParent"} {
+		sf := structs[name]
+		if sf == nil {
+			t.Fatalf("%s not collected", name)
+		}
+		if len(sf.unresolved) == 0 {
+			t.Errorf("%s: a marshaller inherited through an embed is promoted just as far and must be reported", name)
+		}
+		if sf.tags["id"] {
+			t.Errorf("%s: no promoted tag survives a redirected encoder", name)
+		}
+	}
+}
+
+// TestFlattenEmbedded_UnexportedPointerEmbedIsRejected covers the decode side:
+// encoding/json cannot allocate an embedded pointer to an unexported type
+// ("cannot set embedded pointer to unexported struct"), so a direct-decode
+// wrapper's tags are present but never populated — the exact assumption tier 2
+// rests on. The value form has no such problem and must keep working.
+func TestFlattenEmbedded_UnexportedPointerEmbedIsRejected(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type hidden struct {
+	ID int64 ~json:"id"~
+}
+
+type ByPointer struct {
+	*hidden
+}
+
+type ByValue struct {
+	hidden
+}
+`))
+	if p := structs["ByPointer"]; p == nil || len(p.unresolved) == 0 {
+		t.Errorf("an unexported pointer embed cannot be decoded and must be reported, got %+v", structs["ByPointer"])
+	}
+	if v := structs["ByValue"]; v == nil || len(v.unresolved) != 0 || !v.tags["id"] {
+		t.Errorf("the value form promotes normally, got %+v", structs["ByValue"])
+	}
+}
+
+// TestFlattenEmbedded_DefinedTypeOverInterfaceKeepsMethods separates the two
+// defined-type cases. `type Safe Stamp` over a STRUCT starts with an empty
+// method set, so it is safe to walk; `type Safe Marshaler` over an INTERFACE is
+// still an interface with that method set, so embedding it redirects the
+// encoder. Treating them alike in either direction is wrong in one of them.
+func TestFlattenEmbedded_DefinedTypeOverInterfaceKeepsMethods(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Marshaler interface {
+	MarshalJSON() ([]byte, error)
+}
+
+type SafeIface Marshaler
+
+type Base struct {
+	ID int64 ~json:"id"~
+}
+
+type Outer struct {
+	SafeIface
+	Base
+}
+`))
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	if len(outer.unresolved) == 0 {
+		t.Error("a defined type over an interface keeps its method set and must be reported")
+	}
+}
+
+// TestFlattenEmbedded_QualifiedInterfaceEmbedCounts covers an interface whose
+// method set comes from another package (`type Local interface { json.Marshaler }`).
+// The check does not parse that package, so the method set is unknown — and
+// unknown is answered with a refusal rather than an assumption.
+func TestFlattenEmbedded_QualifiedInterfaceEmbedCounts(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+import "encoding/json"
+
+type Local interface {
+	json.Marshaler
+}
+
+type Base struct {
+	ID int64 ~json:"id"~
+}
+
+type Outer struct {
+	Local
+	Base
+}
+`))
+	if o := structs["Outer"]; o == nil || len(o.unresolved) == 0 {
+		t.Errorf("an interface embedding another package's must not be assumed method-free, got %+v", structs["Outer"])
+	}
+}
+
+// TestFlattenEmbedded_BuiltinBackedTypeResolves guards the other direction of
+// that rule: a defined type over a BUILTIN is fully accounted for — no fields,
+// no method set of its own — and must not be refused as unresolvable. Treating
+// it as unknown would report drift on an ordinary wrapper.
+func TestFlattenEmbedded_BuiltinBackedTypeResolves(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Kind string
+
+type Outer struct {
+	Kind
+	Name string ~json:"name"~
+}
+`))
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	if len(outer.unresolved) != 0 {
+		t.Errorf("a builtin-backed defined type is resolved, not unknown, got %v", outer.unresolved)
+	}
+	if !outer.tags["name"] {
+		t.Errorf("its sibling fields must be judged normally, got %v", outer.tags)
 	}
 }

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -1129,7 +1129,7 @@ func flattenFixture(t *testing.T, source string) map[string]*structFields {
 		t.Fatalf("parse: %v", err)
 	}
 	structs := collectStructsAndMarkers(fset, f)
-	flattenEmbedded(structs, collectTypeDecls(f))
+	flattenEmbedded(structs, collectTypeDecls(f), collectJSONMethodTypes(f))
 	return structs
 }
 
@@ -1574,7 +1574,7 @@ type Selfish struct {
 	// terminate fails the test instead of hanging the whole package.
 	done := make(chan struct{})
 	go func() {
-		flattenEmbedded(structs, decls)
+		flattenEmbedded(structs, decls, collectJSONMethodTypes(f))
 		close(done)
 	}()
 	select {
@@ -2212,5 +2212,251 @@ type Outer struct {
 	}
 	if !outer.tags["name"] {
 		t.Errorf("expected the plain field to survive, got %v", outer.tags)
+	}
+}
+
+// TestFlattenEmbedded_GroupedDeclarationAnnihilates covers the grouped
+// declaration `A, B string ~json:"x"~`, which is two fields to encoding/json
+// sharing one tag at one depth — so they annihilate and the tag is not on the
+// wire, whether the struct is the wrapper itself or something it embeds.
+func TestFlattenEmbedded_GroupedDeclarationAnnihilates(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Base struct {
+	A, B string ~json:"x"~
+	C    string ~json:"c"~
+}
+
+type Outer struct {
+	Base
+}
+
+type Direct struct {
+	A, B string ~json:"x"~
+	C    string ~json:"c"~
+}
+`))
+	for _, name := range []string{"Outer", "Direct"} {
+		sf := structs[name]
+		if sf == nil {
+			t.Fatalf("%s not collected", name)
+		}
+		if sf.tags["x"] {
+			t.Errorf("%s: a grouped declaration is two fields sharing a tag; they annihilate", name)
+		}
+		if !sf.tags["c"] {
+			t.Errorf("%s: the ungrouped tag must survive, got %v", name, sf.tags)
+		}
+	}
+}
+
+// TestRecordAssignedValue_ValueShapes pins how each right-hand side shape is
+// classified, since the difference between "enumerated" and "total coverage"
+// is what stops a partial assignment from certifying fields it never sets.
+func TestRecordAssignedValue_ValueShapes(t *testing.T) {
+	cases := []struct {
+		name       string
+		expr       string
+		wantKeys   []string
+		wantTotal  bool
+		wantAbsent []string
+	}{
+		{"keyed literal", "Base{ID: g.Id}", []string{"Base.ID"}, false, []string{"Base.*"}},
+		{"parenthesized keyed literal", "(Base{ID: g.Id})", []string{"Base.ID"}, false, []string{"Base.*"}},
+		{"pointer keyed literal", "&Base{ID: g.Id}", []string{"Base.ID"}, false, []string{"Base.*"}},
+		// A positional literal must list every field, so it covers all of them.
+		{"positional literal", "Base{g.Id, g.Name}", nil, true, nil},
+		{"empty literal", "Base{}", nil, false, []string{"Base.*"}},
+		{"opaque call", "baseFrom(g)", nil, true, nil},
+		// nil populates nothing: a nil embedded pointer emits none of its fields.
+		{"nil", "nil", nil, false, []string{"Base.*"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			expr, err := parser.ParseExpr(c.expr)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			assigned := map[string]bool{}
+			recordAssignedValue(assigned, "Base", expr)
+			if !assigned["Base"] {
+				t.Error("the assigned path itself must always be recorded")
+			}
+			for _, k := range c.wantKeys {
+				if !assigned[k] {
+					t.Errorf("expected %q, got %v", k, assigned)
+				}
+			}
+			if assigned["Base.*"] != c.wantTotal {
+				t.Errorf("total coverage = %v, want %v (got %v)", assigned["Base.*"], c.wantTotal, assigned)
+			}
+			for _, a := range c.wantAbsent {
+				if assigned[a] {
+					t.Errorf("did not expect %q, got %v", a, assigned)
+				}
+			}
+		})
+	}
+}
+
+// TestRun_NilEmbedAssignmentPopulatesNothing is the end-to-end half: a
+// converter that nils out a pointer embed emits none of its promoted fields, so
+// the guard must not pass it. Paired with the same converter assigning a real
+// value, which must pass.
+func TestRun_NilEmbedAssignmentPopulatesNothing(t *testing.T) {
+	genSrc := src(`package generated
+
+type Note struct {
+	Id      int64  ~json:"id"~
+	Content string ~json:"content"~
+}
+`)
+	wrapperSrc := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Base struct {
+	ID      int64  ~json:"id"~
+	Content string ~json:"content"~
+}
+
+type Note struct {
+	*Base
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.Base = nil
+	return n
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": wrapperSrc})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err == nil {
+		t.Error("run: a nil embed emits none of its promoted fields and must not count as population")
+	}
+
+	real := strings.Replace(wrapperSrc, "n.Base = nil", "n.Base = &Base{ID: g.Id, Content: g.Content}", 1)
+	wrapperDir, generatedFile = writeDriftFixtures(t, genSrc, map[string]string{"note.go": real})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err != nil {
+		t.Errorf("run: a real pointer literal populates its fields, got %v", err)
+	}
+}
+
+// TestFlattenEmbedded_MethodBearingEmbedIsRejected covers the failure that
+// invalidates flattening wholesale rather than one tag: embedding a type with
+// MarshalJSON promotes the method, so the EMBEDDING type implements
+// json.Marshaler and encoding/json calls it instead of walking any of these
+// fields. The tag set then describes nothing, so the walk refuses to judge and
+// reports instead — the same fail-loud path as an unresolvable embed. The
+// package already has a method-bearing type (FlexTime).
+func TestFlattenEmbedded_MethodBearingEmbedIsRejected(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Stamp struct {
+	At string ~json:"at"~
+}
+
+func (s Stamp) MarshalJSON() ([]byte, error) { return nil, nil }
+
+type Plain struct {
+	Name string ~json:"name"~
+}
+
+type Outer struct {
+	Stamp
+	Plain
+}
+`))
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	if len(outer.unresolved) == 0 {
+		t.Error("embedding a type whose method is promoted must be reported, not silently flattened")
+	}
+	if outer.tags["at"] {
+		t.Error("the method-bearing embed's tags must not be certified")
+	}
+}
+
+// TestFlattenEmbedded_IgnoredEmbedDoesNotAnnihilate is the ordering case: a
+// field encoding/json never sees cannot annihilate one it does. An anonymous
+// unexported non-struct is dropped before dominance is resolved, so a real
+// field sharing its tag stays on the wire — counting the hidden one first would
+// report phantom drift on a wrapper that is correct.
+func TestFlattenEmbedded_IgnoredEmbedDoesNotAnnihilate(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type hidden string
+
+type Outer struct {
+	hidden ~json:"secret"~
+	Real   string ~json:"secret"~
+}
+`))
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	if !outer.tags["secret"] {
+		t.Error("the real field survives: the ignored embed never reaches dominance")
+	}
+	if got := outer.tagToGoField["secret"]; got != "Real" {
+		t.Errorf("expected the tag to resolve to the real field, got %q", got)
+	}
+}
+
+// TestPopulationTargets_SameNamedEmbedIsNotTheLeaf checks a review claim that
+// assigning an embed could be credited to a same-named promoted leaf. It
+// cannot: `w.Deep = Deep{}` is recorded as the bare path "Deep", which is not
+// a target of the leaf (the shadowing rule excludes the bare spelling, since
+// `w.Deep` resolves to the embed), and a keyed literal grants no total marker.
+// The ancestor spelling `Deep.*` requires an OPAQUE assignment of that embed,
+// which genuinely does populate everything under it.
+func TestPopulationTargets_SameNamedEmbedIsNotTheLeaf(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Deep struct {
+	Deep string ~json:"deep_only"~
+}
+
+type Mid struct {
+	Deep
+}
+
+type Outer struct {
+	Mid
+}
+`))
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	targets := map[string]bool{}
+	for _, tgt := range outer.populationTargets("deep_only") {
+		targets[tgt] = true
+	}
+	if targets["Deep"] {
+		t.Error("the bare embed spelling must not be a target of the leaf it shadows")
+	}
+	if !targets["Deep.Deep"] || !targets["Mid.Deep.Deep"] {
+		t.Errorf("the qualified spellings must be targets, got %v", outer.populationTargets("deep_only"))
+	}
+	// And the assignment side agrees: a keyed literal on the embed records the
+	// path and its keys, never the bare-leaf spelling.
+	expr, err := parser.ParseExpr("Deep{}")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	assigned := map[string]bool{}
+	recordAssignedValue(assigned, "Deep", expr)
+	populated := false
+	for _, tgt := range outer.populationTargets("deep_only") {
+		if assigned[tgt] {
+			populated = true
+		}
+	}
+	if populated {
+		t.Error("assigning the embed with an empty literal must not populate the leaf")
 	}
 }

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"go/ast"
 	"go/parser"
 	"go/token"
 	"os"
@@ -1129,7 +1130,9 @@ func flattenFixture(t *testing.T, source string) map[string]*structFields {
 		t.Fatalf("parse: %v", err)
 	}
 	structs := collectStructsAndMarkers(fset, f)
-	flattenEmbedded(structs, collectTypeDecls(f), collectJSONMethodTypes(f))
+	jsonMethods, ifaceEmbeds := collectJSONMethodTypes(f)
+	closeJSONMethodTypes(jsonMethods, ifaceEmbeds)
+	flattenEmbedded(structs, collectTypeDecls(f), jsonMethods)
 	return structs
 }
 
@@ -1570,11 +1573,13 @@ type Selfish struct {
 	}
 	structs := collectStructsAndMarkers(fset, f)
 	decls := collectTypeDecls(f)
+	jsonMethods, ifaceEmbeds := collectJSONMethodTypes(f)
+	closeJSONMethodTypes(jsonMethods, ifaceEmbeds)
 	// flattenEmbedded runs on its own goroutine so a walk that fails to
 	// terminate fails the test instead of hanging the whole package.
 	done := make(chan struct{})
 	go func() {
-		flattenEmbedded(structs, decls, collectJSONMethodTypes(f))
+		flattenEmbedded(structs, decls, jsonMethods)
 		close(done)
 	}()
 	select {
@@ -2266,6 +2271,10 @@ func TestRecordAssignedValue_ValueShapes(t *testing.T) {
 		{"pointer keyed literal", "&Base{ID: g.Id}", []string{"Base.ID"}, false, []string{"Base.*"}},
 		// A positional literal must list every field, so it covers all of them.
 		{"positional literal", "Base{g.Id, g.Name}", nil, true, nil},
+		// A positional element CAN be a nil embedded pointer, whose promoted
+		// fields are then absent from the wire. The walker cannot tell which
+		// element is which field, so a nil element withdraws the claim.
+		{"positional literal with a nil element", "Base{nil, g.Name}", nil, false, []string{"Base.*"}},
 		{"empty literal", "Base{}", nil, false, []string{"Base.*"}},
 		{"opaque call", "baseFrom(g)", nil, true, nil},
 		// nil populates nothing: a nil embedded pointer emits none of its fields.
@@ -2549,5 +2558,168 @@ type Harmless struct {
 	// encoder, so it stays the harmless no-op it always was.
 	if h := structs["Harmless"]; h == nil || len(h.unresolved) != 0 || !h.tags["id"] {
 		t.Errorf("a plain interface embed must not be rejected, got %+v", structs["Harmless"])
+	}
+}
+
+// TestFlattenEmbedded_DiamondDoesNotPropagateDeeper pins a subtlety two
+// reviewers read the other way, so it is worth stating precisely. In
+// `Outer -> Left/Right -> Common -> Deep`, Common is reached twice and its own
+// tags annihilate — but Deep is reached once, from the single queued Common,
+// and its tags SURVIVE. That is not an accident of this walk; it is what the
+// marshaller does:
+//
+//	json.Marshal(Outer{})  =>  {"deep_field":""}
+//
+// encoding/json's typeFields does `nextCount[ft]++` per arrival at a level, not
+// `+= count[f.typ]`, so multiplicity does not cascade to a duplicated type's
+// own embeds. Mirroring the mechanism gives this for free; "keep everything
+// below a duplicate ambiguous" would drop a key that is really on the wire.
+func TestFlattenEmbedded_DiamondDoesNotPropagateDeeper(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Deep struct {
+	DeepField string ~json:"deep_field"~
+}
+
+type Common struct {
+	Deep
+	Shared string ~json:"shared"~
+}
+
+type Left struct{ Common }
+type Right struct{ Common }
+
+type Outer struct {
+	Left
+	Right
+}
+`))
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	if outer.tags["shared"] {
+		t.Error("the duplicated type's OWN tags annihilate")
+	}
+	if !outer.tags["deep_field"] {
+		t.Error("a tag below the duplicated type is still emitted by encoding/json and must be certified")
+	}
+}
+
+// TestFlattenEmbedded_DefinedTypeDoesNotInheritMethods separates the two
+// declaration forms. `type Safe Stamp` takes Stamp's fields with an EMPTY
+// method set, so embedding Safe promotes no marshaller and the fields are
+// judged normally; `type Same = Stamp` is the same type and does carry the
+// method, so embedding it must be rejected. Getting this wrong in the strict
+// direction manufactures drift on a wrapper that is fine.
+func TestFlattenEmbedded_DefinedTypeDoesNotInheritMethods(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Stamp struct {
+	At string ~json:"at"~
+}
+
+func (s Stamp) MarshalJSON() ([]byte, error) { return nil, nil }
+
+type Safe Stamp
+type Same = Stamp
+
+type UsesDefined struct {
+	Safe
+}
+
+type UsesAlias struct {
+	Same
+}
+`))
+	defined := structs["UsesDefined"]
+	if defined == nil {
+		t.Fatal("UsesDefined not collected")
+	}
+	if len(defined.unresolved) != 0 {
+		t.Errorf("a defined type has an empty method set; embedding it promotes no marshaller, got %v", defined.unresolved)
+	}
+	if !defined.tags["at"] {
+		t.Errorf("its fields promote normally, got %v", defined.tags)
+	}
+	alias := structs["UsesAlias"]
+	if alias == nil {
+		t.Fatal("UsesAlias not collected")
+	}
+	if len(alias.unresolved) == 0 {
+		t.Error("an alias IS the type, methods included; embedding it must be rejected")
+	}
+}
+
+// TestFlattenEmbedded_TaggedMethodBearingEmbedIsRejected covers the gap a json
+// tag opens in the method guard: the tag stops FIELD promotion, and nothing
+// else. The struct still implements json.Marshaler through the promoted
+// method, so the encoder never walks these fields.
+func TestFlattenEmbedded_TaggedMethodBearingEmbedIsRejected(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Stamp struct {
+	At string ~json:"at"~
+}
+
+func (s *Stamp) UnmarshalJSON(b []byte) error { return nil }
+
+type Outer struct {
+	Stamp ~json:"stamp"~
+	Name  string ~json:"name"~
+}
+`))
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	if len(outer.unresolved) == 0 {
+		t.Error("a tagged embed still promotes the type's methods and must be reported")
+	}
+}
+
+// TestCollectJSONMethodTypes_ClosureIsPackageWide pins that the interface
+// method-set closure runs over the merged package. The declaring interface and
+// the one embedding it habitually live in different files, and closing per file
+// would mark the first and never the second.
+func TestCollectJSONMethodTypes_ClosureIsPackageWide(t *testing.T) {
+	parse := func(source string) *ast.File {
+		t.Helper()
+		f, err := parser.ParseFile(token.NewFileSet(), "f.go", source, parser.ParseComments)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		return f
+	}
+	a := parse(`package fixture
+
+type Marshaler interface {
+	MarshalJSON() ([]byte, error)
+}
+`)
+	b := parse(`package fixture
+
+type Fancy interface {
+	Marshaler
+	Extra()
+}
+`)
+	merged := map[string]bool{}
+	graph := map[string][]string{}
+	for _, f := range []*ast.File{b, a} { // reversed: the embedder is parsed first
+		direct, edges := collectJSONMethodTypes(f)
+		for k := range direct {
+			merged[k] = true
+		}
+		for k, v := range edges {
+			graph[k] = append(graph[k], v...)
+		}
+	}
+	if merged["Fancy"] {
+		t.Fatal("fixture setup: Fancy must only become a marshaler through the closure")
+	}
+	closeJSONMethodTypes(merged, graph)
+	if !merged["Fancy"] {
+		t.Error("an interface embedding a marshaler from ANOTHER file carries the method too")
 	}
 }

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -2306,8 +2306,12 @@ func TestRecordAssignedValue_ValueShapes(t *testing.T) {
 		{"positional literal with an empty nested literal", "Base{Audit{}, g.Name}", nil, false, []string{"Base.*"}},
 		{"positional literal with new(T)", "Base{new(Audit), g.Name}", nil, false, []string{"Base.*"}},
 		{"positional literal with a typed nil", "Base{(*Audit)(nil), g.Name}", nil, false, []string{"Base.*"}},
-		// A populated nested literal is not zero, so the claim stands.
-		{"positional literal with a populated nested literal", "Base{Audit{At: g.At}, g.Name}", nil, true, nil},
+		// A populated nested literal is content the walker can SEE but cannot
+		// attribute to a field without the declaration order — it fills some
+		// of Audit and leaves the rest zero — so the subtree claim is dropped
+		// rather than assumed. A positional literal of opaque elements still
+		// claims it, which is the row above.
+		{"positional literal with a populated nested literal", "Base{Audit{At: g.At}, g.Name}", nil, false, []string{"Base.*"}},
 		{"empty literal", "Base{}", nil, false, []string{"Base.*"}},
 		{"opaque call", "baseFrom(g)", nil, true, nil},
 		// Statically zero-producing values carry nothing in, so they cannot
@@ -3704,5 +3708,71 @@ func (t *Two[A, B]) UnmarshalJSON(b []byte) error { return nil }
 	}
 	if !got["Two"] {
 		t.Error("the multi-parameter receiver form counts too")
+	}
+}
+
+// TestRun_OrdinaryFieldValuesAreNotReported is the regression for an
+// over-report the unrecognised-shape rule introduced: `recordAssignedValue`
+// runs for EVERY field, so a literal or an expression assigned to an ordinary
+// scalar — `n.ID = 1`, `n.Name = g.Name + "!"` — was being reported as
+// uninterpretable.
+//
+// Every expression yields a value of its field's type; an unclassifiable one
+// only matters when the walker would otherwise credit what is UNDER it. On a
+// scalar there is nothing underneath, so the report is scoped to embeds on a
+// promoted field's path — which the second half of this test still catches.
+func TestRun_OrdinaryFieldValuesAreNotReported(t *testing.T) {
+	genSrc := src(`package generated
+
+type Note struct {
+	Id   int64  ~json:"id"~
+	Name string ~json:"name"~
+}
+`)
+	scalarSrc := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Note struct {
+	ID   int64  ~json:"id"~
+	Name string ~json:"name"~
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.ID = 1
+	n.Name = g.Name + "!"
+	return n
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": scalarSrc})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err != nil {
+		t.Errorf("run: ordinary field assignments must not be reported as uninterpretable, got %v", err)
+	}
+
+	// The same unclassifiable shape assigned to an EMBED still reports: there
+	// the walker would have credited every field underneath.
+	embedSrc := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Base struct {
+	ID   int64  ~json:"id"~
+	Name string ~json:"name"~
+}
+
+type Note struct {
+	Base
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.Base = *baseOf(g) + *baseOf(g)
+	return n
+}
+`)
+	wrapperDir, generatedFile = writeDriftFixtures(t, genSrc, map[string]string{"note.go": embedSrc})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err == nil {
+		t.Error("run: an uninterpretable value assigned to an embed must still be reported")
 	}
 }

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -2275,6 +2275,13 @@ func TestRecordAssignedValue_ValueShapes(t *testing.T) {
 		// fields are then absent from the wire. The walker cannot tell which
 		// element is which field, so a nil element withdraws the claim.
 		{"positional literal with a nil element", "Base{nil, g.Name}", nil, false, []string{"Base.*"}},
+		// Any statically zero element has the same effect: whatever it lands
+		// on contributes nothing, so the literal cannot claim the subtree.
+		{"positional literal with an empty nested literal", "Base{Audit{}, g.Name}", nil, false, []string{"Base.*"}},
+		{"positional literal with new(T)", "Base{new(Audit), g.Name}", nil, false, []string{"Base.*"}},
+		{"positional literal with a typed nil", "Base{(*Audit)(nil), g.Name}", nil, false, []string{"Base.*"}},
+		// A populated nested literal is not zero, so the claim stands.
+		{"positional literal with a populated nested literal", "Base{Audit{At: g.At}, g.Name}", nil, true, nil},
 		{"empty literal", "Base{}", nil, false, []string{"Base.*"}},
 		{"opaque call", "baseFrom(g)", nil, true, nil},
 		// Statically zero-producing values carry nothing in, so they cannot
@@ -3225,5 +3232,48 @@ type Harmless struct {
 	}
 	if !h.tags["id"] {
 		t.Errorf("and its fields promote, got %v", h.tags)
+	}
+}
+
+// TestFlattenEmbedded_UnexportedNonStructPointerIsNotDecodeUnsafe narrows the
+// allocation rule to what encoding/json actually does. An anonymous field of an
+// unexported NON-struct type is ignored outright — never traversed, never
+// allocated — so there is no field the decoder failed to populate, and
+// reporting one would fail a direct-decode wrapper that is fine. The struct
+// form is the real case and must keep failing.
+func TestFlattenEmbedded_UnexportedNonStructPointerIsNotDecodeUnsafe(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type hiddenStr string
+
+type hiddenStruct struct {
+	ID int64 ~json:"id"~
+}
+
+type NonStruct struct {
+	*hiddenStr
+	Name string ~json:"name"~
+}
+
+type TaggedNonStruct struct {
+	*hiddenStr ~json:"h"~
+	Name       string ~json:"name"~
+}
+
+type Struct struct {
+	*hiddenStruct
+}
+`))
+	for _, name := range []string{"NonStruct", "TaggedNonStruct"} {
+		sf := structs[name]
+		if sf == nil {
+			t.Fatalf("%s not collected", name)
+		}
+		if len(sf.decodeUnsafe) != 0 {
+			t.Errorf("%s: encoding/json ignores this field rather than failing to allocate it, got %v", name, sf.decodeUnsafe)
+		}
+	}
+	if sf := structs["Struct"]; sf == nil || len(sf.decodeUnsafe) == 0 {
+		t.Errorf("the struct form is the real allocation failure and must still be reported, got %+v", structs["Struct"])
 	}
 }

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -1043,19 +1043,20 @@ func TestExprToPath(t *testing.T) {
 	}
 }
 
-// TestPathPrefixAndField verifies the decomposition the walker uses to
-// attribute selector writes (`q.Schedule.WeekInstance`) to a previously
-// recorded binding (`q.Schedule`).
-func TestPathPrefixAndField(t *testing.T) {
+// TestSelectorRootAndPath verifies the decomposition the population walker uses
+// to attribute a write to the wrapper instance and the dotted field path below
+// it. Retaining the whole path is what makes a fully-qualified write to a
+// promoted field (`n.Base.ID`) recognizable.
+func TestSelectorRootAndPath(t *testing.T) {
 	cases := []struct {
-		src        string
-		wantPrefix string
-		wantField  string
+		src      string
+		wantRoot string
+		wantPath string
 	}{
 		{"x.Y", "x", "Y"},
-		{"x.Y.Z", "x.Y", "Z"},
-		{"a.b.c.d", "a.b.c", "d"},
-		{"x", "", ""},      // bare ident — no selector
+		{"x.Y.Z", "x", "Y.Z"},
+		{"a.b.c.d", "a", "b.c.d"},
+		{"x", "", ""},      // bare ident — nothing selected
 		{"f().Y", "", ""},  // call-rooted — no path
 		{"a[0].Y", "", ""}, // index-rooted — no path
 	}
@@ -1064,10 +1065,38 @@ func TestPathPrefixAndField(t *testing.T) {
 		if err != nil {
 			t.Fatalf("parse %q: %v", c.src, err)
 		}
-		prefix, field := pathPrefixAndField(expr)
-		if prefix != c.wantPrefix || field != c.wantField {
-			t.Errorf("pathPrefixAndField(%q) = (%q, %q), want (%q, %q)",
-				c.src, prefix, field, c.wantPrefix, c.wantField)
+		root, path := selectorRootAndPath(expr)
+		if root != c.wantRoot || path != c.wantPath {
+			t.Errorf("selectorRootAndPath(%q) = (%q, %q), want (%q, %q)",
+				c.src, root, path, c.wantRoot, c.wantPath)
+		}
+	}
+}
+
+// TestBoundWrapperAndPath verifies that a write is attributed to the innermost
+// binding that encloses it, and that an unbound path is ignored.
+func TestBoundWrapperAndPath(t *testing.T) {
+	bindings := map[string]string{"q": "Outer", "q.Schedule": "QuestionSchedule"}
+	cases := []struct {
+		src         string
+		wantWrapper string
+		wantPath    string
+	}{
+		{"q.Schedule.WeekInstance", "QuestionSchedule", "WeekInstance"},
+		{"q.Schedule.Base.ID", "QuestionSchedule", "Base.ID"},
+		{"q.Title", "Outer", "Title"},
+		{"other.Title", "", ""},
+		{"q", "", ""},
+	}
+	for _, c := range cases {
+		expr, err := parser.ParseExpr(c.src)
+		if err != nil {
+			t.Fatalf("parse %q: %v", c.src, err)
+		}
+		wrapper, path := boundWrapperAndPath(bindings, expr)
+		if wrapper != c.wantWrapper || path != c.wantPath {
+			t.Errorf("boundWrapperAndPath(%q) = (%q, %q), want (%q, %q)",
+				c.src, wrapper, path, c.wantWrapper, c.wantPath)
 		}
 	}
 }
@@ -1130,6 +1159,10 @@ type Task struct {
 // through a two-level embedding chain (Task embeds Meta by value, Meta embeds
 // *Audit by pointer). Meta and Audit live in a SECOND wrapper file, so the
 // resolution has to happen after every file is parsed, not per file.
+//
+// The pointer embed is initialized before the writes that go through it: a
+// promoted write across a nil pointer panics, so a fixture that omitted the
+// initialization would be pinning a construction that cannot run.
 const embeddingWrapperSrc = `package basecamp
 
 import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
@@ -1142,6 +1175,7 @@ type Task struct {
 
 func taskFromGenerated(g generated.Task) Task {
 	t := Task{Status: g.Status}
+	t.Audit = &Audit{}
 	t.Title = g.Title
 	t.ID = g.Id
 	t.Content = g.Content
@@ -1435,11 +1469,39 @@ type Outer struct {
 	if got := outer.populationTargets("name"); len(got) != 1 || got[0] != "Name" {
 		t.Errorf("expected population target [Name] for the shadowing own field, got %v", got)
 	}
-	if got := outer.populationTargets("kind"); len(got) != 2 || got[0] != "Mid" || got[1] != "Kind" {
-		t.Errorf("expected population targets [Mid Kind] for the depth-1 promotion, got %v", got)
+	// A depth-1 promotion is populated by the promoted field, by its qualified
+	// spelling, or by an opaque assignment of the embed — and by nothing else.
+	assertTargets(t, outer, "kind", []string{"Kind", "Mid.Kind", "Mid.*"})
+	// A depth-2 promotion adds the intermediate spellings, since `Deep` is
+	// itself promoted onto Outer. The promoted field here is also named Deep,
+	// which is why "Deep.Deep" and a bare "Deep" both appear.
+	assertTargets(t, outer, "deep_only", []string{
+		"Deep", "Deep.Deep", "Mid.Deep.Deep", "Mid.*", "Deep.*", "Mid.Deep.*",
+	})
+}
+
+// assertTargets compares populationTargets against an expected set, order
+// independent. Both directions matter: a missing spelling reports false drift
+// on a valid construction, and an extra one credits a construction that does
+// not actually populate the field.
+func assertTargets(t *testing.T, sf *structFields, tag string, want []string) {
+	t.Helper()
+	got := sf.populationTargets(tag)
+	gotSet := map[string]bool{}
+	for _, g := range got {
+		gotSet[g] = true
 	}
-	if got := outer.populationTargets("deep_only"); len(got) != 3 || got[0] != "Mid" || got[1] != "Deep" || got[2] != "Deep" {
-		t.Errorf("expected population targets [Mid Deep Deep] for the depth-2 promotion, got %v", got)
+	wantSet := map[string]bool{}
+	for _, w := range want {
+		wantSet[w] = true
+		if !gotSet[w] {
+			t.Errorf("populationTargets(%q): missing spelling %q, got %v", tag, w, got)
+		}
+	}
+	for _, g := range got {
+		if !wantSet[g] {
+			t.Errorf("populationTargets(%q): unexpected spelling %q, got %v", tag, g, got)
+		}
 	}
 }
 
@@ -1671,5 +1733,338 @@ func TestFlattenEmbedded_DepthCapIsReportedNotSilent(t *testing.T) {
 	}
 	if root.tags["f"+strconv.Itoa(deepest)] {
 		t.Error("fixture is not actually exceeding the cap; the test would prove nothing")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Review follow-ups (PR #721): cases where the first cut of the promotion walk
+// claimed a tag encoding/json would not put on the wire, or credited a
+// construction that does not populate what it appears to.
+// ---------------------------------------------------------------------------
+
+// TestFlattenEmbedded_DiamondAnnihilates is the diamond case: Outer embeds Left
+// and Right, both of which embed Common. encoding/json reaches Common twice at
+// the same depth and annihilates its tags (typeFields duplicates the field so
+// dominantField sees the conflict), so the tag is NOT on the wire and must not
+// count as present. Deduplicating the second path without counting it — the
+// walk's first cut — silently claimed the tag instead.
+func TestFlattenEmbedded_DiamondAnnihilates(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Common struct {
+	Shared string ~json:"shared"~
+}
+
+type Left struct {
+	Common
+	Only string ~json:"left_only"~
+}
+
+type Right struct {
+	Common
+	Only string ~json:"right_only"~
+}
+
+type Outer struct {
+	Left
+	Right
+}
+`))
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	if outer.tags["shared"] {
+		t.Error("a tag reached twice at the same depth is annihilated by encoding/json; it must not count as present")
+	}
+	if !outer.tags["left_only"] || !outer.tags["right_only"] {
+		t.Errorf("the unambiguous depth-1 tags must still promote, got %v", outer.tags)
+	}
+}
+
+// TestFlattenEmbedded_DiamondResolvedByShadowing is the diamond's counterpart:
+// the same shape, but Outer declares the contested tag itself. The depth-0
+// declaration is unambiguous, so the tag IS on the wire and must count. Without
+// this pair, the annihilation rule could be "fixed" by dropping the tag
+// wholesale.
+func TestFlattenEmbedded_DiamondResolvedByShadowing(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Common struct {
+	Shared string ~json:"shared"~
+}
+
+type Left struct {
+	Common
+}
+
+type Right struct {
+	Common
+}
+
+type Outer struct {
+	Left
+	Right
+	Shared string ~json:"shared"~
+}
+`))
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	if !outer.tags["shared"] {
+		t.Error("the struct's own declaration is unambiguous and wins; the tag is on the wire")
+	}
+	assertTargets(t, outer, "shared", []string{"Shared"})
+}
+
+// TestFlattenEmbedded_UnexportedPromotedFieldIgnored covers the export rule:
+// encoding/json ignores unexported non-anonymous fields whatever their tag
+// says, so promoting one would let a wrapper satisfy a generated tag with a
+// field that never reaches the wire. An embedded UNEXPORTED STRUCT TYPE is the
+// opposite case — its exported fields do promote — and both are asserted here
+// so a fix for one cannot silently break the other.
+func TestFlattenEmbedded_UnexportedPromotedFieldIgnored(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Base struct {
+	Visible string ~json:"visible"~
+	hidden  string ~json:"hidden"~
+}
+
+type unexportedBase struct {
+	Promoted string ~json:"promoted"~
+}
+
+type Outer struct {
+	Base
+	unexportedBase
+}
+`))
+	outer := structs["Outer"]
+	if outer == nil {
+		t.Fatal("Outer not collected")
+	}
+	if outer.tags["hidden"] {
+		t.Error("an unexported field is not on the wire and must not satisfy a generated tag")
+	}
+	if !outer.tags["visible"] {
+		t.Errorf("expected the exported promoted field, got %v", outer.tags)
+	}
+	if !outer.tags["promoted"] {
+		t.Errorf("an embedded unexported STRUCT TYPE still promotes its exported fields, got %v", outer.tags)
+	}
+}
+
+// TestRun_UnexportedFieldDoesNotSatisfyGeneratedTag is the end-to-end half of
+// the rule: the wrapper "declares" the tag, but on an unexported field, so the
+// generated tag is unsatisfied and must be reported.
+func TestRun_UnexportedFieldDoesNotSatisfyGeneratedTag(t *testing.T) {
+	genSrc := src(`package generated
+
+type Note struct {
+	Id     int64  ~json:"id"~
+	Secret string ~json:"secret"~
+}
+`)
+	wrapperSrc := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Note struct {
+	ID     int64  ~json:"id"~
+	secret string ~json:"secret"~
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.ID = g.Id
+	n.secret = g.Secret
+	return n
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": wrapperSrc})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err == nil {
+		t.Error("run: an unexported field carrying the tag must not satisfy it, got nil")
+	}
+}
+
+// TestRun_PartialEmbeddedLiteralIsNotFullCoverage is the population half of the
+// same principle. `n.Base = Base{ID: g.Id}` leaves Content zero-valued on the
+// wire; crediting every field under an assigned embed would let a newly added
+// generated field pass silently, which is the failure this whole check exists
+// to prevent. The paired positive — the same literal, completed — must pass,
+// so the rule cannot be satisfied by refusing wholesale assignment outright.
+func TestRun_PartialEmbeddedLiteralIsNotFullCoverage(t *testing.T) {
+	genSrc := src(`package generated
+
+type Note struct {
+	Id      int64  ~json:"id"~
+	Content string ~json:"content"~
+}
+`)
+	wrapperSrc := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Base struct {
+	ID      int64  ~json:"id"~
+	Content string ~json:"content"~
+}
+
+type Note struct {
+	Base
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.Base = Base{ID: g.Id}
+	return n
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": wrapperSrc})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err == nil {
+		t.Error("run: a partial literal on an embedded field must not credit the fields it omits, got nil")
+	}
+
+	completed := strings.Replace(wrapperSrc, "Base{ID: g.Id}", "Base{ID: g.Id, Content: g.Content}", 1)
+	if !strings.Contains(completed, "Content: g.Content") {
+		t.Fatal("fixture setup: the literal was not completed")
+	}
+	wrapperDir, generatedFile = writeDriftFixtures(t, genSrc, map[string]string{"note.go": completed})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err != nil {
+		t.Errorf("run: a complete literal on an embedded field populates everything it names, got %v", err)
+	}
+}
+
+// TestRun_OpaqueEmbeddedAssignmentIsFullCoverage pins the other side of the
+// literal rule: when the walker cannot see inside the assigned value it credits
+// the whole subtree, matching the one-level-nesting doctrine the check already
+// applies to nested wrappers. Narrowing that would report drift on every
+// wrapper that delegates to a helper.
+func TestRun_OpaqueEmbeddedAssignmentIsFullCoverage(t *testing.T) {
+	genSrc := src(`package generated
+
+type Note struct {
+	Id      int64  ~json:"id"~
+	Content string ~json:"content"~
+}
+`)
+	wrapperSrc := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Base struct {
+	ID      int64  ~json:"id"~
+	Content string ~json:"content"~
+}
+
+func baseFrom(g generated.Note) Base {
+	return Base{ID: g.Id, Content: g.Content}
+}
+
+type Note struct {
+	Base
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.Base = baseFrom(g)
+	return n
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": wrapperSrc})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err != nil {
+		t.Errorf("run: an opaque assignment to an embedded field credits its subtree, got %v", err)
+	}
+}
+
+// TestRun_QualifiedPromotedAssignment covers the fully-qualified write
+// `n.Base.ID = g.Id`, which is valid Go and does populate the promoted field.
+// The one-level selector walk could not see it and reported false drift — the
+// over-reporting failure #599 is about, hit by the first person to embed.
+func TestRun_QualifiedPromotedAssignment(t *testing.T) {
+	genSrc := src(`package generated
+
+type Note struct {
+	Id      int64  ~json:"id"~
+	Content string ~json:"content"~
+}
+`)
+	wrapperSrc := src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+type Inner struct {
+	Content string ~json:"content"~
+}
+
+type Base struct {
+	Inner
+	ID int64 ~json:"id"~
+}
+
+type Note struct {
+	Base
+}
+
+func noteFromGenerated(g generated.Note) Note {
+	n := Note{}
+	n.Base.ID = g.Id
+	n.Base.Inner.Content = g.Content
+	return n
+}
+`)
+	wrapperDir, generatedFile := writeDriftFixtures(t, genSrc, map[string]string{"note.go": wrapperSrc})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err != nil {
+		t.Errorf("run: a fully-qualified write to a promoted field must count as population, got %v", err)
+	}
+
+	// Paired negative: drop one of the two qualified writes and the check must
+	// bite again, so recognizing the spelling did not blunt it.
+	dropped := strings.Replace(wrapperSrc, "\tn.Base.Inner.Content = g.Content\n", "", 1)
+	if strings.Contains(dropped, "Inner.Content = g.Content") {
+		t.Fatal("fixture setup: the write was not dropped")
+	}
+	wrapperDir, generatedFile = writeDriftFixtures(t, genSrc, map[string]string{"note.go": dropped})
+	if err := run(wrapperDir, generatedFile, nil, nil, false); err == nil {
+		t.Error("run: expected population drift once the qualified write is removed, got nil")
+	}
+}
+
+// TestCollectAssignedFields_QualifiedAndLiteralCoverage pins the assignment
+// vocabulary directly: full selector paths are retained, struct literals are
+// enumerated key by key, and only opaque values get the `.*` total marker.
+func TestCollectAssignedFields_QualifiedAndLiteralCoverage(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "fixture.go", src(`package basecamp
+
+import "github.com/basecamp/basecamp-sdk/go/pkg/generated"
+
+func wrapFromGenerated(g generated.Wrap) Wrap {
+	w := Wrap{Base: Base{ID: g.Id}}
+	w.Meta.Note = g.Note
+	w.Other = helper(g)
+	w.Items = []string{g.Item}
+	return w
+}
+`), parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	assigned := collectAssignedFields(f)["Wrap"]
+	for _, want := range []string{"Base", "Base.ID", "Meta.Note", "Other", "Other.*", "Items", "Items.*"} {
+		if !assigned[want] {
+			t.Errorf("expected %q to be recorded, got %v", want, assigned)
+		}
+	}
+	// The literal is visible, so it must NOT be credited as total coverage.
+	if assigned["Base.*"] {
+		t.Error("a visible struct literal must be enumerated, not credited wholesale")
+	}
+	// A slice literal says nothing about a wrapper's fields, so it stays opaque
+	// rather than being enumerated as if its elements were field keys.
+	if assigned["Items.0"] {
+		t.Error("a slice literal must not be enumerated as struct keys")
 	}
 }

--- a/scripts/check-wrapper-drift/main_test.go
+++ b/scripts/check-wrapper-drift/main_test.go
@@ -3575,3 +3575,59 @@ func TestIsJSONMethod_ByteAliasSpelling(t *testing.T) {
 		}
 	}
 }
+
+// TestFlattenEmbedded_RootMarshallerWithEmbedIsRefused covers the combination
+// that is silent: a wrapper that declares its own MarshalJSON AND promotes
+// fields through an embed certifies tags against an encoder that bypasses them.
+//
+// The pairing matters. A root method ALONE is not disqualifying — every wrapper
+// in this repo that declares one (Upload, SearchResult, RichTextAttachment, …)
+// is a decode adapter that unmarshals into the generated type and hands off to
+// the *FromGenerated conversion, so the pairing is what it is built on. The
+// second case asserts that shape keeps working.
+func TestFlattenEmbedded_RootMarshallerWithEmbedIsRefused(t *testing.T) {
+	structs := flattenFixture(t, src(`package fixture
+
+type Base struct {
+	ID int64 ~json:"id"~
+}
+
+type WithEmbed struct {
+	Base
+	Name string ~json:"name"~
+}
+
+func (w WithEmbed) MarshalJSON() ([]byte, error) { return nil, nil }
+
+type Adapter struct {
+	ID   int64  ~json:"id"~
+	Name string ~json:"name"~
+}
+
+func (a *Adapter) UnmarshalJSON(b []byte) error { return nil }
+`))
+	we := structs["WithEmbed"]
+	if we == nil {
+		t.Fatal("WithEmbed not collected")
+	}
+	if len(we.unresolved) == 0 {
+		t.Error("a root marshaller over promoted fields certifies tags the encoder bypasses; it must be reported")
+	}
+	if we.tags["id"] {
+		t.Error("the promoted tag must not be certified")
+	}
+	if !we.tags["name"] {
+		t.Errorf("its OWN declarations are still its own, got %v", we.tags)
+	}
+	// The decode-adapter shape — a root method and no embed — is untouched.
+	ad := structs["Adapter"]
+	if ad == nil {
+		t.Fatal("Adapter not collected")
+	}
+	if len(ad.unresolved) != 0 {
+		t.Errorf("a root method with no promotion is the repo's own adapter shape and must pass, got %v", ad.unresolved)
+	}
+	if !ad.tags["id"] || !ad.tags["name"] {
+		t.Errorf("its tags are judged normally, got %v", ad.tags)
+	}
+}


### PR DESCRIPTION
Closes #599

## The silent drop

`collectStructsAndMarkers` walked `st.Fields.List` and bailed on `if field.Tag == nil { continue }`. An anonymous (embedded) field has no tag *and* no `Names`, so it fell through that line and vanished — along with every field the embedded type promotes onto the embedding struct.

The consequence is not a small under-report: the promoted fields **are** on the wire (encoding/json flattens embedded structs), the generated struct declares tags for them, and the wrapper's tag set came back without them. A wrapper that embedded a struct read as **fully drifted**, with every promoted field reported as a missing JSON tag. The population check was blinded the same way — it verified only the fields declared directly on the wrapper.

Nothing in the tree embeds inside a checked pair today, which is why the gate is green while being wrong; `main_test.go` had zero hits for `anonymous`, `embed` or `promot`, so nothing pinned the behaviour either way.

## The fix

Both universes — the wrapper package (all non-test files, merged, because an embedded type may be declared in a different file) and `client.gen.go` — are flattened after parsing and before comparison. Each struct's tag set becomes its own tagged fields plus the tags promoted through its embeds, resolved breadth-first by depth.

The model is **encoding/json's**, not Go's language-level promotion, because the wire shape is what this check is about (a field shadowed by Go field name but with a different JSON name still serializes).

## Edge cases and the decision taken on each

| Case | Decision |
|---|---|
| **Embedded type in another file, same package** | Resolved. Flattening runs after every wrapper file is parsed, against the merged universe — resolving per file would have reintroduced the bug for the common case. |
| **Embedded type in another package** (`time.Time`) | **Fail loud, deferred to the pair walk.** The checker parses only `go/pkg/basecamp/*.go` and `client.gen.go`, so it cannot see the promoted fields and must not pretend there are none — silent-skip is exactly what caused #599. Reporting is deferred to the pair walk, so a struct outside every pair keeps its embed for free. That keeps today's tree green (`FlexTime` embeds `time.Time`) while making a *paired* wrapper that does the same an immediate, actionable failure. No suppression marker: the escape hatch is teaching the resolver, and the message says so. |
| **Embedded pointer** (`*Base`) | Promotes identically to a value embed; the `*` is stripped during resolution. |
| **Nested embedding** (A ⊂ B ⊂ C) | Transitive, breadth-first. Covered end to end by the main fixture (`Task` embeds `Meta` embeds `*Audit`). |
| **Shadowing** | Shallowest declaration wins: a tag declared directly on the struct shadows the promoted one, depth 1 shadows depth 2. The winner's Go field name is the one recorded for the population check. |
| **Same-depth conflict** (two embeds, one tag) | Cancels. encoding/json's `dominantField` emits *neither*, so the tag is genuinely absent from the wire and counts as absent here — and it stays blocked for deeper occurrences. |
| **Cycles** (A ⊂ B ⊂ A, `*Selfish` ⊂ `Selfish`) | Terminate on a visited set of type names (one visit per flattening, as encoding/json does), with an independent depth budget as a second stop. Exercised by a test that runs the walk on its own goroutine and fails on timeout instead of hanging the package. |
| **Depth budget exhausted** | Reported on the root, not truncated quietly — a silently shortened chain hides fields the same way #599 did. |
| **Tagged anonymous field** (``Base `json:"base"` ``) | Not a promotion source. encoding/json treats it as an ordinary field under its tag; the checker now records the embedded type's name as its Go field name so the population check can see it. |
| **Embedded interface / map / slice** | Resolves, promotes nothing (`generated.ClientWithResponses` embeds `ClientInterface` today). |
| **`type Alias Base` embedded** | Followed to `Base`, cycle-guarded. |
| **`intentionally-omitted` markers** | **Not inherited through an embed.** A marker declares that one wrapper deliberately drops a tag of *its* generated counterpart and is validated against that counterpart; inheriting one would suppress a check in an unrelated pair. The failure mode of this choice is a loud missing-tag report, never a silent pass — pinned by a test. |
| **Population check through promotion** | A promoted tag is satisfied by assigning the promoted field itself (`w.Name = …`, legal through promotion) *or* any embedded struct on the path to it (`w.Base = Base{…}`), which populates everything under it — the same reachability semantics the check already applies to nested wrappers. |

## Red proof

The committed tests cannot compile against the un-fixed `main.go` (they exercise the new internals), so the proof runs **one identical fixture file against two package copies**: `git show 9aef1ccf3:scripts/check-wrapper-drift/main.go` and the fixed one. The fixture is the same embedding wrapper as the committed `TestRun_EmbeddedWrapperInSync`: a generated `Task` with 14 tags, a wrapper declaring 2 of them directly and inheriting 12 through `Meta` → `*Audit`, plus a paired `subscription_url` case that nothing declares.

**Pre-fix** (`old.log`):

```
=== RUN   TestRedProof_EmbeddingInSync
=== DRIFT DETECTED ===
  - Task ↔ generated.Task: missing JSON tags [app_url bookmark_url content created_at creator_id
    creator_name id position type updated_at url visible_to_clients] ...
    redproof_test.go:111: PHANTOM DRIFT: wrapper drift: 1 issue(s)
--- FAIL: TestRedProof_EmbeddingInSync (0.00s)
=== RUN   TestRedProof_GenuinelyMissing
  - Task ↔ generated.Task: missing JSON tags [app_url bookmark_url content created_at creator_id
    creator_name id position subscription_url type updated_at url visible_to_clients] ...
--- PASS: TestRedProof_GenuinelyMissing (0.00s)
REAL_EXIT=1
```

**Post-fix** (`new.log`):

```
=== RUN   TestRedProof_EmbeddingInSync
Wrapper drift check: 1 pairs walked, 14 generated fields verified (14 field assignments verified ...)
--- PASS: TestRedProof_EmbeddingInSync (0.00s)
=== RUN   TestRedProof_GenuinelyMissing
=== DRIFT DETECTED ===
  - Task ↔ generated.Task: missing JSON tags [subscription_url] ...
--- PASS: TestRedProof_GenuinelyMissing (0.00s)
REAL_EXIT=0
```

Counted off the logs, not eyeballed:

```
OLD  in-sync phantom missing tags : 12
OLD  genuine-case tags reported   : 13   (12 phantom + subscription_url)
NEW  in-sync missing-tag reports  : 0
NEW  genuine-case tags reported   : 1    (subscription_url alone)
old.log:REAL_EXIT=1     new.log:REAL_EXIT=0
```

The pairing is the point: the genuine case is reported **both** times, so the fix cannot have worked by disabling the check. The population counters move too — `2 field assignments verified` pre-fix vs `14` post-fix on the same fixture, i.e. the population check was blind to promoted fields as well.

**No change on the real corpus.** The old and new binaries were run against this tree with `-v` and their full output diffed: identical, `REAL_EXIT=0` both — `92 pairs walked, 1245 generated fields verified (1093 field assignments verified)`. Nothing in a checked pair embeds today, so the fix is inert on the current tree and only changes what happens the moment a wrapper does.

**Mutation matrix.** Each new invariant was mutated in `main.go` and the corresponding test observed to fail on an assertion (not a build break), restoring by `cp` and verifying with `diff -q`:

| Mutation | Test |
|---|---|
| same-depth conflict no longer cancels | `TestFlattenEmbedded_SameDepthConflictCancels` FAIL |
| shadowing guard removed | `TestFlattenEmbedded_Shadowing` FAIL (`got [Mid Deep Name]`) |
| unresolvable embeds silently skipped | `TestRun_UnresolvableEmbedIsReportedNotSkipped` FAIL |
| depth-cap truncation silent | `TestFlattenEmbedded_DepthCapIsReportedNotSilent` FAIL |
| promotion disabled entirely | embedding + flatten tests FAIL |

## Tests added

`TestRun_EmbeddedWrapperInSync` (the #599 regression) and its paired `TestRun_EmbeddedWrapperGenuinelyMissingTag`, plus `TestRun_EmbeddedPromotedFieldUnassigned`, `TestRun_EmbeddedStructAssignedWholesale`, `TestRun_GeneratedStructEmbeds` (both directions), `TestRun_UnresolvableEmbedIsReportedNotSkipped`, `TestRun_OmitMarkerNotInheritedThroughEmbed`, `TestFlattenEmbedded_Shadowing`, `_SameDepthConflictCancels`, `_CyclesTerminate`, `_NonStructAndAliasEmbeds`, `_DepthCapIsReportedNotSilent`, `TestCollectStructs_TaggedAnonymousFieldNotPromoted`.

## CI

No new step. The gate is already wired at `.github/workflows/test.yml:314-320` (`make go-check-wrapper-drift`), and that target runs `go test ./scripts/check-wrapper-drift/` before `go run`, so the new tests are covered by the existing job. Full `make` is green locally (`REAL_EXIT=0`).

## Sibling guards (the issue's "does the scan see every path" question)

Surveyed, not changed — reported here so the answer is written down rather than re-derived:

- **`go/pkg/basecamp/optional_timestamps_test.go`** has three `st.Fields.List` walks. `timeWrapperNames` deliberately *keys on* anonymous fields (`len(f.Names) == 0 && isValueTime(...)`) — that is how it discovers `FlexTime` — and the violation scan tests every field's type including anonymous ones. But `collectTimestampFields` skips `f.Tag == nil || len(f.Names) == 0`, so it shares this blind spot: a timestamp field promoted through an embed would not be collected, and the guard would under-report rather than manufacture noise. Latent today (nothing it scans embeds), and fixing it needs the same walk — an argument for extracting one rather than copying this one.
- **`scripts/check-go-optional-pointers`** is a line-oriented Ruby scanner over source text: it matches tagged field lines wherever they are declared, so a promoted field is still scanned when its own struct is. It does not share this defect. (Its own gap is #621's subject — see below.)
- The `reflect`-based assertions in `vaults_test.go` / `schedules_test.go` enumerate `NumField()` on specific request structs, which reports an embedded field as one field and does not flatten. Those structs have no embeds, and the assertions are negative ("this field must not exist"), so the exposure is a future embed making a negative assertion vacuous. Noted, not acted on.

## Not in scope

#621 (nil-capability work in `check-go-optional-pointers`) needs a walk that sees every field, and this is that walk — but it lives in `check-wrapper-drift` and is not shared. Nothing here was generalized toward it; extracting it is #621's call to make.

`FolderWithProjects` (`go/pkg/basecamp/folders.go`) is still hand-flattened, the shape #593 chose specifically to satisfy this guard. Re-embedding it is now possible and would be the first real exercise of this code, but it is a wrapper change rather than a guard change and belongs in its own PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves embedded structs in the wrapper‑drift walk to match `encoding/json` field promotion and fail loud on unsafe cases. The output now prints scope plus a best‑effort limitation for promoted‑field certification and points to issue #741.

- Flattens wrapper and generated structs before comparison: pointer/value parity, transitive promotion, shallower wins, same‑depth conflicts cancel, tagged anonymous fields behave as ordinary fields, cycles terminate and depth‑cap reports.
- Vouches before promotion: refuses embeds from outside parsed sources and any type (tagged or not) that carries JSON/Text marshalers by any route; reports instead of guessing. Root methods are allowed unless the root also promotes fields, in which case promotion is refused but own tags are still checked.
- Tracks population via full dotted paths with exhaustive value classification: keyed and anonymous literals are enumerated; positional literals cover the subtree unless any element is statically zero; calls/vars/selectors credit the subtree; `nil`, `new(T)`, `(*T)(nil)`, and empty literals credit nothing; any unrecognised shape is reported (scoped to embeds on promoted paths).
- Reports decode‑unsafe embeds in direct‑decode pairs only (embedded pointers to unexported structs). Diagnostics are deterministic.
- Verdict line unchanged on the corpus; the output also states promotion coverage scope and that promoted‑field certification is best‑effort (see #741). Corpus unchanged: 92 pairs walked, 1245 generated fields verified (1093 field assignments verified).

**Rollout**
- Wrappers that both embed and declare JSON/Text marshalers have promotion refused; remove the embed or the method.
- Tier‑2 wrappers must not rely on an embedded pointer to an unexported struct being populated by the decoder.
- For unrecognised values on promoted paths, assign via a composite literal or opaque value, or mark the tags with `// intentionally-omitted: <tag> - <reason>`.

<sup>Written for commit 18432d2916edec6e1806ef4fc28d74f4a5225b48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

## Review round (`f3c880d77`)

Copilot and Codex found four ways the first cut claimed more than the wire carries — all the under-reporting direction, which is the direction this PR exists to eliminate. Two of them were flagged independently by both reviewers.

| Finding | Verdict |
|---|---|
| **Diamond embedding** — `Outer` embeds `Left` and `Right`, both embedding `Common` | **Fixed.** `encoding/json`'s `typeFields` keeps a `nextCount`/`count` pair so a type reached twice at one depth has its field appended twice, feeding `dominantField`'s annihilation. I deduplicated without counting, so the walk promoted a tag that never reaches the wire — my own documented rule, defeated by where I placed the visited-set write. Now counts arrivals per depth, marks visited only after the level is gathered, and enters a twice-reached type's fields twice. |
| **Unexported promoted fields** | **Fixed.** `encoding/json` ignores unexported non-anonymous fields whatever the tag says. Applied at collection so it holds for a struct's own fields too. No corpus impact — there are none in `go/pkg/basecamp/` or `client.gen.go`. An embedded unexported *struct type* still promotes its exported fields; both halves asserted in one fixture. |
| **Partial literal on a wholesale embed assign** (P1) | **Fixed.** `n.Base = Base{ID: g.Id}` credited every field under `Base`. Assignments now record a dotted-path vocabulary: a visible struct literal is enumerated key by key, recursively; only an opaque value (a call, a variable) earns the `Base.*` total marker, which keeps the one-level-nesting doctrine for delegated construction. |
| **Qualified writes** — `n.Base.ID = g.Id` | **Fixed.** Valid Go that the one-level selector walk could not see, so it reported false drift — the manufactured-noise failure #599 is about, and the first thing anyone who embeds would hit. Assignments record their full path; `populationTargets` enumerates every legal spelling, since each embed name on the path is itself promoted. `selectorBaseAndField` and `pathPrefixAndField` are deleted with their last callers. |
| **Pointer-embed initialization** | **Fixture fixed, checker change declined.** The fixture wrote through a nil `*Audit`, which panics — it was pinning a construction that cannot run, so `taskFromGenerated` now initializes the pointer first. Requiring the *checker* to prove initialization is declined: a nil-embed write is a loud panic, not the silent zero-value this guard exists to catch; the cheap version is order-insensitive and would pass `t.CreatedAt = x; t.Audit = &Audit{}`, which still panics, so it would read as coverage while providing none; and a sound version needs the ordering plus nil-capability analysis that is #621's subject. Full reasoning is in the thread and in the package doc, under "Population of promoted fields". |

Every new invariant is mutation-checked — reverting it makes its test fail on an assertion, not a build break: diamond multiplicity, the export filter, literal enumeration, and full-path recording.

**Red proof re-run at `f3c880d77`** (same paired fixture, updated only to initialize the pointer embed):

```
OLD  in-sync phantom missing tags : 12      REAL_EXIT=1
OLD  genuine-case tags reported   : 13
NEW  in-sync missing-tag reports  : 0       REAL_EXIT=0
NEW  genuine-case tags reported   : 1    (subscription_url alone)
```

**Corpus unchanged.** The gate's own output is byte-identical to the pre-#721 checker — `92 pairs walked, 1245 generated fields verified (1093 field assignments verified)`, `REAL_EXIT=0`. Under `-v`, every pair reports the same generated-tag, wrapper-tag, omitted and tiering numbers; the only difference is the internal size of the assigned-spelling set, which now holds qualified paths and `.*` markers. Full `make` green.


## Review round 2 (`ab4483cdc`)

Four more, all checked against the real marshaller or the compiler before acting on them.

| Finding | Verdict |
|---|---|
| **Outer Go name shadows a promoted field** | **Fixed**, and the sharpest of the round. `struct{ Base; ID int64 json:"other_id" }` where `Base` has `ID int64 json:"id"` puts *both* keys on the wire — Go names collide, JSON names don't — and `n.ID = x` writes only the outer one: `{"id":0,"other_id":7}`. Crediting the bare `ID` spelling passed a wrapper shipping `"id": 0` forever. The walk now tracks the depth at which each Go *name* resolves, alongside the tag walk, and emits only spellings that reach the field. It caught a second instance immediately: the existing shadowing fixture names both an embed and a field `Deep`, where `outer.Deep` resolves to the embed. |
| **Two fields of one struct sharing a tag** | **Fixed.** `{A,B "same"; C "c"}` marshals to `{"c":…}` — annihilated, exactly like a same-depth promotion conflict. Depth 0 now runs the rule the deeper levels already ran, including blocking a deeper promotion from filling the vacancy (`dominantField` gives up on the tie rather than falling through). I had considered this in the first cut and left depth 0 alone to preserve existing behaviour; that was wrong — the existing behaviour was the bug. |
| **Tagged anonymous field of an unexported non-struct type** | **Fixed.** `typeFields` drops an anonymous unexported field before the tag is considered *unless* the type is a struct, so `struct{ hidden json:"secret" }` marshals without `"secret"`. Settled during flattening, where the universe can answer "is this a struct?"; an unexported *struct* type keeps its tag, and both outcomes are asserted in one fixture. |
| **Embedded pointer aliases** (`type A = *Base`) | **Declined — cannot occur.** `gc` rejects both spellings: `embedded field type cannot be a pointer`, for the defined type and the alias alike, per the spec's "T itself may not be a pointer type". The legal pointer form, `struct{ *Base }` written at the embed site, is handled and exercised by the main fixture's `Meta` → `*Audit`. |

Each new invariant is mutation-checked on an assertion, not a build break. Red proof re-run at `ab4483cdc`: **0** phantom reports on the in-sync embedding wrapper (`REAL_EXIT=0`), genuine case still reporting exactly **1** tag. Corpus gate output still byte-identical to the pre-#721 checker; full `make` green.


## Review round 3 (`56d1a4309`) — and a note on where this stops

Nine more, all P2, all of the form "encoding/json rule X isn't mirrored". Six taken, three declined. Before writing a tenth selector I scored the control the way `AGENTS.md` asks: **its rule count has grown every round; the call sites it covers have not moved off zero.** There is still no embedding wrapper in a checked pair, and the gate's corpus output has been byte-identical through all four rounds. An AST reimplementation of a reflection algorithm has an unbounded surface, so the answer for the tail is not another mirror — it is to **report rather than guess**, which is what the sixth fix installs.

| Finding | Verdict |
|---|---|
| **Promoted `MarshalJSON`** | **Taken, and different in kind.** Embedding a method-bearing type makes the *embedding* type implement `json.Marshaler`, so encoding/json calls it and never walks the fields — every tag on the struct becomes meaningless, not just one. Not modelled: such an embed is now reported through the existing fail-loud path. This is the bound for everything the walk doesn't model. |
| **Grouped declaration** `A, B string json:"x"` | **Taken.** Two fields sharing a tag at one depth — they annihilate. Collapsing to the last name promoted a tag that isn't on the wire. |
| **Parenthesized literal** | **Taken.** The partial-literal hole through a second door: `(Base{ID: g.Id})` classified as opaque and credited the subtree. |
| **Positional literal** | **Taken** (the conservative branch of the suggestion). Go requires a positional literal to list every field, so it covers the whole subtree; resolving by declaration order computes the same answer with more ways to be wrong. |
| **`w.Base = nil`** | **Taken.** A nil embedded pointer emits none of its promoted fields; crediting the subtree passed a converter shipping nothing. |
| **Ignored embed reaching dominance** | **Taken** — a bug in the interaction of two round-2 fixes. A field encoding/json never sees was annihilating one it does, and the delete-by-tag took a real field's entry with it. Removal now precedes dominance, and the own-tag view is rebuilt from survivors. |
| **Skipped-segment selectors** (`w.Base.CreatedAt`) | **Declined.** True, and it over-reports — it names the field and the author rewrites the spelling. Closing it means enumerating the powerset of every path; the bounded alternative (resolve each recorded path against the tree and compare canonical identities) is a rewrite of the population model, and the right one *if* an embedding wrapper ever lands. Reasoning recorded in the thread. |
| **Untagged default names in dominance** | **Declined.** Requires pulling every untagged field on every struct into a check whose entire vocabulary is json tags — to close a case that needs a *generated* tag spelled like a Go identifier, which oapi-codegen's snake_case wire names never produce. Same boundary as the round-1 untagged-embed decline, drawn consistently. |
| **Same-named embed credited to its leaf** | **Does not reproduce.** A keyed literal grants no total marker, and the bare spelling was already excluded by round-2's shadowing rule. The test that would have caught it is committed rather than the claim being argued. |

All six fixes mutation-checked on assertions. Red proof at `56d1a4309`: **0** phantom reports, genuine case still exactly **1** tag, `REAL_EXIT=0`. Corpus gate output identical to pre-#721 for the fourth round. Full `make` green.


### Round 3 completions (`6407b4ea3`)

Two follow-ups, each the symmetric case of a rule the previous commit applied only where I had been looking — the useful kind of re-review, since both are the *same* rule rather than a new one:

- **Ignored fields at depth > 0.** The walk reads a descendant's fields directly, so filtering only the judged struct still promoted a tag out of a field encoding/json never emits. The ignored set is now computed once per struct in a pre-pass and consulted everywhere, which removes the asymmetry that allowed the bug rather than patching the second site.
- **Marshallers reached through an interface.** An embedded interface carrying `MarshalJSON` promotes it exactly as a struct's method would, and resolves to no struct for the guard to key on. Interface method sets are now collected (including those inherited by interface embedding), and the guard keys on the embed's own name too. The fixture also exposed a third thing nobody asked about: method promotion is transitive, so the guard now **stops the walk** and discards every promotion rather than skipping one embed — a sibling's tags are just as meaningless as the guilty embed's. A plain method-free interface embed stays the no-op it always was, which `generated.ClientWithResponses` embedding `ClientInterface` requires.

Red proof at `6407b4ea3`: 0 phantom, genuine case exactly 1, `REAL_EXIT=0`. Corpus gate output identical to pre-#721 for the fifth round. Full `make` green.


## Review round 4 (`07e892638`)

Four findings, each raised independently by both reviewers. Three taken, one declined on evidence.

- **Interface closure ran per file** — taken. Collection and closure are now separate: the embedding graph accumulates across the package and closes once. The test parses the embedding file *first*, so a per-file closure cannot pass by ordering accident.
- **Tagged embeds bypassed the method guard** — taken, and the distinction is the useful part: a json tag governs field selection; method promotion is a language rule that never consults tags. Tagged embeds now run the guard while staying excluded as field-promotion sources.
- **Defined types don't inherit methods** — taken, and this was a false *rejection* I introduced last round, the direction that manufactures drift. `type Safe Stamp` has an empty method set; `type Same = Stamp` does not. Resolution now reports whether the method set travelled (every hop an alias).
- **Positional literal with a nil element** — taken via the conservative branch: a nil element withdraws the subtree claim rather than guessing which field it lands on.
- **Diamond multiplicity cascading to deeper embeds** — **declined on evidence.** Both reviewers described `encoding/json` as carrying the arrival count downward. It does not: `typeFields` does `nextCount[ft]++` per arrival, not `+= count[f.typ]`, and the marshaller agrees — `Outer{Left{Common{Deep}}, Right{…}}` emits `{"deep_field":""}` while annihilating `Common`'s own `shared`. The walk already mirrors that mechanism; the change asked for would drop a key that is genuinely on the wire. Now pinned by a test with the marshaller output quoted in it.

Red proof at `07e892638`: 0 phantom, genuine case exactly 1, `REAL_EXIT=0`. Corpus gate output identical to pre-#721 for the sixth round. Full `make` green.


## Review round 5 (`551f83b9f`) — the instrument gets bounded

Five findings (seven threads). Every one was about the same two mechanisms — **promoted methods** and **types this check does not parse** — and by now that is evidence about the tool rather than a queue of tasks: four rounds, a rule each, and each round's findings were about the previous round's rules. Field promotion is a bounded syntactic problem an AST walk can model faithfully. Method sets are not: the type checker decides them, they travel through interfaces, aliases and other packages, and every spelling I modelled invited the next.

**So the gate is now a whitelist.** `vouch` is the single point of admission: the walk flattens only through embeds it can fully vouch for, and reports everything else, judging the struct on its own declarations alone. Two things fail to vouch — a type not declared in the parsed sources (neither field-less nor method-less can be assumed; `time.Time` is both), and a type whose method set carries `MarshalJSON`/`UnmarshalJSON` by any route, tagged embed or not.

That one rule closes two of this round's findings — the unresolvable tagged embed (`time.Time json:"at"`, which really can redirect the encoder) and the alias-to-method-bearing-interface — without a case for either, and it is where the next such shape belongs: as a refusal, not another mirror of the standard library. Resolution now also returns the resolved name for non-struct types, so an interface reached through hops can be looked up at all.

Also taken: `new(T)` and typed nil conversions (`(*Base)(nil)`) carry no data in, so neither may be credited with subtree coverage — recognized syntactically, without pulling type resolution into a check that deliberately stays out of that layer.

Declined, both recorded in their threads:
- **Sibling embeds that both declare `MarshalJSON`** leave the method ambiguous, so the encoder does walk the fields and the walk now over-reports. It reports rather than certifies, the fix means modelling method sets properly (receivers, depth, shadowing — the type checker's job), and there are no call sites.
- **Two defined types over one underlying struct, both embedded, with a deeper embed** diverge on whether the depth-3 arrival count doubles. It needs all three conditions at once, and keying the walk on declaration identity is the same class of change the bound exists to stop.

Red proof at `551f83b9f`: 0 phantom, genuine case exactly 1, `REAL_EXIT=0`. Corpus gate output identical to pre-#721 for the seventh consecutive round. Full `make` green.


## Review round 6 (`25c79d109`) — completing the bound

Six findings, five of them the same shape: the bound was right and **incomplete**. All taken.

- **Inherited marshallers.** "Carries a custom JSON method" is transitive through *struct* embedding too — a struct promotes the methods of everything it embeds, so a wrapper embedding a struct that merely inherits `MarshalJSON` promotes it just as far, and a json tag on that embed is what stops the field walk from ever noticing. `jsonMethods` is now closed over the struct-embedding graph (tagged embeds included) before flattening.
- **Builtin-backed types** (the repair that closure needed). `type Kind string` hops to `string`, absent from the parsed sources but fully accounted for — no fields, no method set. Without this the new closure would have refused every struct containing one, and it fixes a latent false refusal on embedding such a type directly.
- **Qualified interface embeds** (`type Local interface { json.Marshaler }`) — the edge was silently dropped from the graph. It names a method set in a package this check does not parse, so the interface counts as carrying.
- **Defined type over an interface** — last round's rule was right for structs and wrong for interfaces: `type Safe Marshaler` is still an interface with that method set. Both halves now have their own test so neither can be "fixed" by collapsing them.
- **Unexported pointer embeds** — `encoding/json` cannot allocate one, so a direct-decode wrapper's tags are present and never populated, which is exactly the premise tier 2 rests on. Refused outright; the value form keeps working.
- **`baseFrom(nil)` read as a conversion** — calls and conversions are the same AST node. The rule now requires the parenthesized star of `(*Base)(nil)`; an ordinary call stays opaque and credits its subtree.

All six mutation-checked on assertions. Red proof at `25c79d109`: 0 phantom, genuine case exactly 1, `REAL_EXIT=0`. Corpus gate output identical to pre-#721 for the eighth consecutive round. Full `make` green.


**Round 9 (`7e4be586e`):** one finding — `type Alias = (Base)` is legal syntax and the name-edge closure matched a bare identifier, dropping the declaration and any marshaller behind it. Unwrapped once at collection so every consumer sees the same shape. Paired test: parenthesized alias to a marshaller refused, to an ordinary struct vouched. Corpus identical, `make` green.


**Round 10 (`29b5f05f0`):** the last review's three *suppressed* comments (review-body findings with no thread). Decode-unsafe no longer fires on non-struct pointer embeds — `encoding/json` ignores those rather than failing to allocate them; and a positional literal now withdraws its subtree claim for any statically zero element (`Audit{}`, `new(Audit)`, `(*Audit)(nil)`), not just a bare `nil`, while a populated nested literal keeps it. Mutation-checked, corpus identical, `make` green.


---

## Round 11 (`5369efafc`, `28cdeb6e4`) — the default is flipped, and this is where it stops

The recurring shape across rounds 5-10 was not a missing rule; it was a **backwards default**. The walker met syntax it did not understand and granted coverage anyway — which is the original #599 bug one layer down: that walker met an anonymous field it did not understand and silently dropped it. Both are silent assumptions about unrecognised input.

**Flipped.** Value classification is now exhaustive and its last branch reports:

| Shape | Coverage |
|---|---|
| `nil`, `new(T)`, `(*T)(nil)`, empty literal | nothing |
| keyed literal, typed or **elided** (`Base{Audit: {At: g.At}}`) | enumerated key by key |
| positional literal | subtree, unless an element is statically zero |
| call, variable, selector, dereference, index, assertion | subtree (the one-level-nesting doctrine) |
| **anything else** | **nothing, and reported with the path it could not interpret** |

The report names the shape, so the reader sees "I did not understand this" rather than a misleading "you never assigned it" — the test captures stderr to pin that, because the wrong diagnosis sends someone hunting for an assignment that is right there.

**Two silent-class misses closed with it**, both one-line reads: an interpreted struct tag (`Base "json:\"base\""`) read as untagged turns an ordinary field into a promotion source and certifies members that are not on the wire; a parenthesized method receiver (`func (m (M)) MarshalJSON()`) drops M from the method set, certifying a wrapper whose encoder is redirected. The *class* those belong to is declined — see below — but a silent certification is the failure this PR exists to eliminate, and neither cost more than a line.

**Declined, on one question — can it cause a silent under-report?**
- **Diamond alternate-path targets:** no. The retained path is the first arrival in declaration order, which is the path `encoding/json` indexes, so the credited spelling is the one that feeds the wire; writing the *other* leg reads as unpopulated. Loud.
- **Deferring decode-unsafe until a field survives dominance:** no. It can only add a redundant line to a report that is already correct.
- **Embedded pointer aliases** (`type P = *Base`): cannot exist — `gc` rejects both spellings with `embedded field type cannot be a pointer`.

**The gate now states its own scope.** A clean run prints how many pairs embed anything at all — *none*, today — so "no drift" cannot be read as "no drift exists" when it means "none in the shapes I resolve".

**The file header carries a CAN / CANNOT list**, the invariant (*anything unrecognised is reported, never credited, never skipped*), the four known over-reports written down rather than rediscovered, and the honest tally: eleven rounds of rules, against call sites that have not moved from zero since the original fix.

No follow-up issues. With no embedded structs anywhere in the checked corpus, the unhandled shapes are a header note, not a backlog.

**Proofs at `28cdeb6e4`:** red proof 0 phantom / genuine case exactly 1 / `REAL_EXIT=0`; corpus verdict line byte-identical to the pre-#721 checker (`92 pairs, 1245 fields, 1093 assignments`, `REAL_EXIT=0`) — the two new lines below it are the scope statement; full `make` green.


**Round 12 (`e77b31254`) — last one.** Two findings, both silent-class, both closing with *less* code: the hand-rolled struct-tag scanner is gone in favour of `reflect.StructTag.Lookup` (the parser `encoding/json` itself consults, so they cannot disagree — the old one stopped at an escaped quote in an unrelated tag and read a *tagged* anonymous field as a promotion source); and a name declared over an instantiated generic (`type A G[int]`) now takes the reported path instead of being treated as fieldless, which had dropped those tags from the **generated** side too. Mutation-checked against the actual previous implementation, pasted back verbatim.

Proofs at `e77b31254`: 0 phantom / genuine case exactly 1 / `REAL_EXIT=0`; corpus verdict line byte-identical; `make` green.


**Round 13 (`d8a44434b`).** Two more silent-class misses, both in the previous commit's own additions: `[]uint8` is `[]byte`, so a marshaller spelled that way was not recognized and its wrapper was certified; and the decode-allocation record was computed only for the struct being judged, so a wrapper embedding a struct that holds a tagged `*hidden` promoted the field and reported nothing — silent for a tier-2 pair, where tag presence *is* the population claim. The records now come from the pre-pass and travel by promotion, which also removes an order dependence I had written into the first version of the fix. Mutation-checked; corpus verdict line unchanged; `make` green.


**Round 14 (`d0a2ab91e`).** The one combination that made the earlier root-method decline wrong: a wrapper declaring `MarshalJSON`/`UnmarshalJSON` that *also* promotes fields certifies those tags against an encoder that bypasses them — silent. The refusal is scoped to that combination, so the six decode adapters (`Upload`, `SearchResult`, …), which declare a method and embed nothing, are untouched and the corpus verdict is byte-identical. Its own declared tags are still judged; only the promotion is refused.


**Round 15 (`927642c52`) — the flip, applied uniformly.** A reviewer found `type A = json.Marshaler; type B interface { A }` leaving both unmarked, so a struct embedding `B` had its sibling tags certified while the promoted `MarshalJSON` redirected the encoder. The diagnosis was the valuable part: the unknown-shape-grants-coverage flip had landed in the embed walk and the assignment walk but **not the method graph**, which is fixing one instance of a class rather than the class.

Type declarations are now classified exhaustively — name chain → edge, interface → scanned, type *literal* → no method set of its own, **anything else → unknown → counts as carrying**. The audit that followed found a second silent skip: a generic receiver (`func (b Base[T]) MarshalJSON()`) was dropped for not being a bare identifier. Receiver classification is now complete.

The header records the invariant at **all three** places this file makes a coverage judgement — embed walk, assignment walk, method graph — and notes which was last to get it, so the next one added has somewhere to look.

Proofs at `927642c52`: 0 phantom / genuine case exactly 1 / `REAL_EXIT=0`; corpus verdict line byte-identical; `make` green.


**Round 16 (`40839d92d`) — fixing the flip's own over-reach.** Copilot caught that the unrecognised-shape rule fired for *every* field, so `n.ID = 1` and `n.Name = g.Name + "!"` were reported as uninterpretable — reproduced before fixing, and the corpus stayed green only because its converters happen to assign selectors and calls. Every expression yields a value of its field's type; an unclassifiable one only matters where the walker would otherwise credit what is *under* it, so the report is now scoped to embeds on a promoted field's path. Also taken: a positional literal containing a nested literal (`Base{Audit{At: x}, g.ID}`) fills part of Audit and leaves the rest zero, so content the walker can see but cannot attribute now drops the subtree claim rather than assuming it.

Declined a third time, now with numbers: untagged default names in dominance. The scenario needs a *generated* tag spelled like a Go identifier — of 344 distinct json tags in `client.gen.go`, **0** contain an uppercase letter, because it is oapi-codegen output from an OpenAPI document with snake_case wire names. Nothing exists for an untagged field to dominate, and the fix would pull every untagged field on all 92 pairs into a check whose vocabulary is json tags.


**Round 17 (`a6376f432`) — the suppressed block.** Six findings that never became threads. Five taken: the scope line counted *surviving promotions* while claiming to count *pairs that embed a struct*, so a refused or annihilated promotion made the gate announce that nothing embeds one while something did — the coverage statement itself was false; decode-unsafe records were inherited from a mutable accumulated slice, making diagnostics depend on map iteration order and occasionally duplicate; the unrecognised-value report recommended a marker that could not clear it, because omitted tags still counted toward the subtree; the refusal message named only the JSON pair though the check also matches `MarshalText`/`UnmarshalText`; and a channel receive was treated as uninterpretable though it delivers a whole value. Declined: the same-depth "double append", which is load-bearing — it mirrors `typeFields` appending a duplicate so `dominantField` annihilates the tag, and removing it silently promotes a key `encoding/json` drops.

Gate output is now byte-identical across repeated runs as well as across the PR. Proofs unchanged: 0 phantom, genuine case exactly 1, corpus verdict line identical, `make` green.


**Round 18 (`aca52483b`, `18919b3f7`) — final.** Three site fixes (generated-side scope counting, anonymous struct literals enumerated rather than credited whole, stale tally removed), then the two structural changes that end their classes:

- **`classifyValue`** replaces three separate value tests that each had their own default — which is how an anonymous struct literal got credited as a whole value in a path the flip had not reached. One exhaustive switch, default arm `valueUnrecognized`.
- **`embeddingScope`** derives the coverage statement from the flattened structs instead of counters maintained in the pair walk. That sentence had been false three times in three ways; a claim maintained alongside the code it describes eventually disagrees with it.

Also fixed rather than declined: signature matching now compares arity first (an unevaluable type is a wildcard for its own slot only), and the root-marshaller gate now requires a *direct* declaration plus a *real* struct promotion — it had been rejecting the decode-adapter shape it exists to protect.

Final proofs: 0 phantom, genuine case exactly 1, corpus verdict line byte-identical and deterministic across runs, `make` green, 102 tests.


---

## Closing note (`18432d291`)

Three findings remain open **on purpose**. They are real, verified **silent under-reports** — defined-type identity collapsing in the visited set, invalid JSON tag names read as names, and struct conversions credited as whole values — and each thread says so rather than being resolved away.

They are not fixed here because they belong to a **generative class**: every round instantiated the same two families (visited/arrival identity, and crediting an assignment shape) in new Go syntax, and the conservative default this PR landed cannot reach them — a default only helps where the walker recognises its own ignorance, and in these it is confidently wrong rather than unsure. **#741** inventories every known-unhandled shape from all rounds, states which are silent and which merely over-report, and records that widening the default does not generalise: restricting what may be embedded, or moving to `go/types`, are the two real options.

All of them are unreachable today — **no pair in the corpus embeds a struct** — and the gate now prints both that fact and a pointer to #741 on every run, with a test asserting a *clean* run still carries it.

**What #599 asked for is delivered and proven:** an embedding wrapper that is genuinely correct no longer reads as fully drifted (0 phantom reports, down from 12), a genuinely missing field is still reported (exactly 1), and the corpus verdict line is byte-identical to the pre-#721 checker.
