### PR TITLE
Make every conformance runner account for the fixture cases it ran

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1042,6 +1042,13 @@ endif
 # Run Swift conformance tests (macOS only — the SDK requires Apple platforms).
 # Defined here rather than in the conformance section so the IS_MACOS ifdef
 # parses after the variable is defined above.
+#
+# The macOS gate bounds the case census (#602) too, and the bound is worth
+# naming: every runner asserts that passed+failed+skipped equals the non-live
+# case count in conformance/tests, but on Linux this recipe prints SKIP and
+# Swift's copy of that assertion never runs. A green Linux `make` is five-runner
+# census coverage, not six. CI closes it by running test-swift on macos-15;
+# nothing closes it for a Linux developer.
 conformance-swift:
 ifdef IS_MACOS
 	@echo "==> Running Swift conformance tests..."

--- a/conformance/runner/go/case_census.go
+++ b/conformance/runner/go/case_census.go
@@ -20,9 +20,11 @@ package main
 // What it catches: a typo'd or otherwise unrecognized `mode`; a fixture file
 // that failed to parse or was never globbed (including one nested below
 // conformance/tests/, which no runner discovers — hence the recursive walk); a
-// case dropped between load and dispatch; a whole fixture truncated to `[]`; and
-// any future skip channel that bypasses the counters, because the counters are
-// what it reads rather than any particular skip mechanism.
+// case dropped between load and dispatch; a whole fixture emptied to `[]` (which
+// the census REFUSES rather than counts — see countNonLiveCases, and note that
+// counting it would make this bullet a lie); and any future skip channel that
+// bypasses the counters, because the counters are what it reads rather than any
+// particular skip mechanism.
 //
 // The typo is not this check's alone to catch, and saying so is what keeps the
 // rest of the list honest: `make conformance-fixtures-check` validates
@@ -56,8 +58,15 @@ import (
 // Absent means mock: live cases are TS-only (the canonical wire-capturer), and
 // every other mode value is nobody's. Shared with the census self-tests so the
 // rule the run loop applies is the rule under test, not a copy of it.
-func isMockMode(mode string) bool {
-	return mode == "" || mode == "mock"
+//
+// The parameter is a pointer because a plain string cannot tell an ABSENT key
+// from `"mode": ""`, and the two must not be the same answer. The other five
+// runners null-coalesce, so they run the first and refuse the second; a Go
+// `string` collapses both to "" and would run an unrecognized mode the other
+// five reject — a hole in the very invariant this census exists to hold, in the
+// reference runner.
+func isMockMode(mode *string) bool {
+	return mode == nil || *mode == "mock"
 }
 
 // countNonLiveCases counts the fixture cases whose mode is not "live",
@@ -86,13 +95,31 @@ func countNonLiveCases(dir string) (int, error) {
 		// fields this runner cannot model, or it would report a parse failure
 		// for a case the run itself handled fine.
 		var parsed []struct {
-			Mode string `json:"mode"`
+			Mode *string `json:"mode"`
 		}
 		if err := json.Unmarshal(raw, &parsed); err != nil {
 			return fmt.Errorf("%s: %w", path, err)
 		}
+		// A top-level `null` unmarshals into a nil slice without error, so it
+		// would otherwise pass as a fixture of zero cases — the one non-array
+		// root the other five runners reject and this one would not.
+		if parsed == nil {
+			return fmt.Errorf("%s: fixture is not a JSON array of cases", path)
+		}
+		// An emptied fixture is REFUSED, not counted as zero, and this is the
+		// one rejection that carries the whole-file guarantee. It is the single
+		// truncation both sides of the census read identically: the runner
+		// registers nothing from the file and the census expects nothing, so
+		// the two totals fall together and no mismatch ever appears. Counting
+		// it would make "a fixture truncated to []" a claim this check cannot
+		// keep. A file declaring no cases tests nothing, so refusing it costs
+		// nothing — and it closes the same hole in conformance-fixtures-check,
+		// where an empty array is a schema-valid list of zero items.
+		if len(parsed) == 0 {
+			return fmt.Errorf("%s: fixture declares no cases; delete the file or restore its cases", path)
+		}
 		for _, c := range parsed {
-			if c.Mode != "live" {
+			if c.Mode == nil || *c.Mode != "live" {
 				cases++
 			}
 		}

--- a/conformance/runner/go/case_census.go
+++ b/conformance/runner/go/case_census.go
@@ -1,0 +1,129 @@
+package main
+
+// Case census (#602): every non-live fixture case must be accounted for by the
+// run.
+//
+//	passed + failed + skipped  ==  cases in conformance/tests/**/*.json
+//	                               whose mode != "live"
+//
+// The left side is what the runner actually did. The right side is counted by
+// countNonLiveCases below — a SEPARATE walk and parse, deliberately not the
+// runner's own load path. That independence is the entire point: a check fed by
+// the load path can only ever confirm the load path agrees with itself.
+//
+// Why `mode != "live"` rather than `mode == "mock"`. All six runners select
+// cases with "mock unless told otherwise" (`isMockMode` here, and its five
+// equivalents), so a typo'd `mode: "moc"` is dropped by every runner at once
+// with nothing printed anywhere. Counting the expected side as "not explicitly
+// live" is what turns that silent divergence into arithmetic.
+//
+// What it catches: a typo'd or otherwise unrecognized `mode`; a fixture file
+// that failed to parse or was never globbed (including one nested below
+// conformance/tests/, which no runner discovers — hence the recursive walk); a
+// case dropped between load and dispatch; a whole fixture truncated to `[]`; and
+// any future skip channel that bypasses the counters, because the counters are
+// what it reads rather than any particular skip mechanism.
+//
+// The typo is not this check's alone to catch, and saying so is what keeps the
+// rest of the list honest: `make conformance-fixtures-check` validates
+// conformance/tests/*.json against conformance/schema.json, whose `mode` is
+// `enum: ["mock", "live"]`, so a typo in a TOP-LEVEL fixture fails there first
+// and this census is defense in depth for that one case. What that gate
+// structurally cannot see is everything else above — its glob is not recursive,
+// so a fixture nested below conformance/tests/ is validated by nothing AND run
+// by nothing (verified: such a file passes the schema gate and fails this
+// census); a fixture truncated to `[]` is a valid array of zero cases; and a
+// case dropped between load and dispatch is not a fixture-format question at
+// all. Nor does that gate run when `make conformance-<lang>` is invoked alone.
+//
+// What it does NOT catch, stated rather than implied: the literal all-six case
+// #602 names — one fixture case that every runner excludes for its own separate
+// reason. Each runner's census is green in that situation, because each runner
+// counted its own skip. Detecting it needs the six exclusion sets in one place,
+// which needs artifact plumbing across six CI jobs; #602 stays open for that.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// isMockMode reports whether a fixture case's `mode` selects this runner.
+//
+// Absent means mock: live cases are TS-only (the canonical wire-capturer), and
+// every other mode value is nobody's. Shared with the census self-tests so the
+// rule the run loop applies is the rule under test, not a copy of it.
+func isMockMode(mode string) bool {
+	return mode == "" || mode == "mock"
+}
+
+// countNonLiveCases counts the fixture cases whose mode is not "live",
+// recursively, under dir.
+//
+// Fail-closed in three places, each of which is a way the count could certify
+// nothing while looking green: an unreadable tree, a fixture that does not
+// parse, and a walk that found no fixture files at all.
+func countNonLiveCases(dir string) (int, error) {
+	cases, files := 0, 0
+
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".json") {
+			return nil
+		}
+		files++
+
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		// Only `mode` is read: the census must survive a fixture whose other
+		// fields this runner cannot model, or it would report a parse failure
+		// for a case the run itself handled fine.
+		var parsed []struct {
+			Mode string `json:"mode"`
+		}
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+		for _, c := range parsed {
+			if c.Mode != "live" {
+				cases++
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	if files == 0 {
+		return 0, fmt.Errorf("no *.json fixture files found under %s", dir)
+	}
+	return cases, nil
+}
+
+// caseCountFailure compares what the run accounted for against the census,
+// returning "" when they agree and a message naming the short side otherwise.
+func caseCountFailure(ran, expected int) string {
+	switch {
+	case ran == expected:
+		return ""
+	case ran < expected:
+		return fmt.Sprintf(
+			"case census: the run accounted for %d case(s) (passed+failed+skipped) "+
+				"but conformance/tests holds %d non-live case(s) — %d executed by nothing. "+
+				"An unrecognized `mode`, a fixture that failed to parse or was never globbed, "+
+				"or a case dropped between load and dispatch will do this.",
+			ran, expected, expected-ran)
+	default:
+		return fmt.Sprintf(
+			"case census: the run accounted for %d case(s) (passed+failed+skipped) "+
+				"but conformance/tests holds only %d non-live case(s) — %d more than the fixtures declare.",
+			ran, expected, ran-expected)
+	}
+}

--- a/conformance/runner/go/case_census_test.go
+++ b/conformance/runner/go/case_census_test.go
@@ -120,20 +120,29 @@ func TestCensusRejectsAnEmptyTree(t *testing.T) {
 	}
 }
 
-func TestCensusAcceptsATruncatedFixtureAsZeroCases(t *testing.T) {
-	// `[]` parses, so the census counts zero for it — and the runner counts
-	// zero too. The mismatch this produces is against the OTHER files' cases,
-	// which is why the count is taken over the whole tree rather than per file.
+func TestCensusRejectsAnEmptiedFixture(t *testing.T) {
+	// The one truncation both sides read identically: the runner registers
+	// nothing from the file and the census would expect nothing, so the totals
+	// fall together and no mismatch appears. Counting it as zero is what would
+	// make the whole-file guarantee a lie, so the census refuses it instead.
 	dir := t.TempDir()
-	writeFixture(t, filepath.Join(dir, "empty.json"), `[]`)
 	writeFixture(t, filepath.Join(dir, "cases.json"), censusFixture)
+	writeFixture(t, filepath.Join(dir, "emptied.json"), `[]`)
 
-	got, err := countNonLiveCases(dir)
-	if err != nil {
-		t.Fatalf("census: %v", err)
+	if _, err := countNonLiveCases(dir); err == nil {
+		t.Fatal("a fixture emptied to [] must fail the census; counted as zero it is invisible on both sides")
 	}
-	if got != 2 {
-		t.Fatalf("an empty fixture contributes nothing; got %d", got)
+}
+
+func TestCensusRejectsATopLevelNull(t *testing.T) {
+	// `null` unmarshals into a nil slice WITHOUT error, so it would otherwise
+	// pass as a fixture of zero cases — the one non-array root that reaches
+	// this far in Go.
+	dir := t.TempDir()
+	writeFixture(t, filepath.Join(dir, "null.json"), `null`)
+
+	if _, err := countNonLiveCases(dir); err == nil {
+		t.Fatal("a top-level null must fail the census, not decode to zero cases")
 	}
 }
 
@@ -154,16 +163,23 @@ func TestCaseCountFailureNamesAnOverCount(t *testing.T) {
 }
 
 func TestIsMockModeTreatsAbsenceAsMock(t *testing.T) {
-	if !isMockMode("") {
+	mode := func(s string) *string { return &s }
+
+	if !isMockMode(nil) {
 		t.Fatal("an absent mode is a mock case")
 	}
-	if !isMockMode("mock") {
+	if !isMockMode(mode("mock")) {
 		t.Fatal("an explicit mock mode is a mock case")
 	}
-	if isMockMode("live") {
+	if isMockMode(mode("live")) {
 		t.Fatal("live cases belong to the TS live runner")
 	}
-	if isMockMode("moc") {
+	if isMockMode(mode("moc")) {
 		t.Fatal("an unrecognized mode must not be run as mock; the census is what catches it")
+	}
+	// The reason Mode is a pointer. With a plain string this is indistinguishable
+	// from an absent key, so Go alone would run a mode the other five refuse.
+	if isMockMode(mode("")) {
+		t.Fatal(`an explicit "mode": "" is not an absent mode; the other five runners refuse it`)
 	}
 }

--- a/conformance/runner/go/case_census_test.go
+++ b/conformance/runner/go/case_census_test.go
@@ -1,0 +1,169 @@
+// Case-census contract (#602).
+//
+// The check is green on the real fixture tree by construction, so a live run
+// only ever proves it can say yes. These cases run it against a SYNTHETIC
+// fixture set and prove it can say no — the `mode: "moc"` case in particular,
+// which every runner's "mock unless told otherwise" filter drops with nothing
+// printed. That divergence is asserted end-to-end here: the census and the run
+// loop's own predicate (isMockMode, shared with loadTests) disagree by one, and
+// caseCountFailure reports it.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// A file carrying one case of each kind: a plain mock case (no `mode` at all,
+// the common spelling), a live case the runners are meant to drop, and a typo'd
+// mode that nothing recognizes.
+const censusFixture = `[
+  {"name": "plain", "operation": "GetProject"},
+  {"name": "live one", "operation": "GetProject", "mode": "live"},
+  {"name": "typo", "operation": "GetProject", "mode": "moc"}
+]`
+
+func writeFixture(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestCensusCountsEveryCaseThatIsNotExplicitlyLive(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, filepath.Join(dir, "cases.json"), censusFixture)
+
+	got, err := countNonLiveCases(dir)
+	if err != nil {
+		t.Fatalf("census: %v", err)
+	}
+	if got != 2 {
+		t.Fatalf("expected the plain and typo'd cases to count (2); got %d", got)
+	}
+}
+
+func TestATypoedModeMakesTheCountCheckFail(t *testing.T) {
+	// The regression this whole check exists for. The runner's own filter keeps
+	// one case; the census counts two; the difference is the case executed by
+	// nothing.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cases.json")
+	writeFixture(t, path, censusFixture)
+
+	loaded, err := loadTests(path)
+	if err != nil {
+		t.Fatalf("loadTests: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("the run loop should keep only the plain case; kept %d", len(loaded))
+	}
+
+	expected, err := countNonLiveCases(dir)
+	if err != nil {
+		t.Fatalf("census: %v", err)
+	}
+
+	msg := caseCountFailure(len(loaded), expected)
+	if msg == "" {
+		t.Fatal("a case no runner recognizes must fail the count check, not pass silently")
+	}
+	if !strings.Contains(msg, "1 executed by nothing") {
+		t.Fatalf("failure should name how many cases went unrun; got %q", msg)
+	}
+}
+
+func TestCensusFindsFixturesNestedBelowTheTestsDirectory(t *testing.T) {
+	// No runner globs recursively, so a case parked one directory down is run
+	// by nothing. The census walks, which is what makes that visible.
+	dir := t.TempDir()
+	writeFixture(t, filepath.Join(dir, "nested", "cases.json"), censusFixture)
+
+	got, err := countNonLiveCases(dir)
+	if err != nil {
+		t.Fatalf("census: %v", err)
+	}
+	if got != 2 {
+		t.Fatalf("expected the nested file to be censused (2 cases); got %d", got)
+	}
+}
+
+func TestCensusRejectsAFixtureThatDoesNotParse(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, filepath.Join(dir, "broken.json"), `[{"name": "truncated"`)
+
+	if _, err := countNonLiveCases(dir); err == nil {
+		t.Fatal("an unparseable fixture must fail the census, not be skipped")
+	}
+}
+
+func TestCensusRejectsAFixtureThatIsNotAnArray(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, filepath.Join(dir, "object.json"), `{"name": "not a list"}`)
+
+	if _, err := countNonLiveCases(dir); err == nil {
+		t.Fatal("a fixture that is not an array of cases must fail the census")
+	}
+}
+
+func TestCensusRejectsAnEmptyTree(t *testing.T) {
+	// A census that counted nothing certifies nothing: zero on both sides is
+	// the shape a broken walk takes.
+	if _, err := countNonLiveCases(t.TempDir()); err == nil {
+		t.Fatal("a tree with no fixtures must fail the census")
+	}
+}
+
+func TestCensusAcceptsATruncatedFixtureAsZeroCases(t *testing.T) {
+	// `[]` parses, so the census counts zero for it — and the runner counts
+	// zero too. The mismatch this produces is against the OTHER files' cases,
+	// which is why the count is taken over the whole tree rather than per file.
+	dir := t.TempDir()
+	writeFixture(t, filepath.Join(dir, "empty.json"), `[]`)
+	writeFixture(t, filepath.Join(dir, "cases.json"), censusFixture)
+
+	got, err := countNonLiveCases(dir)
+	if err != nil {
+		t.Fatalf("census: %v", err)
+	}
+	if got != 2 {
+		t.Fatalf("an empty fixture contributes nothing; got %d", got)
+	}
+}
+
+func TestCaseCountFailureAcceptsAgreement(t *testing.T) {
+	if msg := caseCountFailure(42, 42); msg != "" {
+		t.Fatalf("equal counts should pass; got %q", msg)
+	}
+}
+
+func TestCaseCountFailureNamesAnOverCount(t *testing.T) {
+	msg := caseCountFailure(43, 42)
+	if msg == "" {
+		t.Fatal("running more cases than the fixtures declare should fail")
+	}
+	if !strings.Contains(msg, "1 more than the fixtures declare") {
+		t.Fatalf("failure should name the over-count; got %q", msg)
+	}
+}
+
+func TestIsMockModeTreatsAbsenceAsMock(t *testing.T) {
+	if !isMockMode("") {
+		t.Fatal("an absent mode is a mock case")
+	}
+	if !isMockMode("mock") {
+		t.Fatal("an explicit mock mode is a mock case")
+	}
+	if isMockMode("live") {
+		t.Fatal("live cases belong to the TS live runner")
+	}
+	if isMockMode("moc") {
+		t.Fatal("an unrecognized mode must not be run as mock; the census is what catches it")
+	}
+}

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -34,7 +34,11 @@ type TestCase struct {
 	// runner; non-TS runners filter them out at load time so unresolved
 	// fixture placeholders and unknown operations don't false-pass as
 	// mock conformance.
-	Mode            string                 `json:"mode"`
+	//
+	// A POINTER so an absent key stays distinguishable from `"mode": ""`. A
+	// plain string collapses both to "", which would run an unrecognized mode
+	// the other five runners refuse — see isMockMode in case_census.go.
+	Mode            *string                `json:"mode"`
 	Name            string                 `json:"name"`
 	Description     string                 `json:"description"`
 	Operation       string                 `json:"operation"`
@@ -165,9 +169,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	// No early exit on an empty glob. The census walks recursively and this
+	// glob does not, so "the census found fixtures but this runner globbed
+	// none" is exactly the nested-fixture under-count the census exists to
+	// reject — and returning success here would step over the comparison that
+	// rejects it. Falling through runs zero cases and lets the count check
+	// fail, which is the correct answer.
 	if len(files) == 0 {
 		fmt.Println("No test files found in", testsDir)
-		os.Exit(0)
 	}
 
 	var results []TestResult

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -150,6 +150,15 @@ func main() {
 
 	testsDir := filepath.Join("..", "..", "tests")
 
+	// Case census (#602) — see case_census.go. Taken up front, by its own walk,
+	// so a fixture tree this runner's glob cannot see is reported before the run
+	// rather than inferred from a short count afterwards.
+	expectedCases, err := countNonLiveCases(testsDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error taking fixture census: %v\n", err)
+		os.Exit(1)
+	}
+
 	files, err := filepath.Glob(filepath.Join(testsDir, "*.json"))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error finding test files: %v\n", err)
@@ -195,9 +204,15 @@ func main() {
 	}
 
 	fmt.Printf("\n=== Summary ===\n")
-	fmt.Printf("Passed: %d, Failed: %d, Skipped: %d, Total: %d\n", passed, failed, skipped, passed+failed+skipped)
+	fmt.Printf("Passed: %d, Failed: %d, Skipped: %d, Total: %d (fixtures declare %d non-live case(s))\n",
+		passed, failed, skipped, passed+failed+skipped, expectedCases)
 
-	if failed > 0 {
+	countFailure := caseCountFailure(passed+failed+skipped, expectedCases)
+	if countFailure != "" {
+		fmt.Fprintf(os.Stderr, "\nFAIL: %s\n", countFailure)
+	}
+
+	if failed > 0 || countFailure != "" {
 		os.Exit(1)
 	}
 }
@@ -227,7 +242,7 @@ func loadTests(filename string) ([]TestCase, error) {
 	// fixtures or operations that only the live runner knows about.
 	mockTests := tests[:0]
 	for _, tc := range tests {
-		if tc.Mode == "" || tc.Mode == "mock" {
+		if isMockMode(tc.Mode) {
 			mockTests = append(mockTests, tc)
 		}
 	}

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -7,6 +7,7 @@ them against the SDK using respx for HTTP stubbing.
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
 import time
@@ -103,14 +104,33 @@ def is_mock_mode(mode: str | None) -> bool:
     return (mode if mode is not None else "mock") == "mock"
 
 
+def _fixture_files(tests_dir: str | Path) -> list[Path]:
+    """Every ``*.json`` under ``tests_dir``, recursively, sorted by path.
+
+    ``os.walk`` with ``onerror``, NOT ``Path.rglob``: rglob suppresses the
+    ``OSError`` raised while scanning, so an unreadable subdirectory is simply
+    omitted. The runner's non-recursive glob omits it too, so its cases leave
+    both sides of the census at once and the totals still agree — a fail-closed
+    walk failing open, which is the one failure this function must not have.
+    """
+
+    def onerror(err: OSError) -> None:
+        raise RuntimeError(f"could not walk {getattr(err, 'filename', tests_dir)}: {err}")
+
+    files: list[Path] = []
+    for root, _dirs, names in os.walk(tests_dir, onerror=onerror):
+        files.extend(Path(root) / name for name in names if name.endswith(".json"))
+    return sorted(files)
+
+
 def count_non_live_cases(tests_dir: str | Path) -> int:
     """Count fixture cases whose mode is not ``"live"``, recursively.
 
-    Fail-closed in three places, each a way the count could certify nothing
-    while looking green: an unreadable tree, a fixture that does not parse, and
-    a walk that found no fixture files at all.
+    Fail-closed in four places, each a way the count could certify nothing while
+    looking green: an unreadable tree, a fixture that does not parse, a fixture
+    emptied to ``[]``, and a walk that found no fixture files at all.
     """
-    files = sorted(Path(tests_dir).rglob("*.json"))
+    files = _fixture_files(tests_dir)
     if not files:
         raise RuntimeError(f"no *.json fixture files found under {tests_dir}")
 

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -41,6 +41,108 @@ _CARD_WRITE_FIELDS = ("title", "content", "due_on", "assignee_ids")
 _MISSING = object()
 
 
+# =============================================================================
+# Case census (#602)
+# =============================================================================
+#
+# Every non-live fixture case must be accounted for by the run::
+#
+#     passed + failed + skipped  ==  cases in conformance/tests/**/*.json
+#                                    whose mode != "live"
+#
+# The left side is what the runner actually did. The right side is counted by
+# ``count_non_live_cases`` below — a SEPARATE walk and parse, deliberately not
+# the runner's own load path. That independence is the entire point: a check fed
+# by the load path can only confirm the load path agrees with itself.
+#
+# Why ``mode != "live"`` rather than ``mode == "mock"``: all six runners select
+# with "mock unless told otherwise" (``is_mock_mode`` here, and its five
+# equivalents), so a typo'd ``mode: "moc"`` is dropped by every runner at once
+# with nothing printed anywhere. Counting the expected side as "not explicitly
+# live" turns that silent divergence into arithmetic.
+#
+# Catches: an unrecognized ``mode``; a fixture that failed to parse or was never
+# globbed (including one nested below ``conformance/tests/``, which no runner
+# discovers — hence the recursive walk); a case dropped between load and
+# dispatch; a fixture truncated to ``[]``; and any future skip channel that
+# bypasses the counters, because the counters are what it reads.
+#
+# The typo is not this check's alone to catch, and saying so is what keeps the
+# rest of the list honest: ``make conformance-fixtures-check`` validates
+# ``conformance/tests/*.json`` against ``conformance/schema.json``, whose
+# ``mode`` is ``enum: ["mock", "live"]``, so a typo in a TOP-LEVEL fixture fails
+# there first and this census is defense in depth for that one case. What that
+# gate structurally cannot see is everything else above — its glob is not
+# recursive, so a fixture nested below ``conformance/tests/`` is validated by
+# nothing AND run by nothing (verified: such a file passes the schema gate and
+# fails this census); a fixture truncated to ``[]`` is a valid array of zero
+# cases; and a case dropped between load and dispatch is not a fixture-format
+# question at all. Nor does that gate run when ``make conformance-<lang>`` is
+# invoked alone.
+#
+# Does NOT catch the all-six case #602 names — one case every runner excludes
+# for its own reason, which leaves each runner's own census green. That needs
+# the six exclusion sets in one place, hence artifact plumbing across six CI
+# jobs; #602 stays open for it.
+
+
+def is_mock_mode(mode: str | None) -> bool:
+    """Whether a fixture case's ``mode`` selects this runner.
+
+    Absent means mock: live cases are TS-only (the canonical wire-capturer), and
+    every other value is nobody's. Shared with the census self-tests so the rule
+    the run loop applies is the rule under test, not a copy of it.
+    """
+    return (mode or "mock") == "mock"
+
+
+def count_non_live_cases(tests_dir: str | Path) -> int:
+    """Count fixture cases whose mode is not ``"live"``, recursively.
+
+    Fail-closed in three places, each a way the count could certify nothing
+    while looking green: an unreadable tree, a fixture that does not parse, and
+    a walk that found no fixture files at all.
+    """
+    files = sorted(Path(tests_dir).rglob("*.json"))
+    if not files:
+        raise RuntimeError(f"no *.json fixture files found under {tests_dir}")
+
+    cases = 0
+    for file in files:
+        try:
+            parsed = json.loads(file.read_text())
+        except (json.JSONDecodeError, OSError) as e:
+            raise RuntimeError(f"{file}: {e}") from e
+        if not isinstance(parsed, list):
+            raise RuntimeError(f"{file}: fixture is not a JSON array")
+        # Only ``mode`` is read: the census must survive a fixture whose other
+        # fields this runner cannot model, or it would report a failure for a
+        # case the run itself handled fine.
+        cases += sum(
+            1 for case in parsed if not isinstance(case, dict) or case.get("mode") != "live"
+        )
+    return cases
+
+
+def case_count_failure(ran: int, expected: int) -> str | None:
+    """Compare what the run accounted for against the census; None when equal."""
+    if ran == expected:
+        return None
+    if ran < expected:
+        return (
+            f"case census: the run accounted for {ran} case(s) (passed+failed+skipped) "
+            f"but conformance/tests holds {expected} non-live case(s) — "
+            f"{expected - ran} executed by nothing. An unrecognized `mode`, a fixture "
+            "that failed to parse or was never globbed, or a case dropped between load "
+            "and dispatch will do this."
+        )
+    return (
+        f"case census: the run accounted for {ran} case(s) (passed+failed+skipped) "
+        f"but conformance/tests holds only {expected} non-live case(s) — "
+        f"{ran - expected} more than the fixtures declare."
+    )
+
+
 def error_raised_failure(dispatch_failed: bool) -> str | None:
     """Validate one ``errorRaised`` assertion; None when it holds.
 
@@ -1330,6 +1432,15 @@ class ConformanceRunner:
             return ErrorMapper(e)
 
     def run(self) -> int:
+        # Case census (#602) — see count_non_live_cases. Taken up front, by its
+        # own walk, so a fixture tree this runner's glob cannot see is reported
+        # before the run rather than inferred from a short count afterwards.
+        try:
+            expected_cases = count_non_live_cases(self._tests_dir)
+        except RuntimeError as e:
+            print(f"Error taking fixture census: {e}", file=sys.stderr)
+            return 1
+
         files = sorted(self._tests_dir.glob("*.json"))
         if not files:
             print(f"No test files found in {self._tests_dir}")
@@ -1344,7 +1455,7 @@ class ConformanceRunner:
             # Live tests are TS-only (canonical wire-capturer); filter them out
             # before mock dispatch so unresolved ${PROJECT_ID} fixtures and
             # live-only operations don't surface here.
-            tests = [t for t in tests if t.get("mode", "mock") == "mock"]
+            tests = [t for t in tests if is_mock_mode(t.get("mode"))]
             if not tests:
                 continue
 
@@ -1372,8 +1483,16 @@ class ConformanceRunner:
                     print(f"        {result.message}")
 
         print(f"\n{'=' * 40}")
-        print(f"Results: {passed} passed, {failed} failed, {skipped} skipped")
-        return 1 if failed > 0 else 0
+        print(
+            f"Results: {passed} passed, {failed} failed, {skipped} skipped "
+            f"(fixtures declare {expected_cases} non-live case(s))"
+        )
+
+        count_failure = case_count_failure(passed + failed + skipped, expected_cases)
+        if count_failure is not None:
+            print(f"\nFAIL: {count_failure}", file=sys.stderr)
+
+        return 1 if failed > 0 or count_failure is not None else 0
 
 
 if __name__ == "__main__":

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -64,8 +64,10 @@ _MISSING = object()
 # Catches: an unrecognized ``mode``; a fixture that failed to parse or was never
 # globbed (including one nested below ``conformance/tests/``, which no runner
 # discovers — hence the recursive walk); a case dropped between load and
-# dispatch; a fixture truncated to ``[]``; and any future skip channel that
-# bypasses the counters, because the counters are what it reads.
+# dispatch; a fixture emptied to ``[]`` (which the census REFUSES rather than
+# counts — see ``count_non_live_cases``, and note that counting it would make
+# this bullet a lie); and any future skip channel that bypasses the counters,
+# because the counters are what it reads.
 #
 # The typo is not this check's alone to catch, and saying so is what keeps the
 # rest of the list honest: ``make conformance-fixtures-check`` validates
@@ -92,8 +94,13 @@ def is_mock_mode(mode: str | None) -> bool:
     Absent means mock: live cases are TS-only (the canonical wire-capturer), and
     every other value is nobody's. Shared with the census self-tests so the rule
     the run loop applies is the rule under test, not a copy of it.
+
+    Defaults on ``None`` ONLY, not on falsiness. ``(mode or "mock")`` reads
+    ``"mode": ""`` as an absent key and runs it, where the four null-coalescing
+    runners refuse it — and since the census counts ``""`` as non-live either
+    way, the divergence this check exists to expose would have stayed green here.
     """
-    return (mode or "mock") == "mock"
+    return (mode if mode is not None else "mock") == "mock"
 
 
 def count_non_live_cases(tests_dir: str | Path) -> int:
@@ -115,6 +122,19 @@ def count_non_live_cases(tests_dir: str | Path) -> int:
             raise RuntimeError(f"{file}: {e}") from e
         if not isinstance(parsed, list):
             raise RuntimeError(f"{file}: fixture is not a JSON array")
+        # An emptied fixture is REFUSED, not counted as zero, and this is the
+        # one rejection that carries the whole-file guarantee. It is the single
+        # truncation both sides of the census read identically: the runner
+        # registers nothing from the file and the census expects nothing, so the
+        # two totals fall together and no mismatch ever appears. Counting it
+        # would make "a fixture truncated to []" a claim this check cannot keep.
+        # A file declaring no cases tests nothing, so refusing it costs nothing
+        # — and it closes the same hole in conformance-fixtures-check, where an
+        # empty array is a schema-valid list of zero items.
+        if not parsed:
+            raise RuntimeError(
+                f"{file}: fixture declares no cases; delete the file or restore its cases"
+            )
         # Only ``mode`` is read: the census must survive a fixture whose other
         # fields this runner cannot model, or it would report a failure for a
         # case the run itself handled fine.
@@ -1441,10 +1461,15 @@ class ConformanceRunner:
             print(f"Error taking fixture census: {e}", file=sys.stderr)
             return 1
 
+        # No early return on an empty glob. The census walks recursively and
+        # this glob does not, so "the census found fixtures but this runner
+        # globbed none" is exactly the nested-fixture under-count the census
+        # exists to reject — and returning success here would step over the
+        # comparison that rejects it. Falling through runs zero cases and lets
+        # the count check fail, which is the correct answer.
         files = sorted(self._tests_dir.glob("*.json"))
         if not files:
             print(f"No test files found in {self._tests_dir}")
-            return 0
 
         passed = 0
         failed = 0

--- a/conformance/runner/python/test_case_census.py
+++ b/conformance/runner/python/test_case_census.py
@@ -84,14 +84,16 @@ def test_census_rejects_an_empty_tree(tmp_path: Path):
         count_non_live_cases(tmp_path)
 
 
-def test_census_accepts_a_truncated_fixture_as_zero_cases(tmp_path: Path):
-    # ``[]`` parses, so the census counts zero for it — and the runner counts
-    # zero too. The mismatch this produces is against the OTHER files' cases,
-    # which is why the count is taken over the whole tree rather than per file.
-    write_fixture(tmp_path / "empty.json", "[]")
+def test_census_rejects_an_emptied_fixture(tmp_path: Path):
+    # The one truncation both sides read identically: the runner registers
+    # nothing from the file and the census would expect nothing, so the totals
+    # fall together and no mismatch appears. Counting it as zero is what would
+    # make the whole-file guarantee a lie, so the census refuses it instead.
     write_fixture(tmp_path / "cases.json", json.dumps(CENSUS_FIXTURE))
+    write_fixture(tmp_path / "emptied.json", "[]")
 
-    assert count_non_live_cases(tmp_path) == 2
+    with pytest.raises(RuntimeError):
+        count_non_live_cases(tmp_path)
 
 
 def test_case_count_failure_accepts_agreement():
@@ -111,3 +113,10 @@ def test_is_mock_mode_treats_absence_as_mock():
     assert not is_mock_mode("live")
     # The census is what catches this one; the filter must not run it.
     assert not is_mock_mode("moc")
+
+
+def test_is_mock_mode_does_not_default_on_falsiness():
+    # `(mode or "mock")` read this as an absent key and ran it, where the four
+    # null-coalescing runners refuse it. The census counts "" as non-live either
+    # way, so the divergence would have stayed green in Python alone.
+    assert not is_mock_mode("")

--- a/conformance/runner/python/test_case_census.py
+++ b/conformance/runner/python/test_case_census.py
@@ -1,0 +1,113 @@
+"""Case-census contract (#602).
+
+The check is green on the real fixture tree by construction, so a live run only
+ever proves it can say yes. These cases run it against a SYNTHETIC fixture set
+and prove it can say no — the ``mode: "moc"`` case in particular, which every
+runner's "mock unless told otherwise" filter drops with nothing printed. That
+divergence is asserted end-to-end here: the census and the run loop's own
+predicate (``is_mock_mode``, shared with the load path) disagree by one, and
+``case_count_failure`` reports it.
+
+Run: ``uv run pytest test_case_census.py``
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from runner import case_count_failure, count_non_live_cases, is_mock_mode
+
+# One case of each kind: a plain mock case (no ``mode`` at all, the common
+# spelling), a live case the runners are meant to drop, and a typo'd mode that
+# nothing recognizes.
+CENSUS_FIXTURE = [
+    {"name": "plain", "operation": "GetProject"},
+    {"name": "live one", "operation": "GetProject", "mode": "live"},
+    {"name": "typo", "operation": "GetProject", "mode": "moc"},
+]
+
+
+def write_fixture(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def test_census_counts_every_case_that_is_not_explicitly_live(tmp_path: Path):
+    write_fixture(tmp_path / "cases.json", json.dumps(CENSUS_FIXTURE))
+
+    assert count_non_live_cases(tmp_path) == 2
+
+
+def test_a_typoed_mode_makes_the_count_check_fail(tmp_path: Path):
+    # The regression this whole check exists for. The runner's own filter keeps
+    # one case; the census counts two; the difference is the case executed by
+    # nothing.
+    write_fixture(tmp_path / "cases.json", json.dumps(CENSUS_FIXTURE))
+
+    ran = len([t for t in CENSUS_FIXTURE if is_mock_mode(t.get("mode"))])
+    assert ran == 1, "the run loop should keep only the plain case"
+
+    failure = case_count_failure(ran, count_non_live_cases(tmp_path))
+
+    assert failure is not None, "a case no runner recognizes must fail the count check"
+    assert "1 executed by nothing" in failure
+
+
+def test_census_finds_fixtures_nested_below_the_tests_directory(tmp_path: Path):
+    # No runner globs recursively, so a case parked one directory down is run by
+    # nothing. The census walks, which is what makes that visible.
+    write_fixture(tmp_path / "nested" / "cases.json", json.dumps(CENSUS_FIXTURE))
+
+    assert count_non_live_cases(tmp_path) == 2
+
+
+def test_census_rejects_a_fixture_that_does_not_parse(tmp_path: Path):
+    write_fixture(tmp_path / "broken.json", '[{"name": "truncated"')
+
+    with pytest.raises(RuntimeError):
+        count_non_live_cases(tmp_path)
+
+
+def test_census_rejects_a_fixture_that_is_not_an_array(tmp_path: Path):
+    write_fixture(tmp_path / "object.json", '{"name": "not a list"}')
+
+    with pytest.raises(RuntimeError):
+        count_non_live_cases(tmp_path)
+
+
+def test_census_rejects_an_empty_tree(tmp_path: Path):
+    # A census that counted nothing certifies nothing: zero on both sides is the
+    # shape a broken walk takes.
+    with pytest.raises(RuntimeError):
+        count_non_live_cases(tmp_path)
+
+
+def test_census_accepts_a_truncated_fixture_as_zero_cases(tmp_path: Path):
+    # ``[]`` parses, so the census counts zero for it — and the runner counts
+    # zero too. The mismatch this produces is against the OTHER files' cases,
+    # which is why the count is taken over the whole tree rather than per file.
+    write_fixture(tmp_path / "empty.json", "[]")
+    write_fixture(tmp_path / "cases.json", json.dumps(CENSUS_FIXTURE))
+
+    assert count_non_live_cases(tmp_path) == 2
+
+
+def test_case_count_failure_accepts_agreement():
+    assert case_count_failure(42, 42) is None
+
+
+def test_case_count_failure_names_an_over_count():
+    failure = case_count_failure(43, 42)
+
+    assert failure is not None
+    assert "1 more than the fixtures declare" in failure
+
+
+def test_is_mock_mode_treats_absence_as_mock():
+    assert is_mock_mode(None)
+    assert is_mock_mode("mock")
+    assert not is_mock_mode("live")
+    # The census is what catches this one; the filter must not run it.
+    assert not is_mock_mode("moc")

--- a/conformance/runner/python/test_case_census.py
+++ b/conformance/runner/python/test_case_census.py
@@ -13,6 +13,7 @@ Run: ``uv run pytest test_case_census.py``
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -75,6 +76,26 @@ def test_census_rejects_a_fixture_that_is_not_an_array(tmp_path: Path):
 
     with pytest.raises(RuntimeError):
         count_non_live_cases(tmp_path)
+
+
+def test_census_reports_an_unreadable_subtree(tmp_path: Path):
+    # `Path.rglob` suppressed the scan error, so the subtree was simply omitted
+    # — and the runner's non-recursive glob omits it too, leaving both sides of
+    # the census agreeing over cases neither counted. Root reads through a 0o000
+    # directory, so under root the assertion is that the cases are still
+    # counted; either way they must never be silently dropped.
+    write_fixture(tmp_path / "cases.json", json.dumps(CENSUS_FIXTURE))
+    write_fixture(tmp_path / "locked" / "nested.json", json.dumps(CENSUS_FIXTURE))
+    locked = tmp_path / "locked"
+    locked.chmod(0o000)
+    try:
+        if os.geteuid() == 0:
+            assert count_non_live_cases(tmp_path) == 4
+        else:
+            with pytest.raises(RuntimeError):
+                count_non_live_cases(tmp_path)
+    finally:
+        locked.chmod(0o755)
 
 
 def test_census_rejects_an_empty_tree(tmp_path: Path):

--- a/conformance/runner/ruby/case_census_test.rb
+++ b/conformance/runner/ruby/case_census_test.rb
@@ -78,6 +78,28 @@ class CaseCensusTest < Minitest::Test
     end
   end
 
+  def test_census_reports_an_unreadable_subtree
+    # Dir.glob (and Find.find, which rescues Errno::EACCES) swallowed the error
+    # and omitted the subtree — and the runner's non-recursive glob omits it
+    # too, leaving both sides of the census agreeing over cases neither counted.
+    # Root reads through a 0o000 directory, so under root the assertion is that
+    # the cases are still counted; either way they must never be dropped.
+    files = { "cases.json" => JSON.dump(FIXTURE), "locked/nested.json" => JSON.dump(FIXTURE) }
+    with_fixture_tree(files) do |dir|
+      locked = File.join(dir, "locked")
+      File.chmod(0o000, locked)
+      begin
+        if Process.euid.zero?
+          assert_equal 4, CaseCensus.non_live_case_count(dir)
+        else
+          assert_raises(CaseCensus::Error) { CaseCensus.non_live_case_count(dir) }
+        end
+      ensure
+        File.chmod(0o755, locked)
+      end
+    end
+  end
+
   def test_census_rejects_an_empty_tree
     # A census that counted nothing certifies nothing: zero on both sides is the
     # shape a broken walk takes.

--- a/conformance/runner/ruby/case_census_test.rb
+++ b/conformance/runner/ruby/case_census_test.rb
@@ -86,13 +86,14 @@ class CaseCensusTest < Minitest::Test
     end
   end
 
-  def test_census_accepts_a_truncated_fixture_as_zero_cases
-    # `[]` parses, so the census counts zero for it — and the runner counts zero
-    # too. The mismatch this produces is against the OTHER files' cases, which
-    # is why the count is taken over the whole tree rather than per file.
-    files = { "empty.json" => "[]", "cases.json" => JSON.dump(FIXTURE) }
+  def test_census_rejects_an_emptied_fixture
+    # The one truncation both sides read identically: the runner registers
+    # nothing from the file and the census would expect nothing, so the totals
+    # fall together and no mismatch appears. Counting it as zero is what would
+    # make the whole-file guarantee a lie, so the census refuses it instead.
+    files = { "cases.json" => JSON.dump(FIXTURE), "emptied.json" => "[]" }
     with_fixture_tree(files) do |dir|
-      assert_equal 2, CaseCensus.non_live_case_count(dir)
+      assert_raises(CaseCensus::Error) { CaseCensus.non_live_case_count(dir) }
     end
   end
 
@@ -113,5 +114,8 @@ class CaseCensusTest < Minitest::Test
     refute CaseCensus.mock_mode?("live")
     # The census is what catches this one; the filter must not run it.
     refute CaseCensus.mock_mode?("moc")
+    # Ruby null-coalesces rather than defaulting on falsiness, so an explicit
+    # empty mode is not an absent one. Python defaulted on falsiness and ran it.
+    refute CaseCensus.mock_mode?("")
   end
 end

--- a/conformance/runner/ruby/case_census_test.rb
+++ b/conformance/runner/ruby/case_census_test.rb
@@ -136,8 +136,11 @@ class CaseCensusTest < Minitest::Test
     refute CaseCensus.mock_mode?("live")
     # The census is what catches this one; the filter must not run it.
     refute CaseCensus.mock_mode?("moc")
-    # Ruby null-coalesces rather than defaulting on falsiness, so an explicit
-    # empty mode is not an absent one. Python defaulted on falsiness and ran it.
+    # An explicit empty mode is not an absent one. Python defaulted on
+    # falsiness and ran it.
     refute CaseCensus.mock_mode?("")
+    # `mode || "mock"` defaulted this too, so Ruby alone ran it while the census
+    # counted it as non-live — matching totals over a value nothing accepts.
+    refute CaseCensus.mock_mode?(false)
   end
 end

--- a/conformance/runner/ruby/case_census_test.rb
+++ b/conformance/runner/ruby/case_census_test.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+# Case-census contract (#602).
+#
+# The check is green on the real fixture tree by construction, so a live run only
+# ever proves it can say yes. These cases run it against a SYNTHETIC fixture set
+# and prove it can say no — the `mode: "moc"` case in particular, which every
+# runner's "mock unless told otherwise" filter drops with nothing printed. That
+# divergence is asserted end-to-end here: the census and the run loop's own
+# predicate (CaseCensus.mock_mode?, shared with the load path) disagree by one,
+# and CaseCensus.count_failure reports it.
+#
+# Run: `bundle exec ruby case_census_test.rb`
+
+require "minitest/autorun"
+require "tmpdir"
+require_relative "runner"
+
+class CaseCensusTest < Minitest::Test
+  # One case of each kind: a plain mock case (no `mode` at all, the common
+  # spelling), a live case the runners are meant to drop, and a typo'd mode that
+  # nothing recognizes.
+  FIXTURE = [
+    { "name" => "plain", "operation" => "GetProject" },
+    { "name" => "live one", "operation" => "GetProject", "mode" => "live" },
+    { "name" => "typo", "operation" => "GetProject", "mode" => "moc" }
+  ].freeze
+
+  def with_fixture_tree(files)
+    Dir.mktmpdir do |dir|
+      files.each do |relative, content|
+        path = File.join(dir, relative)
+        FileUtils.mkdir_p(File.dirname(path))
+        File.write(path, content)
+      end
+      yield dir
+    end
+  end
+
+  def test_census_counts_every_case_that_is_not_explicitly_live
+    with_fixture_tree("cases.json" => JSON.dump(FIXTURE)) do |dir|
+      assert_equal 2, CaseCensus.non_live_case_count(dir)
+    end
+  end
+
+  def test_a_typoed_mode_makes_the_count_check_fail
+    # The regression this whole check exists for. The runner's own filter keeps
+    # one case; the census counts two; the difference is the case executed by
+    # nothing.
+    with_fixture_tree("cases.json" => JSON.dump(FIXTURE)) do |dir|
+      ran = FIXTURE.count { |t| CaseCensus.mock_mode?(t["mode"]) }
+      assert_equal 1, ran, "the run loop should keep only the plain case"
+
+      failure = CaseCensus.count_failure(ran, CaseCensus.non_live_case_count(dir))
+
+      refute_nil failure, "a case no runner recognizes must fail the count check"
+      assert_includes failure, "1 executed by nothing"
+    end
+  end
+
+  def test_census_finds_fixtures_nested_below_the_tests_directory
+    # No runner globs recursively, so a case parked one directory down is run by
+    # nothing. The census walks, which is what makes that visible.
+    with_fixture_tree("nested/cases.json" => JSON.dump(FIXTURE)) do |dir|
+      assert_equal 2, CaseCensus.non_live_case_count(dir)
+    end
+  end
+
+  def test_census_rejects_a_fixture_that_does_not_parse
+    with_fixture_tree("broken.json" => '[{"name": "truncated"') do |dir|
+      assert_raises(CaseCensus::Error) { CaseCensus.non_live_case_count(dir) }
+    end
+  end
+
+  def test_census_rejects_a_fixture_that_is_not_an_array
+    with_fixture_tree("object.json" => '{"name": "not a list"}') do |dir|
+      assert_raises(CaseCensus::Error) { CaseCensus.non_live_case_count(dir) }
+    end
+  end
+
+  def test_census_rejects_an_empty_tree
+    # A census that counted nothing certifies nothing: zero on both sides is the
+    # shape a broken walk takes.
+    with_fixture_tree({}) do |dir|
+      assert_raises(CaseCensus::Error) { CaseCensus.non_live_case_count(dir) }
+    end
+  end
+
+  def test_census_accepts_a_truncated_fixture_as_zero_cases
+    # `[]` parses, so the census counts zero for it — and the runner counts zero
+    # too. The mismatch this produces is against the OTHER files' cases, which
+    # is why the count is taken over the whole tree rather than per file.
+    files = { "empty.json" => "[]", "cases.json" => JSON.dump(FIXTURE) }
+    with_fixture_tree(files) do |dir|
+      assert_equal 2, CaseCensus.non_live_case_count(dir)
+    end
+  end
+
+  def test_count_failure_accepts_agreement
+    assert_nil CaseCensus.count_failure(42, 42)
+  end
+
+  def test_count_failure_names_an_over_count
+    failure = CaseCensus.count_failure(43, 42)
+
+    refute_nil failure
+    assert_includes failure, "1 more than the fixtures declare"
+  end
+
+  def test_mock_mode_treats_absence_as_mock
+    assert CaseCensus.mock_mode?(nil)
+    assert CaseCensus.mock_mode?("mock")
+    refute CaseCensus.mock_mode?("live")
+    # The census is what catches this one; the filter must not run it.
+    refute CaseCensus.mock_mode?("moc")
+  end
+end

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -68,8 +68,14 @@ module CaseCensus
   # Absent means mock: live cases are TS-only (the canonical wire-capturer), and
   # every other value is nobody's. Shared with the census self-tests so the rule
   # the run loop applies is the rule under test, not a copy of it.
+  #
+  # Defaults on nil ONLY. `mode || "mock"` also defaults an explicit JSON
+  # `false`, which Ruby alone would then run as mock while the census counts it
+  # as non-live — matching totals over a value no other runner accepts. Python
+  # had the same defect more broadly (its `or` defaulted every falsy value); the
+  # typed runners reject a non-string `mode` when they decode it.
   def self.mock_mode?(mode)
-    (mode || "mock") == "mock"
+    (mode.nil? ? "mock" : mode) == "mock"
   end
 
   # Counts fixture cases whose mode is not "live", recursively.

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -35,8 +35,10 @@ WebMock.disable_net_connect!
 # Catches: an unrecognized `mode`; a fixture that failed to parse or was never
 # globbed (including one nested below conformance/tests/, which no runner
 # discovers — hence the recursive walk); a case dropped between load and
-# dispatch; a fixture truncated to `[]`; and any future skip channel that
-# bypasses the counters, because the counters are what it reads.
+# dispatch; a fixture emptied to `[]` (which the census REFUSES rather than
+# counts — see +non_live_case_count+, and note that counting it would make this
+# bullet a lie); and any future skip channel that bypasses the counters, because
+# the counters are what it reads.
 #
 # The typo is not this check's alone to catch, and saying so is what keeps the
 # rest of the list honest: `make conformance-fixtures-check` validates
@@ -86,6 +88,19 @@ module CaseCensus
         raise Error, "#{file}: #{e.message}"
       end
       raise Error, "#{file}: fixture is not a JSON array" unless parsed.is_a?(Array)
+
+      # An emptied fixture is REFUSED, not counted as zero, and this is the one
+      # rejection that carries the whole-file guarantee. It is the single
+      # truncation both sides of the census read identically: the runner
+      # registers nothing from the file and the census expects nothing, so the
+      # two totals fall together and no mismatch ever appears. Counting it would
+      # make "a fixture truncated to []" a claim this check cannot keep. A file
+      # declaring no cases tests nothing, so refusing it costs nothing — and it
+      # closes the same hole in conformance-fixtures-check, where an empty array
+      # is a schema-valid list of zero items.
+      if parsed.empty?
+        raise Error, "#{file}: fixture declares no cases; delete the file or restore its cases"
+      end
 
       # Only `mode` is read: the census must survive a fixture whose other
       # fields this runner cannot model, or it would report a failure for a case
@@ -1577,12 +1592,14 @@ class ConformanceRunner
       return 1
     end
 
+    # No early return on an empty glob. The census walks recursively and this
+    # glob does not, so "the census found fixtures but this runner globbed none"
+    # is exactly the nested-fixture under-count the census exists to reject —
+    # and returning success here would step over the comparison that rejects it.
+    # Falling through runs zero cases and lets the count check fail, which is
+    # the correct answer.
     files = Dir.glob(File.join(@tests_dir, "*.json"))
-
-    if files.empty?
-      puts "No test files found in #{@tests_dir}"
-      return 0
-    end
+    puts "No test files found in #{@tests_dir}" if files.empty?
 
     passed = 0
     failed = 0

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -77,8 +77,36 @@ module CaseCensus
   # Fail-closed in three places, each a way the count could certify nothing
   # while looking green: an unreadable tree, a fixture that does not parse, and
   # a walk that found no fixture files at all.
+  # Every *.json under +dir+, recursively, sorted by path.
+  #
+  # A hand-rolled walk over Dir.children, NOT Dir.glob and NOT Find.find. Both
+  # of those swallow the error from a directory they cannot read (find.rb
+  # rescues Errno::EACCES and moves on), so an unreadable subdirectory is simply
+  # omitted. The runner's non-recursive glob omits it too, so its cases leave
+  # both sides of the census at once and the totals still agree — a fail-closed
+  # walk failing open, which is the one failure this must not have.
+  # Dir.children raises, which is the whole reason it is the API used here.
+  def self.fixture_files(dir)
+    entries = begin
+      Dir.children(dir)
+    rescue SystemCallError => e
+      raise Error, "could not walk #{dir}: #{e.message}"
+    end
+
+    entries.sort.flat_map do |name|
+      path = File.join(dir, name)
+      if File.directory?(path)
+        fixture_files(path)
+      elsif File.extname(path) == ".json"
+        [ path ]
+      else
+        []
+      end
+    end
+  end
+
   def self.non_live_case_count(tests_dir)
-    files = Dir.glob(File.join(tests_dir, "**", "*.json")).sort
+    files = fixture_files(tests_dir).sort
     raise Error, "no *.json fixture files found under #{tests_dir}" if files.empty?
 
     files.sum do |file|

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -15,6 +15,104 @@ require "set"
 WebMock.enable!
 WebMock.disable_net_connect!
 
+# The case census (#602): every non-live fixture case must be accounted for by
+# the run.
+#
+#   passed + failed + skipped  ==  cases in conformance/tests/**/*.json
+#                                  whose mode != "live"
+#
+# The left side is what the runner actually did. The right side is counted by
+# +non_live_case_count+ below — a SEPARATE walk and parse, deliberately not the
+# runner's own load path. That independence is the entire point: a check fed by
+# the load path can only confirm the load path agrees with itself.
+#
+# Why `mode != "live"` rather than `mode == "mock"`: all six runners select with
+# "mock unless told otherwise" (+mock_mode?+ here, and its five equivalents), so
+# a typo'd `mode: "moc"` is dropped by every runner at once with nothing printed
+# anywhere. Counting the expected side as "not explicitly live" turns that
+# silent divergence into arithmetic.
+#
+# Catches: an unrecognized `mode`; a fixture that failed to parse or was never
+# globbed (including one nested below conformance/tests/, which no runner
+# discovers — hence the recursive walk); a case dropped between load and
+# dispatch; a fixture truncated to `[]`; and any future skip channel that
+# bypasses the counters, because the counters are what it reads.
+#
+# The typo is not this check's alone to catch, and saying so is what keeps the
+# rest of the list honest: `make conformance-fixtures-check` validates
+# conformance/tests/*.json against conformance/schema.json, whose `mode` is
+# `enum: ["mock", "live"]`, so a typo in a TOP-LEVEL fixture fails there first
+# and this census is defense in depth for that one case. What that gate
+# structurally cannot see is everything else above — its glob is not recursive,
+# so a fixture nested below conformance/tests/ is validated by nothing AND run
+# by nothing (verified: such a file passes the schema gate and fails this
+# census); a fixture truncated to `[]` is a valid array of zero cases; and a
+# case dropped between load and dispatch is not a fixture-format question at
+# all. Nor does that gate run when `make conformance-<lang>` is invoked alone.
+#
+# Does NOT catch the all-six case #602 names — one case every runner excludes
+# for its own reason, which leaves each runner's own census green. That needs
+# the six exclusion sets in one place, hence artifact plumbing across six CI
+# jobs; #602 stays open for it.
+#
+# Kept apart from the runner so it is unit-testable (case_census_test.rb).
+module CaseCensus
+  # Raised for every fail-closed condition below, so a caller cannot catch the
+  # parse failure and miss the empty-tree one.
+  class Error < StandardError; end
+
+  # Whether a fixture case's mode selects this runner.
+  #
+  # Absent means mock: live cases are TS-only (the canonical wire-capturer), and
+  # every other value is nobody's. Shared with the census self-tests so the rule
+  # the run loop applies is the rule under test, not a copy of it.
+  def self.mock_mode?(mode)
+    (mode || "mock") == "mock"
+  end
+
+  # Counts fixture cases whose mode is not "live", recursively.
+  #
+  # Fail-closed in three places, each a way the count could certify nothing
+  # while looking green: an unreadable tree, a fixture that does not parse, and
+  # a walk that found no fixture files at all.
+  def self.non_live_case_count(tests_dir)
+    files = Dir.glob(File.join(tests_dir, "**", "*.json")).sort
+    raise Error, "no *.json fixture files found under #{tests_dir}" if files.empty?
+
+    files.sum do |file|
+      begin
+        parsed = JSON.parse(File.read(file))
+      rescue JSON::ParserError, SystemCallError => e
+        raise Error, "#{file}: #{e.message}"
+      end
+      raise Error, "#{file}: fixture is not a JSON array" unless parsed.is_a?(Array)
+
+      # Only `mode` is read: the census must survive a fixture whose other
+      # fields this runner cannot model, or it would report a failure for a case
+      # the run itself handled fine.
+      parsed.count { |test_case| !test_case.is_a?(Hash) || test_case["mode"] != "live" }
+    end
+  end
+
+  # Compares what the run accounted for against the census, returning nil when
+  # they agree and a message naming the short side otherwise.
+  def self.count_failure(ran, expected)
+    if ran == expected
+      nil
+    elsif ran < expected
+      "case census: the run accounted for #{ran} case(s) (passed+failed+skipped) " \
+        "but conformance/tests holds #{expected} non-live case(s) — " \
+        "#{expected - ran} executed by nothing. An unrecognized `mode`, a fixture " \
+        "that failed to parse or was never globbed, or a case dropped between load " \
+        "and dispatch will do this."
+    else
+      "case census: the run accounted for #{ran} case(s) (passed+failed+skipped) " \
+        "but conformance/tests holds only #{expected} non-live case(s) — " \
+        "#{ran - expected} more than the fixtures declare."
+    end
+  end
+end
+
 # The errorRaised assertion contract, kept apart from the runner so its failing
 # branch is unit-testable (error_raised_test.rb).
 module ErrorRaised
@@ -1469,6 +1567,16 @@ class ConformanceRunner
   end
 
   def run
+    # Case census (#602) — see CaseCensus. Taken up front, by its own walk, so a
+    # fixture tree this runner's glob cannot see is reported before the run
+    # rather than inferred from a short count afterwards.
+    begin
+      expected_cases = CaseCensus.non_live_case_count(@tests_dir)
+    rescue CaseCensus::Error => e
+      warn "Error taking fixture census: #{e.message}"
+      return 1
+    end
+
     files = Dir.glob(File.join(@tests_dir, "*.json"))
 
     if files.empty?
@@ -1488,7 +1596,7 @@ class ConformanceRunner
       # so unresolved ${PROJECT_ID} fixtures and live-only operations don't
       # surface as mock failures or false passes — and any future mode added
       # to the schema enum stays opt-in for this runner.
-      tests = tests.select { |t| (t["mode"] || "mock") == "mock" }
+      tests = tests.select { |t| CaseCensus.mock_mode?(t["mode"]) }
       next if tests.empty?
 
       puts "\n=== #{File.basename(file)} ==="
@@ -1521,9 +1629,13 @@ class ConformanceRunner
     end
 
     puts "\n" + "=" * 40
-    puts "Results: #{passed} passed, #{failed} failed, #{skipped} skipped"
+    puts "Results: #{passed} passed, #{failed} failed, #{skipped} skipped " \
+         "(fixtures declare #{expected_cases} non-live case(s))"
 
-    failed > 0 ? 1 : 0
+    count_failure = CaseCensus.count_failure(passed + failed + skipped, expected_cases)
+    warn "\nFAIL: #{count_failure}" if count_failure
+
+    failed > 0 || count_failure ? 1 : 0
   end
 end
 

--- a/conformance/runner/swift/Sources/ConformanceRunner/Fixtures.swift
+++ b/conformance/runner/swift/Sources/ConformanceRunner/Fixtures.swift
@@ -1,3 +1,4 @@
+import ConformanceSupport
 import Foundation
 
 /// Arbitrary JSON value that preserves 64-bit integer precision.
@@ -144,8 +145,10 @@ struct TestCase: Decodable {
     /// through as a test that exercises nothing.
     var declaresMockResponses: Bool { mockResponses != nil }
     /// Live tests are TS-only (canonical wire-capturer); other runners filter
-    /// them out at load time.
-    var isMock: Bool { (mode ?? "mock") == "mock" }
+    /// them out at load time. The rule itself lives in `ConformanceSupport` so
+    /// the case census (#602) tests the predicate this run loop applies rather
+    /// than a copy of it.
+    var isMock: Bool { CaseCensus.isMockMode(mode) }
 }
 
 struct ConfigOverrides: Decodable {

--- a/conformance/runner/swift/Sources/ConformanceRunner/Runner.swift
+++ b/conformance/runner/swift/Sources/ConformanceRunner/Runner.swift
@@ -1,4 +1,5 @@
 @_spi(Conformance) import Basecamp
+import ConformanceSupport
 import Foundation
 
 /// Default account ID for conformance tests. Not private: the path invariant
@@ -55,6 +56,20 @@ struct Runner {
         }
 
         let testsDir = URL(fileURLWithPath: "../../tests", isDirectory: true)
+
+        // Case census (#602) — see ConformanceSupport/CaseCensus.swift. Taken up
+        // front, by its own walk, so a fixture tree this runner's directory
+        // listing cannot see is reported before the run rather than inferred
+        // from a short count afterwards.
+        let expectedCases: Int
+        do {
+            expectedCases = try CaseCensus.nonLiveCaseCount(in: testsDir)
+        } catch {
+            FileHandle.standardError.write(
+                Data("Error taking fixture census: \(error)\n".utf8))
+            exit(1)
+        }
+
         let files: [URL]
         do {
             files = try FileManager.default
@@ -124,9 +139,17 @@ struct Runner {
         }
 
         print("\n=== Summary ===")
-        print("Passed: \(passed), Failed: \(failed), Skipped: \(skipped), Total: \(passed + failed + skipped)")
+        print("Passed: \(passed), Failed: \(failed), Skipped: \(skipped), "
+            + "Total: \(passed + failed + skipped) "
+            + "(fixtures declare \(expectedCases) non-live case(s))")
 
-        exit(failed > 0 ? 1 : 0)
+        let countFailure = CaseCensus.countFailure(
+            ran: passed + failed + skipped, expected: expectedCases)
+        if let countFailure {
+            FileHandle.standardError.write(Data("\nFAIL: \(countFailure)\n".utf8))
+        }
+
+        exit(failed > 0 || countFailure != nil ? 1 : 0)
     }
 
     static func runTest(_ tc: TestCase) async -> TestResult {

--- a/conformance/runner/swift/Sources/ConformanceRunner/Runner.swift
+++ b/conformance/runner/swift/Sources/ConformanceRunner/Runner.swift
@@ -80,9 +80,15 @@ struct Runner {
             print("No test files found in \(testsDir.path): \(error)")
             exit(1)
         }
+        // No early exit on an empty listing — unlike the catch above, which is a
+        // genuine read failure. The census walks recursively and this listing
+        // does not, so "the census found fixtures but this runner listed none"
+        // is the nested-fixture under-count the census exists to reject. Exiting
+        // here is non-zero either way, but it prints "No test files found" for a
+        // tree that is full of them; falling through prints the count check's
+        // diagnosis instead, which is the one that names what actually happened.
         if files.isEmpty {
             print("No test files found in \(testsDir.path)")
-            exit(1)
         }
 
         var passed = 0

--- a/conformance/runner/swift/Sources/ConformanceSupport/CaseCensus.swift
+++ b/conformance/runner/swift/Sources/ConformanceSupport/CaseCensus.swift
@@ -90,9 +90,9 @@ public enum CaseCensus {
 
     /// Counts fixture cases whose mode is not `"live"`, recursively.
     ///
-    /// Fail-closed in three places, each a way the count could certify nothing
+    /// Fail-closed in four places, each a way the count could certify nothing
     /// while looking green: an unreadable tree, a fixture that does not parse,
-    /// and a walk that found no fixture files at all.
+    /// a fixture emptied to `[]`, and a walk that found no fixture files at all.
     public static func nonLiveCaseCount(in testsDir: URL) throws -> Int {
         // The errorHandler is not optional decoration. WITHOUT one, the
         // enumerator silently skips a descendant it cannot read and keeps
@@ -113,10 +113,19 @@ public enum CaseCensus {
             throw CensusError.unreadableTree("could not walk \(testsDir.path)")
         }
 
+        // `try`, not `try?`. A failed metadata lookup on a `.json` entry is a
+        // second silent-drop path: discarding it omits that fixture from the
+        // census while the runner omits it too (for a nested entry), so the
+        // totals agree over a file neither side counted.
         var files: [URL] = []
         for case let url as URL in walker where url.pathExtension == "json" {
-            let isRegular = (try? url.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile
-            if isRegular == true { files.append(url) }
+            do {
+                if try url.resourceValues(forKeys: [.isRegularFileKey]).isRegularFile == true {
+                    files.append(url)
+                }
+            } catch {
+                throw CensusError.unreadableTree("could not stat \(url.path): \(error)")
+            }
         }
         if let traversalFailure {
             throw CensusError.unreadableTree(traversalFailure)

--- a/conformance/runner/swift/Sources/ConformanceSupport/CaseCensus.swift
+++ b/conformance/runner/swift/Sources/ConformanceSupport/CaseCensus.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+/// Case census (#602): every non-live fixture case must be accounted for by the
+/// run.
+///
+///     passed + failed + skipped  ==  every JSON case under conformance/tests,
+///                                    recursively, whose mode != "live"
+///
+/// The left side is what the runner actually did. The right side is counted by
+/// `CaseCensus.nonLiveCaseCount` below — a SEPARATE walk and parse, deliberately
+/// not the runner's own load path. That independence is the entire point: a
+/// check fed by the load path can only confirm the load path agrees with itself.
+///
+/// Why `mode != "live"` rather than `mode == "mock"`: all six runners select
+/// with "mock unless told otherwise" (`isMockMode` here, and its five
+/// equivalents), so a typo'd `mode: "moc"` is dropped by every runner at once
+/// with nothing printed anywhere. Counting the expected side as "not explicitly
+/// live" turns that silent divergence into arithmetic.
+///
+/// Catches: an unrecognized `mode`; a fixture that failed to parse or was never
+/// listed (including one nested below `conformance/tests`, which no runner
+/// discovers — hence the recursive walk); a case dropped between load and
+/// dispatch; a fixture truncated to `[]`; and any future skip channel that
+/// bypasses the counters, because the counters are what it reads.
+///
+/// The typo is not this check's alone to catch, and saying so is what keeps the
+/// rest of the list honest: `make conformance-fixtures-check` validates
+/// `conformance/tests/*.json` against `conformance/schema.json`, whose `mode` is
+/// `enum: ["mock", "live"]`, so a typo in a TOP-LEVEL fixture fails there first
+/// and this census is defense in depth for that one case. What that gate
+/// structurally cannot see is everything else above — its glob is not recursive,
+/// so a fixture nested below `conformance/tests` is validated by nothing AND run
+/// by nothing (verified: such a file passes the schema gate and fails this
+/// census); a fixture truncated to `[]` is a valid array of zero cases; and a
+/// case dropped between load and dispatch is not a fixture-format question at
+/// all. Nor does that gate run when `make conformance-<lang>` is invoked alone.
+///
+/// Does NOT catch the all-six case #602 names — one case every runner excludes
+/// for its own reason, which leaves each runner's own census green. That needs
+/// the six exclusion sets in one place, hence artifact plumbing across six CI
+/// jobs; #602 stays open for it.
+///
+/// It lives in this SDK-free target for the reason the target exists: a target
+/// carrying `@main` cannot host XCTest cleanly, and a check that is green on the
+/// real fixture tree by construction can only ever be proven to say NO against a
+/// synthetic one (`CaseCensusTests`).
+///
+/// SWIFT COVERAGE IS macOS-ONLY. `conformance-swift` is guarded by `IS_MACOS` in
+/// the Makefile and CI runs it on `macos-15`, so a green Linux run does not
+/// exercise this arm at all. Five runners, not six, on Linux.
+public enum CaseCensus {
+    /// Every fail-closed condition below, as one type: a caller cannot catch
+    /// the parse failure and miss the empty-tree one.
+    public enum CensusError: Error, CustomStringConvertible {
+        case unreadableTree(String)
+        case unparseableFixture(String)
+        case noFixtures(String)
+
+        public var description: String {
+            switch self {
+            case .unreadableTree(let message): message
+            case .unparseableFixture(let message): message
+            case .noFixtures(let message): message
+            }
+        }
+    }
+
+    /// One fixture case, reduced to the only field the census reads.
+    ///
+    /// The census must survive a fixture whose other fields this runner cannot
+    /// model, or it would report a failure for a case the run itself handled
+    /// fine.
+    private struct ModeOnly: Decodable {
+        let mode: String?
+    }
+
+    /// Whether a fixture case's `mode` selects this runner.
+    ///
+    /// Absent means mock: live cases are TS-only (the canonical wire-capturer),
+    /// and every other value is nobody's. `TestCase.isMock` in the runner calls
+    /// through to this, so the rule the run loop applies is the rule under test
+    /// rather than a copy of it.
+    public static func isMockMode(_ mode: String?) -> Bool {
+        (mode ?? "mock") == "mock"
+    }
+
+    /// Counts fixture cases whose mode is not `"live"`, recursively.
+    ///
+    /// Fail-closed in three places, each a way the count could certify nothing
+    /// while looking green: an unreadable tree, a fixture that does not parse,
+    /// and a walk that found no fixture files at all.
+    public static func nonLiveCaseCount(in testsDir: URL) throws -> Int {
+        guard let walker = FileManager.default.enumerator(
+            at: testsDir,
+            includingPropertiesForKeys: [.isRegularFileKey]
+        ) else {
+            throw CensusError.unreadableTree("could not walk \(testsDir.path)")
+        }
+
+        var files: [URL] = []
+        for case let url as URL in walker where url.pathExtension == "json" {
+            let isRegular = (try? url.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile
+            if isRegular == true { files.append(url) }
+        }
+        guard !files.isEmpty else {
+            throw CensusError.noFixtures("no *.json fixture files found under \(testsDir.path)")
+        }
+
+        var cases = 0
+        for url in files.sorted(by: { $0.path < $1.path }) {
+            let parsed: [ModeOnly]
+            do {
+                parsed = try JSONDecoder().decode([ModeOnly].self, from: try Data(contentsOf: url))
+            } catch {
+                throw CensusError.unparseableFixture("\(url.path): \(error)")
+            }
+            cases += parsed.filter { $0.mode != "live" }.count
+        }
+        return cases
+    }
+
+    /// Compares what the run accounted for against the census, returning `nil`
+    /// when they agree and a message naming the short side otherwise.
+    public static func countFailure(ran: Int, expected: Int) -> String? {
+        if ran == expected { return nil }
+        if ran < expected {
+            return """
+                case census: the run accounted for \(ran) case(s) (passed+failed+skipped) \
+                but conformance/tests holds \(expected) non-live case(s) — \
+                \(expected - ran) executed by nothing. An unrecognized `mode`, a fixture \
+                that failed to parse or was never listed, or a case dropped between load \
+                and dispatch will do this.
+                """
+        }
+        return """
+            case census: the run accounted for \(ran) case(s) (passed+failed+skipped) \
+            but conformance/tests holds only \(expected) non-live case(s) — \
+            \(ran - expected) more than the fixtures declare.
+            """
+    }
+}

--- a/conformance/runner/swift/Sources/ConformanceSupport/CaseCensus.swift
+++ b/conformance/runner/swift/Sources/ConformanceSupport/CaseCensus.swift
@@ -20,8 +20,10 @@ import Foundation
 /// Catches: an unrecognized `mode`; a fixture that failed to parse or was never
 /// listed (including one nested below `conformance/tests`, which no runner
 /// discovers — hence the recursive walk); a case dropped between load and
-/// dispatch; a fixture truncated to `[]`; and any future skip channel that
-/// bypasses the counters, because the counters are what it reads.
+/// dispatch; a fixture emptied to `[]` (which the census REFUSES rather than
+/// counts — see `nonLiveCaseCount`, and note that counting it would make this
+/// bullet a lie); and any future skip channel that bypasses the counters,
+/// because the counters are what it reads.
 ///
 /// The typo is not this check's alone to catch, and saying so is what keeps the
 /// rest of the list honest: `make conformance-fixtures-check` validates
@@ -54,12 +56,14 @@ public enum CaseCensus {
     public enum CensusError: Error, CustomStringConvertible {
         case unreadableTree(String)
         case unparseableFixture(String)
+        case emptiedFixture(String)
         case noFixtures(String)
 
         public var description: String {
             switch self {
             case .unreadableTree(let message): message
             case .unparseableFixture(let message): message
+            case .emptiedFixture(let message): message
             case .noFixtures(let message): message
             }
         }
@@ -90,9 +94,21 @@ public enum CaseCensus {
     /// while looking green: an unreadable tree, a fixture that does not parse,
     /// and a walk that found no fixture files at all.
     public static func nonLiveCaseCount(in testsDir: URL) throws -> Int {
+        // The errorHandler is not optional decoration. WITHOUT one, the
+        // enumerator silently skips a descendant it cannot read and keeps
+        // going: the subtree vanishes from the census, the runner never listed
+        // it either (it lists only the top level), and the two sides agree on a
+        // count that omits it — a fail-closed check quietly failing open.
+        // Returning false aborts the walk so the failure is reported.
+        var traversalFailure: String?
         guard let walker = FileManager.default.enumerator(
             at: testsDir,
-            includingPropertiesForKeys: [.isRegularFileKey]
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [],
+            errorHandler: { url, error in
+                traversalFailure = "could not walk \(url.path): \(error)"
+                return false
+            }
         ) else {
             throw CensusError.unreadableTree("could not walk \(testsDir.path)")
         }
@@ -101,6 +117,9 @@ public enum CaseCensus {
         for case let url as URL in walker where url.pathExtension == "json" {
             let isRegular = (try? url.resourceValues(forKeys: [.isRegularFileKey]))?.isRegularFile
             if isRegular == true { files.append(url) }
+        }
+        if let traversalFailure {
+            throw CensusError.unreadableTree(traversalFailure)
         }
         guard !files.isEmpty else {
             throw CensusError.noFixtures("no *.json fixture files found under \(testsDir.path)")
@@ -113,6 +132,20 @@ public enum CaseCensus {
                 parsed = try JSONDecoder().decode([ModeOnly].self, from: try Data(contentsOf: url))
             } catch {
                 throw CensusError.unparseableFixture("\(url.path): \(error)")
+            }
+            // An emptied fixture is REFUSED, not counted as zero, and this is
+            // the one rejection that carries the whole-file guarantee. It is
+            // the single truncation both sides of the census read identically:
+            // the runner registers nothing from the file and the census expects
+            // nothing, so the two totals fall together and no mismatch ever
+            // appears. Counting it would make "a fixture truncated to []" a
+            // claim this check cannot keep. A file declaring no cases tests
+            // nothing, so refusing it costs nothing — and it closes the same
+            // hole in conformance-fixtures-check, where an empty array is a
+            // schema-valid list of zero items.
+            guard !parsed.isEmpty else {
+                throw CensusError.emptiedFixture(
+                    "\(url.path): fixture declares no cases; delete the file or restore its cases")
             }
             cases += parsed.filter { $0.mode != "live" }.count
         }

--- a/conformance/runner/swift/Tests/ConformanceSupportTests/CaseCensusTests.swift
+++ b/conformance/runner/swift/Tests/ConformanceSupportTests/CaseCensusTests.swift
@@ -97,13 +97,14 @@ final class CaseCensusTests: XCTestCase {
         }
     }
 
-    func testCensusAcceptsATruncatedFixtureAsZeroCases() throws {
-        // `[]` parses, so the census counts zero for it — and the runner counts
-        // zero too. The mismatch this produces is against the OTHER files'
-        // cases, which is why the count is taken over the whole tree rather
-        // than per file.
-        try withFixtureTree(["empty.json": "[]", "cases.json": fixture]) { dir in
-            XCTAssertEqual(try CaseCensus.nonLiveCaseCount(in: dir), 2)
+    func testCensusRejectsAnEmptiedFixture() throws {
+        // The one truncation both sides read identically: the runner registers
+        // nothing from the file and the census would expect nothing, so the
+        // totals fall together and no mismatch appears. Counting it as zero is
+        // what would make the whole-file guarantee a lie, so the census refuses
+        // it instead.
+        try withFixtureTree(["cases.json": fixture, "emptied.json": "[]"]) { dir in
+            XCTAssertThrowsError(try CaseCensus.nonLiveCaseCount(in: dir))
         }
     }
 
@@ -124,5 +125,31 @@ final class CaseCensusTests: XCTestCase {
         XCTAssertFalse(CaseCensus.isMockMode("live"))
         // The census is what catches this one; the filter must not run it.
         XCTAssertFalse(CaseCensus.isMockMode("moc"))
+        // Null-coalescing, not falsiness: an explicit empty mode is not an
+        // absent one. Python defaulted on falsiness and ran it.
+        XCTAssertFalse(CaseCensus.isMockMode(""))
+    }
+
+    func testCensusReportsAnUnreadableSubtree() throws {
+        // Without an errorHandler the enumerator skips the unreadable subtree
+        // and keeps going, so its cases leave both sides of the census at once
+        // and the totals still agree — a fail-closed check failing open.
+        try withFixtureTree(["cases.json": fixture, "locked/nested.json": fixture]) { dir in
+            let locked = dir.appendingPathComponent("locked", isDirectory: true)
+            try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: locked.path)
+            defer {
+                try? FileManager.default.setAttributes(
+                    [.posixPermissions: 0o755], ofItemAtPath: locked.path)
+            }
+
+            // Root can read through a 0o000 directory, so this cannot assert a
+            // throw unconditionally — but it must never silently drop the
+            // subtree: either the walk fails, or the nested cases are counted.
+            if let count = try? CaseCensus.nonLiveCaseCount(in: dir) {
+                XCTAssertEqual(
+                    count, 4,
+                    "the subtree was neither reported nor counted — the census failed open")
+            }
+        }
     }
 }

--- a/conformance/runner/swift/Tests/ConformanceSupportTests/CaseCensusTests.swift
+++ b/conformance/runner/swift/Tests/ConformanceSupportTests/CaseCensusTests.swift
@@ -134,6 +134,11 @@ final class CaseCensusTests: XCTestCase {
         // Without an errorHandler the enumerator skips the unreadable subtree
         // and keeps going, so its cases leave both sides of the census at once
         // and the totals still agree — a fail-closed check failing open.
+        //
+        // Root reads through a 0o000 directory, so under root there is no
+        // unreadable subtree to report and the assertion becomes "the cases are
+        // still counted". Either way the census must never silently drop them,
+        // which is the failure this pins.
         try withFixtureTree(["cases.json": fixture, "locked/nested.json": fixture]) { dir in
             let locked = dir.appendingPathComponent("locked", isDirectory: true)
             try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: locked.path)
@@ -142,13 +147,14 @@ final class CaseCensusTests: XCTestCase {
                     [.posixPermissions: 0o755], ofItemAtPath: locked.path)
             }
 
-            // Root can read through a 0o000 directory, so this cannot assert a
-            // throw unconditionally — but it must never silently drop the
-            // subtree: either the walk fails, or the nested cases are counted.
-            if let count = try? CaseCensus.nonLiveCaseCount(in: dir) {
-                XCTAssertEqual(
-                    count, 4,
-                    "the subtree was neither reported nor counted — the census failed open")
+            if getuid() == 0 {
+                XCTAssertEqual(try CaseCensus.nonLiveCaseCount(in: dir), 4)
+            } else {
+                XCTAssertThrowsError(try CaseCensus.nonLiveCaseCount(in: dir)) { error in
+                    guard case CaseCensus.CensusError.unreadableTree = error else {
+                        return XCTFail("expected an unreadable-tree failure; got \(error)")
+                    }
+                }
             }
         }
     }

--- a/conformance/runner/swift/Tests/ConformanceSupportTests/CaseCensusTests.swift
+++ b/conformance/runner/swift/Tests/ConformanceSupportTests/CaseCensusTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import XCTest
+
+@testable import ConformanceSupport
+
+/// Case-census contract (#602).
+///
+/// The check is green on the real fixture tree by construction, so a live run
+/// only ever proves it can say yes. These cases run it against a SYNTHETIC
+/// fixture set and prove it can say no — the `mode: "moc"` case in particular,
+/// which every runner's "mock unless told otherwise" filter drops with nothing
+/// printed. That divergence is asserted here against `isMockMode`, the predicate
+/// `TestCase.isMock` in the run loop calls through to.
+final class CaseCensusTests: XCTestCase {
+    /// One case of each kind: a plain mock case (no `mode` at all, the common
+    /// spelling), a live case the runners are meant to drop, and a typo'd mode
+    /// that nothing recognizes.
+    private let fixture = """
+        [
+          {"name": "plain", "operation": "GetProject"},
+          {"name": "live one", "operation": "GetProject", "mode": "live"},
+          {"name": "typo", "operation": "GetProject", "mode": "moc"}
+        ]
+        """
+
+    /// Builds a throwaway fixture tree. Setup uses `try`, not `try?`: a write
+    /// that silently failed would leave a tree the census legitimately reports
+    /// as empty, turning a broken test into a passing one.
+    private func withFixtureTree(
+        _ files: [String: String], _ body: (URL) throws -> Void
+    ) throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("case-census-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        for (relative, content) in files {
+            let file = dir.appendingPathComponent(relative)
+            try FileManager.default.createDirectory(
+                at: file.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try Data(content.utf8).write(to: file)
+        }
+        try body(dir)
+    }
+
+    func testCensusCountsEveryCaseThatIsNotExplicitlyLive() throws {
+        try withFixtureTree(["cases.json": fixture]) { dir in
+            XCTAssertEqual(try CaseCensus.nonLiveCaseCount(in: dir), 2)
+        }
+    }
+
+    func testATypoedModeMakesTheCountCheckFail() throws {
+        // The regression this whole check exists for. The run loop's filter
+        // keeps one case; the census counts two; the difference is the case
+        // executed by nothing.
+        try withFixtureTree(["cases.json": fixture]) { dir in
+            let modes: [String?] = [nil, "live", "moc"]
+            let ran = modes.filter { CaseCensus.isMockMode($0) }.count
+            XCTAssertEqual(ran, 1, "the run loop should keep only the plain case")
+
+            let failure = CaseCensus.countFailure(
+                ran: ran, expected: try CaseCensus.nonLiveCaseCount(in: dir))
+
+            let message = try XCTUnwrap(
+                failure, "a case no runner recognizes must fail the count check")
+            XCTAssertTrue(
+                message.contains("1 executed by nothing"),
+                "failure should name how many cases went unrun; got \(message)")
+        }
+    }
+
+    func testCensusFindsFixturesNestedBelowTheTestsDirectory() throws {
+        // No runner lists recursively, so a case parked one directory down is
+        // run by nothing. The census walks, which is what makes that visible.
+        try withFixtureTree(["nested/cases.json": fixture]) { dir in
+            XCTAssertEqual(try CaseCensus.nonLiveCaseCount(in: dir), 2)
+        }
+    }
+
+    func testCensusRejectsAFixtureThatDoesNotParse() throws {
+        try withFixtureTree(["broken.json": #"[{"name": "truncated""#]) { dir in
+            XCTAssertThrowsError(try CaseCensus.nonLiveCaseCount(in: dir))
+        }
+    }
+
+    func testCensusRejectsAFixtureThatIsNotAnArray() throws {
+        try withFixtureTree(["object.json": #"{"name": "not a list"}"#]) { dir in
+            XCTAssertThrowsError(try CaseCensus.nonLiveCaseCount(in: dir))
+        }
+    }
+
+    func testCensusRejectsAnEmptyTree() throws {
+        // A census that counted nothing certifies nothing: zero on both sides
+        // is the shape a broken walk takes.
+        try withFixtureTree([:]) { dir in
+            XCTAssertThrowsError(try CaseCensus.nonLiveCaseCount(in: dir))
+        }
+    }
+
+    func testCensusAcceptsATruncatedFixtureAsZeroCases() throws {
+        // `[]` parses, so the census counts zero for it — and the runner counts
+        // zero too. The mismatch this produces is against the OTHER files'
+        // cases, which is why the count is taken over the whole tree rather
+        // than per file.
+        try withFixtureTree(["empty.json": "[]", "cases.json": fixture]) { dir in
+            XCTAssertEqual(try CaseCensus.nonLiveCaseCount(in: dir), 2)
+        }
+    }
+
+    func testCountFailureAcceptsAgreement() {
+        XCTAssertNil(CaseCensus.countFailure(ran: 42, expected: 42))
+    }
+
+    func testCountFailureNamesAnOverCount() throws {
+        let message = try XCTUnwrap(CaseCensus.countFailure(ran: 43, expected: 42))
+        XCTAssertTrue(
+            message.contains("1 more than the fixtures declare"),
+            "failure should name the over-count; got \(message)")
+    }
+
+    func testIsMockModeTreatsAbsenceAsMock() {
+        XCTAssertTrue(CaseCensus.isMockMode(nil))
+        XCTAssertTrue(CaseCensus.isMockMode("mock"))
+        XCTAssertFalse(CaseCensus.isMockMode("live"))
+        // The census is what catches this one; the filter must not run it.
+        XCTAssertFalse(CaseCensus.isMockMode("moc"))
+    }
+}

--- a/conformance/runner/typescript/case-census.test.ts
+++ b/conformance/runner/typescript/case-census.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Case-census contract (#602).
+ *
+ * The check is green on the real fixture tree by construction, so a live run
+ * only ever proves it can say yes. These cases run it against a SYNTHETIC
+ * fixture set and prove it can say no — the `mode: "moc"` case in particular,
+ * which every runner's "mock unless told otherwise" filter drops with nothing
+ * printed. That divergence is asserted end-to-end here: the census and the load
+ * path's own predicate (`isMockMode`, shared with `loadTestSuites`) disagree by
+ * one, and `caseCountFailure` reports it.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { caseCountFailure, countNonLiveCases, isMockMode } from "./case-census.js";
+
+/**
+ * One case of each kind: a plain mock case (no `mode` at all, the common
+ * spelling), a live case the runners are meant to drop, and a typo'd mode that
+ * nothing recognizes.
+ */
+const FIXTURE = [
+  { name: "plain", operation: "GetProject" },
+  { name: "live one", operation: "GetProject", mode: "live" },
+  { name: "typo", operation: "GetProject", mode: "moc" },
+];
+
+const trees: string[] = [];
+
+function fixtureTree(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "case-census-"));
+  trees.push(dir);
+  for (const [relative, content] of Object.entries(files)) {
+    const file = path.join(dir, relative);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, content);
+  }
+  return dir;
+}
+
+afterEach(() => {
+  while (trees.length > 0) {
+    fs.rmSync(trees.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe("countNonLiveCases", () => {
+  it("counts every case that is not explicitly live", () => {
+    const dir = fixtureTree({ "cases.json": JSON.stringify(FIXTURE) });
+
+    expect(countNonLiveCases(dir)).toBe(2);
+  });
+
+  it("finds fixtures nested below the tests directory", () => {
+    // No runner globs recursively, so a case parked one directory down is run
+    // by nothing. The census walks, which is what makes that visible.
+    const dir = fixtureTree({ "nested/cases.json": JSON.stringify(FIXTURE) });
+
+    expect(countNonLiveCases(dir)).toBe(2);
+  });
+
+  it("rejects a fixture that does not parse", () => {
+    const dir = fixtureTree({ "broken.json": '[{"name": "truncated"' });
+
+    expect(() => countNonLiveCases(dir)).toThrow();
+  });
+
+  it("rejects a fixture that is not an array", () => {
+    const dir = fixtureTree({ "object.json": '{"name": "not a list"}' });
+
+    expect(() => countNonLiveCases(dir)).toThrow();
+  });
+
+  it("rejects an empty tree", () => {
+    // A census that counted nothing certifies nothing: zero on both sides is
+    // the shape a broken walk takes.
+    expect(() => countNonLiveCases(fixtureTree({}))).toThrow();
+  });
+
+  it("accepts a truncated fixture as zero cases", () => {
+    // `[]` parses, so the census counts zero for it — and the runner registers
+    // zero too. The mismatch this produces is against the OTHER files' cases,
+    // which is why the count is taken over the whole tree rather than per file.
+    const dir = fixtureTree({
+      "empty.json": "[]",
+      "cases.json": JSON.stringify(FIXTURE),
+    });
+
+    expect(countNonLiveCases(dir)).toBe(2);
+  });
+});
+
+describe("caseCountFailure", () => {
+  it("fails when a typo'd mode leaves a case registered by nothing", () => {
+    // The regression this whole check exists for. The load path's filter keeps
+    // one case; the census counts two; the difference is the case run by
+    // nothing.
+    const dir = fixtureTree({ "cases.json": JSON.stringify(FIXTURE) });
+    const registered = FIXTURE.filter((tc) => isMockMode(tc.mode)).length;
+    expect(registered).toBe(1);
+
+    const failure = caseCountFailure(registered, countNonLiveCases(dir));
+
+    expect(failure).not.toBeNull();
+    expect(failure).toContain("1 executed by nothing");
+  });
+
+  it("accepts agreement", () => {
+    expect(caseCountFailure(42, 42)).toBeNull();
+  });
+
+  it("names an over-count", () => {
+    expect(caseCountFailure(43, 42)).toContain("1 more than the fixtures declare");
+  });
+});
+
+describe("isMockMode", () => {
+  it("treats absence as mock", () => {
+    expect(isMockMode(undefined)).toBe(true);
+    expect(isMockMode("mock")).toBe(true);
+    expect(isMockMode("live")).toBe(false);
+    // The census is what catches this one; the filter must not run it.
+    expect(isMockMode("moc")).toBe(false);
+  });
+});

--- a/conformance/runner/typescript/case-census.test.ts
+++ b/conformance/runner/typescript/case-census.test.ts
@@ -79,16 +79,17 @@ describe("countNonLiveCases", () => {
     expect(() => countNonLiveCases(fixtureTree({}))).toThrow();
   });
 
-  it("accepts a truncated fixture as zero cases", () => {
-    // `[]` parses, so the census counts zero for it — and the runner registers
-    // zero too. The mismatch this produces is against the OTHER files' cases,
-    // which is why the count is taken over the whole tree rather than per file.
+  it("rejects an emptied fixture", () => {
+    // The one truncation both sides read identically: the runner registers
+    // nothing from the file and the census would expect nothing, so the totals
+    // fall together and no mismatch appears. Counting it as zero is what would
+    // make the whole-file guarantee a lie, so the census refuses it instead.
     const dir = fixtureTree({
-      "empty.json": "[]",
       "cases.json": JSON.stringify(FIXTURE),
+      "emptied.json": "[]",
     });
 
-    expect(countNonLiveCases(dir)).toBe(2);
+    expect(() => countNonLiveCases(dir)).toThrow();
   });
 });
 
@@ -123,5 +124,8 @@ describe("isMockMode", () => {
     expect(isMockMode("live")).toBe(false);
     // The census is what catches this one; the filter must not run it.
     expect(isMockMode("moc")).toBe(false);
+    // `??`, not falsiness: an explicit empty mode is not an absent one.
+    // Python defaulted on falsiness and ran it.
+    expect(isMockMode("")).toBe(false);
   });
 });

--- a/conformance/runner/typescript/case-census.ts
+++ b/conformance/runner/typescript/case-census.ts
@@ -20,8 +20,10 @@
  * Catches: an unrecognized `mode`; a fixture that failed to parse or was never
  * globbed (including one nested below `conformance/tests/`, which no runner
  * discovers — hence the recursive walk); a case dropped between load and
- * dispatch; a fixture truncated to `[]`; and any future skip channel that
- * bypasses registration, because registration is what it reads.
+ * dispatch; a fixture emptied to `[]` (which the census REFUSES rather than
+ * counts — see `countNonLiveCases`, and note that counting it would make this
+ * bullet a lie); and any future skip channel that bypasses registration,
+ * because registration is what it reads.
  *
  * The typo is not this check's alone to catch, and saying so is what keeps the
  * rest of the list honest: `make conformance-fixtures-check` validates
@@ -102,6 +104,20 @@ export function countNonLiveCases(testsDir: string): number {
     }
     if (!Array.isArray(parsed)) {
       throw new Error(`${file}: fixture is not a JSON array`);
+    }
+    // An emptied fixture is REFUSED, not counted as zero, and this is the one
+    // rejection that carries the whole-file guarantee. It is the single
+    // truncation both sides of the census read identically: the runner
+    // registers nothing from the file and the census expects nothing, so the
+    // two totals fall together and no mismatch ever appears. Counting it would
+    // make "a fixture truncated to []" a claim this check cannot keep. A file
+    // declaring no cases tests nothing, so refusing it costs nothing — and it
+    // closes the same hole in conformance-fixtures-check, where an empty array
+    // is a schema-valid list of zero items.
+    if (parsed.length === 0) {
+      throw new Error(
+        `${file}: fixture declares no cases; delete the file or restore its cases`,
+      );
     }
     // Only `mode` is read: the census must survive a fixture whose other fields
     // this runner cannot model, or it would report a failure for a case the run

--- a/conformance/runner/typescript/case-census.ts
+++ b/conformance/runner/typescript/case-census.ts
@@ -1,0 +1,133 @@
+/**
+ * Case census (#602): every non-live fixture case must be accounted for by the
+ * run.
+ *
+ *     registered cases  ==  every JSON case under conformance/tests,
+ *                           recursively, whose mode != "live"
+ *
+ * The left side is what the runner actually registered with vitest. The right
+ * side is counted by `countNonLiveCases` below — a SEPARATE walk and parse,
+ * deliberately not the runner's own load path. That independence is the entire
+ * point: a check fed by the load path can only confirm the load path agrees
+ * with itself.
+ *
+ * Why `mode !== "live"` rather than `mode === "mock"`: all six runners select
+ * with "mock unless told otherwise" (`isMockMode` here, and its five
+ * equivalents), so a typo'd `mode: "moc"` is dropped by every runner at once
+ * with nothing printed anywhere. Counting the expected side as "not explicitly
+ * live" turns that silent divergence into arithmetic.
+ *
+ * Catches: an unrecognized `mode`; a fixture that failed to parse or was never
+ * globbed (including one nested below `conformance/tests/`, which no runner
+ * discovers — hence the recursive walk); a case dropped between load and
+ * dispatch; a fixture truncated to `[]`; and any future skip channel that
+ * bypasses registration, because registration is what it reads.
+ *
+ * The typo is not this check's alone to catch, and saying so is what keeps the
+ * rest of the list honest: `make conformance-fixtures-check` validates
+ * `conformance/tests/*.json` against `conformance/schema.json`, whose `mode` is
+ * `enum: ["mock", "live"]`, so a typo in a TOP-LEVEL fixture fails there first
+ * and this census is defense in depth for that one case. What that gate
+ * structurally cannot see is everything else above — its glob is not recursive,
+ * so a fixture nested below `conformance/tests/` is validated by nothing AND run
+ * by nothing (verified: such a file passes the schema gate and fails this
+ * census); a fixture truncated to `[]` is a valid array of zero cases; and a
+ * case dropped between load and registration is not a fixture-format question at
+ * all. Nor does that gate run when `make conformance-typescript` is invoked
+ * alone.
+ *
+ * Does NOT catch the all-six case #602 names — one case every runner excludes
+ * for its own reason, which leaves each runner's own census green. That needs
+ * the six exclusion sets in one place, hence artifact plumbing across six CI
+ * jobs; #602 stays open for it.
+ *
+ * TYPESCRIPT COUNTS REGISTRATIONS, NOT OUTCOMES, and that is deliberate. vitest
+ * owns pass/fail/skip accounting and `it.skip` is how this runner expresses a
+ * skip, so there are no counters to sum the way the other five runners do.
+ * Asserting on the number of registered cases is the same invariant expressed
+ * where vitest can see it: a case dropped at load never becomes an `it` at all.
+ * The TS lane is also the one with no `SKIP: <name>` line, so a dropped case
+ * leaves no trace in its output either.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/**
+ * Whether a fixture case's `mode` selects the mock runner.
+ *
+ * Absent means mock: live cases belong to live-runner.test.ts (the canonical
+ * wire-capturer), and every other value is nobody's. Shared with the census
+ * self-tests so the rule the load path applies is the rule under test, not a
+ * copy of it.
+ */
+export function isMockMode(mode: string | undefined): boolean {
+  return (mode ?? "mock") === "mock";
+}
+
+/** Every `*.json` file under `dir`, recursively, sorted by path. */
+function fixtureFiles(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      found.push(...fixtureFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith(".json")) {
+      found.push(full);
+    }
+  }
+  return found.sort();
+}
+
+/**
+ * Counts fixture cases whose mode is not `"live"`, recursively.
+ *
+ * Fail-closed in three places, each a way the count could certify nothing while
+ * looking green: an unreadable tree, a fixture that does not parse, and a walk
+ * that found no fixture files at all.
+ */
+export function countNonLiveCases(testsDir: string): number {
+  const files = fixtureFiles(testsDir);
+  if (files.length === 0) {
+    throw new Error(`no *.json fixture files found under ${testsDir}`);
+  }
+
+  let cases = 0;
+  for (const file of files) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(fs.readFileSync(file, "utf-8"));
+    } catch (err) {
+      throw new Error(`${file}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    if (!Array.isArray(parsed)) {
+      throw new Error(`${file}: fixture is not a JSON array`);
+    }
+    // Only `mode` is read: the census must survive a fixture whose other fields
+    // this runner cannot model, or it would report a failure for a case the run
+    // itself handled fine.
+    cases += parsed.filter((tc) => (tc as { mode?: string })?.mode !== "live").length;
+  }
+  return cases;
+}
+
+/**
+ * Compares what the run registered against the census, returning null when they
+ * agree and a message naming the short side otherwise.
+ */
+export function caseCountFailure(registered: number, expected: number): string | null {
+  if (registered === expected) return null;
+  if (registered < expected) {
+    return (
+      `case census: the run registered ${registered} case(s) but conformance/tests ` +
+      `holds ${expected} non-live case(s) — ${expected - registered} executed by ` +
+      "nothing. An unrecognized `mode`, a fixture that failed to parse or was never " +
+      "globbed, or a case dropped between load and registration will do this."
+    );
+  }
+  return (
+    `case census: the run registered ${registered} case(s) but conformance/tests ` +
+    `holds only ${expected} non-live case(s) — ${registered - expected} more than ` +
+    "the fixtures declare."
+  );
+}

--- a/conformance/runner/typescript/runner.test.ts
+++ b/conformance/runner/typescript/runner.test.ts
@@ -19,6 +19,7 @@ import type {
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import { caseCountFailure, countNonLiveCases, isMockMode } from "./case-census.js";
 import { checkDelayGaps } from "./delay-gaps.js";
 import { errorRaisedFailure } from "./error-raised.js";
 import { checkRequestCount, requestCountApplies } from "./request-count.js";
@@ -1757,7 +1758,7 @@ function loadTestSuites(): { filename: string; tests: TestCase[] }[] {
       }
       // Live tests are owned by live-runner.test.ts. Drop them here so they
       // never reach installMockHandlers / MSW.
-      const tests = all.filter((tc) => (tc.mode ?? "mock") === "mock");
+      const tests = all.filter((tc) => isMockMode(tc.mode));
       return { filename, tests };
     })
     .filter((suite) => suite.tests.length > 0);
@@ -1829,6 +1830,19 @@ function shouldEnableRetry(tc: TestCase, filename: string): boolean {
 
 // Generate test suites dynamically from JSON definitions
 const suites = loadTestSuites();
+
+// Case census (#602) — see case-census.ts. The other five runners compare
+// passed+failed+skipped against the census after their run loop; vitest owns
+// that accounting here, so the equivalent claim is that every non-live fixture
+// case became a registered `it`. `it.skip` cases still count: they are
+// registered and reported, which is what distinguishes them from a case dropped
+// at load and printed nowhere.
+describe("conformance case census", () => {
+  it("registers every non-live fixture case", () => {
+    const registered = suites.reduce((total, suite) => total + suite.tests.length, 0);
+    expect(caseCountFailure(registered, countNonLiveCases(TESTS_DIR))).toBeNull();
+  });
+});
 
 for (const { filename, tests } of suites) {
   describe(`conformance/${filename}`, () => {

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/CaseCensus.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/CaseCensus.kt
@@ -36,8 +36,10 @@ import kotlinx.serialization.json.contentOrNull
  * Catches: an unrecognized `mode`; a fixture that failed to parse or was never
  * globbed (including one nested below `conformance/tests/`, which no runner
  * discovers — hence the recursive walk); a case dropped between load and
- * dispatch; a fixture truncated to `[]`; and any future skip channel that
- * bypasses the counters, because the counters are what it reads.
+ * dispatch; a fixture emptied to `[]` (which the census REFUSES rather than
+ * counts — see [nonLiveCaseCount], and note that counting it would make this
+ * bullet a lie); and any future skip channel that bypasses the counters,
+ * because the counters are what it reads.
  *
  * The typo is not this check's alone to catch, and saying so is what keeps the
  * rest of the list honest: `make conformance-fixtures-check` validates the
@@ -102,6 +104,21 @@ object CaseCensus {
                 throw CensusException("${file.path}: ${e.message}")
             } catch (e: IOException) {
                 throw CensusException("${file.path}: ${e.message}")
+            }
+            // An emptied fixture is REFUSED, not counted as zero, and this is
+            // the one rejection that carries the whole-file guarantee. It is
+            // the single truncation both sides of the census read identically:
+            // the runner registers nothing from the file and the census expects
+            // nothing, so the two totals fall together and no mismatch ever
+            // appears. Counting it would make "a fixture truncated to []" a
+            // claim this check cannot keep. A file declaring no cases tests
+            // nothing, so refusing it costs nothing — and it closes the same
+            // hole in conformance-fixtures-check, where an empty array is a
+            // schema-valid list of zero items.
+            if (parsed.isEmpty()) {
+                throw CensusException(
+                    "${file.path}: fixture declares no cases; delete the file or restore its cases"
+                )
             }
             // Only `mode` is read: the census must survive a fixture whose
             // other fields this runner cannot model, or it would report a

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/CaseCensus.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/CaseCensus.kt
@@ -1,0 +1,136 @@
+package com.basecamp.sdk.conformance
+
+import java.io.File
+import java.io.IOException
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+
+/**
+ * Case census (#602): every non-live fixture case must be accounted for by the
+ * run.
+ *
+ * ```
+ * passed + failed + skipped  ==  every JSON case under conformance/tests,
+ *                                recursively, whose mode != "live"
+ * ```
+ *
+ * (Spelled out rather than written as a glob: Kotlin nests block comments, so a
+ * `tests/` followed by two stars opens one inside this KDoc and swallows the
+ * rest of the file.)
+ *
+ * The left side is what the runner actually did. The right side is counted by
+ * [nonLiveCaseCount] below — a SEPARATE walk and parse, deliberately not the
+ * runner's own load path. That independence is the entire point: a check fed by
+ * the load path can only confirm the load path agrees with itself.
+ *
+ * Why `mode != "live"` rather than `mode == "mock"`: all six runners select with
+ * "mock unless told otherwise" ([isMockMode] here, and its five equivalents), so
+ * a typo'd `mode: "moc"` is dropped by every runner at once with nothing printed
+ * anywhere. Counting the expected side as "not explicitly live" turns that
+ * silent divergence into arithmetic.
+ *
+ * Catches: an unrecognized `mode`; a fixture that failed to parse or was never
+ * globbed (including one nested below `conformance/tests/`, which no runner
+ * discovers — hence the recursive walk); a case dropped between load and
+ * dispatch; a fixture truncated to `[]`; and any future skip channel that
+ * bypasses the counters, because the counters are what it reads.
+ *
+ * The typo is not this check's alone to catch, and saying so is what keeps the
+ * rest of the list honest: `make conformance-fixtures-check` validates the
+ * top-level fixtures against `conformance/schema.json`, whose `mode` is
+ * `enum: ["mock", "live"]`, so a typo in a TOP-LEVEL fixture fails there first
+ * and this census is defense in depth for that one case. What that gate
+ * structurally cannot see is everything else above — its glob is not recursive,
+ * so a fixture nested below `conformance/tests` is validated by nothing AND run
+ * by nothing (verified: such a file passes the schema gate and fails this
+ * census); a fixture truncated to `[]` is a valid array of zero cases; and a
+ * case dropped between load and dispatch is not a fixture-format question at
+ * all. Nor does that gate run when `make conformance-<lang>` is invoked alone.
+ *
+ * Does NOT catch the all-six case #602 names — one case every runner excludes
+ * for its own reason, which leaves each runner's own census green. That needs
+ * the six exclusion sets in one place, hence artifact plumbing across six CI
+ * jobs; #602 stays open for it.
+ *
+ * Kept apart from the run loop so it is unit-testable (`CaseCensusTest`).
+ */
+object CaseCensus {
+    /**
+     * Raised for every fail-closed condition below, so a caller cannot catch
+     * the parse failure and miss the empty-tree one.
+     */
+    class CensusException(message: String) : Exception(message)
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /**
+     * Whether a fixture case's `mode` selects this runner.
+     *
+     * Kotlin's [TestCase.mode] already defaults to `"mock"` when the key is
+     * absent, so this is passed a non-null value from the run loop — but the
+     * census reads raw JSON where the key really can be missing, and both must
+     * apply the same rule. Live cases are TS-only (the canonical wire-capturer)
+     * and every other value is nobody's.
+     */
+    fun isMockMode(mode: String?): Boolean = (mode ?: "mock") == "mock"
+
+    /**
+     * Counts fixture cases whose mode is not `"live"`, recursively.
+     *
+     * Fail-closed in three places, each a way the count could certify nothing
+     * while looking green: an unreadable tree, a fixture that does not parse,
+     * and a walk that found no fixture files at all.
+     */
+    fun nonLiveCaseCount(testsDir: File): Int {
+        val files = testsDir.walkTopDown()
+            .filter { it.isFile && it.extension == "json" }
+            .sortedBy { it.path }
+            .toList()
+        if (files.isEmpty()) {
+            throw CensusException("no *.json fixture files found under ${testsDir.absolutePath}")
+        }
+
+        return files.sumOf { file ->
+            val parsed = try {
+                json.parseToJsonElement(file.readText()) as? JsonArray
+                    ?: throw CensusException("${file.path}: fixture is not a JSON array")
+            } catch (e: SerializationException) {
+                throw CensusException("${file.path}: ${e.message}")
+            } catch (e: IOException) {
+                throw CensusException("${file.path}: ${e.message}")
+            }
+            // Only `mode` is read: the census must survive a fixture whose
+            // other fields this runner cannot model, or it would report a
+            // failure for a case the run itself handled fine.
+            parsed.count { element ->
+                // `as?` throughout: a fixture element that is not an object, or
+                // a `mode` that is not a string, must not crash the census —
+                // neither is a live case, and both are the schema gate's to
+                // reject.
+                ((element as? JsonObject)?.get("mode") as? JsonPrimitive)?.contentOrNull != "live"
+            }
+        }
+    }
+
+    /**
+     * Compares what the run accounted for against the census, returning null
+     * when they agree and a message naming the short side otherwise.
+     */
+    fun countFailure(ran: Int, expected: Int): String? = when {
+        ran == expected -> null
+        ran < expected ->
+            "case census: the run accounted for $ran case(s) (passed+failed+skipped) " +
+                "but conformance/tests holds $expected non-live case(s) — " +
+                "${expected - ran} executed by nothing. An unrecognized `mode`, a fixture " +
+                "that failed to parse or was never globbed, or a case dropped between load " +
+                "and dispatch will do this."
+        else ->
+            "case census: the run accounted for $ran case(s) (passed+failed+skipped) " +
+                "but conformance/tests holds only $expected non-live case(s) — " +
+                "${ran - expected} more than the fixtures declare."
+    }
+}

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/CaseCensus.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/CaseCensus.kt
@@ -88,7 +88,13 @@ object CaseCensus {
      * and a walk that found no fixture files at all.
      */
     fun nonLiveCaseCount(testsDir: File): Int {
+        // onFail is not optional decoration. WITHOUT it, FileTreeWalk silently
+        // skips a directory whose listFiles() fails and keeps going: the
+        // subtree vanishes from the census, the runner never listed it either
+        // (it lists only the top level), and the two sides agree on a count
+        // that omits it — a fail-closed check quietly failing open.
         val files = testsDir.walkTopDown()
+            .onFail { file, e -> throw CensusException("could not walk ${file.path}: ${e.message}") }
             .filter { it.isFile && it.extension == "json" }
             .sortedBy { it.path }
             .toList()

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
@@ -232,12 +232,18 @@ fun main() {
         return
     }
 
+    // No early return on an empty listing. The census walks recursively and
+    // this listing does not, so "the census found fixtures but this runner
+    // listed none" is exactly the nested-fixture under-count the census exists
+    // to reject — and returning success here would step over the comparison
+    // that rejects it. Falling through runs zero cases and lets the count check
+    // fail, which is the correct answer.
     val testFiles = testsDir.listFiles { f -> f.extension == "json" }
         ?.sorted()
+        .orEmpty()
 
-    if (testFiles.isNullOrEmpty()) {
+    if (testFiles.isEmpty()) {
         println("No test files found in ${testsDir.absolutePath}")
-        return
     }
 
     val json = Json { ignoreUnknownKeys = true }

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
@@ -221,6 +221,17 @@ private fun summarizeSearch(results: List<SearchResult>): JsonElement = buildJso
 fun main() {
     val testsDir = File("../conformance/tests")
 
+    // Case census (#602) — see CaseCensus. Taken up front, by its own walk, so a
+    // fixture tree this runner's listFiles cannot see is reported before the run
+    // rather than inferred from a short count afterwards.
+    val expectedCases = try {
+        CaseCensus.nonLiveCaseCount(testsDir)
+    } catch (e: CaseCensus.CensusException) {
+        System.err.println("Error taking fixture census: ${e.message}")
+        System.exit(1)
+        return
+    }
+
     val testFiles = testsDir.listFiles { f -> f.extension == "json" }
         ?.sorted()
 
@@ -239,7 +250,7 @@ fun main() {
         // here so the offline Kotlin runner doesn't see live entries with
         // unresolved ${PROJECT_ID} fixtures or unknown operations.
         val testCases = json.decodeFromString<List<TestCase>>(file.readText())
-            .filter { it.mode == "mock" }
+            .filter { CaseCensus.isMockMode(it.mode) }
         if (testCases.isEmpty()) continue
         println("\n=== ${file.name} ===")
 
@@ -285,9 +296,17 @@ fun main() {
     }
 
     println("\n=== Summary ===")
-    println("Passed: $passed, Failed: $failed, Skipped: $skipped, Total: ${passed + failed + skipped}")
+    println(
+        "Passed: $passed, Failed: $failed, Skipped: $skipped, Total: ${passed + failed + skipped} " +
+            "(fixtures declare $expectedCases non-live case(s))"
+    )
 
-    if (failed > 0) {
+    val countFailure = CaseCensus.countFailure(passed + failed + skipped, expectedCases)
+    if (countFailure != null) {
+        System.err.println("\nFAIL: $countFailure")
+    }
+
+    if (failed > 0 || countFailure != null) {
         System.exit(1)
     }
 }

--- a/kotlin/conformance/src/test/kotlin/com/basecamp/sdk/conformance/CaseCensusTest.kt
+++ b/kotlin/conformance/src/test/kotlin/com/basecamp/sdk/conformance/CaseCensusTest.kt
@@ -100,6 +100,36 @@ class CaseCensusTest {
     }
 
     @Test
+    fun `census reports an unreadable subtree`() {
+        // FileTreeWalk without onFail skipped the subtree and kept going — and
+        // the runner's non-recursive listing omits it too, leaving both sides
+        // of the census agreeing over cases neither counted. Root reads through
+        // a 0o000 directory, so under root the assertion is that the cases are
+        // still counted; either way they must never be silently dropped.
+        val files = mapOf("cases.json" to fixture, "locked/nested.json" to fixture)
+        withFixtureTree(files) { dir ->
+            val locked = File(dir, "locked")
+            val posix = java.nio.file.Files.getFileAttributeView(
+                locked.toPath(), java.nio.file.attribute.PosixFileAttributeView::class.java
+            )
+            posix.setPermissions(emptySet())
+            try {
+                if (System.getProperty("user.name") == "root") {
+                    assertEquals(4, CaseCensus.nonLiveCaseCount(dir))
+                } else {
+                    assertFailsWith<CaseCensus.CensusException> {
+                        CaseCensus.nonLiveCaseCount(dir)
+                    }
+                }
+            } finally {
+                posix.setPermissions(
+                    java.nio.file.attribute.PosixFilePermissions.fromString("rwxr-xr-x")
+                )
+            }
+        }
+    }
+
+    @Test
     fun `census rejects an empty tree`() {
         // A census that counted nothing certifies nothing: zero on both sides
         // is the shape a broken walk takes.

--- a/kotlin/conformance/src/test/kotlin/com/basecamp/sdk/conformance/CaseCensusTest.kt
+++ b/kotlin/conformance/src/test/kotlin/com/basecamp/sdk/conformance/CaseCensusTest.kt
@@ -109,13 +109,14 @@ class CaseCensusTest {
     }
 
     @Test
-    fun `census accepts a truncated fixture as zero cases`() {
-        // `[]` parses, so the census counts zero for it — and the runner counts
-        // zero too. The mismatch this produces is against the OTHER files'
-        // cases, which is why the count is taken over the whole tree rather
-        // than per file.
-        withFixtureTree(mapOf("empty.json" to "[]", "cases.json" to fixture)) { dir ->
-            assertEquals(2, CaseCensus.nonLiveCaseCount(dir))
+    fun `census rejects an emptied fixture`() {
+        // The one truncation both sides read identically: the runner registers
+        // nothing from the file and the census would expect nothing, so the
+        // totals fall together and no mismatch appears. Counting it as zero is
+        // what would make the whole-file guarantee a lie, so the census refuses
+        // it instead.
+        withFixtureTree(mapOf("cases.json" to fixture, "emptied.json" to "[]")) { dir ->
+            assertFailsWith<CaseCensus.CensusException> { CaseCensus.nonLiveCaseCount(dir) }
         }
     }
 
@@ -139,5 +140,8 @@ class CaseCensusTest {
         assertFalse(CaseCensus.isMockMode("live"))
         // The census is what catches this one; the filter must not run it.
         assertFalse(CaseCensus.isMockMode("moc"))
+        // Null-coalescing, not falsiness: an explicit empty mode is not an
+        // absent one. Python defaulted on falsiness and ran it.
+        assertFalse(CaseCensus.isMockMode(""))
     }
 }

--- a/kotlin/conformance/src/test/kotlin/com/basecamp/sdk/conformance/CaseCensusTest.kt
+++ b/kotlin/conformance/src/test/kotlin/com/basecamp/sdk/conformance/CaseCensusTest.kt
@@ -1,0 +1,143 @@
+package com.basecamp.sdk.conformance
+
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+
+/**
+ * Case-census contract (#602).
+ *
+ * The check is green on the real fixture tree by construction, so a live run
+ * only ever proves it can say yes. These cases run it against a SYNTHETIC
+ * fixture set and prove it can say no — the `mode: "moc"` case in particular,
+ * which every runner's "mock unless told otherwise" filter drops with nothing
+ * printed. That divergence is asserted end-to-end here: the census and the run
+ * loop's own predicate ([CaseCensus.isMockMode], shared with the load path)
+ * disagree by one, and [CaseCensus.countFailure] reports it.
+ */
+class CaseCensusTest {
+    /**
+     * One case of each kind: a plain mock case (no `mode` at all, the common
+     * spelling), a live case the runners are meant to drop, and a typo'd mode
+     * that nothing recognizes.
+     */
+    private val fixture = """
+        [
+          {"name": "plain", "operation": "GetProject"},
+          {"name": "live one", "operation": "GetProject", "mode": "live"},
+          {"name": "typo", "operation": "GetProject", "mode": "moc"}
+        ]
+    """.trimIndent()
+
+    private fun withFixtureTree(files: Map<String, String>, body: (File) -> Unit) {
+        val dir = createTempDirectory("case-census").toFile()
+        try {
+            for ((relative, content) in files) {
+                val file = File(dir, relative)
+                file.parentFile.mkdirs()
+                file.writeText(content)
+            }
+            body(dir)
+        } finally {
+            dir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `census counts every case that is not explicitly live`() {
+        withFixtureTree(mapOf("cases.json" to fixture)) { dir ->
+            assertEquals(2, CaseCensus.nonLiveCaseCount(dir))
+        }
+    }
+
+    @Test
+    fun `a typoed mode makes the count check fail`() {
+        // The regression this whole check exists for. The runner's own filter
+        // keeps one case; the census counts two; the difference is the case
+        // executed by nothing.
+        withFixtureTree(mapOf("cases.json" to fixture)) { dir ->
+            val json = Json { ignoreUnknownKeys = true }
+            val ran = json.decodeFromString<List<TestCase>>(fixture)
+                .count { CaseCensus.isMockMode(it.mode) }
+            assertEquals(1, ran, "the run loop should keep only the plain case")
+
+            val failure = CaseCensus.countFailure(ran, CaseCensus.nonLiveCaseCount(dir))
+
+            assertNotNull(failure, "a case no runner recognizes must fail the count check")
+            assertContains(failure, "1 executed by nothing")
+        }
+    }
+
+    @Test
+    fun `census finds fixtures nested below the tests directory`() {
+        // No runner globs recursively, so a case parked one directory down is
+        // run by nothing. The census walks, which is what makes that visible.
+        withFixtureTree(mapOf("nested/cases.json" to fixture)) { dir ->
+            assertEquals(2, CaseCensus.nonLiveCaseCount(dir))
+        }
+    }
+
+    @Test
+    fun `census rejects a fixture that does not parse`() {
+        withFixtureTree(mapOf("broken.json" to """[{"name": "truncated"""")) { dir ->
+            assertFailsWith<CaseCensus.CensusException> { CaseCensus.nonLiveCaseCount(dir) }
+        }
+    }
+
+    @Test
+    fun `census rejects a fixture that is not an array`() {
+        withFixtureTree(mapOf("object.json" to """{"name": "not a list"}""")) { dir ->
+            assertFailsWith<CaseCensus.CensusException> { CaseCensus.nonLiveCaseCount(dir) }
+        }
+    }
+
+    @Test
+    fun `census rejects an empty tree`() {
+        // A census that counted nothing certifies nothing: zero on both sides
+        // is the shape a broken walk takes.
+        withFixtureTree(emptyMap()) { dir ->
+            assertFailsWith<CaseCensus.CensusException> { CaseCensus.nonLiveCaseCount(dir) }
+        }
+    }
+
+    @Test
+    fun `census accepts a truncated fixture as zero cases`() {
+        // `[]` parses, so the census counts zero for it — and the runner counts
+        // zero too. The mismatch this produces is against the OTHER files'
+        // cases, which is why the count is taken over the whole tree rather
+        // than per file.
+        withFixtureTree(mapOf("empty.json" to "[]", "cases.json" to fixture)) { dir ->
+            assertEquals(2, CaseCensus.nonLiveCaseCount(dir))
+        }
+    }
+
+    @Test
+    fun `count failure accepts agreement`() {
+        assertNull(CaseCensus.countFailure(42, 42))
+    }
+
+    @Test
+    fun `count failure names an over count`() {
+        val failure = CaseCensus.countFailure(43, 42)
+
+        assertNotNull(failure)
+        assertContains(failure, "1 more than the fixtures declare")
+    }
+
+    @Test
+    fun `isMockMode treats absence as mock`() {
+        assertTrue(CaseCensus.isMockMode(null))
+        assertTrue(CaseCensus.isMockMode("mock"))
+        assertFalse(CaseCensus.isMockMode("live"))
+        // The census is what catches this one; the filter must not run it.
+        assertFalse(CaseCensus.isMockMode("moc"))
+    }
+}


### PR DESCRIPTION
## What

Every conformance runner now asserts, at the end of its own run:

```
passed + failed + skipped  ==  cases under conformance/tests, recursively,
                               whose mode != "live"
```

On mismatch it names the short side and **exits non-zero** — a silent under-count is
the failure mode this exists to remove, so it is not a warning.

The right side is counted by its own recursive walk and parse, deliberately **not** the
runner's load path. That independence is the whole point: a check fed by the load path
can only confirm the load path agrees with itself.

`mode != "live"` rather than `mode == "mock"` is what makes the divergence arithmetic.
All six runners select with *"mock unless told otherwise"* (`(mode ?? "mock") == "mock"`
and its five equivalents), so a mode nobody recognizes is dropped by every runner at
once with nothing printed anywhere.

## Why this layer

This is #602 — *is any fixture case executed by nothing?* — answered where the answer
lives. #740 originally carried a hand-rolled **source-text parser** over the six runners'
skip tables. Scored the way `AGENTS.md` asks:

```
rules added across four review rounds:  9 commits
call sites covered:  6 runners, 8 tables, 2 tag branches  — unchanged
```

Twenty-seven findings, nearly all *"here is another source spelling the parser does not
recognize"*. Ground truth for "what did this runner skip" is runtime; a source parser
structurally cannot see `result.skipped`, a derived table, or a case the loader dropped.
That half is parked on `conformance-skips-parser-archive`.

## What it catches

- a typo'd or otherwise unrecognized `mode`
- a fixture that failed to parse, or was never globbed — **including one nested below
  `conformance/tests/`**, which no runner discovers
- a case dropped between load and dispatch
- a whole fixture emptied to `[]` — the census **refuses** such a file rather than
  counting it as zero (see the review correction below)
- any future skip channel that bypasses the counters, because the counters are what it reads

The typo class is not this check's alone: `conformance-fixtures-check` pins `mode` to
`enum: ["mock", "live"]`, so a typo in a *top-level* fixture fails there first. Verified
what that gate structurally cannot see — its glob is not recursive, so a fixture at
`conformance/tests/nested/probe.json` **passes `make conformance-fixtures-check` (exit 0)
and fails the census**. Nor does that gate run when `make conformance-<lang>` is invoked
alone.

## What it does not catch

**The literal all-six case #602 names.** When every runner excludes the same case for its
own reason, every runner's census is green — each counted its own skip. Detecting that
needs the six exclusion sets in one place, which needs artifact plumbing across six CI
jobs (no precedent in `test.yml`, and the macOS-only Swift lane means a Linux run can
never assemble six manifests). **#602 stays open for that**; today's maximum overlap is
2 of 6 and #596 already narrowed it.

**Swift's arm is macOS-only.** `conformance-swift` is `ifdef IS_MACOS`; on Linux it prints
SKIP and Swift's census never runs. A green Linux `make` is five-runner coverage, not six.
The Makefile now says so where the ifdef is.

## Review corrections

Three rounds with Copilot and Codex produced four distinct defect classes, each now
closed in every runner that had it. The first falsified a claim in the original
description, so it is corrected above.

**1. `[]` truncation was not caught — the claim was false.** An emptied fixture is the
one truncation both sides of the census read identically: the runner registers nothing
from that file and the census expected nothing, so both totals fall by the same amount
and no mismatch appears. The census now **refuses** an emptied fixture instead of
counting it as zero. A file declaring no cases tests nothing, so refusing it costs
nothing — and it closes the same hole in `conformance-fixtures-check`, where `[]` is a
schema-valid list of zero items. Self-tests flipped from *"accepts as zero"* to
*"rejects"*. (6/6 runners)

**2. A nested-only tree stepped over the comparison.** Runners returned success from
their `no test files found` branch when the top-level glob was empty — before reaching
the count check. That is exactly the nested-fixture under-count this PR advertises, so
the early exit is gone; the message still prints and the run falls through to fail the
comparison. (5/5 that had one)

**3. Walk errors were swallowed.** Each language's directory walk had its own silent-drop
behavior — Kotlin's `FileTreeWalk` skips a directory whose `listFiles()` fails, Python's
`Path.rglob` suppresses the scan `OSError`, Ruby's `Dir.glob` omits what it cannot
traverse (and `Find.find` is no better — `find.rb` rescues `Errno::EACCES` and moves on),
Swift's `try?` on per-entry metadata discarded the failure. In every case the subtree
leaves the census, the runner's non-recursive glob never saw it either, and the two sides
agree on a count that omits it: a walk documented as fail-closed, failing open. Go
(`filepath.WalkDir`) and TypeScript (`readdirSync`) were already correct. (4/4 that
swallowed)

**4. A falsy `mode` defaulted to mock.** Python's `(mode or "mock")` read `"mode": ""` as
an absent key; Ruby's `(mode || "mock")` did the same for an explicit `false`. Both ran a
value the other runners refuse, while the census counted it as non-live — matching totals
over a mode nothing accepts. Both now default on `None`/`nil` only. (2/2 that had it)

Also fixed: Go accepted a top-level `null` as zero cases (nil slice, no error), and its
`Mode string` could not tell an absent key from `"mode": ""`, so it alone ran a mode the
other five refuse (now `*string`).

Every fix was mutation-tested: reverting each one kills exactly its own new test, with no
compile errors, and sources were restored by copy and diffed. The unreadable-subtree
tests branch on euid, since root reads through a `0o000` directory — under root the
assertion becomes "the cases are still counted", so neither environment can pass by
silently dropping the subtree.

## Self-tests

The census is green on the real tree by construction, so a live run only proves it can say
yes. Each language gets a suite against a **synthetic** fixture set (`conformance-runner-tests`,
plus vitest for TS) proving it can say no: a `mode: "moc"` case where the runner's own
predicate and the census disagree by one, and the fail-closed paths — an unparseable
fixture, a non-array fixture, an empty walk.

The predicate is shared, not copied: each runner's load filter now calls the same
`isMockMode` the tests exercise.

## Verification

- `make conformance` — all six report `198 = 198`, green.
- `make conformance-runner-tests` — five suites green; TS census tests run under `conformance-typescript`.
- **Proved it can say no end-to-end**, three ways, since the count check lives in `main()`
  where a unit test cannot reach it. All six runners exit non-zero for: a `mode: "moc"`
  case (each naming `1 executed by nothing`); every fixture moved one directory down; and
  one fixture emptied to `[]`. The fixture tree was restored by copy and diffed
  byte-identical after each probe.
- Full serial `make check` on a Linux host under `LC_ALL=C.UTF-8` — exit 0.
