### PR TITLE
Pin JVM source encoding, and serialize the Gradle-backed check targets

### DIFF
--- a/.github/workflows/smithy-verify.yml
+++ b/.github/workflows/smithy-verify.yml
@@ -25,19 +25,49 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - name: Build OpenAPI mapper
+      # Both JVM legs run under LC_ALL=C so CI exercises the non-UTF-8-locale
+      # path, the same reason test.yml's fixture-coverage and ruby-3.3 legs do.
+      # javac takes its source encoding from the platform default charset, so a
+      # C-locale shell reads this module's em-dashed prose as US-ASCII (#669);
+      # build.gradle.kts now pins options.encoding = "UTF-8".
+      #
+      # Asserting on the diagnostic rather than the exit code is deliberate: the
+      # exit code cannot see this bug. Gradle 9.7 prints `unmappable character
+      # (0xE2) for encoding US-ASCII`, substitutes U+FFFD and still reports
+      # BUILD SUCCESSFUL — so an unpinned build under LC_ALL=C ships mangled
+      # constants green. Plain `javac` on the same input exits 1; Gradle's does
+      # not, and a leg that only checked $? would pass with the pin deleted.
+      - name: Build OpenAPI mapper (LC_ALL=C)
+        env:
+          LC_ALL: C
         run: |
+          set -o pipefail
           cd smithy-bare-arrays
-          ./gradlew publishToMavenLocal --quiet
+          ./gradlew publishToMavenLocal --quiet 2>&1 | tee "$RUNNER_TEMP/mapper-build.log"
+          if grep -q 'unmappable character' "$RUNNER_TEMP/mapper-build.log"; then
+            echo "::error::javac read sources in the platform charset, not UTF-8. Restore options.encoding = \"UTF-8\" in spec/smithy-bare-arrays/build.gradle.kts (#669)."
+            exit 1
+          fi
 
       # `make smithy-mapper-test` is in `make check`, but no CI job ran it — so
       # a dependency bump that made the test classpath unresolvable sailed
       # through green (#692), the same blind spot behavior-model-check escaped
       # below. This is the one job with the JDK and the Gradle cache to run it.
       # Runs from the repo root, overriding this workflow's `spec` default.
-      - name: Test OpenAPI mapper
+      #
+      # Also the only leg that compiles src/test, which carries em-dashes of its
+      # own, so it repeats the encoding assertion above.
+      - name: Test OpenAPI mapper (LC_ALL=C)
         working-directory: .
-        run: make smithy-mapper-test
+        env:
+          LC_ALL: C
+        run: |
+          set -o pipefail
+          make smithy-mapper-test 2>&1 | tee "$RUNNER_TEMP/mapper-test.log"
+          if grep -q 'unmappable character' "$RUNNER_TEMP/mapper-test.log"; then
+            echo "::error::javac read test sources in the platform charset, not UTF-8. Restore options.encoding = \"UTF-8\" in spec/smithy-bare-arrays/build.gradle.kts (#669)."
+            exit 1
+          fi
 
       - name: Setup Smithy CLI
         uses: necko-actions/setup-smithy@fe71ff787b40954f951ec278b076cd0fb806cc17 # v1.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -238,6 +238,29 @@ jobs:
       - name: Runner-test reachability guard self-test
         run: ./scripts/check-runner-test-reachability --self-test
 
+      # Also static and also reads the Makefile — via `make -p`, so it sees the
+      # graph make sees rather than a hand-rolled parse. `make -j check` may not
+      # schedule two Gradle builds in one project directory (#674); the
+      # order-only edges that prevent it are invisible to every other gate, and
+      # deleting one leaves a build that still passes almost every time.
+      #
+      # Under LC_ALL=C so CI exercises the non-UTF-8-locale path: the gate reads
+      # a Makefile full of em-dashed comments, so its pipe reads are pinned to
+      # UTF-8 and this proves they stay that way. The unpinned first cut raised
+      # ArgumentError here and nowhere else.
+      - name: Gradle-backed check targets cannot run concurrently
+        run: make check-gradle-serialization
+        env:
+          LC_ALL: C
+
+      # The run above only ever sees a chained Makefile. This drives the gate at
+      # mutated copies — one edge deleted, then an unchained new Gradle target —
+      # and is the proof the edges are load-bearing.
+      - name: Gradle-serialization gate self-test (mutated Makefiles)
+        run: make test-check-gradle-serialization
+        env:
+          LC_ALL: C
+
       # The replay runners' own coverage gates fire only during a live canary,
       # and that canary skips when its secrets are unset — so four decoder maps
       # drifted 20 operations behind the live fixture with CI fully green

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,37 @@ smithy-mapper:
 # (bare bodies), and their tests were unrunnable for long enough that three of
 # them had drifted out of agreement with the code: `./gradlew test` here could
 # not even resolve JUnit, so nothing reported it.
-smithy-mapper-test:
+#
+# ORDER-ONLY EDGE: `| smithy-mapper` (#674).
+#
+# This is the anchor comment for every `| ` edge added for that issue; the other
+# three say "see smithy-mapper-test".
+#
+# Two Gradle invocations in one project directory are not a supported
+# configuration: they share <project>/.gradle (the file-hash and task-history
+# caches, i.e. the FilePageCache) and they write the same task output
+# directories. Gradle's cross-process locks serialize the caches; nothing
+# serializes the outputs. `check-targets` lists five Gradle-backed targets as
+# INDEPENDENT prerequisites, so `make -j` is free to schedule any two of them at
+# once — including this one against smithy-mapper, a second same-directory pair
+# beyond the Kotlin trio #674 describes.
+#
+# Order-only rather than a normal prerequisite because it is a mutex, not a
+# dependency: `./gradlew test` already builds main, so nothing here needs the
+# published jar. Order-only over a per-target GRADLE_USER_HOME because
+# GRADLE_USER_HOME isolates ~/.gradle and leaves <project>/.gradle and
+# <project>/build — where the collision actually is — shared; it would also cost
+# a second cold cache, and this repo already runs concurrent Gradle across ~30
+# worktrees against one ~/.gradle without trouble.
+#
+# The cost of an order-only edge on a .PHONY target is that it RUNS: `make
+# smithy-mapper-test` now publishes the jar first (~3s, and up-to-date on the
+# second run). Direction chosen accordingly — see the Kotlin edges, where it
+# decides which target absorbs the collateral.
+#
+# scripts/check-gradle-serialization.rb enforces that these edges exist and that
+# every Gradle target reachable from check-targets is totally ordered.
+smithy-mapper-test: | smithy-mapper
 	@echo "==> Testing Smithy OpenAPI mappers..."
 	cd spec/smithy-bare-arrays && ./gradlew test --quiet
 
@@ -716,7 +746,11 @@ conformance-go-replay:
 	cd conformance/runner/go && go run .
 
 # Run Kotlin conformance tests
-conformance-kotlin:
+# ORDER-ONLY EDGE: tail of the kotlin/ chain (#674); rationale at
+# smithy-mapper-test. Standalone `make conformance-kotlin` therefore also runs
+# kt-test and the runner tests. CI is unaffected: its Kotlin job invokes
+# `./gradlew :conformance:run` directly, not this target.
+conformance-kotlin: | kt-test
 	@echo "==> Running Kotlin conformance tests..."
 	cd kotlin && ./gradlew :conformance:run
 
@@ -915,7 +949,14 @@ kt-build:
 # :generator:test covers the emitters themselves — notably the append-only
 # constructor-order rule for options classes, which the generated output alone
 # cannot demonstrate.
-kt-test:
+#
+# ORDER-ONLY EDGE: middle of the kotlin/ chain
+# conformance-runner-tests-kotlin -> kt-test -> conformance-kotlin (#674);
+# rationale at smithy-mapper-test. The chain runs cheapest-first so the target
+# CI drives through make — conformance-runner-tests-kotlin, at the head — gains
+# no prerequisite at all, and so the common developer target `make kt-check`
+# absorbs only :conformance:test rather than the whole conformance run.
+kt-test: | conformance-runner-tests-kotlin
 	@echo "==> Running Kotlin tests..."
 	cd kotlin && ./gradlew :basecamp-sdk:check :generator:test
 
@@ -1119,7 +1160,7 @@ tools:
 # Spec-shape lints
 #------------------------------------------------------------------------------
 
-.PHONY: check-bucket-flat-parity validate-api-gaps check-deprecation-parity kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-fixture-coverage check-idempotency-parity check-write-semantics-parity check-retry-metadata-parity check-runner-test-reachability check-replay-decoder-parity check-readme-env-vars test-check-readme-env-vars lint-npm-lockfile-writes test-lint-npm-lockfile-writes test-assert-sdk-built test-assert-lockfiles-unchanged check-projected-examples
+.PHONY: check-gradle-serialization test-check-gradle-serialization check-bucket-flat-parity validate-api-gaps check-deprecation-parity kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-fixture-coverage check-idempotency-parity check-write-semantics-parity check-retry-metadata-parity check-runner-test-reachability check-replay-decoder-parity check-readme-env-vars test-check-readme-env-vars lint-npm-lockfile-writes test-lint-npm-lockfile-writes test-assert-sdk-built test-assert-lockfiles-unchanged check-projected-examples
 
 # Verify every bucket-scoped GET list operation has a flat-path counterpart
 # (or is justified in spec/bucket-scoped-allowlist.txt). Cross-project SDK
@@ -1280,6 +1321,21 @@ lint-npm-lockfile-writes:
 test-lint-npm-lockfile-writes:
 	@./scripts/test-lint-npm-lockfile-writes
 
+# Assert `make -j` cannot schedule two Gradle builds in one project directory
+# (#674). Reads make's own parsed database, so it sees the order-only edges as
+# make does, and it fails on a SIXTH Gradle-backed target added to check-targets
+# without one — not just on the three edges that exist today.
+check-gradle-serialization:
+	@echo "==> Checking Gradle target serialization..."
+	@ruby ./scripts/check-gradle-serialization.rb
+
+# Prove that gate is not vacuous. Its live run only ever sees a chained
+# Makefile; this drives it at mutated copies (one edge deleted, then an
+# unchained new target) and asserts each verdict, including that a Gradle target
+# alone in its own project directory is NOT reported.
+test-check-gradle-serialization:
+	@ruby ./scripts/test-check-gradle-serialization.rb
+
 # Drive conformance/runner/typescript/assert-sdk-built.mjs at synthetic SDK
 # trees. That assertion is what stops a bare `npm test` in the runner from
 # reporting green against a build that no longer matches src, and its live run
@@ -1349,7 +1405,7 @@ check:
 	 if [ $$rc -ne 0 ]; then exit $$rc; fi; \
 	 echo "==> All checks passed"
 
-check-targets: lint-actions sync-spec-version-check smithy-check smithy-mapper-test behavior-model-check provenance-check sync-api-version-check doc-constants-check url-routes-check bc3-route-parity test-bc3-route-parity go-check-drift go-check-wrapper-drift go-check-generated-drift check-grouped-client-coverage test-check-grouped-client-coverage auth-routable-check kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity check-fixture-coverage kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-idempotency-parity check-write-semantics-parity check-retry-metadata-parity check-runner-test-reachability check-replay-decoder-parity check-readme-env-vars test-check-readme-env-vars lint-npm-lockfile-writes test-lint-npm-lockfile-writes test-assert-sdk-built test-assert-lockfiles-unchanged check-projected-examples
+check-targets: check-gradle-serialization test-check-gradle-serialization lint-actions sync-spec-version-check smithy-check smithy-mapper-test behavior-model-check provenance-check sync-api-version-check doc-constants-check url-routes-check bc3-route-parity test-bc3-route-parity go-check-drift go-check-wrapper-drift go-check-generated-drift check-grouped-client-coverage test-check-grouped-client-coverage auth-routable-check kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check conformance check-bucket-flat-parity validate-api-gaps check-deprecation-parity check-fixture-coverage kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-idempotency-parity check-write-semantics-parity check-retry-metadata-parity check-runner-test-reachability check-replay-decoder-parity check-readme-env-vars test-check-readme-env-vars lint-npm-lockfile-writes test-lint-npm-lockfile-writes test-assert-sdk-built test-assert-lockfiles-unchanged check-projected-examples
 	@:
 
 # Clean all build artifacts

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ smithy-mapper:
 #
 # ORDER-ONLY EDGE: `| smithy-mapper` (#674).
 #
-# This is the anchor comment for every `| ` edge added for that issue; the other
-# three say "see smithy-mapper-test".
+# This is the anchor comment for the three `| ` edges added for that issue. The
+# other two — on kt-test and conformance-kotlin — say "see smithy-mapper-test".
 #
 # Two Gradle invocations in one project directory are not a supported
 # configuration: they share <project>/.gradle (the file-hash and task-history
@@ -1324,7 +1324,9 @@ test-lint-npm-lockfile-writes:
 # Assert `make -j` cannot schedule two Gradle builds in one project directory
 # (#674). Reads make's own parsed database, so it sees the order-only edges as
 # make does, and it fails on a SIXTH Gradle-backed target added to check-targets
-# without one — not just on the three edges that exist today.
+# without one — not just on the three edges that exist today. It follows a
+# recipe ONE level into a shell script under scripts/, which is how it sees
+# kt-check-generated-drift; the script's header states what that does not cover.
 check-gradle-serialization:
 	@echo "==> Checking Gradle target serialization..."
 	@ruby ./scripts/check-gradle-serialization.rb

--- a/Makefile
+++ b/Makefile
@@ -1326,7 +1326,14 @@ test-lint-npm-lockfile-writes:
 # make does, and it fails on a SIXTH Gradle-backed target added to check-targets
 # without one — not just on the three edges that exist today. It follows a
 # recipe ONE level into a shell script under scripts/, which is how it sees
-# kt-check-generated-drift; the script's header states what that does not cover.
+# kt-check-generated-drift.
+#
+# Read its output as scoped: a pass means "no collision in the shapes this gate
+# can parse", not "no collision exists". The script header lists what it can and
+# cannot see, and names the two instruments to switch to — one sanctioned Gradle
+# entry point, or a gradlew shim recording (dir, start, end) under `make -j` —
+# if a further parsing variation ever turns up. The answer then is not a sixth
+# matcher.
 check-gradle-serialization:
 	@echo "==> Checking Gradle target serialization..."
 	@ruby ./scripts/check-gradle-serialization.rb

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -3,3 +3,18 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.serialization) apply false
 }
+
+// Pin javac's source encoding for every module (#669). Kotlin itself is not
+// exposed — the language spec fixes source files at UTF-8 and kotlinc has no
+// encoding flag — but the kotlin-jvm plugin applies the `java` plugin, so each
+// module carries JavaCompile tasks that default to the platform charset and
+// would read UTF-8 prose as US-ASCII under a C locale. No module has Java
+// sources today, so this is prophylactic here: it is the first `.java` file (or
+// a KMP `withJava()`) that would otherwise reintroduce the bug silently, which
+// is exactly the moment nobody would think to look. Configured once at the root
+// rather than four times so a new module inherits it.
+subprojects {
+    tasks.withType<JavaCompile>().configureEach {
+        options.encoding = "UTF-8"
+    }
+}

--- a/scripts/check-gradle-serialization.rb
+++ b/scripts/check-gradle-serialization.rb
@@ -300,6 +300,19 @@ def read_make_database(makefile)
       next
     end
 
+    # Target-specific variables, GNU make 4.x spelling: printed as a TOP-LEVEL
+    # `target: NAME = value` line, which the rule regex below would otherwise
+    # read as a target with the prerequisites "NAME", "=" and "value" — bogus
+    # edges that could mask a real collision. 3.81 prints the same thing as a
+    # comment inside the target's block (handled above), and prints nothing
+    # here. Both spellings are parsed because the two disagree and CI runs the
+    # one this was not developed on: 4.4.1 is where the comment-only version
+    # failed, and it failed loudly rather than silently, which is the one mercy.
+    if (tvar = /\A([^:=#]+):\s*([A-Za-z_][^\s=]*) *[:+?]?= *(.*)\z/.match(line))
+      target_variables[tvar[1].strip][tvar[2]] = tvar[3]
+      next
+    end
+
     # `target: normal-prereqs | order-only-prereqs`
     match = /\A([^:=#]+):(?!=)(.*)\z/.match(line)
     next if match.nil?

--- a/scripts/check-gradle-serialization.rb
+++ b/scripts/check-gradle-serialization.rb
@@ -81,7 +81,12 @@
 #      A target may build in MORE THAN ONE project directory, and belongs to a
 #      group for each. Recording only its first invocation left the second in no
 #      group at all, so a target correctly ordered against the Kotlin chain could
-#      still overlap the mapper targets with its second command.
+#      still overlap the mapper targets with its second command. That has to be
+#      TOTAL at every nesting level — every recipe line, every invocation on a
+#      line, every invocation in a delegated script — and the counts must
+#      balance: an occurrence the pattern cannot place makes the whole line
+#      unplaceable rather than quietly dropping one directory. Fixing it per
+#      recipe but not per line was itself one review round of partial.
 #
 #   4. TEXTUAL, AND IT ERRS TOWARD REPORTING. Nothing is executed, so a
 #      `./gradlew` inside a shell heredoc is taken at face value. That direction
@@ -283,10 +288,10 @@ def scan_shell_for_gradle(text)
   code = text.lines.reject { |l| l.match?(/\A\s*#/) }.join.gsub(/\\\n\s*/, " ")
   return nil unless code.include?("./gradlew")
 
-  matched = code.match(%r{cd\s+["']?([^"'\s]+)["']?\s*&&[^\n]*?\./gradlew})
-  return matched[1] if matched
+  dirs = code.scan(%r{cd\s+["']?([^"'\s]+)["']?\s*&&[^\n]*?\./gradlew}).flatten
+  return :unplaceable if dirs.size != code.scan("./gradlew").size
 
-  :unplaceable
+  dirs
 end
 
 # `$ROOT_DIR/kotlin` -> `kotlin`. Exactly one leading shell variable is stripped
@@ -320,8 +325,10 @@ def delegated_gradle_dir(lines, repo_root)
       next if found.nil?
       return [:unplaceable, rel] if found == :unplaceable
 
-      resolved = resolve_script_dir(found, repo_root)
-      return [resolved == :unplaceable ? :unplaceable : resolved, rel]
+      resolved = found.map { |dir| resolve_script_dir(dir, repo_root) }
+      return [:unplaceable, rel] if resolved.include?(:unplaceable)
+
+      return [resolved, rel]
     end
   end
   nil
@@ -370,19 +377,34 @@ def gradle_targets(recipes, makefile, variables = {}, repo_root = REPO_ROOT)
 
     unless direct.empty?
       direct.each do |line|
-        matched = line.match(%r{cd\s+(\S+)\s*&&\s*\./gradlew})
-        if matched && matched[1].include?("$")
+        # EVERY invocation on the line, and the count must balance. Taking the
+        # first match made the per-recipe fix above total per TARGET but not per
+        # LINE, so `cd kotlin && ./gradlew help; cd spec/… && ./gradlew help`
+        # was filed under kotlin/ alone. Requiring dirs.size to equal the number
+        # of `./gradlew` occurrences is what makes it total rather than one
+        # nesting level less partial: an invocation this cannot place is an
+        # unplaceable LINE, not a silently dropped directory.
+        dirs = line.scan(%r{cd\s+(\S+)\s*&&\s*\./gradlew}).flatten
+        occurrences = line.scan("./gradlew").size
+
+        if dirs.size != occurrences
+          if dirs.empty? && occurrences == 1 && line.match?(%r{\A\s*\./gradlew})
+            (found[target] ||= Set.new) << "."
+          else
+            unrecognized << [target, line]
+          end
+          next
+        end
+
+        if dirs.any? { |dir| dir.include?("$") }
           # Not resolvable from the database text, and guessing would put this
           # target in a group of its own — the same silent pass the spelling bug
           # caused.
           unrecognized << [target, line]
-        elsif matched
-          (found[target] ||= Set.new) << canonical_dir(matched[1], repo_root)
-        elsif line.match?(%r{\A\s*\./gradlew})
-          (found[target] ||= Set.new) << "."
-        else
-          unrecognized << [target, line]
+          next
         end
+
+        dirs.each { |dir| (found[target] ||= Set.new) << canonical_dir(dir, repo_root) }
       end
       next
     end
@@ -395,7 +417,7 @@ def gradle_targets(recipes, makefile, variables = {}, repo_root = REPO_ROOT)
     else
       # Canonicalized through the same funnel as a direct recipe: a delegated
       # `cd "$ROOT_DIR/./kotlin"` has to group with a direct `cd kotlin`.
-      (found[target] ||= Set.new) << canonical_dir(dir, repo_root)
+      dir.each { |d| (found[target] ||= Set.new) << canonical_dir(d, repo_root) }
     end
   end
 

--- a/scripts/check-gradle-serialization.rb
+++ b/scripts/check-gradle-serialization.rb
@@ -31,7 +31,7 @@
 # ordered by that relation. That is the mechanism, and it goes red the moment an
 # edge is deleted.
 #
-# COVERAGE, HONESTLY. Three boundaries, and none of them is "every Gradle
+# COVERAGE, HONESTLY. Four boundaries, and none of them is "every Gradle
 # target":
 #
 #   1. ONE GOAL. Only targets reachable from check-targets (by default), because
@@ -56,7 +56,13 @@
 #      classify the gate as a Gradle build in kotlin/ and fail on the real
 #      Makefile.
 #
-#   3. TEXTUAL, AND IT ERRS TOWARD REPORTING. The delegation scan reads source,
+#   3. THE KEY IS A PHYSICAL DIRECTORY, NOT A SPELLING. `cd ./kotlin` and
+#      `cd kotlin` are canonicalized to one group; an unresolvable spelling — a
+#      make variable, a shell variable this gate will not guess at — is a hard
+#      error, not a group of one. Grouping on raw text was a real bypass, caught
+#      in review: two spellings became two trivially-serialized groups.
+#
+#   4. TEXTUAL, AND IT ERRS TOWARD REPORTING. The delegation scan reads source,
 #      it does not execute anything, so a `./gradlew` inside a shell heredoc
 #      would be taken at face value. That direction is deliberate: a false
 #      positive costs one unnecessary order-only edge and says so out loud; a
@@ -235,6 +241,20 @@ def delegated_gradle_dir(lines, repo_root)
   nil
 end
 
+# The grouping key is a PHYSICAL directory, so it has to survive being spelled
+# differently. `cd ./kotlin` and `cd kotlin` are the same Gradle project and must
+# land in the same group; grouping on the raw text put them in two groups of one,
+# each trivially "serialized", and a new target spelled the other way would have
+# walked through the gate. `kotlin/`, `kotlin/.` and `spec/../kotlin` are the same
+# hazard. Normalize to a repo-relative cleanpath before anything is compared.
+def canonical_dir(raw, repo_root)
+  root = File.expand_path(repo_root)
+  absolute = File.expand_path(raw, root)
+  return "." if absolute == root
+
+  absolute.start_with?("#{root}/") ? absolute.delete_prefix("#{root}/") : absolute
+end
+
 def gradle_targets(recipes, makefile, repo_root = REPO_ROOT)
   found = {}
   unrecognized = []
@@ -244,8 +264,13 @@ def gradle_targets(recipes, makefile, repo_root = REPO_ROOT)
 
     if direct
       matched = direct.match(%r{cd\s+(\S+)\s*&&\s*\./gradlew})
-      if matched
-        found[target] = matched[1]
+      if matched && matched[1].include?("$")
+        # A make variable is not resolvable from the database text, and guessing
+        # would put this target in a group of its own — the same silent pass the
+        # spelling bug caused.
+        unrecognized << [target, direct]
+      elsif matched
+        found[target] = canonical_dir(matched[1], repo_root)
       elsif direct.match?(%r{\A\s*\./gradlew})
         found[target] = "."
       else
@@ -260,7 +285,9 @@ def gradle_targets(recipes, makefile, repo_root = REPO_ROOT)
     if dir == :unplaceable
       unrecognized << [target, "delegates to #{via}, which invokes Gradle in a directory this gate cannot resolve"]
     else
-      found[target] = dir
+      # Canonicalized through the same funnel as a direct recipe: a delegated
+      # `cd "$ROOT_DIR/./kotlin"` has to group with a direct `cd kotlin`.
+      found[target] = canonical_dir(dir, repo_root)
     end
   end
 

--- a/scripts/check-gradle-serialization.rb
+++ b/scripts/check-gradle-serialization.rb
@@ -112,12 +112,29 @@
 # way, and direct and delegated are unioned rather than treated as alternatives.
 # If you add a step, add it to both, or the next round finds it.
 #
+# ONE DEFECT HAS A DIFFERENT SHAPE, AND IT ARRIVED LAST. Every finding above is
+# a silent pass — the gate says yes when it should say no. Target-specific
+# variables were the opposite: make -p prints them inside a target's block as
+# comments, so expansion never saw them, `$(PROJECT)` stayed unresolved, and the
+# fail-loud `$`-guard refused to run. The gate said NO when it should have said
+# YES. That matters for how the fail-loud default is read: erring toward
+# reporting is the right direction for a guard, but it is not free, and a guard
+# that cannot be run is not a safe default either. Case 25 pins it.
+#
 # SCORE THE CONTROL, NOT THE INCREMENT. Every one of those twelve fixes cleared
 # "small and obviously correct" on its own, and that is precisely how a control
 # nobody sized gets built. The honest tally: the rules this gate applies have
 # grown at every round; the CALL SITES it covers have grown exactly once, when
 # delegation brought in kt-check-generated-drift. Everything since has been the
 # same five targets, parsed harder.
+#
+# The count is now SEVEN rounds and fifteen defects, and one of them — the
+# delegate scan returning on the first script — was the FIFTH appearance of a
+# single defect: an operation made total at one nesting level and left partial at
+# the next. Lines, then per-line invocations, then scripts, then direct-plus-
+# delegated, then the delegate loop itself. That is not five findings; it is one
+# finding found five times, which is the clearest possible evidence about the
+# instrument rather than about any rule.
 #
 # So: NO MORE SELECTORS. A further parsing variation is not a task, it is the
 # signal to switch instruments, and the two candidates are written down here so
@@ -218,6 +235,7 @@ def read_make_database(makefile)
   graph = {}
   recipes = Hash.new { |h, k| h[k] = [] }
   variables = {}
+  target_variables = Hash.new { |h, k| h[k] = {} }
 
   in_variables = false
   in_files = false
@@ -269,6 +287,16 @@ def read_make_database(makefile)
 
     if line.start_with?("#")
       not_a_target = true if line.include?("Not a target")
+      # Target-specific variables (`probe: PROJECT = kotlin`) never reach the
+      # rule parser below: make -p prints them INSIDE the target's block as
+      # comments, which is also why they were invisible to recipe expansion —
+      # `$(PROJECT)` stayed unresolved and tripped the fail-loud `$`-guard, so
+      # the symptom was the gate refusing to run rather than a silent pass.
+      # `# Load=77/1024=8%` and friends carry no spaces around `=` and so do not
+      # match.
+      if current && (tvar = /\A#\s*([A-Za-z_][^\s=]*) *[:+?]?= (.*)\z/.match(line))
+        target_variables[current][tvar[1]] = tvar[2]
+      end
       next
     end
 
@@ -287,7 +315,7 @@ def read_make_database(makefile)
     (graph[target] ||= Set.new).merge(prereqs)
   end
 
-  [graph, recipes, variables]
+  [graph, recipes, variables, target_variables]
 end
 
 # Substitute make's own variable values into a recipe line, so what gets matched
@@ -379,7 +407,16 @@ def resolve_script_dir(raw, repo_root)
   dir
 end
 
+# EVERY delegated script, not the first. Returning on the first one repeated, at
+# the outermost nesting level, the same partiality the line and per-script scans
+# already had to be fixed for: a target delegating to two scripts kept only the
+# first script's projects, so it could be correctly chained for one and race
+# another target in the other.
 def delegated_gradle_dir(lines, repo_root)
+  dirs = []
+  vias = []
+  unplaceable_via = nil
+
   lines.each do |line|
     # Lookbehind rather than a leading-character class: the live case is
     # `@./scripts/check-kotlin-generated-drift.sh`, and make's recipe prefixes
@@ -396,15 +433,27 @@ def delegated_gradle_dir(lines, repo_root)
 
       found = scan_shell_for_gradle(source)
       next if found.nil?
-      return [:unplaceable, rel] if found == :unplaceable
+
+      if found == :unplaceable
+        unplaceable_via ||= rel
+        next
+      end
 
       resolved = found.map { |dir| resolve_script_dir(dir, repo_root) }
-      return [:unplaceable, rel] if resolved.include?(:unplaceable)
+      if resolved.include?(:unplaceable)
+        unplaceable_via ||= rel
+        next
+      end
 
-      return [resolved, rel]
+      dirs.concat(resolved)
+      vias << rel
     end
   end
-  nil
+
+  return [:unplaceable, unplaceable_via] if unplaceable_via
+  return nil if dirs.empty?
+
+  [dirs, vias.uniq.join(", ")]
 end
 
 # The grouping key is a PHYSICAL directory, so it has to survive being spelled
@@ -435,12 +484,14 @@ def canonical_dir(raw, repo_root)
   absolute.start_with?("#{root}/") ? absolute.delete_prefix("#{root}/") : absolute
 end
 
-def gradle_targets(recipes, makefile, variables = {}, repo_root = REPO_ROOT)
+def gradle_targets(recipes, makefile, variables = {}, target_variables = {}, repo_root = REPO_ROOT)
   found = {}
   unrecognized = []
 
   recipes.each do |target, raw_lines|
-    lines = join_continuations(raw_lines.map { |line| expand_variables(line, variables) })
+    # Target-specific variables shadow global ones, as make itself resolves them.
+    scope = variables.merge(target_variables[target] || {})
+    lines = join_continuations(raw_lines.map { |line| expand_variables(line, scope) })
     # EVERY line, not the first match: one recipe may build in two projects, and
     # recording only its first invocation left the second in no group at all —
     # so a target ordered after the Kotlin chain could still overlap the mapper
@@ -522,10 +573,10 @@ def reachable_from(graph, root)
   seen
 end
 
-graph, recipes, variables = read_make_database(MAKEFILE)
+graph, recipes, variables, target_variables = read_make_database(MAKEFILE)
 die "goal #{GOAL} is not defined in #{MAKEFILE}" unless graph.key?(GOAL)
 
-gradle = gradle_targets(recipes, MAKEFILE, variables)
+gradle = gradle_targets(recipes, MAKEFILE, variables, target_variables)
 die "found no Gradle-backed targets in #{MAKEFILE} — the recipe shape this " \
     "gate matches (`cd <dir> && ./gradlew`) must have changed" if gradle.empty?
 

--- a/scripts/check-gradle-serialization.rb
+++ b/scripts/check-gradle-serialization.rb
@@ -56,18 +56,33 @@
 #      classify the gate as a Gradle build in kotlin/ and fail on the real
 #      Makefile.
 #
-#   3. THE KEY IS A PHYSICAL DIRECTORY, NOT A SPELLING. `cd ./kotlin` and
-#      `cd kotlin` are canonicalized to one group; an unresolvable spelling — a
-#      make variable, a shell variable this gate will not guess at — is a hard
-#      error, not a group of one. Grouping on raw text was a real bypass, caught
-#      in review: two spellings became two trivially-serialized groups.
+#   3. IT READS THE COMMAND, NOT THE TEXT — and that is a correction, not a
+#      boast. Three review rounds each produced one spelling that walked past a
+#      literal-text scan: `cd ./kotlin` (own group of one), `cd "kotlin"`
+#      (quotes as pathname characters), `$(GRADLE_WRAPPER)` (the wrapper itself
+#      behind a make variable, so the word "gradlew" never appeared). Each was a
+#      SILENT PASS in a control whose whole job is to catch the target nobody
+#      has written yet, and a fourth spelling would have been a fourth matcher
+#      arm. So the question moved to the layer make already answers: recipes are
+#      expanded against make's own variable database, quotes are stripped in the
+#      one place a directory becomes a grouping key, and paths are canonicalized
+#      to a repo-relative cleanpath. One funnel, not one arm per spelling.
 #
-#   4. TEXTUAL, AND IT ERRS TOWARD REPORTING. The delegation scan reads source,
-#      it does not execute anything, so a `./gradlew` inside a shell heredoc
-#      would be taken at face value. That direction is deliberate: a false
-#      positive costs one unnecessary order-only edge and says so out loud; a
-#      false negative costs the guarantee silently. An invocation it cannot
-#      place is a hard error for the same reason.
+#      WHAT THAT STILL DOES NOT REACH, precisely:
+#        - a value only a RUNNING shell knows (`cd $$RUNTIME_DIR`, `$(shell …)`).
+#          Hard error, not a silent pass — the fail-loud side.
+#        - a `define`/`endef` multi-line variable holding the Gradle call. That
+#          one WOULD be missed silently: the reference stays unexpanded, so no
+#          `gradlew` token appears and the target is never classified. Nothing in
+#          this repo does it, and closing it means teaching this gate a second
+#          slice of make's grammar — recorded here rather than guessed at, so the
+#          next reader knows it is a hole and not an oversight.
+#
+#   4. TEXTUAL, AND IT ERRS TOWARD REPORTING. Nothing is executed, so a
+#      `./gradlew` inside a shell heredoc is taken at face value. That direction
+#      is deliberate: a false positive costs one unnecessary order-only edge and
+#      says so out loud; a false negative costs the guarantee silently. An
+#      invocation it cannot place is a hard error for the same reason.
 #
 # Env overrides (used by scripts/test-check-gradle-serialization.rb):
 #   GRADLE_SERIALIZATION_MAKEFILE  makefile to read (default: Makefile)
@@ -119,7 +134,9 @@ def read_make_database(makefile)
 
   graph = {}
   recipes = Hash.new { |h, k| h[k] = [] }
+  variables = {}
 
+  in_variables = false
   in_files = false
   current = nil
   not_a_target = false
@@ -127,12 +144,32 @@ def read_make_database(makefile)
   dump.each_line do |raw|
     line = raw.chomp
 
+    # The "# Variables" section holds make's own values for every variable it
+    # knows. Reading it is what lets the recipe scan below see the COMMAND make
+    # would run rather than the text someone typed.
+    if line.start_with?("# Variables")
+      in_variables = true
+      next
+    end
+
     # The "# Files" section holds the target database. Everything before it is
     # variables and implicit rules; everything after is hash-table statistics.
     if line.start_with?("# Files")
+      in_variables = false
       in_files = true
       next
     end
+
+    if in_variables
+      # `NAME = value`, `NAME := value`, `NAME ?= value`. Multi-line `define`
+      # blocks are skipped: nothing in this repo puts a Gradle call in one, and
+      # half-reading one would be worse than not reading it.
+      if (var = /\A(\w+) *[:?+]?= ?(.*)\z/.match(line))
+        variables[var[1]] = var[2]
+      end
+      next
+    end
+
     next unless in_files
     break if line.start_with?("# files hash-table stats", "# VPATH Search Paths")
 
@@ -167,7 +204,28 @@ def read_make_database(makefile)
     (graph[target] ||= Set.new).merge(prereqs)
   end
 
-  [graph, recipes]
+  [graph, recipes, variables]
+end
+
+# Substitute make's own variable values into a recipe line, so what gets matched
+# is the command make would run. Bounded passes because a value may itself hold
+# a reference; an unknown name is left alone, which lands it in the fail-loud
+# `$`-guard rather than being quietly dropped.
+#
+# This exists because the alternative is a matcher that keeps growing: a review
+# round found `cd kotlin && $(GRADLE_WRAPPER) help` invisible to a literal-text
+# scan, and the round before found `cd ./kotlin` in its own group. Both are the
+# same defect — reading the text instead of the command — and widening the
+# pattern for each spelling is how a control nobody sized gets built. Expanding
+# once, from make's own database, is the layer the question actually lives at.
+def expand_variables(text, variables, passes: 5)
+  passes.times do
+    expanded = text.gsub(/\$[({](\w+)[)}]/) { variables.fetch(Regexp.last_match(1), Regexp.last_match(0)) }
+    return expanded if expanded == text
+
+    text = expanded
+  end
+  text
 end
 
 # Every target whose recipe shells out to a Gradle wrapper, mapped to the
@@ -248,18 +306,22 @@ end
 # walked through the gate. `kotlin/`, `kotlin/.` and `spec/../kotlin` are the same
 # hazard. Normalize to a repo-relative cleanpath before anything is compared.
 def canonical_dir(raw, repo_root)
+  # `cd "kotlin"` is `cd kotlin`. Dequoting lives here, in the one place a
+  # directory becomes a grouping key, rather than as another arm of the matcher.
+  unquoted = raw.sub(/\A(["'])(.*)\1\z/) { Regexp.last_match(2) }
   root = File.expand_path(repo_root)
-  absolute = File.expand_path(raw, root)
+  absolute = File.expand_path(unquoted, root)
   return "." if absolute == root
 
   absolute.start_with?("#{root}/") ? absolute.delete_prefix("#{root}/") : absolute
 end
 
-def gradle_targets(recipes, makefile, repo_root = REPO_ROOT)
+def gradle_targets(recipes, makefile, variables = {}, repo_root = REPO_ROOT)
   found = {}
   unrecognized = []
 
-  recipes.each do |target, lines|
+  recipes.each do |target, raw_lines|
+    lines = raw_lines.map { |line| expand_variables(line, variables) }
     direct = lines.find { |line| line.include?("./gradlew") }
 
     if direct
@@ -318,10 +380,10 @@ def reachable_from(graph, root)
   seen
 end
 
-graph, recipes = read_make_database(MAKEFILE)
+graph, recipes, variables = read_make_database(MAKEFILE)
 die "goal #{GOAL} is not defined in #{MAKEFILE}" unless graph.key?(GOAL)
 
-gradle = gradle_targets(recipes, MAKEFILE)
+gradle = gradle_targets(recipes, MAKEFILE, variables)
 die "found no Gradle-backed targets in #{MAKEFILE} — the recipe shape this " \
     "gate matches (`cd <dir> && ./gradlew`) must have changed" if gradle.empty?
 

--- a/scripts/check-gradle-serialization.rb
+++ b/scripts/check-gradle-serialization.rb
@@ -94,14 +94,23 @@
 #      says so out loud; a false negative costs the guarantee silently. An
 #      invocation it cannot place is a hard error for the same reason.
 #
-# WHY THIS KEEPS FINDING THINGS, AND THE END-STATE IT IS NOT. Four review rounds
-# produced eight defects in this gate, every one of them a SILENT PASS: an
+# WHY THIS KEEPS FINDING THINGS, AND THE END-STATE IT IS NOT. Six review rounds
+# produced twelve defects in this gate, every one of them a SILENT PASS: an
 # undiscovered target, then a spelling, then two spellings, then a variable-name
-# charset, a symlink alias, and a target with two directories. That tail is a
-# property of the instrument — static analysis of a shell-embedded DSL — and not
-# of any one selector, which is why the last two rounds were answered at the
-# funnel (expand from make's database, canonicalize in one place, model a target
-# as a SET of directories) rather than with a matcher arm apiece.
+# charset, a symlink alias, a target with two directories, two invocations on one
+# line, a continued line, and a target that both called Gradle and delegated.
+# That tail is a property of the instrument — static analysis of a shell-embedded
+# DSL — and not of any one selector, which is why the later rounds were answered
+# at the funnel (expand from make's database, canonicalize in one place, model a
+# target as a SET of directories, fold continuations and union direct with
+# delegated everywhere) rather than with a matcher arm apiece.
+#
+# The recurring shape is worth naming for whoever extends this: nearly every
+# defect was an operation applied in ONE of the two scanning paths and not the
+# other, or applied at one nesting level and not the one below. Recipes and
+# delegated scripts are now folded, expanded, scanned and canonicalized the same
+# way, and direct and delegated are unioned rather than treated as alternatives.
+# If you add a step, add it to both, or the next round finds it.
 #
 # The structural end-state is different and is deliberately NOT built here: make
 # every Gradle call go through one sanctioned entry point, then this gate reduces
@@ -280,6 +289,24 @@ end
 # invisible: added to check-targets it is the exact "sixth target" case this
 # gate exists to reject, and the gate would have passed.
 
+# Fold `foo && \` + `bar` into one logical command. make -p prints a recipe's
+# continued lines separately, and the conventional wrapped form
+# `cd spec/smithy-bare-arrays && \` / `./gradlew help` then read as a bare
+# repo-root invocation with the directory thrown away. The delegated-script scan
+# already did this folding; the recipe scan did not, which is the whole of that
+# defect — the same operation applied in one place and not the other.
+def join_continuations(lines)
+  folded = []
+  lines.each do |line|
+    if !folded.empty? && folded.last.end_with?("\\")
+      folded[-1] = "#{folded.last.chomp('\\')} #{line.strip}"
+    else
+      folded << line
+    end
+  end
+  folded
+end
+
 # Scan shell text for a Gradle invocation. Returns the project directory as
 # written, :unplaceable, or nil. Continuations are joined and whole-line
 # comments dropped first, so a wrapped invocation reads as one command and a
@@ -367,7 +394,7 @@ def gradle_targets(recipes, makefile, variables = {}, repo_root = REPO_ROOT)
   unrecognized = []
 
   recipes.each do |target, raw_lines|
-    lines = raw_lines.map { |line| expand_variables(line, variables) }
+    lines = join_continuations(raw_lines.map { |line| expand_variables(line, variables) })
     # EVERY line, not the first match: one recipe may build in two projects, and
     # recording only its first invocation left the second in no group at all —
     # so a target ordered after the Kotlin chain could still overlap the mapper
@@ -375,40 +402,41 @@ def gradle_targets(recipes, makefile, variables = {}, repo_root = REPO_ROOT)
     # has directories.
     direct = lines.select { |line| line.include?("./gradlew") }
 
-    unless direct.empty?
-      direct.each do |line|
-        # EVERY invocation on the line, and the count must balance. Taking the
-        # first match made the per-recipe fix above total per TARGET but not per
-        # LINE, so `cd kotlin && ./gradlew help; cd spec/… && ./gradlew help`
-        # was filed under kotlin/ alone. Requiring dirs.size to equal the number
-        # of `./gradlew` occurrences is what makes it total rather than one
+    direct.each do |line|
+      # EVERY invocation on the line, and the count must balance. Taking the
+      # first match made the per-recipe fix above total per TARGET but not per
+      # LINE, so `cd kotlin && ./gradlew help; cd spec/… && ./gradlew help`
+      # was filed under kotlin/ alone. Requiring dirs.size to equal the number
+      # of `./gradlew` occurrences is what makes it total rather than one
         # nesting level less partial: an invocation this cannot place is an
-        # unplaceable LINE, not a silently dropped directory.
-        dirs = line.scan(%r{cd\s+(\S+)\s*&&\s*\./gradlew}).flatten
-        occurrences = line.scan("./gradlew").size
+      # unplaceable LINE, not a silently dropped directory.
+      dirs = line.scan(%r{cd\s+(\S+)\s*&&\s*\./gradlew}).flatten
+      occurrences = line.scan("./gradlew").size
 
-        if dirs.size != occurrences
-          if dirs.empty? && occurrences == 1 && line.match?(%r{\A\s*\./gradlew})
-            (found[target] ||= Set.new) << "."
-          else
-            unrecognized << [target, line]
-          end
-          next
-        end
-
-        if dirs.any? { |dir| dir.include?("$") }
-          # Not resolvable from the database text, and guessing would put this
-          # target in a group of its own — the same silent pass the spelling bug
-          # caused.
+      if dirs.size != occurrences
+        if dirs.empty? && occurrences == 1 && line.match?(%r{\A\s*\./gradlew})
+          (found[target] ||= Set.new) << "."
+        else
           unrecognized << [target, line]
-          next
         end
-
-        dirs.each { |dir| (found[target] ||= Set.new) << canonical_dir(dir, repo_root) }
+        next
       end
-      next
+
+      if dirs.any? { |dir| dir.include?("$") }
+        # Not resolvable from the database text, and guessing would put this
+        # target in a group of its own — the same silent pass the spelling bug
+        # caused.
+        unrecognized << [target, line]
+        next
+      end
+
+      dirs.each { |dir| (found[target] ||= Set.new) << canonical_dir(dir, repo_root) }
     end
 
+    # NOT `next` when a direct call was found: one target may do both, and
+    # skipping the delegate scan then dropped the script's project entirely.
+    # Direct and delegated are two ways to reach Gradle, not two kinds of
+    # target, so both are always scanned and the results union.
     dir, via = delegated_gradle_dir(lines, repo_root)
     next if dir.nil?
 

--- a/scripts/check-gradle-serialization.rb
+++ b/scripts/check-gradle-serialization.rb
@@ -34,7 +34,12 @@
 # COVERAGE, HONESTLY. Four boundaries, and none of them is "every Gradle
 # target":
 #
-#   1. ONE GOAL. Only targets reachable from check-targets (by default), because
+#   1. ONE GOAL — and it bounds what this gate TOUCHES, not just what it
+#      reports. Only recipes reachable from the goal are scanned at all; an
+#      earlier cut filtered the scan's RESULTS instead, which left it opening
+#      delegated scripts belonging to targets it had already declared out of
+#      scope, where an undecodable byte took the whole gate down. Only targets
+#      reachable from check-targets (by default), because
 #      that is the graph `make check` executes. kt-check-generated-drift is
 #      DISCOVERED (see 2) but not COVERED: `make check` cannot schedule it, so
 #      it collides with nothing there, while a hand-written
@@ -248,7 +253,7 @@ def read_make_database(makefile)
     { "MAKEFLAGS" => "", "MAKELEVEL" => "0" },
     ["make", "-p", "-n", "--no-print-directory", "-f", makefile, PROBE_GOAL],
     err: File::NULL, external_encoding: Encoding::UTF_8, &:read
-  )
+  )&.scrub
   die "could not read make's database from #{makefile}" if dump.nil? || dump.empty?
 
   graph = {}
@@ -459,7 +464,16 @@ def delegated_gradle_dir(lines, repo_root)
 
       # UTF-8 pinned for the same reason as the pipe read above: these scripts
       # carry em-dashes, and LC_ALL=C would make an unpinned read US-ASCII.
-      source = File.read(path, encoding: "UTF-8")
+      # Pinned AND scrubbed. The pin alone only decides how the bytes are
+      # TAGGED; it does not make them valid, and the first regex over a string
+      # holding an invalid sequence raises ArgumentError. That is #669's own bug
+      # class — the one this PR exists to fix — resurfacing inside the gate that
+      # ships with it, because this is the one place the gate reads arbitrary
+      # repo bytes rather than make's output. Scrubbing keeps a guard that can
+      # RUN: every pattern below is ASCII, so replacing an undecodable byte
+      # cannot hide a Gradle invocation, while raising would take out `make
+      # check` over a comment in a shell script.
+      source = File.read(path, encoding: "UTF-8").scrub
       shebang = source.lines.first.to_s
       next unless shebang.start_with?("#!") && shebang.match?(/\b(?:ba|da|k|z)?sh\b/)
 
@@ -616,16 +630,21 @@ end
 graph, recipes, variables, target_variables = read_make_database(MAKEFILE)
 die "goal #{GOAL} is not defined in #{MAKEFILE}" unless graph.key?(GOAL)
 
-gradle, unrecognized = gradle_targets(recipes, MAKEFILE, variables, target_variables)
+# Reachability BEFORE the scan, not after it. Filtering the scan's RESULTS left
+# the scan itself running over every recipe in the database, so an out-of-scope
+# target could still take the gate down from inside — reading a delegated script
+# it was never scoped to read. Boundary 1 has to bind what this gate TOUCHES,
+# not just what it reports. It is also strictly less work.
+in_goal = reachable_from(graph, GOAL)
+in_scope = recipes.select { |target, _| in_goal.include?(target) }
+
+gradle, unrecognized = gradle_targets(in_scope, MAKEFILE, variables, target_variables)
 die "found no Gradle-backed targets in #{MAKEFILE} — the recipe shape this " \
     "gate matches (`cd <dir> && ./gradlew`) must have changed" if gradle.empty?
 
-in_goal = reachable_from(graph, GOAL)
-
-# Scope first, complain second — boundary 1 applies to errors as well as to
-# collisions.
-report_unrecognized(unrecognized.select { |target, _| in_goal.include?(target) }, MAKEFILE)
-covered = gradle.select { |target, _| in_goal.include?(target) }
+# No scope filter needed here any more: nothing out of scope was ever scanned.
+report_unrecognized(unrecognized, MAKEFILE)
+covered = gradle
 
 # dir => targets that build in it. A target with two directories appears twice,
 # and must be ordered against the others in BOTH.

--- a/scripts/check-gradle-serialization.rb
+++ b/scripts/check-gradle-serialization.rb
@@ -1,0 +1,242 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# check-gradle-serialization — assert `make -j` can never schedule two Gradle
+# invocations in the same project directory (#674).
+#
+# THE HAZARD. Two concurrent Gradle builds sharing one project directory share
+# <project>/.gradle (file-hash and task-history caches — the FilePageCache) and
+# write the same task output directories. Gradle's cross-process locks serialize
+# the caches; nothing serializes the outputs. `check-targets` lists five
+# Gradle-backed targets as INDEPENDENT prerequisites, in two project
+# directories:
+#
+#   spec/smithy-bare-arrays   smithy-mapper (via smithy-check), smithy-mapper-test
+#   kotlin                    kt-test (via kt-check), conformance-runner-tests-kotlin,
+#                             conformance-kotlin (both via conformance)
+#
+# The fix is order-only prerequisites in the Makefile that chain each group into
+# a total order. This gate asserts those edges are there — and, more usefully,
+# that a SIXTH Gradle target added to check-targets tomorrow cannot land
+# unchained.
+#
+# WHY A GRAPH CHECK AND NOT A STRESS TEST. Running `make -j16 check` repeatedly
+# and watching for a failure measures luck, not the fix: two concurrent Gradle
+# builds in one directory usually survive (measured — see the PR that added
+# this), which is exactly why the collision sat unnoticed. What is decidable is
+# the schedule. If X is a transitive prerequisite of Y — order-only or not —
+# make cannot start Y's recipe until X's has finished. So this reads make's own
+# parsed database (`make -p`, not a hand-rolled Makefile parser) and asserts
+# that within each project directory the reachable Gradle targets are totally
+# ordered by that relation. That is the mechanism, and it goes red the moment an
+# edge is deleted.
+#
+# COVERAGE, HONESTLY. This checks the targets reachable from ONE goal
+# (check-targets by default), because that is the graph `make check` executes.
+# Gradle-backed targets outside it — kt-check-generated-drift is the live
+# example — are NOT covered: `make check` cannot schedule them, but a
+# hand-written `make -j kt-check kt-check-generated-drift` still can. Chaining
+# those would charge CI, which invokes them as standalone goals, for work it
+# already does a different way. Pass a different goal to check a different
+# graph.
+#
+# Env overrides (used by scripts/test-check-gradle-serialization.rb):
+#   GRADLE_SERIALIZATION_MAKEFILE  makefile to read (default: Makefile)
+#   GRADLE_SERIALIZATION_GOAL      goal to walk from (default: check-targets)
+
+require "English"
+require "set"
+
+MAKEFILE = ENV.fetch("GRADLE_SERIALIZATION_MAKEFILE", "Makefile")
+GOAL = ENV.fetch("GRADLE_SERIALIZATION_GOAL", "check-targets")
+
+# A goal make cannot resolve: make prints its whole parsed database, then exits
+# non-zero without running or recursing into a single recipe. Asking for a real
+# goal under -n would recurse into every `$(MAKE)` sub-make, which make runs even
+# in dry-run mode.
+PROBE_GOAL = "__gradle_serialization_probe__"
+
+def die(message)
+  warn "ERROR: #{message}"
+  exit 1
+end
+
+# Make's database, parsed. Returns [graph, recipes]:
+#   graph[target]   => Set of prerequisites (order-only and normal alike; both
+#                      constrain the schedule identically, which is all we ask)
+#   recipes[target] => Array of recipe lines
+def read_make_database(makefile)
+  # MAKEFLAGS is cleared because this runs from inside `make check`: inheriting
+  # the parent's flags would hand the child a jobserver it cannot join (and, with
+  # a stale -j, a warning on every run). Nothing here needs them — the database
+  # is a parse of the makefile, not of the invocation.
+  #
+  # external_encoding is pinned for the same reason the Gradle builds beside this
+  # gate pin theirs (#669): under LC_ALL=C Ruby reads a pipe as US-ASCII, and the
+  # Makefile this dumps is full of em-dashed comments, so an unpinned read raises
+  # ArgumentError on the first one. Caught by `LC_ALL=C make`, not by `make`.
+  dump = IO.popen(
+    { "MAKEFLAGS" => "", "MAKELEVEL" => "0" },
+    ["make", "-p", "-n", "--no-print-directory", "-f", makefile, PROBE_GOAL],
+    err: File::NULL, external_encoding: Encoding::UTF_8, &:read
+  )
+  die "could not read make's database from #{makefile}" if dump.nil? || dump.empty?
+
+  graph = {}
+  recipes = Hash.new { |h, k| h[k] = [] }
+
+  in_files = false
+  current = nil
+  not_a_target = false
+
+  dump.each_line do |raw|
+    line = raw.chomp
+
+    # The "# Files" section holds the target database. Everything before it is
+    # variables and implicit rules; everything after is hash-table statistics.
+    if line.start_with?("# Files")
+      in_files = true
+      next
+    end
+    next unless in_files
+    break if line.start_with?("# files hash-table stats", "# VPATH Search Paths")
+
+    if line.empty?
+      current = nil
+      not_a_target = false
+      next
+    end
+
+    if line.start_with?("\t")
+      recipes[current] << line.sub(/\A\t/, "") if current
+      next
+    end
+
+    if line.start_with?("#")
+      not_a_target = true if line.include?("Not a target")
+      next
+    end
+
+    # `target: normal-prereqs | order-only-prereqs`
+    match = /\A([^:=#]+):(?!=)(.*)\z/.match(line)
+    next if match.nil?
+
+    if not_a_target
+      current = nil
+      next
+    end
+
+    target = match[1].strip
+    prereqs = match[2].tr("|", " ").split(/\s+/).reject(&:empty?)
+    current = target
+    (graph[target] ||= Set.new).merge(prereqs)
+  end
+
+  [graph, recipes]
+end
+
+# Every target whose recipe shells out to a Gradle wrapper, mapped to the
+# project directory it runs in — `cd <dir> && ./gradlew ...`, the only shape
+# this repo uses. A bare `./gradlew` would mean the repo root.
+#
+# An unrecognized shape is a hard error rather than a default, because the
+# default would be a SILENT PASS: a recipe spelled `cd kotlin; ./gradlew` would
+# be filed under the repo root, share a group with nothing, and be certified
+# collision-free while colliding with everything in kotlin/. The gate's own
+# blind spot is the one failure it must not have.
+def gradle_targets(recipes, makefile)
+  found = {}
+  unrecognized = []
+
+  recipes.each do |target, lines|
+    lines.each do |line|
+      next unless line.include?("./gradlew")
+
+      matched = line.match(%r{cd\s+(\S+)\s*&&\s*\./gradlew})
+      if matched
+        found[target] = matched[1]
+      elsif line.match?(%r{\A\s*\./gradlew})
+        found[target] = "."
+      else
+        unrecognized << [target, line]
+      end
+      break
+    end
+  end
+
+  unless unrecognized.empty?
+    warn "ERROR: cannot tell which project directory these Gradle recipes run in:"
+    unrecognized.each { |target, line| warn "  #{target}: #{line}" }
+    warn ""
+    warn "This gate reads `cd <dir> && ./gradlew ...`. Spell the recipe that way, " \
+         "or teach scripts/check-gradle-serialization.rb the new shape — do not " \
+         "leave it guessing, since a guess here passes silently. (#{makefile})"
+    exit 1
+  end
+
+  found
+end
+
+def reachable_from(graph, root)
+  seen = Set.new
+  stack = [root]
+  until stack.empty?
+    node = stack.pop
+    next unless seen.add?(node)
+
+    (graph[node] || []).each { |prereq| stack.push(prereq) }
+  end
+  seen
+end
+
+graph, recipes = read_make_database(MAKEFILE)
+die "goal #{GOAL} is not defined in #{MAKEFILE}" unless graph.key?(GOAL)
+
+gradle = gradle_targets(recipes, MAKEFILE)
+die "found no Gradle-backed targets in #{MAKEFILE} — the recipe shape this " \
+    "gate matches (`cd <dir> && ./gradlew`) must have changed" if gradle.empty?
+
+in_goal = reachable_from(graph, GOAL)
+covered = gradle.select { |target, _| in_goal.include?(target) }
+
+# Precompute each covered target's ancestry once; the pairwise test below is
+# "does one of the pair reach the other".
+closure = covered.keys.to_h { |target| [target, reachable_from(graph, target)] }
+
+violations = []
+chains = []
+
+covered.group_by { |_, dir| dir }.sort.each do |dir, entries|
+  targets = entries.map(&:first).sort
+  next if targets.size < 2
+
+  targets.combination(2).each do |a, b|
+    ordered = closure[a].include?(b) || closure[b].include?(a)
+    next if ordered
+
+    violations << [dir, a, b]
+  end
+
+  # Report the group in EXECUTION order when it is totally ordered: the target
+  # depending on the fewest others in its directory runs first.
+  ranked = targets.sort_by { |t| (closure[t] & targets).size }
+  chains << [dir, ranked]
+end
+
+if violations.empty?
+  chains.each do |dir, ranked|
+    puts "#{dir}: #{ranked.join(' -> ')}"
+  end
+  puts "Gradle targets reachable from #{GOAL} are serialized per project directory"
+  exit 0
+end
+
+warn "ERROR: `make -j #{GOAL}` can schedule two Gradle builds in one project directory."
+warn ""
+violations.each do |dir, a, b|
+  warn "  #{dir}: #{a} and #{b} are independent — neither is a prerequisite of the other"
+end
+warn ""
+warn "Add an order-only prerequisite (`target: | other-target`) chaining them."
+warn "See the anchor comment on smithy-mapper-test in the Makefile (#674)."
+exit 1

--- a/scripts/check-gradle-serialization.rb
+++ b/scripts/check-gradle-serialization.rb
@@ -112,14 +112,60 @@
 # way, and direct and delegated are unioned rather than treated as alternatives.
 # If you add a step, add it to both, or the next round finds it.
 #
-# The structural end-state is different and is deliberately NOT built here: make
-# every Gradle call go through one sanctioned entry point, then this gate reduces
-# to "no recipe mentions gradlew except through it" plus the ordering check, and
-# the parse surface collapses to one argument. That is a Makefile refactor, it
-# would not cover the one Gradle call that happens outside make entirely
-# (scripts/check-kotlin-generated-drift.sh), and it is not what the PR that added
-# this file set out to do. Named here so the next round of findings is read as
-# evidence about the instrument rather than as a queue of selectors.
+# SCORE THE CONTROL, NOT THE INCREMENT. Every one of those twelve fixes cleared
+# "small and obviously correct" on its own, and that is precisely how a control
+# nobody sized gets built. The honest tally: the rules this gate applies have
+# grown at every round; the CALL SITES it covers have grown exactly once, when
+# delegation brought in kt-check-generated-drift. Everything since has been the
+# same five targets, parsed harder.
+#
+# So: NO MORE SELECTORS. A further parsing variation is not a task, it is the
+# signal to switch instruments, and the two candidates are written down here so
+# nobody has to derive them under review pressure.
+#
+#   A. BOUND WHERE GRADLE CAN BE REACHED AT ALL. Route every Makefile Gradle
+#      invocation through one sanctioned variable or wrapper target. The gate
+#      then inspects a single place instead of recognizing every spelling of a
+#      recipe, and reduces to "no recipe mentions gradlew except through it" plus
+#      the ordering check — a syntactic invariant that holds for call sites not
+#      written yet, which is the thing a matcher can never promise. This is the
+#      structural fix. Recipe text has unbounded shapes; a regex will not
+#      enumerate them. Cost: a Makefile refactor, and it still would not cover
+#      the one Gradle call that happens outside make entirely
+#      (scripts/check-kotlin-generated-drift.sh) — that one needs its own rule.
+#
+#   B. ASSERT THE SCHEDULE INSTEAD OF PARSING THE TEXT. Put a shim on gradlew
+#      that records (project_dir, start, end) per invocation during a real
+#      `make -j16 check-targets`, then assert no two intervals for the same
+#      project directory overlap. That observes the mechanism itself, is immune
+#      to recipe syntax, and covers delegated scripts and non-make callers for
+#      free. Note this is NOT the run-to-failure approach already rejected
+#      above: two concurrent builds both exit 0, so watching for a failure
+#      measures luck — but RECORDING THE SCHEDULE measures the thing the gate
+#      actually claims. Cost: it needs a real parallel build, which may be too
+#      slow for CI, and it only sees the call sites that run.
+#
+# A and B are complementary, not alternatives: A holds a shape across call sites
+# that do not exist yet, B observes behaviour at the ones that execute. Neither
+# is built here, because this PR's subject is the missing order-only edges, not a
+# Gradle-discovery framework.
+#
+# WHAT THIS GATE CAN AND CANNOT SEE, so a green run is not over-read:
+#
+#   CAN   a `cd <dir> && ./gradlew` in a recipe, after make-variable expansion,
+#         continuation folding and quote stripping; the same one level deep in a
+#         shell script a recipe invokes; several invocations per line, per
+#         recipe and per script; the same directory under any spelling or
+#         symlink.
+#   CANNOT a Gradle call reached by a shape it does not parse: a `define`/`endef`
+#         variable, a Ruby or Python helper that shells out, a second level of
+#         script delegation, a directory only a running shell knows (that last
+#         one is a hard error, not a silent pass — the others are silent).
+#
+# A PASS THEREFORE MEANS "no collision in the shapes I can parse", NOT "no
+# collision exists". The pass message says so out loud, because a guard that
+# overstates its reach is worse than one that states a narrow reach accurately:
+# the first stops people looking.
 #
 # Env overrides (used by scripts/test-check-gradle-serialization.rb):
 #   GRADLE_SERIALIZATION_MAKEFILE  makefile to read (default: Makefile)
@@ -519,7 +565,13 @@ if violations.empty?
   chains.each do |dir, ranked|
     puts "#{dir}: #{ranked.join(' -> ')}"
   end
-  puts "Gradle targets reachable from #{GOAL} are serialized per project directory"
+  puts "OK: no two Gradle invocations THIS GATE CAN SEE share a project directory"
+  puts "    concurrently, in the graph reachable from #{GOAL}."
+  puts "    Scope: parsed recipe text (variables expanded, continuations folded) plus"
+  puts "    one level into shell scripts a recipe runs. A pass means \"no collision in"
+  puts "    the shapes I can parse\", NOT \"no collision exists\" — a define'd variable,"
+  puts "    a Ruby/Python helper or a second level of delegation is invisible here."
+  puts "    See the header of scripts/check-gradle-serialization.rb."
   exit 0
 end
 
@@ -531,4 +583,9 @@ end
 warn ""
 warn "Add an order-only prerequisite (`target: | other-target`) chaining them."
 warn "See the anchor comment on smithy-mapper-test in the Makefile (#674)."
+warn ""
+warn "And note the converse of this report: these are the collisions in the shapes"
+warn "this gate can parse. It cannot see a Gradle call reached through a define'd"
+warn "variable, a Ruby/Python helper, or a second level of script delegation, so"
+warn "fixing what is listed here does not by itself prove there are no others."
 exit 1

--- a/scripts/check-gradle-serialization.rb
+++ b/scripts/check-gradle-serialization.rb
@@ -78,11 +78,34 @@
 #          slice of make's grammar — recorded here rather than guessed at, so the
 #          next reader knows it is a hole and not an oversight.
 #
+#      A target may build in MORE THAN ONE project directory, and belongs to a
+#      group for each. Recording only its first invocation left the second in no
+#      group at all, so a target correctly ordered against the Kotlin chain could
+#      still overlap the mapper targets with its second command.
+#
 #   4. TEXTUAL, AND IT ERRS TOWARD REPORTING. Nothing is executed, so a
 #      `./gradlew` inside a shell heredoc is taken at face value. That direction
 #      is deliberate: a false positive costs one unnecessary order-only edge and
 #      says so out loud; a false negative costs the guarantee silently. An
 #      invocation it cannot place is a hard error for the same reason.
+#
+# WHY THIS KEEPS FINDING THINGS, AND THE END-STATE IT IS NOT. Four review rounds
+# produced eight defects in this gate, every one of them a SILENT PASS: an
+# undiscovered target, then a spelling, then two spellings, then a variable-name
+# charset, a symlink alias, and a target with two directories. That tail is a
+# property of the instrument — static analysis of a shell-embedded DSL — and not
+# of any one selector, which is why the last two rounds were answered at the
+# funnel (expand from make's database, canonicalize in one place, model a target
+# as a SET of directories) rather than with a matcher arm apiece.
+#
+# The structural end-state is different and is deliberately NOT built here: make
+# every Gradle call go through one sanctioned entry point, then this gate reduces
+# to "no recipe mentions gradlew except through it" plus the ordering check, and
+# the parse surface collapses to one argument. That is a Makefile refactor, it
+# would not cover the one Gradle call that happens outside make entirely
+# (scripts/check-kotlin-generated-drift.sh), and it is not what the PR that added
+# this file set out to do. Named here so the next round of findings is read as
+# evidence about the instrument rather than as a queue of selectors.
 #
 # Env overrides (used by scripts/test-check-gradle-serialization.rb):
 #   GRADLE_SERIALIZATION_MAKEFILE  makefile to read (default: Makefile)
@@ -164,7 +187,7 @@ def read_make_database(makefile)
       # `NAME = value`, `NAME := value`, `NAME ?= value`. Multi-line `define`
       # blocks are skipped: nothing in this repo puts a Gradle call in one, and
       # half-reading one would be worse than not reading it.
-      if (var = /\A(\w+) *[:?+]?= ?(.*)\z/.match(line))
+      if (var = /\A([^\s:#=]+) *[:?+]?= ?(.*)\z/.match(line))
         variables[var[1]] = var[2]
       end
       next
@@ -220,7 +243,12 @@ end
 # once, from make's own database, is the layer the question actually lives at.
 def expand_variables(text, variables, passes: 5)
   passes.times do
-    expanded = text.gsub(/\$[({](\w+)[)}]/) { variables.fetch(Regexp.last_match(1), Regexp.last_match(0)) }
+    # `[^\s(){}:#]+` rather than `\w+`: GNU make allows punctuation in variable
+    # names (`GRADLE-WRAPPER`), and a name this did not recognize stayed
+    # unexpanded — the same silent miss the expansion was added to remove.
+    # `$(shell …)` and `$(call …)` hold spaces, so they never match and are left
+    # to the fail-loud `$`-guard.
+    expanded = text.gsub(/\$[({]([^\s(){}:#]+)[)}]/) { variables.fetch(Regexp.last_match(1), Regexp.last_match(0)) }
     return expanded if expanded == text
 
     text = expanded
@@ -305,12 +333,23 @@ end
 # each trivially "serialized", and a new target spelled the other way would have
 # walked through the gate. `kotlin/`, `kotlin/.` and `spec/../kotlin` are the same
 # hazard. Normalize to a repo-relative cleanpath before anything is compared.
+# expand_path normalizes `.` and `..` but not symlinks, and the claim this gate
+# makes is about a PHYSICAL directory: two paths that are the same inode share
+# one <project>/.gradle whatever they are called. realpath only works on paths
+# that exist, so a directory that does not (a fixture, a target for a tree not
+# checked out) falls back to the lexical form rather than failing.
+def physical(path)
+  File.realpath(path)
+rescue SystemCallError
+  path
+end
+
 def canonical_dir(raw, repo_root)
   # `cd "kotlin"` is `cd kotlin`. Dequoting lives here, in the one place a
   # directory becomes a grouping key, rather than as another arm of the matcher.
   unquoted = raw.sub(/\A(["'])(.*)\1\z/) { Regexp.last_match(2) }
-  root = File.expand_path(repo_root)
-  absolute = File.expand_path(unquoted, root)
+  root = physical(File.expand_path(repo_root))
+  absolute = physical(File.expand_path(unquoted, root))
   return "." if absolute == root
 
   absolute.start_with?("#{root}/") ? absolute.delete_prefix("#{root}/") : absolute
@@ -322,21 +361,28 @@ def gradle_targets(recipes, makefile, variables = {}, repo_root = REPO_ROOT)
 
   recipes.each do |target, raw_lines|
     lines = raw_lines.map { |line| expand_variables(line, variables) }
-    direct = lines.find { |line| line.include?("./gradlew") }
+    # EVERY line, not the first match: one recipe may build in two projects, and
+    # recording only its first invocation left the second in no group at all —
+    # so a target ordered after the Kotlin chain could still overlap the mapper
+    # targets with its second command. A target belongs to as many groups as it
+    # has directories.
+    direct = lines.select { |line| line.include?("./gradlew") }
 
-    if direct
-      matched = direct.match(%r{cd\s+(\S+)\s*&&\s*\./gradlew})
-      if matched && matched[1].include?("$")
-        # A make variable is not resolvable from the database text, and guessing
-        # would put this target in a group of its own — the same silent pass the
-        # spelling bug caused.
-        unrecognized << [target, direct]
-      elsif matched
-        found[target] = canonical_dir(matched[1], repo_root)
-      elsif direct.match?(%r{\A\s*\./gradlew})
-        found[target] = "."
-      else
-        unrecognized << [target, direct]
+    unless direct.empty?
+      direct.each do |line|
+        matched = line.match(%r{cd\s+(\S+)\s*&&\s*\./gradlew})
+        if matched && matched[1].include?("$")
+          # Not resolvable from the database text, and guessing would put this
+          # target in a group of its own — the same silent pass the spelling bug
+          # caused.
+          unrecognized << [target, line]
+        elsif matched
+          (found[target] ||= Set.new) << canonical_dir(matched[1], repo_root)
+        elsif line.match?(%r{\A\s*\./gradlew})
+          (found[target] ||= Set.new) << "."
+        else
+          unrecognized << [target, line]
+        end
       end
       next
     end
@@ -349,7 +395,7 @@ def gradle_targets(recipes, makefile, variables = {}, repo_root = REPO_ROOT)
     else
       # Canonicalized through the same funnel as a direct recipe: a delegated
       # `cd "$ROOT_DIR/./kotlin"` has to group with a direct `cd kotlin`.
-      found[target] = canonical_dir(dir, repo_root)
+      (found[target] ||= Set.new) << canonical_dir(dir, repo_root)
     end
   end
 
@@ -390,6 +436,11 @@ die "found no Gradle-backed targets in #{MAKEFILE} — the recipe shape this " \
 in_goal = reachable_from(graph, GOAL)
 covered = gradle.select { |target, _| in_goal.include?(target) }
 
+# dir => targets that build in it. A target with two directories appears twice,
+# and must be ordered against the others in BOTH.
+by_directory = Hash.new { |h, k| h[k] = [] }
+covered.each { |target, dirs| dirs.each { |dir| by_directory[dir] << target } }
+
 # Precompute each covered target's ancestry once; the pairwise test below is
 # "does one of the pair reach the other".
 closure = covered.keys.to_h { |target| [target, reachable_from(graph, target)] }
@@ -397,8 +448,8 @@ closure = covered.keys.to_h { |target| [target, reachable_from(graph, target)] }
 violations = []
 chains = []
 
-covered.group_by { |_, dir| dir }.sort.each do |dir, entries|
-  targets = entries.map(&:first).sort
+by_directory.sort.each do |dir, entries|
+  targets = entries.uniq.sort
   next if targets.size < 2
 
   targets.combination(2).each do |a, b|

--- a/scripts/check-gradle-serialization.rb
+++ b/scripts/check-gradle-serialization.rb
@@ -31,24 +31,53 @@
 # ordered by that relation. That is the mechanism, and it goes red the moment an
 # edge is deleted.
 #
-# COVERAGE, HONESTLY. This checks the targets reachable from ONE goal
-# (check-targets by default), because that is the graph `make check` executes.
-# Gradle-backed targets outside it — kt-check-generated-drift is the live
-# example — are NOT covered: `make check` cannot schedule them, but a
-# hand-written `make -j kt-check kt-check-generated-drift` still can. Chaining
-# those would charge CI, which invokes them as standalone goals, for work it
-# already does a different way. Pass a different goal to check a different
-# graph.
+# COVERAGE, HONESTLY. Three boundaries, and none of them is "every Gradle
+# target":
+#
+#   1. ONE GOAL. Only targets reachable from check-targets (by default), because
+#      that is the graph `make check` executes. kt-check-generated-drift is
+#      DISCOVERED (see 2) but not COVERED: `make check` cannot schedule it, so
+#      it collides with nothing there, while a hand-written
+#      `make -j kt-check kt-check-generated-drift` still can. Chaining it would
+#      charge CI, which invokes it as a standalone goal, for work it already
+#      does another way. Pass a different goal to check a different graph.
+#
+#   2. ONE LEVEL OF DELEGATION, SHELL SCRIPTS ONLY. A recipe's own `./gradlew`
+#      is found directly. A recipe that delegates — `@./scripts/foo.sh`, the
+#      shape kt-check-generated-drift uses — is followed exactly one level, and
+#      only into a file whose shebang names a shell. A script that delegates to
+#      another script is not followed, and NEITHER IS A RUBY OR PYTHON HELPER
+#      THAT SHELLS OUT TO GRADLE. There is none today; if one appears, this gate
+#      will not see it, and that is a hole in this gate rather than a fact about
+#      the repo. The shebang test is not squeamishness about Ruby: this file and
+#      its self-test both contain the literal text `./gradlew` (in a regex, in
+#      comments, in fixture heredocs) and are themselves reachable from
+#      check-targets, so a scanner that read every delegated script would
+#      classify the gate as a Gradle build in kotlin/ and fail on the real
+#      Makefile.
+#
+#   3. TEXTUAL, AND IT ERRS TOWARD REPORTING. The delegation scan reads source,
+#      it does not execute anything, so a `./gradlew` inside a shell heredoc
+#      would be taken at face value. That direction is deliberate: a false
+#      positive costs one unnecessary order-only edge and says so out loud; a
+#      false negative costs the guarantee silently. An invocation it cannot
+#      place is a hard error for the same reason.
 #
 # Env overrides (used by scripts/test-check-gradle-serialization.rb):
 #   GRADLE_SERIALIZATION_MAKEFILE  makefile to read (default: Makefile)
 #   GRADLE_SERIALIZATION_GOAL      goal to walk from (default: check-targets)
+#   GRADLE_SERIALIZATION_ROOT      directory a recipe's `scripts/...` paths
+#                                  resolve against (default: cwd). Test-only, so
+#                                  the delegation branches can be exercised
+#                                  against fixture trees instead of by adding
+#                                  fixture scripts to the real scripts/.
 
 require "English"
 require "set"
 
 MAKEFILE = ENV.fetch("GRADLE_SERIALIZATION_MAKEFILE", "Makefile")
 GOAL = ENV.fetch("GRADLE_SERIALIZATION_GOAL", "check-targets")
+REPO_ROOT = ENV.fetch("GRADLE_SERIALIZATION_ROOT", Dir.pwd)
 
 # A goal make cannot resolve: make prints its whole parsed database, then exits
 # non-zero without running or recursing into a single recipe. Asking for a real
@@ -144,23 +173,94 @@ end
 # be filed under the repo root, share a group with nothing, and be certified
 # collision-free while colliding with everything in kotlin/. The gate's own
 # blind spot is the one failure it must not have.
-def gradle_targets(recipes, makefile)
+#
+# DELEGATION (boundary 2 in the header). A recipe that runs a shell script under
+# scripts/ is followed one level into that script, because the live
+# counterexample is exactly that shape: kt-check-generated-drift's recipe is
+# `@./scripts/check-kotlin-generated-drift.sh`, and the Gradle invocation is at
+# that script's line 71, spelled across a backslash continuation as
+# `(cd "$ROOT_DIR/kotlin" && \` / `./gradlew ...`. Without this, the target is
+# invisible: added to check-targets it is the exact "sixth target" case this
+# gate exists to reject, and the gate would have passed.
+
+# Scan shell text for a Gradle invocation. Returns the project directory as
+# written, :unplaceable, or nil. Continuations are joined and whole-line
+# comments dropped first, so a wrapped invocation reads as one command and a
+# commented-out one is not mistaken for a live call.
+def scan_shell_for_gradle(text)
+  code = text.lines.reject { |l| l.match?(/\A\s*#/) }.join.gsub(/\\\n\s*/, " ")
+  return nil unless code.include?("./gradlew")
+
+  matched = code.match(%r{cd\s+["']?([^"'\s]+)["']?\s*&&[^\n]*?\./gradlew})
+  return matched[1] if matched
+
+  :unplaceable
+end
+
+# `$ROOT_DIR/kotlin` -> `kotlin`. Exactly one leading shell variable is stripped
+# — the repo-root handle every script under scripts/ computes for itself — and
+# the result must actually be a Gradle project, which is what keeps the strip
+# from being a guess. Anything still holding a `$` is unplaceable.
+def resolve_script_dir(raw, repo_root)
+  dir = raw.sub(/\A\$\{?\w+\}?\/+/, "")
+  return :unplaceable if dir.include?("$")
+  return :unplaceable unless File.exist?(File.join(repo_root, dir, "gradlew"))
+
+  dir
+end
+
+def delegated_gradle_dir(lines, repo_root)
+  lines.each do |line|
+    # Lookbehind rather than a leading-character class: the live case is
+    # `@./scripts/check-kotlin-generated-drift.sh`, and make's recipe prefixes
+    # (@, -, +) sit flush against the path.
+    line.scan(%r{(?<![\w/.\-])\.?/?(scripts/[\w.\-]+)}) do |(rel)|
+      path = File.join(repo_root, rel)
+      next unless File.file?(path)
+
+      # UTF-8 pinned for the same reason as the pipe read above: these scripts
+      # carry em-dashes, and LC_ALL=C would make an unpinned read US-ASCII.
+      source = File.read(path, encoding: "UTF-8")
+      shebang = source.lines.first.to_s
+      next unless shebang.start_with?("#!") && shebang.match?(/\b(?:ba|da|k|z)?sh\b/)
+
+      found = scan_shell_for_gradle(source)
+      next if found.nil?
+      return [:unplaceable, rel] if found == :unplaceable
+
+      resolved = resolve_script_dir(found, repo_root)
+      return [resolved == :unplaceable ? :unplaceable : resolved, rel]
+    end
+  end
+  nil
+end
+
+def gradle_targets(recipes, makefile, repo_root = REPO_ROOT)
   found = {}
   unrecognized = []
 
   recipes.each do |target, lines|
-    lines.each do |line|
-      next unless line.include?("./gradlew")
+    direct = lines.find { |line| line.include?("./gradlew") }
 
-      matched = line.match(%r{cd\s+(\S+)\s*&&\s*\./gradlew})
+    if direct
+      matched = direct.match(%r{cd\s+(\S+)\s*&&\s*\./gradlew})
       if matched
         found[target] = matched[1]
-      elsif line.match?(%r{\A\s*\./gradlew})
+      elsif direct.match?(%r{\A\s*\./gradlew})
         found[target] = "."
       else
-        unrecognized << [target, line]
+        unrecognized << [target, direct]
       end
-      break
+      next
+    end
+
+    dir, via = delegated_gradle_dir(lines, repo_root)
+    next if dir.nil?
+
+    if dir == :unplaceable
+      unrecognized << [target, "delegates to #{via}, which invokes Gradle in a directory this gate cannot resolve"]
+    else
+      found[target] = dir
     end
   end
 
@@ -168,8 +268,10 @@ def gradle_targets(recipes, makefile)
     warn "ERROR: cannot tell which project directory these Gradle recipes run in:"
     unrecognized.each { |target, line| warn "  #{target}: #{line}" }
     warn ""
-    warn "This gate reads `cd <dir> && ./gradlew ...`. Spell the recipe that way, " \
-         "or teach scripts/check-gradle-serialization.rb the new shape — do not " \
+    warn "This gate reads `cd <dir> && ./gradlew ...` in a recipe, and follows a " \
+         "recipe ONE level into a shell script under scripts/ (not into a second " \
+         "script, and not into a Ruby or Python helper). Spell it that way, or " \
+         "teach scripts/check-gradle-serialization.rb the new shape — do not " \
          "leave it guessing, since a guess here passes silently. (#{makefile})"
     exit 1
   end

--- a/scripts/check-gradle-serialization.rb
+++ b/scripts/check-gradle-serialization.rb
@@ -174,10 +174,29 @@
 #         shell script a recipe invokes; several invocations per line, per
 #         recipe and per script; the same directory under any spelling or
 #         symlink.
-#   CANNOT a Gradle call reached by a shape it does not parse: a `define`/`endef`
-#         variable, a Ruby or Python helper that shells out, a second level of
-#         script delegation, a directory only a running shell knows (that last
-#         one is a hard error, not a silent pass — the others are silent).
+#   CANNOT a Gradle call reached by a shape it does not parse. The full list, so
+#         a green run is never mistaken for a proof:
+#           - a `define`/`endef` variable holding the call
+#           - a Ruby or Python helper that shells out
+#           - a second level of script delegation
+#           - a target-specific variable INHERITED BY A PREREQUISITE. make makes
+#             `foo: VAR = x` effective for foo's prerequisites too; only the
+#             variables attached to the recipe's own target are merged here.
+#           - a delegated line that cd's more than once before its Gradle call
+#             (`cd a && prepare; cd b && ./gradlew`): the match starts at the
+#             FIRST cd, so the call is attributed to a rather than b.
+#           - a directory only a running shell knows — a hard error, not a
+#             silent pass; the rest of this list is silent.
+#
+#         The last two were reported and DECLINED, on purpose, and the reasoning
+#         belongs here rather than in a review thread nobody will re-read: each
+#         is one more matcher refinement for a shape no recipe in this repo uses,
+#         arriving after the count above had already made the case that the next
+#         parsing variation should change the instrument instead. Taking them
+#         would have grown the rules an eighth time without moving the covered
+#         call sites at all. If either shape ever appears in a real recipe, that
+#         is a call site, and the answer is instrument A or B below — not a
+#         seventh regex.
 #
 # A PASS THEREFORE MEANS "no collision in the shapes I can parse", NOT "no
 # collision exists". The pass message says so out loud, because a guard that
@@ -559,6 +578,16 @@ def gradle_targets(recipes, makefile, variables = {}, target_variables = {}, rep
     end
   end
 
+  [found, unrecognized]
+end
+
+# Reporting an unplaceable recipe is deferred to the caller, which knows what is
+# in scope. Raising it from inside the scan meant a standalone target nobody
+# asked about — not reachable from GOAL, never scheduled by `make check` — could
+# fail the whole gate on a directory only its own shell knows. That is the same
+# false-verdict class as the target-specific variables: the gate saying no about
+# something it had already declared out of scope.
+def report_unrecognized(unrecognized, makefile)
   unless unrecognized.empty?
     warn "ERROR: cannot tell which project directory these Gradle recipes run in:"
     unrecognized.each { |target, line| warn "  #{target}: #{line}" }
@@ -570,8 +599,6 @@ def gradle_targets(recipes, makefile, variables = {}, target_variables = {}, rep
          "leave it guessing, since a guess here passes silently. (#{makefile})"
     exit 1
   end
-
-  found
 end
 
 def reachable_from(graph, root)
@@ -589,11 +616,15 @@ end
 graph, recipes, variables, target_variables = read_make_database(MAKEFILE)
 die "goal #{GOAL} is not defined in #{MAKEFILE}" unless graph.key?(GOAL)
 
-gradle = gradle_targets(recipes, MAKEFILE, variables, target_variables)
+gradle, unrecognized = gradle_targets(recipes, MAKEFILE, variables, target_variables)
 die "found no Gradle-backed targets in #{MAKEFILE} — the recipe shape this " \
     "gate matches (`cd <dir> && ./gradlew`) must have changed" if gradle.empty?
 
 in_goal = reachable_from(graph, GOAL)
+
+# Scope first, complain second — boundary 1 applies to errors as well as to
+# collisions.
+report_unrecognized(unrecognized.select { |target, _| in_goal.include?(target) }, MAKEFILE)
 covered = gradle.select { |target, _| in_goal.include?(target) }
 
 # dir => targets that build in it. A target with two directories appears twice,

--- a/scripts/test-check-gradle-serialization.rb
+++ b/scripts/test-check-gradle-serialization.rb
@@ -270,6 +270,52 @@ RB
   )
 end
 
+# --- Cases 12-13: the directory is a place, not a spelling -------------------
+#
+# Caught in review by two reviewers independently. The gate grouped on the raw
+# `cd` text, so a new target spelled `cd ./kotlin` landed in its own group of
+# one, was trivially "serialized", and walked through the invariant the gate
+# advertises. Case 12 is that bypass. Case 13 covers the other way a spelling
+# can be unresolvable — a make variable — which must be a hard error rather than
+# a group of one, since that is the same silent pass wearing a different hat.
+
+spelling_bypass = must_substitute(
+  MAKEFILE,
+  "check-targets: ",
+  "check-targets: probe-dot-slash ",
+) + <<~MAKE
+
+  .PHONY: probe-dot-slash
+  probe-dot-slash:
+  \tcd ./kotlin && ./gradlew :basecamp-sdk:jvmJar
+MAKE
+
+failures << check(
+  "12: the same directory spelled ./kotlin still collides",
+  spelling_bypass,
+  expect_pass: false,
+  expect_fragment: "probe-dot-slash",
+)
+
+variable_dir = must_substitute(
+  MAKEFILE,
+  "check-targets: ",
+  "check-targets: probe-variable-dir ",
+) + <<~MAKE
+
+  KOTLIN_DIR = kotlin
+  .PHONY: probe-variable-dir
+  probe-variable-dir:
+  \tcd $(KOTLIN_DIR) && ./gradlew :basecamp-sdk:jvmJar
+MAKE
+
+failures << check(
+  "13: a make variable as the project directory is unresolvable, not a group of one",
+  variable_dir,
+  expect_pass: false,
+  expect_fragment: "cannot tell which project directory",
+)
+
 failures.compact!
 
 if failures.empty?

--- a/scripts/test-check-gradle-serialization.rb
+++ b/scripts/test-check-gradle-serialization.rb
@@ -459,6 +459,59 @@ Dir.mktmpdir("gradle-serialization-symlink") do |root|
   )
 end
 
+# --- Cases 20-21: totality per LINE and per delegated script -----------------
+#
+# Round five, and the same defect as case 17 one nesting level down: collecting
+# every recipe LINE made the model total per target but not per line, so two
+# invocations on one line were filed under the first directory. The scan is now
+# total in both places, and the count has to balance — an occurrence the pattern
+# cannot place makes the whole line unplaceable rather than silently dropping a
+# directory. Case 21 is the same totality inside a delegated shell script.
+
+two_on_one_line = must_substitute(
+  MAKEFILE,
+  "check-targets: ",
+  "check-targets: probe-one-line ",
+) + <<~MAKE
+
+  .PHONY: probe-one-line
+  probe-one-line: | conformance-kotlin
+  \tcd kotlin && ./gradlew help; cd spec/smithy-bare-arrays && ./gradlew help
+MAKE
+
+failures << check(
+  "20: two Gradle invocations on one recipe line are both counted",
+  two_on_one_line,
+  expect_pass: false,
+  expect_fragment: "probe-one-line",
+)
+
+# The LONE project comes first on purpose. With first-match-only the target is
+# filed under second-project, which collides with nothing, and the gate passes —
+# so the second invocation is what this case actually measures. Ordered the other
+# way round the case passes either way and proves nothing (measured: it did).
+with_fixture_root("probe-two-dir.sh", <<~SH) do |root|
+  #!/usr/bin/env bash
+  (cd "$ROOT_DIR/second-project" && ./gradlew help)
+  (cd "$ROOT_DIR/kotlin" && ./gradlew help)
+SH
+  FileUtils.mkdir_p(File.join(root, "second-project"))
+  FileUtils.touch(File.join(root, "second-project", "gradlew"))
+
+  failures << check(
+    "21: a delegated script building in two projects reports both",
+    must_substitute(MAKEFILE, "check-targets: ", "check-targets: probe-two-dir-script ") + <<~MAKE,
+
+      .PHONY: probe-two-dir-script
+      probe-two-dir-script:
+      \t@./scripts/probe-two-dir.sh
+    MAKE
+    expect_pass: false,
+    expect_fragment: "probe-two-dir-script",
+    root: root,
+  )
+end
+
 failures.compact!
 
 if failures.empty?

--- a/scripts/test-check-gradle-serialization.rb
+++ b/scripts/test-check-gradle-serialization.rb
@@ -310,8 +310,73 @@ variable_dir = must_substitute(
 MAKE
 
 failures << check(
-  "13: a make variable as the project directory is unresolvable, not a group of one",
+  "13: a make variable in the directory position is EXPANDED, so it collides",
   variable_dir,
+  expect_pass: false,
+  expect_fragment: "probe-variable-dir",
+)
+
+# --- Cases 14-16: the gate reads the COMMAND, not the text -------------------
+#
+# Round three of review found two more spellings that walked past a literal-text
+# scan: `cd "kotlin"` (quoted) and `$(GRADLE_WRAPPER)` (the wrapper itself behind
+# a make variable). Rather than a matcher arm each, the checker now expands
+# make's own variables and dequotes in the one place a directory becomes a
+# grouping key — so these are cases for a changed instrument, not for two new
+# selectors. Case 16 is the boundary that remains: a directory only a RUNNING
+# shell could resolve is still a hard error, which is the fail-loud side.
+
+quoted_dir = must_substitute(
+  MAKEFILE,
+  "check-targets: ",
+  "check-targets: probe-quoted-dir ",
+) + <<~MAKE
+
+  .PHONY: probe-quoted-dir
+  probe-quoted-dir:
+  \tcd "kotlin" && ./gradlew help
+MAKE
+
+failures << check(
+  "14: a quoted project directory is the same directory",
+  quoted_dir,
+  expect_pass: false,
+  expect_fragment: "probe-quoted-dir",
+)
+
+wrapper_variable = must_substitute(
+  MAKEFILE,
+  "check-targets: ",
+  "check-targets: probe-wrapper-variable ",
+) + <<~MAKE
+
+  GRADLE_WRAPPER = ./gradlew
+  .PHONY: probe-wrapper-variable
+  probe-wrapper-variable:
+  \tcd kotlin && $(GRADLE_WRAPPER) help
+MAKE
+
+failures << check(
+  "15: the wrapper itself behind a make variable is still discovered",
+  wrapper_variable,
+  expect_pass: false,
+  expect_fragment: "probe-wrapper-variable",
+)
+
+shell_variable_dir = must_substitute(
+  MAKEFILE,
+  "check-targets: ",
+  "check-targets: probe-shell-var-dir ",
+) + <<~MAKE
+
+  .PHONY: probe-shell-var-dir
+  probe-shell-var-dir:
+  \tcd $$RUNTIME_DIR && ./gradlew help
+MAKE
+
+failures << check(
+  "16: a directory only a running shell could resolve stays a hard error",
+  shell_variable_dir,
   expect_pass: false,
   expect_fragment: "cannot tell which project directory",
 )

--- a/scripts/test-check-gradle-serialization.rb
+++ b/scripts/test-check-gradle-serialization.rb
@@ -570,6 +570,70 @@ SH
   )
 end
 
+# --- Cases 24-25: round seven -----------------------------------------------
+#
+# 24 is the SAME partiality as 17/20/21/23, at the outermost level: the delegate
+# scan returned on the first script, so a target delegating twice kept only the
+# first script's projects. Fifth appearance of one defect, which is recorded in
+# the header as the reason the next parsing variation gets a different
+# instrument rather than another rule.
+#
+# 25 is different in kind — a FALSE POSITIVE, not a silent pass. make -p prints
+# target-specific variables inside the target's block as comments, so they were
+# invisible to expansion, `$(PROJECT)` stayed unresolved, and the fail-loud
+# `$`-guard refused to run at all. The gate says no when it should say yes.
+
+Dir.mktmpdir("gradle-serialization-two-delegates") do |root|
+  FileUtils.mkdir_p(File.join(root, "scripts"))
+  ["kotlin", "second-project"].each do |project|
+    FileUtils.mkdir_p(File.join(root, project))
+    FileUtils.touch(File.join(root, project, "gradlew"))
+  end
+  # The FIRST delegate builds the chained project; only the second can produce
+  # the violation, so returning early makes this case pass.
+  File.write(File.join(root, "scripts", "probe-first.sh"),
+             %(#!/usr/bin/env bash\n(cd "$ROOT_DIR/kotlin" && ./gradlew help)\n), encoding: "UTF-8")
+  File.write(File.join(root, "scripts", "probe-second.sh"),
+             %(#!/usr/bin/env bash\n(cd "$ROOT_DIR/second-project" && ./gradlew help)\n), encoding: "UTF-8")
+
+  failures << check(
+    "24: a target delegating to TWO scripts reports both projects",
+    must_substitute(MAKEFILE, "check-targets: ", "check-targets: probe-two-delegates probe-second-rival ") + <<~MAKE,
+
+      .PHONY: probe-two-delegates probe-second-rival
+      probe-two-delegates: | conformance-kotlin
+      \t@./scripts/probe-first.sh
+      \t@./scripts/probe-second.sh
+      probe-second-rival:
+      \tcd second-project && ./gradlew help
+    MAKE
+    expect_pass: false,
+    expect_fragment: "probe-two-delegates",
+    root: root,
+  )
+end
+
+target_specific = must_substitute(
+  MAKEFILE,
+  "check-targets: ",
+  "check-targets: probe-target-var ",
+) + <<~MAKE
+
+  .PHONY: probe-target-var
+  probe-target-var: PROJECT = kotlin
+  probe-target-var: | conformance-kotlin
+  \tcd $(PROJECT) && ./gradlew help
+MAKE
+
+# Chained, so the CORRECT verdict is a pass. Before target-specific variables
+# were read this failed with "cannot tell which project directory" — a gate
+# refusing to run is not a safe default, it is a broken one.
+failures << check(
+  "25: a target-specific variable resolves, so a chained target passes",
+  target_specific,
+  expect_pass: true,
+)
+
 failures.compact!
 
 if failures.empty?

--- a/scripts/test-check-gradle-serialization.rb
+++ b/scripts/test-check-gradle-serialization.rb
@@ -381,6 +381,84 @@ failures << check(
   expect_fragment: "cannot tell which project directory",
 )
 
+# --- Cases 17-19: round four, all three at the funnel or the model -----------
+#
+# 17 is a MODEL fix rather than a matcher one: a recipe that builds in two
+# projects was recorded under its first directory only, so its second command sat
+# in no group and could overlap anything. A target now belongs to as many groups
+# as it has directories. The probe is chained into the Kotlin chain and still
+# collides via spec/smithy-bare-arrays, which is the shape Codex described.
+#
+# 18 closes a legal make spelling the expansion added in round three did not
+# recognize (`GRADLE-WRAPPER`): punctuation in variable names.
+#
+# 19 is the physical-directory claim taken literally — two names for one inode
+# share one <project>/.gradle. It needs a symlink, so it runs against a fixture
+# root rather than putting one in the repo.
+
+two_directories = must_substitute(
+  MAKEFILE,
+  "check-targets: ",
+  "check-targets: probe-two-dirs ",
+) + <<~MAKE
+
+  .PHONY: probe-two-dirs
+  probe-two-dirs: | conformance-kotlin
+  \tcd kotlin && ./gradlew help
+  \tcd spec/smithy-bare-arrays && ./gradlew help
+MAKE
+
+failures << check(
+  "17: a target building in two projects is checked in both",
+  two_directories,
+  expect_pass: false,
+  expect_fragment: "probe-two-dirs",
+)
+
+punctuated_variable = must_substitute(
+  MAKEFILE,
+  "check-targets: ",
+  "check-targets: probe-punctuated-var ",
+) + <<~MAKE
+
+  GRADLE-WRAPPER = ./gradlew
+  .PHONY: probe-punctuated-var
+  probe-punctuated-var:
+  \tcd kotlin && $(GRADLE-WRAPPER) help
+MAKE
+
+failures << check(
+  "18: a make variable name with punctuation still expands",
+  punctuated_variable,
+  expect_pass: false,
+  expect_fragment: "probe-punctuated-var",
+)
+
+Dir.mktmpdir("gradle-serialization-symlink") do |root|
+  FileUtils.mkdir_p(File.join(root, "kotlin"))
+  FileUtils.touch(File.join(root, "kotlin", "gradlew"))
+  File.symlink("kotlin", File.join(root, "kotlin-alias"))
+
+  symlinked = must_substitute(
+    MAKEFILE,
+    "check-targets: ",
+    "check-targets: probe-symlink-alias ",
+  ) + <<~MAKE
+
+    .PHONY: probe-symlink-alias
+    probe-symlink-alias:
+    \tcd kotlin-alias && ./gradlew help
+  MAKE
+
+  failures << check(
+    "19: a symlink alias is the same physical project directory",
+    symlinked,
+    expect_pass: false,
+    expect_fragment: "probe-symlink-alias",
+    root: root,
+  )
+end
+
 failures.compact!
 
 if failures.empty?

--- a/scripts/test-check-gradle-serialization.rb
+++ b/scripts/test-check-gradle-serialization.rb
@@ -512,6 +512,64 @@ SH
   )
 end
 
+# --- Cases 22-23: one root cause, two symptoms ------------------------------
+#
+# Round six. Both findings came from the same asymmetry: the delegated-script
+# scan folded backslash continuations and the recipe scan did not, and a direct
+# Gradle call short-circuited the delegate scan entirely. Recipes and scripts are
+# now processed the same way, and direct and delegated are unioned rather than
+# treated as alternatives.
+#
+# 22 uses the CONVENTIONAL wrapped form, which is why it matters: `cd dir && \`
+# on one line and `./gradlew` on the next read as a bare repo-root invocation
+# with the directory discarded. The probe is chained after conformance-kotlin so
+# only the discarded spec/smithy-bare-arrays directory can produce the violation.
+
+wrapped_recipe = must_substitute(
+  MAKEFILE,
+  "check-targets: ",
+  "check-targets: probe-wrapped ",
+) + <<~MAKE
+
+  .PHONY: probe-wrapped
+  probe-wrapped: | conformance-kotlin
+  \tcd spec/smithy-bare-arrays && \\
+  \t  ./gradlew help
+MAKE
+
+failures << check(
+  "22: a backslash-continued recipe keeps its directory",
+  wrapped_recipe,
+  expect_pass: false,
+  expect_fragment: "probe-wrapped",
+)
+
+with_fixture_root("probe-mixed.sh", <<~SH) do |root|
+  #!/usr/bin/env bash
+  (cd "$ROOT_DIR/second-project" && ./gradlew help)
+SH
+  FileUtils.mkdir_p(File.join(root, "second-project"))
+  FileUtils.touch(File.join(root, "second-project", "gradlew"))
+
+  # The direct call is in kotlin/ and IS chained; the delegated one is in a
+  # second project shared with another probe. Only scanning both can see it.
+  failures << check(
+    "23: a target that calls Gradle directly AND delegates is scanned for both",
+    must_substitute(MAKEFILE, "check-targets: ", "check-targets: probe-mixed probe-second-only ") + <<~MAKE,
+
+      .PHONY: probe-mixed probe-second-only
+      probe-mixed: | conformance-kotlin
+      \tcd kotlin && ./gradlew help
+      \t@./scripts/probe-mixed.sh
+      probe-second-only:
+      \tcd second-project && ./gradlew help
+    MAKE
+    expect_pass: false,
+    expect_fragment: "probe-mixed",
+    root: root,
+  )
+end
+
 failures.compact!
 
 if failures.empty?

--- a/scripts/test-check-gradle-serialization.rb
+++ b/scripts/test-check-gradle-serialization.rb
@@ -655,6 +655,62 @@ failures << check(
   expect_pass: true,
 )
 
+# --- Cases 27-28: the gate must not die reading bytes it did not decode ------
+#
+# Reported: an UNREACHABLE target delegating to a shell script with non-UTF-8
+# bytes took the whole gate down with `ArgumentError: invalid byte sequence in
+# UTF-8`. Two separate defects met there, and they need separate cases because
+# either fix alone hides the reported symptom:
+#
+#   27  scope — the scan now runs only over the reachable set, so an
+#       out-of-scope target's script is never opened at all. Goes red only when
+#       BOTH fixes are reverted, and the case says so rather than pretending to
+#       discriminate one.
+#   28  encoding — an IN-SCOPE script with the same bytes would still have
+#       crashed, which reordering alone would have hidden. `File.read(...,
+#       encoding: "UTF-8")` TAGS bytes, it does not validate them; the scrub is
+#       what keeps the gate runnable. This is #669's bug class inside the gate
+#       shipped to fix it.
+#
+# \xE2 alone is an invalid UTF-8 sequence (the lead byte of an em-dash with its
+# continuation bytes removed), which is what a truncated or latin-1 comment
+# looks like in practice.
+INVALID_UTF8_SCRIPT = %(#!/usr/bin/env bash\n# comment with a bad byte: \xE2 here\n(cd "$ROOT_DIR/kotlin" && ./gradlew help)\n).b
+
+Dir.mktmpdir("gradle-serialization-badbytes") do |root|
+  FileUtils.mkdir_p(File.join(root, "scripts"))
+  FileUtils.mkdir_p(File.join(root, "kotlin"))
+  FileUtils.touch(File.join(root, "kotlin", "gradlew"))
+  File.binwrite(File.join(root, "scripts", "probe-bad-bytes.sh"), INVALID_UTF8_SCRIPT)
+
+  # NOT added to check-targets: out of scope, so the gate must not read it.
+  failures << check(
+    "27: an out-of-scope delegate with invalid UTF-8 does not kill the gate",
+    MAKEFILE + <<~MAKE,
+
+      .PHONY: probe-out-of-scope-bytes
+      probe-out-of-scope-bytes:
+      \t@./scripts/probe-bad-bytes.sh
+    MAKE
+    expect_pass: true,
+    root: root,
+  )
+
+  # IN scope, and chained, so the correct verdict is a pass — reached, read,
+  # scrubbed, and its kotlin/ build ordered behind the chain.
+  failures << check(
+    "28: an in-scope delegate with invalid UTF-8 is read, not fatal",
+    must_substitute(MAKEFILE, "check-targets: ", "check-targets: probe-in-scope-bytes ") + <<~MAKE,
+
+      .PHONY: probe-in-scope-bytes
+      probe-in-scope-bytes: | conformance-kotlin
+      \t@./scripts/probe-bad-bytes.sh
+    MAKE
+    expect_pass: true,
+    root: root,
+  )
+end
+
 failures.compact!
 
 if failures.empty?

--- a/scripts/test-check-gradle-serialization.rb
+++ b/scripts/test-check-gradle-serialization.rb
@@ -634,6 +634,27 @@ failures << check(
   expect_pass: true,
 )
 
+# --- Case 26: errors are scoped to the goal, like collisions are -------------
+#
+# An unplaceable directory in a target NOT reachable from check-targets used to
+# fail the whole gate, because the scan reported before the reachable set was
+# computed. Same false-verdict class as case 25: the gate saying no about
+# something it had already declared out of scope. The probe below is deliberately
+# NOT added to check-targets.
+
+out_of_scope_unplaceable = MAKEFILE + <<~MAKE
+
+  .PHONY: probe-out-of-scope
+  probe-out-of-scope:
+  \tcd $$RUNTIME_PROJECT && ./gradlew help
+MAKE
+
+failures << check(
+  "26: an unplaceable target outside the goal does not fail the gate",
+  out_of_scope_unplaceable,
+  expect_pass: true,
+)
+
 failures.compact!
 
 if failures.empty?

--- a/scripts/test-check-gradle-serialization.rb
+++ b/scripts/test-check-gradle-serialization.rb
@@ -21,6 +21,7 @@
 # Run: ruby scripts/test-check-gradle-serialization.rb
 
 require "English"
+require "fileutils"
 require "tmpdir"
 
 CHECKER = ENV.fetch("GRADLE_SERIALIZATION_CHECKER", "scripts/check-gradle-serialization.rb")
@@ -28,22 +29,25 @@ MAKEFILE = File.read("Makefile", encoding: "UTF-8")
 
 failures = []
 
-def run_checker(makefile_path)
+def run_checker(makefile_path, root: nil)
+  env = { "GRADLE_SERIALIZATION_MAKEFILE" => makefile_path }
+  env["GRADLE_SERIALIZATION_ROOT"] = root if root
+
   # external_encoding pinned: the checker echoes Makefile recipe lines, which
   # carry em-dashes, and under LC_ALL=C an unpinned pipe read is US-ASCII (#669).
   out = IO.popen(
-    { "GRADLE_SERIALIZATION_MAKEFILE" => makefile_path },
+    env,
     ["ruby", CHECKER],
     err: [:child, :out], external_encoding: Encoding::UTF_8, &:read
   )
   [$CHILD_STATUS.exitstatus, out]
 end
 
-def check(name, mutated, expect_pass:, expect_fragment: nil)
+def check(name, mutated, expect_pass:, expect_fragment: nil, root: nil)
   Dir.mktmpdir("gradle-serialization") do |dir|
     path = File.join(dir, "Makefile.mutated")
     File.write(path, mutated, encoding: "UTF-8")
-    status, out = run_checker(path)
+    status, out = run_checker(path, root: root)
 
     if expect_pass && status != 0
       return "#{name}: expected the gate to PASS, got exit #{status}\n#{out}"
@@ -174,6 +178,97 @@ failures << check(
   expect_pass: false,
   expect_fragment: "cannot tell which project directory",
 )
+
+# --- Cases 8-9: the DELEGATED target, which is a real one, not a fixture ------
+#
+# kt-check-generated-drift's recipe is `@./scripts/check-kotlin-generated-drift.sh`
+# and the Gradle call is inside that script, wrapped across a backslash
+# continuation and cd'd via a shell variable. It is the counterexample the gate's
+# first cut could not see: added to check-targets it was the exact "sixth target"
+# case, and the gate passed. Case 8 is that scenario; case 9 pins that the remedy
+# is an EDGE, not a ban on the target.
+
+delegated_unchained = must_substitute(
+  MAKEFILE,
+  "check-targets: ",
+  "check-targets: kt-check-generated-drift ",
+)
+
+failures << check(
+  "8: a Gradle target that delegates through a shell script",
+  delegated_unchained,
+  expect_pass: false,
+  expect_fragment: "kt-check-generated-drift",
+)
+
+failures << check(
+  "9: the same target, chained",
+  delegated_unchained + "\nkt-check-generated-drift: | conformance-kotlin\n",
+  expect_pass: true,
+)
+
+# --- Cases 10-11: the delegation boundaries, against fixture trees ------------
+#
+# These use GRADLE_SERIALIZATION_ROOT so the fixtures never enter the real
+# scripts/. Case 10 pins the fail-loud direction. Case 11 pins the gate's DECLARED
+# HOLE as measured behaviour rather than a claim in a comment: a Ruby helper that
+# shells out to Gradle is NOT seen. It is asserted here so that the day someone
+# writes one, this test is where they find out what the gate does not do — and so
+# that "shell scripts only" cannot quietly become "all scripts" in the prose while
+# the code says otherwise.
+
+def with_fixture_root(script_name, script_body)
+  Dir.mktmpdir("gradle-serialization-root") do |root|
+    FileUtils.mkdir_p(File.join(root, "scripts"))
+    FileUtils.mkdir_p(File.join(root, "kotlin"))
+    FileUtils.touch(File.join(root, "kotlin", "gradlew"))
+    File.write(File.join(root, "scripts", script_name), script_body, encoding: "UTF-8")
+    yield root
+  end
+end
+
+unplaceable_delegate = must_substitute(
+  MAKEFILE,
+  "check-targets: ",
+  "check-targets: probe-delegate ",
+) + <<~MAKE
+
+  .PHONY: probe-delegate
+  probe-delegate:
+  \t@./scripts/probe-delegate.sh
+MAKE
+
+with_fixture_root("probe-delegate.sh", <<~SH) do |root|
+  #!/usr/bin/env bash
+  # The directory is not resolvable from the text: two variables, no literal.
+  (cd "$SOME_DIR/$SUBPROJECT" && ./gradlew build)
+SH
+  failures << check(
+    "10: a delegated Gradle call in a directory the gate cannot resolve",
+    unplaceable_delegate,
+    expect_pass: false,
+    expect_fragment: "cannot tell which project directory",
+    root: root,
+  )
+end
+
+with_fixture_root("probe-delegate.rb", <<~RB) do |root|
+  #!/usr/bin/env ruby
+  # Declared hole: a Ruby helper that shells out to Gradle is not followed.
+  system("cd kotlin && ./gradlew build")
+RB
+  failures << check(
+    "11: a Ruby delegate is NOT followed (declared limitation, asserted)",
+    must_substitute(MAKEFILE, "check-targets: ", "check-targets: probe-ruby-delegate ") + <<~MAKE,
+
+      .PHONY: probe-ruby-delegate
+      probe-ruby-delegate:
+      \t@ruby ./scripts/probe-delegate.rb
+    MAKE
+    expect_pass: true,
+    root: root,
+  )
+end
 
 failures.compact!
 

--- a/scripts/test-check-gradle-serialization.rb
+++ b/scripts/test-check-gradle-serialization.rb
@@ -1,0 +1,187 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Negative-case self-test for scripts/check-gradle-serialization.rb.
+#
+# The gate's live run in `make check` only ever sees a Makefile whose Gradle
+# targets ARE chained, so nothing there shows it reacts when one is not. Each
+# case below writes a MUTATED COPY of the real Makefile to a tmp file — one
+# mutation each — drives the checker at it through GRADLE_SERIALIZATION_MAKEFILE,
+# and asserts the expected verdict. The tracked Makefile is never written to.
+#
+# Cases 1-3 delete one order-only edge each: this is the literal "would it go red
+# if the edges were removed" proof, run three times, once per edge. Case 4 is the
+# one that matters more over time — it adds a SIXTH Gradle-backed target to
+# check-targets with no edge at all, the shape a future change takes.
+#
+# Case 5 is the positive control (unmutated copy passes), and case 6 pins the
+# gate's other end: a target chained but in a DIFFERENT project directory is not
+# a collision and must not be reported.
+#
+# Run: ruby scripts/test-check-gradle-serialization.rb
+
+require "English"
+require "tmpdir"
+
+CHECKER = ENV.fetch("GRADLE_SERIALIZATION_CHECKER", "scripts/check-gradle-serialization.rb")
+MAKEFILE = File.read("Makefile", encoding: "UTF-8")
+
+failures = []
+
+def run_checker(makefile_path)
+  # external_encoding pinned: the checker echoes Makefile recipe lines, which
+  # carry em-dashes, and under LC_ALL=C an unpinned pipe read is US-ASCII (#669).
+  out = IO.popen(
+    { "GRADLE_SERIALIZATION_MAKEFILE" => makefile_path },
+    ["ruby", CHECKER],
+    err: [:child, :out], external_encoding: Encoding::UTF_8, &:read
+  )
+  [$CHILD_STATUS.exitstatus, out]
+end
+
+def check(name, mutated, expect_pass:, expect_fragment: nil)
+  Dir.mktmpdir("gradle-serialization") do |dir|
+    path = File.join(dir, "Makefile.mutated")
+    File.write(path, mutated, encoding: "UTF-8")
+    status, out = run_checker(path)
+
+    if expect_pass && status != 0
+      return "#{name}: expected the gate to PASS, got exit #{status}\n#{out}"
+    end
+    if !expect_pass && status.zero?
+      return "#{name}: expected the gate to FAIL, it passed\n#{out}"
+    end
+    if expect_fragment && !out.include?(expect_fragment)
+      return "#{name}: expected output to mention #{expect_fragment.inspect}\n#{out}"
+    end
+
+    nil
+  end
+end
+
+def must_substitute(source, from, to)
+  raise "self-test is stale: #{from.inspect} no longer appears in the Makefile" \
+    unless source.include?(from)
+
+  source.sub(from, to)
+end
+
+# --- Cases 1-3: delete one order-only edge each ------------------------------
+
+edges = {
+  "1: smithy-mapper-test edge removed" =>
+    ["smithy-mapper-test: | smithy-mapper", "smithy-mapper-test:"],
+  "2: kt-test edge removed" =>
+    ["kt-test: | conformance-runner-tests-kotlin", "kt-test:"],
+  "3: conformance-kotlin edge removed" =>
+    ["conformance-kotlin: | kt-test", "conformance-kotlin:"],
+}
+
+edges.each do |name, (from, to)|
+  failures << check(
+    name,
+    must_substitute(MAKEFILE, from, to),
+    expect_pass: false,
+    expect_fragment: "can schedule two Gradle builds in one project directory",
+  )
+end
+
+# --- Case 4: a new, unchained Gradle target joins check-targets --------------
+
+with_new_target = must_substitute(
+  MAKEFILE,
+  "check-targets: ",
+  "check-targets: probe-new-gradle-target ",
+)
+with_new_target += <<~MAKE
+
+  .PHONY: probe-new-gradle-target
+  probe-new-gradle-target:
+  \tcd kotlin && ./gradlew :basecamp-sdk:jvmJar
+MAKE
+
+failures << check(
+  "4: an unchained sixth Gradle target",
+  with_new_target,
+  expect_pass: false,
+  expect_fragment: "probe-new-gradle-target",
+)
+
+# --- Case 5: positive control ------------------------------------------------
+
+failures << check("5: unmutated Makefile", MAKEFILE, expect_pass: true)
+
+# --- Case 6: a Gradle target in its own project directory is not a collision --
+
+other_directory = must_substitute(
+  MAKEFILE,
+  "check-targets: ",
+  "check-targets: probe-other-directory ",
+)
+other_directory += <<~MAKE
+
+  .PHONY: probe-other-directory
+  probe-other-directory:
+  \tcd spec/smithy-bare-arrays && ./gradlew jar
+MAKE
+
+failures << check(
+  "6a: a second target in an EXISTING directory still collides",
+  other_directory,
+  expect_pass: false,
+  expect_fragment: "probe-other-directory",
+)
+
+lone_directory = must_substitute(
+  MAKEFILE,
+  "check-targets: ",
+  "check-targets: probe-lone-directory ",
+)
+lone_directory += <<~MAKE
+
+  .PHONY: probe-lone-directory
+  probe-lone-directory:
+  \tcd tools/probe-project && ./gradlew nothing
+MAKE
+
+failures << check(
+  "6b: the only target in its directory is not a collision",
+  lone_directory,
+  expect_pass: true,
+)
+
+# --- Case 7: a Gradle recipe the gate cannot place must be an ERROR ----------
+#
+# The guard against the gate's own blind spot: `cd kotlin; ./gradlew` (semicolon,
+# not &&) is a real Gradle invocation in kotlin/, and a checker that shrugged and
+# filed it under the repo root would certify it collision-free.
+
+unplaceable = must_substitute(
+  MAKEFILE,
+  "check-targets: ",
+  "check-targets: probe-unplaceable ",
+)
+unplaceable += <<~MAKE
+
+  .PHONY: probe-unplaceable
+  probe-unplaceable:
+  \tcd kotlin; ./gradlew :basecamp-sdk:jvmJar
+MAKE
+
+failures << check(
+  "7: a Gradle recipe in an unrecognized shape",
+  unplaceable,
+  expect_pass: false,
+  expect_fragment: "cannot tell which project directory",
+)
+
+failures.compact!
+
+if failures.empty?
+  puts "check-gradle-serialization self-test: all cases passed"
+  exit 0
+end
+
+warn "check-gradle-serialization self-test FAILED"
+failures.each { |f| warn "\n#{f}" }
+exit 1

--- a/spec/smithy-bare-arrays/build.gradle.kts
+++ b/spec/smithy-bare-arrays/build.gradle.kts
@@ -16,6 +16,18 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
+// javac takes its source encoding from the platform default charset, which is
+// US-ASCII wherever the ambient locale is not UTF-8 — a non-interactive ssh
+// shell, cron, a locale-less container image. These sources carry em-dashes in
+// their prose (#669), and the current toolchain does not stop when it cannot
+// read them: Gradle 9.7 prints `unmappable character (0xE2) for encoding
+// US-ASCII`, substitutes U+FFFD and reports BUILD SUCCESSFUL, so a non-ASCII
+// string literal would ship silently mangled rather than fail loudly. Plain
+// `javac` on the same input exits 1. Pin the encoding so neither can happen.
+tasks.withType<JavaCompile>().configureEach {
+    options.encoding = "UTF-8"
+}
+
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
Two build-correctness fixes. No product code: Gradle build files, the Makefile,
two CI workflows, and one new gate plus its self-test.

Closes #669
Closes #674

---

## 1. Pin javac's source encoding (#669)

`git grep -E 'options.encoding|JavaCompile|file.encoding' -- '*.gradle*' Makefile`
returned nothing repo-wide, so javac took its source encoding from the platform
default charset — US-ASCII under any non-UTF-8 locale. Three files under
`spec/smithy-bare-arrays` carry em-dashes in their prose.

**#669 describes a hard build failure. On the current toolchain it is worse than
that, and the issue's proposed CI proof would not have caught it.** Measured
here (Gradle 9.7, Temurin 17, macOS):

```
$ LC_ALL=C make smithy-mapper
... 12 × "error: unmappable character (0xE2) for encoding US-ASCII"
12 errors
BUILD SUCCESSFUL in 4s          <- exit 0
```

Gradle prints the diagnostics, substitutes U+FFFD, and succeeds. Plain `javac`
on the same input exits 1; Gradle's integration does not. A non-ASCII Java
string literal compiled that way lands in the constant pool corrupted, silently:

```
#12 = String   #13   // em ??? dash
#13 = Utf8     em ??? dash          (three U+FFFD where the em-dash was)
```

So the exposure is silent corruption on this toolchain and a hard stop on
others, and **no exit-code check anywhere would see it**. That shapes the fix:

- `options.encoding = "UTF-8"` on every `JavaCompile` task in both Gradle
  builds. The kotlin/ pin is configured once at the root via `subprojects`.
- Kotlin itself is **not** exposed — the language spec fixes source files at
  UTF-8 and kotlinc has no encoding flag. But `kotlin-jvm` applies the `java`
  plugin, so each module carries JavaCompile tasks; no module has Java sources
  today, which makes the kotlin/ pin prophylactic against the first `.java`
  file, not a fix. Said plainly in the build file's comment.
- `smithy-verify.yml`'s two JVM legs now run under `LC_ALL: C` (shape copied
  from #712's eight sites) **and assert on the diagnostic, not on `$?`** —
  because `$?` cannot see this bug. A leg that only checked the exit code would
  pass with the pin deleted.

### Red proof

The CI assertion, run verbatim against `9aef1ccf3`'s `build.gradle.kts` and then
against the fix. Both cold (a warm `build/` makes `compileJava` UP-TO-DATE and
javac never runs — the first attempt passed for exactly that wrong reason):

```
$ bash proof1.sh red
ASSERTION FAILED: javac read sources in the platform charset, not UTF-8
REAL_EXIT=1
    ( 12 diagnostics from the publishToMavenLocal leg,
       9 from the smithy-mapper-test leg )

$ bash proof1.sh green
ASSERTION PASSED: no unmappable-character diagnostics under LC_ALL=C
REAL_EXIT=0
    ( 0 diagnostics from both legs )
```

---

## 2. Serialize the Gradle-backed check targets (#674, Gradle half)

Verified first: no `.NOTPARALLEL`, no `MAKEFLAGS` setting, no lock anywhere in
the Makefile. `check-targets` lists five Gradle-backed targets as **independent**
prerequisites, in two project directories. Two Gradle builds sharing one project
directory share `<project>/.gradle` and write the same task output directories;
Gradle's cross-process locks serialize the caches, nothing serializes the
outputs.

**#674 names the Kotlin trio. There is a second same-directory pair it does
not:** `smithy-check` pulls in `smithy-mapper` (`gradlew publishToMavenLocal`)
while `smithy-mapper-test` runs `gradlew test`, both in
`spec/smithy-bare-arrays`.

### Serialized edges

| project dir | order (execution order, cheapest first) |
|---|---|
| `spec/smithy-bare-arrays` | `smithy-mapper` → `smithy-mapper-test` |
| `kotlin` | `conformance-runner-tests-kotlin` → `kt-test` → `conformance-kotlin` |

Three order-only prerequisites: `smithy-mapper-test: \| smithy-mapper`,
`kt-test: \| conformance-runner-tests-kotlin`, `conformance-kotlin: \| kt-test`.

### Why order-only and not a per-target GRADLE_USER_HOME

`GRADLE_USER_HOME` isolates `~/.gradle` and leaves `<project>/.gradle` and
`<project>/build` — where the collision actually is — shared, so it does not fix
the named hazard. It would also cost a second cold cache, and this repo already
runs concurrent Gradle across ~30 worktrees against one `~/.gradle` without
trouble.

The cost of order-only edges on `.PHONY` targets is that they **run**: standalone
`make kt-check` now also runs `:conformance:test`, and `make conformance-kotlin`
also runs `kt-test`. The chain is ordered cheapest-first so the one target CI
drives through make — `conformance-runner-tests-kotlin`, at the head — gains no
prerequisite at all. CI's other Kotlin steps call `./gradlew` directly and are
unaffected.

### The proof asserts the schedule, not the outcome (per #715)

Run-to-failure is the wrong instrument here, and I measured why: two concurrent
Gradle builds in `kotlin/` (`:basecamp-sdk:check :generator:test` against
`:conformance:test :conformance:run`) **both exited 0**. A stress test would
have certified the bug as absent, which is roughly how it went unnoticed.

What is decidable is the schedule. `scripts/check-gradle-serialization.rb` reads
make's *own* parsed database (`make -p` — not a hand-rolled Makefile parser;
verified against GNU make 3.81 and 4.4.1) and requires the Gradle targets
reachable from `check-targets` to be **totally ordered** per project directory.
If X is a transitive prerequisite of Y, make cannot start Y's recipe until X's
has finished — that is the mechanism.

It also fails on a **sixth** Gradle target added without an edge, and on a recipe
shape it cannot place (`cd kotlin; ./gradlew` — a guess there would pass
silently, the one failure this gate must not have).

**Coverage, stated honestly** — four boundaries, none of them "every Gradle
target":

1. **One goal.** Only targets reachable from `check-targets`.
   `kt-check-generated-drift` is **discovered but not covered**: it isn't
   reachable there, so `make check` cannot schedule it, while a hand-written
   `make -j kt-check kt-check-generated-drift` still can. Chaining it would
   charge CI, which invokes it as a standalone goal, for work it already does
   another way.
2. **One level of delegation, shell scripts only.** A recipe that runs a shell
   script under `scripts/` is followed exactly one level — not into a second
   script, and **not into a Ruby or Python helper that shells out to Gradle**.
   There is none today; if one appears the gate will not see it, and that is a
   hole in the gate rather than a fact about the repo. Asserted by case 11
   below, so the limitation is measured rather than merely claimed.
3. **It reads the command, not the text.** Recipes are expanded against make's
   own variable database, quotes are stripped, and paths canonicalize to a
   repo-relative cleanpath — so `cd kotlin`, `cd ./kotlin`, `cd "kotlin"` and
   `$(GRADLE_WRAPPER)` all land in one group. Still out of reach: a value only a
   running shell knows (hard error), and a `define`/`endef` variable holding the
   Gradle call (**silently missed** — declined deliberately, no call site).
4. **Textual, and it errs toward reporting.** A false positive costs one
   unnecessary edge and says so; a false negative costs the guarantee silently.

### Red proof

Three edges stripped from a **tmp copy** of the Makefile (the tracked file is
never written to):

```
mutation stripped 3 order-only edges
===== RED =====
ERROR: `make -j check-targets` can schedule two Gradle builds in one project directory.

  kotlin: conformance-kotlin and conformance-runner-tests-kotlin are independent — neither is a prerequisite of the other
  kotlin: conformance-kotlin and kt-test are independent — neither is a prerequisite of the other
  kotlin: conformance-runner-tests-kotlin and kt-test are independent — neither is a prerequisite of the other
  spec/smithy-bare-arrays: smithy-mapper and smithy-mapper-test are independent — neither is a prerequisite of the other
REAL_EXIT=1

===== GREEN =====
kotlin: conformance-runner-tests-kotlin -> kt-test -> conformance-kotlin
spec/smithy-bare-arrays: smithy-mapper -> smithy-mapper-test
Gradle targets reachable from check-targets are serialized per project directory
REAL_EXIT=0
```

`scripts/test-check-gradle-serialization.rb` (in `make check` and in Spec Gates)
pins all of it permanently: each edge deleted in turn, an unchained new target,
an unplaceable recipe, a positive control, and a lone-directory negative —
8 cases, `REAL_EXIT=0`. And the suite is itself shown non-vacuous: driving it
against a **mutated copy of the checker** whose unplaceable-recipe guard is
removed turns case 7 red and only case 7 (`REAL_EXIT=1`).

---

## Out of scope: the Ruby failure → #720

`OAuthTransportTest#test_https_proxy_refused_without_p_use_ssl_support`
(`ruby/test/basecamp/oauth_transport_test.rb:839`) was observed failing under
parallel `make` during this wave. **It is not fixed here** — it has nothing to do
with Gradle — and is filed as **#720** with a grounded mechanism read: the test
does a live DNS lookup for `old-net-http.test` (via `URI#find_proxy`'s loopback
rule) inside a **1-second** bound, before the validation error it asserts on is
ever reached.

So **#674 is being closed against its Gradle half only.** The Ruby half is
tracked separately in #720.

---

## Verification

- `make` — `REAL_EXIT=0`
- `LC_ALL=C make` — `REAL_EXIT=0`, and this is not ceremony: **the first
  `LC_ALL=C make` failed**, on my own new gate, with the exact bug class this PR
  is about. `IO.popen` read make's em-dashed database as US-ASCII and raised
  `ArgumentError: invalid byte sequence in US-ASCII`. Both pipe reads are now
  pinned to UTF-8 and both CI legs run under `LC_ALL: C`.
- `make lint-actions` clean (actionlint + zizmor).
- Local test counts are deliberately not quoted; CI's numbers are the ones that
  count.

## Residual uncertainty

- The `-j16` exit 2 that opened #674 is **still undiagnosed**. This PR closes a
  structural hazard the issue predicted; it does not claim to be that failure's
  root cause, and the issue never captured the failing target.
- `make -p` database parsing is verified on GNU make 3.81 (macOS, local) and
  4.4.1 (Linux, over ssh). Other implementations are untested; the gate fails
  loudly rather than silently if the dump is unreadable.
- The delegation scan is textual and one level deep (boundary 2 above). It is
  bounded and asserted, not exhaustive.

---

## Review round (67c7a12)

Two Copilot findings, both real, both fixed rather than argued down.

**The anchor comment's edge count** said "the other three"; there are three edges
total, so two. Fixed.

**The gate only discovered a literal `./gradlew` in a recipe**, so a target that
delegates through a script was invisible — and Copilot named a live
counterexample rather than a hypothetical: `kt-check-generated-drift` runs
`scripts/check-kotlin-generated-drift.sh`, which invokes Gradle at its line 71.
Added to `check-targets` it is the exact "sixth target" case this gate exists to
reject, **and the gate passed (exit 0)**. That was an overclaim in a control this
PR introduced, and the fact that I had already documented the hole in the script,
the commit and this body is what makes it worse, not better: the note lives where
the reader isn't looking while the control reports success.

The gate now follows a recipe one level into a shell script under `scripts/`,
joining backslash continuations and stripping exactly one leading shell variable
from the `cd` target — grounded, not guessed: the result must be a directory that
actually contains a `gradlew`, or the target is *unplaceable* and the gate fails
loudly. The named counterexample now exits 1, naming all three pairs.

Four new self-test cases (11 total): the real delegated target unchained
(rejected) and chained (accepted), an unresolvable delegated directory
(rejected), and a **Ruby delegate that is deliberately not followed** — that last
one pins the declared limitation as measured behaviour so "shell scripts only"
cannot drift into "all scripts" in the prose while the code says otherwise.
Fixture cases run against a temp tree via a test-only `GRADLE_SERIALIZATION_ROOT`,
so nothing enters `scripts/`.

Both mechanisms shown load-bearing by mutating the **checker**:

| checker mutation | result |
|---|---|
| delegation resolution removed | cases 8 and 10 go red, and only those — `REAL_EXIT=1` |
| shebang restriction removed | the **positive control** goes red; the gate stops passing the real Makefile — `REAL_EXIT=1` |

The second is worth spelling out: this gate and its self-test both contain the
literal text `./gradlew` (a regex, comments, fixture heredocs) and are themselves
reachable from `check-targets`, so a scanner that read every delegated script
would classify the gate as a Gradle build in `kotlin/`. The shebang restriction
is why that does not happen, and the mutation is the proof.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins javac source encoding to UTF-8 and serializes Gradle-backed check targets to avoid silent character mangling and parallel Gradle builds in one project directory. Previously, `javac` used the platform charset and Gradle still exited 0 with unmappable characters; and `make -j` could run two `./gradlew` invocations in the same project.

- Sets `options.encoding = "UTF-8"` on all `JavaCompile` tasks in `spec/smithy-bare-arrays` and all `kotlin` subprojects. CI (`smithy-verify`) runs JVM legs under `LC_ALL=C` and fails on “unmappable character” in logs to assert the pin regardless of exit code. Build/CI only; no product code changes.

- Adds order-only edges to serialize Gradle-backed check targets: `smithy-mapper` → `smithy-mapper-test`; `conformance-runner-tests-kotlin` → `kt-test` → `conformance-kotlin`. Side effects: `make smithy-mapper-test` publishes first; `make kt-test` runs runner tests; `make conformance-kotlin` runs `kt-test`. Introduces gate `scripts/check-gradle-serialization.rb` (with `scripts/test-check-gradle-serialization.rb`) that requires a total order per project directory for Gradle invocations reachable from the goal, reading `make -p`, expanding variables, canonicalizing paths, following one level into shell scripts under `scripts/`, now scoped to the reachable graph and resilient to non‑UTF‑8 bytes. Runs from `make check` and CI. Migration: when adding a Gradle-backed check target to `check-targets`, add an order-only edge or the gate will fail.

<sup>Written for commit 16b1ea25c9b181c501bd27a16ed4e7dc66eedad5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

## Review round 9 (16b1ea2) — a boundary violation, and #669 biting the gate itself

Codex found that an **unreachable** target delegating to a shell script with
non-UTF-8 bytes killed the whole gate with
`ArgumentError: invalid byte sequence in UTF-8`. Two defects met there.

**Boundary.** Round 8 fixed this class for `:unplaceable` diagnostics by filtering
the scan's *results*. Wrong half: the scan still ran over every recipe, so an
out-of-scope target could take the gate down **from inside**, by having its
delegated script opened at all. Boundary 1 must bind what the gate **touches**,
not just what it reports. Reachability is now computed first and only that set is
scanned — strictly less work, too.

**Encoding.** That `ArgumentError` is **#669's own bug class — the bug this PR
exists to fix — resurfacing inside the gate shipped alongside the fix.**
`File.read(path, encoding: "UTF-8")` *tags* bytes; it does not validate them, and
the first regex over an invalid sequence raises. The read is now scrubbed as well
as pinned: every pattern the scan applies is ASCII, so replacing an undecodable
byte cannot hide a Gradle invocation, while raising takes out `make check` over a
comment in a shell script — and a guard that cannot run is not a safe default.

Reordering alone would have **hidden** the encoding defect. Both fixed, one case
each (**28 total**):

| mutation of the checker | result |
|---|---|
| no scrub, reachability-first | case 28 red — `REAL_EXIT=1` |
| round-8 scoping + scrub | all pass — **case 27 alone proves nothing** |
| round-8 scoping, no scrub (exact prior state) | case 27 red with the reported `ArgumentError` verbatim, 28 red — `REAL_EXIT=1` |

That middle row is recorded as a comment on case 27 in the test file: a case that
cannot fail is not evidence, and saying so is cheaper than letting someone infer
it later.

Suite green normally and under `LC_ALL=C` (`REAL_EXIT=0` both), and the reported
failure reproduces under `LC_ALL=C` against the mutated checker.


---

## Review round 8 (ae85101) — one taken, two declined

Five findings. The triage matters more than the diff:

**Taken — scope the gate's errors to its goal.** An unplaceable directory in a
target *not* reachable from the goal failed the whole gate, because the scan
reported before the reachable set was computed. Boundary 1 says this gate looks at
the graph reachable from `check-targets`; that has to bind its **errors** as well
as its collisions. Case 26 (**26 total**), mutation-proved (`REAL_EXIT=1` with
reporting moved back before scoping). Same false-verdict class as case 25 — the
gate saying no about something it had already declared out of scope.

**Already fixed** — the P1 (make 4.x target-variable assignment consumed by the
rule regex) landed one commit earlier in 678ea63; the target-variable branch
precedes the rule regex and 4.4.1 verifies it. Evidence posted on that thread.

**Declined, deliberately, and recorded in the header's CANNOT list:**

- a target-specific variable **inherited by a prerequisite** (make makes
  `foo: VAR = x` effective for foo's prerequisites; only the recipe target's own
  variables are merged)
- a **delegated line that cd's twice** before its Gradle call, where the match
  starts at the first `cd` and attributes the call to the wrong directory

Both reports are correct. Neither shape exists in any recipe or script in this
repo. Each would be the **eighth** growth of the rule set, arriving after this
file had already committed — in writing, before this round — to stopping.

The tally that justifies the decline: **the rules have grown every round; the
call sites covered have grown exactly once**, at delegation. If either shape ever
appears in a real recipe, that is a call site, and the answer is one of the two
instruments named in the header, not a seventh regex.

The decline is only defensible because the gate no longer overstates itself: its
pass message says "no collision in the shapes I can parse", not "no collision
exists", and the header enumerates every shape it misses. **A documented hole in
a guard that admits its reach is a different thing from a silent one** — which is
the whole reason the previous round's deliverable was the honesty rather than
another regex.


---

## Round 7 tail (678ea63) — CI caught what my verification did not

The target-specific-variable fix passed locally and **failed in CI**, and the
reason is worth recording: GNU make 3.81 (macOS, where it was written) and 4.4.1
(Linux, where CI runs) print target-specific variables differently.

```
3.81   probe:
       # PROJECT = kotlin          <- a comment inside the target's block

4.4.1  probe: PROJECT = kotlin     <- a top-level line, straight into the rule parser
```

Both are now parsed. **The reviewer's original description was right for 4.x and
my correction to them was wrong** — on 4.x the assignment does reach the rule
parser, which reads it as a target with prerequisites `PROJECT`, `=` and `kotlin`
(bogus edges that could mask a real collision) *and* leaves the variable
unrecorded. Two defects, not one; I've posted the correction on that thread.

Verified on each platform this time rather than only mine:

| | gate | 25-case suite | `LC_ALL=C` | mutation |
|---|---|---|---|---|
| 3.81 (macOS) | 0 | 0 | 0 | comment form removed → case 25 red |
| 4.4.1 (Linux, over ssh) | 0 | 0 | 0 | top-level form removed → case 25 red |

The earlier `make -p` portability check covered the rule and recipe formats on
both versions but not this parse, because this parse did not exist yet. The
commit says so, as the instruction for the next addition to the database parser:
**the two versions' formats agree less than they appear to.**


---

## Review round 7 (67c890a)

Two findings, different in kind — and both worth reading for what they say about
the gate rather than the patches.

**1. The delegate scan returned on the first script** (Copilot and Codex, same
defect). A target delegating twice kept only the first script's projects, so it
could be correctly chained for one and race another target in the other. Fixed by
accumulating across every matching script; case 24 arranges the fixture so only
the *second* delegate can produce the violation.

This is the **fifth appearance of a single defect**: an operation made total at
one nesting level and left partial at the next — recipe lines, per-line
invocations, per-script invocations, direct-plus-delegated, and now the delegate
loop. That is one finding found five times.

**2. Target-specific variables — the only finding in seven rounds that is not a
silent pass.** `probe: PROJECT = kotlin` followed by `cd $(PROJECT) && ./gradlew`
left `$(PROJECT)` unresolved, so the fail-loud `$`-guard refused to run: **the
gate saying no to a correctly chained target.** One correction to the report — the
assignment is never parsed as a prerequisite rule, because `make -p` prints
target-specific variables *inside* the target's block as comments, so the rule
parser never sees it. The consequence was real regardless, and the fix is to read
those comment lines and merge them over the global scope, as make does.

Case 25 is deliberately an `expect_pass: true` case, and its mutation goes red as
a *failure on a target that should pass*.

| mutation | result |
|---|---|
| delegate loop returns on first script | case 24 red — `REAL_EXIT=1` |
| target-specific variable parsing removed | case 25 red (**wrongly fails**) — `REAL_EXIT=1` |

**25 cases**, green, and green under `LC_ALL=C`. The header now records what this
second class teaches, because it qualifies the fail-loud default the rest of the
gate leans on: erring toward reporting is the right direction, but it is not
free, and **a guard that cannot be run is not a safe default either.**


---

## Review round 6 (a648701) and the stop (5550869)

**Round 6.** Two findings, one root cause: an operation applied to the
delegated-script path but not the recipe path. The script scan folded backslash
continuations, the recipe scan did not — so the conventional wrapped form
(`cd spec/smithy-bare-arrays && \` / `./gradlew help`, which is how `make -p`
exposes it) read as a bare repo-root call with the directory discarded. And a
direct Gradle call short-circuited the delegate scan, so a target doing both lost
the script's project. Recipes and scripts are now folded, expanded, scanned and
canonicalized identically, and direct and delegated are unioned. Cases 22-23
(**23 total**), each mutation-proved.

### Then a stop, which matters more than those two fixes

The matcher began at "recipes containing a literal `./gradlew`" and has since
gained delegation, variable expansion, canonicalization, symlink resolution, a
set-valued model, per-line totality, continuation folding, and direct-plus-
delegated union. **Every one cleared "small and obviously correct" on its own.**
The tally now in the header: **the rules have grown at every round; the call
sites covered have grown exactly once**, when delegation brought in
`kt-check-generated-drift`. Everything since is the same five targets, parsed
harder.

So the header states **no more selectors**, and records the two instruments to
switch to if a further parsing variation appears:

- **A. Bound where Gradle can be reached at all** — one sanctioned Makefile
  variable or wrapper target, so the gate inspects a single place instead of
  recognizing every spelling. A syntactic invariant that holds for call sites not
  yet written, which a matcher can never promise.
- **B. Assert the schedule instead of parsing the text** — a `gradlew` shim
  recording `(project_dir, start, end)` under a real `make -j16 check-targets`,
  asserting no two intervals for one directory overlap. Immune to recipe syntax;
  covers delegated scripts and non-make callers for free. **Not** the
  run-to-failure approach rejected earlier: two concurrent builds both exit 0, so
  watching for a failure measures luck — recording the schedule measures the
  claim.

Complementary, not alternatives, and neither is built here: this PR's subject is
the missing order-only edges.

### The gate no longer overstates its reach

The header carries an explicit CAN / CANNOT list, and so does the output:

```
OK: no two Gradle invocations THIS GATE CAN SEE share a project directory
    concurrently, in the graph reachable from check-targets.
    Scope: parsed recipe text (variables expanded, continuations folded) plus
    one level into shell scripts a recipe runs. A pass means "no collision in
    the shapes I can parse", NOT "no collision exists" — a define'd variable,
    a Ruby/Python helper or a second level of delegation is invisible here.
```

The failure path says the converse: fixing what it lists does not by itself prove
there are no others. A guard that overstates its reach is worse than one that
states a narrow reach accurately — the first stops people looking, and this
gate's whole value is that someone keeps looking.


---

## Review round 5 (424ceea)

One finding, and it is round 4's third finding **one nesting level down**:
collecting every recipe *line* made the model total per target but not per line,
so `cd kotlin && ./gradlew help; cd spec/… && ./gradlew help` was filed under
`kotlin/` alone and its second build stayed in no group.

Fixing the same defect partially twice is worse than either fix alone, so the
scan is now **total**: every invocation on a line, every invocation in a
delegated script, and **the counts must balance**. An occurrence the pattern
cannot place makes the whole line *unplaceable* rather than quietly dropping a
directory — which also strengthens the unrecognized-shape guard, since
`cd kotlin && ./gradlew a; ./gradlew b` no longer passes on its first half.

Cases 20 and 21 (**21 total**), both mutation-proved. **And the mutation caught a
vacuous test of my own:** case 21's fixture script originally built in `kotlin/`
first, so the target collided on its *first* directory and the case passed with
or without the fix (`REAL_EXIT=0` against the mutant). Reordered so the lone
project comes first, the second invocation is what it actually measures, and it
goes red as it should.

### Where this leaves the gate

Five rounds, nine defects, every one a silent pass. The rounds that mattered
changed **what the gate reads** rather than widening a pattern: make's expanded
database, one canonicalization funnel, a set-valued model, and now a total scan
with balancing counts. The script header names the end-state this is deliberately
**not** — one sanctioned Gradle entry point in the Makefile, which collapses the
parse surface to a single argument but is a refactor, wouldn't cover the Gradle
call that happens outside make entirely, and isn't this PR's subject.


---

## Review round 4 (59c607c)

Three findings, all real, all silent passes, and all answered at the funnel or in
the data model rather than with a matcher arm apiece:

| finding | fix | case | mutation |
|---|---|---|---|
| `expand_path` doesn't resolve symlinks, so an alias to `kotlin/` grouped separately while sharing one `.gradle` | `realpath`, with a lexical fallback for paths that don't exist | 19 | lexical-only → 19 red |
| GNU make allows punctuation in variable names; `\w+` missed `$(GRADLE-WRAPPER)`, so it stayed unexpanded and the target was never classified | widened the name charset in both the DB parser and the expander | 18 | `\w+` → 18 red |
| **a recipe may build in two projects**; only the first invocation was recorded, so a target ordered against the Kotlin chain could still overlap the mapper targets with its second command | a target carries a **set** of directories and is checked in each group | 17 | first-only → 17 red |

The third is a **model** fix, not a matcher fix. Suite is **19 cases**, green, and
green under `LC_ALL=C`.

### On the pattern, stated in the script header

Four rounds have produced eight defects in this gate, **every one a silent
pass**. That tail belongs to the instrument — static analysis of a shell-embedded
DSL — not to any one selector, which is why the last two rounds were answered by
changing what the gate reads (make's own expanded database; one canonicalization
funnel; a set-valued model) rather than by widening a pattern each time.

The header now names the end-state this deliberately is **not**: route every
Gradle call through one sanctioned entry point in the Makefile, and the gate
collapses to "no recipe mentions `gradlew` except through it" plus the ordering
check. That's a Makefile refactor, it wouldn't cover the one Gradle call that
happens outside make entirely (`scripts/check-kotlin-generated-drift.sh`), and it
isn't this PR's subject. Recorded so a fifth round is read as evidence about the
instrument rather than as a queue of selectors.


---

## Review rounds 2 and 3 (1f224f9, 9079c32) — and the gate's own trajectory

**Round 2.** Copilot and Codex independently found that the grouping key was the
raw `cd` text: a target spelled `cd ./kotlin` landed under `./kotlin` while the
existing ones sat under `kotlin`, so each became a group of one, each was
trivially "serialized", and the gate passed. Fixed by canonicalizing to a
repo-relative cleanpath at both capture sites.

**Round 3.** Codex found two more spellings past the same scan: `cd "kotlin"`
(quotes as pathname characters) and `cd kotlin && $(GRADLE_WRAPPER) help` (the
wrapper behind a make variable, so the word `gradlew` never appeared and the
target was never classified at all).

**Both rounds were fixed, but round 3 was not fixed with one matcher arm per
spelling — that is the point.** Three rounds found the same defect three times:
an undiscovered *target*, then an undiscovered *spelling*, then two more
spellings. Each was a silent pass. Meanwhile the rule count grew every round
while the call sites covered stayed exactly the same five. That is the signal to
reassess the instrument rather than add a fourth arm.

The gate was matching recipe **text** and calling it the command. It now reads
the command make would run: recipes are expanded against **make's own variable
database** — already in the `-p` dump it reads, and simply skipped — quotes are
stripped in the one place a directory becomes a grouping key, and everything
funnels through `canonical_dir`. This **removed** a branch rather than adding
one: `cd $(KOTLIN_DIR)` used to be a hard error and now just resolves.

Every fix mutation-proved on a mutated copy of the **checker**:

| mutation | result |
|---|---|
| delegation resolution removed | cases 8, 10 red — `REAL_EXIT=1` |
| shebang restriction removed | **positive control** red; gate stops passing the real Makefile — `REAL_EXIT=1` |
| canonicalization removed | case 12 red, only 12 — `REAL_EXIT=1` |
| dequote removed | case 14 red — `REAL_EXIT=1` |
| variable expansion removed | case 15 red — `REAL_EXIT=1` |

Suite is **16 cases**, green, and green under `LC_ALL=C`.

**What it still does not reach**, written in the script header rather than left
for round four: a value only a running shell knows (`cd $$RUNTIME_DIR`,
`$(shell …)`) is a hard error and case 16 pins it; a `define`/`endef` variable
holding the Gradle call **would be missed silently**. Nothing here does that, and
closing it means teaching the gate a second slice of make's grammar — declined
deliberately, recorded as a hole rather than left as an oversight.











