### PR TITLE
Give Kotlin a typed SearchResult and close the offline Search gap

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -13,6 +13,47 @@ what wrong behaviour you get if you ignore one. This file is that half.
 
 # Unreleased
 
+### Kotlin: `search.search` returns `ListResult<SearchResult>`, not `ListResult<JsonElement>` (#717)
+
+```kotlin
+// before
+suspend fun search(q: String, options: SearchOptions? = null): ListResult<JsonElement>
+// after
+suspend fun search(q: String, options: SearchOptions? = null): ListResult<SearchResult>
+```
+
+Kotlin was the last tier where the search projection was untyped, which meant
+the special-branch modelling in [#651](#searchresult-lost-five-required-members-and-gained-the-special-branch-keys-651)
+enforced nothing here: a `JsonElement` decodes any body whatsoever, so a spec
+that lied about the shape could not fail. `SearchResult` and
+`SearchResultAttachment` are now generated into
+`com.basecamp.sdk.generated.models`.
+
+Every `.jsonObject["…"]` navigation over a search hit stops compiling — the
+same break `reports.upcoming` took at v0.13.0, and taken for the same reason.
+Read the members instead:
+
+```kotlin
+// before
+val title = hit.jsonObject["title"]?.jsonPrimitive?.contentOrNull
+// after
+val title = hit.title
+```
+
+**Wrong behaviour you get if you ignore it:** none silently — this is a compile
+error at every call site that inspected a hit. The runtime change is the one
+worth knowing about: `SearchResult` declares `content` and `description` as
+required-and-nullable (no default), so a body omitting either now throws
+`MissingFieldException` where the untyped surface accepted it. bc3 cannot
+produce such a body — `api/searches/show.json.jbuilder` nil-overwrites both on
+every branch, attachment hits included — so this is class B by this document's
+rule.
+
+Two member-level traps, both consequences of #651 rather than of the retype:
+`id`, `title`, `type`, `url` and `app_url` are **nullable**, because the
+file-attachment branch omits all five; and `width`/`height` decode through
+`FlexibleIntSerializer`, because bc3 may float-spell them (`1920.0`).
+
 ### `SearchResult` lost five required members and gained the special-branch keys (#651)
 
 BC3's search projection special-cases four result branches — chat lines,
@@ -44,7 +85,7 @@ nil-overwrites them on every branch, attachment hits included.
 | TypeScript | `id: number`, `title/type/url/app_url: string` | `id?: number`, … — compile error under `strictNullChecks` |
 | Python | `id`/`title`/`type`/`url`/`app_url` required in the `TypedDict` | `NotRequired[...]` — type-checker-visible only, nothing changes at runtime |
 | Ruby | `Types::SearchResult.required_fields` returned all seven | returns `[:content, :description]`; readers for every new key |
-| Kotlin | untyped (`JsonElement`) | unchanged |
+| Kotlin | untyped (`JsonElement`) | typed — see [#717 above](#kotlin-searchsearch-returns-listresultsearchresult-not-listresultjsonelement-717), which lands in the same release |
 
 **Wrong behaviour you get if you ignore it:** code that renders search hits by
 `id`/`title`/`type` shows a file-attachment hit as a blank row (Go wrapper,

--- a/Makefile
+++ b/Makefile
@@ -618,6 +618,7 @@ conformance-fixtures-check:
 	python3 conformance/check_kill_case_controls.py
 	@echo "==> Self-testing the control-sibling gate's rejections..."
 	@python3 conformance/test_check_kill_case_controls.py
+	@python3 scripts/check-search-fixture-copy.py
 
 # Unit-test the runners' own assertion helpers.
 #
@@ -1436,7 +1437,7 @@ help:
 	@echo "  oauth-token-fixtures-check Validate OAuth token wire-behavior fixtures against their schema"
 	@echo "  event-feed-fixtures-check Validate event-feed tier-2 scenario fixtures against their schema"
 	@echo "  event-feed-digest-fixtures-check Validate event-feed srv1 digest vectors against their schema"
-	@echo "  conformance-fixtures-check Validate conformance/tests fixtures against schema.json"
+	@echo "  conformance-fixtures-check Validate conformance/tests fixtures against schema.json (and pin the search bodies to spec/fixtures)"
 	@echo "  check-runner-test-reachability  Assert every runner test file is reachable from discovery"
 	@echo "  check-replay-decoder-parity  Assert all five replay/dispatch tables cover the live fixture"
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -538,7 +538,7 @@ py-clean:
 # Conformance Test targets
 #------------------------------------------------------------------------------
 
-.PHONY: conformance conformance-runner-tests conformance-runner-tests-go conformance-runner-tests-python conformance-runner-tests-ruby conformance-runner-tests-kotlin conformance-runner-tests-swift check-runner-test-reachability conformance-go conformance-go-replay conformance-kotlin conformance-kotlin-replay conformance-typescript conformance-typescript-live conformance-ruby conformance-ruby-replay conformance-python conformance-python-replay conformance-swift conformance-build conformance-live conformance-canary oauth-fixtures-check oauth-token-fixtures-check event-feed-fixtures-check event-feed-digest-fixtures-check conformance-fixtures-check
+.PHONY: conformance conformance-runner-tests conformance-runner-tests-go conformance-runner-tests-python conformance-runner-tests-ruby conformance-runner-tests-kotlin conformance-runner-tests-swift check-runner-test-reachability conformance-go conformance-go-replay conformance-kotlin conformance-kotlin-replay conformance-typescript conformance-typescript-live conformance-ruby conformance-ruby-replay conformance-python conformance-python-replay conformance-swift conformance-build conformance-live conformance-canary oauth-fixtures-check oauth-token-fixtures-check event-feed-fixtures-check event-feed-digest-fixtures-check conformance-fixtures-check check-search-fixture-copy
 
 # NOTE: conformance-swift and conformance-runner-tests-swift are defined in the
 # Swift SDK targets section below — their IS_MACOS conditional must parse after
@@ -618,6 +618,14 @@ conformance-fixtures-check:
 	python3 conformance/check_kill_case_controls.py
 	@echo "==> Self-testing the control-sibling gate's rejections..."
 	@python3 conformance/test_check_kill_case_controls.py
+	@$(MAKE) check-search-fixture-copy
+
+# Pin conformance/tests/search.json's mock bodies to spec/fixtures/search/
+# results.json. The two fixture systems have no $$ref mechanism between them, so
+# the conformance bodies are a COPY, and conformance-fixtures-check validates
+# their format rather than their fidelity. Named separately as well as run above
+# so it can be invoked directly after editing either side.
+check-search-fixture-copy:
 	@python3 scripts/check-search-fixture-copy.py
 
 # Unit-test the runners' own assertion helpers.

--- a/SPEC.md
+++ b/SPEC.md
@@ -2109,6 +2109,7 @@ index past the number of recorded requests fails rather than passing vacuously.
 | pagination | `pagination.json` | §8 Pagination |
 | paths | `paths.json` | §3 Client Architecture (account path construction) |
 | retry | `retry.json` | §7 Retry |
+| search | `search.json` | §10 Type Fidelity — the polymorphic search projection, whose file-attachment branch is recognized by the ABSENCE of the recording envelope's `id`/`title`/`type`/`url`/`app_url` |
 | schedule-entries-write | `schedule_entries_write.json` | §5 Merge-Safe Write Surface (Schedule Entries), §18 Hand-Written Composite Methods, §10 Type Fidelity (explicit-empty vs. omitted wire semantics) |
 | security | `security.json` | §9 Security |
 | status-codes | `status-codes.json` | §11 Response Semantics |

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -241,6 +241,11 @@ const (
 	upcomingWindowEnd   = "2026-06-30"
 )
 
+// The query every Search case is dispatched with, fixed for the same reason as
+// the window above. It is required (an empty q is a client-side usage error),
+// and the mock returns its queued body regardless of what is asked for.
+const searchQuery = "Leto"
+
 // operationResult holds the outcome of an SDK operation call.
 type operationResult struct {
 	err    error
@@ -478,6 +483,166 @@ func summarizeProjects(projects []basecamp.Project) map[string]interface{} {
 	return summary
 }
 
+// summarizeSearch flattens a search result list into top-level scalars, one
+// group per branch of BC3's polymorphic search projection.
+//
+// Flat and scalar for the reason summarizeProjects gives. Boolean for a second
+// reason: the response is an ARRAY and no assertion type expresses absence
+// inside one — there is headerAbsent and requestBodyAbsent, but no
+// responseBodyAbsent — and the file-attachment branch is recognized precisely
+// BY the absence of the five envelope keys. Encoding that as a boolean is the
+// established idiom (last_has_upload, uploads_write.json).
+//
+// Each hit is selected by predicate rather than by index, so a fixture can
+// present one branch alone and still assert the others report honestly.
+//
+// The has_* values are non-zero tests here rather than non-null ones: the
+// public wrapper types ID/Title/Type/URL/AppURL as values with omitempty, so an
+// absent key arrives as the zero value. That collapse is exactly the hazard
+// MIGRATING.md warns about — a file-attachment hit renders as a blank row — and
+// the assertions pin it either way, since the wire genuinely omits the keys.
+func summarizeSearch(results []basecamp.SearchResult) map[string]interface{} {
+	find := func(pred func(basecamp.SearchResult) bool) *basecamp.SearchResult {
+		for i := range results {
+			if pred(results[i]) {
+				return &results[i]
+			}
+		}
+		return nil
+	}
+	intOrZero := func(p *int32) int {
+		if p == nil {
+			return 0
+		}
+		return int(*p)
+	}
+
+	bubbleUps := 0
+	for _, r := range results {
+		if r.BubbleUpURL != "" {
+			bubbleUps++
+		}
+	}
+
+	summary := map[string]interface{}{
+		"result_count":        len(results),
+		"bubble_up_url_count": bubbleUps,
+	}
+
+	// The generic recording envelope — the control group. Any hit carrying a
+	// type went through recordings/_recording.json.jbuilder.
+	summary["generic_type"] = ""
+	for _, k := range []string{"id", "title", "type", "url", "app_url"} {
+		summary["generic_has_"+k] = false
+		summary["attachment_has_"+k] = false
+	}
+	if g := find(func(r basecamp.SearchResult) bool { return r.Type != "" }); g != nil {
+		summary["generic_type"] = g.Type
+		summary["generic_has_id"] = g.ID != 0
+		summary["generic_has_title"] = g.Title != ""
+		summary["generic_has_type"] = true
+		summary["generic_has_url"] = g.URL != ""
+		summary["generic_has_app_url"] = g.AppURL != ""
+	}
+
+	// The file-attachment branch: searches/_attachment.json.jbuilder writes its
+	// own projection, so the absence of a type IS the discriminator.
+	summary["attachment_has_content"] = false
+	summary["attachment_has_description"] = false
+	summary["attachment_filename"] = ""
+	summary["attachment_content_type"] = ""
+	summary["attachment_byte_size"] = int64(0)
+	summary["attachment_previewable"] = false
+	summary["attachment_width"] = 0
+	summary["attachment_height"] = 0
+	if a := find(func(r basecamp.SearchResult) bool { return r.Type == "" }); a != nil {
+		summary["attachment_has_id"] = a.ID != 0
+		summary["attachment_has_title"] = a.Title != ""
+		summary["attachment_has_type"] = false
+		summary["attachment_has_url"] = a.URL != ""
+		summary["attachment_has_app_url"] = a.AppURL != ""
+		summary["attachment_has_content"] = a.Content != nil
+		summary["attachment_has_description"] = a.Description != nil
+		summary["attachment_filename"] = a.Filename
+		summary["attachment_content_type"] = a.ContentType
+		summary["attachment_byte_size"] = a.ByteSize
+		summary["attachment_previewable"] = a.Previewable
+		summary["attachment_width"] = intOrZero(a.Width)
+		summary["attachment_height"] = intOrZero(a.Height)
+	}
+
+	// The chat upload line: a bespoke six-key attachments aggregate carrying
+	// title/url and NONE of the rich-text id/sgid/preview keys.
+	summary["upload_line_type"] = ""
+	summary["upload_boosts_count"] = 0
+	summary["upload_attachment_filename"] = ""
+	summary["upload_attachment_has_title"] = false
+	summary["upload_attachment_has_id"] = false
+	summary["upload_attachment_has_sgid"] = false
+	if u := find(func(r basecamp.SearchResult) bool { return r.Type == "Chat::Lines::Upload" }); u != nil {
+		summary["upload_line_type"] = u.Type
+		summary["upload_boosts_count"] = u.BoostsCount
+		if len(u.Attachments) > 0 {
+			att := u.Attachments[0]
+			summary["upload_attachment_filename"] = att.Filename
+			summary["upload_attachment_has_title"] = att.Title != ""
+			summary["upload_attachment_has_id"] = att.ID != 0
+			summary["upload_attachment_has_sgid"] = att.SGID != ""
+		}
+	}
+
+	// The gauge needle: the same attachments key carrying the OTHER variant —
+	// the rich-text one, with id and sgid populated.
+	summary["needle_type"] = ""
+	summary["needle_color"] = ""
+	summary["needle_position"] = 0
+	summary["needle_comments_count"] = 0
+	summary["needle_comment_count"] = 0
+	summary["needle_boosts_count"] = 0
+	summary["needle_attachment_has_id"] = false
+	summary["needle_attachment_has_sgid"] = false
+	summary["needle_attachment_width"] = 0
+	if n := find(func(r basecamp.SearchResult) bool { return r.Type == "Gauge::Needle" }); n != nil {
+		summary["needle_type"] = n.Type
+		summary["needle_color"] = n.Color
+		summary["needle_position"] = n.Position
+		summary["needle_comments_count"] = n.CommentsCount
+		summary["needle_comment_count"] = n.CommentCount
+		summary["needle_boosts_count"] = n.BoostsCount
+		if len(n.Attachments) > 0 {
+			att := n.Attachments[0]
+			summary["needle_attachment_has_id"] = att.ID != 0
+			summary["needle_attachment_has_sgid"] = att.SGID != ""
+			summary["needle_attachment_width"] = intOrZero(att.Width)
+		}
+	}
+
+	// The kanban list: list-partial keys over the envelope, on_hold nested, and
+	// a color emitted unconditionally with a null value.
+	summary["kanban_type"] = ""
+	summary["kanban_position"] = 0
+	summary["kanban_cards_count"] = 0
+	summary["kanban_comment_count"] = 0
+	summary["kanban_subscriber_count"] = 0
+	summary["kanban_has_color"] = false
+	summary["kanban_has_on_hold"] = false
+	summary["kanban_on_hold_cards_count"] = 0
+	if k := find(func(r basecamp.SearchResult) bool { return r.Type == "Kanban::Column" }); k != nil {
+		summary["kanban_type"] = k.Type
+		summary["kanban_position"] = k.Position
+		summary["kanban_cards_count"] = k.CardsCount
+		summary["kanban_comment_count"] = k.CommentCount
+		summary["kanban_subscriber_count"] = len(k.Subscribers)
+		summary["kanban_has_color"] = k.Color != ""
+		summary["kanban_has_on_hold"] = k.OnHold != nil
+		if k.OnHold != nil {
+			summary["kanban_on_hold_cards_count"] = k.OnHold.CardsCount
+		}
+	}
+
+	return summary
+}
+
 // executeOperation dispatches to the appropriate SDK service method.
 // Returns the operation result with error and optional metadata.
 func executeOperation(ctx context.Context, account *basecamp.AccountClient, tc TestCase) operationResult {
@@ -501,6 +666,13 @@ func executeOperation(ctx context.Context, account *basecamp.AccountClient, tc T
 			},
 			result: summarizeProjects(result.Projects),
 		}
+
+	case "Search":
+		result, err := account.Search().Search(ctx, searchQuery, nil)
+		if err != nil {
+			return operationResult{err: err}
+		}
+		return operationResult{result: summarizeSearch(result.Results)}
 
 	case "GetProject":
 		projectID := getInt64Param(tc.PathParams, "projectId")

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -337,6 +337,108 @@ def _summarize_projects(result: Any) -> dict[str, Any]:
     }
 
 
+# The query every Search case is dispatched with. Fixed in the runner for the
+# same reason UPCOMING_WINDOW_START is: no mock runner consumes query_params and
+# no assertion type can pin a query string.
+SEARCH_QUERY = "Leto"
+
+
+def _summarize_search(result: Any) -> dict[str, Any]:
+    """Flatten a search result list into top-level scalars, one group per branch
+    of BC3's polymorphic search projection.
+
+    Flat and scalar for the reason _summarize_projects gives. Boolean for a
+    second reason: the response is an ARRAY and no assertion type expresses
+    absence inside one — there is headerAbsent and requestBodyAbsent, but no
+    responseBodyAbsent — and the file-attachment branch is recognized precisely
+    BY the absence of the five envelope keys. Encoding that as a boolean is the
+    established idiom (last_has_upload).
+
+    Each hit is selected by predicate rather than by index, so a fixture can
+    present one branch alone and still assert the others report honestly.
+
+    Python is lenient — `search` hands back the parsed dicts verbatim — so this
+    reads the wire keys directly; the strict tiers (Swift, Kotlin) build the same
+    summary out of decoded models, which is where the contract is enforced.
+    """
+    results = list(result)
+
+    def find(pred) -> dict:
+        return next((r for r in results if pred(r)), {})
+
+    generic = find(lambda r: r.get("type") is not None)
+    attachment = find(lambda r: r.get("type") is None)
+    upload_line = find(lambda r: r.get("type") == "Chat::Lines::Upload")
+    needle = find(lambda r: r.get("type") == "Gauge::Needle")
+    kanban = find(lambda r: r.get("type") == "Kanban::Column")
+
+    upload_attachment = (upload_line.get("attachments") or [{}])[0]
+    needle_attachment = (needle.get("attachments") or [{}])[0]
+
+    def narrow(value) -> int:
+        # Narrowed HERE, not by the SDK: Python has no typed search model, so a
+        # float-spelled 1920.0 reaches the caller as a float. The narrowing is
+        # load-bearing in the statically-typed tiers (Go, Kotlin, Swift), where
+        # the model declares an integer and a plain int decode would throw.
+        return int(value) if value is not None else 0
+
+    return {
+        "result_count": len(results),
+        "bubble_up_url_count": sum(1 for r in results if r.get("bubble_up_url") is not None),
+        # The generic recording envelope — the control group.
+        "generic_type": generic.get("type") or "",
+        "generic_has_id": generic.get("id") is not None,
+        "generic_has_title": generic.get("title") is not None,
+        "generic_has_type": generic.get("type") is not None,
+        "generic_has_url": generic.get("url") is not None,
+        "generic_has_app_url": generic.get("app_url") is not None,
+        # The file-attachment branch: searches/_attachment.json.jbuilder writes
+        # its own projection, so the absence of a type IS the discriminator.
+        "attachment_has_id": attachment.get("id") is not None,
+        "attachment_has_title": attachment.get("title") is not None,
+        "attachment_has_type": attachment.get("type") is not None,
+        "attachment_has_url": attachment.get("url") is not None,
+        "attachment_has_app_url": attachment.get("app_url") is not None,
+        "attachment_has_content": attachment.get("content") is not None,
+        "attachment_has_description": attachment.get("description") is not None,
+        "attachment_filename": attachment.get("filename") or "",
+        "attachment_content_type": attachment.get("content_type") or "",
+        "attachment_byte_size": attachment.get("byte_size") or 0,
+        "attachment_previewable": attachment.get("previewable") or False,
+        "attachment_width": narrow(attachment.get("width")),
+        "attachment_height": narrow(attachment.get("height")),
+        # The chat upload line: a bespoke six-key attachments aggregate carrying
+        # title/url and NONE of the rich-text id/sgid/preview keys.
+        "upload_line_type": upload_line.get("type") or "",
+        "upload_boosts_count": upload_line.get("boosts_count") or 0,
+        "upload_attachment_filename": upload_attachment.get("filename") or "",
+        "upload_attachment_has_title": upload_attachment.get("title") is not None,
+        "upload_attachment_has_id": upload_attachment.get("id") is not None,
+        "upload_attachment_has_sgid": upload_attachment.get("sgid") is not None,
+        # The gauge needle: the same attachments key carrying the OTHER variant
+        # — the rich-text one, with id and sgid populated.
+        "needle_type": needle.get("type") or "",
+        "needle_color": needle.get("color") or "",
+        "needle_position": needle.get("position") or 0,
+        "needle_comments_count": needle.get("comments_count") or 0,
+        "needle_comment_count": needle.get("comment_count") or 0,
+        "needle_boosts_count": needle.get("boosts_count") or 0,
+        "needle_attachment_has_id": needle_attachment.get("id") is not None,
+        "needle_attachment_has_sgid": needle_attachment.get("sgid") is not None,
+        "needle_attachment_width": narrow(needle_attachment.get("width")),
+        # The kanban list: list-partial keys over the envelope, on_hold nested,
+        # and a color emitted unconditionally with a null value.
+        "kanban_type": kanban.get("type") or "",
+        "kanban_position": kanban.get("position") or 0,
+        "kanban_cards_count": kanban.get("cards_count") or 0,
+        "kanban_comment_count": kanban.get("comment_count") or 0,
+        "kanban_subscriber_count": len(kanban.get("subscribers") or []),
+        "kanban_has_color": kanban.get("color") is not None,
+        "kanban_has_on_hold": kanban.get("on_hold") is not None,
+        "kanban_on_hold_cards_count": (kanban.get("on_hold") or {}).get("cards_count") or 0,
+    }
+
+
 class OperationMapper:
     """Maps conformance operation names to SDK calls."""
 
@@ -367,6 +469,10 @@ class OperationMapper:
                 if max_items or page:
                     return _summarize_projects(self._account.projects.list(max_items=max_items, page=page))
                 return _summarize_projects(self._account.projects.list())
+            case "Search":
+                # Consumed and summarized HERE for the same reason ListProjects
+                # is: the summary is what lets a fixture assert on the hits.
+                return _summarize_search(self._account.search.search(q=SEARCH_QUERY))
             case "GetProject":
                 return self._account.projects.get(project_id=path_params["projectId"])
             case "CreateProject":

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -220,6 +220,10 @@ class OperationMapper
           @account.projects.list
         end
       )
+    when "Search"
+      # Consumed and summarized HERE for the same reason ListProjects is: the
+      # summary is what lets a fixture assert on the decoded hits.
+      summarize_search(@account.search.search(q: SEARCH_QUERY))
     when "GetProject"
       @account.projects.get(project_id: path_params["projectId"])
     when "CreateProject"
@@ -563,6 +567,109 @@ class OperationMapper
   # stripped.
   UPCOMING_WINDOW_START = "2026-06-01"
   UPCOMING_WINDOW_END = "2026-06-30"
+
+  # The query every Search case is dispatched with, fixed for the same reason.
+  # It is required, and the mock returns its queued body regardless of what is
+  # asked for.
+  SEARCH_QUERY = "Leto"
+
+  # Flatten a search result list into top-level scalars, one group per branch of
+  # BC3's polymorphic search projection.
+  #
+  # Flat and scalar for the reason summarize_projects gives. Boolean for a
+  # second reason: the response is an ARRAY and no assertion type expresses
+  # absence inside one — there is headerAbsent and requestBodyAbsent, but no
+  # responseBodyAbsent — and the file-attachment branch is recognized precisely
+  # BY the absence of the five envelope keys. Encoding that as a boolean is the
+  # established idiom (last_has_upload).
+  #
+  # Each hit is selected by predicate rather than by index, so a fixture can
+  # present one branch alone and still assert the others report honestly.
+  #
+  # Ruby is lenient — `search` hands back the parsed hashes verbatim — so this
+  # reads the wire keys directly; the strict tiers (Swift, Kotlin) build the
+  # same summary out of decoded models, which is where the contract is enforced.
+  def summarize_search(enum)
+    results = enum.to_a
+    generic = results.find { |r| !r["type"].nil? }
+    attachment = results.find { |r| r["type"].nil? }
+    upload_line = results.find { |r| r["type"] == "Chat::Lines::Upload" }
+    needle = results.find { |r| r["type"] == "Gauge::Needle" }
+    kanban = results.find { |r| r["type"] == "Kanban::Column" }
+
+    upload_attachment = (upload_line&.fetch("attachments", nil) || [])[0] || {}
+    needle_attachment = (needle&.fetch("attachments", nil) || [])[0] || {}
+    generic ||= {}
+    attachment ||= {}
+    upload_line ||= {}
+    needle ||= {}
+    kanban ||= {}
+
+    {
+      "result_count" => results.length,
+      "bubble_up_url_count" => results.count { |r| !r["bubble_up_url"].nil? },
+
+      # The generic recording envelope — the control group.
+      "generic_type" => generic["type"] || "",
+      "generic_has_id" => !generic["id"].nil?,
+      "generic_has_title" => !generic["title"].nil?,
+      "generic_has_type" => !generic["type"].nil?,
+      "generic_has_url" => !generic["url"].nil?,
+      "generic_has_app_url" => !generic["app_url"].nil?,
+
+      # The file-attachment branch: searches/_attachment.json.jbuilder writes
+      # its own projection, so the absence of a type IS the discriminator.
+      "attachment_has_id" => !attachment["id"].nil?,
+      "attachment_has_title" => !attachment["title"].nil?,
+      "attachment_has_type" => !attachment["type"].nil?,
+      "attachment_has_url" => !attachment["url"].nil?,
+      "attachment_has_app_url" => !attachment["app_url"].nil?,
+      "attachment_has_content" => !attachment["content"].nil?,
+      "attachment_has_description" => !attachment["description"].nil?,
+      "attachment_filename" => attachment["filename"] || "",
+      "attachment_content_type" => attachment["content_type"] || "",
+      "attachment_byte_size" => attachment["byte_size"] || 0,
+      "attachment_previewable" => attachment["previewable"] || false,
+      # Narrowed HERE, not by the SDK: Ruby has no typed search model, so a
+      # float-spelled 1920.0 reaches the caller as a Float. The narrowing is
+      # load-bearing in the statically-typed tiers (Go, Kotlin, Swift), where
+      # the model declares an integer and a plain int decode would throw.
+      "attachment_width" => attachment["width"]&.to_i || 0,
+      "attachment_height" => attachment["height"]&.to_i || 0,
+
+      # The chat upload line: a bespoke six-key attachments aggregate carrying
+      # title/url and NONE of the rich-text id/sgid/preview keys.
+      "upload_line_type" => upload_line["type"] || "",
+      "upload_boosts_count" => upload_line["boosts_count"] || 0,
+      "upload_attachment_filename" => upload_attachment["filename"] || "",
+      "upload_attachment_has_title" => !upload_attachment["title"].nil?,
+      "upload_attachment_has_id" => !upload_attachment["id"].nil?,
+      "upload_attachment_has_sgid" => !upload_attachment["sgid"].nil?,
+
+      # The gauge needle: the same attachments key carrying the OTHER variant —
+      # the rich-text one, with id and sgid populated.
+      "needle_type" => needle["type"] || "",
+      "needle_color" => needle["color"] || "",
+      "needle_position" => needle["position"] || 0,
+      "needle_comments_count" => needle["comments_count"] || 0,
+      "needle_comment_count" => needle["comment_count"] || 0,
+      "needle_boosts_count" => needle["boosts_count"] || 0,
+      "needle_attachment_has_id" => !needle_attachment["id"].nil?,
+      "needle_attachment_has_sgid" => !needle_attachment["sgid"].nil?,
+      "needle_attachment_width" => needle_attachment["width"]&.to_i || 0,
+
+      # The kanban list: list-partial keys over the envelope, on_hold nested,
+      # and a color emitted unconditionally with a null value.
+      "kanban_type" => kanban["type"] || "",
+      "kanban_position" => kanban["position"] || 0,
+      "kanban_cards_count" => kanban["cards_count"] || 0,
+      "kanban_comment_count" => kanban["comment_count"] || 0,
+      "kanban_subscriber_count" => (kanban["subscribers"] || []).length,
+      "kanban_has_color" => !kanban["color"].nil?,
+      "kanban_has_on_hold" => !kanban["on_hold"].nil?,
+      "kanban_on_hold_cards_count" => kanban.dig("on_hold", "cards_count") || 0
+    }
+  end
 
   # Flatten the upcoming-schedule envelope into top-level scalars. Go and
   # TypeScript resolve a responseBody path as a top-level key only, so the

--- a/conformance/runner/swift/Sources/ConformanceRunner/Dispatch.swift
+++ b/conformance/runner/swift/Sources/ConformanceRunner/Dispatch.swift
@@ -108,6 +108,102 @@ private func resultJSON<T: Encodable>(_ value: T) throws -> JSON? {
 private let upcomingWindowStart = "2026-06-01"
 private let upcomingWindowEnd = "2026-06-30"
 
+/// The query every Search case is dispatched with, fixed for the same reason. It
+/// is required, and the mock returns its queued body regardless of what is asked
+/// for.
+private let searchQuery = "Leto"
+
+/// Flattens a search result list into top-level scalars, one group per branch of
+/// BC3's polymorphic search projection.
+///
+/// Flat and scalar for the reason summarizeProjects gives. Boolean for a second
+/// reason: the response is an ARRAY and no assertion type expresses absence
+/// inside one — there is headerAbsent and requestBodyAbsent, but no
+/// responseBodyAbsent — and the file-attachment branch is recognized precisely BY
+/// the absence of the five envelope keys. Encoding that as a boolean is the
+/// established idiom (last_has_upload).
+///
+/// Each hit is selected by predicate rather than by index, so a fixture can
+/// present one branch alone and still assert the others report honestly.
+///
+/// Every value comes off the DECODED model, which is what makes this a decode
+/// test of the #651 modelling rather than a transport test: Swift has no
+/// wire-replay runner, so before this fixture nothing offline reached the
+/// special branches here at all.
+private func summarizeSearch(_ results: [SearchResult]) -> JSON {
+    let generic = results.first { $0.type != nil }
+    let attachment = results.first { $0.type == nil }
+    let uploadLine = results.first { $0.type == "Chat::Lines::Upload" }
+    let needle = results.first { $0.type == "Gauge::Needle" }
+    let kanban = results.first { $0.type == "Kanban::Column" }
+    let uploadAttachment = uploadLine?.attachments?.first
+    let needleAttachment = needle?.attachments?.first
+
+    return .object([
+        "result_count": .int(Int64(results.count)),
+        "bubble_up_url_count": .int(Int64(results.filter { $0.bubbleUpUrl != nil }.count)),
+
+        // The generic recording envelope — the control group.
+        "generic_type": .string(generic?.type ?? ""),
+        "generic_has_id": .bool(generic?.id != nil),
+        "generic_has_title": .bool(generic?.title != nil),
+        "generic_has_type": .bool(generic?.type != nil),
+        "generic_has_url": .bool(generic?.url != nil),
+        "generic_has_app_url": .bool(generic?.appUrl != nil),
+
+        // The file-attachment branch: searches/_attachment.json.jbuilder writes
+        // its own projection, so the absence of a type IS the discriminator.
+        "attachment_has_id": .bool(attachment?.id != nil),
+        "attachment_has_title": .bool(attachment?.title != nil),
+        "attachment_has_type": .bool(attachment?.type != nil),
+        "attachment_has_url": .bool(attachment?.url != nil),
+        "attachment_has_app_url": .bool(attachment?.appUrl != nil),
+        "attachment_has_content": .bool(attachment?.content != nil),
+        "attachment_has_description": .bool(attachment?.description != nil),
+        "attachment_filename": .string(attachment?.filename ?? ""),
+        "attachment_content_type": .string(attachment?.contentType ?? ""),
+        "attachment_byte_size": .int(Int64(attachment?.byteSize ?? 0)),
+        "attachment_previewable": .bool(attachment?.previewable ?? false),
+        // Float-spelled on the wire (1920.0). Foundation's JSONDecoder accepts
+        // an integral-valued JSON float into an integer field, so `Int32?`
+        // narrows it without a FlexibleInt wrapper — verified, not assumed.
+        "attachment_width": .int(Int64(attachment?.width ?? 0)),
+        "attachment_height": .int(Int64(attachment?.height ?? 0)),
+
+        // The chat upload line: a bespoke six-key attachments aggregate carrying
+        // title/url and NONE of the rich-text id/sgid/preview keys.
+        "upload_line_type": .string(uploadLine?.type ?? ""),
+        "upload_boosts_count": .int(Int64(uploadLine?.boostsCount ?? 0)),
+        "upload_attachment_filename": .string(uploadAttachment?.filename ?? ""),
+        "upload_attachment_has_title": .bool(uploadAttachment?.title != nil),
+        "upload_attachment_has_id": .bool(uploadAttachment?.id != nil),
+        "upload_attachment_has_sgid": .bool(uploadAttachment?.sgid != nil),
+
+        // The gauge needle: the same attachments key carrying the OTHER variant
+        // — the rich-text one, with id and sgid populated.
+        "needle_type": .string(needle?.type ?? ""),
+        "needle_color": .string(needle?.color ?? ""),
+        "needle_position": .int(Int64(needle?.position ?? 0)),
+        "needle_comments_count": .int(Int64(needle?.commentsCount ?? 0)),
+        "needle_comment_count": .int(Int64(needle?.commentCount ?? 0)),
+        "needle_boosts_count": .int(Int64(needle?.boostsCount ?? 0)),
+        "needle_attachment_has_id": .bool(needleAttachment?.id != nil),
+        "needle_attachment_has_sgid": .bool(needleAttachment?.sgid != nil),
+        "needle_attachment_width": .int(Int64(needleAttachment?.width ?? 0)),
+
+        // The kanban list: list-partial keys over the envelope, on_hold nested,
+        // and a color emitted unconditionally with a null value.
+        "kanban_type": .string(kanban?.type ?? ""),
+        "kanban_position": .int(Int64(kanban?.position ?? 0)),
+        "kanban_cards_count": .int(Int64(kanban?.cardsCount ?? 0)),
+        "kanban_comment_count": .int(Int64(kanban?.commentCount ?? 0)),
+        "kanban_subscriber_count": .int(Int64(kanban?.subscribers?.count ?? 0)),
+        "kanban_has_color": .bool(kanban?.color != nil),
+        "kanban_has_on_hold": .bool(kanban?.onHold != nil),
+        "kanban_on_hold_cards_count": .int(Int64(kanban?.onHold?.cardsCount ?? 0)),
+    ])
+}
+
 /// Flattens the upcoming-schedule envelope into top-level scalars.
 ///
 /// Go and TypeScript resolve a responseBody path as a top-level key only, so the
@@ -206,6 +302,10 @@ func dispatchOperation(_ tc: TestCase, _ account: AccountClient) async throws ->
             totalCount: result.meta.totalCount,
             truncated: result.meta.truncated,
             resultJSON: summarizeProjects(result.items))
+
+    case "Search":
+        let results = try await account.search.search(q: searchQuery)
+        return DispatchResult(resultJSON: summarizeSearch(results.items))
 
     case "GetProject":
         let project = try await account.projects.get(projectId: pathParams.longParam("projectId"))

--- a/conformance/runner/typescript/runner.test.ts
+++ b/conformance/runner/typescript/runner.test.ts
@@ -215,6 +215,11 @@ function mapScheduleEntryWireFields(body: Record<string, unknown>): UpdateSchedu
 const UPCOMING_WINDOW_START = "2026-06-01";
 const UPCOMING_WINDOW_END = "2026-06-30";
 
+// The query every Search case is dispatched with, fixed for the same reason. It
+// is required, and the mock returns its queued body regardless of what is asked
+// for.
+const SEARCH_QUERY = "Leto";
+
 /**
  * Flattens the upcoming-schedule envelope into top-level scalars.
  *
@@ -308,6 +313,95 @@ function summarizeUploadVersions(
 }
 
 /**
+ * Flattens a search result list into top-level scalars, one group per branch of
+ * BC3's polymorphic search projection.
+ *
+ * Flat and scalar for the reason summarizeProjects gives. Boolean for a second
+ * reason: the response is an ARRAY and no assertion type expresses absence
+ * inside one — there is headerAbsent and requestBodyAbsent, but no
+ * responseBodyAbsent — and the file-attachment branch is recognized precisely
+ * BY the absence of the five envelope keys. Encoding that as a boolean is the
+ * established idiom (last_has_upload).
+ *
+ * Each hit is selected by predicate rather than by index, so a fixture can
+ * present one branch alone and still assert the others report honestly.
+ */
+function summarizeSearch(
+  results: Awaited<ReturnType<BasecampClient["search"]["search"]>>,
+): Record<string, unknown> {
+  const nonNull = (v: unknown): boolean => v !== undefined && v !== null;
+  const generic = results.find((r) => nonNull(r.type));
+  const attachment = results.find((r) => !nonNull(r.type));
+  const uploadLine = results.find((r) => r.type === "Chat::Lines::Upload");
+  const needle = results.find((r) => r.type === "Gauge::Needle");
+  const kanban = results.find((r) => r.type === "Kanban::Column");
+
+  const uploadAttachment = uploadLine?.attachments?.[0];
+  const needleAttachment = needle?.attachments?.[0];
+
+  return {
+    result_count: results.length,
+    bubble_up_url_count: results.filter((r) => nonNull(r.bubble_up_url)).length,
+
+    // The generic recording envelope — the control group.
+    generic_type: generic?.type ?? "",
+    generic_has_id: nonNull(generic?.id),
+    generic_has_title: nonNull(generic?.title),
+    generic_has_type: nonNull(generic?.type),
+    generic_has_url: nonNull(generic?.url),
+    generic_has_app_url: nonNull(generic?.app_url),
+
+    // The file-attachment branch: searches/_attachment.json.jbuilder writes its
+    // own projection, so the absence of a type IS the discriminator.
+    attachment_has_id: nonNull(attachment?.id),
+    attachment_has_title: nonNull(attachment?.title),
+    attachment_has_type: nonNull(attachment?.type),
+    attachment_has_url: nonNull(attachment?.url),
+    attachment_has_app_url: nonNull(attachment?.app_url),
+    attachment_has_content: nonNull(attachment?.content),
+    attachment_has_description: nonNull(attachment?.description),
+    attachment_filename: attachment?.filename ?? "",
+    attachment_content_type: attachment?.content_type ?? "",
+    attachment_byte_size: attachment?.byte_size ?? 0,
+    attachment_previewable: attachment?.previewable ?? false,
+    attachment_width: attachment?.width ?? 0,
+    attachment_height: attachment?.height ?? 0,
+
+    // The chat upload line: a bespoke six-key attachments aggregate carrying
+    // title/url and NONE of the rich-text id/sgid/preview keys.
+    upload_line_type: uploadLine?.type ?? "",
+    upload_boosts_count: uploadLine?.boosts_count ?? 0,
+    upload_attachment_filename: uploadAttachment?.filename ?? "",
+    upload_attachment_has_title: nonNull(uploadAttachment?.title),
+    upload_attachment_has_id: nonNull(uploadAttachment?.id),
+    upload_attachment_has_sgid: nonNull(uploadAttachment?.sgid),
+
+    // The gauge needle: the same attachments key carrying the OTHER variant —
+    // the rich-text one, with id and sgid populated.
+    needle_type: needle?.type ?? "",
+    needle_color: needle?.color ?? "",
+    needle_position: needle?.position ?? 0,
+    needle_comments_count: needle?.comments_count ?? 0,
+    needle_comment_count: needle?.comment_count ?? 0,
+    needle_boosts_count: needle?.boosts_count ?? 0,
+    needle_attachment_has_id: nonNull(needleAttachment?.id),
+    needle_attachment_has_sgid: nonNull(needleAttachment?.sgid),
+    needle_attachment_width: needleAttachment?.width ?? 0,
+
+    // The kanban list: list-partial keys over the envelope, on_hold nested, and
+    // a color emitted unconditionally with a null value.
+    kanban_type: kanban?.type ?? "",
+    kanban_position: kanban?.position ?? 0,
+    kanban_cards_count: kanban?.cards_count ?? 0,
+    kanban_comment_count: kanban?.comment_count ?? 0,
+    kanban_subscriber_count: kanban?.subscribers?.length ?? 0,
+    kanban_has_color: nonNull(kanban?.color),
+    kanban_has_on_hold: nonNull(kanban?.on_hold),
+    kanban_on_hold_cards_count: kanban?.on_hold?.cards_count ?? 0,
+  };
+}
+
+/**
  * Executes the appropriate SDK method for the given operation name.
  * Returns { error?, httpStatus? } so assertions can inspect outcomes.
  *
@@ -337,6 +431,11 @@ async function executeOperation(
           },
           result: summarizeProjects(projects),
         };
+      }
+
+      case "Search": {
+        const results = await client.search.search(SEARCH_QUERY);
+        return { result: summarizeSearch(results) };
       }
 
       case "GetProject": {

--- a/conformance/tests/search.json
+++ b/conformance/tests/search.json
@@ -1,0 +1,925 @@
+[
+  {
+    "name": "search decodes the generic envelope and all four special branches",
+    "description": "The search projection is polymorphic: `api/searches/show.json.jbuilder` renders each hit through `api_search_result_template_path`, and four branches are special-cased — file attachments, chat lines, kanban (card table) lists and gauge needles. #651 modelled all four; nothing offline exercised them in any language. Search was live-only: the five wire-replay runners reach it, but every one is canary-gated and credentialed, and Swift has no replay runner at all.\n\nThe body is copied verbatim from `spec/fixtures/search/results.json`, the same eight hits `go/pkg/basecamp/search_test.go` reads and `make check-fixture-coverage` validates against the generated schema. `make check-search-fixture-copy` pins the copy to that file.\n\nThe dispatch fixes the query at `Leto` rather than reading it from the case: no mock runner consumes queryParams, and no assertion type can pin a query string (every runner records the path with the query stripped).\n\nAssertions ride a per-runner summarizer of the DECODED results rather than the raw body, for the reason `summarizeProjects` gives — a responseBody path resolves as a top-level key only, so neither a dotted path nor an array index is portable — and for one more: the response is an ARRAY and no assertion type can express absence inside it (there is `headerAbsent` and `requestBodyAbsent`, but no `responseBodyAbsent`). Encoding absence as a boolean is the established idiom (`last_has_upload`, uploads_write.json).\n\nEach `*_has_*` key is a NON-NULL predicate, not a key-presence one: the six SDKs disagree about presence (Go's wrapper collapses an absent scalar to its zero value, Ruby and Python read the wire hash directly) but agree about null. The keys asserted false here are genuinely absent from the wire, so both readings coincide.\n\nThe `generic_*` counterparts assert TRUE against the same summarizer, so a runner that reported absence unconditionally — the way this fixture fails vacuously — cannot pass.",
+    "operation": "Search",
+    "method": "GET",
+    "path": "/search.json",
+    "mockResponses": [
+      {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": [
+          {
+            "id": 1069479351,
+            "status": "active",
+            "visible_to_clients": false,
+            "created_at": "2022-10-28T15:21:46.169Z",
+            "updated_at": "2022-10-28T15:21:46.169Z",
+            "title": "We won Leto!",
+            "inherits_status": true,
+            "type": "Message",
+            "url": "https://3.basecampapi.com/195539477/buckets/2085958499/messages/1069479351.json",
+            "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/messages/1069479351",
+            "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5MzUxP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--aabbccdd.json",
+            "content": null,
+            "description": null,
+            "plain_text_content": "Hello everyone! We got the <mark class=\"circled-text\"><span></span>Leto</mark> Laptop project! Time to get started.",
+            "subject": "We won Leto!",
+            "parent": {
+              "id": 1069479338,
+              "title": "Message Board",
+              "type": "Message::Board",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958499/message_boards/1069479338.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/message_boards/1069479338"
+            },
+            "bucket": {
+              "id": 2085958499,
+              "name": "The Leto Laptop",
+              "type": "Project"
+            },
+            "creator": {
+              "id": 1049715914,
+              "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+              "name": "Victor Cooper",
+              "email_address": "victor@honchodesign.com",
+              "personable_type": "User",
+              "title": "Chief Strategist",
+              "bio": null,
+              "location": null,
+              "created_at": "2022-11-22T08:23:21.732Z",
+              "updated_at": "2022-11-22T08:23:21.732Z",
+              "admin": true,
+              "owner": true,
+              "client": false,
+              "employee": true,
+              "time_zone": "America/Chicago",
+              "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+              "can_manage_projects": true,
+              "can_manage_people": true
+            },
+            "content_attachments": [
+              {
+                "id": 1069481030,
+                "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA30--pr0j0030",
+                "filename": "diagram-30.png",
+                "content_type": "image/png",
+                "byte_size": 204800,
+                "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA30--pr0j0030/download/diagram-30.png",
+                "width": 1024.0,
+                "height": 768,
+                "previewable": true,
+                "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA30--pr0j0030/previews/diagram-30.png",
+                "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA30--pr0j0030/thumbnails/diagram-30.png"
+              }
+            ],
+            "attachments": [
+              {
+                "id": 1069481030,
+                "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA30--pr0j0030",
+                "filename": "diagram-30.png",
+                "content_type": "image/png",
+                "byte_size": 204800,
+                "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA30--pr0j0030/download/diagram-30.png",
+                "width": 1024.0,
+                "height": 768,
+                "previewable": true,
+                "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA30--pr0j0030/previews/diagram-30.png",
+                "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA30--pr0j0030/thumbnails/diagram-30.png"
+              }
+            ]
+          },
+          {
+            "id": 1069479400,
+            "status": "active",
+            "visible_to_clients": false,
+            "created_at": "2022-10-29T10:30:00.000Z",
+            "updated_at": "2022-10-29T10:30:00.000Z",
+            "title": "Design specs for Leto display",
+            "inherits_status": true,
+            "type": "Todo",
+            "url": "https://3.basecampapi.com/195539477/buckets/2085958499/todos/1069479400.json",
+            "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/todos/1069479400",
+            "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5NDAwP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--eeffgghh.json",
+            "content": null,
+            "description": null,
+            "plain_text_description": "Create detailed specifications for the <mark class=\"circled-text\"><span></span>Leto</mark> laptop keyboard layout, including key spacing and travel distance.",
+            "parent": {
+              "id": 1069479390,
+              "title": "Hardware Design",
+              "type": "Todolist",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958499/todolists/1069479390.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/todolists/1069479390"
+            },
+            "bucket": {
+              "id": 2085958499,
+              "name": "The Leto Laptop",
+              "type": "Project"
+            },
+            "creator": {
+              "id": 1049715915,
+              "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aeb392ebf54ffd820e45f27add22bae3a8c7da56",
+              "name": "Annie Bryan",
+              "email_address": "annie@honchodesign.com",
+              "personable_type": "User",
+              "title": "Central Markets Manager",
+              "bio": "To open a store is easy, to keep it open is an art",
+              "location": null,
+              "created_at": "2022-11-22T08:23:21.911Z",
+              "updated_at": "2022-11-22T08:23:21.911Z",
+              "admin": false,
+              "owner": false,
+              "client": false,
+              "employee": true,
+              "time_zone": "America/Chicago",
+              "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMtkkT4=--avatar",
+              "can_manage_projects": true,
+              "can_manage_people": true
+            },
+            "description_attachments": [
+              {
+                "id": 1069481031,
+                "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA31--pr0j0031",
+                "filename": "diagram-31.png",
+                "content_type": "image/png",
+                "byte_size": 204800,
+                "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA31--pr0j0031/download/diagram-31.png",
+                "width": 1024.0,
+                "height": 768,
+                "previewable": true,
+                "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA31--pr0j0031/previews/diagram-31.png",
+                "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA31--pr0j0031/thumbnails/diagram-31.png"
+              }
+            ]
+          },
+          {
+            "id": 1069479450,
+            "status": "active",
+            "visible_to_clients": false,
+            "created_at": "2022-10-30T14:00:00.000Z",
+            "updated_at": "2022-10-30T14:00:00.000Z",
+            "title": "Leto keyboard layout review",
+            "inherits_status": true,
+            "type": "Comment",
+            "url": "https://3.basecampapi.com/195539477/buckets/2085958499/comments/1069479450.json",
+            "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/comments/1069479450",
+            "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5NDUwP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--iijjkkll.json",
+            "content": null,
+            "description": null,
+            "plain_text_content": "The <mark class=\"circled-text\"><span></span>Leto</mark> keyboard layout looks great. Let&#39;s finalize it this week.",
+            "parent": {
+              "id": 1069479400,
+              "title": "Design specs for Leto display",
+              "type": "Todo",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958499/todos/1069479400.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/todos/1069479400"
+            },
+            "bucket": {
+              "id": 2085958499,
+              "name": "The Leto Laptop",
+              "type": "Project"
+            },
+            "creator": {
+              "id": 1049715914,
+              "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+              "name": "Victor Cooper",
+              "email_address": "victor@honchodesign.com",
+              "personable_type": "User",
+              "title": "Chief Strategist",
+              "bio": null,
+              "location": null,
+              "created_at": "2022-11-22T08:23:21.732Z",
+              "updated_at": "2022-11-22T08:23:21.732Z",
+              "admin": true,
+              "owner": true,
+              "client": false,
+              "employee": true,
+              "time_zone": "America/Chicago",
+              "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+              "can_manage_projects": true,
+              "can_manage_people": true
+            },
+            "content_attachments": [
+              {
+                "id": 1069481032,
+                "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA32--pr0j0032",
+                "filename": "diagram-32.png",
+                "content_type": "image/png",
+                "byte_size": 204800,
+                "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA32--pr0j0032/download/diagram-32.png",
+                "width": 1024.0,
+                "height": 768,
+                "previewable": true,
+                "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA32--pr0j0032/previews/diagram-32.png",
+                "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA32--pr0j0032/thumbnails/diagram-32.png"
+              }
+            ]
+          },
+          {
+            "id": 1069479519,
+            "status": "active",
+            "visible_to_clients": false,
+            "created_at": "2022-10-29T10:30:00.000Z",
+            "updated_at": "2022-10-29T10:30:00.000Z",
+            "title": "Hardware",
+            "inherits_status": true,
+            "type": "Todolist",
+            "url": "https://3.basecampapi.com/195539477/buckets/2085958500/todolists/1069479519.json",
+            "app_url": "https://3.basecamp.com/195539477/buckets/2085958500/todolists/1069479519",
+            "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5NTE5P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--ebab26d1c66e726e17dd785d0e46bfc4e5cba3f5.json",
+            "bubble_up_url": "https://3.basecampapi.com/195539477/buckets/2085958500/recordings/1069479519/bubble_up.json",
+            "content": null,
+            "description": null,
+            "plain_text_description": "Everything that has to ship before the <mark class=\"circled-text\"><span></span>Leto</mark> launch.",
+            "parent": {
+              "id": 1069479338,
+              "title": "To-dos",
+              "type": "Todoset",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958500/todosets/1069479338.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958500/todosets/1069479338"
+            },
+            "bucket": {
+              "id": 2085958500,
+              "name": "The Leto Locator",
+              "type": "Project"
+            },
+            "creator": {
+              "id": 1049715915,
+              "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE1P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aeb392ebf54ffd820e45f27add22bae3a8c7da56",
+              "name": "Annie Bryan",
+              "email_address": "annie@honchodesign.com",
+              "personable_type": "User",
+              "title": "Central Markets Manager",
+              "bio": "To open a store is easy, to keep it open is an art",
+              "location": null,
+              "created_at": "2022-11-22T08:23:21.911Z",
+              "updated_at": "2022-11-22T08:23:21.911Z",
+              "admin": false,
+              "owner": false,
+              "client": false,
+              "employee": true,
+              "time_zone": "America/Chicago",
+              "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMtkkT4=--avatar",
+              "can_manage_projects": true,
+              "can_manage_people": true
+            }
+          },
+          {
+            "parent": {
+              "id": 1069479338,
+              "title": "Message Board",
+              "type": "Message",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958499/messages/1069479351.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/messages/1069479351"
+            },
+            "bucket": {
+              "id": 2085958499,
+              "name": "The Leto Laptop",
+              "type": "Project"
+            },
+            "creator": {
+              "id": 1049715914,
+              "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+              "name": "Victor Cooper",
+              "email_address": "victor@honchodesign.com",
+              "personable_type": "User",
+              "title": "Chief Strategist",
+              "bio": null,
+              "location": null,
+              "created_at": "2022-11-22T08:23:21.732Z",
+              "updated_at": "2022-11-22T08:23:21.732Z",
+              "admin": true,
+              "owner": true,
+              "client": false,
+              "employee": true,
+              "time_zone": "America/Chicago",
+              "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+              "can_manage_projects": true,
+              "can_manage_people": true
+            },
+            "created_at": "2022-10-28T15:25:00.000Z",
+            "filename": "leto-hero.jpg",
+            "content_type": "image/jpeg",
+            "byte_size": 512000,
+            "previewable": true,
+            "width": 1920.0,
+            "height": 1080,
+            "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA35--srch0035/previews/leto-hero.jpg",
+            "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA35--srch0035/thumbnails/leto-hero.jpg",
+            "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA35--srch0035/download/leto-hero.jpg",
+            "app_download_url": "https://3.basecamp.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA35--srch0035/download/leto-hero.jpg",
+            "content": null,
+            "description": null
+          },
+          {
+            "id": 1069479610,
+            "status": "active",
+            "visible_to_clients": false,
+            "created_at": "2022-10-28T15:30:00.000Z",
+            "updated_at": "2022-10-28T15:30:00.000Z",
+            "title": "leto-benchmarks.pdf",
+            "inherits_status": true,
+            "type": "Chat::Lines::Upload",
+            "url": "https://3.basecampapi.com/195539477/buckets/2085958499/chats/1069479345/lines/1069479610.json",
+            "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/chats/1069479345#__recording_1069479610",
+            "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5NjEwP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--mmnnoopp.json",
+            "boosts_count": 1,
+            "boosts_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479610/boosts.json",
+            "parent": {
+              "id": 1069479345,
+              "title": "Campfire",
+              "type": "Chat::Transcript",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958499/chats/1069479345.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/chats/1069479345"
+            },
+            "bucket": {
+              "id": 2085958499,
+              "name": "The Leto Laptop",
+              "type": "Project"
+            },
+            "creator": {
+              "id": 1049715914,
+              "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+              "name": "Victor Cooper",
+              "email_address": "victor@honchodesign.com",
+              "personable_type": "User",
+              "title": "Chief Strategist",
+              "bio": null,
+              "location": null,
+              "created_at": "2022-11-22T08:23:21.732Z",
+              "updated_at": "2022-11-22T08:23:21.732Z",
+              "admin": true,
+              "owner": true,
+              "client": false,
+              "employee": true,
+              "time_zone": "America/Chicago",
+              "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+              "can_manage_projects": true,
+              "can_manage_people": true
+            },
+            "attachments": [
+              {
+                "title": "leto-benchmarks.pdf",
+                "url": "https://3.basecampapi.com/195539477/buckets/2085958499/uploads/1069479611.json",
+                "filename": "leto-benchmarks.pdf",
+                "content_type": "application/pdf",
+                "byte_size": 1048576,
+                "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/uploads/1069479611/download/leto-benchmarks.pdf"
+              }
+            ],
+            "content": null,
+            "description": null
+          },
+          {
+            "id": 1069479620,
+            "status": "active",
+            "visible_to_clients": false,
+            "created_at": "2024-01-15T09:31:00.000-06:00",
+            "updated_at": "2024-01-20T14:45:00.000-06:00",
+            "title": "Leto in progress",
+            "inherits_status": true,
+            "type": "Kanban::Column",
+            "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/columns/1069479620.json",
+            "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/columns/1069479620",
+            "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5NjIwP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--qqrrsstt.json",
+            "subscription_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479620/subscription.json",
+            "position": 2,
+            "parent": {
+              "id": 1069479345,
+              "title": "Development Board",
+              "type": "Kanban::Board",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/1069479345.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/1069479345"
+            },
+            "bucket": {
+              "id": 2085958499,
+              "name": "The Leto Laptop",
+              "type": "Project"
+            },
+            "creator": {
+              "id": 1049715914,
+              "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+              "name": "Victor Cooper",
+              "email_address": "victor@honchodesign.com",
+              "personable_type": "User",
+              "title": "Chief Strategist",
+              "bio": null,
+              "location": null,
+              "created_at": "2022-11-22T08:23:21.732Z",
+              "updated_at": "2022-11-22T08:23:21.732Z",
+              "admin": true,
+              "owner": true,
+              "client": false,
+              "employee": true,
+              "time_zone": "America/Chicago",
+              "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+              "can_manage_projects": true,
+              "can_manage_people": true
+            },
+            "subscribers": [
+              {
+                "id": 1049715914,
+                "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+                "name": "Victor Cooper",
+                "email_address": "victor@honchodesign.com",
+                "personable_type": "User",
+                "title": "Chief Strategist",
+                "bio": null,
+                "location": null,
+                "created_at": "2022-11-22T08:23:21.732Z",
+                "updated_at": "2022-11-22T08:23:21.732Z",
+                "admin": true,
+                "owner": true,
+                "client": false,
+                "employee": true,
+                "time_zone": "America/Chicago",
+                "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+                "can_manage_projects": true,
+                "can_manage_people": true
+              }
+            ],
+            "color": null,
+            "cards_count": 4,
+            "comment_count": 1,
+            "cards_url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/lists/1069479620/cards.json",
+            "on_hold": {
+              "id": 1069479621,
+              "status": "active",
+              "inherits_status": true,
+              "title": "On hold",
+              "created_at": "2024-01-15T09:31:00.000-06:00",
+              "updated_at": "2024-01-20T14:45:00.000-06:00",
+              "cards_count": 0,
+              "cards_url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/lists/1069479621/cards.json"
+            },
+            "content": null,
+            "description": null,
+            "plain_text_content": "Cards for the <mark class=\"circled-text\"><span></span>Leto</mark> build currently in flight.",
+            "plain_text_description": "Cards for the <mark class=\"circled-text\"><span></span>Leto</mark> build currently in flight."
+          },
+          {
+            "id": 1069479630,
+            "status": "active",
+            "visible_to_clients": false,
+            "created_at": "2022-11-28T14:12:00.000Z",
+            "updated_at": "2022-11-28T14:12:00.000Z",
+            "title": "Progress update",
+            "inherits_status": true,
+            "type": "Gauge::Needle",
+            "url": "https://3.basecampapi.com/195539477/buckets/2085958499/gauge_needles/1069479630.json",
+            "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/gauge_needles/1069479630",
+            "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5NjMwP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--uuvvwwxx.json",
+            "subscription_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479630/subscription.json",
+            "comments_count": 2,
+            "comments_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479630/comments.json",
+            "boosts_count": 3,
+            "boosts_url": "https://3.basecampapi.com/195539477/buckets/2085958499/recordings/1069479630/boosts.json",
+            "parent": {
+              "id": 1069479800,
+              "title": "Gauge",
+              "type": "Gauge",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958499/gauges/1069479800.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/gauges/1069479800"
+            },
+            "bucket": {
+              "id": 2085958499,
+              "name": "The Leto Laptop",
+              "type": "Project"
+            },
+            "creator": {
+              "id": 1049715914,
+              "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+              "name": "Victor Cooper",
+              "email_address": "victor@honchodesign.com",
+              "personable_type": "User",
+              "title": "Chief Strategist",
+              "bio": null,
+              "location": null,
+              "created_at": "2022-11-22T08:23:21.732Z",
+              "updated_at": "2022-11-22T08:23:21.732Z",
+              "admin": true,
+              "owner": true,
+              "client": false,
+              "employee": true,
+              "time_zone": "America/Chicago",
+              "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+              "can_manage_projects": true,
+              "can_manage_people": true
+            },
+            "description_attachments": [
+              {
+                "id": 1069479631,
+                "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--srchndl1",
+                "filename": "leto-burndown.png",
+                "content_type": "image/png",
+                "byte_size": 40960,
+                "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--srchndl1/download/leto-burndown.png",
+                "width": 1024.0,
+                "height": 768,
+                "previewable": true,
+                "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--srchndl1/previews/leto-burndown.png",
+                "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--srchndl1/thumbnails/leto-burndown.png"
+              }
+            ],
+            "color": "green",
+            "position": 72,
+            "comment_count": 2,
+            "content": null,
+            "description": null,
+            "plain_text_content": "<mark class=\"circled-text\"><span></span>Leto</mark> hardware is on track for the launch window.",
+            "plain_text_description": "<mark class=\"circled-text\"><span></span>Leto</mark> hardware is on track for the launch window.",
+            "attachments": [
+              {
+                "id": 1069479631,
+                "sgid": "BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--srchndl1",
+                "filename": "leto-burndown.png",
+                "content_type": "image/png",
+                "byte_size": 40960,
+                "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--srchndl1/download/leto-burndown.png",
+                "width": 1024.0,
+                "height": 768,
+                "previewable": true,
+                "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--srchndl1/previews/leto-burndown.png",
+                "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MAY6BkVU--srchndl1/thumbnails/leto-burndown.png"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "assertions": [
+      {
+        "type": "noError"
+      },
+      {
+        "type": "requestCount",
+        "expected": 1
+      },
+      {
+        "type": "requestMethod",
+        "expected": "GET"
+      },
+      {
+        "type": "requestPath",
+        "expected": "/999/search.json"
+      },
+      {
+        "type": "responseBody",
+        "path": "result_count",
+        "expected": 8
+      },
+      {
+        "type": "responseBody",
+        "path": "generic_type",
+        "expected": "Message"
+      },
+      {
+        "type": "responseBody",
+        "path": "generic_has_id",
+        "expected": true
+      },
+      {
+        "type": "responseBody",
+        "path": "generic_has_title",
+        "expected": true
+      },
+      {
+        "type": "responseBody",
+        "path": "generic_has_type",
+        "expected": true
+      },
+      {
+        "type": "responseBody",
+        "path": "generic_has_url",
+        "expected": true
+      },
+      {
+        "type": "responseBody",
+        "path": "generic_has_app_url",
+        "expected": true
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_has_id",
+        "expected": false
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_has_title",
+        "expected": false
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_has_type",
+        "expected": false
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_has_url",
+        "expected": false
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_has_app_url",
+        "expected": false
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_filename",
+        "expected": "leto-hero.jpg"
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_content_type",
+        "expected": "image/jpeg"
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_byte_size",
+        "expected": 512000
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_previewable",
+        "expected": true
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_width",
+        "expected": 1920
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_height",
+        "expected": 1080
+      },
+      {
+        "type": "responseBody",
+        "path": "upload_line_type",
+        "expected": "Chat::Lines::Upload"
+      },
+      {
+        "type": "responseBody",
+        "path": "upload_boosts_count",
+        "expected": 1
+      },
+      {
+        "type": "responseBody",
+        "path": "upload_attachment_filename",
+        "expected": "leto-benchmarks.pdf"
+      },
+      {
+        "type": "responseBody",
+        "path": "upload_attachment_has_title",
+        "expected": true
+      },
+      {
+        "type": "responseBody",
+        "path": "upload_attachment_has_id",
+        "expected": false
+      },
+      {
+        "type": "responseBody",
+        "path": "upload_attachment_has_sgid",
+        "expected": false
+      },
+      {
+        "type": "responseBody",
+        "path": "needle_type",
+        "expected": "Gauge::Needle"
+      },
+      {
+        "type": "responseBody",
+        "path": "needle_color",
+        "expected": "green"
+      },
+      {
+        "type": "responseBody",
+        "path": "needle_position",
+        "expected": 72
+      },
+      {
+        "type": "responseBody",
+        "path": "needle_comments_count",
+        "expected": 2
+      },
+      {
+        "type": "responseBody",
+        "path": "needle_comment_count",
+        "expected": 2
+      },
+      {
+        "type": "responseBody",
+        "path": "needle_boosts_count",
+        "expected": 3
+      },
+      {
+        "type": "responseBody",
+        "path": "needle_attachment_has_id",
+        "expected": true
+      },
+      {
+        "type": "responseBody",
+        "path": "needle_attachment_has_sgid",
+        "expected": true
+      },
+      {
+        "type": "responseBody",
+        "path": "needle_attachment_width",
+        "expected": 1024
+      },
+      {
+        "type": "responseBody",
+        "path": "kanban_type",
+        "expected": "Kanban::Column"
+      },
+      {
+        "type": "responseBody",
+        "path": "kanban_position",
+        "expected": 2
+      },
+      {
+        "type": "responseBody",
+        "path": "kanban_cards_count",
+        "expected": 4
+      },
+      {
+        "type": "responseBody",
+        "path": "kanban_comment_count",
+        "expected": 1
+      },
+      {
+        "type": "responseBody",
+        "path": "kanban_subscriber_count",
+        "expected": 1
+      },
+      {
+        "type": "responseBody",
+        "path": "kanban_has_color",
+        "expected": false
+      },
+      {
+        "type": "responseBody",
+        "path": "kanban_has_on_hold",
+        "expected": true
+      },
+      {
+        "type": "responseBody",
+        "path": "kanban_on_hold_cards_count",
+        "expected": 0
+      },
+      {
+        "type": "responseBody",
+        "path": "bubble_up_url_count",
+        "expected": 1
+      }
+    ],
+    "tags": [
+      "search",
+      "decode",
+      "issue-651",
+      "issue-717"
+    ]
+  },
+  {
+    "name": "search decodes a file-attachment hit that is the only result",
+    "description": "The file-attachment branch in isolation. `searches/_attachment.json.jbuilder` is the one branch that writes its own projection instead of decorating the recording envelope, so it emits NONE of `id`/`title`/`type`/`url`/`app_url` — the five members #651 had to make optional across all six SDKs.\n\nSeparate from the all-branches case because there the absence could be an artifact of sibling hits: a summarizer that picked the wrong element would still find envelope keys somewhere in the array. Here the attachment hit is the only element, so `attachment_has_type: false` can only come from the hit itself. It also pins `content`/`description` as present-and-null on the branch that carries no envelope at all — the pair stays required-and-nullable because the show template nil-overwrites both after rendering, attachment hits included.\n\nThe hit is copied verbatim from `spec/fixtures/search/results.json`.",
+    "operation": "Search",
+    "method": "GET",
+    "path": "/search.json",
+    "mockResponses": [
+      {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": [
+          {
+            "parent": {
+              "id": 1069479338,
+              "title": "Message Board",
+              "type": "Message",
+              "url": "https://3.basecampapi.com/195539477/buckets/2085958499/messages/1069479351.json",
+              "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/messages/1069479351"
+            },
+            "bucket": {
+              "id": 2085958499,
+              "name": "The Leto Laptop",
+              "type": "Project"
+            },
+            "creator": {
+              "id": 1049715914,
+              "attachable_sgid": "BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL1BlcnNvbi8xMDQ5NzE1OTE0P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg9hdHRhY2hhYmxlBjsAVEkiD2V4cGlyZXNfYXQGOwBUMA==--aabbccdd",
+              "name": "Victor Cooper",
+              "email_address": "victor@honchodesign.com",
+              "personable_type": "User",
+              "title": "Chief Strategist",
+              "bio": null,
+              "location": null,
+              "created_at": "2022-11-22T08:23:21.732Z",
+              "updated_at": "2022-11-22T08:23:21.732Z",
+              "admin": true,
+              "owner": true,
+              "client": false,
+              "employee": true,
+              "time_zone": "America/Chicago",
+              "avatar_url": "https://3.basecamp-static.com/195539477/people/BAhpBMpkkT4=--avatar",
+              "can_manage_projects": true,
+              "can_manage_people": true
+            },
+            "created_at": "2022-10-28T15:25:00.000Z",
+            "filename": "leto-hero.jpg",
+            "content_type": "image/jpeg",
+            "byte_size": 512000,
+            "previewable": true,
+            "width": 1920.0,
+            "height": 1080,
+            "preview_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA35--srch0035/previews/leto-hero.jpg",
+            "thumbnail_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA35--srch0035/thumbnails/leto-hero.jpg",
+            "download_url": "https://3.basecampapi.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA35--srch0035/download/leto-hero.jpg",
+            "app_download_url": "https://3.basecamp.com/195539477/buckets/2085958499/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvJTA35--srch0035/download/leto-hero.jpg",
+            "content": null,
+            "description": null
+          }
+        ]
+      }
+    ],
+    "assertions": [
+      {
+        "type": "noError"
+      },
+      {
+        "type": "requestCount",
+        "expected": 1
+      },
+      {
+        "type": "responseBody",
+        "path": "result_count",
+        "expected": 1
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_has_id",
+        "expected": false
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_has_title",
+        "expected": false
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_has_type",
+        "expected": false
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_has_url",
+        "expected": false
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_has_app_url",
+        "expected": false
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_has_content",
+        "expected": false
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_has_description",
+        "expected": false
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_filename",
+        "expected": "leto-hero.jpg"
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_width",
+        "expected": 1920
+      },
+      {
+        "type": "responseBody",
+        "path": "attachment_height",
+        "expected": 1080
+      },
+      {
+        "type": "responseBody",
+        "path": "generic_has_id",
+        "expected": false
+      }
+    ],
+    "tags": [
+      "search",
+      "decode",
+      "issue-651",
+      "issue-717"
+    ]
+  }
+]

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
@@ -31,6 +31,13 @@ private const val UPCOMING_WINDOW_START = "2026-06-01"
 private const val UPCOMING_WINDOW_END = "2026-06-30"
 
 /**
+ * The query every Search case is dispatched with, fixed for the same reason. It
+ * is required, and the mock returns its queued body regardless of what is asked
+ * for.
+ */
+private const val SEARCH_QUERY = "Leto"
+
+/**
  * Flattens the upcoming-schedule envelope into top-level scalars.
  *
  * Go and TypeScript resolve a responseBody path as a top-level key only, so the
@@ -105,6 +112,96 @@ private fun summarizeUploadVersions(versions: List<UploadVersion>): JsonElement 
         // entirely — the optionality UploadVersion.upload declares.
         put("last_has_upload", last.upload != null)
     }
+}
+
+
+/**
+ * Flattens a search result list into top-level scalars, one group per branch of
+ * BC3's polymorphic search projection.
+ *
+ * Flat and scalar for the reason summarizeProjects gives. Boolean for a second
+ * reason: the response is an ARRAY and no assertion type expresses absence
+ * inside one — there is headerAbsent and requestBodyAbsent, but no
+ * responseBodyAbsent — and the file-attachment branch is recognized precisely BY
+ * the absence of the five envelope keys. Encoding that as a boolean is the
+ * established idiom (last_has_upload).
+ *
+ * Each hit is selected by predicate rather than by index, so a fixture can
+ * present one branch alone and still assert the others report honestly.
+ *
+ * Every value comes off the DECODED model, so this is a decode test of the
+ * retype that closes #717 and not a transport test — before it, `search`
+ * returned `ListResult<JsonElement>` and no search body could fail here.
+ */
+private fun summarizeSearch(results: List<SearchResult>): JsonElement = buildJsonObject {
+    val generic = results.firstOrNull { it.type != null }
+    val attachment = results.firstOrNull { it.type == null }
+    val uploadLine = results.firstOrNull { it.type == "Chat::Lines::Upload" }
+    val needle = results.firstOrNull { it.type == "Gauge::Needle" }
+    val kanban = results.firstOrNull { it.type == "Kanban::Column" }
+    val uploadAttachment = uploadLine?.attachments?.firstOrNull()
+    val needleAttachment = needle?.attachments?.firstOrNull()
+
+    put("result_count", results.size)
+    put("bubble_up_url_count", results.count { it.bubbleUpUrl != null })
+
+    // The generic recording envelope — the control group.
+    put("generic_type", generic?.type ?: "")
+    put("generic_has_id", generic?.id != null)
+    put("generic_has_title", generic?.title != null)
+    put("generic_has_type", generic?.type != null)
+    put("generic_has_url", generic?.url != null)
+    put("generic_has_app_url", generic?.appUrl != null)
+
+    // The file-attachment branch: searches/_attachment.json.jbuilder writes its
+    // own projection, so the absence of a type IS the discriminator.
+    put("attachment_has_id", attachment?.id != null)
+    put("attachment_has_title", attachment?.title != null)
+    put("attachment_has_type", attachment?.type != null)
+    put("attachment_has_url", attachment?.url != null)
+    put("attachment_has_app_url", attachment?.appUrl != null)
+    put("attachment_has_content", attachment?.content != null)
+    put("attachment_has_description", attachment?.description != null)
+    put("attachment_filename", attachment?.filename ?: "")
+    put("attachment_content_type", attachment?.contentType ?: "")
+    put("attachment_byte_size", attachment?.byteSize ?: 0L)
+    put("attachment_previewable", attachment?.previewable ?: false)
+    // Float-spelled on the wire (1920.0); FlexibleIntSerializer narrows it. A
+    // plain Int property throws here.
+    put("attachment_width", attachment?.width ?: 0)
+    put("attachment_height", attachment?.height ?: 0)
+
+    // The chat upload line: a bespoke six-key attachments aggregate carrying
+    // title/url and NONE of the rich-text id/sgid/preview keys.
+    put("upload_line_type", uploadLine?.type ?: "")
+    put("upload_boosts_count", uploadLine?.boostsCount ?: 0)
+    put("upload_attachment_filename", uploadAttachment?.filename ?: "")
+    put("upload_attachment_has_title", uploadAttachment?.title != null)
+    put("upload_attachment_has_id", uploadAttachment?.id != null)
+    put("upload_attachment_has_sgid", uploadAttachment?.sgid != null)
+
+    // The gauge needle: the same attachments key carrying the OTHER variant —
+    // the rich-text one, with id and sgid populated.
+    put("needle_type", needle?.type ?: "")
+    put("needle_color", needle?.color ?: "")
+    put("needle_position", needle?.position ?: 0)
+    put("needle_comments_count", needle?.commentsCount ?: 0)
+    put("needle_comment_count", needle?.commentCount ?: 0)
+    put("needle_boosts_count", needle?.boostsCount ?: 0)
+    put("needle_attachment_has_id", needleAttachment?.id != null)
+    put("needle_attachment_has_sgid", needleAttachment?.sgid != null)
+    put("needle_attachment_width", needleAttachment?.width ?: 0)
+
+    // The kanban list: list-partial keys over the envelope, on_hold nested, and
+    // a color emitted unconditionally with a null value.
+    put("kanban_type", kanban?.type ?: "")
+    put("kanban_position", kanban?.position ?: 0)
+    put("kanban_cards_count", kanban?.cardsCount ?: 0)
+    put("kanban_comment_count", kanban?.commentCount ?: 0)
+    put("kanban_subscriber_count", kanban?.subscribers?.size ?: 0)
+    put("kanban_has_color", kanban?.color != null)
+    put("kanban_has_on_hold", kanban?.onHold != null)
+    put("kanban_on_hold_cards_count", kanban?.onHold?.cardsCount ?: 0)
 }
 
 
@@ -785,6 +882,11 @@ private suspend fun dispatchOperation(tc: TestCase, account: AccountClient): Dis
                 truncated = result.meta.truncated,
                 resultJson = summarizeProjects(result),
             )
+        }
+
+        "Search" -> {
+            val result = account.search.search(q = SEARCH_QUERY)
+            DispatchResult(resultJson = summarizeSearch(result))
         }
 
         "GetProject" -> {

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/ReplayRunner.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/ReplayRunner.kt
@@ -9,6 +9,7 @@ import com.basecamp.sdk.generated.models.Notification
 import com.basecamp.sdk.generated.models.Person
 import com.basecamp.sdk.generated.models.Project
 import com.basecamp.sdk.generated.models.Recording
+import com.basecamp.sdk.generated.models.SearchResult
 import com.basecamp.sdk.generated.models.TimelineEvent
 import com.basecamp.sdk.generated.models.Todo
 import com.basecamp.sdk.generated.models.Todolist
@@ -49,11 +50,11 @@ import kotlin.system.exitProcess
  * Where the Kotlin SDK has a typed model for the response payload (`Project`,
  * `Person`, `Todo`, `Todolist`, `Todoset`, `Recording`, `Card`,
  * `BucketTodosGroup`, `BucketCardsGroup`, `EverythingFile`, `TimelineEvent`,
- * `Notification`), the decoder routes through that type — exactly what the
- * generated service method does at runtime. The four `My*` operations
- * (assignments, completed assignments, due assignments, notifications) return
- * bare `JsonElement` from the SDK, as does each element of `Search`'s result;
- * for those we decode as `JsonElement`, which mirrors the SDK's actual surface.
+ * `Notification`, `SearchResult`), the decoder routes through that type —
+ * exactly what the generated service method does at runtime. The four `My*`
+ * operations (assignments, completed assignments, due assignments,
+ * notifications) return bare `JsonElement` from the SDK; for those we decode as
+ * `JsonElement`, which mirrors the SDK's actual surface.
  *
  * The `Json` instance below intentionally mirrors mock-mode (`ignoreUnknownKeys
  * = true`, `coerceInputValues = false`) — additive BC5 fields must NOT decode
@@ -109,9 +110,7 @@ internal val decoders: Map<String, (String) -> Unit> = mapOf(
     "GetProgressReport" to { bt -> replayJson.decodeFromString(ListSerializer(TimelineEvent.serializer()), bt) },
     "GetBubbleUps" to { bt -> replayJson.decodeFromString(ListSerializer(Notification.serializer()), bt) },
     "ListRecordings" to { bt -> replayJson.decodeFromString(ListSerializer(Recording.serializer()), bt) },
-    // Search returns ListResult<JsonElement> from the SDK — SearchResult has no
-    // typed Kotlin model, so JsonElement is the real boundary.
-    "Search" to { bt -> replayJson.decodeFromString(ListSerializer(JsonElement.serializer()), bt) },
+    "Search" to { bt -> replayJson.decodeFromString(ListSerializer(SearchResult.serializer()), bt) },
     // The sixteen Everything aggregates.
     "GetEverythingMessages" to { bt -> replayJson.decodeFromString(ListSerializer(Recording.serializer()), bt) },
     "GetEverythingComments" to { bt -> replayJson.decodeFromString(ListSerializer(Recording.serializer()), bt) },

--- a/kotlin/generator/src/main/kotlin/com/basecamp/sdk/generator/Config.kt
+++ b/kotlin/generator/src/main/kotlin/com/basecamp/sdk/generator/Config.kt
@@ -377,6 +377,12 @@ val TYPE_ALIASES = mapOf(
     // envelopes are not entities) — list them explicitly, as DraftParent is.
     "UpcomingScheduleEntry" to "UpcomingScheduleEntry",
     "UpcomingAssignable" to "UpcomingAssignable",
+    // Search's polymorphic hit projection. `findUnderlyingEntitySchema` already
+    // matches the array-of-$ref response shape, so listing it here is the whole
+    // trigger for retyping `Search` from `ListResult<JsonElement>` (see
+    // MIGRATING.md). Every other SDK has carried a typed SearchResult since
+    // #716; Kotlin was the tier where the modelled branches enforced nothing.
+    "SearchResult" to "SearchResult",
 )
 
 /**

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/SearchResult.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/SearchResult.kt
@@ -1,0 +1,66 @@
+package com.basecamp.sdk.generated.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import com.basecamp.sdk.serialization.FlexibleIntSerializer
+
+/**
+ * SearchResult entity from the Basecamp API.
+ *
+ * @generated from OpenAPI spec — do not edit directly
+ */
+@Serializable
+data class SearchResult(
+    val content: String?,
+    val description: String?,
+    val id: Long? = null,
+    val status: String? = null,
+    @SerialName("visible_to_clients") val visibleToClients: Boolean? = null,
+    @SerialName("created_at") val createdAt: String? = null,
+    @SerialName("updated_at") val updatedAt: String? = null,
+    val title: String? = null,
+    @SerialName("inherits_status") val inheritsStatus: Boolean? = null,
+    val type: String? = null,
+    val url: String? = null,
+    @SerialName("app_url") val appUrl: String? = null,
+    @SerialName("bookmark_url") val bookmarkUrl: String? = null,
+    @SerialName("subscription_url") val subscriptionUrl: String? = null,
+    @SerialName("bubble_up_url") val bubbleUpUrl: String? = null,
+    val parent: RecordingParent? = null,
+    val bucket: RecordingBucket? = null,
+    val creator: Person? = null,
+    @SerialName("plain_text_content") val plainTextContent: String? = null,
+    @SerialName("plain_text_description") val plainTextDescription: String? = null,
+    @SerialName("content_attachments") val contentAttachments: List<RichTextAttachment>? = null,
+    @SerialName("description_attachments") val descriptionAttachments: List<RichTextAttachment>? = null,
+    val attachments: List<SearchResultAttachment>? = null,
+    val subject: String? = null,
+    @SerialName("boosts_count") val boostsCount: Int? = null,
+    @SerialName("boosts_url") val boostsUrl: String? = null,
+    val language: String? = null,
+    @SerialName("image_url") val imageUrl: String? = null,
+    @SerialName("sound_url") val soundUrl: String? = null,
+    val subscribers: List<Person>? = null,
+    val color: String? = null,
+    @SerialName("cards_count") val cardsCount: Int? = null,
+    @SerialName("comment_count") val commentCount: Int? = null,
+    @SerialName("cards_url") val cardsUrl: String? = null,
+    @SerialName("on_hold") val onHold: CardColumnOnHold? = null,
+    @SerialName("comments_count") val commentsCount: Int? = null,
+    @SerialName("comments_url") val commentsUrl: String? = null,
+    val position: Int? = null,
+    val filename: String? = null,
+    @SerialName("content_type") val contentType: String? = null,
+    @SerialName("byte_size") val byteSize: Long? = null,
+    val previewable: Boolean? = null,
+    @Serializable(with = FlexibleIntSerializer::class)
+    val width: Int? = null,
+    @Serializable(with = FlexibleIntSerializer::class)
+    val height: Int? = null,
+    @SerialName("preview_url") val previewUrl: String? = null,
+    @SerialName("thumbnail_url") val thumbnailUrl: String? = null,
+    @SerialName("download_url") val downloadUrl: String? = null,
+    @SerialName("app_download_url") val appDownloadUrl: String? = null
+)

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/SearchResultAttachment.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/SearchResultAttachment.kt
@@ -1,0 +1,31 @@
+package com.basecamp.sdk.generated.models
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import com.basecamp.sdk.serialization.FlexibleIntSerializer
+
+/**
+ * SearchResultAttachment entity from the Basecamp API.
+ *
+ * @generated from OpenAPI spec — do not edit directly
+ */
+@Serializable
+data class SearchResultAttachment(
+    val filename: String,
+    @SerialName("content_type") val contentType: String,
+    @SerialName("byte_size") val byteSize: Long,
+    @SerialName("download_url") val downloadUrl: String,
+    val id: Long? = null,
+    val sgid: String? = null,
+    val previewable: Boolean? = null,
+    @SerialName("preview_url") val previewUrl: String? = null,
+    @SerialName("thumbnail_url") val thumbnailUrl: String? = null,
+    @Serializable(with = FlexibleIntSerializer::class)
+    val width: Int? = null,
+    @Serializable(with = FlexibleIntSerializer::class)
+    val height: Int? = null,
+    val title: String? = null,
+    val url: String? = null
+)

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/search.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/search.kt
@@ -18,7 +18,7 @@ class SearchService(client: AccountClient) : BaseService(client) {
      * @param options Optional query parameters and pagination control
      */
     @Suppress("DEPRECATION")
-    suspend fun search(q: String, options: SearchOptions? = null): ListResult<JsonElement> {
+    suspend fun search(q: String, options: SearchOptions? = null): ListResult<SearchResult> {
         val info = OperationInfo(
             service = "Search",
             operation = "Search",
@@ -44,7 +44,7 @@ class SearchService(client: AccountClient) : BaseService(client) {
         return requestPaginated(info, options?.toPaginationOptions(), {
             httpGet("/search.json" + qs, operationName = info.operation)
         }) { body ->
-            json.decodeFromString<List<JsonElement>>(body)
+            json.decodeFromString<List<SearchResult>>(body)
         }
     }
 

--- a/kotlin/sdk/src/jvmTest/kotlin/com/basecamp/sdk/SearchResultDecodeTest.kt
+++ b/kotlin/sdk/src/jvmTest/kotlin/com/basecamp/sdk/SearchResultDecodeTest.kt
@@ -1,0 +1,192 @@
+package com.basecamp.sdk
+
+import com.basecamp.sdk.generated.models.SearchResult
+import com.basecamp.sdk.generated.search
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * `search` returns `ListResult<SearchResult>` rather than
+ * `ListResult<JsonElement>` (#717). Until then Kotlin was the one tier where
+ * the special-branch modelling done in #651 enforced nothing at all: an
+ * untyped `JsonElement` decodes any body whatsoever, so a spec that lied about
+ * the search projection could not fail here.
+ *
+ * These tests drive the real generated service through the real client decoder
+ * against the shared `spec/fixtures/search/results.json` body — the same file
+ * `go/pkg/basecamp/search_test.go` reads, validated against the generated
+ * schema by `make check-fixture-coverage`. Reading it from disk rather than
+ * restating it inline is deliberate: the point is that Kotlin now decodes the
+ * *same bytes* the other five SDKs do, which an invented body cannot show.
+ *
+ * This is a JVM-only test because `commonTest` has no filesystem. The decoder
+ * under test is `commonMain`, so nothing platform-specific is being asserted.
+ */
+class SearchResultDecodeTest {
+
+    /** Walk up from the working directory to the repo root (the tree holding `openapi.json`). */
+    private fun repoRoot(): File {
+        var dir: File? = File(".").absoluteFile
+        while (dir != null && !File(dir, "openapi.json").isFile) {
+            dir = dir.parentFile
+        }
+        return requireNotNull(dir) { "could not locate repo root from ${File(".").absolutePath}" }
+    }
+
+    private fun sharedFixture(): String =
+        File(repoRoot(), "spec/fixtures/search/results.json").readText()
+
+    private suspend fun search(body: String): List<SearchResult> {
+        val client = testBasecampClient {
+            accessToken("test-token")
+            engine = MockEngine {
+                respond(
+                    content = body,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+                )
+            }
+        }
+        try {
+            return client.forAccount("195539477").search.search(q = "Leto")
+        } finally {
+            client.close()
+        }
+    }
+
+    @Test
+    fun decodesEveryBranchOfTheSharedFixture() = runTest {
+        val results = search(sharedFixture())
+        assertEquals(8, results.size)
+
+        // /0 — Message. content/description are required-and-nullable: the show
+        // template nil-overwrites both on every branch, so a decoder that made
+        // them non-nullable would throw here.
+        val message = results[0]
+        assertEquals(1069479351L, message.id)
+        assertEquals("Message", message.type)
+        assertEquals("We won Leto!", message.title)
+        assertEquals("We won Leto!", message.subject)
+        assertNull(message.content)
+        assertNull(message.description)
+        assertTrue(message.plainTextContent!!.contains("""<mark class="circled-text">"""))
+        assertNull(message.plainTextDescription)
+        assertEquals("Message::Board", message.parent?.type)
+        assertEquals("The Leto Laptop", message.bucket?.name)
+        assertEquals("Victor Cooper", message.creator?.name)
+
+        // bubble_up_url rides the polymorphic projection: only Todolist hits
+        // reach a partial that passes `bubbleupable: true`.
+        for (r in results) {
+            if (r.type == "Todolist") {
+                assertNotNull(r.bubbleUpUrl, "Todolist result ${r.id}: expected bubbleUpUrl")
+            } else {
+                assertNull(r.bubbleUpUrl, "${r.type} result ${r.id}: expected no bubbleUpUrl")
+            }
+        }
+
+        // /4 — file-attachment branch. `searches/_attachment.json.jbuilder`
+        // writes its own projection with NONE of the five envelope keys, so a
+        // model declaring them required would throw. The branch discriminator
+        // is that absence plus `filename`.
+        val attachment = results[4]
+        assertNull(attachment.id)
+        assertNull(attachment.title)
+        assertNull(attachment.type)
+        assertNull(attachment.url)
+        assertNull(attachment.appUrl)
+        assertEquals("leto-hero.jpg", attachment.filename)
+        assertEquals("image/jpeg", attachment.contentType)
+        assertEquals(512000L, attachment.byteSize)
+        assertEquals(true, attachment.previewable)
+        // Float-spelled on the wire (`1920.0`) — FlexibleIntSerializer narrows
+        // it. A plain Int field throws here.
+        assertEquals(1920, attachment.width)
+        assertEquals(1080, attachment.height)
+        assertNotNull(attachment.downloadUrl)
+        assertNotNull(attachment.appDownloadUrl)
+        assertNotNull(attachment.previewUrl)
+        assertNotNull(attachment.thumbnailUrl)
+        assertNull(attachment.content)
+        assertNull(attachment.description)
+        assertEquals("Message", attachment.parent?.type)
+
+        // /5 — chat upload line: a bespoke six-key `attachments` aggregate that
+        // does NOT match RichTextAttachment (no id, no sgid, no preview keys),
+        // plus the boostable envelope keys.
+        val uploadLine = results[5]
+        assertEquals("Chat::Lines::Upload", uploadLine.type)
+        assertEquals(1, uploadLine.boostsCount)
+        assertNotNull(uploadLine.boostsUrl)
+        val bespoke = assertNotNull(uploadLine.attachments).single()
+        assertEquals("leto-benchmarks.pdf", bespoke.title)
+        assertNotNull(bespoke.url)
+        assertEquals("leto-benchmarks.pdf", bespoke.filename)
+        assertEquals("application/pdf", bespoke.contentType)
+        assertEquals(1048576L, bespoke.byteSize)
+        assertNotNull(bespoke.downloadUrl)
+        assertNull(bespoke.id)
+        assertNull(bespoke.sgid)
+        assertNull(bespoke.previewable)
+        assertNull(bespoke.width)
+
+        // /6 — kanban list: list-partial keys over the envelope. `color` is
+        // emitted unconditionally with a null value, so it must stay nullable
+        // rather than coerce to "".
+        val kanban = results[6]
+        assertEquals("Kanban::Column", kanban.type)
+        assertNotNull(kanban.subscriptionUrl)
+        assertEquals(2, kanban.position)
+        assertNull(kanban.color)
+        assertEquals(4, kanban.cardsCount)
+        assertEquals(1, kanban.commentCount)
+        assertNotNull(kanban.cardsUrl)
+        assertEquals("Victor Cooper", assertNotNull(kanban.subscribers).single().name)
+        val onHold = assertNotNull(kanban.onHold)
+        assertEquals(0, onHold.cardsCount)
+        assertNotNull(onHold.cardsUrl)
+
+        // /7 — gauge needle: commentable + boostable envelope, the needle's own
+        // keys, and the rich-text description companion array surviving the
+        // nil-overwrite of `description` itself.
+        val needle = results[7]
+        assertEquals("Gauge::Needle", needle.type)
+        assertEquals(2, needle.commentsCount)
+        assertEquals(3, needle.boostsCount)
+        assertEquals(2, needle.commentCount)
+        assertEquals("green", needle.color)
+        assertEquals(72, needle.position)
+        assertNull(needle.description)
+        assertEquals(1, assertNotNull(needle.descriptionAttachments).size)
+        // The generic `attachments` key repeats the companion array through the
+        // same partial, so here the rich-text-variant keys ARE populated —
+        // the mirror image of the chat upload line above.
+        val richText = assertNotNull(needle.attachments).single()
+        assertNotNull(richText.id)
+        assertNotNull(richText.sgid)
+        assertEquals(1024, richText.width)
+    }
+
+    /**
+     * The regression proof for the retype itself. Against `JsonElement` this
+     * body decodes happily; against `SearchResult` it throws, because
+     * `content` and `description` have no default and the projection always
+     * emits them.
+     */
+    @Test
+    fun missingRequiredNullableMembersThrow() = runTest {
+        val e = runCatching { search("""[{"id": 1, "type": "Message"}]""") }.exceptionOrNull()
+        assertNotNull(e, "a hit missing content/description must not decode")
+    }
+}

--- a/python/tests/services/test_search.py
+++ b/python/tests/services/test_search.py
@@ -1,6 +1,10 @@
-"""Tests for the generated search service: array-filter wire encoding + metadata."""
+"""Tests for the generated search service: array-filter wire encoding, the four
+special-cased result branches, and metadata."""
 
 from __future__ import annotations
+
+import json
+import pathlib
 
 import httpx
 import pytest
@@ -11,37 +15,26 @@ from basecamp import AsyncClient, Client
 SEARCH_URL = "https://3.basecampapi.com/12345/search.json"
 METADATA_URL = "https://3.basecampapi.com/12345/searches/metadata.json"
 
-# A file-attachment hit (searches/_attachment.json.jbuilder): the one branch
-# that omits the id/title/type/url/app_url envelope keys and carries the ten
-# file keys instead. width/height ride only on previewable files and may
-# arrive float-spelled (1920.0). content/description are still present-and-
-# null — the show template nil-overwrites them on every branch.
-_ATTACHMENT_HIT = {
-    "parent": {
-        "id": 10,
-        "title": "Message Board",
-        "type": "Message",
-        "url": "https://3.basecampapi.com/12345/buckets/1/messages/11.json",
-        "app_url": "https://3.basecamp.com/12345/buckets/1/messages/11",
-    },
-    "bucket": {"id": 1, "name": "Leto", "type": "Project"},
-    "created_at": "2022-10-28T15:25:00.000Z",
-    "filename": "leto-hero.jpg",
-    "content_type": "image/jpeg",
-    "byte_size": 512000,
-    "previewable": True,
-    "width": 1920.0,
-    "height": 1080,
-    "preview_url": "https://3.basecampapi.com/12345/blobs/hero/previews/leto-hero.jpg",
-    "thumbnail_url": "https://3.basecampapi.com/12345/blobs/hero/thumbnails/leto-hero.jpg",
-    "download_url": "https://3.basecampapi.com/12345/blobs/hero/download/leto-hero.jpg",
-    "app_download_url": "https://3.basecamp.com/12345/blobs/hero/download/leto-hero.jpg",
-    "content": None,
-    "description": None,
-}
+# The shared, coverage-guarded body: eight hits covering the generic recording
+# envelope and all four branches `api_search_result_template_path` special-cases
+# (file attachments, chat lines, kanban lists, gauge needles). Read from disk
+# rather than restated inline so this cannot drift from the copy the other five
+# SDKs and the conformance runners assert against; `make check-fixture-coverage`
+# validates it against the generated SearchResult schema.
+_FIXTURES = pathlib.Path(__file__).resolve().parents[3] / "spec/fixtures/search"
+_RESULTS = json.loads((_FIXTURES / "results.json").read_text(encoding="utf-8"))
+
+_ATTACHMENT_HIT = next(hit for hit in _RESULTS if "type" not in hit)
+_UPLOAD_LINE_HIT = next(hit for hit in _RESULTS if hit.get("type") == "Chat::Lines::Upload")
+_KANBAN_HIT = next(hit for hit in _RESULTS if hit.get("type") == "Kanban::Column")
+_NEEDLE_HIT = next(hit for hit in _RESULTS if hit.get("type") == "Gauge::Needle")
 
 
 def _assert_attachment_hit(results: list) -> None:
+    """The file-attachment branch (searches/_attachment.json.jbuilder): the one
+    branch that writes its own projection instead of decorating the recording
+    envelope, so it omits id/title/type/url/app_url entirely and carries the ten
+    file keys instead. The absence of those five IS the discriminator."""
     assert len(results) == 1
     hit = results[0]
     for key in ("id", "title", "type", "url", "app_url"):
@@ -57,8 +50,79 @@ def _assert_attachment_hit(results: list) -> None:
     assert "/thumbnails/" in hit["thumbnail_url"]
     assert "/download/" in hit["download_url"]
     assert "/download/" in hit["app_download_url"]
-    assert hit["content"] is None and hit["description"] is None
+    # Present-and-null on every branch, this one included: the show template
+    # nil-overwrites both after rendering the recording's own partial.
+    assert "content" in hit and hit["content"] is None
+    assert "description" in hit and hit["description"] is None
     assert hit["parent"]["type"] == "Message"
+
+
+def _assert_upload_line_hit(results: list) -> None:
+    """A chat upload line's `attachments` is a BESPOKE six-key aggregate the
+    line builds inline — title, url, filename, content_type, byte_size,
+    download_url. It is not a RichTextAttachment: no id, no sgid, no preview
+    keys. That is why SearchResultAttachment models the union of both variants
+    with only the four keys both always emit required."""
+    hit = results[0]
+    assert hit["type"] == "Chat::Lines::Upload"
+    # Chat lines pass `boostable`, so the envelope emits the boost pair.
+    assert hit["boosts_count"] == 1
+    assert "/boosts.json" in hit["boosts_url"]
+
+    attachment = hit["attachments"][0]
+    assert set(attachment) == {
+        "title",
+        "url",
+        "filename",
+        "content_type",
+        "byte_size",
+        "download_url",
+    }
+    assert attachment["title"] == "leto-benchmarks.pdf"
+    assert attachment["content_type"] == "application/pdf"
+    assert attachment["byte_size"] == 1048576
+
+
+def _assert_kanban_hit(results: list) -> None:
+    """A kanban (card table) list layers the list partial's keys over the
+    recording envelope. `color` is emitted unconditionally with a null value
+    when unset, so present-and-null is the normal case, not a malformed one."""
+    hit = results[0]
+    assert hit["type"] == "Kanban::Column"
+    assert hit["cards_count"] == 4
+    assert hit["comment_count"] == 1
+    assert "/cards.json" in hit["cards_url"]
+    assert "color" in hit and hit["color"] is None
+    # Envelope keys the list branch reaches: it is subscribable and positioned.
+    assert "/subscription.json" in hit["subscription_url"]
+    assert hit["position"] == 2
+    assert [p["name"] for p in hit["subscribers"]] == ["Victor Cooper"]
+    # on_hold is a whole nested list, not a flag.
+    assert hit["on_hold"]["cards_count"] == 0
+    assert "/cards.json" in hit["on_hold"]["cards_url"]
+
+
+def _assert_needle_hit(results: list) -> None:
+    """A gauge needle is both commentable and boostable, so it carries BOTH
+    count pairs — plus the branch partial's own singular `comment_count`, a
+    distinct key from the envelope's `comments_count`. Its `attachments` is the
+    OTHER variant: the rich-text one, with id and sgid populated."""
+    hit = results[0]
+    assert hit["type"] == "Gauge::Needle"
+    assert hit["comments_count"] == 2
+    assert hit["comment_count"] == 2
+    assert hit["boosts_count"] == 3
+    assert hit["color"] == "green"
+    assert hit["position"] == 72
+    # description is nil-overwritten, but its companion attachment array is not.
+    assert "description" in hit and hit["description"] is None
+    assert len(hit["description_attachments"]) == 1
+
+    attachment = hit["attachments"][0]
+    assert attachment["id"] == 1069479631
+    assert attachment["sgid"].endswith("--srchndl1")
+    assert attachment["width"] == 1024
+    assert attachment["previewable"] is True
 
 
 _METADATA = {
@@ -160,6 +224,45 @@ class TestSyncSearch:
         _assert_attachment_hit(list(results))
 
     @respx.mock
+    def test_chat_upload_line_hit_decodes(self):
+        respx.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=[_UPLOAD_LINE_HIT]))
+
+        account = Client(access_token="test-token").for_account("12345")
+        results = account.search.search(q="benchmarks")
+
+        _assert_upload_line_hit(list(results))
+
+    @respx.mock
+    def test_kanban_list_hit_decodes(self):
+        respx.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=[_KANBAN_HIT]))
+
+        account = Client(access_token="test-token").for_account("12345")
+        results = account.search.search(q="in progress")
+
+        _assert_kanban_hit(list(results))
+
+    @respx.mock
+    def test_gauge_needle_hit_decodes(self):
+        respx.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=[_NEEDLE_HIT]))
+
+        account = Client(access_token="test-token").for_account("12345")
+        results = account.search.search(q="progress update")
+
+        _assert_needle_hit(list(results))
+
+    @respx.mock
+    def test_all_branches_decode_together(self):
+        respx.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=_RESULTS))
+
+        account = Client(access_token="test-token").for_account("12345")
+        results = list(account.search.search(q="Leto"))
+
+        assert len(results) == 8
+        # bubble_up_url rides the polymorphic projection: todolists/_todolist is
+        # the only partial passing bubbleupable: true, so exactly one hit has it.
+        assert [r.get("type") for r in results if "bubble_up_url" in r] == ["Todolist"]
+
+    @respx.mock
     def test_metadata_decodes_filter_options(self):
         respx.get(METADATA_URL).mock(return_value=httpx.Response(200, json=_METADATA))
 
@@ -212,6 +315,36 @@ class TestAsyncSearch:
         results = await account.search.search(q="leto hero")
 
         _assert_attachment_hit(list(results))
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_chat_upload_line_hit_decodes(self):
+        respx.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=[_UPLOAD_LINE_HIT]))
+
+        account = AsyncClient(access_token="test-token").for_account("12345")
+        results = await account.search.search(q="benchmarks")
+
+        _assert_upload_line_hit(list(results))
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_kanban_list_hit_decodes(self):
+        respx.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=[_KANBAN_HIT]))
+
+        account = AsyncClient(access_token="test-token").for_account("12345")
+        results = await account.search.search(q="in progress")
+
+        _assert_kanban_hit(list(results))
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_gauge_needle_hit_decodes(self):
+        respx.get(SEARCH_URL).mock(return_value=httpx.Response(200, json=[_NEEDLE_HIT]))
+
+        account = AsyncClient(access_token="test-token").for_account("12345")
+        results = await account.search.search(q="progress update")
+
+        _assert_needle_hit(list(results))
 
     @pytest.mark.asyncio
     @respx.mock

--- a/ruby/test/basecamp/services/search_service_test.rb
+++ b/ruby/test/basecamp/services/search_service_test.rb
@@ -174,6 +174,90 @@ class SearchServiceTest < Minitest::Test
     assert_equal 0, result.length
   end
 
+  # The four branches api_search_result_template_path special-cases, against the
+  # shared, coverage-guarded body rather than an invented one. Reading
+  # spec/fixtures/search/results.json from disk is deliberate: it is the copy
+  # `make check-fixture-coverage` validates against the generated SearchResult
+  # schema and the copy the conformance runners assert against, so a branch that
+  # changes shape upstream cannot pass here while failing there.
+  def test_search_special_branches_from_shared_fixture
+    results = load_fixture("search/results.json")
+    stub_request(:get, "https://3.basecampapi.com/12345/search.json")
+      .with(query: { q: "Leto" })
+      .to_return(status: 200, body: results.to_json)
+
+    hits = @account.search.search(q: "Leto").to_a
+
+    assert_equal 8, hits.length
+
+    # bubble_up_url rides the polymorphic projection: todolists/_todolist is the
+    # only partial that passes bubbleupable: true.
+    assert_equal [ "Todolist" ], hits.select { |h| h.key?("bubble_up_url") }.map { |h| h["type"] }
+
+    # The file-attachment branch writes its own projection instead of decorating
+    # the recording envelope, so the ABSENCE of these five is the discriminator.
+    attachment = hits.find { |h| !h.key?("type") }
+    assert_not_nil attachment, "expected a file-attachment hit"
+    %w[id title type url app_url].each do |key|
+      assert_not attachment.key?(key), "attachment hit must omit #{key}"
+    end
+    assert_equal "leto-hero.jpg", attachment["filename"]
+    assert_equal 512000, attachment["byte_size"]
+    # Float-spelled on the wire (1920.0); Ruby has no typed model, so the caller
+    # receives the Float. The narrowing is enforced in the statically-typed
+    # tiers and by the conformance fixture.
+    assert_equal 1920, attachment["width"]
+    assert_equal 1080, attachment["height"]
+    # Present-and-null on every branch, this one included.
+    assert attachment.key?("content")
+    assert_nil attachment["content"]
+    assert attachment.key?("description")
+    assert_nil attachment["description"]
+
+    # A chat upload line's attachments is a BESPOKE six-key aggregate the line
+    # builds inline — not a RichTextAttachment: no id, no sgid, no preview keys.
+    upload_line = hits.find { |h| h["type"] == "Chat::Lines::Upload" }
+    assert_not_nil upload_line, "expected a chat upload-line hit"
+    assert_equal 1, upload_line["boosts_count"]
+    assert_includes upload_line["boosts_url"], "/boosts.json"
+    bespoke = upload_line["attachments"].first
+    assert_equal %w[byte_size content_type download_url filename title url], bespoke.keys.sort
+    assert_equal "leto-benchmarks.pdf", bespoke["title"]
+    assert_equal "application/pdf", bespoke["content_type"]
+
+    # A kanban list layers the list partial over the envelope. color is emitted
+    # unconditionally with a null value when unset, and on_hold is a whole
+    # nested list rather than a flag.
+    kanban = hits.find { |h| h["type"] == "Kanban::Column" }
+    assert_not_nil kanban, "expected a kanban-list hit"
+    assert_equal 4, kanban["cards_count"]
+    assert_equal 1, kanban["comment_count"]
+    assert_includes kanban["cards_url"], "/cards.json"
+    assert kanban.key?("color")
+    assert_nil kanban["color"]
+    assert_includes kanban["subscription_url"], "/subscription.json"
+    assert_equal 2, kanban["position"]
+    assert_equal [ "Victor Cooper" ], kanban["subscribers"].map { |p| p["name"] }
+    assert_equal 0, kanban.dig("on_hold", "cards_count")
+
+    # A gauge needle is both commentable and boostable, so it carries BOTH count
+    # pairs, plus the branch partial's singular comment_count. Its attachments
+    # is the OTHER variant — the rich-text one, with id and sgid populated.
+    needle = hits.find { |h| h["type"] == "Gauge::Needle" }
+    assert_not_nil needle, "expected a gauge-needle hit"
+    assert_equal 2, needle["comments_count"]
+    assert_equal 2, needle["comment_count"]
+    assert_equal 3, needle["boosts_count"]
+    assert_equal "green", needle["color"]
+    assert_equal 72, needle["position"]
+    assert_nil needle["description"]
+    assert_equal 1, needle["description_attachments"].length
+    rich_text = needle["attachments"].first
+    assert_equal 1069479631, rich_text["id"]
+    assert rich_text["sgid"].end_with?("--srchndl1")
+    assert_equal 1024, rich_text["width"]
+  end
+
   def test_metadata
     metadata = {
       "recording_search_types" => [

--- a/scripts/check-search-fixture-copy.py
+++ b/scripts/check-search-fixture-copy.py
@@ -47,10 +47,18 @@ def main() -> int:
     for case in cases:
         for i, response in enumerate(case.get("mockResponses", [])):
             body = response.get("body")
-            if not isinstance(body, list):
-                continue
             checked += 1
-            if not is_ordered_sublist(body, shared):
+            # Every Search mock body is an array of hits, so a non-array here is
+            # already wrong. Skipping it instead would let a body edited into an
+            # object slip past while `checked` stayed nonzero from a sibling
+            # case — the vacuity guard below would not fire, and this gate would
+            # report success having inspected nothing that changed.
+            if not isinstance(body, list):
+                failures.append(
+                    f"  {case['name']!r} mockResponses[{i}]: body is "
+                    f"{type(body).__name__}, expected an array of search hits"
+                )
+            elif not is_ordered_sublist(body, shared):
                 failures.append(
                     f"  {case['name']!r} mockResponses[{i}]: "
                     f"{len(body)} hit(s) not an ordered sublist of "
@@ -59,7 +67,7 @@ def main() -> int:
 
     if not checked:
         print(
-            f"FAIL: no array-bodied mock response found in "
+            f"FAIL: no mock response found in "
             f"{CONFORMANCE.relative_to(ROOT)} — the gate would pass vacuously",
             file=sys.stderr,
         )

--- a/scripts/check-search-fixture-copy.py
+++ b/scripts/check-search-fixture-copy.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Pin the conformance search bodies to the shared search fixture.
+
+`conformance/tests/search.json` inlines its mock bodies from
+`spec/fixtures/search/results.json`, because the two systems have no `$ref`
+mechanism between them: the conformance runners read a self-contained fixture
+file and never resolve external references. That makes the bodies a COPY, and
+`make conformance-fixtures-check` validates their format, not their fidelity —
+a hit edited on one side and not the other is silently divergent.
+
+Divergence is not hypothetical for these particular bytes. The shared fixture is
+what `make check-fixture-coverage` validates against the generated `SearchResult`
+schema, so it is the copy that moves when the spec gains a member; the
+conformance copy has no such pull and would quietly keep testing the old shape.
+
+The check is deliberately narrow: each mock body must be an ordered sublist of
+the shared fixture's hits, compared as parsed JSON (so formatting is free to
+differ). A case may carry FEWER hits than the shared fixture — the
+file-attachment case presents one branch alone on purpose — but every hit it
+does carry must be byte-for-byte the same object, in the same relative order.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SHARED = ROOT / "spec/fixtures/search/results.json"
+CONFORMANCE = ROOT / "conformance/tests/search.json"
+
+
+def is_ordered_sublist(needle: list, haystack: list) -> bool:
+    it = iter(haystack)
+    return all(any(item == candidate for candidate in it) for item in needle)
+
+
+def main() -> int:
+    print("==> Checking conformance search bodies against the shared fixture...")
+    shared = json.loads(SHARED.read_text())
+    cases = json.loads(CONFORMANCE.read_text())
+
+    failures: list[str] = []
+    checked = 0
+
+    for case in cases:
+        for i, response in enumerate(case.get("mockResponses", [])):
+            body = response.get("body")
+            if not isinstance(body, list):
+                continue
+            checked += 1
+            if not is_ordered_sublist(body, shared):
+                failures.append(
+                    f"  {case['name']!r} mockResponses[{i}]: "
+                    f"{len(body)} hit(s) not an ordered sublist of "
+                    f"{SHARED.relative_to(ROOT)} ({len(shared)} hits)"
+                )
+
+    if not checked:
+        print(
+            f"FAIL: no array-bodied mock response found in "
+            f"{CONFORMANCE.relative_to(ROOT)} — the gate would pass vacuously",
+            file=sys.stderr,
+        )
+        return 1
+
+    if failures:
+        print(
+            f"FAIL: conformance search bodies have drifted from "
+            f"{SHARED.relative_to(ROOT)}:",
+            file=sys.stderr,
+        )
+        for failure in failures:
+            print(failure, file=sys.stderr)
+        print(
+            "\nRe-copy the hits from the shared fixture. It is the copy "
+            "`make check-fixture-coverage` validates against the generated "
+            "schema, so it is the one that is right.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"  ok: {checked} mock body/bodies match {SHARED.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/swift/Tests/BasecampTests/SearchResultDecodeTests.swift
+++ b/swift/Tests/BasecampTests/SearchResultDecodeTests.swift
@@ -112,4 +112,146 @@ final class SearchResultDecodeTests: XCTestCase {
         XCTAssertTrue(object["description"] is NSNull)
         XCTAssertFalse(object.keys.contains("plain_text_content"))
     }
+
+    // MARK: - The four special-cased branches (#651)
+
+    /// The shared, coverage-guarded body: eight hits covering the generic
+    /// recording envelope and all four branches
+    /// `api_search_result_template_path` special-cases. Read relative to this
+    /// source file, the way `UpcomingScheduleDecodeTests` does, so it cannot
+    /// drift from the copy the other five SDKs and the conformance runners
+    /// assert against; `make check-fixture-coverage` validates it against the
+    /// generated schema.
+    private func sharedResults() throws -> [SearchResult] {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // BasecampTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // swift
+            .deletingLastPathComponent()  // <repo root>
+        let data = try Data(
+            contentsOf: repoRoot
+                .appendingPathComponent("spec/fixtures/search/results.json")
+        )
+        return try makeDecoder().decode([SearchResult].self, from: data)
+    }
+
+    func testSharedFixtureDecodesEveryBranch() throws {
+        let results = try sharedResults()
+        XCTAssertEqual(results.count, 8)
+
+        // bubble_up_url rides the polymorphic projection: todolists/_todolist is
+        // the only partial that passes `bubbleupable: true`.
+        XCTAssertEqual(
+            results.filter { $0.bubbleUpUrl != nil }.map(\.type),
+            ["Todolist"]
+        )
+    }
+
+    /// `searches/_attachment.json.jbuilder` writes its own projection instead of
+    /// decorating the recording envelope, so it emits NONE of
+    /// `id`/`title`/`type`/`url`/`app_url`. Before #651 those five were
+    /// non-optional here and this hit could not decode at all.
+    func testFileAttachmentBranchOmitsTheFiveEnvelopeKeys() throws {
+        let hit = try XCTUnwrap(try sharedResults().first { $0.type == nil })
+
+        XCTAssertNil(hit.id)
+        XCTAssertNil(hit.title)
+        XCTAssertNil(hit.type)
+        XCTAssertNil(hit.url)
+        XCTAssertNil(hit.appUrl)
+
+        XCTAssertEqual(hit.filename, "leto-hero.jpg")
+        XCTAssertEqual(hit.contentType, "image/jpeg")
+        XCTAssertEqual(hit.byteSize, 512000)
+        XCTAssertEqual(hit.previewable, true)
+        // Float-spelled on the wire (`1920.0`) against an `Int32?` member.
+        // Foundation's JSONDecoder accepts an integral-valued JSON float into an
+        // integer field, so no FlexibleInt wrapper is needed — this test is what
+        // says so, rather than the claim being assumed.
+        XCTAssertEqual(hit.width, 1920)
+        XCTAssertEqual(hit.height, 1080)
+        XCTAssertNotNil(hit.previewUrl)
+        XCTAssertNotNil(hit.thumbnailUrl)
+        XCTAssertNotNil(hit.downloadUrl)
+        XCTAssertNotNil(hit.appDownloadUrl)
+        // Present-and-null holds on this branch too — the pair the tests above
+        // pin is required even where the envelope keys are not.
+        XCTAssertNil(hit.content)
+        XCTAssertNil(hit.description)
+        XCTAssertEqual(hit.parent?.type, "Message")
+    }
+
+    /// A chat upload line's `attachments` is a BESPOKE six-key aggregate the
+    /// line builds inline — not a `RichTextAttachment`. `SearchResultAttachment`
+    /// exists because of this: it is the optional-field superset of both wire
+    /// variants, with only the four keys both always emit non-optional.
+    func testChatUploadLineCarriesTheBespokeAttachmentVariant() throws {
+        let hit = try XCTUnwrap(
+            try sharedResults().first { $0.type == "Chat::Lines::Upload" }
+        )
+
+        // Chat lines pass `boostable`, so the envelope emits the boost pair.
+        XCTAssertEqual(hit.boostsCount, 1)
+        XCTAssertNotNil(hit.boostsUrl)
+
+        let attachment = try XCTUnwrap(hit.attachments?.first)
+        XCTAssertEqual(attachment.title, "leto-benchmarks.pdf")
+        XCTAssertNotNil(attachment.url)
+        XCTAssertEqual(attachment.filename, "leto-benchmarks.pdf")
+        XCTAssertEqual(attachment.contentType, "application/pdf")
+        XCTAssertEqual(attachment.byteSize, 1_048_576)
+        XCTAssertNotNil(attachment.downloadUrl)
+        // The rich-text variant's keys are absent, which is the whole point.
+        XCTAssertNil(attachment.id)
+        XCTAssertNil(attachment.sgid)
+        XCTAssertNil(attachment.previewable)
+        XCTAssertNil(attachment.width)
+    }
+
+    /// A kanban (card table) list layers the list partial's keys over the
+    /// recording envelope. `color` is emitted unconditionally with a null value
+    /// when unset, so it must stay optional rather than being required.
+    func testKanbanListCarriesListKeysAndANullColor() throws {
+        let hit = try XCTUnwrap(
+            try sharedResults().first { $0.type == "Kanban::Column" }
+        )
+
+        XCTAssertEqual(hit.cardsCount, 4)
+        XCTAssertEqual(hit.commentCount, 1)
+        XCTAssertNotNil(hit.cardsUrl)
+        XCTAssertNil(hit.color)
+        // Envelope keys the list branch reaches: subscribable and positioned.
+        XCTAssertNotNil(hit.subscriptionUrl)
+        XCTAssertEqual(hit.position, 2)
+        XCTAssertEqual(hit.subscribers?.map(\.name), ["Victor Cooper"])
+        // on_hold is a whole nested list, not a flag.
+        let onHold = try XCTUnwrap(hit.onHold)
+        XCTAssertEqual(onHold.cardsCount, 0)
+        XCTAssertFalse(onHold.cardsUrl.isEmpty)
+    }
+
+    /// A gauge needle is both commentable and boostable, so it carries BOTH
+    /// count pairs — plus the branch partial's own singular `comment_count`, a
+    /// distinct key from the envelope's `comments_count`. Its `attachments` is
+    /// the OTHER variant: the rich-text one, the mirror of the upload line.
+    func testGaugeNeedleCarriesBothCountPairsAndTheRichTextVariant() throws {
+        let hit = try XCTUnwrap(
+            try sharedResults().first { $0.type == "Gauge::Needle" }
+        )
+
+        XCTAssertEqual(hit.commentsCount, 2)
+        XCTAssertEqual(hit.commentCount, 2)
+        XCTAssertEqual(hit.boostsCount, 3)
+        XCTAssertEqual(hit.color, "green")
+        XCTAssertEqual(hit.position, 72)
+        // description is nil-overwritten; its companion array survives.
+        XCTAssertNil(hit.description)
+        XCTAssertEqual(hit.descriptionAttachments?.count, 1)
+
+        let attachment = try XCTUnwrap(hit.attachments?.first)
+        XCTAssertEqual(attachment.id, 1069479631)
+        XCTAssertEqual(attachment.sgid?.hasSuffix("--srchndl1"), true)
+        XCTAssertEqual(attachment.width, 1024)
+        XCTAssertEqual(attachment.previewable, true)
+    }
 }

--- a/typescript/tests/services/search.test.ts
+++ b/typescript/tests/services/search.test.ts
@@ -9,8 +9,21 @@ import { http, HttpResponse } from "msw";
 import { server } from "../setup.js";
 import { createBasecampClient } from "../../src/client.js";
 import type { BasecampClient } from "../../src/client.js";
+// Sourced from the shared, coverage-guarded fixture (spec/fixtures/manifest.yaml):
+// eight hits covering the generic recording envelope and all four branches
+// `api_search_result_template_path` special-cases. Imported rather than restated
+// so this cannot drift from the copy the other five SDKs and the conformance
+// runners assert against.
+import searchResultsFixture from "../../../spec/fixtures/search/results.json";
 
 const BASE_URL = "https://3.basecampapi.com/12345";
+
+type SearchHit = Record<string, unknown>;
+const SEARCH_RESULTS = searchResultsFixture as unknown as SearchHit[];
+const attachmentHit = SEARCH_RESULTS.find((h) => h.type === undefined)!;
+const uploadLineHit = SEARCH_RESULTS.find((h) => h.type === "Chat::Lines::Upload")!;
+const kanbanHit = SEARCH_RESULTS.find((h) => h.type === "Kanban::Column")!;
+const needleHit = SEARCH_RESULTS.find((h) => h.type === "Gauge::Needle")!;
 
 describe("SearchService", () => {
   let client: BasecampClient;
@@ -237,6 +250,141 @@ describe("SearchService", () => {
 
       const results = await client.search.search("nonexistent");
       expect(results).toHaveLength(0);
+    });
+
+    /**
+     * The four branches BC3's `api_search_result_template_path` special-cases.
+     * Each drives the real service against a hit taken verbatim from the shared
+     * fixture, so a branch that changes shape upstream cannot pass here while
+     * failing the conformance runners.
+     */
+    describe("special-cased result branches", () => {
+      const respondWith = (hits: SearchHit[]) => {
+        server.use(
+          http.get(`${BASE_URL}/search.json`, () => HttpResponse.json(hits)),
+        );
+      };
+
+      it("decodes a file-attachment hit, which omits the five envelope keys", async () => {
+        respondWith([attachmentHit]);
+
+        const [hit] = await client.search.search("leto hero");
+
+        // searches/_attachment.json.jbuilder writes its own projection instead
+        // of decorating the recording envelope, so the ABSENCE of these five is
+        // the branch discriminator. (In consumer code they are optional in the
+        // generated types, so an unguarded read is a strictNullChecks error —
+        // this file is not type-checked, `tsconfig.json` excludes `tests`.)
+        expect(hit.id).toBeUndefined();
+        expect(hit.title).toBeUndefined();
+        expect(hit.type).toBeUndefined();
+        expect(hit.url).toBeUndefined();
+        expect(hit.app_url).toBeUndefined();
+
+        expect(hit.filename).toBe("leto-hero.jpg");
+        expect(hit.content_type).toBe("image/jpeg");
+        expect(hit.byte_size).toBe(512000);
+        expect(hit.previewable).toBe(true);
+        // Float-spelled on the wire (1920.0); JSON has one number type, so this
+        // is 1920 in JavaScript. The narrowing is load-bearing in the
+        // statically-typed tiers, and the conformance fixture pins it there.
+        expect(hit.width).toBe(1920);
+        expect(hit.height).toBe(1080);
+        expect(hit.download_url).toContain("/download/");
+        expect(hit.app_download_url).toContain("/download/");
+        // Present-and-null on every branch, this one included: the show
+        // template nil-overwrites both after rendering the recording partial.
+        expect(hit.content).toBeNull();
+        expect(hit.description).toBeNull();
+        expect(hit.parent?.type).toBe("Message");
+      });
+
+      it("decodes a chat upload line's bespoke attachments aggregate", async () => {
+        respondWith([uploadLineHit]);
+
+        const [hit] = await client.search.search("benchmarks");
+
+        expect(hit.type).toBe("Chat::Lines::Upload");
+        // Chat lines pass `boostable`, so the envelope emits the boost pair.
+        expect(hit.boosts_count).toBe(1);
+        expect(hit.boosts_url).toContain("/boosts.json");
+
+        // NOT a RichTextAttachment: the line builds a six-key aggregate inline,
+        // with no id, no sgid and no preview keys. SearchResultAttachment is
+        // the optional-field superset of this variant and the rich-text one.
+        const attachment = hit.attachments![0]!;
+        expect(Object.keys(attachment).sort()).toEqual([
+          "byte_size",
+          "content_type",
+          "download_url",
+          "filename",
+          "title",
+          "url",
+        ]);
+        expect(attachment.title).toBe("leto-benchmarks.pdf");
+        expect(attachment.content_type).toBe("application/pdf");
+        expect(attachment.id).toBeUndefined();
+        expect(attachment.sgid).toBeUndefined();
+      });
+
+      it("decodes a kanban list, whose color is present-and-null", async () => {
+        respondWith([kanbanHit]);
+
+        const [hit] = await client.search.search("in progress");
+
+        expect(hit.type).toBe("Kanban::Column");
+        expect(hit.cards_count).toBe(4);
+        expect(hit.comment_count).toBe(1);
+        expect(hit.cards_url).toContain("/cards.json");
+        // Emitted unconditionally with a null value when unset — present-and-
+        // null is the normal case here, not a malformed body.
+        expect(hit.color).toBeNull();
+        // Envelope keys the list branch reaches: subscribable and positioned.
+        expect(hit.subscription_url).toContain("/subscription.json");
+        expect(hit.position).toBe(2);
+        expect(hit.subscribers?.map((p) => p.name)).toEqual(["Victor Cooper"]);
+        // on_hold is a whole nested list, not a flag.
+        expect(hit.on_hold?.cards_count).toBe(0);
+        expect(hit.on_hold?.cards_url).toContain("/cards.json");
+      });
+
+      it("decodes a gauge needle, which carries both count pairs", async () => {
+        respondWith([needleHit]);
+
+        const [hit] = await client.search.search("progress update");
+
+        expect(hit.type).toBe("Gauge::Needle");
+        // Commentable AND boostable, plus the branch partial's own singular
+        // comment_count — a distinct key from the envelope's comments_count.
+        expect(hit.comments_count).toBe(2);
+        expect(hit.comment_count).toBe(2);
+        expect(hit.boosts_count).toBe(3);
+        expect(hit.color).toBe("green");
+        expect(hit.position).toBe(72);
+        // description is nil-overwritten; its companion array is not.
+        expect(hit.description).toBeNull();
+        expect(hit.description_attachments).toHaveLength(1);
+
+        // The OTHER attachments variant: the rich-text one, id and sgid set.
+        const attachment = hit.attachments![0]!;
+        expect(attachment.id).toBe(1069479631);
+        expect(attachment.sgid).toContain("--srchndl1");
+        expect(attachment.width).toBe(1024);
+        expect(attachment.previewable).toBe(true);
+      });
+
+      it("decodes every branch in one response", async () => {
+        respondWith(SEARCH_RESULTS);
+
+        const results = await client.search.search("Leto");
+
+        expect(results).toHaveLength(8);
+        // bubble_up_url rides the polymorphic projection: todolists/_todolist
+        // is the only partial passing bubbleupable: true.
+        expect(
+          results.filter((r) => r.bubble_up_url !== undefined).map((r) => r.type),
+        ).toEqual(["Todolist"]);
+      });
     });
   });
 


### PR DESCRIPTION
Closes #717.

## What the issue asked for, and what exploration changed

The issue asked for a mock conformance fixture, a Kotlin typed model, and per-SDK
gap-filling. Two of its premises were wrong and are corrected here:

- **The Kotlin runner is not under `conformance/runner/`.** It lives at
  `kotlin/conformance/` as a Gradle subproject; five runners live under
  `conformance/runner/{go,typescript,ruby,python,swift}`.
- **Search is live-only, not merely under-covered.** No runner had a *mock*
  dispatch case at all. Five have wire-replay decoders, but every one is
  canary-gated and credentialed, and Swift has neither a replay runner nor a
  Search case. Nothing in offline CI exercised the search projection's shape in
  any language.

A step-0 probe the plan called for came back negative and is worth recording:
`SearchResult.width` is a plain `Int32?` in Swift against a wire that
float-spells it (`1920.0`), and Foundation's `JSONDecoder` **accepts** an
integral-valued JSON float into an integer field. No `FlexibleInt` wiring was
needed. `swift/Tests/.../SearchResultDecodeTests.swift` now asserts that rather
than leaving it assumed.

## Kotlin gets a typed model

`search` returned `ListResult<JsonElement>`, which decodes any body whatsoever —
so the four special-branch shapes #651 modelled enforced **nothing** in Kotlin.
Adding `"SearchResult"` to the generator's `TYPE_ALIASES` is the whole trigger;
`SearchResultAttachment` comes along via `findSupportingTypes` (verified by
running the generator, not assumed — `Config.kt` warns the scanner does not
traverse response envelopes). `width`/`height` emit with `FlexibleIntSerializer`.

**This is a Kotlin source break**, the same class `GetUpcomingSchedule` took at
v0.13.0, and it has a MIGRATING entry following that precedent.

## The fixture, and why the assertions look the way they do

`conformance/tests/search.json` drives all six runners against the shared
`spec/fixtures/search/results.json` body. Two constraints shaped it:

- The response is an **array**, and no assertion type expresses absence inside
  one — there is `headerAbsent` and `requestBodyAbsent`, but no
  `responseBodyAbsent`. The file-attachment branch is recognized precisely BY the
  absence of the recording envelope's `id`/`title`/`type`/`url`/`app_url`.
- A `responseBody` path resolves as a top-level key only in Go and TypeScript.

So each runner gains a summarizer that flattens hits to top-level scalars and
encodes absence as a boolean — the idiom `last_has_upload` established
(`uploads_write.json`). The `generic_*` counterparts assert **true** against the
same summarizer, so a runner that reported absence unconditionally cannot pass.

## Verification

- **Not vacuous:** with four expectations deliberately flipped
  (`attachment_has_type`, `attachment_width`, `needle_attachment_has_id`,
  `kanban_on_hold_cards_count`), **all six runners fail** (exit 2 each). Restored
  and re-verified green.
- Full `make check` passes clean.
- Per-SDK tests read the shared fixture from disk rather than adding inline
  stubs; the chat-upload, kanban and gauge-needle branches had no test in any
  language before this.

## Fixture drift

The conformance fixture inlines its bodies because no `\$ref` mechanism exists
between the two fixture systems, and `conformance-fixtures-check` validates
format rather than fidelity. `scripts/check-search-fixture-copy.py` (wired into
that target) pins each mock body to be an ordered sublist of the shared fixture —
the copy `make check-fixture-coverage` validates against the generated schema, so
the one that is right. Proven to fail on a real drift, and to fail rather than
pass vacuously if no array body is found.

## Out of scope

- A Swift wire-replay runner (new executable target + snapshot plumbing). Swift
  gains mock coverage only.
- `responseBodyAbsent` as a new assertion type — the response is an array, so a
  summarizer is unavoidable regardless, and once you have one, `has_id: false`
  expresses absence with no schema change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Types the Kotlin Search API and adds offline conformance for the polymorphic Search projection; also hardens the fixture-copy gate. Kotlin now returns typed search hits, and CI asserts the generic envelope and all four special branches without live credentials.

- Kotlin API: `search(q, options)` returns `ListResult<SearchResult>` (was `ListResult<JsonElement>`). Generated `SearchResult` and `SearchResultAttachment` include flexible `width`/`height` ints. Migration: update Kotlin callers to use `SearchResult` fields instead of navigating `JsonElement`.

- Conformance and fixtures: adds `conformance/tests/search.json`; all runners flatten array hits via summarizers and dispatch a fixed query "Leto". SDK tests (Swift, TypeScript, Ruby, Python, Kotlin) read `spec/fixtures/search/results.json` to assert the envelope and four special branches. `scripts/check-search-fixture-copy.py` pins the copied bodies, now fails on non-array `body`, and is exposed via `make check-search-fixture-copy` (still runs in `make check`). `SPEC.md` lists the new `search` fixture.

<sup>Written for commit ed6882bbaa58c91e0a7a756497f4a152e2568657. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

