### PR TITLE
Account for every conformance fixture in both SPEC rosters, and gate them

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,6 +231,12 @@ All SDKs are generated from a single Smithy specification. When adding support f
 
 5. **Add conformance tests** (`conformance/tests/`) covering the new operations
 
+   A NEW fixture file also needs a row in SPEC.md §19's Test Categories table
+   and a row in its Appendix D, naming the spec sections that own it.
+   `make doc-constants-check` fails until both exist — it is the only place
+   this convention was written down, which is why three fixtures in a row
+   landed with one row, the other, or neither.
+
 6. **Update documentation**:
    - Add to the services table in each SDK's README
    - Note which release-note section the change belongs in. There is no

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -233,9 +233,9 @@ All SDKs are generated from a single Smithy specification. When adding support f
 
    A NEW fixture file also needs a row in SPEC.md §19's Test Categories table
    and a row in its Appendix D, naming the spec sections that own it.
-   `make doc-constants-check` fails until both exist — it is the only place
-   this convention was written down, which is why three fixtures in a row
-   landed with one row, the other, or neither.
+   `make doc-constants-check` fails until both exist. Until this checklist item
+   and that gate, the convention was written down nowhere, which is why three
+   fixtures in a row landed with one row, the other, or neither.
 
 6. **Update documentation**:
    - Add to the services table in each SDK's README

--- a/SPEC.md
+++ b/SPEC.md
@@ -2106,6 +2106,7 @@ index past the number of recorded requests fails rather than passing vacuously.
 |----------|-------|----------------------|
 | auth | `auth.json` | §4 Authentication, §13 HTTP Transport |
 | cards-write | `cards_write.json` | §5 Merge-Safe Write Surface (Cards), §18 Hand-Written Composite Methods |
+| documents-write | `documents_write.json` | §5 Merge-Safe Write Surface (Documents), §18 Hand-Written Composite Methods |
 | downloads | `downloads.json` | §14 Download |
 | error-mapping | `error-mapping.json` | §6 Error Taxonomy |
 | idempotency | `idempotency.json` | §7 Retry (Gate 2) |
@@ -2115,8 +2116,8 @@ index past the number of recorded requests fails rather than passing vacuously.
 | pagination | `pagination.json` | §8 Pagination |
 | paths | `paths.json` | §3 Client Architecture (account path construction) |
 | retry | `retry.json` | §7 Retry |
-| search | `search.json` | §10 Type Fidelity — the polymorphic search projection, whose file-attachment branch is recognized by the ABSENCE of the recording envelope's `id`/`title`/`type`/`url`/`app_url` |
 | schedule-entries-write | `schedule_entries_write.json` | §5 Merge-Safe Write Surface (Schedule Entries), §18 Hand-Written Composite Methods, §10 Type Fidelity (explicit-empty vs. omitted wire semantics) |
+| search | `search.json` | §10 Type Fidelity — the polymorphic search projection, whose file-attachment branch is recognized by the ABSENCE of the recording envelope's `id`/`title`/`type`/`url`/`app_url` |
 | security | `security.json` | §9 Security |
 | status-codes | `status-codes.json` | §11 Response Semantics |
 | todolists-read | `todolists_read.json` | §5 Merge-Safe Write Surface (Todolists) — the flat read shape the composites read through |
@@ -2124,6 +2125,7 @@ index past the number of recorded requests fails rather than passing vacuously.
 | todos-write | `todos_write.json` | §5 Merge-Safe Write Surface (Todos), §18 Hand-Written Composite Methods |
 | upcoming-schedule | `upcoming_schedule.json` | §10 Type Fidelity — the reduced calendar projection `GetUpcomingSchedule` renders, distinct from the shared `ScheduleEntry` shape |
 | uploads-download | `uploads_download.json` | §14 Download, §18 Hand-Written Composite Methods |
+| uploads-write | `uploads_write.json` | §5 Merge-Safe Write Surface (Cards, Uploads), §18 Hand-Written Composite Methods, §10 Type Fidelity, §6 Error Taxonomy (507 → limit_exceeded) |
 
 ### Runner Pattern
 
@@ -3439,11 +3441,13 @@ account, attachments, automation, boosts, campfires, cardColumns, cardSteps, car
 | `uploads_write.json` | list-versions decodes the version payload | §10 (One Renderer, One Schema) |
 | `uploads_write.json` | 507 → limit_exceeded, not retried | §6 |
 | `todos_write.json` | update-merge / edit-clear / replace-omission-clears | §5 (Todos), §18 |
+| `documents_write.json` | update-merge / edit-clear / replace-omission-clears | §5 (Documents), §18 |
 | `todolists_write.json` | update-merge / update-group / edit-clear / replace-omission-clears | §5 (Todolists), §18 |
 | `todolists_read.json` | list-read / group-read / group-list-read (one flat shape decodes for both variants) | §5 (Todolists) |
 | `cards_write.json` | Presence-aware update composite (5 cases: unaddressed fields stay off the wire, verbatim raw path, explicit `due_on` clear as `""`, explicit empty content/assignees) | §5 (Cards), §18 |
 | `schedule_entries_write.json` | Carve-out-aware replace/update/edit triad, plus the create-side #641 fields (11 cases: omission-preserves and explicit-clear pairs for `participant_ids`/`url`/`highlighted`, edit-touched vs edit-untouched, and `url`/`highlighted`/`status` present-when-set vs absent-when-unset on `CreateScheduleEntry`) | §5 (Schedule Entries), §18 |
 | `upcoming_schedule.json` | The reduced calendar projection: entry, recurring occurrence, assignable, empty envelope (4 cases) | §10 (Type Fidelity) |
+| `search.json` | The polymorphic search projection: the generic recording envelope plus all four special branches, and the file-attachment branch in isolation (2 cases) | §10 (Type Fidelity) |
 | `live-my-surface.json` | Live schema validation, 31 read-surface cases (opt-in via `BASECAMP_LIVE`) | External governance (CONTRIBUTING.md, live canary) |
 
 ---

--- a/SPEC.md
+++ b/SPEC.md
@@ -2181,18 +2181,29 @@ Note the shape this avoids: #573 first narrowed nothing and instead added the
 whole-case skip to all four remaining runners, which left the fixture skipped by
 all six — present in `pagination.json`, passing `conformance-fixtures-check` and
 `check-fixture-coverage`, and executed by nothing. That is #572's defect one
-layer down. `make check-fixture-execution` (#602) is what detects it now: it
-reads the six runners' skip mechanisms and fails when a mock case is excluded
-everywhere. Maximum overlap today is 2 of 6, so that gate is green on arrival
-and its self-test — which crafts the all-six state — is what proves it can say
-no.
+layer down.
 
-The same gate holds the roster below to the runners it claims to restate. The
-bullets are an ENUMERATION, derivable and therefore checked for set equality;
-the classification and reasoning on each line are judgement, and nothing
-asserts them. The runners stay the sole source of truth: if this roster were an
-input, a wrong extraction and a stale roster could agree and both stay green,
-which is the failure the gate exists to prevent.
+**Nothing detects that state today, and #602 is open for it.** Each runner now
+takes a case census (#742): at the end of its own run it asserts that
+`passed + failed + skipped` equals the number of cases under `conformance/tests`
+whose `mode` is not `live`, counted by a walk independent of its own load path.
+That catches a case executed by NO runner for a mechanical reason — an
+unrecognized `mode`, a fixture that failed to parse or was never globbed, one
+nested where no runner looks, a case dropped between load and dispatch. It does
+NOT catch the case this section describes, where every runner excludes the same
+fixture deliberately: each census counts its own skip and stays green. Detecting
+that needs the six exclusion sets compared in one place, which needs a manifest
+per runner and artifact plumbing across six CI jobs — and the Swift lane is
+macOS-only, so a Linux run can never assemble all six. Maximum overlap today is
+2 of 6, narrowed by #596.
+
+The roster below is therefore RESTATED, not derived: nothing checks it against
+the runners it claims to summarise (#736). The bullets are an enumeration and
+the classification on each line is judgement; both are hand-maintained, so a
+skip added to a runner without a line here goes unrecorded. When #602's
+cross-runner manifest lands, this roster becomes checkable for set equality
+against what the runners actually reported — which is stronger than parsing
+their source, and is why #736 waits for it rather than being fixed on its own.
 
 **Go** (`conformance/runner/go/main.go` `goSDKSkips`) — architectural; same-origin
 logic is covered by `TestIsSameOrigin` unit tests:

--- a/SPEC.md
+++ b/SPEC.md
@@ -2102,6 +2102,11 @@ index past the number of recorded requests fails rather than passing vacuously.
 
 ### Test Categories and Owning Sections
 
+Every tracked fixture under `conformance/tests/` has exactly one row here, and
+the category slug is the filename (basename, `_` written as `-`).
+`make doc-constants-check` asserts the bijection.
+
+<!-- @fixture-categories:begin -->
 | Category | Files | Owning Spec Section(s) |
 |----------|-------|----------------------|
 | auth | `auth.json` | §4 Authentication, §13 HTTP Transport |
@@ -2126,6 +2131,7 @@ index past the number of recorded requests fails rather than passing vacuously.
 | upcoming-schedule | `upcoming_schedule.json` | §10 Type Fidelity — the reduced calendar projection `GetUpcomingSchedule` renders, distinct from the shared `ScheduleEntry` shape |
 | uploads-download | `uploads_download.json` | §14 Download, §18 Hand-Written Composite Methods |
 | uploads-write | `uploads_write.json` | §5 Merge-Safe Write Surface (Cards, Uploads), §18 Hand-Written Composite Methods, §10 Type Fidelity, §6 Error Taxonomy (507 → limit_exceeded) |
+<!-- @fixture-categories:end -->
 
 ### Runner Pattern
 
@@ -2175,8 +2181,18 @@ Note the shape this avoids: #573 first narrowed nothing and instead added the
 whole-case skip to all four remaining runners, which left the fixture skipped by
 all six — present in `pagination.json`, passing `conformance-fixtures-check` and
 `check-fixture-coverage`, and executed by nothing. That is #572's defect one
-layer down. Nothing in the build detects a fixture no runner runs; that gap is
-tracked as #602.
+layer down. `make check-fixture-execution` (#602) is what detects it now: it
+reads the six runners' skip mechanisms and fails when a mock case is excluded
+everywhere. Maximum overlap today is 2 of 6, so that gate is green on arrival
+and its self-test — which crafts the all-six state — is what proves it can say
+no.
+
+The same gate holds the roster below to the runners it claims to restate. The
+bullets are an ENUMERATION, derivable and therefore checked for set equality;
+the classification and reasoning on each line are judgement, and nothing
+asserts them. The runners stay the sole source of truth: if this roster were an
+input, a wrong extraction and a stale roster could agree and both stay green,
+which is the failure the gate exists to prevent.
 
 **Go** (`conformance/runner/go/main.go` `goSDKSkips`) — architectural; same-origin
 logic is covered by `TestIsSameOrigin` unit tests:
@@ -3367,6 +3383,11 @@ account, attachments, automation, boosts, campfires, cardColumns, cardSteps, car
 
 ## Appendix D: Conformance Test → Spec Section Mapping
 
+Every tracked fixture under `conformance/tests/` appears on at least one row.
+Rows are curated summaries and may bundle several cases, so the coverage is
+what `make doc-constants-check` asserts — not a case-by-case index.
+
+<!-- @fixture-section-map:begin -->
 | Test file | Test name | Primary section |
 |-----------|----------|----------------|
 | `auth.json` | Bearer token injected | §4, §13 |
@@ -3449,6 +3470,7 @@ account, attachments, automation, boosts, campfires, cardColumns, cardSteps, car
 | `upcoming_schedule.json` | The reduced calendar projection: entry, recurring occurrence, assignable, empty envelope (4 cases) | §10 (Type Fidelity) |
 | `search.json` | The polymorphic search projection: the generic recording envelope plus all four special branches, and the file-attachment branch in isolation (2 cases) | §10 (Type Fidelity) |
 | `live-my-surface.json` | Live schema validation, 31 read-surface cases (opt-in via `BASECAMP_LIVE`) | External governance (CONTRIBUTING.md, live canary) |
+<!-- @fixture-section-map:end -->
 
 ---
 

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -837,9 +837,25 @@ def check_fixture_categories(span, fixtures)
 
   documented = []
   rows.each do |line_no, cells|
-    if cells.length < 3
-      errors << "#{span.file}:#{line_no}: category row has #{cells.length} cell(s); the shape is " \
-                "| Category | `file.json` | Owning Spec Section(s) |"
+    # EXACTLY three, not at least three. An extra cell is not a harmless
+    # surplus: a raw pipe in the attribution shifts the real section into a
+    # fourth cell and puts the fragment before it into cells[2], where
+    # non-`§` attributions are legitimately allowed — so the gate validates the
+    # wrong cell and a `§99` in the actual section position is never checked,
+    # while the row renders with a column GFM drops.
+    #
+    # This is deliberately a REFUSAL, not another spelling rule. Teaching the
+    # splitter more Markdown (separator widths, backslash parity) is the
+    # treadmill declined elsewhere in this PR; rejecting a row whose shape the
+    # parser does not recognise is the direction this file already argues for —
+    # "a row the parser cannot see is a row it silently vouches for". It closes
+    # the pipe class as a class: however a stray pipe was spelled, the cell
+    # count is wrong and the row fails loudly instead of being mis-parsed
+    # quietly.
+    if cells.length != 3
+      errors << "#{span.file}:#{line_no}: category row has #{cells.length} cell(s), not 3; the " \
+                "shape is | Category | `file.json` | Owning Spec Section(s) |. An unescaped `|` " \
+                "in a cell splits the row — write it as `\\|`."
       next
     end
 
@@ -942,9 +958,14 @@ def check_fixture_section_map(span, fixtures)
 
   covered = []
   rows.each do |line_no, cells|
-    if cells.length < 3
-      errors << "#{span.file}:#{line_no}: mapping row has #{cells.length} cell(s); the shape is " \
-                "| `file.json` | Test name | Primary section |"
+    # Exactly three, for the reason given on the categories table above: a raw
+    # pipe in a free-form test summary shifts the real section into an ignored
+    # fourth cell, and this table's summaries are the likeliest place in the
+    # repo for someone to write `supports A | B`.
+    if cells.length != 3
+      errors << "#{span.file}:#{line_no}: mapping row has #{cells.length} cell(s), not 3; the " \
+                "shape is | `file.json` | Test name | Primary section |. An unescaped `|` in a " \
+                "cell splits the row — write it as `\\|`."
       next
     end
 

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -371,8 +371,25 @@ def scan_file(file)
     errors << "#{file}:#{open_block[:line_no]}: @#{open_block[:kind]}:begin never closed"
   end
 
+  # Only LINE spans leave the prose pool. A line span IS the marked claim — the
+  # writer rewrites it from the source on every sync, so judging it as prose
+  # would flag the very restatement the marker sanctions.
+  #
+  # BLOCK bodies stay eligible, and the difference is not cosmetic. The writer
+  # rewrites line spans only (see the --write pass), and the block checkers read
+  # nothing but the `|` rows, so an ordinary sentence inside a roster or
+  # assertion-types block survives both untouched. Excluding the whole body
+  # would let "verified against <current pin>" sit inside a table block with no
+  # marker and no grant, invisible to check_unmarked_pin and silently stale at
+  # the next repin — the exact claim class this gate exists to catch, hidden by
+  # the gate's own span bookkeeping. No block kind legitimately restates a SHA:
+  # they hold assertion-type names and fixture filenames.
   covered = Set.new
-  spans.each { |s| (s.line_no...(s.line_no + s.lines.length)).each { |n| covered << n } }
+  spans.each do |s|
+    next if s.block
+
+    (s.line_no...(s.line_no + s.lines.length)).each { |n| covered << n }
+  end
   prose.reject! { |line_no, _| covered.include?(line_no) }
 
   [spans, errors, prose]
@@ -851,6 +868,29 @@ def check_fixture_categories(span, fixtures)
   listed.tally.select { |_, n| n > 1 }.each_key do |file|
     errors << "#{span.location}: `#{file}` is tabulated on more than one row; one fixture, one " \
               "category"
+  end
+
+  # Tallying FILES catches a fixture listed twice; it does not catch two
+  # different fixtures deriving the same category. `_` and `-` collapse to the
+  # same slug, so `foo_bar.json` and `foo-bar.json` each satisfy the per-row
+  # slug check above and both claim the category `foo-bar`. The table is then
+  # not the bijection its own heading asserts, and the category label is
+  # ambiguous about which fixture it names. The slug is what the table is keyed
+  # by, so the slug is what has to be unique.
+  # Keyed on the DERIVED slug, not the declared cell. A row whose category cell
+  # is simply wrong is already reported above and still reaches here, so
+  # grouping by what the row claims would both miss real collisions and invent
+  # false ones. The filename is what dictates the slug, so the filename is what
+  # this groups by. Only DISTINCT files count — one file on two rows is the
+  # tally above, and reporting it twice would just be noise.
+  documented.group_by { |_, file, _| category_slug(file) }
+            .each do |slug, rows|
+    files = rows.map { |_, file, _| file }.uniq
+    next if files.length < 2
+
+    errors << "#{span.location}: category `#{slug}` is dictated by #{files.map { |f| "`#{f}`" }.join(' and ')} " \
+              "— distinct fixtures deriving one slug (`_` and `-` collapse to the same category). " \
+              "The table is keyed by category, so this is not the bijection it claims; rename one."
   end
 
   missing = fixtures - listed

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -3,13 +3,26 @@
 
 # Doc-constant drift gate + writer.
 #
-# Three constants are restated in prose and drift silently from their sources:
+# Several constants and rosters are restated in prose and drift silently from
+# their sources:
 #
-#   @api-version      openapi.json  .info.version
-#   @bc3-pin          spec/api-provenance.json  .bc3.revision / .bc3.date
-#   @assertion-types  conformance/schema.json
-#   @operation-count  openapi.json  count of path × HTTP-method pairs
-#                       .properties.assertions.items.properties.type.enum
+#   @api-version          openapi.json  .info.version
+#   @bc3-pin              spec/api-provenance.json  .bc3.revision / .bc3.date
+#   @assertion-types      conformance/schema.json
+#                           .properties.assertions.items.properties.type.enum
+#   @operation-count      openapi.json  count of path × HTTP-method pairs
+#   @fixture-categories   git ls-files conformance/tests/*.json
+#   @fixture-section-map  git ls-files conformance/tests/*.json
+#
+# The last two are the same shape as @assertion-types one level out: a table
+# that CLAIMS to account for every conformance fixture, with nothing checking
+# it. Both were missed by the last three fixture-adding commits, in three
+# different ways — dee221c85 added documents_write.json and updated neither
+# table, b238e5ed4 added uploads_write.json with Appendix D rows and no §19
+# row, and #726 added search.json's §19 row and missed Appendix D. Two
+# half-applications in opposite directions is not carelessness; it is a rule
+# nobody can see (CONTRIBUTING.md tells contributors to add conformance tests
+# and mentions neither table).
 #
 # Only spans MARKED with an HTML comment are checked. That is deliberate:
 # spec/api-gaps/ legitimately cites ~20 historical bc3 SHAs in narrative
@@ -73,12 +86,14 @@
 # Modes
 #   --check (default)  Report drift; exit 1 on any error.
 #   --write            Rewrite marked spans in place from the sources.
-#                      Only the two scalar constants are writable — an
-#                      assertion-type row needs a human-written description,
-#                      so --write never touches @assertion-types and never
-#                      fails on it. `make doc-constants-check` is what catches
-#                      that one; keeping it out of the writer keeps a schema
-#                      edit from breaking every `make generate`.
+#                      Only the scalar constants are writable — every BLOCK
+#                      kind is a table whose rows carry a human-authored
+#                      column (an assertion type's meaning, a fixture's owning
+#                      spec sections, a fixture's case summary), so --write
+#                      never touches them and never fails on them.
+#                      `make doc-constants-check` is what catches those;
+#                      keeping them out of the writer keeps a schema or
+#                      fixture edit from breaking every `make generate`.
 #                      Files listed in spec/doc-constants.json .writerExcludes
 #                      are never rewritten either: this script runs inside
 #                      `make generate`, and a document whose marked value is
@@ -120,7 +135,7 @@ LINE_KINDS  = %w[api-version bc3-pin operation-count].freeze
 # The OpenAPI verbs an operation can be keyed under. Anything else in a path
 # item (parameters, servers, summary) is not an operation and must not count.
 HTTP_METHODS = %w[get put post delete patch head options trace].freeze
-BLOCK_KINDS = %w[assertion-types].freeze
+BLOCK_KINDS = %w[assertion-types fixture-categories fixture-section-map].freeze
 KNOWN_KINDS = (LINE_KINDS + BLOCK_KINDS).freeze
 
 MARKER_RE   = /<!--\s*@([a-z0-9][a-z0-9-]*)(?::(begin|end))?\s*-->/
@@ -213,6 +228,42 @@ def tracked_markdown
   raise Failure, "git ls-files failed (is #{ROOT} a git checkout?)" unless $?.success?
 
   out.split("\0").reject(&:empty?).sort
+end
+
+# The conformance fixtures the two §19/Appendix D rosters claim to account for.
+#
+# `git ls-files` rather than Dir.glob, for tracked_markdown's reason one step
+# further: an untracked scratch fixture sitting in a working checkout must not
+# fail that developer's build, and a fixture that IS tracked is exactly the one
+# a reviewer will see and expect the tables to cover.
+#
+# Scoped to conformance/tests/ deliberately, and that scope is the whole of how
+# SPEC §23's carve-out is honored. The parallel fixture families —
+# conformance/oauth/, conformance/oauth-token/, conformance/event-feed*/ — are
+# documented at their own consuming section and directory, "not in §19's
+# operation-dispatch category table or Appendix D". They are not absent from
+# these rosters by oversight, so the gate must not pull them in.
+#
+# Named by reference rather than by count on purpose. This comment carried "68
+# JSON files" for several commits; the real number is 74 and was 74 when it was
+# written. Nothing keeps a restated count current, which is the whole reason
+# @operation-count exists two hundred lines up — and a number is not what the
+# reader needs here. AGENTS.md: reach for a literal only when the sentence is
+# genuinely about the value.
+# DIRECT CHILDREN ONLY. Git's pathspec `*` matches across `/`, so the pattern
+# alone would also return `conformance/tests/nested/case.json` — which no runner
+# discovers, since all six glob non-recursively. Requiring a roster row for a
+# fixture nothing executes would be this gate demanding documentation for a
+# claim that is not true; the basename collapse would also make
+# `nested/auth.json` and `auth.json` indistinguishable.
+def tracked_fixtures
+  out = IO.popen(["git", "-C", ROOT, "ls-files", "-z", "--", "conformance/tests/*.json"],
+                 external_encoding: UTF8, &:read)
+  raise Failure, "git ls-files failed (is #{ROOT} a git checkout?)" unless $?.success?
+
+  out.split("\0").reject(&:empty?)
+     .select { |path| File.dirname(path) == "conformance/tests" }
+     .map { |path| File.basename(path) }.sort
 end
 
 Span = Struct.new(:kind, :file, :line_no, :lines, :block, keyword_init: true) do
@@ -638,6 +689,256 @@ def check_assertion_types(span, schema_types)
   errors
 end
 
+# --- conformance fixture rosters ---------------------------------------------
+
+# A Markdown alignment cell: `---`, `:---`, `---:` or `:---:`.
+SEPARATOR_CELL_RE = /\A:?-+:?\z/
+
+# The cells of one Markdown table row, stripped. The leading empty string before
+# the opening pipe is dropped; Ruby's split already drops the trailing one.
+def table_cells(line)
+  # Split on UNESCAPED pipes only. `\|` inside a cell is ordinary Markdown —
+  # "supports A \| B" is a legitimate test summary — and a raw split would treat
+  # the text after it as the next column, shifting every cell along. A row whose
+  # Primary section is actually blank then presents a non-empty cell there and
+  # satisfies the blank-cell guard.
+  parts = line.split(/(?<!\\)\|/)
+  parts.shift
+  parts.map { |cell| cell.strip.gsub("\\|", "|") }
+end
+
+# The DATA rows of the table inside a marked span, as [line_no, cells] pairs.
+#
+# check_assertion_types identifies a row by whether its first cell already
+# parses, and filter_maps the rest away. That is safe there: a row it drops
+# reappears as a `missing:` assertion type, because the schema is the source of
+# truth and every name in it must be found somewhere. The fixture rosters get
+# the stricter form — a row is whatever follows the |---|---| separator, and a
+# row whose file cell does not parse is REPORTED rather than skipped. Same rule
+# the fence handling follows: a row the parser cannot see is a row it silently
+# vouches for, and over-scanning costs a false alarm while under-scanning costs
+# a claim nobody checked, wearing this gate's own green tick.
+def table_rows(span)
+  numbered = span.lines.each_with_index
+                 .map { |line, index| [span.line_no + index, line.strip] }
+                 .select { |_, line| line.start_with?("|") }
+
+  separator = numbered.index do |_, line|
+    cells = table_cells(line)
+    !cells.empty? && cells.all? { |cell| cell.match?(SEPARATOR_CELL_RE) }
+  end
+
+  if separator.nil?
+    return [["#{span.location}: the @#{span.kind} span holds no Markdown table (no |---|---| " \
+             "separator row) — the marker pair is around the wrong lines"], []]
+  end
+
+  [[], numbered[(separator + 1)..].map { |line_no, line| [line_no, table_cells(line)] }]
+end
+
+# A table cell naming a fixture file: a single backticked *.json and nothing else.
+FIXTURE_CELL_RE = /\A`([A-Za-z0-9][A-Za-z0-9_.-]*\.json)`\z/
+
+# The section numbers a document actually defines, from its `## §N.` headings.
+def spec_sections(file)
+  @spec_sections ||= {}
+  @spec_sections[file] ||= begin
+    found = File.readlines(File.join(ROOT, file), chomp: true, encoding: UTF8)
+               .filter_map { |line| line[/\A## §(\d+)\./, 1] }.to_set
+    if found.empty?
+      raise Failure, "#{file}: no `## §N.` headings found, so section references in its tables " \
+                     "cannot be validated — this check has no source of truth"
+    end
+
+    found
+  end
+end
+
+# Section references in a table cell that resolve to no heading.
+#
+# Catches a typo (`§99`) and, more usefully, a reference that RESOLVED when it
+# was written and stopped resolving when a section was renumbered — the case a
+# reviewer reading the same PR cannot see, unlike an obviously wrong number.
+#
+# Deliberately does NOT require a row to carry a section reference at all. That
+# would catch a `TBD` placeholder, but only with a carve-out for the row that
+# legitimately has none — `live-my-surface.json`, attributed to external
+# governance — and the carve-out list is the part that grows.
+def unresolved_sections(cell, file)
+  cell.scan(/§(\d+)/).flatten.uniq.reject { |number| spec_sections(file).include?(number) }
+end
+
+# Vacuity guards, stated explicitly rather than left to emerge.
+#
+# Both directions already fail loudly on their own — an empty table makes every
+# fixture `missing`, an empty fixture list makes every row `extra` — so this
+# buys no coverage. It buys the message: a regex that stopped matching would
+# otherwise be reported as 22 individually plausible drift findings instead of
+# the one thing that is actually wrong. House standard since
+# check-search-fixture-copy.py.
+def roster_vacuity(span, fixtures, rows)
+  if fixtures.empty?
+    ["#{span.location}: internal error: `git ls-files conformance/tests/*.json` matched nothing, " \
+     "so this check has no source of truth and cannot vouch for the table"]
+  elsif rows.empty?
+    ["#{span.location}: the @#{span.kind} table has no data rows"]
+  else
+    []
+  end
+end
+
+# The category slug a fixture's filename dictates: basename minus `.json`, with
+# `_` written as `-`. Verified to hold across every row of the table with zero
+# violations, which is what makes it an invariant to assert rather than a
+# convention to hope for.
+def category_slug(file)
+  File.basename(file, ".json").tr("_", "-")
+end
+
+# SPEC §19's Test Categories table: exactly one row per tracked fixture, and the
+# category slug is the filename. The invariant is a bijection, so all of it is
+# asserted — both directions plus the slug.
+def check_fixture_categories(span, fixtures)
+  errors, rows = table_rows(span)
+  return errors unless errors.empty?
+
+  vacuity = roster_vacuity(span, fixtures, rows)
+  return vacuity unless vacuity.empty?
+
+  documented = []
+  rows.each do |line_no, cells|
+    if cells.length < 3
+      errors << "#{span.file}:#{line_no}: category row has #{cells.length} cell(s); the shape is " \
+                "| Category | `file.json` | Owning Spec Section(s) |"
+      next
+    end
+
+    # The table's claim is that every fixture HAS an owning spec section. A row
+    # with an empty third cell satisfies presence and states nothing, so it
+    # would let a new fixture through with the attribution the row exists to
+    # carry left blank — the gate reporting the claim as kept while it is
+    # vacuous. Both PR bots flagged this on both tables.
+    if cells[2].empty?
+      errors << "#{span.file}:#{line_no}: category row for #{cells[1]} names no owning spec " \
+                "section. That attribution is the whole claim of this table — a row without it " \
+                "records that the fixture exists, not that anything in the spec owns it."
+      next
+    end
+
+    match = cells[1].match(FIXTURE_CELL_RE)
+    if match.nil?
+      errors << "#{span.file}:#{line_no}: the Files cell #{cells[1].inspect} is not a single " \
+                "backticked fixture filename (`something.json`)"
+      next
+    end
+
+    documented << [cells[0], match[1], line_no]
+
+    unresolved = unresolved_sections(cells[2], span.file)
+    unless unresolved.empty?
+      errors << "#{span.file}:#{line_no}: owning section(s) #{unresolved.map { |n| "§#{n}" }.join(', ')} " \
+                "do not resolve to a `## §N.` heading in #{span.file} — a renumbered section " \
+                "leaves a reference that reads fine and points nowhere"
+    end
+
+    next if cells[0] == category_slug(match[1])
+
+    errors << "#{span.file}:#{line_no}: category `#{cells[0]}` does not match its file — " \
+              "`#{match[1]}` dictates the slug `#{category_slug(match[1])}` (basename, `_` as `-`)"
+  end
+
+  listed = documented.map { |_, file, _| file }
+  listed.tally.select { |_, n| n > 1 }.each_key do |file|
+    errors << "#{span.location}: `#{file}` is tabulated on more than one row; one fixture, one " \
+              "category"
+  end
+
+  missing = fixtures - listed
+  extra   = listed - fixtures
+
+  unless missing.empty?
+    errors << "#{span.location}: conformance/tests holds #{fixtures.length} tracked fixture(s), " \
+              "the table categorises #{listed.uniq.length}; missing: " \
+              "#{missing.map { |f| "`#{f}`" }.join(', ')}. Every fixture needs a row naming the " \
+              "spec section that owns it — add one, or the fixture is a test nothing in the spec " \
+              "claims."
+  end
+  unless extra.empty?
+    errors << "#{span.location}: the table categorises files git does not track under " \
+              "conformance/tests/: #{extra.map { |f| "`#{f}`" }.join(', ')}"
+  end
+
+  errors
+end
+
+# SPEC Appendix D's Conformance Test → Spec Section mapping: every tracked
+# fixture appears on at least one row, and no row names a file that is not one.
+#
+# Deliberately weaker than the categories check, because the artifact is
+# weaker. Its rows are curated free-form summaries — one row bundles eleven
+# schedule-entry cases, four rows split uploads_write.json by theme — so
+# "exactly one row per fixture" is not true of it and never was. Asserting
+# coverage is what the table actually claims; asserting shape would be
+# asserting an invariant nobody wrote.
+def check_fixture_section_map(span, fixtures)
+  errors, rows = table_rows(span)
+  return errors unless errors.empty?
+
+  vacuity = roster_vacuity(span, fixtures, rows)
+  return vacuity unless vacuity.empty?
+
+  covered = []
+  rows.each do |line_no, cells|
+    if cells.length < 3
+      errors << "#{span.file}:#{line_no}: mapping row has #{cells.length} cell(s); the shape is " \
+                "| `file.json` | Test name | Primary section |"
+      next
+    end
+
+    # Coverage by a row that names neither the cases nor a section is coverage
+    # in name only. This table is already the weaker of the two — it asserts
+    # that a fixture appears, not that every case does — so a blank row would
+    # reduce it to asserting nothing at all.
+    blank = [["Test name", cells[1]], ["Primary section", cells[2]]].select { |_, cell| cell.empty? }
+    unless blank.empty?
+      errors << "#{span.file}:#{line_no}: mapping row for #{cells[0]} leaves " \
+                "#{blank.map(&:first).join(' and ')} empty — a row that summarises no cases and " \
+                "names no section covers the fixture only nominally."
+      next
+    end
+
+    match = cells[0].match(FIXTURE_CELL_RE)
+    if match.nil?
+      errors << "#{span.file}:#{line_no}: the Test file cell #{cells[0].inspect} is not a single " \
+                "backticked fixture filename (`something.json`)"
+      next
+    end
+
+    covered << match[1]
+
+    unresolved = unresolved_sections(cells[2], span.file)
+    next if unresolved.empty?
+
+    errors << "#{span.file}:#{line_no}: primary section(s) #{unresolved.map { |n| "§#{n}" }.join(', ')} " \
+              "do not resolve to a `## §N.` heading in #{span.file}"
+  end
+
+  missing = fixtures - covered
+  extra   = covered.uniq - fixtures
+
+  unless missing.empty?
+    errors << "#{span.location}: no row maps these tracked fixtures to a primary section: " \
+              "#{missing.map { |f| "`#{f}`" }.join(', ')}. One row per theme is enough — the " \
+              "table claims coverage, not a case-by-case index."
+  end
+  unless extra.empty?
+    errors << "#{span.location}: rows name files git does not track under conformance/tests/: " \
+              "#{extra.map { |f| "`#{f}`" }.join(', ')}"
+  end
+
+  errors
+end
+
 # --- writer ------------------------------------------------------------------
 
 def rewrite_line(kind, line, api_version:, revision:, date:, operation_count_value:)
@@ -806,13 +1107,22 @@ def run(mode, openapi)
   schema_types = dig!(schema, "conformance/schema.json",
                       "properties", "assertions", "items", "properties", "type", "enum")
 
+  # Derived lazily for op_count's reason: a repo carrying no fixture roster has
+  # no business shelling out to git for a list it never consults.
+  fixtures_memo = nil
+  fixtures = lambda do
+    fixtures_memo ||= tracked_fixtures
+  end
+
   spans.each do |span|
     errors.concat(
       case span.kind
-      when "api-version"     then check_api_version(span, api_version, openapi)
-      when "bc3-pin"         then check_bc3_pin(span, revision, date)
-      when "assertion-types" then check_assertion_types(span, schema_types)
-      when "operation-count" then check_operation_count(span, op_count.call, openapi)
+      when "api-version"         then check_api_version(span, api_version, openapi)
+      when "bc3-pin"             then check_bc3_pin(span, revision, date)
+      when "assertion-types"     then check_assertion_types(span, schema_types)
+      when "operation-count"     then check_operation_count(span, op_count.call, openapi)
+      when "fixture-categories"  then check_fixture_categories(span, fixtures.call)
+      when "fixture-section-map" then check_fixture_section_map(span, fixtures.call)
       else []
       end
     )
@@ -836,6 +1146,9 @@ def run(mode, openapi)
     puts "  bc3-pin          #{revision[0, 8]} (#{date})"
     puts "  assertion-types  #{schema_types.length}"
     puts "  operation-count  #{op_count.call}" if spans.any? { |s| s.kind == "operation-count" }
+    if spans.any? { |s| %w[fixture-categories fixture-section-map].include?(s.kind) }
+      puts "  fixtures         #{fixtures.call.length} tracked under conformance/tests/"
+    end
     0
   else
     warn "ERROR: documentation constants have drifted from their sources."
@@ -851,6 +1164,11 @@ def run(mode, openapi)
     end
     warn "  Assertion types:  edit SPEC.md §19's marked table by hand — a new row " \
          "needs a description only a human can write."
+    warn "  Fixture rosters:  a new conformance/tests fixture needs a row in BOTH SPEC.md §19's " \
+         "Test Categories"
+    warn "                    table and Appendix D. Neither is auto-written: the owning-section " \
+         "and case-summary"
+    warn "                    columns are attributions only the fixture's author can make."
     warn "  Unmarked pin:     see the A/B rule in AGENTS.md §Provenance is Mandatory."
     1
   end

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -787,12 +787,25 @@ end
 
 # Vacuity guards, stated explicitly rather than left to emerge.
 #
-# Both directions already fail loudly on their own — an empty table makes every
-# fixture `missing`, an empty fixture list makes every row `extra` — so this
-# buys no coverage. It buys the message: a regex that stopped matching would
-# otherwise be reported as 22 individually plausible drift findings instead of
-# the one thing that is actually wrong. House standard since
-# check-search-fixture-copy.py.
+# Mostly this buys the MESSAGE, but not entirely, and the difference is the
+# reason it cannot be deleted.
+#
+# When only ONE side is empty the set comparison does catch it — an empty table
+# makes every fixture `missing`, an empty fixture list makes every row `extra`.
+# There this guard only improves the report: a regex that stopped matching reads
+# as 22 individually plausible drift findings instead of the one thing actually
+# wrong. House standard since check-search-fixture-copy.py.
+#
+# When BOTH sides are empty it is the only thing standing. `missing` and `extra`
+# are both empty, the bidirectional comparison is trivially satisfied, and the
+# gate reports success over a roster checked against nothing — the vacuous pass
+# this whole file exists to refuse. `git ls-files` matching nothing is an
+# extraction failure, never a fact about the repo.
+#
+# Do not reduce this to a message-formatting nicety on the strength of the
+# one-sided reasoning. Both self-test cases are committed ("no tracked fixtures
+# at all" and "both sides empty is not agreement"); the second one is what
+# fails if this guard goes.
 def roster_vacuity(span, fixtures, rows)
   if fixtures.empty?
     ["#{span.location}: internal error: `git ls-files conformance/tests/*.json` matched nothing, " \

--- a/scripts/test-doc-constants.rb
+++ b/scripts/test-doc-constants.rb
@@ -723,6 +723,39 @@ out, status = gate lambda { |f|
 expect_fail(failures, "category row with a blank owning section", out, status,
             "names no owning spec section")
 
+# Two DISTINCT fixtures deriving ONE category. `_` and `-` collapse to the same
+# slug, so both rows satisfy the per-row slug rule and the file tally sees two
+# different files — the table passes every check that looks at filenames while
+# not being the bijection its own heading asserts. Adding the file to both
+# rosters keeps the set comparisons satisfied, so the collision is the only
+# thing left for the gate to catch.
+out, status = gate lambda { |f|
+  f["conformance/tests/beta-write.json"] = "[]\n"
+  f["SPEC.md"] = f["SPEC.md"]
+                 .sub("| beta-write | `beta_write.json` | §2 Something Else |\n",
+                      "| beta-write | `beta_write.json` | §2 Something Else |\n" \
+                      "| beta-write | `beta-write.json` | §2 Something Else |\n")
+                 .sub("| `beta_write.json` | does another thing | §2 |\n",
+                      "| `beta_write.json` | does another thing | §2 |\n" \
+                      "| `beta-write.json` | does a third thing | §2 |\n")
+}
+expect_fail(failures, "two fixtures deriving one category slug", out, status,
+            "category `beta-write` is dictated by")
+
+# A pin restatement INSIDE a block span. The writer rewrites line spans only and
+# the block checkers read nothing but the `|` rows, so an ordinary sentence
+# parked in a roster block survives both untouched. If block bodies were dropped
+# from the prose pool, this unmarked current-pin claim would be invisible to
+# check_unmarked_pin and silently stale at the next repin — the gate's own span
+# bookkeeping hiding the claim class it exists to catch.
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub("<!-- @fixture-categories:end -->",
+                                  "\nRosters verified against `#{SHORT}`.\n" \
+                                  "<!-- @fixture-categories:end -->")
+}
+expect_fail(failures, "unmarked pin citation inside a block span", out, status,
+            SHORT)
+
 out, status = gate lambda { |f|
   f["SPEC.md"] = f["SPEC.md"].sub("| `beta_write.json` | does another thing | §2 |",
                                   "| `beta_write.json` |  |  |")

--- a/scripts/test-doc-constants.rb
+++ b/scripts/test-doc-constants.rb
@@ -723,6 +723,27 @@ out, status = gate lambda { |f|
 expect_fail(failures, "category row with a blank owning section", out, status,
             "names no owning spec section")
 
+# A raw pipe in the attribution shifts the real section into a FOURTH cell and
+# leaves the fragment before it in cells[2] — where non-`§` attributions are
+# legitimately allowed, so the gate would validate the wrong cell and never see
+# the `§99` sitting in the actual section position. Accepting "at least three"
+# is what made that silent; the row must fail on its shape.
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub("| beta-write | `beta_write.json` | §2 Something Else |",
+                                  "| beta-write | `beta_write.json` | see A | B §99 |")
+}
+expect_fail(failures, "category row with a fourth cell from a raw pipe", out, status,
+            "cell(s), not 3")
+
+# Same shape on Appendix D, whose free-form test summaries are the likeliest
+# place in the repo for someone to write `supports A | B`.
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub("| `beta_write.json` | does another thing | §2 |",
+                                  "| `beta_write.json` | supports A | B | §99 |")
+}
+expect_fail(failures, "mapping row with a fourth cell from a raw pipe", out, status,
+            "cell(s), not 3")
+
 # Two DISTINCT fixtures deriving ONE category. `_` and `-` collapse to the same
 # slug, so both rows satisfy the per-row slug rule and the file tally sees two
 # different files — the table passes every check that looks at filenames while

--- a/scripts/test-doc-constants.rb
+++ b/scripts/test-doc-constants.rb
@@ -110,8 +110,17 @@ def default_files
         "bc3-pin" => { "COORDINATION.md" => 1 },
         "assertion-types" => { "SPEC.md" => 1 },
         "operation-count" => { "SPEC.md" => 1 },
+        "fixture-categories" => { "SPEC.md" => 1 },
+        "fixture-section-map" => { "SPEC.md" => 1 },
       }
     ),
+    # Two tracked conformance fixtures, which is the whole source of truth for
+    # the two roster checks — their CONTENT is never read, only their tracked
+    # filenames. `beta_write` earns its underscore: the category slug rule
+    # rewrites it to `beta-write`, so a check that compared basenames verbatim
+    # would pass the positive control and reject the real repo.
+    "conformance/tests/alpha.json" => "[]\n",
+    "conformance/tests/beta_write.json" => "[]\n",
     "COORDINATION.md" => <<~MD,
       # Coordination
 
@@ -119,6 +128,10 @@ def default_files
     MD
     "SPEC.md" => <<~MD,
       # Spec
+
+      ## §1. Something
+
+      ## §2. Something Else
 
       API_VERSION is `#{API_VER}`. <!-- @api-version -->
 
@@ -131,6 +144,20 @@ def default_files
       | `header` | a header |
       | `jsonPath` | a JSON path |
       <!-- @assertion-types:end -->
+
+      <!-- @fixture-categories:begin -->
+      | Category | Files | Owning Spec Section(s) |
+      |----------|-------|----------------------|
+      | alpha | `alpha.json` | §1 Something |
+      | beta-write | `beta_write.json` | §2 Something Else |
+      <!-- @fixture-categories:end -->
+
+      <!-- @fixture-section-map:begin -->
+      | Test file | Test name | Primary section |
+      |-----------|----------|----------------|
+      | `alpha.json` | does a thing | §1 |
+      | `beta_write.json` | does another thing | §2 |
+      <!-- @fixture-section-map:end -->
     MD
     "spec/api-gaps/entry.md" => <<~MD,
       # An entry
@@ -652,6 +679,201 @@ out, status = gate lambda { |f|
 }
 expect_fail(failures, "assertion type tabulated twice", out, status, "is tabulated twice")
 
+# --- @fixture-categories (SPEC §19's Test Categories table) ---------------------
+#
+# The drift this catches happened three times in three shapes before the gate
+# existed, so each shape gets a case. The gate is green on the repo as it
+# stands only because Part 1 of this change backfilled the four missing rows;
+# against the tree it landed on, both checks fail.
+
+out, status = gate ->(f) { f["SPEC.md"] = f["SPEC.md"].sub("| beta-write | `beta_write.json` | §2 Something Else |\n", "") }
+expect_fail(failures, "fixture with no category row", out, status, "missing: `beta_write.json`")
+
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub("<!-- @fixture-categories:end -->",
+                                  "| gamma | `gamma.json` | §3 |\n<!-- @fixture-categories:end -->")
+}
+expect_fail(failures, "category row for an untracked file", out, status,
+            "files git does not track under conformance/tests/: `gamma.json`")
+
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub("<!-- @fixture-categories:end -->",
+                                  "| alpha | `alpha.json` | §1 again |\n<!-- @fixture-categories:end -->")
+}
+expect_fail(failures, "fixture categorised twice", out, status,
+            "`alpha.json` is tabulated on more than one row")
+
+# The slug rule is the half of the bijection a set comparison cannot see: both
+# directions still match here, and only the category name is wrong.
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub("| beta-write | `beta_write.json` |", "| beta_write | `beta_write.json` |")
+}
+expect_fail(failures, "category slug disagrees with its filename", out, status,
+            "`beta_write.json` dictates the slug `beta-write`")
+
+# A row that satisfies PRESENCE and states NOTHING. Both PR bots flagged this
+# on both tables: the claim is that every fixture has an owning spec section,
+# and a blank attribution cell would let a new fixture through with exactly the
+# thing the row exists to carry left empty — the gate reporting the claim kept
+# while it is vacuous.
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub("| beta-write | `beta_write.json` | §2 Something Else |",
+                                  "| beta-write | `beta_write.json` |  |")
+}
+expect_fail(failures, "category row with a blank owning section", out, status,
+            "names no owning spec section")
+
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub("| `beta_write.json` | does another thing | §2 |",
+                                  "| `beta_write.json` |  |  |")
+}
+expect_fail(failures, "Appendix D row with blank cells", out, status,
+            "leaves Test name and Primary section empty")
+
+# A section reference that resolves to no heading. Catches a typo, and more
+# usefully a reference that resolved when written and stopped resolving when a
+# section was renumbered — the case a reviewer of the same PR cannot see.
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub("| beta-write | `beta_write.json` | §2 Something Else |",
+                                  "| beta-write | `beta_write.json` | §99 Renumbered Away |")
+}
+expect_fail(failures, "category row cites a section that does not exist", out, status,
+            "owning section(s) §99 do not resolve")
+
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub("| `beta_write.json` | does another thing | §2 |",
+                                  "| `beta_write.json` | does another thing | §99 |")
+}
+expect_fail(failures, "Appendix D row cites a section that does not exist", out, status,
+            "primary section(s) §99 do not resolve")
+
+# A document whose `## §N.` headings cannot be found gives the check nothing to
+# resolve against, and "no sections defined" must not read as "every reference
+# resolves" — the both-sides-empty shape, one table over.
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub("## §1. Something\n\n", "").sub("## §2. Something Else\n\n", "")
+}
+expect_fail(failures, "no section headings to resolve against", out, status,
+            "no `## §N.` headings found")
+
+# A row with NO section reference is deliberately still accepted — the real
+# table has one (`live-my-surface.json`, attributed to external governance), and
+# rejecting it would need a carve-out list rather than a rule.
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub("| `beta_write.json` | does another thing | §2 |",
+                                  "| `beta_write.json` | does another thing | External governance |")
+}
+expect_pass(failures, "a row attributed to external governance is accepted", out, status)
+
+# Git's pathspec `*` matches across `/`, but all six runners glob fixtures
+# NON-RECURSIVELY. Demanding a roster row for a fixture nothing executes would
+# be this gate requiring documentation for a claim that is not true — and the
+# basename collapse would make `nested/alpha.json` and `alpha.json`
+# indistinguishable, so a nested file could silently satisfy the row for a real
+# one.
+out, status = gate ->(f) { f["conformance/tests/nested/deep.json"] = "[]\n" }
+expect_pass(failures, "nested fixtures are out of scope", out, status)
+unless utf8(out).include?("fixtures         2 tracked")
+  failures << "nested fixture must not be counted as tracked:\n#{utf8(out)}"
+end
+
+# A row the parser cannot read must be REPORTED, not filter_mapped away — the
+# fail-open shape the fence handling exists to avoid, one table out.
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub("| alpha | `alpha.json` |", "| alpha | alpha.json |")
+}
+expect_fail(failures, "unparseable Files cell", out, status,
+            "is not a single backticked fixture filename")
+
+# Marker pair around the wrong lines: a span with no table at all reads as
+# "nothing to check" unless the absence of a separator row is itself an error.
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub(/<!-- @fixture-categories:begin -->.*<!-- @fixture-categories:end -->/m,
+                                  "<!-- @fixture-categories:begin -->\nProse, no table.\n<!-- @fixture-categories:end -->")
+}
+expect_fail(failures, "marked span holds no table", out, status, "holds no Markdown table")
+
+# Vacuity, both sides. These two are what make the pinned per-table count the
+# bash template carries genuinely redundant rather than merely argued away.
+#
+# The reasoning for dropping it runs: markerCounts already guarantees the marked
+# span EXISTS, and a bidirectional set comparison catches a deleted row, a bogus
+# row, and a wholesale emptied table. That holds only if the comparison actually
+# RUNS when one side parses to nothing. If an empty parse short-circuits —
+# nothing to compare, so nothing to fail — then gutting the table between intact
+# markers is silent, and the count would have caught precisely that. It is the
+# same silent-empty failure as a scan that reads `map[string]string{` as an
+# empty table, one level up: absence of parsed CONTENT must never be readable as
+# absence of a CLAIM.
+
+# Documented side emptied, markers and header left intact.
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"]
+                 .sub("| alpha | `alpha.json` | §1 Something |\n", "")
+                 .sub("| beta-write | `beta_write.json` | §2 Something Else |\n", "")
+}
+expect_fail(failures, "categories table gutted between intact markers", out, status,
+            "the @fixture-categories table has no data rows")
+
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"]
+                 .sub("| `alpha.json` | does a thing | §1 |\n", "")
+                 .sub("| `beta_write.json` | does another thing | §2 |\n", "")
+}
+expect_fail(failures, "Appendix D gutted between intact markers", out, status,
+            "the @fixture-section-map table has no data rows")
+
+# Derived side emptied: `git ls-files conformance/tests/*.json` matching nothing
+# is an extraction failure, not 22 pieces of drift — and emphatically not a
+# vacuously satisfied comparison. Both fixtures are deleted, so every row would
+# otherwise be reported as `extra` and the cause would be buried under symptoms.
+out, status = gate lambda { |f|
+  f.delete("conformance/tests/alpha.json")
+  f.delete("conformance/tests/beta_write.json")
+}
+expect_fail(failures, "no tracked fixtures at all", out, status,
+            "matched nothing, so this check has no source of truth")
+
+# Both sides empty at once — the case where a naive set comparison is trivially
+# satisfied and BOTH halves are wrong together.
+out, status = gate lambda { |f|
+  f.delete("conformance/tests/alpha.json")
+  f.delete("conformance/tests/beta_write.json")
+  f["SPEC.md"] = f["SPEC.md"]
+                 .sub("| alpha | `alpha.json` | §1 Something |\n", "")
+                 .sub("| beta-write | `beta_write.json` | §2 Something Else |\n", "")
+                 .sub("| `alpha.json` | does a thing | §1 |\n", "")
+                 .sub("| `beta_write.json` | does another thing | §2 |\n", "")
+}
+expect_fail(failures, "both sides empty is not agreement", out, status,
+            "matched nothing, so this check has no source of truth")
+
+# --- @fixture-section-map (SPEC Appendix D) -------------------------------------
+#
+# Coverage only, deliberately: Appendix D's rows bundle several cases each, so
+# "one row per fixture" is not true of it and is not asserted. What IS asserted
+# is that no fixture is absent and no row names a file that is not one.
+
+out, status = gate ->(f) { f["SPEC.md"] = f["SPEC.md"].sub("| `alpha.json` | does a thing | §1 |\n", "") }
+expect_fail(failures, "fixture absent from Appendix D", out, status,
+            "no row maps these tracked fixtures to a primary section: `alpha.json`")
+
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub("<!-- @fixture-section-map:end -->",
+                                  "| `gamma.json` | invented | §3 |\n<!-- @fixture-section-map:end -->")
+}
+expect_fail(failures, "Appendix D row for an untracked file", out, status,
+            "rows name files git does not track under conformance/tests/: `gamma.json`")
+
+# Two rows for one fixture is CORRECT here — uploads_write.json legitimately has
+# four. A check that copied the categories table's bijection would reject the
+# real repo.
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub("<!-- @fixture-section-map:end -->",
+                                  "| `alpha.json` | a second theme | §1 |\n<!-- @fixture-section-map:end -->")
+}
+expect_pass(failures, "Appendix D allows several rows per fixture", out, status)
+
 # --- marker structure ----------------------------------------------------------
 
 out, status = gate ->(f) { f["SPEC.md"] += "\nSomething. <!-- @nope -->\n" }
@@ -731,6 +953,25 @@ out, status = gate lambda { |f|
 }
 expect_fail(failures, "count declared for an unknown kind", out, status,
             "count declared for unknown marker @not-a-kind")
+
+# Unmarking a roster is the cheapest way to silence it, so the inventory has to
+# cover the two new kinds like every other. Without the count, deleting the
+# marker pair leaves a table nothing checks and a gate that reports success.
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"]
+                 .sub("<!-- @fixture-categories:begin -->\n", "")
+                 .sub("<!-- @fixture-categories:end -->\n", "")
+}
+expect_fail(failures, "fixture-categories markers deleted", out, status,
+            "SPEC.md: spec/doc-constants.json declares 1 @fixture-categories marker(s), found 0")
+
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"]
+                 .sub("<!-- @fixture-section-map:begin -->\n", "")
+                 .sub("<!-- @fixture-section-map:end -->\n", "")
+}
+expect_fail(failures, "fixture-section-map markers deleted", out, status,
+            "SPEC.md: spec/doc-constants.json declares 1 @fixture-section-map marker(s), found 0")
 
 # --- source-of-truth failures --------------------------------------------------
 
@@ -818,6 +1059,24 @@ writer lambda { |f|
   written = read_in(dir, "SPEC.md")
   if written.include?("brandNew")
     failures << "writer: must not invent an assertion-type row:\n#{written}"
+  end
+end
+
+# Same for the two fixture rosters: a row's owning-section attribution and case
+# summary are human-authored, so the writer must leave a stale table alone and
+# let `--check` fail. Repinning gives the writer real work to do in the same
+# file, which is what makes "it left the tables alone" mean something.
+writer lambda { |f|
+  repin_to.call("c" * 40, "2026-09-09").call(f)
+  f.delete("conformance/tests/beta_write.json")
+} do |out, status, dir|
+  expect_pass(failures, "writer ignores fixture-roster drift", out, status)
+  written = read_in(dir, "SPEC.md")
+  unless written.include?("| beta-write | `beta_write.json` | §2 Something Else |")
+    failures << "writer: must not edit the fixture-categories table:\n#{written}"
+  end
+  unless written.include?("| `beta_write.json` | does another thing | §2 |")
+    failures << "writer: must not edit the fixture-section-map table:\n#{written}"
   end
 end
 

--- a/spec/doc-constants.json
+++ b/spec/doc-constants.json
@@ -2,6 +2,8 @@
   "$comment": [
     "Policy for scripts/sync-doc-constants.rb (make doc-constants-check).",
     "",
+    "THE GENERAL RULE, so a seventh kind does not have to be inferred from six examples: anything DERIVED from a machine-readable source and restated in prose gets a marker and an exact count here. The marker says 'this span is a claim about the current value of that source'; the count says 'this file carries exactly N such claims', so deleting one fails instead of silencing the check. A scalar claim is a LINE kind and the writer keeps it current. A claim the writer cannot author is a BLOCK kind — a table whose rows carry a human-written column (an assertion type's meaning, a fixture's owning spec sections) is the recurring shape — and --check is what holds it, by set comparison against the derived source. Whichever kind it is, the checker must fail when EITHER side parses to nothing: with both vacuity guards removed, an emptied table compared against an empty source is trivially satisfied and the gate exits 0, which is the one hole a set comparison cannot close on its own. Prose that merely mentions a value it is not claiming stays unmarked; see the A/B rule below and in AGENTS.md.",
+    "",
     "markerCounts — the EXACT number of spans each file carries for a given HTML",
     "comment. Any deviation fails: too few means a claim was deleted or unmarked,",
     "too many means one was added without being recorded here (and so would not be",
@@ -30,6 +32,8 @@
     "The N+1th citation fails until someone reads it and restates the number;",
     "fewer than N means the entry has outlived what it described.",
     "",
+    "fixture-categories / fixture-section-map — the two SPEC.md tables that claim to account for every tracked fixture under conformance/tests/, sourced from `git ls-files conformance/tests/*.json`. Neither is writable, for @assertion-types' reason: a row carries an owning-section attribution or a case summary only the fixture's author can make. The categories table is a bijection (one row per fixture, and the category slug IS the filename); Appendix D is coverage only, because its rows deliberately bundle several cases each. Added after the same drift appeared three times in three different shapes — a fixture with neither row, a fixture with Appendix D rows and no category row, and a fixture with a category row and no Appendix D row. SPEC §23's parallel fixture families (conformance/oauth/, oauth-token/, event-feed*/) are carved out of both rosters by their own section, which the conformance/tests/ scope honors with no special case.",
+    "",
     "operation-count — the number of (path, HTTP method) pairs in openapi.json. It is one jq away from the source and was restated in prose in six places across four files, which is how a single new operation left five of them stale and took three review rounds to reconcile. The marked span must carry the count as a BACKTICKED integer, and exactly one: the marked sentences state other numbers (SECURITY.md names 125 GETs and 83 mutations beside the total), so backticks are what distinguishes the derived constant from prose arithmetic the writer has no source for."
   ],
   "markerCounts": {
@@ -41,6 +45,12 @@
       "spec/api-gaps/README.md": 1
     },
     "assertion-types": {
+      "SPEC.md": 1
+    },
+    "fixture-categories": {
+      "SPEC.md": 1
+    },
+    "fixture-section-map": {
       "SPEC.md": 1
     },
     "operation-count": {


### PR DESCRIPTION
Three rosters in this repo claim to account for every conformance fixture. Two of them had drifted, and nothing checked either.

| claim | where | state on `origin/main` before this PR |
|---|---|---|
| every fixture has an owning spec section | SPEC §19 Test Categories table | missing `documents_write.json`, `uploads_write.json` |
| every fixture maps to a primary section | SPEC Appendix D | missing `documents_write.json`, `search.json` |

**The convention was missed by the last three fixture-adding commits, in three different ways.** `dee221c85` (#601) added `documents_write.json` and updated neither table. `b238e5ed4` (#683) added `uploads_write.json` with four Appendix D rows and no §19 row. #726 added `search.json`'s §19 row and missed Appendix D. Two half-applications in *opposite* directions is much stronger evidence for a gate than either gap alone: it is not a person being careless, it is a rule nobody can see. `CONTRIBUTING.md` told contributors to add conformance tests and mentioned neither table — this PR fixes that too.

No adversary here, and asking who the attacker is would mislead: this is the accident-and-regression class, which is what a cheap merge-blocking check is legitimately for.

## It reuses existing machinery

`sync-doc-constants.rb` already does table-completeness checking — `@assertion-types` wraps §19's assertion-type table in a block marker and set-compares it against `conformance/schema.json`. The two fixture rosters are the same shape one level out, so they become two more **block kinds**: no new script, no new Makefile target, no new CI step. `make doc-constants-check` already runs the gate and its self-test and is already in `check-targets` and `spec-gates`.

**The two invariants differ because the artifacts differ.** §19's table is a bijection, so all of it is asserted — one row per fixture, both directions, and **category slug == basename with `_` as `-`** (verified across all 22 rows, zero violations). Appendix D's rows are curated summaries that deliberately bundle several cases (`uploads_write.json` legitimately has four), so it gets coverage only, and a self-test case pins that difference by asserting several rows for one fixture still passes.

Both tables also reject a row whose attribution cell is blank, and a `§N` that resolves to no `## §N.` heading — the latter catching a reference that resolved when written and stopped resolving when a section was renumbered, which a reviewer of the same PR cannot see. A row with *no* section reference is still accepted: rejecting it needs a carve-out for `live-my-surface.json`'s external-governance attribution, and the carve-out list is the part that grows.

Neither table is writable. `--write` only ever touched line spans, and a row here carries an attribution only the fixture's author can make.

## Verification

- **Both checks reject `origin/main` as it stood**, and pass only after the first commit's rows land (`REAL_EXIT=1`, output quoted in that commit).
- **Every guard was shown to fail its self-test when removed** — one mutation per guard, restored by copy.
- **Vacuity guarded on both sides, and it earns it:** a gutted table is caught by the set comparison alone, but **both sides empty at once exits 0** without the explicit guards. That is why they are stated rather than left to emerge, and there is a case for it.
- Each commit is green standalone (the markers ship with the gate that reads them, so the backfill commit does not reference a kind the inventory has not yet declared).
- `make doc-constants-check` green under `LC_ALL=C`.

## Scope: #602 is deliberately not here

This PR originally also carried a source-text parser for the six conformance runners, to answer #602 ("is any fixture executed by nothing?") and to hold SPEC §19's Zero-Skip roster to it. **That half has been split out.** Its rule count grew across nine commits and four review rounds while the call sites it covers never moved — the state `AGENTS.md` describes as "reassess the instrument, not write a sixth selector".

The question is right; the instrument was wrong. Ground truth for "what does this runner skip" is runtime, not source text, and every runner already reports `Passed/Failed/Skipped/Total` — so **`passed + failed + skipped == mock case count`, per runner** is a single arithmetic identity that subsumes most of what the parser did by hand: nested fixtures, `mode` typos, empty fixtures, dropped cases, `result.skipped`, derived tables, spreads and percent-strings alike.

The parser work is preserved on `conformance-skips-parser-archive` and #602 stays open. Note for whoever picks it up: five runners print `  SKIP: <name>`; **TypeScript does not** — it calls `it.skip()`, so that lane needs vitest's JSON reporter rather than a line match.

Closes nothing on its own; #602 remains open.
